### PR TITLE
[9.3] [Task Manager] add refresh/search when getting API keys (#254981)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -847,7 +847,6 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
-        executionContext: mockExecutionContextStart,
       });
 
       let getApiKeysCallCount = 0;
@@ -952,7 +951,6 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
-        executionContext: mockExecutionContextStart,
       });
 
       let getApiKeysCallCount = 0;
@@ -1051,7 +1049,6 @@ describe('TaskStore', () => {
         canEncryptSavedObjects: true,
         getIsSecurityEnabled: () => true,
         basePath: basePathMock,
-        executionContext: mockExecutionContextStart,
       });
 
       let getApiKeysCallCount = 0;

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -812,6 +812,309 @@ describe('TaskStore', () => {
       });
     });
 
+    test('returns all API keys when first getApiKeys search misses a key, but finds after refresh', async () => {
+      const logger = mockLogger();
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
+      const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const indicesRefreshSpy = jest
+        .spyOn(mockEsClient.indices, 'refresh')
+        .mockResolvedValue({} as never);
+
+      const refreshStore = new TaskStore({
+        logger,
+        index: 'tasky',
+        taskManagerId: '',
+        serializer: mockSerializer,
+        esClient: mockEsClient,
+        definitions: taskDefinitions,
+        savedObjectsRepository: savedObjectsClient,
+        adHocTaskCounter,
+        allowReadingInvalidState: false,
+        requestTimeouts: { update_by_query: 1000 },
+        savedObjectsService: coreStart.savedObjects,
+        security: coreStart.security,
+        canEncryptSavedObjects: true,
+        getIsSecurityEnabled: () => true,
+        basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
+      });
+
+      let getApiKeysCallCount = 0;
+      esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest
+        .fn()
+        .mockImplementation(() => {
+          getApiKeysCallCount++;
+          return Promise.resolve({
+            close: jest.fn(),
+            find: function* finder() {
+              if (getApiKeysCallCount === 1) {
+                yield {
+                  saved_objects: [
+                    {
+                      id: 'task1',
+                      attributes: { ...mockTask, id: 'task1', apiKey: 'decryptedKey1' },
+                    },
+                  ],
+                };
+              } else {
+                yield {
+                  saved_objects: [
+                    {
+                      id: 'task2',
+                      attributes: { ...mockTask, id: 'task2', apiKey: 'decryptedKey2' },
+                    },
+                  ],
+                };
+              }
+            },
+          });
+        });
+      refreshStore.registerEncryptedSavedObjectsClient(esoClient);
+
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
+          {
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
+          },
+        ],
+      });
+
+      const result = await refreshStore.msearch([{}]);
+
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('decryptedKey2');
+      expect(indicesRefreshSpy).toHaveBeenCalledWith({ index: 'tasky' });
+      expect(esoClient.createPointInTimeFinderDecryptedAsInternalUser).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Refreshing index to get recently created API keys for tasks'
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test('returns partial API keys when first getApiKeys search misses a key, and second search after refresh still does not find it', async () => {
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
+      const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      jest.spyOn(mockEsClient.indices, 'refresh').mockResolvedValue({} as never);
+      const logger = mockLogger();
+
+      const refreshStore = new TaskStore({
+        logger,
+        index: 'tasky',
+        taskManagerId: '',
+        serializer: mockSerializer,
+        esClient: mockEsClient,
+        definitions: taskDefinitions,
+        savedObjectsRepository: savedObjectsClient,
+        adHocTaskCounter,
+        allowReadingInvalidState: false,
+        requestTimeouts: { update_by_query: 1000 },
+        savedObjectsService: coreStart.savedObjects,
+        security: coreStart.security,
+        canEncryptSavedObjects: true,
+        getIsSecurityEnabled: () => true,
+        basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
+      });
+
+      let getApiKeysCallCount = 0;
+      esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest
+        .fn()
+        .mockImplementation(() => {
+          getApiKeysCallCount++;
+          return Promise.resolve({
+            close: jest.fn(),
+            find: function* finder() {
+              if (getApiKeysCallCount === 1) {
+                yield {
+                  saved_objects: [
+                    {
+                      id: 'task1',
+                      attributes: { ...mockTask, id: 'task1', apiKey: 'decryptedKey1' },
+                    },
+                  ],
+                };
+              } else {
+                yield { saved_objects: [] };
+              }
+            },
+          });
+        });
+      refreshStore.registerEncryptedSavedObjectsClient(esoClient);
+
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
+          {
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
+          },
+        ],
+      });
+
+      const result = await refreshStore.msearch([{}]);
+
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('encryptedKey2');
+      expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Refreshing index to get recently created API keys for tasks'
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'Unable to obtain API key for task task2 after retry'
+      );
+    });
+
+    test('returns partial API keys when refresh fails', async () => {
+      const mockSerializer = savedObjectsServiceMock.createSerializer();
+      mockSerializer.isRawSavedObject = jest.fn().mockReturnValue(true);
+      mockSerializer.rawToSavedObject = jest
+        .fn()
+        .mockImplementation((doc: { _source?: { task?: { id?: string } } }) => ({
+          id: doc._source?.task?.id ?? 'task1',
+          version: '123',
+          type: 'task',
+          references: [],
+          attributes: doc._source?.task ?? mockTask,
+        }));
+
+      const mockEsClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      jest.spyOn(mockEsClient.indices, 'refresh').mockRejectedValue(new Error('bad refresh'));
+      const logger = mockLogger();
+
+      const refreshStore = new TaskStore({
+        logger,
+        index: 'tasky',
+        taskManagerId: '',
+        serializer: mockSerializer,
+        esClient: mockEsClient,
+        definitions: taskDefinitions,
+        savedObjectsRepository: savedObjectsClient,
+        adHocTaskCounter,
+        allowReadingInvalidState: false,
+        requestTimeouts: { update_by_query: 1000 },
+        savedObjectsService: coreStart.savedObjects,
+        security: coreStart.security,
+        canEncryptSavedObjects: true,
+        getIsSecurityEnabled: () => true,
+        basePath: basePathMock,
+        executionContext: mockExecutionContextStart,
+      });
+
+      let getApiKeysCallCount = 0;
+      esoClient.createPointInTimeFinderDecryptedAsInternalUser = jest
+        .fn()
+        .mockImplementation(() => {
+          getApiKeysCallCount++;
+          return Promise.resolve({
+            close: jest.fn(),
+            find: function* finder() {
+              if (getApiKeysCallCount === 1) {
+                yield {
+                  saved_objects: [
+                    {
+                      id: 'task1',
+                      attributes: { ...mockTask, id: 'task1', apiKey: 'decryptedKey1' },
+                    },
+                  ],
+                };
+              } else {
+                yield { saved_objects: [] };
+              }
+            },
+          });
+        });
+      refreshStore.registerEncryptedSavedObjectsClient(esoClient);
+
+      mockEsClient.msearch.mockResponse({
+        took: 0,
+        responses: [
+          {
+            hits: {
+              hits: [
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task1', apiKey: 'encryptedKey1' } },
+                },
+                {
+                  _index: '.kibana_task_manager_8.16.0_001',
+                  _source: { task: { ...mockTask, id: 'task2', apiKey: 'encryptedKey2' } },
+                },
+              ],
+            },
+            took: 0,
+            _shards: { failed: 0, successful: 1, total: 1 },
+            timed_out: false,
+            status: 200,
+          },
+        ],
+      });
+
+      const result = await refreshStore.msearch([{}]);
+
+      expect(result.docs).toHaveLength(2);
+      expect(result.docs[0].apiKey).toBe('decryptedKey1');
+      expect(result.docs[1].apiKey).toBe('encryptedKey2');
+      expect(mockEsClient.indices.refresh).toHaveBeenCalledWith({ index: 'tasky' });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Refreshing index to get recently created API keys for tasks'
+      );
+      expect(logger.error).toHaveBeenCalledWith('Error refreshing index tasky: bad refresh');
+    });
+
     test('pushes error from call cluster to errors$', async () => {
       const firstErrorPromise = store.errors$.pipe(first()).toPromise();
       esClient.msearch.mockResponse({

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -263,18 +263,54 @@ export class TaskStore {
     return userScopeAndApiKey;
   }
 
-  private async bulkGetDecryptedTaskApiKeys(ids: string[]) {
-    const result = new Map<string, string | undefined>();
-    if (!this.canEncryptSo() || !ids.length) {
+  private async bulkGetDecryptedTaskApiKeys(
+    taskIds: string[]
+  ): Promise<Map<string, string | undefined>> {
+    if (!this.canEncryptSo() || !taskIds.length) {
+      return new Map<string, string | undefined>();
+    }
+
+    const result = await this.getApiKeys(taskIds);
+
+    // the search doesn't wait for refresh, so may miss a newly created key
+    const idsOfMissingKeys = taskIds.filter((id) => result.get(id) === undefined);
+
+    if (idsOfMissingKeys.length === 0) return result;
+
+    // do a refresh, and get the remaining keys
+    this.logger.warn('Refreshing index to get recently created API keys for tasks');
+
+    // refresh; if that fails, return what we currently have
+    try {
+      await this.esClient.indices.refresh({ index: this.index });
+    } catch (e) {
+      this.logger.error(`Error refreshing index ${this.index}: ${e.message}`);
       return result;
     }
 
+    // get the missing keys, a log an error if they continue to be missing
+    const missingResult = await this.getApiKeys(idsOfMissingKeys);
+
+    for (const id of idsOfMissingKeys) {
+      const foundKey = missingResult.get(id);
+      if (foundKey === undefined) {
+        this.logger.error(`Unable to obtain API key for task ${id} after retry`);
+      } else {
+        result.set(id, foundKey);
+      }
+    }
+
+    return result;
+  }
+
+  private async getApiKeys(taskIds: string[]) {
     const kueryNode = nodeBuilder.or(
-      ids.map((id) => {
+      taskIds.map((id) => {
         return nodeBuilder.is(`${TASK_SO_NAME}.id`, `${TASK_SO_NAME}:${id}`);
       })
     );
 
+    const result = new Map<string, string | undefined>();
     const finder =
       await this.esoClient!.createPointInTimeFinderDecryptedAsInternalUser<SerializedConcreteTaskInstance>(
         {
@@ -288,8 +324,8 @@ export class TaskStore {
         result.set(savedObject.id, savedObject.attributes.apiKey);
       });
     }
-    await finder.close();
 
+    await finder.close();
     return result;
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Task Manager] add refresh/search when getting API keys (#254981)](https://github.com/elastic/kibana/pull/254981)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2026-03-10T01:21:00Z","message":"[Task Manager] add refresh/search when getting API keys (#254981)\n\nresolves https://github.com/elastic/kibana/issues/253128\n\n## Summary\n\nMost of task manager's i/o can work without index refreshes, as we make\nheavy use of `mget`. For cases where we do have to do a search, we\nassume the results may be stale.\n\nFor newly created tasks with API keys, when the API key is retrieved\nfrom the ESO, it's done via a search. We've asked for an `mget` version\nof this: https://github.com/elastic/kibana/issues/253130\n\nThis can result in not finding the ESO/key, and using `undefined`\ninstead of an actual value, if the index isn't refreshed before we do\nthe search. This happens a small % of the time.\n\nUntil then, we will have to re-search after a refresh to pick up these\nnot-yet-refreshed ESOs.\n\n### AI usage\n\nSee\nhttps://github.com/elastic/kibana/pull/254981#issuecomment-3970128984\nfor information about a test case generated from Cursor.","sha":"b18300c855a12440af2247dfbcc31a4f0958ba86","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","backport:all-open","ci:build-cloud-image","ci:cloud-deploy","ci:cloud-redeploy","ci:cloud-persist-deployment","ci:project-deploy-elasticsearch","ci:project-persist-deployment","ci:project-redeploy","v9.4.0"],"title":"[Task Manager] add refresh/search when getting API keys","number":254981,"url":"https://github.com/elastic/kibana/pull/254981","mergeCommit":{"message":"[Task Manager] add refresh/search when getting API keys (#254981)\n\nresolves https://github.com/elastic/kibana/issues/253128\n\n## Summary\n\nMost of task manager's i/o can work without index refreshes, as we make\nheavy use of `mget`. For cases where we do have to do a search, we\nassume the results may be stale.\n\nFor newly created tasks with API keys, when the API key is retrieved\nfrom the ESO, it's done via a search. We've asked for an `mget` version\nof this: https://github.com/elastic/kibana/issues/253130\n\nThis can result in not finding the ESO/key, and using `undefined`\ninstead of an actual value, if the index isn't refreshed before we do\nthe search. This happens a small % of the time.\n\nUntil then, we will have to re-search after a refresh to pick up these\nnot-yet-refreshed ESOs.\n\n### AI usage\n\nSee\nhttps://github.com/elastic/kibana/pull/254981#issuecomment-3970128984\nfor information about a test case generated from Cursor.","sha":"b18300c855a12440af2247dfbcc31a4f0958ba86"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254981","number":254981,"mergeCommit":{"message":"[Task Manager] add refresh/search when getting API keys (#254981)\n\nresolves https://github.com/elastic/kibana/issues/253128\n\n## Summary\n\nMost of task manager's i/o can work without index refreshes, as we make\nheavy use of `mget`. For cases where we do have to do a search, we\nassume the results may be stale.\n\nFor newly created tasks with API keys, when the API key is retrieved\nfrom the ESO, it's done via a search. We've asked for an `mget` version\nof this: https://github.com/elastic/kibana/issues/253130\n\nThis can result in not finding the ESO/key, and using `undefined`\ninstead of an actual value, if the index isn't refreshed before we do\nthe search. This happens a small % of the time.\n\nUntil then, we will have to re-search after a refresh to pick up these\nnot-yet-refreshed ESOs.\n\n### AI usage\n\nSee\nhttps://github.com/elastic/kibana/pull/254981#issuecomment-3970128984\nfor information about a test case generated from Cursor.","sha":"b18300c855a12440af2247dfbcc31a4f0958ba86"}},{"url":"https://github.com/elastic/kibana/pull/256814","number":256814,"branch":"8.19","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/256815","number":256815,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->