### PR TITLE
Bedrock prompt caching

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
@@ -52,9 +52,10 @@ export const bedrockClaudeAdapter: InferenceConnectorAdapter = {
       role: message.role,
       content: message.rawContent,
     }));
+    const cachePoint = { cachePoint: { type: 'default' as const } };
     const systemMessage = noToolUsage
-      ? [{ text: addNoToolUsageDirective(system) }]
-      : [{ text: system }];
+      ? [{ text: addNoToolUsageDirective(system) }, cachePoint]
+      : [{ text: system }, cachePoint];
     const bedRockTools =
       noToolUsage && !hasToolUseMessages ? [] : toolsToConverseBedrock(tools, messages);
     const connector = executor.getConnector();


### PR DESCRIPTION
Adds a cachePoint marker after the system message in the Bedrock Claude adapter. This enables the Bedrock Converse API's prompt caching feature -- on subsequent calls with the same system prompt prefix, cached input tokens are served ~2x faster and at 90% lower cost. The cache has a 5-minute TTL and is a no-op for non-Anthropic models.

before, using on Dashboard creation: 
<img width="326" height="75" alt="Screenshot 2026-03-10 at 08 02 25" src="https://github.com/user-attachments/assets/7c3f8f48-b044-41b9-a913-72cbc04c644a" />

after:
<img width="291" height="70" alt="Screenshot 2026-03-10 at 08 02 45" src="https://github.com/user-attachments/assets/d48fd93b-2cc4-46f7-b76d-3da2b4fc6a11" />
