### PR TITLE
[FTR][Alerting] Split `alerting/group2/config_non_dedicated_task_runner` config

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -157,7 +157,9 @@ enabled:
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group9/config.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group10/config.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/config_with_schedule_circuit_breaker.ts
-  - x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
+  - x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_1.ts
+  - x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_2.ts
+  - x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_3.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/config_non_dedicated_task_runner.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group1/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group2/config.ts

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_1.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_1.ts
@@ -14,7 +14,7 @@ export default createTestConfig('security_and_spaces', {
   ssl: true,
   enableActionsProxy: true,
   publicBaseUrl: true,
-  testFiles: [require.resolve('./tests')],
+  testFiles: [require.resolve('./tests/index_non_dedicated_1')],
   useDedicatedTaskRunner: false,
   experimentalFeatures: [
     'sentinelOneConnectorOn',

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_2.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_2.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createTestConfig } from '../../common/config';
+import { EmailMaximumBodyLength } from './config';
+
+export default createTestConfig('security_and_spaces', {
+  disabledPlugins: [],
+  license: 'trial',
+  ssl: true,
+  enableActionsProxy: true,
+  publicBaseUrl: true,
+  testFiles: [require.resolve('./tests/index_non_dedicated_2')],
+  useDedicatedTaskRunner: false,
+  experimentalFeatures: [
+    'sentinelOneConnectorOn',
+    'crowdstrikeConnectorOn',
+    'microsoftDefenderEndpointOn',
+  ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
+  indexRefreshInterval: '1s',
+});

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_3.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_3.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createTestConfig } from '../../common/config';
+import { EmailMaximumBodyLength } from './config';
+
+export default createTestConfig('security_and_spaces', {
+  disabledPlugins: [],
+  license: 'trial',
+  ssl: true,
+  enableActionsProxy: true,
+  publicBaseUrl: true,
+  testFiles: [require.resolve('./tests/index_non_dedicated_3')],
+  useDedicatedTaskRunner: false,
+  experimentalFeatures: [
+    'sentinelOneConnectorOn',
+    'crowdstrikeConnectorOn',
+    'microsoftDefenderEndpointOn',
+  ],
+  emailMaximumBodyLength: EmailMaximumBodyLength,
+  indexRefreshInterval: '1s',
+});

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_1.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_1.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers, tearDown } from '../../../setup';
+
+export default function connectorsTests({ loadTestFile, getService }: FtrProviderContext) {
+  describe('Connectors', () => {
+    before(async () => {
+      await setupSpacesAndUsers(getService);
+    });
+
+    after(async () => {
+      await tearDown(getService);
+    });
+
+    loadTestFile(require.resolve('./connector_types/oauth_access_token'));
+    loadTestFile(require.resolve('./connector_types/cases_webhook'));
+    loadTestFile(require.resolve('./connector_types/jira'));
+    loadTestFile(require.resolve('./connector_types/jira_service_management'));
+    loadTestFile(require.resolve('./connector_types/resilient'));
+    loadTestFile(require.resolve('./connector_types/servicenow_itsm'));
+    loadTestFile(require.resolve('./connector_types/servicenow_sir'));
+    loadTestFile(require.resolve('./connector_types/servicenow_itom'));
+    loadTestFile(require.resolve('./connector_types/swimlane'));
+    loadTestFile(require.resolve('./connector_types/email'));
+    loadTestFile(require.resolve('./connector_types/es_index'));
+    loadTestFile(require.resolve('./connector_types/es_index_preconfigured'));
+    loadTestFile(require.resolve('./connector_types/opsgenie'));
+    loadTestFile(require.resolve('./connector_types/pagerduty'));
+    loadTestFile(require.resolve('./connector_types/server_log'));
+    loadTestFile(require.resolve('./connector_types/slack_webhook'));
+    loadTestFile(require.resolve('./connector_types/slack_api'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_2.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_2.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers, tearDown } from '../../../setup';
+
+export default function connectorsTests({ loadTestFile, getService }: FtrProviderContext) {
+  describe('Connectors', () => {
+    before(async () => {
+      await setupSpacesAndUsers(getService);
+    });
+
+    after(async () => {
+      await tearDown(getService);
+    });
+
+    loadTestFile(require.resolve('./connector_types/webhook'));
+    loadTestFile(require.resolve('./connector_types/http'));
+    loadTestFile(require.resolve('./connector_types/xmatters'));
+    loadTestFile(require.resolve('./connector_types/tines'));
+    loadTestFile(require.resolve('./connector_types/torq'));
+    loadTestFile(require.resolve('./connector_types/openai'));
+    loadTestFile(require.resolve('./connector_types/d3security'));
+    loadTestFile(require.resolve('./connector_types/thehive'));
+    loadTestFile(require.resolve('./connector_types/bedrock'));
+    loadTestFile(require.resolve('./connector_types/gemini'));
+    loadTestFile(require.resolve('./connector_types/xsoar'));
+    loadTestFile(require.resolve('./connector_types/get_webhook_secret_headers_keys'));
+    loadTestFile(require.resolve('./create'));
+    loadTestFile(require.resolve('./delete'));
+    loadTestFile(require.resolve('./execute'));
+    loadTestFile(require.resolve('./get_all'));
+    loadTestFile(require.resolve('./get_all_system'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_3.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index_non_dedicated_3.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers, tearDown } from '../../../setup';
+
+export default function connectorsTests({ loadTestFile, getService }: FtrProviderContext) {
+  describe('Connectors', () => {
+    before(async () => {
+      await setupSpacesAndUsers(getService);
+    });
+
+    after(async () => {
+      await tearDown(getService);
+    });
+
+    loadTestFile(require.resolve('./get'));
+    loadTestFile(require.resolve('./connector_types'));
+    loadTestFile(require.resolve('./connector_types_system'));
+    loadTestFile(require.resolve('./update'));
+    loadTestFile(require.resolve('./bulk_enqueue'));
+    loadTestFile(require.resolve('./sub_feature_descriptions'));
+
+    /**
+     * Sub action framework
+     */
+
+    loadTestFile(require.resolve('./sub_action_framework'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_1.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_1.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('alerting api integration security and spaces enabled - Group 2 - Non-dedicated 1', function () {
+    loadTestFile(require.resolve('./actions/index_non_dedicated_1'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_2.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_2.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('alerting api integration security and spaces enabled - Group 2 - Non-dedicated 2', function () {
+    loadTestFile(require.resolve('./actions/index_non_dedicated_2'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_3.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/index_non_dedicated_3.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('alerting api integration security and spaces enabled - Group 2 - Non-dedicated 3', function () {
+    loadTestFile(require.resolve('./actions/index_non_dedicated_3'));
+    loadTestFile(require.resolve('./telemetry'));
+    loadTestFile(require.resolve('./alerting'));
+  });
+}


### PR DESCRIPTION
## Summary

Split `x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts` (~32 minutes) into smaller groups targeting 15–20 minutes each.

- Split `config_non_dedicated_task_runner.ts` into 3 configs within `group2/`
- Created 6 new index files to partition 50 test entries across `config_non_dedicated_task_runner_1.ts`, `config_non_dedicated_task_runner_2.ts`, `config_non_dedicated_task_runner_3.ts`
- Registered all 3 new configs in `.buildkite/ftr_platform_stateful_configs.yml`

### New configs

* `x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_1.ts`
* `x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_2.ts`
* `x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner_3.ts`

