### PR TITLE
[Lens][Annotations] Add maxSize to annotations schema 

### DIFF
--- a/src/platform/plugins/private/event_annotation/server/content_management/schema/v1/cm_services.ts
+++ b/src/platform/plugins/private/event_annotation/server/content_management/schema/v1/cm_services.ts
@@ -33,7 +33,7 @@ const eventAnnotationGroupAttributesSchema = schema.object(
     title: schema.string(),
     description: schema.maybe(schema.string()),
     ignoreGlobalFilters: schema.boolean(),
-    annotations: schema.arrayOf(schema.any()),
+    annotations: schema.arrayOf(schema.any(), { maxSize: 100 }),
     dataViewSpec: schema.oneOf([schema.literal(null), schema.object({}, { unknowns: 'allow' })]),
   },
   { unknowns: 'forbid' }


### PR DESCRIPTION
## Summary

This PR set the max number of events per annotation groups in the Event Annotation Group schema, following our security conversions.





