### PR TITLE
[One Workflow] Escape wrong i18n message

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/common/connector_action_schema.ts
@@ -500,7 +500,7 @@ export const staticConnectors: BaseConnectorContract[] = [
       ),
     description: i18n.translate('workflows.connectors.kibana.request.description', {
       defaultMessage:
-        'Make a generic request to a Kibana API. APIs that return 204 No Content or 304 Not Modified produce an empty output ({}).',
+        "Make a generic request to a Kibana API. APIs that return 204 No Content or 304 Not Modified produce an empty output ('{}').",
     }),
   },
 ];


### PR DESCRIPTION
## Summary

Fixes the following error when using kibana:
```
Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "workflows.connectors.kibana.request.description", rendering default message verbatim
MessageID: workflows.connectors.kibana.request.description
Default Message: Make a generic request to a Kibana API. APIs that return 204 No Content or 304 Not Modified produce an empty output ({}).
Description: undefined

Locale: en


EMPTY_ARGUMENT
```

