### PR TITLE
[content-list] Add createdBy column, filter, and user profile service

### DIFF
--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_builder.tsx
@@ -33,6 +33,7 @@ import {
   createMockFavoritesClient,
   createStoryFindItems,
   mockTagsService,
+  mockUserProfileServices,
   toJsx,
 } from '../stories_helpers';
 import { BuilderPanel } from './builder_panel';
@@ -146,6 +147,10 @@ const usePreview = (state: PlaygroundState) => {
     };
   }, [data.totalItems, data.isLoading, data.hasItems, favoritesClient]);
 
+  const hasCreatedBy =
+    toolbar.filters.some((f) => f.type === 'createdBy') ||
+    table.columns.some((c) => c.type === 'createdBy');
+
   const providerFeatures = useMemo(
     () => ({
       sorting: features.sorting
@@ -157,6 +162,7 @@ const usePreview = (state: PlaygroundState) => {
       search: features.search ? {} : (false as const),
       tags: hasTags ? true : (false as const),
       starred: hasStarred ? true : (false as const),
+      createdBy: hasCreatedBy ? true : (false as const),
     }),
     [
       features.sorting,
@@ -166,6 +172,7 @@ const usePreview = (state: PlaygroundState) => {
       sortFields,
       hasTags,
       hasStarred,
+      hasCreatedBy,
     ]
   );
 
@@ -202,6 +209,8 @@ const usePreview = (state: PlaygroundState) => {
             return <Column.Name key={col.instanceId} {...cleanProps} />;
           case 'updatedAt':
             return <Column.UpdatedAt key={col.instanceId} {...cleanProps} />;
+          case 'createdBy':
+            return <Column.CreatedBy key={col.instanceId} {...cleanProps} />;
           case 'type': {
             const { columnTitle, ...rest } = cleanProps;
             return (
@@ -277,6 +286,13 @@ const usePreview = (state: PlaygroundState) => {
                 </React.Fragment>
               );
             }
+            if (f.type === 'createdBy') {
+              return (
+                <React.Fragment key={f.instanceId}>
+                  <Filters.CreatedBy />
+                </React.Fragment>
+              );
+            }
             return null;
           })
         : [
@@ -295,15 +311,18 @@ const usePreview = (state: PlaygroundState) => {
   const tableTitle = `${provider.entityPlural} table`;
 
   const services = useMemo(() => {
-    const s: Record<string, unknown> = {};
+    const svc: Record<string, unknown> = {};
     if (hasTags) {
-      s.tags = mockTagsService;
+      svc.tags = mockTagsService;
     }
     if (hasStarred && favoritesClient) {
-      s.favorites = favoritesClient;
+      svc.favorites = favoritesClient;
     }
-    return Object.keys(s).length > 0 ? s : undefined;
-  }, [hasTags, hasStarred, favoritesClient]);
+    if (hasCreatedBy) {
+      svc.userProfile = mockUserProfileServices;
+    }
+    return Object.keys(svc).length > 0 ? svc : undefined;
+  }, [hasTags, hasStarred, favoritesClient, hasCreatedBy]);
 
   const providerProps = useMemo(
     () => ({
@@ -312,7 +331,7 @@ const usePreview = (state: PlaygroundState) => {
       features: providerFeatures,
       isReadOnly: provider.isReadOnly,
       item: providerItemConfig,
-      ...(services && { services }),
+      services,
     }),
     [labels, dataSource, providerFeatures, provider.isReadOnly, providerItemConfig, services]
   );

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/playground/playground_state.ts
@@ -11,7 +11,7 @@
 // Types
 // =============================================================================
 
-export type ColumnType = 'name' | 'updatedAt' | 'actions' | 'type' | 'starred';
+export type ColumnType = 'name' | 'updatedAt' | 'createdBy' | 'actions' | 'type' | 'starred';
 
 export interface ActiveColumn {
   instanceId: string;
@@ -28,7 +28,7 @@ export interface ActiveAction {
   type: ActionType;
 }
 
-export type FilterType = 'sort' | 'tags' | 'starred';
+export type FilterType = 'sort' | 'tags' | 'starred' | 'createdBy';
 
 export interface ActiveFilter {
   instanceId: string;
@@ -114,6 +114,16 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
     ],
   },
   {
+    type: 'createdBy',
+    label: 'Column.CreatedBy',
+    allowMultiple: false,
+    defaultProps: {},
+    configurableProps: [
+      { name: 'width', label: 'width', type: 'string', defaultValue: '' },
+      { name: 'columnTitle', label: 'columnTitle', type: 'string', defaultValue: '' },
+    ],
+  },
+  {
     type: 'type',
     label: 'Column (Type)',
     allowMultiple: false,
@@ -146,6 +156,7 @@ export const FILTER_DEFINITIONS: { type: FilterType; label: string }[] = [
   { type: 'starred', label: 'Filters.Starred' },
   { type: 'sort', label: 'Filters.Sort' },
   { type: 'tags', label: 'Filters.Tags' },
+  { type: 'createdBy', label: 'Filters.CreatedBy' },
 ];
 
 export const ACTION_DEFINITIONS: { type: ActionType; label: string }[] = [

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-docs/src/stories_helpers.tsx
@@ -36,9 +36,10 @@ import {
   createMockFavoritesClient,
   extractTagIds,
   mockTagsService,
+  mockUserProfileServices,
 } from '@kbn/content-list-mock-data';
 
-export { mockTagsService, createMockFavoritesClient };
+export { mockTagsService, createMockFavoritesClient, mockUserProfileServices };
 
 // =============================================================================
 // Mock Data
@@ -117,6 +118,8 @@ export const createStoryFindItems = (options?: {
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
         tags: extractTagIds(item.references),
+        createdBy: item.createdBy,
+        managed: (item as { managed?: boolean }).managed,
       })),
       total: result.total,
       counts: result.counts,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-mock-data/storybook/helpers.ts
@@ -13,7 +13,7 @@ import { MOCK_DASHBOARDS, type DashboardMockItem } from './dashboards';
 import { MOCK_MAPS, type MapMockItem } from './maps';
 import { MOCK_FILES, type FileMockItem } from './files';
 import { MOCK_VISUALIZATIONS, type VisualizationMockItem } from './visualizations';
-import { MOCK_USER_PROFILES } from './user_profiles';
+
 import { mockFavoritesClient } from './services';
 
 /** Shape compatible with `ActiveFilters` from `@kbn/content-list-provider`. Defined locally to avoid circular dependency. */
@@ -378,52 +378,6 @@ export const NULL_USER = 'no-user';
  * Build a map of email → uid for user profile lookup.
  * Used to resolve email-based createdBy filters to user IDs.
  */
-const EMAIL_TO_UID_MAP: Record<string, string> = MOCK_USER_PROFILES.reduce<Record<string, string>>(
-  (acc, profile) => {
-    if (profile.user.email) {
-      acc[profile.user.email] = profile.uid;
-    }
-    return acc;
-  },
-  {}
-);
-
-/**
- * Resolve a filter value (email or uid) to a user ID.
- * Supports both email-based filtering (new) and uid-based filtering (legacy).
- */
-function resolveToUid(filterValue: string): string | undefined {
-  // If it's an email, resolve to uid
-  if (EMAIL_TO_UID_MAP[filterValue]) {
-    return EMAIL_TO_UID_MAP[filterValue];
-  }
-  // If it's already a uid (or unknown value), return as-is
-  return filterValue;
-}
-
-/**
- * Check if an item's creator matches the filter values.
- * Handles both email and uid filter values for backwards compatibility.
- */
-function matchesUserFilter(itemCreatedBy: string | undefined, filterValues: string[]): boolean {
-  // Resolve all filter values to uids
-  const resolvedUids = filterValues
-    .filter((v) => v !== NULL_USER)
-    .map(resolveToUid)
-    .filter((uid): uid is string => uid !== undefined);
-
-  // Check if NULL_USER is in the filter (matches items without creator)
-  const includesNullUser = filterValues.includes(NULL_USER);
-
-  // Item has no creator
-  if (!itemCreatedBy) {
-    return includesNullUser;
-  }
-
-  // Check if item's createdBy matches any resolved uid
-  return resolvedUids.includes(itemCreatedBy);
-}
-
 /**
  * Create mock findItems function for dashboard stories.
  * Simplified API for examples - just pass optional delay.
@@ -485,11 +439,7 @@ export const createSimpleMockFindItems = (
       );
     }
 
-    // Apply user filters (createdBy) - supports both email and uid filter values
-    const usersFilter = (filters as { users?: string[] }).users;
-    if (usersFilter && usersFilter.length > 0) {
-      items = items.filter((item) => matchesUserFilter(item.createdBy, usersFilter));
-    }
+    // User filtering is applied client-side by the provider, not the data source.
 
     // Apply starred filter.
     if (filters.starredOnly) {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/index.ts
@@ -26,7 +26,6 @@ export type {
 
 // Hooks.
 export { useContentListItems, useContentListState } from './src/state';
-export type { ContentListQueryData } from './src/state';
 export {
   useContentListSort,
   useContentListSearch,
@@ -35,18 +34,19 @@ export {
   useFilterDisplay,
   useContentListFilters,
   useTagFilterToggle,
+  useUserFilterToggle,
   TAG_FILTER_ID,
   DeleteConfirmationModal,
   DeleteConfirmationComponent,
   useDeleteConfirmation,
+  useContentListUserFilter,
 } from './src/features';
 
 // State.
 export { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './src/state';
 export type { ContentListAction } from './src/state';
 
-// Types.
-export type { ContentListItem, ContentListItemConfig } from './src/item';
+// Types — features.
 export type {
   ContentListFeatures,
   ContentListSupports,
@@ -65,10 +65,16 @@ export type {
   DeleteConfirmationComponentProps,
   UseDeleteConfirmationOptions,
   UseDeleteConfirmationReturn,
+  UseContentListUserFilterReturn,
+  CreatorsList,
 } from './src/features';
+export { MANAGED_USER_FILTER, NO_CREATOR_USER_FILTER } from './src/features';
+
+// Types — datasource.
 export type {
   ActiveFilters,
   IncludeExcludeFilter,
+  UserFilter,
   FilterCounts,
   FindItemsFn,
   FindItemsParams,
@@ -76,5 +82,15 @@ export type {
   DataSourceConfig,
 } from './src/datasource';
 
+// Types — item.
+export type { ContentListItem, ContentListItemConfig } from './src/item';
+
+// Types — services.
+export type { UserProfileService } from './src/services';
+
+// Types — state.
+export type { ContentListQueryData } from './src/state';
+
 // Utilities.
 export { contentListKeys } from './src/query';
+export { contentListQueryClient } from './src/query';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/moon.yml
@@ -23,6 +23,8 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/content-management-tags'
   - '@kbn/content-management-favorites-public'
+  - '@kbn/content-management-user-profiles'
+  - '@kbn/user-profile-components'
   - '@kbn/i18n'
 tags:
   - shared-browser

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/context/provider.tsx
@@ -10,6 +10,7 @@
 import React, { useMemo, createContext, useContext, type ReactNode } from 'react';
 import { ContentManagementTagsProvider } from '@kbn/content-management-tags';
 import { FavoritesContextProvider } from '@kbn/content-management-favorites-public';
+import { UserProfilesProvider } from '@kbn/content-management-user-profiles';
 import type { ContentListCoreConfig, ContentListConfig, ContentListServices } from './types';
 import type { ContentListFeatures, ContentListSupports } from '../features';
 import type { DataSourceConfig } from '../datasource';
@@ -58,7 +59,7 @@ export type ContentListProviderProps = ContentListConfig & {
 
 /**
  * Main provider component for content list functionality, including data fetching
- * (via React Query), sorting, search, and tags filtering.
+ * (via React Query), sorting, search, tags filtering, and user profile resolution.
  *
  * Props like `dataSource`, `features`, and `services` should be stable references to avoid
  * unnecessary re-renders. Configuration from `features.sorting`, `features.pagination`, and
@@ -70,9 +71,9 @@ export type ContentListProviderProps = ContentListConfig & {
  * and filtering in child components. The tags service's `parseSearchQuery` (if present)
  * is passed through to support extracting tag filters from the search bar query text.
  *
- * When `services.favorites` is provided (and `features.starred` is not `false`), the provider
- * wraps children with `FavoritesContextProvider`, enabling star buttons and starred
- * filtering in child components.
+ * When `services.userProfile` is provided (and `features.createdBy` is not `false`), the
+ * provider automatically wraps children with the user profiles context, enabling avatar
+ * display and user filtering in child components.
  */
 export const ContentListProvider = ({
   children,
@@ -89,11 +90,16 @@ export const ContentListProvider = ({
   // At least one of id or queryKeyScope is guaranteed by ContentListIdentity type.
   const queryKeyScope = queryKeyScopeProp ?? `${id}-listing`;
 
-  const { tags: tagsService, favorites: favoritesService } = services ?? {};
+  const {
+    tags: tagsService,
+    favorites: favoritesService,
+    userProfile: userProfileService,
+  } = services ?? {};
 
   // Service-dependent features: enabled by default when service exists, unless explicitly disabled.
   const supportsTags = features.tags !== false && !!tagsService;
   const supportsStarred = features.starred !== false && !!favoritesService;
+  const supportsCreatedBy = features.createdBy !== false && !!userProfileService;
 
   // Resolve feature support flags.
   // Selection is disabled when explicitly set to `false` or when the list is read-only.
@@ -105,6 +111,7 @@ export const ContentListProvider = ({
       selection: features.selection !== false && !isReadOnly,
       tags: supportsTags,
       starred: supportsStarred,
+      createdBy: supportsCreatedBy,
     }),
     [
       features.sorting,
@@ -114,6 +121,7 @@ export const ContentListProvider = ({
       isReadOnly,
       supportsTags,
       supportsStarred,
+      supportsCreatedBy,
     ]
   );
 
@@ -158,6 +166,18 @@ export const ContentListProvider = ({
       <FavoritesContextProvider favoritesClient={favoritesService}>
         {content}
       </FavoritesContextProvider>
+    );
+  }
+
+  // Wrap with user profiles provider when user profile service is available.
+  if (supportsCreatedBy && userProfileService) {
+    content = (
+      <UserProfilesProvider
+        getUserProfile={userProfileService.getUserProfile}
+        bulkGetUserProfiles={userProfileService.bulkGetUserProfiles}
+      >
+        {content}
+      </UserProfilesProvider>
     );
   }
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/datasource/types.ts
@@ -10,7 +10,7 @@
 import type { ContentListItem } from '../item';
 
 /**
- * Include/exclude filter shape used by tag, type, lastResponse, and other filter dimensions.
+ * Include/exclude filter shape used by `tag`, and plugin-provided `custom` filter dimensions.
  */
 export interface IncludeExcludeFilter {
   /** Values that items must match (include filter). */
@@ -23,31 +23,58 @@ export interface IncludeExcludeFilter {
 export const TAG_FILTER_ID = 'tag';
 
 /**
+ * User filter state for creator-based filtering.
+ *
+ * Separates UI-driven selections (popover / avatar clicks) from text-driven
+ * query bar clauses so they can be managed independently:
+ *
+ * - `uid` holds UIDs resolved from email or sentinel values selected through UI controls.
+ *   The {@link CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER} action checks this array to
+ *   decide whether to add or remove an email from the query bar.
+ * - `query` maps raw text values typed in the query bar (e.g. `createdBy:"Jane Doe"`)
+ *   to the UIDs they resolve to. Text clauses are "sticky" — only removed by manually
+ *   editing the query bar or clearing all filters.
+ *
+ * Client-side filtering uses the deduplicated union of all UIDs from both fields.
+ */
+export interface UserFilter {
+  /** UIDs resolved from email or sentinel values selected via UI controls. */
+  uid: string[];
+  /**
+   * Text-driven query values mapped to their resolved UIDs.
+   *
+   * Keys are the raw text values from `createdBy:` clauses (names, usernames, etc.).
+   * Values are arrays of UIDs that each text value resolved to.
+   * E.g. `{ "Jane Doe": ["uid123", "uid456"], "clint": ["uid789"] }`.
+   */
+  query: Record<string, string[]>;
+}
+
+/**
  * Active filters applied to the content list.
  *
- * Filter dimensions (e.g. `tag`, `type`, `lastResponse`) are keyed by their
- * `fieldName` and hold an {@link IncludeExcludeFilter}. The index signature is
- * required to allow arbitrary filter dimensions, but note:
- *
- * - The `search` key is always `string | undefined` — access it directly.
- * - All other keys return `IncludeExcludeFilter | string | undefined`; use
- *   {@link getIncludeExcludeFilter} to safely narrow them to `IncludeExcludeFilter`.
+ * Each built-in filter dimension (`search`, `tag`, `user`) has an explicit,
+ * precisely-typed field. Plugin-provided filter dimensions (e.g. `type`,
+ * `lastResponse`) live under the `custom` record.
  */
 export interface ActiveFilters {
   /** Search text extracted from the search bar, without filter syntax. */
   search?: string;
   /** When `true`, restrict results to starred items only. */
   starredOnly?: boolean;
-  [filterId: string]: IncludeExcludeFilter | string | boolean | undefined;
+  /** Tag include/exclude filter. */
+  tag?: IncludeExcludeFilter;
+  /** User filter for creator-based filtering. Applied client-side; never sent to the server. */
+  user?: UserFilter;
+  /** Plugin-provided filter dimensions keyed by their `fieldName`. */
+  custom?: Record<string, IncludeExcludeFilter | undefined>;
 }
 
 /**
- * Returns the filter value as `IncludeExcludeFilter` if it is an object; otherwise `undefined`.
- * Use when accessing `include`/`exclude` on a filter dimension, since the index signature
- * allows `string`, `boolean`, and `IncludeExcludeFilter`.
+ * Narrows a filter value to {@link IncludeExcludeFilter} if it is one; otherwise returns `undefined`.
  */
 export const getIncludeExcludeFilter = (
-  value: IncludeExcludeFilter | string | boolean | undefined
+  value: IncludeExcludeFilter | undefined
 ): IncludeExcludeFilter | undefined => (value && typeof value === 'object' ? value : undefined);
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/index.ts
@@ -7,14 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  IncludeExcludeFilter,
-  UserFilter,
-  FilterCounts,
-  ActiveFilters,
-  FindItemsParams,
-  FindItemsResult,
-  FindItemsFn,
-  DataSourceConfig,
-} from './types';
-export { getIncludeExcludeFilter, TAG_FILTER_ID } from './types';
+export { useContentListUserFilter } from './use_content_list_user_filter';
+export { useUserFilterToggle } from './use_user_filter_toggle';
+export type { UseContentListUserFilterReturn, CreatorsList } from './types';
+export { MANAGED_USER_FILTER, NO_CREATOR_USER_FILTER } from './types';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/types.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserFilter } from '../../../datasource';
+
+/**
+ * Sentinel value for items managed by Elastic (not user-created).
+ *
+ * Used in the user filter selection to represent managed items.
+ */
+export const MANAGED_USER_FILTER = '__managed__';
+
+/**
+ * Sentinel value for items with no creator attribution.
+ *
+ * Used in the user filter selection to represent items lacking a `createdBy` field.
+ */
+export const NO_CREATOR_USER_FILTER = '__no_creator__';
+
+/**
+ * Summary of all unique creators found across the full (unfiltered) item list.
+ *
+ * Derived from the query result before client-side user filtering is applied,
+ * so the creator list never shrinks when a filter is active.
+ */
+export interface CreatorsList {
+  /** UIDs of all users who created items. */
+  uids: string[];
+  /** Whether any items have no creator. */
+  hasNoCreator: boolean;
+  /** Whether any items are managed. */
+  hasManaged: boolean;
+}
+
+/**
+ * Return value from the `useContentListUserFilter` hook.
+ */
+export interface UseContentListUserFilterReturn {
+  /** Deduplicated UIDs from all active user filter sources (UI + text). */
+  selectedUsers: string[];
+  /** Whether user filtering is supported (service + feature flag). */
+  isSupported: boolean;
+  /** Replace the {@link UserFilter} object. Pass `undefined` to clear. */
+  setSelectedUsers: (userFilter: UserFilter | undefined) => void;
+  /** Whether any user filter is currently active. */
+  hasActiveFilter: boolean;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_content_list_user_filter.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_content_list_user_filter.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ContentListProvider, type FindItemsResult, type FindItemsParams } from '../../../..';
+import type { UserProfileService } from '../../../services';
+import { useContentListUserFilter } from './use_content_list_user_filter';
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+const mockUserProfileService: UserProfileService = {
+  getUserProfile: jest.fn(),
+  bulkGetUserProfiles: jest.fn(),
+};
+
+const createWrapper =
+  (options: { withService?: boolean } = {}) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'item', entityPlural: 'items' }}
+        dataSource={{ findItems: mockFindItems }}
+        services={options.withService ? { userProfile: mockUserProfileService } : undefined}
+      >
+        {children}
+      </ContentListProvider>
+    );
+
+describe('useContentListUserFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty selectedUsers by default', () => {
+    const { result } = renderHook(() => useContentListUserFilter(), {
+      wrapper: createWrapper({ withService: true }),
+    });
+
+    expect(result.current.selectedUsers).toEqual([]);
+    expect(result.current.hasActiveFilter).toBe(false);
+  });
+
+  it('reports isSupported as true when user profile service is provided', () => {
+    const { result } = renderHook(() => useContentListUserFilter(), {
+      wrapper: createWrapper({ withService: true }),
+    });
+
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it('reports isSupported as false when user profile service is not provided', () => {
+    const { result } = renderHook(() => useContentListUserFilter(), {
+      wrapper: createWrapper({ withService: false }),
+    });
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it('updates selectedUsers when setSelectedUsers is called', () => {
+    const { result } = renderHook(() => useContentListUserFilter(), {
+      wrapper: createWrapper({ withService: true }),
+    });
+
+    act(() => {
+      result.current.setSelectedUsers({ uid: ['user-1', 'user-2'], query: {} });
+    });
+
+    expect(result.current.selectedUsers).toEqual(['user-1', 'user-2']);
+    expect(result.current.hasActiveFilter).toBe(true);
+  });
+
+  it('clears users when setSelectedUsers is called with undefined', () => {
+    const { result } = renderHook(() => useContentListUserFilter(), {
+      wrapper: createWrapper({ withService: true }),
+    });
+
+    act(() => {
+      result.current.setSelectedUsers({ uid: ['user-1'], query: {} });
+    });
+
+    expect(result.current.hasActiveFilter).toBe(true);
+
+    act(() => {
+      result.current.setSelectedUsers(undefined);
+    });
+
+    expect(result.current.selectedUsers).toEqual([]);
+    expect(result.current.hasActiveFilter).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_content_list_user_filter.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_content_list_user_filter.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback, useMemo } from 'react';
+import type { UserFilter } from '../../../datasource';
+import { useContentListConfig } from '../../../context';
+import { useContentListState } from '../../../state';
+import { CONTENT_LIST_ACTIONS } from '../../../state/types';
+import type { UseContentListUserFilterReturn } from './types';
+
+/**
+ * Compute the deduplicated union of all UIDs from a {@link UserFilter}.
+ *
+ * Combines `uid` (email/sentinel-driven from UI controls) with all resolved
+ * UIDs from `query` (text-driven from the query bar).
+ */
+const resolveAllUids = (filter: UserFilter | undefined): string[] => {
+  if (!filter) {
+    return [];
+  }
+  const set = new Set([...filter.uid, ...Object.values(filter.query).flat()]);
+  return Array.from(set);
+};
+
+/**
+ * Hook for managing user filter state in the content list.
+ *
+ * `selectedUsers` is the deduplicated union of all UIDs resolved from
+ * `filters.user.uid` (UI-driven) and `filters.user.query` (text-driven).
+ * This is used for popover checked state and badge count.
+ *
+ * Dispatches `SET_USER_FILTER` to update only the `user` portion of
+ * `ActiveFilters`, preserving all other filters (search, tags, etc.)
+ * at the reducer level.
+ *
+ * @returns {@link UseContentListUserFilterReturn} with selected users
+ *   and helpers for updating them.
+ */
+export const useContentListUserFilter = (): UseContentListUserFilterReturn => {
+  const { supports } = useContentListConfig();
+  const { state, dispatch } = useContentListState();
+
+  const selectedUsers = useMemo(() => resolveAllUids(state.filters?.user), [state.filters?.user]);
+
+  const hasActiveFilter = selectedUsers.length > 0;
+
+  const setSelectedUsers = useCallback(
+    (userFilter: UserFilter | undefined) => {
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      });
+    },
+    [dispatch]
+  );
+
+  return {
+    selectedUsers,
+    isSupported: supports.createdBy,
+    setSelectedUsers,
+    hasActiveFilter,
+  };
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_user_filter_toggle.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/filtering/user_profile/use_user_filter_toggle.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import { useContentListConfig } from '../../../context';
+import { useContentListState } from '../../../state/use_content_list_state';
+import { CONTENT_LIST_ACTIONS } from '../../../state/types';
+
+/**
+ * Hook that returns a stable callback for toggling a user in the content list
+ * filter, or `null` when created-by filtering is not supported.
+ *
+ * Dispatches {@link CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER} which:
+ * - Checks whether `uid` is present in `filters.user.uid` to decide add vs remove.
+ * - Adds/removes the `queryValue` (email) in the `createdBy:()` query clause.
+ * - Does **not** mutate `filters.user` directly — the renderer re-derives it.
+ *
+ * @param uid - The user UID (or sentinel value like `MANAGED_USER_FILTER`).
+ * @param queryValue - The display value for the query bar (typically the user's
+ *   email, or `'managed'`/`'none'` for sentinel values).
+ *
+ * @example
+ * ```tsx
+ * const toggleUser = useUserFilterToggle();
+ * if (toggleUser) {
+ *   <button onClick={() => toggleUser('u_jane', 'jane@elastic.co')}>
+ *     <UserAvatarTip uid="u_jane" />
+ *   </button>
+ * }
+ * ```
+ */
+export const useUserFilterToggle = (): ((uid: string, queryValue: string) => void) | null => {
+  const { supports } = useContentListConfig();
+  const { dispatch } = useContentListState();
+
+  const toggle = useCallback(
+    (uid: string, queryValue: string) => {
+      dispatch({
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid, queryValue },
+      });
+    },
+    [dispatch]
+  );
+
+  if (!supports.createdBy) {
+    return null;
+  }
+
+  return toggle;
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/index.ts
@@ -36,6 +36,15 @@ export {
   TAG_FILTER_ID,
 } from './filtering';
 
+// User profile filtering feature.
+export type { UseContentListUserFilterReturn, CreatorsList } from './filtering/user_profile';
+export {
+  useContentListUserFilter,
+  useUserFilterToggle,
+  MANAGED_USER_FILTER,
+  NO_CREATOR_USER_FILTER,
+} from './filtering/user_profile';
+
 // Delete feature.
 export type {
   DeleteConfirmationModalProps,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/features/types.ts
@@ -43,6 +43,13 @@ export interface ContentListFeatures {
    * - `false`: Explicitly disables starring even if `services.favorites` is present.
    */
   starred?: boolean;
+  /**
+   * CreatedBy feature configuration.
+   *
+   * - `true` or `undefined`: Auto-enabled when `services.userProfile` is provided.
+   * - `false`: Explicitly disables created-by column and filter even if the service is present.
+   */
+  createdBy?: boolean;
 }
 
 /**
@@ -88,6 +95,7 @@ export const isSearchConfig = (search: ContentListFeatures['search']): search is
  *   <div>
  *     {supports.sorting && <SortDropdown />}
  *     {supports.tags && <TagFilter />}
+ *     {supports.createdBy && <CreatedByFilter />}
  *   </div>
  * );
  * ```
@@ -105,4 +113,6 @@ export interface ContentListSupports {
   tags: boolean;
   /** Whether starring items is supported. */
   starred: boolean;
+  /** Whether created-by column and user filtering is supported. */
+  createdBy: boolean;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/item/types.ts
@@ -29,6 +29,10 @@ export type ContentListItem<T = Record<string, unknown>> = T & {
   updatedAt?: Date;
   /** Optional array of tag IDs associated with this item. */
   tags?: string[];
+  /** User ID of the item's creator. */
+  createdBy?: string;
+  /** Whether the item is managed by Elastic (not user-created). */
+  managed?: boolean;
 };
 
 /**

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/query/use_content_list_items_query.ts
@@ -24,6 +24,10 @@ const DEFAULT_PAGE = { index: 0, size: 20 };
  * This hook:
  * - Fetches items using the configured `findItems` function.
  * - Returns query data directly (items, loading, error) without dispatching.
+ * - Excludes `users` from server params — user filtering is applied client-side
+ *   after the query returns, matching the original `TableListView` behavior. This
+ *   ensures the full item list is always available for deriving the creator list
+ *   shown in the filter.
  *
  * Note: Items are expected to already be in `ContentListItem` format.
  * Transformation should happen in the `findItems` implementation.
@@ -33,21 +37,28 @@ const DEFAULT_PAGE = { index: 0, size: 20 };
  */
 export const useContentListItemsQuery = (
   clientState: ContentListClientState
-): ContentListQueryData & { refetch: () => void } => {
+): Omit<ContentListQueryData, 'allCreators'> & { refetch: () => void } => {
   const { dataSource, queryKeyScope, supports } = useContentListConfig();
 
   // Build query parameters from client state.
   // Only include sort if sorting is supported; otherwise, let the data source use its natural order.
   // Only include page if pagination is supported; otherwise, use a sensible default.
-  const queryParams = useMemo(
-    () => ({
-      searchQuery: clientState.filters.search ?? '',
-      filters: clientState.filters,
+  // Exclude `user` from server params — user filtering is applied client-side.
+  const queryParams = useMemo(() => {
+    const { user: _user, ...serverFilters } = clientState.filters;
+    return {
+      searchQuery: serverFilters.search ?? '',
+      filters: serverFilters,
       sort: supports.sorting ? clientState.sort : undefined,
       page: supports.pagination ? clientState.page : DEFAULT_PAGE,
-    }),
-    [clientState.filters, clientState.sort, clientState.page, supports.sorting, supports.pagination]
-  );
+    };
+  }, [
+    clientState.filters,
+    clientState.sort,
+    clientState.page,
+    supports.sorting,
+    supports.pagination,
+  ]);
 
   // React Query for data fetching.
   // `keepPreviousData` retains the previous results while a new query loads,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/index.ts
@@ -8,3 +8,4 @@
  */
 
 export type { ContentListServices } from './types';
+export type { UserProfileService } from './user_profile';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/types.ts
@@ -9,6 +9,7 @@
 
 import type { ContentManagementTagsServices } from '@kbn/content-management-tags';
 import type { FavoritesClientPublic } from '@kbn/content-management-favorites-public';
+import type { UserProfileService } from './user_profile';
 
 /**
  * Services provided to the content list provider to enable additional capabilities.
@@ -35,4 +36,12 @@ export interface ContentListServices {
    * filter in toolbar) unless explicitly disabled via `features.starred: false`.
    */
   favorites?: FavoritesClientPublic;
+  /**
+   * User profile service for resolving creator avatars and filtering by user.
+   *
+   * Provides `getUserProfile` for single lookups and `bulkGetUserProfiles` for
+   * batch resolution. When present, enables the `createdBy` column and filter
+   * automatically (unless `features.createdBy` is `false`).
+   */
+  userProfile?: UserProfileService;
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/user_profile/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/user_profile/index.ts
@@ -7,14 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  IncludeExcludeFilter,
-  UserFilter,
-  FilterCounts,
-  ActiveFilters,
-  FindItemsParams,
-  FindItemsResult,
-  FindItemsFn,
-  DataSourceConfig,
-} from './types';
-export { getIncludeExcludeFilter, TAG_FILTER_ID } from './types';
+export type { UserProfileService } from './types';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/user_profile/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/services/user_profile/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UserProfile } from '@kbn/user-profile-components';
+
+/**
+ * User profile service interface for the content list provider.
+ *
+ * Provides user profile resolution for rendering avatars and filtering
+ * by creator. Consumers supply an implementation that wraps Kibana's
+ * `core.userProfile.bulkGet` or an equivalent mock.
+ */
+export interface UserProfileService {
+  /** Fetch a single user profile by uid. */
+  getUserProfile: (uid: string) => Promise<UserProfile>;
+  /** Fetch multiple user profiles by uid. */
+  bulkGetUserProfiles: (uids: string[]) => Promise<UserProfile[]>;
+}

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_provider.tsx
@@ -14,6 +14,8 @@ import { DEFAULT_FILTERS } from './types';
 import { ContentListStateContext } from './use_content_list_state';
 import { useContentListConfig } from '../context';
 import { isSortingConfig, isPaginationConfig, isSearchConfig } from '../features';
+import { MANAGED_USER_FILTER, NO_CREATOR_USER_FILTER } from '../features';
+import type { CreatorsList } from '../features';
 import { DEFAULT_PAGE_SIZE } from '../features/pagination';
 import { getPersistedPageSize } from '../features/pagination';
 import type { PaginationConfig } from '../features/pagination';
@@ -54,6 +56,7 @@ const resolveInitialPageSize = (
  * This provider:
  * - Manages client-controlled state (search, filters, sort, pagination, selection) via reducer.
  * - Uses React Query for data fetching with caching and deduplication.
+ * - Applies user filtering client-side after fetch, so the full creator list is always available.
  * - Combines client state with query data for a unified state interface.
  *
  * Note: Initial state is derived from `features.sorting`, `features.pagination`, and
@@ -103,8 +106,10 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
   const [clientState, dispatch] = useReducer(reducer, initialClientState);
 
   // Use React Query for data fetching - returns query data directly.
+  // Note: the query excludes `user` from the server request — user filtering
+  // is applied client-side below, matching the original `TableListView` pattern.
   const {
-    items,
+    items: unfilteredItems,
     totalItems,
     counts,
     isLoading,
@@ -112,6 +117,55 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
     error,
     refetch: queryRefetch,
   } = useContentListItemsQuery(clientState);
+
+  // Derive the full creator list from the unfiltered query result.
+  // This is computed before user filtering so the "Created by" filter popover
+  // always shows every creator, regardless of the active filter selection.
+  const allCreators: CreatorsList = useMemo(() => {
+    const uids = new Set<string>();
+    let hasNoCreator = false;
+    let hasManaged = false;
+
+    for (const item of unfilteredItems) {
+      if (item.managed) {
+        hasManaged = true;
+      } else if (item.createdBy) {
+        uids.add(item.createdBy);
+      } else {
+        hasNoCreator = true;
+      }
+    }
+
+    return { uids: Array.from(uids), hasNoCreator, hasManaged };
+  }, [unfilteredItems]);
+
+  // Apply user filter client-side using the deduplicated union of all UIDs
+  // from `user.uid` (UI-driven) and `user.query` (text-driven).
+  const userFilter = clientState.filters.user;
+  const items = useMemo(() => {
+    if (!userFilter) {
+      return unfilteredItems;
+    }
+
+    const allUids = new Set([...userFilter.uid, ...Object.values(userFilter.query).flat()]);
+
+    if (allUids.size === 0) {
+      return unfilteredItems;
+    }
+
+    return unfilteredItems.filter((item) => {
+      if (item.managed && allUids.has(MANAGED_USER_FILTER)) {
+        return true;
+      }
+      if (!item.createdBy && !item.managed && allUids.has(NO_CREATOR_USER_FILTER)) {
+        return true;
+      }
+      if (item.createdBy && allUids.has(item.createdBy)) {
+        return true;
+      }
+      return false;
+    });
+  }, [unfilteredItems, userFilter]);
 
   // Expose refetch for manual refresh.
   const refetch = useCallback(() => queryRefetch(), [queryRefetch]);
@@ -122,6 +176,7 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
       state: {
         ...clientState,
         items,
+        allCreators,
         totalItems,
         counts,
         isLoading,
@@ -131,7 +186,18 @@ export const ContentListStateProvider = ({ children }: ContentListStateProviderP
       dispatch,
       refetch,
     }),
-    [clientState, items, totalItems, counts, isLoading, isFetching, error, dispatch, refetch]
+    [
+      clientState,
+      items,
+      allCreators,
+      totalItems,
+      counts,
+      isLoading,
+      isFetching,
+      error,
+      dispatch,
+      refetch,
+    ]
   );
 
   return (

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.test.ts
@@ -302,6 +302,22 @@ describe('state_reducer', () => {
 
       expect(newState.selection.selectedIds).toEqual([]);
     });
+
+    it('preserves user filter when search changes', () => {
+      const userFilter = { uid: ['user-1', 'user-2'], query: {} };
+      const initialState = createInitialState({
+        filters: { search: 'old', user: userFilter },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_SEARCH,
+        payload: { queryText: 'new search', filters: { search: 'new search' } },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toEqual(userFilter);
+      expect(newState.filters.search).toBe('new search');
+    });
   });
 
   describe('CLEAR_FILTERS', () => {
@@ -375,6 +391,23 @@ describe('state_reducer', () => {
       const newState = reducer(initialState, action);
 
       expect(newState.selection.selectedIds).toEqual([]);
+    });
+
+    it('clears user filter when filters are cleared', () => {
+      const initialState = createInitialState({
+        filters: {
+          search: 'test',
+          user: { uid: ['user-1', 'user-2'], query: { 'Jane Doe': ['user-1'] } },
+        },
+        search: { queryText: 'test createdBy:jane@elastic.co' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.CLEAR_FILTERS,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toBeUndefined();
     });
   });
 
@@ -506,7 +539,7 @@ describe('state_reducer', () => {
         expect(newState.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
       });
 
-      it('works for non-tag filter dimensions', () => {
+      it('works for non-tag filter dimensions (custom)', () => {
         const initialState = createInitialState();
         const action: ContentListAction = {
           type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
@@ -520,7 +553,7 @@ describe('state_reducer', () => {
 
         const newState = reducer(initialState, action);
 
-        expect(newState.filters.type).toEqual({ include: ['dashboard'], exclude: [] });
+        expect(newState.filters.custom?.type).toEqual({ include: ['dashboard'], exclude: [] });
         expect(newState.filters.tag).toBeUndefined();
       });
     });
@@ -707,7 +740,10 @@ describe('state_reducer', () => {
 
       it('preserves other filter dimensions', () => {
         const initialState = createInitialState({
-          filters: { search: 'my query', type: { include: ['dashboard'], exclude: [] } },
+          filters: {
+            search: 'my query',
+            custom: { type: { include: ['dashboard'], exclude: [] } },
+          },
         });
         const action: ContentListAction = {
           type: CONTENT_LIST_ACTIONS.TOGGLE_FILTER,
@@ -722,7 +758,7 @@ describe('state_reducer', () => {
         const newState = reducer(initialState, action);
 
         expect(newState.filters.search).toBe('my query');
-        expect(newState.filters.type).toEqual({ include: ['dashboard'], exclude: [] });
+        expect(newState.filters.custom?.type).toEqual({ include: ['dashboard'], exclude: [] });
       });
     });
 
@@ -752,6 +788,343 @@ describe('state_reducer', () => {
 
         parseSpy.mockRestore();
       });
+    });
+  });
+
+  describe('TOGGLE_USER_FILTER', () => {
+    it('adds a user to filters.user.uid when not active', () => {
+      const initialState = createInitialState();
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toEqual({ uid: ['user-1'], query: {} });
+    });
+
+    it('removes a user from filters.user.uid when already active', () => {
+      const initialState = createInitialState({
+        filters: { user: { uid: ['user-1', 'user-2'], query: {} } },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toEqual({ uid: ['user-2'], query: {} });
+    });
+
+    it('clears filters.user when last user is removed and no text queries exist', () => {
+      const initialState = createInitialState({
+        filters: { user: { uid: ['user-1'], query: {} } },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toBeUndefined();
+    });
+
+    it('preserves text queries when toggling uid', () => {
+      const initialState = createInitialState({
+        filters: {
+          user: { uid: ['user-1'], query: { 'Jane Doe': ['user-1'] } },
+        },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.user).toEqual({
+        uid: [],
+        query: { 'Jane Doe': ['user-1'] },
+      });
+    });
+
+    it('updates query text with createdBy clause when adding user', () => {
+      const initialState = createInitialState({
+        search: { queryText: 'dashboard' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toContain('createdBy');
+      expect(newState.search.queryText).toContain('jane@elastic.co');
+    });
+
+    it('removes createdBy clause from query text when removing user', () => {
+      const initialState = createInitialState({
+        search: { queryText: 'dashboard createdBy:(jane@elastic.co)' },
+        filters: { user: { uid: ['user-1'], query: {} } },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).not.toContain('jane@elastic.co');
+    });
+
+    it('resets page index to 0', () => {
+      const initialState = createInitialState({
+        page: { index: 3, size: 20 },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.page.index).toBe(0);
+      expect(newState.page.size).toBe(20);
+    });
+
+    it('clears selection', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
+
+    it('preserves query text on parse failure', () => {
+      const parseSpy = jest.spyOn(Query, 'parse').mockImplementation(() => {
+        throw new Error('parse error');
+      });
+
+      const initialState = createInitialState({
+        search: { queryText: 'some broken query' },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.search.queryText).toBe('some broken query');
+      expect(newState.filters.user).toEqual({ uid: ['user-1'], query: {} });
+
+      parseSpy.mockRestore();
+    });
+
+    it('preserves other filters when toggling user', () => {
+      const initialState = createInitialState({
+        filters: {
+          search: 'dashboard',
+          tag: { include: ['tag-1'], exclude: [] },
+        },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER,
+        payload: { uid: 'user-1', queryValue: 'jane@elastic.co' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters.search).toBe('dashboard');
+      expect(newState.filters.tag).toEqual({ include: ['tag-1'], exclude: [] });
+      expect(newState.filters.user).toEqual({ uid: ['user-1'], query: {} });
+    });
+  });
+
+  describe('SET_FILTERS', () => {
+    it('sets filters', () => {
+      const initialState = createInitialState();
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'hello', user: userFilter },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'hello', user: userFilter });
+    });
+
+    it('replaces existing filters', () => {
+      const initialState = createInitialState({
+        filters: { search: 'old', user: { uid: ['user-1'], query: {} } },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'new' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'new' });
+    });
+
+    it('preserves sort when setting filters', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { user: userFilter },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('clears selection when filters change', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { user: userFilter },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
+
+    it('resets page index to 0 when filters change', () => {
+      const initialState = createInitialState({
+        page: { index: 3, size: 20 },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { search: 'new' },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.page.index).toBe(0);
+      expect(newState.page.size).toBe(20);
+    });
+
+    it('returns a new state object', () => {
+      const initialState = createInitialState();
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_FILTERS,
+        payload: { user: userFilter },
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
+    });
+  });
+
+  describe('SET_USER_FILTER', () => {
+    it('sets user filter while preserving other filters', () => {
+      const initialState = createInitialState({
+        filters: { search: 'dashboard' },
+      });
+      const userFilter = { uid: ['user-1', 'user-2'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'dashboard', user: userFilter });
+    });
+
+    it('clears user filter when payload is undefined', () => {
+      const initialState = createInitialState({
+        filters: { search: 'dashboard', user: { uid: ['user-1'], query: {} } },
+      });
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: undefined,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.filters).toEqual({ search: 'dashboard', user: undefined });
+    });
+
+    it('preserves sort when setting user filter', () => {
+      const initialState = createInitialState({
+        sort: { field: 'title', direction: 'asc' },
+      });
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.sort).toEqual({ field: 'title', direction: 'asc' });
+    });
+
+    it('clears selection when user filter changes', () => {
+      const initialState = createInitialState({
+        selection: { selectedIds: ['1', '2'] },
+      });
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.selection.selectedIds).toEqual([]);
+    });
+
+    it('resets page index to 0 when user filter changes', () => {
+      const initialState = createInitialState({
+        page: { index: 3, size: 20 },
+      });
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.page.index).toBe(0);
+      expect(newState.page.size).toBe(20);
+    });
+
+    it('returns a new state object', () => {
+      const initialState = createInitialState();
+      const userFilter = { uid: ['user-1'], query: {} };
+      const action: ContentListAction = {
+        type: CONTENT_LIST_ACTIONS.SET_USER_FILTER,
+        payload: userFilter,
+      };
+
+      const newState = reducer(initialState, action);
+
+      expect(newState).not.toBe(initialState);
     });
   });
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/state_reducer.ts
@@ -9,7 +9,7 @@
 
 import { Query } from '@elastic/eui';
 import type { IncludeExcludeFilter, ActiveFilters } from '../datasource';
-import { getIncludeExcludeFilter } from '../datasource';
+import { TAG_FILTER_ID } from '../datasource';
 import type { ContentListClientState, ContentListAction } from './types';
 import { CONTENT_LIST_ACTIONS, DEFAULT_FILTERS } from './types';
 
@@ -19,6 +19,37 @@ const normalizeIncludeExclude = (
   exclude: string[]
 ): IncludeExcludeFilter | undefined =>
   include.length === 0 && exclude.length === 0 ? undefined : { include, exclude };
+
+/**
+ * Read the current {@link IncludeExcludeFilter} for a filter dimension,
+ * routing to `filters.tag` for the built-in tag filter and to
+ * `filters.custom[filterId]` for plugin-provided dimensions.
+ */
+const readFilterDimension = (
+  filters: ActiveFilters,
+  filterId: string
+): IncludeExcludeFilter | undefined =>
+  filterId === TAG_FILTER_ID ? filters.tag : filters.custom?.[filterId];
+
+/**
+ * Write an updated {@link IncludeExcludeFilter} for a filter dimension,
+ * routing to `filters.tag` or `filters.custom[filterId]`.
+ */
+const writeFilterDimension = (
+  filters: ActiveFilters,
+  filterId: string,
+  value: IncludeExcludeFilter | undefined
+): ActiveFilters => {
+  if (filterId === TAG_FILTER_ID) {
+    return { ...filters, tag: value };
+  }
+  const { [filterId]: _, ...restCustom } = filters.custom ?? {};
+  const nextCustom = value ? { ...restCustom, [filterId]: value } : restCustom;
+  return {
+    ...filters,
+    custom: Object.keys(nextCustom).length > 0 ? nextCustom : undefined,
+  };
+};
 
 /**
  * Default selection state.
@@ -49,7 +80,7 @@ export const reducer = (
       return {
         ...state,
         search: { queryText: action.payload.queryText },
-        filters: action.payload.filters,
+        filters: { ...action.payload.filters, user: state.filters.user },
         page: { ...state.page, index: 0 },
         selection: { ...DEFAULT_SELECTION },
       };
@@ -57,7 +88,7 @@ export const reducer = (
     case CONTENT_LIST_ACTIONS.TOGGLE_FILTER: {
       const { filterId, valueId, valueName, withModifierKey } = action.payload;
       const { filters, search } = state;
-      const existingFilter = getIncludeExcludeFilter(filters[filterId]);
+      const existingFilter = readFilterDimension(filters, filterId);
       const currentInclude = existingFilter?.include ?? [];
       const currentExclude = existingFilter?.exclude ?? [];
 
@@ -79,10 +110,7 @@ export const reducer = (
       }
 
       const nextFilterValue = normalizeIncludeExclude(nextInclude, nextExclude);
-      const { [filterId]: _, ...rest } = filters;
-      const nextFilters: ActiveFilters = nextFilterValue
-        ? { ...rest, [filterId]: nextFilterValue }
-        : rest;
+      const nextFilters = writeFilterDimension(filters, filterId, nextFilterValue);
 
       let nextQueryText = search.queryText;
       try {
@@ -116,6 +144,77 @@ export const reducer = (
         ...state,
         filters: { ...DEFAULT_FILTERS },
         search: { queryText: '' },
+        page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
+      };
+
+    case CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER: {
+      const { uid, queryValue } = action.payload;
+      const currentUids = state.filters.user?.uid ?? [];
+      const isActive = currentUids.includes(uid);
+
+      const nextUid = isActive ? currentUids.filter((u) => u !== uid) : [...currentUids, uid];
+
+      const currentQuery = state.filters.user?.query ?? {};
+      const hasActiveUids = nextUid.length > 0 || Object.keys(currentQuery).length > 0;
+      const nextUserFilter = hasActiveUids ? { uid: nextUid, query: currentQuery } : undefined;
+
+      let nextQueryText = state.search.queryText;
+      try {
+        let nextQuery = nextQueryText ? Query.parse(nextQueryText) : Query.parse('');
+
+        const existing = new Set<string>();
+        const clauses = nextQuery.ast.getFieldClauses('createdBy');
+        if (clauses) {
+          for (const clause of clauses) {
+            const vs = Array.isArray(clause.value) ? clause.value : [clause.value];
+            vs.forEach((v) => existing.add(String(v)));
+          }
+        }
+
+        nextQuery = nextQuery
+          .removeSimpleFieldClauses('createdBy')
+          .removeOrFieldClauses('createdBy');
+
+        if (isActive) {
+          existing.delete(queryValue);
+        } else {
+          existing.add(queryValue);
+        }
+
+        for (const v of existing) {
+          nextQuery = nextQuery.addOrFieldValue('createdBy', v, true, 'eq');
+        }
+
+        nextQueryText = nextQuery.text;
+      } catch {
+        // Preserve query text on parse failure.
+      }
+
+      return {
+        ...state,
+        search: { queryText: nextQueryText },
+        filters: { ...state.filters, user: nextUserFilter },
+        page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
+      };
+    }
+
+    case CONTENT_LIST_ACTIONS.SET_USER_FILTER:
+      return {
+        ...state,
+        filters: {
+          ...state.filters,
+          user: action.payload,
+        },
+        page: { ...state.page, index: 0 },
+        selection: { ...DEFAULT_SELECTION },
+      };
+
+    case CONTENT_LIST_ACTIONS.SET_FILTERS:
+      return {
+        ...state,
+        filters: action.payload,
         page: { ...state.page, index: 0 },
         selection: { ...DEFAULT_SELECTION },
       };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/types.ts
@@ -8,8 +8,9 @@
  */
 
 import type { Dispatch } from 'react';
-import type { ActiveFilters, FilterCounts } from '../datasource';
+import type { ActiveFilters, FilterCounts, UserFilter } from '../datasource';
 import type { ContentListItem } from '../item';
+import type { CreatorsList } from '../features';
 
 /**
  * Action type constants for state reducer.
@@ -21,6 +22,12 @@ export const CONTENT_LIST_ACTIONS = {
   CLEAR_FILTERS: 'CLEAR_FILTERS',
   /** Toggle a value's include/exclude state for any filter dimension, updating filters and query text atomically. */
   TOGGLE_FILTER: 'TOGGLE_FILTER',
+  /** Update only the `user` portion of `ActiveFilters`. */
+  SET_USER_FILTER: 'SET_USER_FILTER',
+  /** Toggle a single user's email in the query text, updating the `createdBy` clause atomically. */
+  TOGGLE_USER_FILTER: 'TOGGLE_USER_FILTER',
+  /** Replace the entire `ActiveFilters` object. */
+  SET_FILTERS: 'SET_FILTERS',
   /** Set sort field and direction. */
   SET_SORT: 'SET_SORT',
   /** Set page index. */
@@ -34,9 +41,7 @@ export const CONTENT_LIST_ACTIONS = {
 /**
  * Default filter state.
  */
-export const DEFAULT_FILTERS: ActiveFilters = {
-  search: undefined,
-};
+export const DEFAULT_FILTERS: ActiveFilters = {};
 
 /**
  * Client-controlled state managed by the reducer.
@@ -59,7 +64,8 @@ export interface ContentListClientState {
    * Always updated atomically with `search.queryText` via `SET_SEARCH`.
    * When no tag service is configured, `filters.search` equals `search.queryText`.
    * When tag parsing is available, `filters.search` contains only the free-text
-   * portion and `filters.tag`, `filters.type`, etc. hold structured filters.
+   * portion and `filters.tag`, `filters.custom`, etc. hold structured filters.
+   * The `user` field is always applied client-side and never sent to the server.
    */
   filters: ActiveFilters;
   /** Sort state. */
@@ -89,8 +95,15 @@ export interface ContentListClientState {
  * This is read-only state derived from the data fetching layer.
  */
 export interface ContentListQueryData {
-  /** Currently loaded items (transformed for rendering). */
+  /** Currently loaded items (after client-side user filtering). */
   items: ContentListItem[];
+  /**
+   * Summary of all unique creators from the unfiltered query result.
+   *
+   * Derived before client-side user filtering so the creator list shown in
+   * the filter popover never shrinks when a filter is active.
+   */
+  allCreators: CreatorsList;
   /** Total number of items matching the current query (for pagination). */
   totalItems: number;
   /**
@@ -152,6 +165,31 @@ interface ToggleFilterAction {
   payload: { filterId: string; valueId: string; valueName: string; withModifierKey: boolean };
 }
 
+/** Update only the `user` portion of active filters. */
+interface SetUserFilterAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_USER_FILTER;
+  payload: UserFilter | undefined;
+}
+
+/**
+ * Toggle a single user's email in the `createdBy` query clause.
+ *
+ * Checks whether `uid` is present in `filters.user.uid` to decide add vs remove.
+ * Updates both `search.queryText` and `filters.user` atomically.
+ * The renderer's `useEffect` syncs `filters.user` again when the query prop changes,
+ * but the reducer sets it directly so client-side filtering reflects immediately.
+ */
+interface ToggleUserFilterAction {
+  type: typeof CONTENT_LIST_ACTIONS.TOGGLE_USER_FILTER;
+  payload: { uid: string; queryValue: string };
+}
+
+/** Replace the entire active filters object. */
+interface SetFiltersAction {
+  type: typeof CONTENT_LIST_ACTIONS.SET_FILTERS;
+  payload: ActiveFilters;
+}
+
 /** Set sort field and direction. */
 interface SetSortAction {
   type: typeof CONTENT_LIST_ACTIONS.SET_SORT;
@@ -167,6 +205,9 @@ export type ContentListAction =
   | SetSearchAction
   | ClearFiltersAction
   | ToggleFilterAction
+  | SetUserFilterAction
+  | ToggleUserFilterAction
+  | SetFiltersAction
   | SetSortAction
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_INDEX; payload: { index: number } }
   | { type: typeof CONTENT_LIST_ACTIONS.SET_PAGE_SIZE; payload: { size: number } }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/src/state/use_content_list_items.ts
@@ -38,6 +38,7 @@ export const useContentListItems = () => {
 
   return {
     items: state.items,
+    allCreators: state.allCreators,
     totalItems: state.totalItems,
     counts: state.counts,
     isLoading: state.isLoading,

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-provider/tsconfig.json
@@ -15,6 +15,8 @@
     "@kbn/content-list-mock-data",
     "@kbn/i18n",
     "@kbn/content-management-tags",
-    "@kbn/content-management-favorites-public"
+    "@kbn/content-management-favorites-public",
+    "@kbn/content-management-user-profiles",
+    "@kbn/user-profile-components",
   ]
 }

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/index.ts
@@ -44,6 +44,10 @@ export {
   type StarredColumnProps,
   type StarredCellProps,
   type StarButtonProps,
+  CreatedByColumn,
+  CreatedByCell,
+  type CreatedByColumnProps,
+  type CreatedByCellProps,
 } from './src/column';
 export type { ColumnNamespace, ColumnProps } from './src/column';
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/moon.yml
@@ -26,6 +26,8 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/i18n-react'
   - '@kbn/content-list-toolbar'
+  - '@kbn/user-profile-components'
+  - '@kbn/content-management-user-profiles'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/delete/delete_action.test.tsx
@@ -28,6 +28,7 @@ const defaultContext: ActionBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    createdBy: false,
   },
   actions: { onDelete },
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/action/edit/edit_action.test.tsx
@@ -24,6 +24,7 @@ const defaultContext: ActionBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    createdBy: false,
   },
 };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/actions/actions_builder.test.tsx
@@ -33,6 +33,7 @@ const defaultContext: ColumnBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    createdBy: false,
   },
 };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ColumnBuilderContext } from '../types';
+import { buildCreatedByColumn, type CreatedByColumnProps } from './created_by_builder';
+
+/** The column returned by `buildCreatedByColumn` is always a field column with a render function. */
+type CreatedByColumn = EuiTableFieldDataColumnType<ContentListItem>;
+
+const defaultContext: ColumnBuilderContext = {
+  itemConfig: undefined,
+  isReadOnly: false,
+  entityName: 'dashboard',
+  supports: {
+    sorting: true,
+    pagination: false,
+    search: false,
+    selection: false,
+    tags: false,
+    createdBy: true,
+  },
+};
+
+describe('created by column builder', () => {
+  describe('buildCreatedByColumn', () => {
+    it('returns a column with defaults when props are empty', () => {
+      const result = buildCreatedByColumn({}, defaultContext);
+
+      expect(result).toMatchObject({
+        field: 'createdBy',
+        name: 'Created by',
+        sortable: false,
+        'data-test-subj': 'content-list-table-column-createdBy',
+      });
+    });
+
+    it('uses custom column title', () => {
+      const props: CreatedByColumnProps = { columnTitle: 'Author' };
+      const result = buildCreatedByColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ name: 'Author' });
+    });
+
+    it('applies custom width', () => {
+      const props: CreatedByColumnProps = { width: '200px' };
+      const result = buildCreatedByColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ width: '200px' });
+    });
+
+    it('does not include width when not specified', () => {
+      const result = buildCreatedByColumn({}, defaultContext);
+      expect(result).not.toHaveProperty('width');
+    });
+
+    it('defaults sortable to false', () => {
+      const result = buildCreatedByColumn({}, defaultContext);
+      expect(result).toMatchObject({ sortable: false });
+    });
+
+    it('respects sortable true when sorting is supported', () => {
+      const props: CreatedByColumnProps = { sortable: true };
+      const result = buildCreatedByColumn(props, defaultContext);
+
+      expect(result).toMatchObject({ sortable: true });
+    });
+
+    it('forces sortable false when sorting is unsupported', () => {
+      const context: ColumnBuilderContext = {
+        ...defaultContext,
+        supports: {
+          sorting: false,
+          pagination: false,
+          search: false,
+          selection: false,
+          tags: false,
+          createdBy: true,
+        },
+      };
+      const props: CreatedByColumnProps = { sortable: true };
+
+      const result = buildCreatedByColumn(props, context);
+
+      expect(result).toMatchObject({ sortable: false });
+    });
+
+    it('provides a render function', () => {
+      const result = buildCreatedByColumn({}, defaultContext) as CreatedByColumn;
+      expect(result.render).toBeInstanceOf(Function);
+    });
+
+    it('render function returns a React element', () => {
+      const result = buildCreatedByColumn({}, defaultContext) as CreatedByColumn;
+      const item: ContentListItem = { id: '1', title: 'Test', createdBy: 'user-1' };
+      const element = result.render?.('user-1', item);
+
+      expect(React.isValidElement(element)).toBe(true);
+    });
+
+    it('passes entityName and entityNamePlural to CreatedByCell via render', () => {
+      const context: ColumnBuilderContext = {
+        ...defaultContext,
+        entityName: 'visualization',
+        entityNamePlural: 'visualizations',
+      };
+      const result = buildCreatedByColumn({}, context) as CreatedByColumn;
+      const item: ContentListItem = { id: '1', title: 'Test', managed: true };
+      const element = result.render?.('', item);
+
+      expect(React.isValidElement(element)).toBe(true);
+      expect((element as React.ReactElement).props).toMatchObject({
+        entityName: 'visualization',
+        entityNamePlural: 'visualizations',
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_builder.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { ContentListItem } from '@kbn/content-list-provider';
+import type { ColumnBuilderContext } from '../types';
+import { column } from '../part';
+import { CreatedByCell } from './created_by_cell';
+
+/** Default i18n-translated column title for the created by column. */
+const DEFAULT_CREATED_BY_COLUMN_TITLE = i18n.translate(
+  'contentManagement.contentList.table.column.createdBy.title',
+  { defaultMessage: 'Created by' }
+);
+
+/**
+ * Props for the `Column.CreatedBy` preset component.
+ */
+export interface CreatedByColumnProps {
+  /** Column width (CSS value like `'200px'` or `'40%'`). */
+  width?: string;
+  /** Custom column title. Defaults to `'Created by'`. */
+  columnTitle?: string;
+  /** Whether the column is sortable. @default false */
+  sortable?: boolean;
+}
+
+/**
+ * Build an `EuiBasicTableColumn` from `Column.CreatedBy` declarative attributes.
+ *
+ * @param attributes - The declarative attributes from the parsed `Column.CreatedBy` element.
+ * @param context - Builder context with provider configuration.
+ * @returns An `EuiBasicTableColumn<ContentListItem>` for the created-by column.
+ */
+export const buildCreatedByColumn = (
+  attributes: CreatedByColumnProps,
+  context: ColumnBuilderContext
+): EuiBasicTableColumn<ContentListItem> => {
+  const { columnTitle, width, sortable: sortableProp } = attributes;
+
+  const supportsSorting = context.supports?.sorting ?? true;
+  const sortable = supportsSorting ? sortableProp ?? false : false;
+
+  return {
+    field: 'createdBy',
+    name: columnTitle ?? DEFAULT_CREATED_BY_COLUMN_TITLE,
+    sortable,
+    ...(width && { width }),
+    'data-test-subj': 'content-list-table-column-createdBy',
+    render: (_value: unknown, item: ContentListItem) => (
+      <CreatedByCell
+        item={item}
+        entityName={context.entityName}
+        entityNamePlural={context.entityNamePlural}
+      />
+    ),
+  };
+};
+
+/**
+ * Created by column specification component for `ContentListTable`.
+ *
+ * This is a declarative component that renders nothing — it tells the
+ * `ContentListTable` to include a "Created by" column displaying user avatars,
+ * the Elastic managed icon, or a "no creator" tip.
+ *
+ * Requires `services.userProfile` on the `ContentListProvider` for avatar resolution.
+ *
+ * @example Basic usage
+ * ```tsx
+ * const { Column } = ContentListTable;
+ *
+ * <ContentListTable title="Dashboards">
+ *   <Column.Name />
+ *   <Column.CreatedBy />
+ * </ContentListTable>
+ * ```
+ *
+ * @example With custom width
+ * ```tsx
+ * <Column.CreatedBy width="150px" />
+ * ```
+ */
+export const CreatedByColumn = column.createPreset({
+  name: 'createdBy',
+  resolve: buildCreatedByColumn,
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_cell.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_cell.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { UserProfile } from '@kbn/user-profile-components';
+import {
+  ContentListProvider,
+  type FindItemsResult,
+  type FindItemsParams,
+  type ContentListItem,
+  type UserProfileService,
+} from '@kbn/content-list-provider';
+import { CreatedByCell } from './created_by_cell';
+
+const mockProfile: UserProfile = {
+  uid: 'user-1',
+  enabled: true,
+  user: {
+    username: 'jdoe',
+    full_name: 'Jane Doe',
+    email: 'jdoe@elastic.co',
+  },
+  data: {
+    avatar: { imageUrl: '', initials: 'JD', color: '#FF0000' },
+  },
+};
+
+const mockUserProfileService: UserProfileService = {
+  getUserProfile: jest.fn(async () => mockProfile),
+  bulkGetUserProfiles: jest.fn(async () => [mockProfile]),
+};
+
+const mockFindItems = jest.fn(
+  async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+    items: [],
+    total: 0,
+  })
+);
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ContentListProvider
+    id="test-list"
+    labels={{ entity: 'item', entityPlural: 'items' }}
+    dataSource={{ findItems: mockFindItems }}
+    services={{ userProfile: mockUserProfileService }}
+  >
+    {children}
+  </ContentListProvider>
+);
+
+const createItem = (overrides?: Partial<ContentListItem>): ContentListItem => ({
+  id: '1',
+  title: 'Test Item',
+  ...overrides,
+});
+
+describe('CreatedByCell', () => {
+  it('renders ManagedAvatarTip for managed items', () => {
+    render(
+      <Wrapper>
+        <CreatedByCell item={createItem({ managed: true })} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('managedAvatarTip')).toBeInTheDocument();
+  });
+
+  it('renders UserAvatarTip for items with createdBy', async () => {
+    render(
+      <Wrapper>
+        <CreatedByCell item={createItem({ createdBy: 'user-1' })} />
+      </Wrapper>
+    );
+
+    // The `UserAvatarTip` fetches the profile asynchronously.
+    const avatar = await screen.findByTestId('userAvatarTip-jdoe');
+    expect(avatar).toBeInTheDocument();
+  });
+
+  it('renders NoCreatorTip for items without createdBy and not managed', () => {
+    render(
+      <Wrapper>
+        <CreatedByCell item={createItem()} />
+      </Wrapper>
+    );
+
+    // `NoCreatorTip` renders an `EuiIconTip` with "Additional information" text.
+    expect(screen.getByText('Additional information')).toBeInTheDocument();
+  });
+
+  it('prioritizes managed over createdBy', () => {
+    render(
+      <Wrapper>
+        <CreatedByCell item={createItem({ managed: true, createdBy: 'user-1' })} />
+      </Wrapper>
+    );
+
+    // Managed flag takes priority.
+    expect(screen.getByTestId('managedAvatarTip')).toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_cell.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/created_by_cell.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { memo, useCallback } from 'react';
+import { css } from '@emotion/react';
+import {
+  UserAvatarTip,
+  ManagedAvatarTip,
+  NoCreatorTip,
+  useUserProfile,
+} from '@kbn/content-management-user-profiles';
+import {
+  useUserFilterToggle,
+  MANAGED_USER_FILTER,
+  type ContentListItem,
+} from '@kbn/content-list-provider';
+
+const avatarButtonStyles = css`
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  line-height: 0;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+/**
+ * Props for the {@link CreatedByCell} component.
+ */
+export interface CreatedByCellProps {
+  /** The content list item to render the creator for. */
+  item: ContentListItem;
+  /**
+   * Entity name for display in the managed/no-creator tooltips.
+   * Passed through to `ManagedAvatarTip` and `NoCreatorTip`.
+   */
+  entityName?: string;
+  /**
+   * Plural entity name for display in the no-creator tooltip.
+   * Passed through to `NoCreatorTip`.
+   */
+  entityNamePlural?: string;
+}
+
+/**
+ * Clickable user avatar that toggles the created-by filter on click.
+ *
+ * Fetches the user profile to resolve the email for the query bar display value.
+ * Uses `useUserProfile`, which is deduplicated and cached via React Query.
+ */
+const ClickableUserAvatar = memo(
+  ({ uid, toggle }: { uid: string; toggle: (uid: string, queryValue: string) => void }) => {
+    const profileQuery = useUserProfile(uid);
+    const queryValue = profileQuery.data?.user.email ?? profileQuery.data?.user.username ?? uid;
+
+    const handleClick = useCallback(() => {
+      toggle(uid, queryValue);
+    }, [uid, queryValue, toggle]);
+
+    return (
+      <button type="button" css={avatarButtonStyles} onClick={handleClick}>
+        <UserAvatarTip uid={uid} />
+      </button>
+    );
+  }
+);
+
+ClickableUserAvatar.displayName = 'ClickableUserAvatar';
+
+/**
+ * Clickable managed avatar that toggles the managed filter on click.
+ */
+const ClickableManagedAvatar = memo(
+  ({
+    entityName,
+    toggle,
+  }: {
+    entityName?: string;
+    toggle: (uid: string, queryValue: string) => void;
+  }) => {
+    const handleClick = useCallback(() => {
+      toggle(MANAGED_USER_FILTER, 'managed');
+    }, [toggle]);
+
+    return (
+      <button type="button" css={avatarButtonStyles} onClick={handleClick}>
+        <ManagedAvatarTip {...{ entityName }} />
+      </button>
+    );
+  }
+);
+
+ClickableManagedAvatar.displayName = 'ClickableManagedAvatar';
+
+/**
+ * Renders the appropriate avatar or tip for a content list item's creator.
+ *
+ * - **Managed items**: Shows the Elastic logo (`ManagedAvatarTip`).
+ * - **Items with a `createdBy` uid**: Shows the user's avatar (`UserAvatarTip`).
+ * - **Items without a creator**: Shows an info tip (`NoCreatorTip`).
+ *
+ * When created-by filtering is supported, clicking the avatar toggles a user
+ * filter — the same behavior tags have in the name cell. The query bar updates
+ * to show `createdBy:(email)`.
+ *
+ * Requires `UserProfilesProvider` to be an ancestor in the component tree.
+ * This is automatically provided by `ContentListProvider` when `services.userProfile`
+ * is configured.
+ */
+export const CreatedByCell = memo(({ item, entityName, entityNamePlural }: CreatedByCellProps) => {
+  const { createdBy, managed } = item;
+  const toggleUser = useUserFilterToggle();
+
+  if (managed) {
+    if (toggleUser) {
+      return <ClickableManagedAvatar {...{ entityName, toggle: toggleUser }} />;
+    }
+    return <ManagedAvatarTip {...{ entityName }} />;
+  }
+
+  if (createdBy) {
+    if (toggleUser) {
+      return <ClickableUserAvatar uid={createdBy} toggle={toggleUser} />;
+    }
+    return <UserAvatarTip uid={createdBy} />;
+  }
+
+  return <NoCreatorTip {...{ entityNamePlural }} />;
+});
+
+CreatedByCell.displayName = 'CreatedByCell';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/created_by/index.ts
@@ -7,14 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  IncludeExcludeFilter,
-  UserFilter,
-  FilterCounts,
-  ActiveFilters,
-  FindItemsParams,
-  FindItemsResult,
-  FindItemsFn,
-  DataSourceConfig,
-} from './types';
-export { getIncludeExcludeFilter, TAG_FILTER_ID } from './types';
+export {
+  CreatedByColumn,
+  buildCreatedByColumn,
+  type CreatedByColumnProps,
+} from './created_by_builder';
+export { CreatedByCell, type CreatedByCellProps } from './created_by_cell';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/index.ts
@@ -32,6 +32,12 @@ export {
   StarButton,
   type StarButtonProps,
 } from './starred';
+export {
+  CreatedByColumn,
+  type CreatedByColumnProps,
+  CreatedByCell,
+  type CreatedByCellProps,
+} from './created_by';
 
 // Namespace type for TypeScript typing of `Column`.
 export type { ColumnNamespace } from './part';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/name/name_builder.test.tsx
@@ -27,6 +27,7 @@ const defaultContext: ColumnBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    createdBy: false,
   },
 };
 
@@ -79,6 +80,7 @@ describe('name column builder', () => {
           selection: true,
           tags: false,
           starred: false,
+          createdBy: false,
         },
       };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/part.ts
@@ -16,6 +16,7 @@ import type { NameColumnProps } from './name/name_builder';
 import type { UpdatedAtColumnProps } from './updated_at/updated_at_builder';
 import type { ActionsColumnProps } from './actions/actions_builder';
 import type { StarredColumnProps } from './starred/starred_builder';
+import type { CreatedByColumnProps } from './created_by/created_by_builder';
 
 /**
  * Props for the `Column` component (custom columns).
@@ -49,7 +50,7 @@ export interface ColumnProps {
  * Namespace interface for `Column` sub-components.
  *
  * The base `Column` accepts {@link ColumnProps}; pre-built columns
- * are properties (e.g., `Column.Name`, `Column.Actions`).
+ * are properties (e.g., `Column.Name`, `Column.Actions`, `Column.CreatedBy`).
  */
 export interface ColumnNamespace {
   (props: ColumnProps): ReactNode;
@@ -62,6 +63,7 @@ export interface ColumnNamespace {
    * @param props - {@link StarredColumnProps}
    */
   Starred: (props: StarredColumnProps) => ReactNode;
+  CreatedBy: (props: CreatedByColumnProps) => ReactNode;
 }
 
 /** Preset-to-props mapping for table columns. */
@@ -70,6 +72,7 @@ export interface ColumnPresets {
   updatedAt: UpdatedAtColumnProps;
   actions: ActionsColumnProps;
   starred: StarredColumnProps;
+  createdBy: CreatedByColumnProps;
 }
 
 /** Part factory for table columns. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/types.ts
@@ -36,6 +36,8 @@ export interface BuilderContext {
   isReadOnly?: boolean;
   /** Entity name for display in tooltips and messages. */
   entityName?: string;
+  /** Plural entity name for display in tooltips and messages. */
+  entityNamePlural?: string;
   /** Feature support flags from the provider. */
   supports?: ContentListSupports;
   /** Callbacks for action orchestration. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/column/updated_at/updated_at_builder.test.tsx
@@ -29,6 +29,7 @@ const defaultContext: ColumnBuilderContext = {
     selection: true,
     tags: false,
     starred: false,
+    createdBy: false,
   },
 };
 
@@ -81,6 +82,7 @@ describe('updated at column builder', () => {
           selection: true,
           tags: false,
           starred: false,
+          createdBy: false,
         },
       };
 

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.stories.tsx
@@ -47,6 +47,7 @@ import {
   createMockFindItems,
   extractTagIds,
   mockTagsService,
+  mockUserProfileServices,
 } from '@kbn/content-list-mock-data/storybook';
 import { ContentListTable } from './content_list_table';
 
@@ -61,6 +62,9 @@ import { ContentListTable } from './content_list_table';
  * - Sorting (locale-aware for strings).
  * - Configurable delay for loading states.
  * - Empty state simulation.
+ *
+ * Note: user filtering is applied client-side by the provider, so `findItems`
+ * never receives `users` in its filter params.
  */
 const createStoryFindItems = (options?: {
   items?: typeof MOCK_DASHBOARDS;
@@ -98,6 +102,8 @@ const createStoryFindItems = (options?: {
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
         tags: extractTagIds(item.references),
+        createdBy: item.createdBy,
+        managed: (item as { managed?: boolean }).managed,
       })),
       total: result.total,
       counts: result.counts,
@@ -389,10 +395,12 @@ interface PlaygroundArgs {
   isReadOnly: boolean;
   hasPagination: boolean;
   hasTags: boolean;
+  hasCreatedByColumn: boolean;
   compressed: boolean;
   tableLayout: 'auto' | 'fixed';
   showDescription: boolean;
   showTags: boolean;
+  showCreatedByColumn: boolean;
   showTypeColumn: boolean;
   showActions: boolean;
   showCustomActions: boolean;
@@ -478,6 +486,17 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
     [addToast]
   );
 
+  const services: ContentListServices | undefined = useMemo(() => {
+    const svc: ContentListServices = {};
+    if (args.hasTags) {
+      svc.tags = mockTagsService;
+    }
+    if (args.hasCreatedByColumn) {
+      svc.userProfile = mockUserProfileServices;
+    }
+    return Object.keys(svc).length > 0 ? svc : undefined;
+  }, [args.hasTags, args.hasCreatedByColumn]);
+
   // Build a display element representing the consumer-facing JSX.
   // `toJsx()` (inside `StateDiagnosticPanel`) serializes it automatically.
   const displayElement = useMemo(
@@ -489,6 +508,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
       >
         <Column.Name showDescription={args.showDescription} showTags={args.showTags} />
         <Column.UpdatedAt />
+        {args.showCreatedByColumn && <Column.CreatedBy />}
         {args.showTypeColumn && (
           <Column
             id="type"
@@ -531,6 +551,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
       args.tableLayout,
       args.showDescription,
       args.showTags,
+      args.showCreatedByColumn,
       args.showTypeColumn,
       args.showActions,
       args.showCustomActions,
@@ -539,13 +560,8 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
     ]
   );
 
-  const services: ContentListServices | undefined = useMemo(
-    () => (args.hasTags ? { tags: mockTagsService } : undefined),
-    [args.hasTags]
-  );
-
   // Key forces re-mount when configuration changes.
-  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.hasTags}-${args.showActions}-${args.showSelection}`;
+  const key = `${args.hasItems}-${args.isLoading}-${args.isReadOnly}-${args.hasPagination}-${args.hasTags}-${args.hasCreatedByColumn}-${args.showActions}-${args.showSelection}`;
 
   return (
     <>
@@ -563,6 +579,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
           pagination: args.hasPagination ? { initialPageSize: 10 } : (false as const),
           selection: args.showSelection,
           tags: args.hasTags,
+          createdBy: args.hasCreatedByColumn,
         }}
         services={services}
       >
@@ -576,6 +593,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
           >
             <Column.Name showDescription={args.showDescription} showTags={args.showTags} />
             <Column.UpdatedAt />
+            {args.showCreatedByColumn && <Column.CreatedBy />}
             {args.showTypeColumn && (
               <Column
                 id="type"
@@ -636,6 +654,7 @@ export const Table: PlaygroundStory = {
     isReadOnly: false,
     hasPagination: true,
     hasTags: true,
+    hasCreatedByColumn: true,
     showTypeColumn: false,
     showActions: true,
     showCustomActions: false,
@@ -643,6 +662,7 @@ export const Table: PlaygroundStory = {
     hasClickableRows: true,
     showDescription: true,
     showTags: true,
+    showCreatedByColumn: true,
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
     compressed: false,
@@ -685,6 +705,11 @@ export const Table: PlaygroundStory = {
       description: 'Enable tag filtering. Provides a mock tags service.',
       table: { category: 'Features' },
     },
+    hasCreatedByColumn: {
+      control: 'boolean',
+      description: 'Enable user profile service for created-by column and filter.',
+      table: { category: 'Features' },
+    },
     compressed: {
       control: 'boolean',
       description: 'Use compact table style.',
@@ -706,6 +731,12 @@ export const Table: PlaygroundStory = {
       description: 'Show tag badges in Name column. Clicking a tag toggles a filter.',
       table: { category: 'Columns' },
       if: { arg: 'hasTags' },
+    },
+    showCreatedByColumn: {
+      control: 'boolean',
+      description: 'Add a "Created by" column with user avatars.',
+      table: { category: 'Columns' },
+      if: { arg: 'hasCreatedByColumn' },
     },
     showTypeColumn: {
       control: 'boolean',

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/content_list_table.tsx
@@ -23,6 +23,7 @@ import {
   UpdatedAtColumn,
   ActionsColumn,
   StarredColumn,
+  CreatedByColumn,
 } from './column';
 import { Action as BaseAction, EditAction, DeleteAction } from './action';
 import { useColumns, useSorting, useSelection } from './hooks';
@@ -175,6 +176,7 @@ export const Column = Object.assign(BaseColumn, {
   UpdatedAt: UpdatedAtColumn,
   Actions: ActionsColumn,
   Starred: StarredColumn,
+  CreatedBy: CreatedByColumn,
 });
 
 // Create Action namespace with sub-components.

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/src/hooks/use_columns.ts
@@ -65,6 +65,7 @@ export const useColumns = (
       itemConfig,
       isReadOnly,
       entityName: labels.entity,
+      entityNamePlural: labels.entityPlural,
       supports,
       actions: { onDelete },
     };
@@ -76,5 +77,5 @@ export const useColumns = (
     // parent render, so including them would defeat memoization. Re-running when context
     // deps change is sufficient.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemConfig, isReadOnly, labels.entity, supports, onDelete]);
+  }, [itemConfig, isReadOnly, labels.entity, labels.entityPlural, supports, onDelete]);
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-table/tsconfig.json
@@ -27,6 +27,8 @@
     "@kbn/i18n",
     "@kbn/i18n-react",
     "@kbn/content-list-toolbar",
+    "@kbn/user-profile-components",
+    "@kbn/content-management-user-profiles",
   ],
   "exclude": [
     "target/**/*"

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/index.ts
@@ -21,9 +21,11 @@ export {
   Filters,
   SortFilter,
   TagFilter,
+  CreatedByFilter,
   type FiltersProps,
   type SortFilterProps,
   type TagFilterProps,
+  type CreatedByFilterProps,
 } from './src/filters';
 
 // Selection bar component for direct imports.
@@ -56,6 +58,7 @@ export {
 export {
   parseFiltersFromQuery,
   useTagQueryParser,
+  useCreatedByQueryParser,
   type QueryParser,
   type QueryParserResult,
 } from './src/filters';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/moon.yml
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/moon.yml
@@ -25,6 +25,8 @@ dependsOn:
   - '@kbn/i18n'
   - '@kbn/shared-ux-utility'
   - '@kbn/content-management-favorites-public'
+  - '@kbn/user-profile-components'
+  - '@kbn/content-management-user-profiles'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.stories.tsx
@@ -28,7 +28,7 @@ import {
   useContentListSearch,
   useContentListPagination,
   useContentListFilters,
-  useContentListConfig,
+  useContentListUserFilter,
 } from '@kbn/content-list-provider';
 import type {
   FindItemsParams,
@@ -40,6 +40,8 @@ import {
   createMockFindItems,
   extractTagIds,
   mockTagsService,
+  mockUserProfileServices,
+  MOCK_USER_PROFILES_MAP,
 } from '@kbn/content-list-mock-data/storybook';
 import { ContentListToolbar } from './content_list_toolbar';
 
@@ -51,6 +53,8 @@ import { ContentListToolbar } from './content_list_toolbar';
  * Creates a mock `findItems` function with configurable behavior.
  *
  * Supports sorting, search, tag filtering, and configurable delay.
+ * Note: user filtering is applied client-side by the provider, so `findItems`
+ * never receives `users` in its filter params.
  */
 const createStoryFindItems = (options?: { delay?: number }) => {
   const { delay = 0 } = options ?? {};
@@ -76,6 +80,8 @@ const createStoryFindItems = (options?: { delay?: number }) => {
         type: item.type,
         updatedAt: item.updatedAt ? new Date(item.updatedAt) : undefined,
         tags: extractTagIds(item.references),
+        createdBy: item.createdBy,
+        managed: (item as { managed?: boolean }).managed,
       })),
       total: result.total,
       counts: result.counts,
@@ -107,7 +113,7 @@ const StateDiagnosticPanel = ({
   const { search } = useContentListSearch();
   const { filters } = useContentListFilters();
   const pagination = useContentListPagination();
-  const config = useContentListConfig();
+  const { selectedUsers, isSupported: hasCreatedBy } = useContentListUserFilter();
 
   const toolbarJsx = useMemo(() => {
     if (useDeclarativeConfig) {
@@ -115,6 +121,7 @@ const StateDiagnosticPanel = ({
   <ContentListToolbar.Filters>
     <ContentListToolbar.Filters.Tags />
     <ContentListToolbar.Filters.Sort />
+    <ContentListToolbar.Filters.CreatedBy />
   </ContentListToolbar.Filters>
 </ContentListToolbar>`;
     }
@@ -174,14 +181,6 @@ const StateDiagnosticPanel = ({
               </EuiFlexItem>
               <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
                 <EuiTitle size="xxs">
-                  <h3>Sorting Config</h3>
-                </EuiTitle>
-                <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
-                  {JSON.stringify(config.features.sorting, null, 2)}
-                </EuiCodeBlock>
-              </EuiFlexItem>
-              <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
-                <EuiTitle size="xxs">
                   <h3>Search</h3>
                 </EuiTitle>
                 <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
@@ -196,6 +195,20 @@ const StateDiagnosticPanel = ({
                   {JSON.stringify(filters, null, 2)}
                 </EuiCodeBlock>
               </EuiFlexItem>
+              {hasCreatedBy && (
+                <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
+                  <EuiTitle size="xxs">
+                    <h3>User Filter</h3>
+                  </EuiTitle>
+                  <EuiCodeBlock language="json" fontSize="s" paddingSize="s">
+                    {JSON.stringify(
+                      { selectedUsers: selectedUsers.length > 0 ? selectedUsers : '(none)' },
+                      null,
+                      2
+                    )}
+                  </EuiCodeBlock>
+                </EuiFlexItem>
+              )}
               {pagination.isSupported && (
                 <EuiFlexItem grow={1} style={{ minWidth: 200 }}>
                   <EuiTitle size="xxs">
@@ -231,7 +244,21 @@ const StateDiagnosticPanel = ({
 };
 
 /**
- * Simple item list to show sorted results.
+ * Resolves a creator UID to a display name using the mock profile map.
+ */
+const resolveCreatorName = (createdBy?: string, managed?: boolean): string => {
+  if (managed) {
+    return 'Managed';
+  }
+  if (!createdBy) {
+    return '—';
+  }
+  const profile = MOCK_USER_PROFILES_MAP[createdBy];
+  return profile?.user.full_name ?? createdBy;
+};
+
+/**
+ * Simple item list to show sorted/filtered results with creator info.
  */
 const ItemList = () => {
   const { items, isLoading } = useContentListItems();
@@ -243,13 +270,25 @@ const ItemList = () => {
   return (
     <EuiPanel hasBorder paddingSize="m">
       <EuiTitle size="xxs">
-        <h3>Items (sorted)</h3>
+        <h3>Items ({items.length})</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
       {items.map((item, index) => (
-        <EuiText key={item.id} size="s">
-          {index + 1}. {item.title}
-        </EuiText>
+        <EuiFlexGroup key={item.id} gutterSize="s" responsive={false} alignItems="baseline">
+          <EuiFlexItem grow={false} style={{ minWidth: 24 }}>
+            <EuiText size="s" color="subdued">
+              {index + 1}.
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow>
+            <EuiText size="s">{item.title}</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color={item.managed ? 'accent' : 'hollow'}>
+              {resolveCreatorName(item.createdBy, item.managed)}
+            </EuiBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ))}
     </EuiPanel>
   );
@@ -283,6 +322,7 @@ interface PlaygroundArgs {
   hasSorting: boolean;
   hasPagination: boolean;
   hasTags: boolean;
+  hasCreatedByFilter: boolean;
   useDeclarativeConfig: boolean;
   showDiagnostics: boolean;
 }
@@ -326,12 +366,19 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
     [args.hasSorting, args.hasPagination, args.hasTags]
   );
 
-  const services: ContentListServices | undefined = useMemo(
-    () => (args.hasTags ? { tags: mockTagsService } : undefined),
-    [args.hasTags]
-  );
+  const services: ContentListServices | undefined = useMemo(() => {
+    const svc: ContentListServices = {};
+    if (args.hasTags) {
+      svc.tags = mockTagsService;
+    }
+    if (args.hasCreatedByFilter) {
+      svc.userProfile = mockUserProfileServices;
+    }
+    return Object.keys(svc).length > 0 ? svc : undefined;
+  }, [args.hasTags, args.hasCreatedByFilter]);
 
-  const key = `${args.hasSorting}-${args.hasPagination}-${args.hasTags}-${args.useDeclarativeConfig}`;
+  // Key forces re-mount when configuration changes.
+  const key = `${args.hasSorting}-${args.hasPagination}-${args.hasTags}-${args.hasCreatedByFilter}-${args.useDeclarativeConfig}`;
 
   const { Filters } = ContentListToolbar;
 
@@ -368,6 +415,7 @@ const PlaygroundStoryWrapper = ({ args }: { args: PlaygroundArgs }) => {
             <Filters>
               <Filters.Tags />
               <Filters.Sort />
+              <Filters.CreatedBy />
             </Filters>
           </ContentListToolbar>
         </>
@@ -410,6 +458,7 @@ export const Toolbar: PlaygroundStory = {
     hasSorting: true,
     hasPagination: true,
     hasTags: true,
+    hasCreatedByFilter: true,
     showDiagnostics: true,
     entityName: 'dashboard',
     entityNamePlural: 'dashboards',
@@ -449,6 +498,11 @@ export const Toolbar: PlaygroundStory = {
     hasTags: {
       control: 'boolean',
       description: 'Enable tag filtering. Provides a mock tags service with 8 tags.',
+      table: { category: 'Features' },
+    },
+    hasCreatedByFilter: {
+      control: 'boolean',
+      description: 'Enable "Created by" filter (provides user profile service).',
       table: { category: 'Features' },
     },
     showDiagnostics: {

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/content_list_toolbar.tsx
@@ -22,6 +22,7 @@ import { parseFiltersFromQuery } from './filters/query_parser';
 import type { QueryParser } from './filters/query_parser';
 import { useTagQueryParser } from './filters/tags/use_tag_query_parser';
 import { useStarredQueryParser } from './filters/starred/use_starred_query_parser';
+import { useCreatedByQueryParser } from './filters/created_by/use_created_by_query_parser';
 import { useFilters } from './hooks';
 import { SelectionBar } from './selection_bar';
 
@@ -100,10 +101,11 @@ const ContentListToolbarComponent = ({
   // `handleSearchChange` itself never needs to change.
   const tagParser = useTagQueryParser();
   const starredParser = useStarredQueryParser();
+  const createdByParser = useCreatedByQueryParser();
   const queryParsers = useMemo(
     (): ReadonlyArray<QueryParser> =>
-      [tagParser, starredParser].filter((p): p is QueryParser => p !== null),
-    [tagParser, starredParser]
+      [tagParser, starredParser, createdByParser].filter((p): p is QueryParser => p !== null),
+    [tagParser, starredParser, createdByParser]
   );
 
   const handleSearchChange = useCallback(

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { filter } from '../part';
+import { CreatedByRenderer } from './created_by_renderer';
+
+/**
+ * Props for the `Filters.CreatedBy` declarative component.
+ *
+ * Note: `CreatedByFilter` is a non-rendering declarative component whose
+ * props are parsed as attributes during filter resolution. Because `EuiSearchBar`
+ * instantiates `custom_component` filters itself, attributes cannot be forwarded
+ * to the underlying {@link CreatedByRenderer}.
+ */
+export type CreatedByFilterProps = Record<string, never>;
+
+/**
+ * `CreatedByFilter` declarative component (non-rendering).
+ *
+ * Specifies that a "Created by" filter popover should appear in the toolbar.
+ * The `resolve` callback checks whether user profile filtering is available
+ * and returns a `SearchFilterConfig` wrapping {@link CreatedByRenderer}, or
+ * `undefined` to skip the filter entirely.
+ *
+ * @example
+ * ```tsx
+ * <Filters>
+ *   <Filters.CreatedBy />
+ *   <Filters.Sort />
+ * </Filters>
+ * ```
+ */
+export const CreatedByFilter = filter.createPreset({
+  name: 'createdBy',
+  resolve: (_attributes, { hasCreatedBy }) => {
+    if (!hasCreatedBy) {
+      return undefined;
+    }
+    return { type: 'custom_component', component: CreatedByRenderer };
+  },
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by_renderer.test.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by_renderer.test.tsx
@@ -1,0 +1,243 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Query } from '@elastic/eui';
+import type { UserProfile } from '@kbn/user-profile-components';
+import {
+  ContentListProvider,
+  contentListQueryClient,
+  type FindItemsParams,
+  type FindItemsResult,
+  type UserProfileService,
+} from '@kbn/content-list-provider';
+import { CreatedByRenderer } from './created_by_renderer';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockProfiles: UserProfile[] = [
+  {
+    uid: 'user-1',
+    enabled: true,
+    user: { username: 'jdoe', full_name: 'Jane Doe', email: 'jdoe@elastic.co' },
+    data: {},
+  },
+  {
+    uid: 'user-2',
+    enabled: true,
+    user: { username: 'bsmith', full_name: 'Bob Smith', email: 'bsmith@elastic.co' },
+    data: {},
+  },
+];
+
+const mockUserProfileService: UserProfileService = {
+  getUserProfile: jest.fn(async (uid: string) => {
+    const found = mockProfiles.find((p) => p.uid === uid);
+    return found ?? { uid, enabled: true, user: { username: uid }, data: {} };
+  }),
+  bulkGetUserProfiles: jest.fn(async (uids: string[]) => {
+    return uids.map((uid) => {
+      const found = mockProfiles.find((p) => p.uid === uid);
+      return found ?? { uid, enabled: true, user: { username: uid }, data: {} };
+    });
+  }),
+};
+
+/** Items with a variety of `createdBy` and `managed` states. */
+const mockItems = [
+  { id: '1', title: 'Item 1', createdBy: 'user-1' },
+  { id: '2', title: 'Item 2', createdBy: 'user-2' },
+  { id: '3', title: 'Item 3', managed: true },
+  { id: '4', title: 'Item 4' }, // no creator
+];
+
+const createMockFindItems = (items = mockItems) =>
+  jest.fn(
+    async (_params: FindItemsParams): Promise<FindItemsResult> => ({
+      items,
+      total: items.length,
+    })
+  );
+
+/** Wraps children in a `ContentListProvider` with user profile service. */
+const createWrapper =
+  (findItems = createMockFindItems()) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <ContentListProvider
+        id="test-list"
+        labels={{ entity: 'item', entityPlural: 'items' }}
+        dataSource={{ findItems }}
+        services={{ userProfile: mockUserProfileService }}
+      >
+        {children}
+      </ContentListProvider>
+    );
+
+/** Dummy `query` prop required by `CreatedByRendererProps`. */
+const dummyQuery = {} as Query;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CreatedByRenderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear the singleton query client cache to prevent data leaking between tests.
+    contentListQueryClient.clear();
+  });
+
+  it('renders the "Created by" filter button', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+  });
+
+  it('applies the default data-test-subj', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('contentListCreatedByFilter')).toBeInTheDocument();
+    });
+  });
+
+  it('applies a custom data-test-subj', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} data-test-subj="my-filter" />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('my-filter')).toBeInTheDocument();
+    });
+  });
+
+  it('opens the popover when the button is clicked', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /created by/i }));
+
+    // The popover title should appear.
+    await waitFor(() => {
+      const matches = screen.getAllByText('Created by');
+      // Button label + popover title.
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('shows user profile names once popover is open', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /created by/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+      expect(screen.getByText('Bob Smith')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Managed" entry when managed items exist', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /created by/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Managed')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "No creator" entry when items without creators exist', async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /created by/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No creator')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show "Managed" when no managed items exist', async () => {
+    const items = [
+      { id: '1', title: 'Item 1', createdBy: 'user-1' },
+      { id: '2', title: 'Item 2', createdBy: 'user-2' },
+    ];
+    const Wrapper = createWrapper(createMockFindItems(items));
+    render(
+      <Wrapper>
+        <CreatedByRenderer query={dummyQuery} />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /created by/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /created by/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Managed')).not.toBeInTheDocument();
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by_renderer.tsx
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/created_by_renderer.tsx
@@ -1,0 +1,372 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo, useCallback, useEffect, useRef } from 'react';
+import {
+  EuiSelectable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useEuiTheme,
+  type EuiSelectableOption,
+  type Query,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  useContentListItems,
+  useContentListUserFilter,
+  MANAGED_USER_FILTER,
+  NO_CREATOR_USER_FILTER,
+  type UserFilter,
+} from '@kbn/content-list-provider';
+import {
+  useUserProfiles,
+  UserAvatarTip,
+  ManagedAvatarTip,
+  NoCreatorTip,
+} from '@kbn/content-management-user-profiles';
+import { useFilterPopover, FilterPopover } from '../filter_popover';
+
+const FIELD_NAME = 'createdBy';
+
+const MANAGED_QUERY_VALUE = 'managed';
+const NO_CREATOR_QUERY_VALUE = 'none';
+
+const i18nText = {
+  title: i18n.translate('contentManagement.contentList.createdByFilter.title', {
+    defaultMessage: 'Created by',
+  }),
+  noCreatorLabel: i18n.translate('contentManagement.contentList.createdByFilter.noCreator', {
+    defaultMessage: 'No creator',
+  }),
+  managedLabel: i18n.translate('contentManagement.contentList.createdByFilter.managed', {
+    defaultMessage: 'Managed',
+  }),
+  ariaLabel: i18n.translate('contentManagement.contentList.createdByFilter.ariaLabel', {
+    defaultMessage: 'Filter by creator',
+  }),
+};
+
+/**
+ * Props for the {@link CreatedByRenderer} component.
+ *
+ * When used with `EuiSearchBar` `custom_component` filters, the search bar
+ * passes `query` and `onChange` props. The created-by filter uses these to
+ * keep the query bar text in sync (e.g. `createdBy:(jane@elastic.co)`).
+ */
+export interface CreatedByRendererProps {
+  /** Query object from `EuiSearchBar`. */
+  query: Query;
+  /** `onChange` callback from `EuiSearchBar`. */
+  onChange?: (query: Query) => void;
+  /** Optional `data-test-subj` attribute for testing. */
+  'data-test-subj'?: string;
+}
+
+/**
+ * Option item for the created-by selectable list.
+ * Uses `EuiSelectableOption` with a required `key` for user/sentinel identification.
+ */
+type CreatedByOption = EuiSelectableOption & {
+  /** The user ID, or a sentinel value for special options. */
+  key: string;
+};
+
+/**
+ * Extract all `createdBy` field values from an EUI `Query` object.
+ */
+const getCreatedByQueryValues = (query: Query): string[] => {
+  try {
+    const clauses = query.ast.getFieldClauses(FIELD_NAME);
+    if (!clauses || clauses.length === 0) {
+      return [];
+    }
+
+    const result: string[] = [];
+    for (const clause of clauses) {
+      const vs = Array.isArray(clause.value) ? clause.value : [clause.value];
+      result.push(...vs.map(String));
+    }
+    return result;
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Remove all `createdBy` field clauses from a `Query` object.
+ */
+const removeAllCreatedByClauses = (query: Query): Query =>
+  query.removeSimpleFieldClauses(FIELD_NAME).removeOrFieldClauses(FIELD_NAME);
+
+/**
+ * Build a `Query` with the given `createdBy` values added as OR-field clauses.
+ */
+const addCreatedByClauses = (query: Query, values: string[]): Query => {
+  let updated = query;
+  for (const v of values) {
+    updated = updated.addOrFieldValue(FIELD_NAME, v, true, 'eq');
+  }
+  return updated;
+};
+
+/**
+ * Check shallow equality between two {@link UserFilter} objects.
+ */
+const isUserFilterEqual = (a: UserFilter | undefined, b: UserFilter | undefined): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  if (a.uid.length !== b.uid.length || !a.uid.every((v, i) => v === b.uid[i])) {
+    return false;
+  }
+  const aKeys = Object.keys(a.query);
+  const bKeys = Object.keys(b.query);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    const av = a.query[key];
+    const bv = b.query[key];
+    if (!bv || av.length !== bv.length || !av.every((v, i) => v === bv[i])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * `CreatedByRenderer` component for the toolbar "Created by" filter popover.
+ *
+ * Renders a filterable list of unique creators extracted from the current items.
+ * Each option shows a user avatar. Special entries are provided for "Managed"
+ * items (created by Elastic) and items with no creator.
+ *
+ * Syncs the filter selection with the `EuiSearchBar` query text so the query bar
+ * displays `createdBy:(email)` when a creator is selected. Email is the primary
+ * display value; typing a name (e.g. `createdBy:"Jane Doe"`) also works and may
+ * match multiple users.
+ *
+ * This component is the sole authority for deriving `filters.user` from the
+ * query bar text. It classifies each `createdBy` clause as email-driven
+ * (→ `user.uid`) or text-driven (→ `user.query` map) and dispatches
+ * `SET_USER_FILTER` with the full {@link UserFilter} object.
+ */
+export const CreatedByRenderer = ({
+  query,
+  onChange,
+  'data-test-subj': dataTestSubj = 'contentListCreatedByFilter',
+}: CreatedByRendererProps) => {
+  const { euiTheme } = useEuiTheme();
+  const { allCreators } = useContentListItems();
+  const { selectedUsers, setSelectedUsers } = useContentListUserFilter();
+  const { isOpen, toggle, close } = useFilterPopover();
+
+  // Eagerly fetch profiles so the email/UID mapping is available for query sync.
+  const profilesQuery = useUserProfiles(allCreators.uids);
+
+  // UID → query value (email primary, username fallback).
+  const uidToQueryValue = useMemo(() => {
+    const map = new Map<string, string>();
+    map.set(MANAGED_USER_FILTER, MANAGED_QUERY_VALUE);
+    map.set(NO_CREATOR_USER_FILTER, NO_CREATOR_QUERY_VALUE);
+
+    for (const profile of profilesQuery.data ?? []) {
+      map.set(profile.uid, profile.user.email ?? profile.user.username);
+    }
+    return map;
+  }, [profilesQuery.data]);
+
+  // Reverse map: email/sentinel string (lowercased) → UID.
+  // Uses a single-value map (last-write-wins) rather than `string[]` because
+  // email addresses are unique. Username collisions are theoretically possible
+  // but extremely unlikely; `queryValueToUids` handles the multi-match case.
+  const emailToUid = useMemo(() => {
+    const map = new Map<string, string>();
+    map.set(MANAGED_QUERY_VALUE, MANAGED_USER_FILTER);
+    map.set(NO_CREATOR_QUERY_VALUE, NO_CREATOR_USER_FILTER);
+
+    for (const profile of profilesQuery.data ?? []) {
+      const { email, username } = profile.user;
+      if (email) {
+        map.set(email.toLowerCase(), profile.uid);
+      }
+      if (username) {
+        map.set(username.toLowerCase(), profile.uid);
+      }
+    }
+    return map;
+  }, [profilesQuery.data]);
+
+  // Query value (email, name, sentinel) → UID[]. Names may match multiple users.
+  const queryValueToUids = useMemo(() => {
+    const map = new Map<string, string[]>();
+    map.set(MANAGED_QUERY_VALUE, [MANAGED_USER_FILTER]);
+    map.set(NO_CREATOR_QUERY_VALUE, [NO_CREATOR_USER_FILTER]);
+
+    for (const profile of profilesQuery.data ?? []) {
+      const { email, full_name: name, username } = profile.user;
+
+      for (const val of [email, name, username].filter(Boolean) as string[]) {
+        const key = val.toLowerCase();
+        const existing = map.get(key) ?? [];
+        if (!existing.includes(profile.uid)) {
+          map.set(key, [...existing, profile.uid]);
+        }
+      }
+    }
+    return map;
+  }, [profilesQuery.data]);
+
+  // Track the current `UserFilter` so the sync effect can skip no-op dispatches.
+  const currentUserFilterRef = useRef<UserFilter | undefined>(undefined);
+
+  // Sync `createdBy` clauses from the query → `filters.user`.
+  // Classifies each clause as email-driven (→ `uid`) or text-driven (→ `query` map).
+  useEffect(() => {
+    if (!profilesQuery.data) {
+      return;
+    }
+
+    const queryValues = getCreatedByQueryValues(query);
+
+    if (queryValues.length === 0) {
+      if (currentUserFilterRef.current) {
+        currentUserFilterRef.current = undefined;
+        setSelectedUsers(undefined);
+      }
+      return;
+    }
+
+    const nextUid: string[] = [];
+    const nextQuery: Record<string, string[]> = {};
+
+    for (const rawValue of queryValues) {
+      const lower = rawValue.toLowerCase();
+      const directUid = emailToUid.get(lower);
+      if (directUid) {
+        if (!nextUid.includes(directUid)) {
+          nextUid.push(directUid);
+        }
+      } else {
+        const resolved = queryValueToUids.get(lower) ?? [];
+        nextQuery[rawValue] = resolved;
+      }
+    }
+
+    const nextFilter: UserFilter = { uid: nextUid, query: nextQuery };
+
+    if (!isUserFilterEqual(currentUserFilterRef.current, nextFilter)) {
+      currentUserFilterRef.current = nextFilter;
+      setSelectedUsers(nextFilter);
+    }
+  }, [query, profilesQuery.data, emailToUid, queryValueToUids, setSelectedUsers]);
+
+  // Build selectable options from profiles and special entries.
+  const options = useMemo((): CreatedByOption[] => {
+    const result: CreatedByOption[] = [];
+
+    if (allCreators.hasManaged) {
+      result.push({
+        key: MANAGED_USER_FILTER,
+        label: i18nText.managedLabel,
+        prepend: <ManagedAvatarTip />,
+        checked: selectedUsers.includes(MANAGED_USER_FILTER) ? 'on' : undefined,
+      });
+    }
+
+    if (profilesQuery.data) {
+      for (const profile of profilesQuery.data) {
+        const { uid } = profile;
+        result.push({
+          key: uid,
+          label: profile.user.full_name ?? profile.user.username,
+          prepend: <UserAvatarTip uid={uid} />,
+          checked: selectedUsers.includes(uid) ? 'on' : undefined,
+        });
+      }
+    } else {
+      for (const uid of allCreators.uids) {
+        result.push({
+          key: uid,
+          label: uid,
+          checked: selectedUsers.includes(uid) ? 'on' : undefined,
+        });
+      }
+    }
+
+    if (allCreators.hasNoCreator) {
+      result.push({
+        key: NO_CREATOR_USER_FILTER,
+        label: i18nText.noCreatorLabel,
+        prepend: <NoCreatorTip />,
+        checked: selectedUsers.includes(NO_CREATOR_USER_FILTER) ? 'on' : undefined,
+      });
+    }
+
+    return result;
+  }, [allCreators, profilesQuery.data, selectedUsers]);
+
+  const handleSelectChange = useCallback(
+    (updatedOptions: EuiSelectableOption[]) => {
+      const selectedUids = updatedOptions
+        .filter((opt) => opt.checked === 'on')
+        .map((opt) => opt.key ?? '')
+        .filter(Boolean);
+
+      // Preserve text-driven queries from the current filter.
+      const currentQuery = currentUserFilterRef.current?.query ?? {};
+
+      // Optimistically dispatch the new UserFilter to avoid popover flicker.
+      const optimisticFilter: UserFilter = { uid: selectedUids, query: currentQuery };
+      currentUserFilterRef.current = optimisticFilter;
+      setSelectedUsers(optimisticFilter);
+
+      // Update the query bar text: preserve sticky text values, add email values for new UIDs.
+      if (onChange) {
+        const cleaned = removeAllCreatedByClauses(query);
+        const textValues = Object.keys(currentQuery);
+        const emailValues = selectedUids
+          .map((uid) => uidToQueryValue.get(uid))
+          .filter(Boolean) as string[];
+        const updated = addCreatedByClauses(cleaned, [...textValues, ...emailValues]);
+        onChange(updated);
+      }
+    },
+    [setSelectedUsers, onChange, query, uidToQueryValue]
+  );
+
+  return (
+    <FilterPopover
+      title={i18nText.title}
+      activeCount={selectedUsers.length}
+      isOpen={isOpen}
+      onToggle={toggle}
+      onClose={close}
+      panelWidth={euiTheme.base * 20}
+      data-test-subj={dataTestSubj}
+    >
+      <EuiSelectable
+        aria-label={i18nText.ariaLabel}
+        options={options}
+        onChange={handleSelectChange}
+        data-test-subj="createdBySelectOptions"
+        listProps={{ bordered: false }}
+      >
+        {(list) => (
+          <EuiFlexGroup direction="column" gutterSize="none">
+            <EuiFlexItem grow={false}>{list}</EuiFlexItem>
+          </EuiFlexGroup>
+        )}
+      </EuiSelectable>
+    </FilterPopover>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/index.ts
@@ -7,14 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  IncludeExcludeFilter,
-  UserFilter,
-  FilterCounts,
-  ActiveFilters,
-  FindItemsParams,
-  FindItemsResult,
-  FindItemsFn,
-  DataSourceConfig,
-} from './types';
-export { getIncludeExcludeFilter, TAG_FILTER_ID } from './types';
+export { CreatedByFilter, type CreatedByFilterProps } from './created_by';
+export { CreatedByRenderer, type CreatedByRendererProps } from './created_by_renderer';
+export { useCreatedByQueryParser } from './use_created_by_query_parser';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/use_created_by_query_parser.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/use_created_by_query_parser.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useCreatedByQueryParser } from './use_created_by_query_parser';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseContentListUserFilter = jest.fn();
+jest.mock('@kbn/content-list-provider', () => ({
+  useContentListUserFilter: () => mockUseContentListUserFilter(),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useCreatedByQueryParser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns `null` when createdBy is not supported.', () => {
+    mockUseContentListUserFilter.mockReturnValue({
+      isSupported: false,
+      selectedUsers: [],
+      setSelectedUsers: jest.fn(),
+      hasActiveFilter: false,
+    });
+
+    const { result } = renderHook(() => useCreatedByQueryParser());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns a parser when createdBy is supported.', () => {
+    mockUseContentListUserFilter.mockReturnValue({
+      isSupported: true,
+      selectedUsers: [],
+      setSelectedUsers: jest.fn(),
+      hasActiveFilter: false,
+    });
+
+    const { result } = renderHook(() => useCreatedByQueryParser());
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current?.parse).toBe('function');
+  });
+
+  describe('parse', () => {
+    beforeEach(() => {
+      mockUseContentListUserFilter.mockReturnValue({
+        isSupported: true,
+        selectedUsers: [],
+        setSelectedUsers: jest.fn(),
+        hasActiveFilter: false,
+      });
+    });
+
+    it('passes through query text with no `createdBy` clauses unchanged.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('hello world');
+      expect(output.searchQuery).toBe('hello world');
+      expect(output.filters).toEqual({});
+    });
+
+    it('strips a single `createdBy:value` clause from the query text.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('hello createdBy:jane@elastic.co world');
+      expect(output.searchQuery).not.toContain('createdBy');
+      expect(output.searchQuery).toContain('hello');
+      expect(output.searchQuery).toContain('world');
+      expect(output.filters).toEqual({});
+    });
+
+    it('strips a quoted `createdBy:"value"` clause from the query text.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('createdBy:"Jane Doe" dashboard');
+      expect(output.searchQuery).not.toContain('createdBy');
+      expect(output.searchQuery).not.toContain('Jane Doe');
+      expect(output.searchQuery).toContain('dashboard');
+      expect(output.filters).toEqual({});
+    });
+
+    it('strips multiple `createdBy` values in OR syntax.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('createdBy:(jane@elastic.co OR bob@elastic.co)');
+      expect(output.searchQuery).not.toContain('createdBy');
+      expect(output.searchQuery).not.toContain('jane@elastic.co');
+      expect(output.searchQuery).not.toContain('bob@elastic.co');
+      expect(output.filters).toEqual({});
+    });
+
+    it('strips `managed` and `none` sentinel values.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('createdBy:(managed OR none) search text');
+      expect(output.searchQuery).not.toContain('createdBy');
+      expect(output.searchQuery).not.toContain('managed');
+      expect(output.searchQuery).not.toContain('none');
+      expect(output.searchQuery).toContain('search text');
+      expect(output.filters).toEqual({});
+    });
+
+    it('handles unparseable query text gracefully.', () => {
+      const { result } = renderHook(() => useCreatedByQueryParser());
+      const parser = result.current!;
+
+      const output = parser.parse('createdBy:');
+      expect(output.searchQuery).toBe('createdBy:');
+      expect(output.filters).toEqual({});
+    });
+  });
+});

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/use_created_by_query_parser.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/created_by/use_created_by_query_parser.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+import { Query } from '@elastic/eui';
+import { useContentListUserFilter } from '@kbn/content-list-provider';
+import type { QueryParser, QueryParserResult } from '../query_parser';
+
+const FIELD_NAME = 'createdBy';
+
+/**
+ * Returns a {@link QueryParser} that strips `createdBy:value` clauses from the
+ * search bar query text so they are not treated as plain-text search terms.
+ *
+ * The actual UID mapping (email/name → user ID) is handled by
+ * {@link CreatedByRenderer}, which reads the `query` prop from `EuiSearchBar`
+ * and syncs selections to the provider via `setSelectedUsers`. This parser only
+ * needs to clean the text — it returns an empty `filters` object because the
+ * renderer owns the `filters.user` state.
+ *
+ * Returns `null` when created-by filtering is not supported, causing the
+ * toolbar to skip this parser entirely.
+ */
+export const useCreatedByQueryParser = (): QueryParser | null => {
+  const { isSupported } = useContentListUserFilter();
+
+  return useMemo((): QueryParser | null => {
+    if (!isSupported) {
+      return null;
+    }
+
+    return {
+      parse(queryText: string): QueryParserResult {
+        try {
+          const query = Query.parse(queryText);
+          const clauses = query.ast.getFieldClauses(FIELD_NAME);
+
+          if (!clauses || clauses.length === 0) {
+            return { searchQuery: queryText, filters: {} };
+          }
+
+          const cleaned = query
+            .removeSimpleFieldClauses(FIELD_NAME)
+            .removeOrFieldClauses(FIELD_NAME);
+
+          return { searchQuery: cleaned.text, filters: {} };
+        } catch {
+          return { searchQuery: queryText, filters: {} };
+        }
+      },
+    };
+  }, [isSupported]);
+};

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_resolve.test.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filter_resolve.test.ts
@@ -12,16 +12,19 @@ import { filter, type FilterContext } from './part';
 import { SortRenderer } from './sort';
 import { TagFilterRenderer } from './tags';
 import { StarredFilterRenderer } from './starred';
+import { CreatedByRenderer } from './created_by';
 
 // Ensure preset resolve callbacks are registered.
 import './sort/sort';
 import './tags/tag_filter';
 import './starred/starred_filter';
+import './created_by/created_by';
 
 const createContext = (overrides: Partial<FilterContext> = {}): FilterContext => ({
   hasSorting: false,
   hasTags: false,
   hasStarred: false,
+  hasCreatedBy: false,
   ...overrides,
 });
 
@@ -61,6 +64,30 @@ describe('filter.resolve', () => {
 
     it('returns `undefined` for the sort preset when sorting is unavailable.', () => {
       const result = filter.resolve(createSortPart(), createContext({ hasSorting: false }));
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('createdBy preset', () => {
+    const createCreatedByPart = (): ParsedPart => ({
+      type: 'part',
+      part: 'filter',
+      preset: 'createdBy',
+      instanceId: 'createdBy',
+      attributes: {},
+    });
+
+    it('returns a `SearchFilterConfig` for the createdBy preset when createdBy is available.', () => {
+      const result = filter.resolve(createCreatedByPart(), createContext({ hasCreatedBy: true }));
+
+      expect(result).toBeDefined();
+      expect(result).toMatchObject({ type: 'custom_component' });
+      expect((result as { component: unknown }).component).toBe(CreatedByRenderer);
+    });
+
+    it('returns `undefined` for the createdBy preset when createdBy is unavailable.', () => {
+      const result = filter.resolve(createCreatedByPart(), createContext({ hasCreatedBy: false }));
 
       expect(result).toBeUndefined();
     });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/filters.ts
@@ -12,6 +12,7 @@ import { filtersPart } from './part';
 import { SortFilter } from './sort';
 import { TagFilter } from './tags';
 import { StarredFilter } from './starred';
+import { CreatedByFilter } from './created_by';
 
 /**
  * Props for the {@link Filters} container component.
@@ -39,6 +40,7 @@ export interface FiltersProps {
  * <ContentListToolbar>
  *   <Filters>
  *     <Filters.Tags />
+ *     <Filters.CreatedBy />
  *     <Filters.Sort />
  *   </Filters>
  * </ContentListToolbar>
@@ -51,4 +53,5 @@ export const Filters = Object.assign(FiltersComponent, {
   Sort: SortFilter,
   Tags: TagFilter,
   Starred: StarredFilter,
+  CreatedBy: CreatedByFilter,
 });

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/index.ts
@@ -24,6 +24,13 @@ export {
   type StarredFilterRendererProps,
   useStarredQueryParser,
 } from './starred';
+export {
+  CreatedByFilter,
+  type CreatedByFilterProps,
+  CreatedByRenderer,
+  type CreatedByRendererProps,
+  useCreatedByQueryParser,
+} from './created_by';
 
 // Common popover components.
 export { FilterPopover, useFilterPopover, type FilterPopoverProps } from './filter_popover';

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/part.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/filters/part.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SearchFilterConfig } from '@elastic/eui';
+import type { CreatedByFilterProps } from './created_by';
 import { toolbar } from '../assembly';
 
 /**
@@ -48,6 +49,7 @@ export interface FilterPresets {
   sort: SortFilterProps;
   tags: TagFilterProps;
   starred: StarredFilterProps;
+  createdBy: CreatedByFilterProps;
 }
 
 /** Context passed to filter `resolve` callbacks. */
@@ -58,6 +60,8 @@ export interface FilterContext {
   hasTags: boolean;
   /** Whether starred filtering is available from the provider. */
   hasStarred: boolean;
+  /** Whether created-by filtering is available from the provider. */
+  hasCreatedBy: boolean;
 }
 
 /** Part factory for toolbar filters. */

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/src/hooks/use_filters.ts
@@ -11,17 +11,27 @@ import { Children, Fragment, isValidElement, useMemo } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import type { SearchFilterConfig } from '@elastic/eui';
 import type { ParsedPart } from '@kbn/content-list-assembly';
-import { useContentListSort, useFilterDisplay } from '@kbn/content-list-provider';
+import {
+  useContentListSort,
+  useFilterDisplay,
+  useContentListUserFilter,
+} from '@kbn/content-list-provider';
 import { filter } from '../filters/part';
 import { Filters, type FiltersProps } from '../filters/filters';
 import type { FilterContext } from '../filters/part';
 
-// Default order: starred toggle → tag facet → sort. Each resolves to undefined when its
-// corresponding service/feature is absent, so unused entries are silently dropped.
+/**
+ * Default filter parts when no declarative children are provided.
+ *
+ * Each preset's `resolve` callback gates on its own feature flag, so including
+ * a preset here is safe — it resolves to `undefined` and is filtered out when
+ * the corresponding feature is unsupported.
+ */
 const DEFAULT_PARTS: ParsedPart[] = [
   { type: 'part', part: 'filter', preset: 'starred', instanceId: 'starred', attributes: {} },
   { type: 'part', part: 'filter', preset: 'tags', instanceId: 'tags', attributes: {} },
   { type: 'part', part: 'filter', preset: 'sort', instanceId: 'sort', attributes: {} },
+  { type: 'part', part: 'filter', preset: 'createdBy', instanceId: 'createdBy', attributes: {} },
 ];
 
 /**
@@ -74,7 +84,7 @@ const parseFilterParts = (children: ReactNode): ParsedPart[] => {
  * 1. Extract `<Filters>` children from the toolbar's children.
  * 2. Parse declarative `Filter` presets via `filter.parseChildren`.
  * 3. Resolve `SearchFilterConfig` objects via `filter.resolve`.
- * 4. Fall back to default filters (tags + sort) if none are found.
+ * 4. Fall back to default filters (tags + sort + createdBy) if none are found.
  *
  * @param children - React children from the toolbar component.
  * @returns Array of EUI search filter configs ready for `EuiSearchBar`.
@@ -82,6 +92,7 @@ const parseFilterParts = (children: ReactNode): ParsedPart[] => {
 export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   const { isSupported: hasSorting } = useContentListSort();
   const { hasTags, hasStarred } = useFilterDisplay();
+  const { isSupported: hasCreatedBy } = useContentListUserFilter();
 
   // Note: `children` is used as a memo dependency. React children are often
   // unstable references (new JSX objects each render), so this memo may
@@ -90,10 +101,10 @@ export const useFilters = (children: ReactNode): SearchFilterConfig[] => {
   // consider keying on a more stable signal.
   return useMemo(() => {
     const parts = parseFilterParts(children);
-    const context: FilterContext = { hasSorting, hasTags, hasStarred };
+    const context: FilterContext = { hasSorting, hasTags, hasStarred, hasCreatedBy };
 
     return parts
       .map((part) => filter.resolve(part, context))
       .filter((f): f is SearchFilterConfig => f !== undefined);
-  }, [children, hasSorting, hasTags, hasStarred]);
+  }, [children, hasSorting, hasTags, hasStarred, hasCreatedBy]);
 };

--- a/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_list/kbn-content-list-toolbar/tsconfig.json
@@ -29,5 +29,7 @@
     "@kbn/i18n",
     "@kbn/shared-ux-utility",
     "@kbn/content-management-favorites-public",
+    "@kbn/user-profile-components",
+    "@kbn/content-management-user-profiles",
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds first-class support for displaying and filtering by item creators in the content list, building on the existing `TableListView` pattern of client-side user filtering.

- **`kbn-content-list-provider`**: Adds `UserFilter` type and `createdBy` feature flag. Introduces `SET_USER_FILTER`, `TOGGLE_USER_FILTER`, and `SET_FILTERS` reducer actions. User filtering is applied client-side after fetch (matching `TableListView` behavior) so the full creator list is always available for the filter popover. Exports `useContentListUserFilter`, `useUserFilterToggle`, `CreatorsList`, `MANAGED_USER_FILTER`, and `NO_CREATOR_USER_FILTER`. Adds `UserProfileService` interface and `userProfile` service slot. Refactors `ActiveFilters` from an open index signature to explicit typed fields (`tag`, `user`, `custom`) for better type safety. Routes `TOGGLE_FILTER` through `readFilterDimension`/`writeFilterDimension` helpers that correctly handle the tag vs. custom dimension split.
- **`kbn-content-list-table`**: Adds `Column.CreatedBy` preset backed by `CreatedByCell` — renders `UserAvatarTip`, `ManagedAvatarTip`, or `NoCreatorTip` depending on item state. Clicking an avatar toggles the creator filter (same UX as tag clicks in the name column).
- **`kbn-content-list-toolbar`**: Adds `Filters.CreatedBy` preset backed by `CreatedByRenderer` — a popover with an `EuiSelectable` list of unique creators derived from the unfiltered item set. Syncs selection with the `EuiSearchBar` query bar via `createdBy:(email)` clauses. Adds `useCreatedByQueryParser` that strips `createdBy:` clauses from the free-text search sent to the server.

## Test plan

- [x] All unit tests pass for `@kbn/content-list-provider`, `@kbn/content-list-table`, and `@kbn/content-list-toolbar` (42 total test suites, 0 failures).
- [ ] Verify storybook playground shows "Created by" column and filter when `hasCreatedByColumn` / `hasCreatedByFilter` are enabled.
- [ ] Clicking an avatar in the table toggles the creator filter and updates the query bar.
- [ ] Selecting users in the "Created by" popover filters the item list client-side.
- [ ] Clearing all filters resets the user filter and query bar.
- [ ] Disabling the service (`userProfile: undefined`) hides the column and filter even when `features.createdBy` is not explicitly `false`.