### PR TITLE
[9.2] [FTR][Lens] Split `lens/tsvb` config (#256712)

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -230,7 +230,9 @@ enabled:
   - x-pack/platform/test/functional/apps/lens/group5/config.ts
   - x-pack/platform/test/functional/apps/lens/group6/config.ts
   - x-pack/platform/test/functional/apps/lens/group7/config.ts
-  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
+  - x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
   - x-pack/platform/test/functional/apps/lens/open_in_lens/agg_based/config.ts
   - x-pack/platform/test/functional/apps/lens/open_in_lens/dashboard/config.ts
   - x-pack/platform/test/functional/apps/license_management/config.ts

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../../../config.base.ts'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/dashboard.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/dashboard.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, timeToVisualize, dashboard, canvas, header } =

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/index.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsArchiver } from '@kbn/es-archiver';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
+  const browser = getService('browser');
+  const log = getService('log');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const { timePicker } = getPageObjects(['timePicker']);
+  const config = getService('config');
+  let remoteEsArchiver;
+
+  describe('lens app - TSVB Open in Lens - group 1', () => {
+    const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
+    const localIndexPatternString = 'logstash-*';
+    const remoteIndexPatternString = 'ftr-remote:logstash-*';
+    const localFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/default',
+    };
+
+    const remoteFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/default',
+    };
+    let esNode: EsArchiver;
+    let fixtureDirs: {
+      lensBasic: string;
+      lensDefault: string;
+    };
+    let indexPatternString: string;
+    before(async () => {
+      log.debug('Starting lens before method');
+      await browser.setWindowSize(1280, 1200);
+      try {
+        config.get('esTestCluster.ccs');
+        remoteEsArchiver = getService('remoteEsArchiver' as 'esArchiver');
+        esNode = remoteEsArchiver;
+        fixtureDirs = remoteFixtures;
+        indexPatternString = remoteIndexPatternString;
+      } catch (error) {
+        esNode = esArchiver;
+        fixtureDirs = localFixtures;
+        indexPatternString = localIndexPatternString;
+      }
+
+      await esNode.load(esArchive);
+      await kibanaServer.uiSettings.update({
+        defaultIndex: indexPatternString,
+        'dateFormat:tz': 'UTC',
+        // changing the timepicker default here saves us from having to set it in Discover (~8s)
+        // The TSVB tests are using a slightly difference end date, so it needs to be set manually here
+        'timepicker:timeDefaults': `{ "from": "${timePicker.defaultStartTime}", "to": "Sep 22, 2015 @ 18:31:44.000" }`,
+      });
+      await kibanaServer.importExport.load(fixtureDirs.lensBasic);
+      await kibanaServer.importExport.load(fixtureDirs.lensDefault);
+    });
+
+    loadTestFile(require.resolve('./dashboard'));
+    loadTestFile(require.resolve('./timeseries'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/timeseries.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/timeseries.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts
@@ -8,10 +8,10 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const functionalConfig = await readConfigFile(require.resolve('../../../../config.base.ts'));
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
 
   return {
-    ...functionalConfig.getAll(),
+    ...baseConfig.getAll(),
     testFiles: [require.resolve('.')],
   };
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/gauge.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/gauge.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EsArchiver } from '@kbn/es-archiver';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
@@ -17,7 +17,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const config = getService('config');
   let remoteEsArchiver;
 
-  describe('lens app - TSVB Open in Lens', () => {
+  describe('lens app - TSVB Open in Lens - group 2', () => {
     const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
     const localIndexPatternString = 'logstash-*';
     const remoteIndexPatternString = 'ftr-remote:logstash-*';
@@ -63,18 +63,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
       await kibanaServer.importExport.load(fixtureDirs.lensDefault);
     });
 
-    after(async () => {
-      await esArchiver.unload(esArchive);
-      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
-      await kibanaServer.importExport.unload(fixtureDirs.lensBasic);
-      await kibanaServer.importExport.unload(fixtureDirs.lensDefault);
-    });
-
-    loadTestFile(require.resolve('./dashboard'));
-    loadTestFile(require.resolve('./metric'));
     loadTestFile(require.resolve('./gauge'));
-    loadTestFile(require.resolve('./timeseries'));
-    loadTestFile(require.resolve('./top_n'));
-    loadTestFile(require.resolve('./table'));
+    loadTestFile(require.resolve('./metric'));
   });
 }

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/metric.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/metric.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
+
+  return {
+    ...baseConfig.getAll(),
+    testFiles: [require.resolve('.')],
+  };
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/index.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/index.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsArchiver } from '@kbn/es-archiver';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ({ loadTestFile, getService, getPageObjects }: FtrProviderContext) {
+  const browser = getService('browser');
+  const log = getService('log');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const { timePicker } = getPageObjects(['timePicker']);
+  const config = getService('config');
+  let remoteEsArchiver;
+
+  describe('lens app - TSVB Open in Lens - group 3', () => {
+    const esArchive = 'x-pack/platform/test/fixtures/es_archives/logstash_functional';
+    const localIndexPatternString = 'logstash-*';
+    const remoteIndexPatternString = 'ftr-remote:logstash-*';
+    const localFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/default',
+    };
+
+    const remoteFixtures = {
+      lensBasic: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/lens_basic.json',
+      lensDefault: 'x-pack/platform/test/functional/fixtures/kbn_archives/lens/ccs/default',
+    };
+    let esNode: EsArchiver;
+    let fixtureDirs: {
+      lensBasic: string;
+      lensDefault: string;
+    };
+    let indexPatternString: string;
+    before(async () => {
+      log.debug('Starting lens before method');
+      await browser.setWindowSize(1280, 1200);
+      try {
+        config.get('esTestCluster.ccs');
+        remoteEsArchiver = getService('remoteEsArchiver' as 'esArchiver');
+        esNode = remoteEsArchiver;
+        fixtureDirs = remoteFixtures;
+        indexPatternString = remoteIndexPatternString;
+      } catch (error) {
+        esNode = esArchiver;
+        fixtureDirs = localFixtures;
+        indexPatternString = localIndexPatternString;
+      }
+
+      await esNode.load(esArchive);
+      await kibanaServer.uiSettings.update({
+        defaultIndex: indexPatternString,
+        'dateFormat:tz': 'UTC',
+        // changing the timepicker default here saves us from having to set it in Discover (~8s)
+        // The TSVB tests are using a slightly difference end date, so it needs to be set manually here
+        'timepicker:timeDefaults': `{ "from": "${timePicker.defaultStartTime}", "to": "Sep 22, 2015 @ 18:31:44.000" }`,
+      });
+      await kibanaServer.importExport.load(fixtureDirs.lensBasic);
+      await kibanaServer.importExport.load(fixtureDirs.lensDefault);
+    });
+
+    loadTestFile(require.resolve('./top_n'));
+    loadTestFile(require.resolve('./table'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/table.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/table.ts
@@ -13,7 +13,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([

--- a/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/top_n.ts
+++ b/x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/top_n.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const { visualize, visualBuilder, lens, header } = getPageObjects([


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[FTR][Lens] Split `lens/tsvb` config (#256712)](https://github.com/elastic/kibana/pull/256712)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cesare de Cal","email":"cesare.decal@elastic.co"},"sourceCommit":{"committedDate":"2026-03-10T08:07:35Z","message":"[FTR][Lens] Split `lens/tsvb` config (#256712)\n\n## Summary\n\nSplit\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts`\n(~34 minutes) into smaller groups targeting 15–20 minutes each.\n\n- Split into 3 groups from the original monolithic config\n- Moved 6 test files across `group1/`, `group2/`, `group3/`\n- Registered all new configs in\n`.buildkite/ftr_platform_stateful_configs.yml`\n\n> [!NOTE]\n> This PR was generated automatically by an AI coding agent ([Buildkite\nbuild](https://buildkite.com/elastic/appex-qa-ai-ftr-config-splitter/builds/30)).\n> Please review carefully before merging.\n\n### New configs\n\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts`\n(12 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts`\n(15 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts`\n(21 min)\n\n[Buildkite\nbuild](https://buildkite.com/elastic/kibana-pull-request/builds/406857)","sha":"2542e375fd8499f28da17e4b7bf3ecf8ea123085","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","FTR","backport:version","v9.4.0","v9.2.7","v9.3.2"],"title":"[FTR][Lens] Split `lens/tsvb` config","number":256712,"url":"https://github.com/elastic/kibana/pull/256712","mergeCommit":{"message":"[FTR][Lens] Split `lens/tsvb` config (#256712)\n\n## Summary\n\nSplit\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts`\n(~34 minutes) into smaller groups targeting 15–20 minutes each.\n\n- Split into 3 groups from the original monolithic config\n- Moved 6 test files across `group1/`, `group2/`, `group3/`\n- Registered all new configs in\n`.buildkite/ftr_platform_stateful_configs.yml`\n\n> [!NOTE]\n> This PR was generated automatically by an AI coding agent ([Buildkite\nbuild](https://buildkite.com/elastic/appex-qa-ai-ftr-config-splitter/builds/30)).\n> Please review carefully before merging.\n\n### New configs\n\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts`\n(12 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts`\n(15 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts`\n(21 min)\n\n[Buildkite\nbuild](https://buildkite.com/elastic/kibana-pull-request/builds/406857)","sha":"2542e375fd8499f28da17e4b7bf3ecf8ea123085"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256712","number":256712,"mergeCommit":{"message":"[FTR][Lens] Split `lens/tsvb` config (#256712)\n\n## Summary\n\nSplit\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/config.ts`\n(~34 minutes) into smaller groups targeting 15–20 minutes each.\n\n- Split into 3 groups from the original monolithic config\n- Moved 6 test files across `group1/`, `group2/`, `group3/`\n- Registered all new configs in\n`.buildkite/ftr_platform_stateful_configs.yml`\n\n> [!NOTE]\n> This PR was generated automatically by an AI coding agent ([Buildkite\nbuild](https://buildkite.com/elastic/appex-qa-ai-ftr-config-splitter/builds/30)).\n> Please review carefully before merging.\n\n### New configs\n\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group1/config.ts`\n(12 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group2/config.ts`\n(15 min)\n*\n`x-pack/platform/test/functional/apps/lens/open_in_lens/tsvb/group3/config.ts`\n(21 min)\n\n[Buildkite\nbuild](https://buildkite.com/elastic/kibana-pull-request/builds/406857)","sha":"2542e375fd8499f28da17e4b7bf3ecf8ea123085"}},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->