### PR TITLE
[Discover] Remove redundant cleanups for tabs FTRs

### DIFF
--- a/src/platform/test/functional/apps/discover/tabs2/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs2/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_filters'));
     loadTestFile(require.resolve('./_navigation'));
     loadTestFile(require.resolve('./_sharing'));

--- a/src/platform/test/functional/apps/discover/tabs3/index.ts
+++ b/src/platform/test/functional/apps/discover/tabs3/index.ts
@@ -44,26 +44,6 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
       await discover.waitUntilTabIsLoaded();
     });
 
-    after(async () => {
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/discover'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/logstash_functional'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield'
-      );
-      await esArchiver.unload(
-        'src/platform/test/functional/fixtures/es_archiver/kibana_sample_data_flights'
-      );
-      await kibanaServer.importExport.unload(
-        'src/platform/test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern'
-      );
-      await kibanaServer.uiSettings.unset('defaultIndex');
-      await kibanaServer.savedObjects.cleanStandardList();
-    });
-
     loadTestFile(require.resolve('./_tab_preview'));
     loadTestFile(require.resolve('./_time_range'));
   });


### PR DESCRIPTION
## Summary

The cleanup hook is no longer needed, as CI automatically shuts down the test servers after execution.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


