### PR TITLE
[Scout] Add retry to spaces selector in Scout

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/test/scout/ui/fixtures/page_objects/spaces.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/ui/fixtures/page_objects/spaces.ts
@@ -28,8 +28,8 @@ export class SpacesPage {
     });
   }
 
-  async isSpacesSelectorVisible() {
-    return await this.page.testSubj.isVisible('spacesNavSelector');
+  spacesSelectorLocator() {
+    return this.page.testSubj.locator('spacesNavSelector');
   }
 
   async openSpacesSelector() {

--- a/x-pack/platform/plugins/shared/spaces/test/scout/ui/tests/spaces_selection_serverless.spec.ts
+++ b/x-pack/platform/plugins/shared/spaces/test/scout/ui/tests/spaces_selection_serverless.spec.ts
@@ -30,8 +30,7 @@ test.describe(
       const isHeaderVisible = await pageObjects.spaces.isProjectHeaderVisible();
       expect(isHeaderVisible).toBe(true);
 
-      const isSelectorVisible = await pageObjects.spaces.isSpacesSelectorVisible();
-      expect(isSelectorVisible).toBe(true);
+      await expect(pageObjects.spaces.spacesSelectorLocator()).toBeVisible();
     });
 
     test('as Viewer - does not display the manage button in the space selection menu', async ({
@@ -60,8 +59,7 @@ test.describe(
       const isHeaderVisible = await pageObjects.spaces.isProjectHeaderVisible();
       expect(isHeaderVisible).toBe(true);
 
-      const isSelectorVisible = await pageObjects.spaces.isSpacesSelectorVisible();
-      expect(isSelectorVisible).toBe(true);
+      await expect(pageObjects.spaces.spacesSelectorLocator()).toBeVisible();
     });
 
     test('as Admin - displays the manage button in the space selection menu', async ({


### PR DESCRIPTION
## Summary

This PR changes spaces selector to re-try rather than try and once and fail, to avoid fix flakinss.

Closes: https://github.com/elastic/kibana/issues/256806



