### PR TITLE
[APM] SLO callout in service views flashes causing major layout shifting

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/apm_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/apm_overview/index.tsx
@@ -35,6 +35,7 @@ import { ServiceOverviewInstancesChartAndTable } from '../service_overview_insta
 import { ServiceOverviewThroughputChart } from '../service_overview_throughput_chart';
 import { SloCallout } from '../../../shared/slo_callout';
 import { useLocalStorage } from '../../../../hooks/use_local_storage';
+import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
 
 const latencyChartHeight = 200;
 
@@ -84,7 +85,7 @@ export function ApmOverview() {
   const nonLatencyChartHeight = isSingleColumn ? latencyChartHeight : chartHeight;
   const rowDirection: EuiFlexGroupProps['direction'] = isSingleColumn ? 'column' : 'row';
 
-  const { hasSlos } = useServiceSloContext();
+  const { hasSlos, sloFetchStatus } = useServiceSloContext();
 
   const trackEvent = useUiTracker({ app: 'apm' });
   const [sloCalloutDismissed, setSloCalloutDismissed] = useLocalStorage(
@@ -103,9 +104,12 @@ export function ApmOverview() {
   const onErrorsTableLoad = useCallback(() => handleOnLoadTable('errors'), []);
   const onDependenciesTableLoad = useCallback(() => handleOnLoadTable('dependencies'), []);
 
+  const shouldRenderCallout =
+    !sloCalloutDismissed && !hasSlos && sloFetchStatus === FETCH_STATUS.SUCCESS;
+
   return (
     <>
-      {!sloCalloutDismissed && !hasSlos && (
+      {shouldRenderCallout && (
         <>
           <SloCallout
             dismissCallout={dismissSloCallout}


### PR DESCRIPTION
## Summary

Closes #256872

Waits for slo fetch status to be `success` before determining wether to render the SLO callout in services views. This should prevent the component from rendering for services with SLOs where it shouldn't render while the request is in flight.


## UI Reproduction


https://github.com/user-attachments/assets/22114737-5359-4aaa-843d-df1a68052bcb

---

### After

https://github.com/user-attachments/assets/a0e927e9-e0ac-4ed3-aec1-d0637645fd7e

