### PR TITLE
[Security Solution] fix small issue with analyzer preview not rendering when alert rule parameter index is an array

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/analyzer_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/analyzer_preview.test.tsx
@@ -107,6 +107,24 @@ describe('<AnalyzerPreview />', () => {
     });
   });
 
+  it('should use all rule parameters indices when provided as an array', async () => {
+    const hit = createMockHit({
+      'kibana.alert.rule.parameters': {
+        index: ['rule-parameters-index-1', 'rule-parameters-index-2'],
+      },
+    });
+    const wrapper = renderAnalyzerPreview(hit);
+
+    expect(mockUseAlertPrevalenceFromProcessTree).toHaveBeenCalledWith({
+      documentId: 'eventId',
+      indices: ['rule-parameters-index-1', 'rule-parameters-index-2'],
+    });
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId(ANALYZER_PREVIEW_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
   it('should use ancestor id as document id when shouldUseAncestor is true', async () => {
     const hit = createMockHit({
       'kibana.alert.rule.indices': ['rule-indices'],

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/analyzer_preview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/analyzer_preview.tsx
@@ -54,8 +54,15 @@ export const AnalyzerPreview = memo(
 
     const alertIndices = useMemo(() => {
       const ruleIndices = getFieldValue(hit, ALERT_RULE_INDICES) as string[];
-      const ruleParameters = getFieldValue(hit, ALERT_RULE_PARAMETERS) as { index: string };
-      const ruleParametersIndices = ruleParameters ? [ruleParameters.index] : [];
+      const ruleParameters = getFieldValue(hit, ALERT_RULE_PARAMETERS) as {
+        index: string | string[];
+      };
+      const ruleParametersIndices =
+        ruleParameters && ruleParameters.index
+          ? Array.isArray(ruleParameters.index)
+            ? ruleParameters.index
+            : [ruleParameters.index]
+          : [];
       return ruleIndices?.length > 0 ? ruleIndices : ruleParametersIndices;
     }, [hit]);
     const indices = alertIndices.length > 0 ? alertIndices : dataViewIndices;


### PR DESCRIPTION
## Summary

This PR fixes a small issue where analyzer preview isn't rendering correctly when the `rule.parameters.index` field on an alert document contains an array of indices instead of a string of a single index.

### Before

<img width="1453" height="888" alt="Screenshot 2026-03-10 at 10 21 38 AM" src="https://github.com/user-attachments/assets/0dd4d7a5-1ee5-491a-8279-c2422929986c" />

### After

<img width="1234" height="885" alt="Screenshot 2026-03-10 at 10 22 24 AM" src="https://github.com/user-attachments/assets/0d9b6468-b727-49b2-aa75-faf35335f41d" />

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.