### PR TITLE
EIS development script: update README

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -41,13 +41,13 @@ yarn run ts-node x-pack/solutions/observability/packages/kbn-genai-cli/recipes/h
 
 ## EIS
 
-You can connect your local Elasticsearch to the Elastic Inference Service (EIS) using Cloud Connected Mode (CCM) by running `node scripts/eis.js`. This script configures your local Elasticsearch instance to use a real EIS endpoint without needing to run the EIS Gateway locally.
+You can connect your local Elasticsearch to the Elastic Inference Service (EIS) using Cloud Connect (aka. Cloud Connected Mode CCM) by running `node scripts/eis.js`. This script configures your local Elasticsearch instance to use a real EIS endpoint without needing to run EIS locally.
 
 ### Prerequisites
 
 1. **Vault Access**: Make sure you have configured Vault to point at Elastic's [Infra Vault](https://docs.elastic.dev/vault#infra-vault) server and that you're logged in via `vault login --method oidc`. The script will fetch the EIS API key from `secret/kibana-issues/dev/inference/kibana-eis-ccm`.
 
-2. **Elasticsearch**: Start Elasticsearch with the CCM URL flag:
+2. **Elasticsearch**: Start Elasticsearch with the EIS URL of the QA environment and an Enterprise trial license:
 
    ```bash
    yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
@@ -60,11 +60,13 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 ### Usage
 
 ```bash
-# Start Elasticsearch with CCM enabled
+# Start Elasticsearch with the EIS URL of the QA environment and an Enterprise trial license
 yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
 
-# In a separate terminal, configure CCM
+# In a separate terminal, configure EIS API key
 node scripts/eis.js
 ```
 
-The script will fetch the API key from Vault and configure Cloud Connected Mode in your local Elasticsearch instance.
+The script will fetch the EIS API key from Vault and register it in your local Elasticsearch instance using an internal Cloud Connect APIs.
+
+**Important**: note that the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected to the Cloud Connect page in Kibana.

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -41,7 +41,7 @@ yarn run ts-node x-pack/solutions/observability/packages/kbn-genai-cli/recipes/h
 
 ## EIS
 
-You can connect your local Elasticsearch to the Elastic Inference Service (EIS) using Cloud Connect (aka. Cloud Connected Mode CCM) by running `node scripts/eis.js`. This script configures your local Elasticsearch instance to use a real EIS endpoint without needing to run EIS locally.
+You can connect your local Elasticsearch to the Elastic Inference Service (EIS) using Cloud Connect (aka. Cloud Connected Mode, CCM) by running `node scripts/eis.js`. This script configures your local Elasticsearch instance to use a real EIS endpoint without needing to run EIS locally.
 
 ### Prerequisites
 
@@ -69,4 +69,4 @@ node scripts/eis.js
 
 The script will fetch the EIS API key from Vault and register it in your local Elasticsearch instance using an internal Cloud Connect APIs.
 
-**Important**: note that the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected to the Cloud Connect page in Kibana.
+**Important**: note that the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected to the Cloud Connect page in Kibana. However, you should have access to all built-in EIS inference endpoints after running this script. 

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -67,6 +67,6 @@ yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inferenc
 node scripts/eis.js
 ```
 
-The script will fetch the EIS API key from Vault and register it in your local Elasticsearch instance using an internal Cloud Connect APIs.
+The script will fetch the EIS API key from Vault and register it in your local Elasticsearch instance using an internal Cloud Connect API.
 
 **Important**: note that the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected to the Cloud Connect page in Kibana. However, you should have access to all built-in EIS inference endpoints after running this script. 


### PR DESCRIPTION
- Use "Cloud Connect" as it is the official feature name
- Talk about the EIS URL instead of the CCM flag
- Add clarifying comment about Cloud Connect status after the script ran

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated EIS/Cloud Connect terminology and kept CCM as an alias
  * Revised setup guidance to use QA environment EIS URL with an Enterprise trial license
  * Replaced CCM usage instructions with guidance to configure an EIS API key (fetch from Vault and register via Cloud Connect APIs)
  * Clarified the script only enables EIS; full Cloud Connect onboarding may not be completed though built-in inference endpoints become available after running it
<!-- end of auto-generated comment: release notes by coderabbit.ai -->