### PR TITLE
[Cases] Update cases api docs

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -14021,7 +14021,7 @@ paths:
             curl \
               --request DELETE 'https://localhost:5601/api/cases?ids=%5B%22030e6e34-6470-4001-864f-b229511ad188%22%2C%22e662ff34-0493-4538-b9d1-6706ced02ff2%22%5D' \
               --header "Authorization: $API_KEY" \
-              --header "Content-Type: application/json"
+              --header "Content-Type: application/json" \
               --header "kbn-xsrf: true"
         - label: Console
           lang: console
@@ -14194,11 +14194,10 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+        Returns case details. The response does not include a comments property;  use the find case comments API to retrieve comments. The totalComment field  reflects the actual number of user comments on the case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
       operationId: getCaseDefaultSpace
       parameters:
         - $ref: '#/components/parameters/Cases_case_id'
-        - $ref: '#/components/parameters/Cases_includeComments'
       responses:
         '200':
           content:
@@ -14206,10 +14205,10 @@ paths:
               examples:
                 getDefaultCaseResponse:
                   $ref: '#/components/examples/Cases_get_case_response'
-                getDefaultObservabilityCaseReponse:
+                getDefaultObservabilityCaseResponse:
                   $ref: '#/components/examples/Cases_get_case_observability_response'
               schema:
-                $ref: '#/components/schemas/Cases_case_response_properties'
+                $ref: '#/components/schemas/Cases_case_response_get_case'
           description: Indicates a successful call.
         '401':
           content:
@@ -14398,8 +14397,11 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                findCaseCommentsResponse:
+                  $ref: '#/components/examples/Cases_find_case_comments_response'
               schema:
-                $ref: '#/components/schemas/Cases_case_response_properties'
+                $ref: '#/components/schemas/Cases_find_comments_response'
           description: Indicates a successful call.
         '401':
           content:
@@ -14407,7 +14409,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Cases_response_4xx'
           description: Authorization information is missing or invalid.
-      summary: Find case comments and alerts
+      summary: Find case comments
       tags:
         - cases
       x-metaTags:
@@ -14576,7 +14578,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Retrives a paginated list of user activity for a case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+        Retrieves a paginated list of user activity for a case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
       operationId: findCaseActivityDefaultSpace
       parameters:
         - $ref: '#/components/parameters/Cases_case_id'
@@ -14674,7 +14676,7 @@ paths:
 
         Refer to [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces) for more information.
 
-        Get setting details such as the closure type, custom fields, templatse, and the default connector for cases. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on where the cases were created.
+        Get setting details such as the closure type, custom fields, templates, and the default connector for cases. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on where the cases were created.
       operationId: getCaseConfigurationDefaultSpace
       parameters:
         - $ref: '#/components/parameters/Cases_owner_filter'
@@ -72245,6 +72247,7 @@ components:
         description: A case description.
         owner: cases
         settings:
+          extractObservables: false
           syncAlerts: true
         tags:
           - tag-1
@@ -72283,6 +72286,7 @@ components:
         id: 66b9aa00-94fa-11ea-9f74-e7e108796192
         owner: cases
         settings:
+          extractObservables: false
           syncAlerts: true
         severity: low
         status: open
@@ -72369,6 +72373,28 @@ components:
                 - uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
             type: assignees
             version: WzM1ODg4LDFb
+    Cases_find_case_comments_response:
+      summary: Paginated list of user comments for a case
+      value:
+        comments:
+          - comment: A new comment
+            created_at: '2023-10-07T19:32:13.104Z'
+            created_by:
+              email: null
+              full_name: null
+              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+              username: elastic
+            id: 8048b460-fe2b-11ec-b15d-779a7c8bbcc3
+            owner: cases
+            pushed_at: null
+            pushed_by: null
+            type: user
+            updated_at: null
+            updated_by: null
+            version: WzIzLDFd
+        page: 1
+        per_page: 20
+        total: 1
     Cases_find_case_response:
       summary: Retrieve the first five cases with the `tag-1` tag, in ascending order by last update time.
       value:
@@ -72402,6 +72428,7 @@ components:
             id: abed3a70-71bd-11ea-a0b2-c51ea50a58e2
             owner: cases
             settings:
+              extractObservables: false
               syncAlerts: true
             severity: low
             status: open
@@ -72495,50 +72522,13 @@ components:
           updated_by: null
           version: WzEyLDNd
     Cases_get_case_observability_response:
-      summary: Retrieves information about an Observability case including its alerts and comments.
+      summary: Get case response (Observability). Comments are not included; use the find case comments API. totalComment reflects the actual count.
       value:
         assignees:
           - uid: u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0
         category: null
         closed_at: null
         closed_by: null
-        comments:
-          - alertId:
-              - a6e12ac4-7bce-457b-84f6-d7ce8deb8446
-            created_at: '2023-11-06T19:29:38.424Z'
-            created_by:
-              email: null
-              full_name: null
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-              username: elastic
-            id: 59d438d0-79a9-4864-8d4b-e63adacebf6e
-            index:
-              - .internal.alerts-observability.logs.alerts-default-000001
-            owner: observability
-            pushed_at: null
-            pushed_by: null
-            rule:
-              id: 03e4eb87-62ca-4e5d-9570-3d7625e9669d
-              name: Observability rule
-            type: alert
-            updated_at: null
-            updated_by: null
-            version: WzY3LDJd
-          - comment: The first comment.
-            created_at: '2023-11-06T19:29:57.812Z'
-            created_by:
-              email: null
-              full_name: null
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-              username: elastic
-            id: d99342d3-3aa3-4b80-90ec-a702607604f5
-            owner: observability
-            pushed_at: null
-            pushed_by: null
-            type: user
-            updated_at: null
-            updated_by: null
-            version: WzcyLDJd
         connector:
           fields: null
           id: none
@@ -72556,6 +72546,7 @@ components:
         id: c3ff7550-def1-4e90-b6bc-c9969a4a09b1
         owner: observability
         settings:
+          extractObservables: false
           syncAlerts: false
         severity: low
         status: in-progress
@@ -72573,29 +72564,13 @@ components:
           username: elastic
         version: WzI0NywyXQ==
     Cases_get_case_response:
-      summary: Retrieves information about a case including its comments.
+      summary: Get case response. Comments are not included; use the find case comments API. totalComment reflects the actual count.
       value:
         assignees:
           - uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
         category: null
         closed_at: null
         closed_by: null
-        comments:
-          - comment: A new comment
-            created_at: '2023-10-13T15:40:32.335Z'
-            created_by:
-              email: null
-              full_name: null
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-              username: elastic
-            id: 2134c1d0-02c2-11ed-85f2-4f7c222ca2fa
-            owner: cases
-            pushed_at: null
-            pushed_by: null
-            type: user
-            updated_at: null
-            updated_by: null
-            version: WzM3LDFd
         connector:
           fields: null
           id: none
@@ -72620,13 +72595,14 @@ components:
         id: 31cdada0-02c1-11ed-85f2-4f7c222ca2fa
         owner: cases
         settings:
+          extractObservables: false
           syncAlerts: true
         severity: low
         status: open
         tags:
           - tag 1
         title: Case title 1
-        totalAlerts: 0
+        totalAlerts: 1
         totalComment: 1
         updated_at: '2023-10-13T15:40:32.335Z'
         updated_by:
@@ -72706,6 +72682,7 @@ components:
         id: b917f300-0ed9-11ed-bd18-65557fe66949
         owner: cases
         settings:
+          extractObservables: false
           syncAlerts: true
         severity: low
         status: open
@@ -72903,6 +72880,7 @@ components:
             description: A case description.
             id: a18b38a0-71b0-11ea-a0b2-c51ea50a58e2
             settings:
+              extractObservables: false
               syncAlerts: true
             tags:
               - tag-1
@@ -72952,6 +72930,7 @@ components:
           id: 66b9aa00-94fa-11ea-9f74-e7e108796192
           owner: cases
           settings:
+            extractObservables: false
             syncAlerts: true
           severity: low
           status: open
@@ -76856,14 +76835,6 @@ components:
           minItems: 1
           type: string
         type: array
-    Cases_includeComments:
-      deprecated: true
-      description: Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.
-      in: query
-      name: includeComments
-      schema:
-        default: true
-        type: boolean
     Cases_kbn_xsrf:
       description: Cross-site request forgery protection
       in: header
@@ -77939,6 +77910,144 @@ components:
         - email
         - full_name
         - username
+    Cases_case_response_get_case:
+      description: |
+        Case details returned by the get case API. The comments property is not included in the response. Use the find case comments API to retrieve comments. totalComment reflects the actual number of user comments.
+      properties:
+        assignees:
+          $ref: '#/components/schemas/Cases_assignees'
+        category:
+          description: The case category.
+          nullable: true
+          type: string
+        closed_at:
+          format: date-time
+          nullable: true
+          type: string
+        closed_by:
+          $ref: '#/components/schemas/Cases_case_response_closed_by_properties'
+        connector:
+          discriminator:
+            mapping:
+              .cases-webhook: '#/components/schemas/Cases_connector_properties_cases_webhook'
+              .jira: '#/components/schemas/Cases_connector_properties_jira'
+              .none: '#/components/schemas/Cases_connector_properties_none'
+              .resilient: '#/components/schemas/Cases_connector_properties_resilient'
+              .servicenow: '#/components/schemas/Cases_connector_properties_servicenow'
+              .servicenow-sir: '#/components/schemas/Cases_connector_properties_servicenow_sir'
+              .swimlane: '#/components/schemas/Cases_connector_properties_swimlane'
+            propertyName: type
+          oneOf:
+            - $ref: '#/components/schemas/Cases_connector_properties_none'
+            - $ref: '#/components/schemas/Cases_connector_properties_cases_webhook'
+            - $ref: '#/components/schemas/Cases_connector_properties_jira'
+            - $ref: '#/components/schemas/Cases_connector_properties_resilient'
+            - $ref: '#/components/schemas/Cases_connector_properties_servicenow'
+            - $ref: '#/components/schemas/Cases_connector_properties_servicenow_sir'
+            - $ref: '#/components/schemas/Cases_connector_properties_swimlane'
+          title: Case response properties for connectors
+        created_at:
+          example: '2022-05-13T09:16:17.416Z'
+          format: date-time
+          type: string
+        created_by:
+          $ref: '#/components/schemas/Cases_case_response_created_by_properties'
+        customFields:
+          description: Custom field values for the case.
+          items:
+            type: object
+            properties:
+              key:
+                description: |
+                  The unique identifier for the custom field. The key value must exist in the case configuration settings.
+                type: string
+              type:
+                description: |
+                  The custom field type. It must match the type specified in the case configuration settings.
+                enum:
+                  - text
+                  - toggle
+                type: string
+              value:
+                description: |
+                  The custom field value. If the custom field is required, it cannot be explicitly set to null. However, for cases that existed when the required custom field was added, the default value stored in Elasticsearch is `undefined`. The value returned in the API and user interface in this case is `null`.
+                oneOf:
+                  - maxLength: 160
+                    minLength: 1
+                    nullable: true
+                    type: string
+                  - type: boolean
+          type: array
+        description:
+          example: A case description.
+          type: string
+        duration:
+          description: |
+            The elapsed time from the creation of the case to its closure (in seconds). If the case has not been closed, the duration is set to null. If the case was closed after less than half a second, the duration is rounded down to zero.
+          example: 120
+          nullable: true
+          type: integer
+        external_service:
+          $ref: '#/components/schemas/Cases_external_service'
+        id:
+          example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+          type: string
+        owner:
+          $ref: '#/components/schemas/Cases_owner'
+        settings:
+          $ref: '#/components/schemas/Cases_settings'
+        severity:
+          $ref: '#/components/schemas/Cases_case_severity'
+        status:
+          $ref: '#/components/schemas/Cases_case_status'
+        tags:
+          example:
+            - tag-1
+          items:
+            type: string
+          type: array
+        title:
+          example: Case title 1
+          type: string
+        totalAlerts:
+          example: 0
+          type: integer
+        totalComment:
+          description: The number of user comments on the case. Use the find case comments API to retrieve comment content.
+          example: 1
+          type: integer
+        updated_at:
+          format: date-time
+          nullable: true
+          type: string
+        updated_by:
+          $ref: '#/components/schemas/Cases_case_response_updated_by_properties'
+        version:
+          example: WzUzMiwxXQ==
+          type: string
+      required:
+        - closed_at
+        - closed_by
+        - connector
+        - created_at
+        - created_by
+        - description
+        - duration
+        - external_service
+        - id
+        - owner
+        - settings
+        - severity
+        - status
+        - tags
+        - title
+        - totalAlerts
+        - totalComment
+        - updated_at
+        - updated_by
+        - version
+      title: Get case response
+      type: object
     Cases_case_response_properties:
       title: Case response properties
       type: object
@@ -78570,6 +78679,29 @@ components:
               example: elastic
               nullable: true
               type: string
+    Cases_find_comments_response:
+      title: Find case comments response
+      type: object
+      properties:
+        comments:
+          description: Paginated list of user comments for the case.
+          items:
+            $ref: '#/components/schemas/Cases_user_comment_response_properties'
+          type: array
+        page:
+          description: The current page index.
+          type: integer
+        per_page:
+          description: The number of items per page.
+          type: integer
+        total:
+          description: The total number of comments.
+          type: integer
+      required:
+        - comments
+        - page
+        - per_page
+        - total
     Cases_owner:
       description: |
         The application that owns the cases: Stack Management, Observability, or Elastic Security.
@@ -78968,7 +79100,8 @@ components:
       type: object
       properties:
         extractObservables:
-          description: Auto extracts observables
+          description: |
+            When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
           example: false
           type: boolean
         syncAlerts:

--- a/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
+++ b/src/platform/packages/private/kbn-validate-oas/src/oas_error_baseline.json
@@ -1,4 +1,4 @@
 {
-  "./oas_docs/output/kibana.yaml": 1238,
+  "./oas_docs/output/kibana.yaml": 1237,
   "./oas_docs/output/kibana.serverless.yaml": 1131
 }

--- a/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/kibana_request_builder.test.ts
@@ -204,21 +204,6 @@ describe('buildKibanaRequest', () => {
       });
     });
 
-    it('should handle query parameters', () => {
-      const result = buildKibanaRequest(
-        'kibana.getCase',
-        {
-          caseId: 'test-case-id',
-          includeComments: true,
-        },
-        'cases-space'
-      );
-
-      expect(result.path).toBe('/s/cases-space/api/cases/test-case-id');
-      expect(result.query).toBeDefined();
-      expect(result.query).toHaveProperty('includeComments');
-    });
-
     it('should handle requests with no body', () => {
       const result = buildKibanaRequest('kibana.getCase', { caseId: 'test-case' }, 'monitoring');
 

--- a/src/platform/packages/shared/kbn-workflows/spec/kibana/generated/kibana.get_case.gen.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/kibana/generated/kibana.get_case.gen.ts
@@ -47,7 +47,7 @@ You must have \`read\` privileges for the **Cases** feature in the **Management*
   parameterTypes: {
     headerParams: [],
     pathParams: ['caseId'],
-    urlParams: ['includeComments'],
+    urlParams: [],
     bodyParams: [],
   },
   paramsSchema: z.object({

--- a/src/platform/packages/shared/kbn-workflows/spec/kibana/generated/schemas/kibana_openapi_zod.gen.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/kibana/generated/schemas/kibana_openapi_zod.gen.ts
@@ -987,11 +987,7 @@ export const get_case_default_space_request = z.object({
             description: 'The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded.'
         })
     }),
-    query: z.optional(z.object({
-        includeComments: z.optional(z.boolean().register(z.globalRegistry, {
-            description: 'Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.'
-        })).default(true)
-    }))
+    query: z.optional((z.never())),
 });
 
 /**

--- a/src/platform/packages/shared/kbn-workflows/spec/lib/samples/kibana_steps.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/lib/samples/kibana_steps.ts
@@ -106,7 +106,6 @@ export const KIBANA_VALID_SAMPLE_STEPS = [
     type: 'kibana.getCase',
     with: {
       caseId: '123',
-      includeComments: true,
     },
   },
   {
@@ -221,9 +220,7 @@ export const KIBANA_INVALID_SAMPLE_STEPS = [
     step: {
       name: 'get_case_without_case_id',
       type: 'kibana.getCase',
-      with: {
-        includeComments: true,
-      },
+      with: {},
     },
     zodErrorMessage: 'Invalid input: expected string, received undefined',
     diagnosticErrorMessage: /Missing property "caseId"/,

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/create_get_update_case.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/create_get_update_case.ts
@@ -123,5 +123,4 @@ steps:
     type: kibana.getCase
     with:
       caseId: \${{variables.case_id}}
-      includeComments: false
 `;

--- a/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
+++ b/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
@@ -294,8 +294,9 @@ export const Settings = z.object({
    */
   syncAlerts: z.boolean(),
   /**
-   * Auto extracts observables
-   */
+      * When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
+
+      */
   extractObservables: z.boolean().optional(),
 });
 
@@ -912,6 +913,78 @@ export const UpdateCaseConfigurationRequest = z.object({
   version: z.string(),
 });
 
+/**
+  * Case details returned by the get case API. The comments property is not included in the response. Use the find case comments API to retrieve comments. totalComment reflects the actual number of user comments.
+
+  */
+export type CaseResponseGetCase = z.infer<typeof CaseResponseGetCase>;
+export const CaseResponseGetCase = z.object({
+  assignees: Assignees.optional(),
+  /**
+   * The case category.
+   */
+  category: z.string().nullable().optional(),
+  closed_at: z.string().datetime().nullable(),
+  closed_by: CaseResponseClosedByProperties,
+  connector: z.discriminatedUnion('type', [
+    ConnectorPropertiesNone,
+    ConnectorPropertiesCasesWebhook,
+    ConnectorPropertiesJira,
+    ConnectorPropertiesResilient,
+    ConnectorPropertiesServicenow,
+    ConnectorPropertiesServicenowSir,
+    ConnectorPropertiesSwimlane,
+  ]),
+  created_at: z.string().datetime(),
+  created_by: CaseResponseCreatedByProperties,
+  /**
+   * Custom field values for the case.
+   */
+  customFields: z
+    .array(
+      z.object({
+        /**
+      * The unique identifier for the custom field. The key value must exist in the case configuration settings.
+
+      */
+        key: z.string().optional(),
+        /**
+      * The custom field type. It must match the type specified in the case configuration settings.
+
+      */
+        type: z.enum(['text', 'toggle']).optional(),
+        /**
+      * The custom field value. If the custom field is required, it cannot be explicitly set to null. However, for cases that existed when the required custom field was added, the default value stored in Elasticsearch is `undefined`. The value returned in the API and user interface in this case is `null`.
+
+      */
+        value: z.union([z.string().min(1).max(160).nullable(), z.boolean()]).optional(),
+      })
+    )
+    .optional(),
+  description: z.string(),
+  /**
+      * The elapsed time from the creation of the case to its closure (in seconds). If the case has not been closed, the duration is set to null. If the case was closed after less than half a second, the duration is rounded down to zero.
+
+      */
+  duration: z.number().int().nullable(),
+  external_service: ExternalService,
+  id: z.string(),
+  owner: Owner,
+  settings: Settings,
+  severity: CaseSeverity,
+  status: CaseStatus,
+  tags: z.array(z.string()),
+  title: z.string(),
+  totalAlerts: z.number().int(),
+  /**
+   * The number of user comments on the case. Use the find case comments API to retrieve comment content.
+   */
+  totalComment: z.number().int(),
+  updated_at: z.string().datetime().nullable(),
+  updated_by: CaseResponseUpdatedByProperties,
+  version: z.string(),
+});
+
 export type AlertResponseProperties = z.infer<typeof AlertResponseProperties>;
 export const AlertResponseProperties = z.object({
   attached_at: z.string().datetime().optional(),
@@ -1056,6 +1129,26 @@ export const UpdateCaseCommentRequest = z.discriminatedUnion('type', [
   UpdateAlertCommentRequestProperties,
   UpdateUserCommentRequestProperties,
 ]);
+
+export type FindCommentsResponse = z.infer<typeof FindCommentsResponse>;
+export const FindCommentsResponse = z.object({
+  /**
+   * Paginated list of user comments for the case.
+   */
+  comments: z.array(UserCommentResponseProperties),
+  /**
+   * The current page index.
+   */
+  page: z.number().int(),
+  /**
+   * The number of items per page.
+   */
+  per_page: z.number().int(),
+  /**
+   * The total number of comments.
+   */
+  total: z.number().int(),
+});
 
 export type Actions = z.infer<typeof Actions>;
 export const Actions = z.enum(['add', 'create', 'delete', 'push_to_service', 'update']);

--- a/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
+++ b/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
@@ -294,9 +294,9 @@ export const Settings = z.object({
    */
   syncAlerts: z.boolean(),
   /**
-   * When `true`, observables (for example, IPs, hashes, URLs) are
-   * automatically extracted from case comments. Defaults to `false` if omitted.
-   */
+      * When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
+
+      */
   extractObservables: z.boolean().optional(),
 });
 

--- a/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
+++ b/x-pack/platform/plugins/shared/cases/common/bundled-types.gen.ts
@@ -294,9 +294,9 @@ export const Settings = z.object({
    */
   syncAlerts: z.boolean(),
   /**
-      * When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
-
-      */
+   * When `true`, observables (for example, IPs, hashes, URLs) are
+   * automatically extracted from case comments. Defaults to `false` if omitted.
+   */
   extractObservables: z.boolean().optional(),
 });
 

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -797,7 +797,7 @@ paths:
       summary: Get case information
       operationId: getCaseDefaultSpace
       description: |
-        Returns case details. The response does not include a comments property; use the find case comments API to retrieve comments. The totalComment field reflects the actual number of user comments on the case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+        Returns case details. The response does not include a comments property;  use the find case comments API to retrieve comments. The totalComment field  reflects the actual number of user comments on the case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
       tags:
         - cases
       parameters:
@@ -808,11 +808,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/case_response_properties'
+                $ref: '#/components/schemas/case_response_get_case'
               examples:
                 getDefaultCaseResponse:
                   $ref: '#/components/examples/get_case_response'
-                getDefaultObservabilityCaseReponse:
+                getDefaultObservabilityCaseResponse:
                   $ref: '#/components/examples/get_case_observability_response'
         '401':
           description: Authorization information is missing or invalid.
@@ -958,7 +958,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/case_response_properties'
+                $ref: '#/components/schemas/find_comments_response'
+              examples:
+                findCaseCommentsResponse:
+                  $ref: '#/components/examples/find_case_comments_response'
         '401':
           description: Authorization information is missing or invalid.
           content:
@@ -1732,7 +1735,8 @@ components:
           type: boolean
           example: true
         extractObservables:
-          description: Auto extracts observables
+          description: |
+            When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
           type: boolean
           example: false
     case_severity:
@@ -2659,6 +2663,144 @@ components:
             The version of the connector. To retrieve the version value, use the get configuration API.
           type: string
           example: WzIwMiwxXQ==
+    case_response_get_case:
+      title: Get case response
+      description: |
+        Case details returned by the get case API. The comments property is not included in the response. Use the find case comments API to retrieve comments. totalComment reflects the actual number of user comments.
+      type: object
+      required:
+        - closed_at
+        - closed_by
+        - connector
+        - created_at
+        - created_by
+        - description
+        - duration
+        - external_service
+        - id
+        - owner
+        - settings
+        - severity
+        - status
+        - tags
+        - title
+        - totalAlerts
+        - totalComment
+        - updated_at
+        - updated_by
+        - version
+      properties:
+        assignees:
+          $ref: '#/components/schemas/assignees'
+        category:
+          type: string
+          description: The case category.
+          nullable: true
+        closed_at:
+          type: string
+          format: date-time
+          nullable: true
+        closed_by:
+          $ref: '#/components/schemas/case_response_closed_by_properties'
+        connector:
+          title: Case response properties for connectors
+          oneOf:
+            - $ref: '#/components/schemas/connector_properties_none'
+            - $ref: '#/components/schemas/connector_properties_cases_webhook'
+            - $ref: '#/components/schemas/connector_properties_jira'
+            - $ref: '#/components/schemas/connector_properties_resilient'
+            - $ref: '#/components/schemas/connector_properties_servicenow'
+            - $ref: '#/components/schemas/connector_properties_servicenow_sir'
+            - $ref: '#/components/schemas/connector_properties_swimlane'
+          discriminator:
+            propertyName: type
+            mapping:
+              .none: '#/components/schemas/connector_properties_none'
+              .cases-webhook: '#/components/schemas/connector_properties_cases_webhook'
+              .jira: '#/components/schemas/connector_properties_jira'
+              .resilient: '#/components/schemas/connector_properties_resilient'
+              .servicenow: '#/components/schemas/connector_properties_servicenow'
+              .servicenow-sir: '#/components/schemas/connector_properties_servicenow_sir'
+              .swimlane: '#/components/schemas/connector_properties_swimlane'
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-05-13T09:16:17.416Z'
+        created_by:
+          $ref: '#/components/schemas/case_response_created_by_properties'
+        customFields:
+          type: array
+          description: Custom field values for the case.
+          items:
+            type: object
+            properties:
+              key:
+                description: |
+                  The unique identifier for the custom field. The key value must exist in the case configuration settings.
+                type: string
+              type:
+                description: |
+                  The custom field type. It must match the type specified in the case configuration settings.
+                type: string
+                enum:
+                  - text
+                  - toggle
+              value:
+                description: |
+                  The custom field value. If the custom field is required, it cannot be explicitly set to null. However, for cases that existed when the required custom field was added, the default value stored in Elasticsearch is `undefined`. The value returned in the API and user interface in this case is `null`.
+                oneOf:
+                  - type: string
+                    minLength: 1
+                    maxLength: 160
+                    nullable: true
+                  - type: boolean
+        description:
+          type: string
+          example: A case description.
+        duration:
+          type: integer
+          description: |
+            The elapsed time from the creation of the case to its closure (in seconds). If the case has not been closed, the duration is set to null. If the case was closed after less than half a second, the duration is rounded down to zero.
+          nullable: true
+          example: 120
+        external_service:
+          $ref: '#/components/schemas/external_service'
+        id:
+          type: string
+          example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+        owner:
+          $ref: '#/components/schemas/owner'
+        settings:
+          $ref: '#/components/schemas/settings'
+        severity:
+          $ref: '#/components/schemas/case_severity'
+        status:
+          $ref: '#/components/schemas/case_status'
+        tags:
+          type: array
+          items:
+            type: string
+          example:
+            - tag-1
+        title:
+          type: string
+          example: Case title 1
+        totalAlerts:
+          type: integer
+          example: 0
+        totalComment:
+          type: integer
+          description: The number of user comments on the case. Use the find case comments API to retrieve comment content.
+          example: 1
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_by:
+          $ref: '#/components/schemas/case_response_updated_by_properties'
+        version:
+          type: string
+          example: WzUzMiwxXQ==
     alert_response_properties:
       type: object
       properties:
@@ -2849,6 +2991,29 @@ components:
         mapping:
           alert: '#/components/schemas/update_alert_comment_request_properties'
           user: '#/components/schemas/update_user_comment_request_properties'
+    find_comments_response:
+      title: Find case comments response
+      type: object
+      required:
+        - comments
+        - page
+        - per_page
+        - total
+      properties:
+        comments:
+          type: array
+          description: Paginated list of user comments for the case.
+          items:
+            $ref: '#/components/schemas/user_comment_response_properties'
+        page:
+          type: integer
+          description: The current page index.
+        per_page:
+          type: integer
+          description: The number of items per page.
+        total:
+          type: integer
+          description: The total number of comments.
     actions:
       type: string
       enum:
@@ -3666,12 +3831,12 @@ components:
         - tag 1
         - tag 2
     get_case_response:
-      summary: Retrieves information about a case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
+      summary: Get case response. Comments are not included; use the find case comments API. totalComment reflects the actual count.
       value:
         id: 31cdada0-02c1-11ed-85f2-4f7c222ca2fa
         version: WzM2LDFd
         totalComment: 1
-        totalAlerts: 0
+        totalAlerts: 1
         title: Case title 1
         tags:
           - tag 1
@@ -3714,7 +3879,7 @@ components:
           fields: null
         external_service: null
     get_case_observability_response:
-      summary: Retrieves information about an Observability case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
+      summary: Get case response (Observability). Comments are not included; use the find case comments API. totalComment reflects the actual count.
       value:
         description: An Observability case description.
         owner: observability
@@ -3898,6 +4063,28 @@ components:
           type: .none
           fields: null
         external_service: null
+    find_case_comments_response:
+      summary: Paginated list of user comments for a case
+      value:
+        page: 1
+        per_page: 20
+        total: 1
+        comments:
+          - id: 8048b460-fe2b-11ec-b15d-779a7c8bbcc3
+            version: WzIzLDFd
+            type: user
+            owner: cases
+            comment: A new comment
+            created_at: '2023-10-07T19:32:13.104Z'
+            created_by:
+              email: null
+              full_name: null
+              username: elastic
+              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+            pushed_at: null
+            pushed_by: null
+            updated_at: null
+            updated_by: null
     get_comment_response:
       summary: A single user comment retrieved from a case
       value:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -75,7 +75,7 @@ paths:
             curl \
               --request DELETE 'https://localhost:5601/api/cases?ids=%5B%22030e6e34-6470-4001-864f-b229511ad188%22%2C%22e662ff34-0493-4538-b9d1-6706ced02ff2%22%5D' \
               --header "Authorization: $API_KEY" \
-              --header "Content-Type: application/json"
+              --header "Content-Type: application/json" \
               --header "kbn-xsrf: true"
         - label: Console
           lang: console
@@ -218,7 +218,7 @@ paths:
       summary: Get case settings
       operationId: getCaseConfigurationDefaultSpace
       description: |
-        Get setting details such as the closure type, custom fields, templatse, and the default connector for cases. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on where the cases were created.
+        Get setting details such as the closure type, custom fields, templates, and the default connector for cases. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on where the cases were created.
       tags:
         - cases
       parameters:
@@ -797,12 +797,11 @@ paths:
       summary: Get case information
       operationId: getCaseDefaultSpace
       description: |
-        You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+        Returns case details. The response does not include a comments property; use the find case comments API to retrieve comments. The totalComment field reflects the actual number of user comments on the case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
       tags:
         - cases
       parameters:
         - $ref: '#/components/parameters/case_id'
-        - $ref: '#/components/parameters/includeComments'
       responses:
         '200':
           description: Indicates a successful call.
@@ -942,7 +941,7 @@ paths:
                 $ref: '#/components/schemas/response_4xx'
   /api/cases/{caseId}/comments/_find:
     get:
-      summary: Find case comments and alerts
+      summary: Find case comments
       operationId: findCaseCommentsDefaultSpace
       description: |
         Retrieves a paginated list of comments for a case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
@@ -1053,7 +1052,7 @@ paths:
     get:
       summary: Find case activity
       description: |
-        Retrives a paginated list of user activity for a case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+        Retrieves a paginated list of user activity for a case. You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
       operationId: findCaseActivityDefaultSpace
       tags:
         - cases
@@ -1371,14 +1370,6 @@ components:
       schema:
         type: string
         example: 9c235210-6834-11ea-a78c-6ffb38a34414
-    includeComments:
-      in: query
-      name: includeComments
-      description: Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.
-      deprecated: true
-      schema:
-        type: boolean
-        default: true
     comment_id:
       in: path
       name: commentId
@@ -3248,6 +3239,7 @@ components:
             parent: null
         settings:
           syncAlerts: true
+          extractObservables: false
         owner: cases
         customFields:
           - type: text
@@ -3268,6 +3260,7 @@ components:
         description: A case description.
         settings:
           syncAlerts: true
+          extractObservables: false
         owner: cases
         customFields:
           - key: d312efda-ec2b-42ec-9e2c-84981795c581
@@ -3317,6 +3310,7 @@ components:
               - tag-1
             settings:
               syncAlerts: true
+              extractObservables: false
             customFields:
               - key: fcc6840d-eb14-42df-8aaf-232201a705ec
                 type: toggle
@@ -3337,6 +3331,7 @@ components:
             - tag-1
           settings:
             syncAlerts: true
+            extractObservables: false
           owner: cases
           description: A case description.
           duration: null
@@ -3402,6 +3397,7 @@ components:
             description: Case description
             settings:
               syncAlerts: true
+              extractObservables: false
             owner: cases
             customFields:
               - type: text
@@ -3670,26 +3666,10 @@ components:
         - tag 1
         - tag 2
     get_case_response:
-      summary: Retrieves information about a case including its comments.
+      summary: Retrieves information about a case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
       value:
         id: 31cdada0-02c1-11ed-85f2-4f7c222ca2fa
         version: WzM2LDFd
-        comments:
-          - id: 2134c1d0-02c2-11ed-85f2-4f7c222ca2fa
-            version: WzM3LDFd
-            type: user
-            owner: cases
-            comment: A new comment
-            created_at: '2023-10-13T15:40:32.335Z'
-            created_by:
-              email: null
-              full_name: null
-              username: elastic
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-            pushed_at: null
-            pushed_by: null
-            updated_at: null
-            updated_by: null
         totalComment: 1
         totalAlerts: 0
         title: Case title 1
@@ -3697,6 +3677,7 @@ components:
           - tag 1
         settings:
           syncAlerts: true
+          extractObservables: false
         owner: cases
         category: null
         customFields:
@@ -3733,12 +3714,13 @@ components:
           fields: null
         external_service: null
     get_case_observability_response:
-      summary: Retrieves information about an Observability case including its alerts and comments.
+      summary: Retrieves information about an Observability case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
       value:
         description: An Observability case description.
         owner: observability
         settings:
           syncAlerts: false
+          extractObservables: false
         tags:
           - observability
           - tag 1
@@ -3773,43 +3755,6 @@ components:
         version: WzI0NywyXQ==
         totalComment: 1
         totalAlerts: 1
-        comments:
-          - alertId:
-              - a6e12ac4-7bce-457b-84f6-d7ce8deb8446
-            index:
-              - .internal.alerts-observability.logs.alerts-default-000001
-            type: alert
-            rule:
-              id: 03e4eb87-62ca-4e5d-9570-3d7625e9669d
-              name: Observability rule
-            owner: observability
-            created_at: '2023-11-06T19:29:38.424Z'
-            created_by:
-              email: null
-              full_name: null
-              username: elastic
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-            pushed_at: null
-            pushed_by: null
-            updated_at: null
-            updated_by: null
-            id: 59d438d0-79a9-4864-8d4b-e63adacebf6e
-            version: WzY3LDJd
-          - comment: The first comment.
-            type: user
-            owner: observability
-            created_at: '2023-11-06T19:29:57.812Z'
-            created_by:
-              email: null
-              full_name: null
-              username: elastic
-              profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
-            pushed_at: null
-            pushed_by: null
-            updated_at: null
-            updated_by: null
-            id: d99342d3-3aa3-4b80-90ec-a702607604f5
-            version: WzcyLDJd
     get_case_alerts_response:
       summary: Retrieves all alerts attached to a case
       value:
@@ -3985,6 +3930,7 @@ components:
           - tag 1
         settings:
           syncAlerts: true
+          extractObservables: false
         owner: cases
         duration: null
         severity: low

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -1736,7 +1736,7 @@ components:
           example: true
         extractObservables:
           description: |
-            When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
+            When `true`, observables (for example, IPs, hashes, URLs) are automatically extracted from case comments. Defaults to `false` if omitted.
           type: boolean
           example: false
     case_severity:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/bundled-types.schema.yaml
@@ -1736,7 +1736,7 @@ components:
           example: true
         extractObservables:
           description: |
-            When `true`, observables (for example, IPs, hashes, URLs) are automatically extracted from case comments. Defaults to `false` if omitted.
+            When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments. Optional; defaults to false when omitted.
           type: boolean
           example: false
     case_severity:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/create_case_request.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/create_case_request.yaml
@@ -15,7 +15,8 @@ value:
       }
     },
     "settings": {
-      "syncAlerts": true
+      "syncAlerts": true,
+      "extractObservables": false
     },
     "owner": "cases",
     "customFields": [

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/create_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/create_case_response.yaml
@@ -12,6 +12,7 @@ value:
   description: A case description.
   settings:
     syncAlerts: true
+    extractObservables: false
   owner: cases
   customFields:
     - key: d312efda-ec2b-42ec-9e2c-84981795c581

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_comments_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_comments_response.yaml
@@ -1,0 +1,21 @@
+summary: Paginated list of user comments for a case
+value:
+  page: 1
+  per_page: 20
+  total: 1
+  comments:
+    - id: 8048b460-fe2b-11ec-b15d-779a7c8bbcc3
+      version: WzIzLDFd
+      type: user
+      owner: cases
+      comment: A new comment
+      created_at: 2023-10-07T19:32:13.104Z
+      created_by:
+        email: null
+        full_name: null
+        username: elastic
+        profile_uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+      pushed_at: null
+      pushed_by: null
+      updated_at: null
+      updated_by: null

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/find_case_response.yaml
@@ -14,7 +14,7 @@ value:
         "title": "Case title",
         "tags": [ "tag-1" ],
         "description": "Case description",
-        "settings": { "syncAlerts": true },
+        "settings": { "syncAlerts": true, "extractObservables": false },
         "owner": "cases",
         "customFields": [
           {

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_observability_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_observability_response.yaml
@@ -1,4 +1,4 @@
-summary: Retrieves information about an Observability case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
+summary: Get case response (Observability). Comments are not included; use the find case comments API. totalComment reflects the actual count.
 value: 
   {
   "description": "An Observability case description.",
@@ -48,5 +48,4 @@ value:
   "version": "WzI0NywyXQ==",
   "totalComment": 1,
   "totalAlerts": 1,
-  "comments": [],
 }

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_observability_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_observability_response.yaml
@@ -1,10 +1,11 @@
-summary: Retrieves information about an Observability case including its alerts and comments.
+summary: Retrieves information about an Observability case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
 value: 
   {
   "description": "An Observability case description.",
   "owner": "observability",
   "settings": {
-    "syncAlerts": false
+    "syncAlerts": false,
+    "extractObservables": false
   },
   "tags": [
     "observability",
@@ -47,51 +48,5 @@ value:
   "version": "WzI0NywyXQ==",
   "totalComment": 1,
   "totalAlerts": 1,
-  "comments": [
-    {
-      "alertId": [
-        "a6e12ac4-7bce-457b-84f6-d7ce8deb8446"
-      ],
-      "index": [
-        ".internal.alerts-observability.logs.alerts-default-000001"
-      ],
-      "type": "alert",
-      "rule": {
-        "id": "03e4eb87-62ca-4e5d-9570-3d7625e9669d",
-        "name": "Observability rule"
-      },
-      "owner": "observability",
-      "created_at": "2023-11-06T19:29:38.424Z",
-      "created_by": {
-        "email": null,
-        "full_name": null,
-        "username": "elastic",
-        "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
-      },
-      "pushed_at": null,
-      "pushed_by": null,
-      "updated_at": null,
-      "updated_by": null,
-      "id": "59d438d0-79a9-4864-8d4b-e63adacebf6e",
-      "version": "WzY3LDJd"
-    },
-    {
-      "comment": "The first comment.",
-      "type": "user",
-      "owner": "observability",
-      "created_at": "2023-11-06T19:29:57.812Z",
-      "created_by": {
-        "email": null,
-        "full_name": null,
-        "username": "elastic",
-        "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
-      },
-      "pushed_at": null,
-      "pushed_by": null,
-      "updated_at": null,
-      "updated_by": null,
-      "id": "d99342d3-3aa3-4b80-90ec-a702607604f5",
-      "version": "WzcyLDJd"
-    }
-  ]
+  "comments": [],
 }

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
@@ -1,31 +1,14 @@
-summary: Retrieves information about a case including its comments.
+summary: Retrieves information about a case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
 value: 
   {
     "id":"31cdada0-02c1-11ed-85f2-4f7c222ca2fa",
     "version":"WzM2LDFd",
-    "comments":[{
-      "id":"2134c1d0-02c2-11ed-85f2-4f7c222ca2fa",
-      "version":"WzM3LDFd",
-      "type":"user",
-      "owner":"cases",
-      "comment":"A new comment",
-      "created_at":"2023-10-13T15:40:32.335Z",
-      "created_by":{
-        "email":null,
-        "full_name":null,
-        "username":"elastic",
-        "profile_uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
-      },
-      "pushed_at":null,
-      "pushed_by":null,
-      "updated_at":null,
-      "updated_by":null
-    }],
+     "comments":[],
     "totalComment":1,
-    "totalAlerts":0,
+    "totalAlerts":1,
     "title":"Case title 1",
     "tags":["tag 1"],
-    "settings":{"syncAlerts":true},
+    "settings":{"syncAlerts":true,"extractObservables":false},
     "owner":"cases",
     "category":null,
     "customFields": [

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/get_case_response.yaml
@@ -1,9 +1,8 @@
-summary: Retrieves information about a case. The response omits comments; use the find case comments API to retrieve them. totalComment reflects the actual number of user comments.
+summary: Get case response. Comments are not included; use the find case comments API. totalComment reflects the actual count.
 value: 
   {
     "id":"31cdada0-02c1-11ed-85f2-4f7c222ca2fa",
     "version":"WzM2LDFd",
-     "comments":[],
     "totalComment":1,
     "totalAlerts":1,
     "title":"Case title 1",

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/push_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/push_case_response.yaml
@@ -12,7 +12,8 @@ value:
       "tag 1"
     ],
     "settings": {
-      "syncAlerts": true
+      "syncAlerts": true,
+      "extractObservables": false
     },
     "owner": "cases",
     "duration": null,

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/update_case_request.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/update_case_request.yaml
@@ -18,7 +18,8 @@ value:
       "description": "A case description.",
       "tags": [ "tag-1" ],
       "settings": {
-        "syncAlerts": true
+        "syncAlerts": true,
+        "extractObservables": false
       },
       "customFields": [
         {

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/update_case_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/examples/update_case_response.yaml
@@ -10,7 +10,8 @@ value:
       "title": "Case title 1",
       "tags": [ "tag-1" ],
       "settings": {
-        "syncAlerts": true
+        "syncAlerts": true,
+        "extractObservables": false
       },
       "owner": "cases",
       "description": "A case description.",

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/includeComments.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/parameters/includeComments.yaml
@@ -1,7 +1,0 @@
-in: query
-name: includeComments
-description: Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.
-deprecated: true
-schema:
-  type: boolean
-  default: true

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_get_case.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/case_response_get_case.yaml
@@ -1,0 +1,124 @@
+# GET /api/cases/{caseId} response. Comments are not returned (omitted from response);
+# use the find case comments API to retrieve comments. totalComment reflects the actual count.
+title: Get case response
+description: >
+  Case details returned by the get case API. The comments property is not included in the response.
+  Use the find case comments API to retrieve comments. totalComment reflects the actual number of user comments.
+type: object
+required:
+  - closed_at
+  - closed_by
+  - connector
+  - created_at
+  - created_by
+  - description
+  - duration
+  - external_service
+  - id
+  - owner
+  - settings
+  - severity
+  - status
+  - tags
+  - title
+  - totalAlerts
+  - totalComment
+  - updated_at
+  - updated_by
+  - version
+properties:
+  assignees:
+    $ref: 'assignees.yaml'
+  category:
+    type: string
+    description: The case category.
+    nullable: true
+  closed_at:
+    type: string
+    format: date-time
+    nullable: true
+  closed_by:
+    $ref: 'case_response_closed_by_properties.yaml'
+  connector:
+    title: Case response properties for connectors
+    oneOf:
+      - $ref: 'connector_properties_none.yaml'
+      - $ref: 'connector_properties_cases_webhook.yaml'
+      - $ref: 'connector_properties_jira.yaml'
+      - $ref: 'connector_properties_resilient.yaml'
+      - $ref: 'connector_properties_servicenow.yaml'
+      - $ref: 'connector_properties_servicenow_sir.yaml'
+      - $ref: 'connector_properties_swimlane.yaml'
+    discriminator:
+      propertyName: type
+      mapping:
+        .none: 'connector_properties_none.yaml'
+        .cases-webhook: 'connector_properties_cases_webhook.yaml'
+        .jira: 'connector_properties_jira.yaml'
+        .resilient: 'connector_properties_resilient.yaml'
+        .servicenow: 'connector_properties_servicenow.yaml'
+        .servicenow-sir: 'connector_properties_servicenow_sir.yaml'
+        .swimlane: 'connector_properties_swimlane.yaml'
+  created_at:
+    type: string
+    format: date-time
+    example: '2022-05-13T09:16:17.416Z'
+  created_by:
+    $ref: 'case_response_created_by_properties.yaml'
+  customFields:
+    type: array
+    description: Custom field values for the case.
+    items:
+      type: object
+      properties:
+        $ref: 'case_customfields.yaml'
+  description:
+    type: string
+    example: A case description.
+  duration:
+    type: integer
+    description: >
+      The elapsed time from the creation of the case to its closure (in seconds).
+      If the case has not been closed, the duration is set to null. If the case
+      was closed after less than half a second, the duration is rounded down to
+      zero.
+    nullable: true
+    example: 120
+  external_service:
+    $ref: 'external_service.yaml'
+  id:
+    type: string
+    example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+  owner:
+    $ref: 'owner.yaml'
+  settings:
+    $ref: 'settings.yaml'
+  severity:
+    $ref: 'case_severity.yaml'
+  status:
+    $ref: 'case_status.yaml'
+  tags:
+    type: array
+    items:
+      type: string
+    example:
+      - tag-1
+  title:
+    type: string
+    example: Case title 1
+  totalAlerts:
+    type: integer
+    example: 0
+  totalComment:
+    type: integer
+    description: The number of user comments on the case. Use the find case comments API to retrieve comment content.
+    example: 1
+  updated_at:
+    type: string
+    format: date-time
+    nullable: true
+  updated_by:
+    $ref: 'case_response_updated_by_properties.yaml'
+  version:
+    type: string
+    example: WzUzMiwxXQ==

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/find_comments_response.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/find_comments_response.yaml
@@ -1,0 +1,24 @@
+# Response for GET /api/cases/{caseId}/comments/_find (find case comments).
+# Returns only user comments; alerts are not included.
+title: Find case comments response
+type: object
+required:
+  - comments
+  - page
+  - per_page
+  - total
+properties:
+  comments:
+    type: array
+    description: Paginated list of user comments for the case.
+    items:
+      $ref: 'user_comment_response_properties.yaml'
+  page:
+    type: integer
+    description: The current page index.
+  per_page:
+    type: integer
+    description: The number of items per page.
+  total:
+    type: integer
+    description: The total number of comments.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/settings.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/components/schemas/settings.yaml
@@ -8,6 +8,8 @@ properties:
     type: boolean
     example: true
   extractObservables:
-    description: Auto extracts observables
+    description: >
+      When true, observables (e.g. IPs, hashes, URLs) are automatically extracted from case comments.
+      Optional; defaults to false when omitted.
     type: boolean
     example: false

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases.yaml
@@ -64,7 +64,7 @@ delete:
         curl \
           --request DELETE 'https://localhost:5601/api/cases?ids=%5B%22030e6e34-6470-4001-864f-b229511ad188%22%2C%22e662ff34-0493-4538-b9d1-6706ced02ff2%22%5D' \
           --header "Authorization: $API_KEY" \
-          --header "Content-Type: application/json"
+          --header "Content-Type: application/json" \
           --header "kbn-xsrf: true"
     - label: Console
       lang: console

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@configure.yaml
@@ -2,7 +2,7 @@ get:
   summary: Get case settings
   operationId: getCaseConfigurationDefaultSpace
   description: >
-    Get setting details such as the closure type, custom fields, templatse, and the default connector for cases.
+    Get setting details such as the closure type, custom fields, templates, and the default connector for cases.
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
     feature privileges, depending on where the cases were created.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
@@ -18,11 +18,11 @@ get:
       content:
         application/json:
           schema:
-            $ref: '../components/schemas/case_response_properties.yaml'
+            $ref: '../components/schemas/case_response_get_case.yaml'
           examples:
             getDefaultCaseResponse:
               $ref: '../components/examples/get_case_response.yaml'
-            getDefaultObservabilityCaseReponse:
+            getDefaultObservabilityCaseResponse:
               $ref: '../components/examples/get_case_observability_response.yaml'
     '401':
       description: Authorization information is missing or invalid.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}.yaml
@@ -2,6 +2,9 @@ get:
   summary: Get case information
   operationId: getCaseDefaultSpace
   description: >
+    Returns case details. The response does not include a comments property; 
+    use the find case comments API to retrieve comments. The totalComment field 
+    reflects the actual number of user comments on the case.
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
     feature privileges, depending on the owner of the case you're seeking.
@@ -9,7 +12,6 @@ get:
     - cases
   parameters:
     - $ref: '../components/parameters/case_id.yaml'
-    - $ref: '../components/parameters/includeComments.yaml'
   responses:
     '200':
       description: Indicates a successful call.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
@@ -17,7 +17,10 @@ get:
       content:
         application/json:
           schema:
-            $ref: '../components/schemas/case_response_properties.yaml'
+            $ref: '../components/schemas/find_comments_response.yaml'
+          examples:
+            findCaseCommentsResponse:
+              $ref: '../components/examples/find_case_comments_response.yaml'
     '401':
       description: Authorization information is missing or invalid.
       content:

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@comments@_find.yaml
@@ -1,5 +1,5 @@
 get:
-  summary: Find case comments and alerts
+  summary: Find case comments
   operationId: findCaseCommentsDefaultSpace
   description: >
     Retrieves a paginated list of comments for a case.

--- a/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
+++ b/x-pack/platform/plugins/shared/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Find case activity
   description: >
-    Retrives a paginated list of user activity for a case.
+    Retrieves a paginated list of user activity for a case.
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
     feature privileges, depending on the owner of the case you're seeking.

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
@@ -43,7 +43,7 @@ export const getCaseRoute = () =>
         });
 
         const { comments, ...caseWithoutComments } = res;
-
+        // empty array is returned for comments to comply with the API contract
         return response.ok({
           body: { ...caseWithoutComments, comments: [] },
         });

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
@@ -45,7 +45,7 @@ export const getCaseRoute = () =>
         const { comments, ...caseWithoutComments } = res;
 
         return response.ok({
-          body: caseWithoutComments,
+          body: { ...caseWithoutComments, comments: [] },
         });
       } catch (error) {
         throw createCaseError({

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
@@ -43,9 +43,9 @@ export const getCaseRoute = () =>
         });
 
         const { comments, ...caseWithoutComments } = res;
-        // empty array is returned for comments to comply with the API contract
+
         return response.ok({
-          body: { ...caseWithoutComments, comments: [] },
+          body: caseWithoutComments,
         });
       } catch (error) {
         throw createCaseError({

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/comments/find_comments.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/comments/find_comments.ts
@@ -24,9 +24,9 @@ export const findCommentsRoute = createCasesRoute({
   },
   routerOptions: {
     access: 'public',
-    summary: `Find case comments and alerts`,
+    summary: `Find case comments`,
     tags: ['oas-tag:cases'],
-    description: 'Retrieves a paginated list of comments and alerts for a case.',
+    description: 'Retrieves a paginated list of comments for a case.',
     // You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases with the comments you're seeking.
   },
   handler: async ({ context, request, response }) => {

--- a/x-pack/platform/test/cases_api_integration/common/lib/mock.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/mock.ts
@@ -201,7 +201,7 @@ export const getCaseWithoutCommentsResp = (
   req: CasePostRequest = postCaseReq
 ): Partial<Case> => {
   const { comments, ...caseWithoutComments } = postCaseResp(id, req);
-  return caseWithoutComments;
+  return { comments: [], ...caseWithoutComments };
 };
 
 interface CommentRequestWithID {

--- a/x-pack/platform/test/cases_api_integration/common/lib/mock.ts
+++ b/x-pack/platform/test/cases_api_integration/common/lib/mock.ts
@@ -201,7 +201,7 @@ export const getCaseWithoutCommentsResp = (
   req: CasePostRequest = postCaseReq
 ): Partial<Case> => {
   const { comments, ...caseWithoutComments } = postCaseResp(id, req);
-  return { comments: [], ...caseWithoutComments };
+  return caseWithoutComments;
 };
 
 interface CommentRequestWithID {


### PR DESCRIPTION
## Summary

Updated cases API docs to address:

- Removed alert reference in find comment api. Related: https://github.com/elastic/kibana/pull/156863
   - Updated response schema and examples - existing response uses full case response, which is not correct
- Removed `includeComment` param in get case api. [it is always false for public api](https://github.com/elastic/kibana/blob/ab858f5d9f3f91104b083c5b6d31363e41804828/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts#L40-L42) but the response example contains comments, related: https://github.com/elastic/kibana/issues/207739
- Included `extractObservables` to case request and response
- Fixed typos

### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.