### PR TITLE
[FTR][ML] Split `ml/anomaly_detection_jobs` config

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -252,7 +252,9 @@ enabled:
   - x-pack/platform/test/functional/apps/maps/group2/config.ts
   - x-pack/platform/test/functional/apps/maps/group3/config.ts
   - x-pack/platform/test/functional/apps/maps/group4/config.ts
-  - x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/config.ts
+  - x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/config.ts
+  - x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/config.ts
+  - x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/config.ts
   - x-pack/platform/test/functional/apps/ml/anomaly_detection_integrations/config.ts
   - x-pack/platform/test/functional/apps/ml/anomaly_detection_result_views/config.ts
   - x-pack/platform/test/functional/apps/ml/data_frame_analytics/group1/config.ts

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/config.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../../config.base.ts'));
+
+  return {
+    ...functionalConfig.getAll(),
+    testFiles: [require.resolve('.')],
+    junit: {
+      reportName: 'Chrome X-Pack UI Functional Tests - ML anomaly_detection_jobs - group1',
+    },
+  };
+}

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/index.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const config = getService('config');
@@ -13,7 +13,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const esNode = isCcs ? getService('remoteEsArchiver' as 'esArchiver') : getService('esArchiver');
   const ml = getService('ml');
 
-  describe('machine learning - anomaly detection', function () {
+  describe('machine learning - anomaly detection - group1', function () {
     this.tags(['skipFirefox']);
 
     before(async () => {
@@ -30,9 +30,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await ml.securityCommon.cleanMlRoles();
 
       await esNode.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
-      await esNode.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-      await esNode.unload('x-pack/platform/test/fixtures/es_archives/ml/categorization_small');
-      await esNode.unload('x-pack/platform/test/fixtures/es_archives/ml/event_rate_nanos');
 
       await ml.testResources.resetKibanaTimeZone();
     });
@@ -43,17 +40,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       loadTestFile(require.resolve('./job_expanded_details'));
       loadTestFile(require.resolve('./single_metric_job_without_datafeed_start'));
       loadTestFile(require.resolve('./multi_metric_job'));
-      loadTestFile(require.resolve('./population_job'));
-      loadTestFile(require.resolve('./geo_job'));
       loadTestFile(require.resolve('./saved_search_job'));
-      loadTestFile(require.resolve('./advanced_job'));
-      loadTestFile(require.resolve('./categorization_job'));
-      loadTestFile(require.resolve('./date_nanos_job'));
-      loadTestFile(require.resolve('./custom_urls'));
-      loadTestFile(require.resolve('./delete_job_and_delete_annotations'));
-      loadTestFile(require.resolve('./convert_single_metric_job_to_multi_metric'));
-      loadTestFile(require.resolve('./convert_jobs_to_advanced_job'));
-      loadTestFile(require.resolve('./supplied_configurations'));
     }
   });
 }

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/job_expanded_details.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/job_expanded_details.ts
@@ -7,8 +7,8 @@
 
 import type { Job } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
 import { JOB_STATE } from '@kbn/ml-plugin/common';
-import { QuickFilterButtonTypes } from '../../../services/ml/job_table';
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import { QuickFilterButtonTypes } from '../../../../services/ml/job_table';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/multi_metric_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/multi_metric_job.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { FieldStatsType } from '../common/types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FieldStatsType } from '../../common/types';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/saved_search_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/saved_search_job.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/single_metric_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/single_metric_job.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { FieldStatsType } from '../common/types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FieldStatsType } from '../../common/types';
 
 export default function ({ getService }: FtrProviderContext) {
   const config = getService('config');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/single_metric_job_without_datafeed_start.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/single_metric_job_without_datafeed_start.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/categorization_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/categorization_job.ts
@@ -5,76 +5,57 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { FieldStatsType } from '../common/types';
+import { CATEGORY_EXAMPLES_VALIDATION_STATUS } from '@kbn/ml-category-validator';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FieldStatsType } from '../../common/types';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  const jobId = `ec_population_1_${Date.now()}`;
+  const jobId = `categorization_${Date.now()}`;
   const jobIdClone = `${jobId}_clone`;
   const jobDescription =
-    'Create population job based on the ecommerce sample dataset with 2h bucketspan over customer_id' +
-    ' - detectors: (Mean(products.base_price) by customer_gender), (Mean(products.quantity) by category.leyword)';
-  const jobGroups = ['automated', 'ecommerce', 'population'];
+    'Create categorization job based on the ft_categorization dataset with a count rare';
+  const jobGroups = ['automated', 'categorization'];
   const jobGroupsClone = [...jobGroups, 'clone'];
-  const populationField = 'customer_id';
-  const detectors = [
-    {
-      identifier: 'Mean(products.base_price)',
-      splitField: 'customer_gender',
-      frontCardTitle: 'FEMALE',
-      numberOfBackCards: 1,
-    },
-    {
-      identifier: 'Mean(products.quantity)',
-      splitField: 'category.keyword',
-      frontCardTitle: "Men's Clothing",
-      numberOfBackCards: 5,
-    },
-  ];
-  const fieldStatsEntries = [
-    {
-      fieldName: 'currency',
-      type: 'keyword' as FieldStatsType,
-      expectedValues: ['EUR'],
-    },
-  ];
-
-  const bucketSpan = '2h';
-  const memoryLimit = '8mb';
+  const detectorTypeIdentifier = 'Rare';
+  const categorizationFieldIdentifier = 'field1';
+  const categorizationExampleCount = 5;
+  const bucketSpan = '1d';
+  const memoryLimit = '15mb';
 
   function getExpectedRow(expectedJobId: string, expectedJobGroups: string[]) {
     return {
       id: expectedJobId,
       description: jobDescription,
       jobGroups: [...new Set(expectedJobGroups)].sort(),
-      recordCount: '4,675',
+      recordCount: '1,000',
       memoryStatus: 'ok',
       jobState: 'closed',
       datafeedState: 'stopped',
-      latestTimestamp: '2023-07-12 23:45:36',
+      latestTimestamp: '2019-11-21 00:01:13',
     };
   }
 
   function getExpectedCounts(expectedJobId: string) {
     return {
       job_id: expectedJobId,
-      processed_record_count: '4,675',
-      processed_field_count: '23,375',
-      input_bytes: '867.7 KB',
-      input_field_count: '23,375',
+      processed_record_count: '1,000',
+      processed_field_count: '1,000',
+      input_bytes: '148.8 KB',
+      input_field_count: '1,000',
       invalid_date_count: '0',
       missing_field_count: '0',
       out_of_order_timestamp_count: '0',
-      empty_bucket_count: '0',
+      empty_bucket_count: '23',
       sparse_bucket_count: '0',
-      bucket_count: '371',
-      earliest_record_timestamp: '2023-06-12 00:04:19',
-      latest_record_timestamp: '2023-07-12 23:45:36',
-      input_record_count: '4,675',
-      latest_bucket_timestamp: '2023-07-12 22:00:00',
+      bucket_count: '230',
+      earliest_record_timestamp: '2019-04-05 11:25:35',
+      latest_record_timestamp: '2019-11-21 00:01:13',
+      input_record_count: '1,000',
+      latest_bucket_timestamp: '2019-11-21 00:00:00',
+      latest_empty_bucket_timestamp: '2019-11-17 00:00:00',
     };
   }
 
@@ -83,22 +64,31 @@ export default function ({ getService }: FtrProviderContext) {
       job_id: expectedJobId,
       result_type: 'model_size_stats',
       model_bytes_exceeded: '0.0 B',
-      total_by_field_count: '25',
-      total_over_field_count: '92',
-      total_partition_field_count: '3',
+      // not checking total_by_field_count as the number of categories might change
+      total_over_field_count: '0',
+      total_partition_field_count: '2',
       bucket_allocation_failures_count: '0',
       memory_status: 'ok',
-      timestamp: '2023-07-12 20:00:00',
+      timestamp: '2019-11-20 00:00:00',
     };
   }
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
 
-  describe('population', function () {
+  const fieldStatsEntries = [
+    {
+      fieldName: 'field1',
+      type: 'keyword' as FieldStatsType,
+    },
+  ];
+
+  describe('categorization', function () {
     this.tags(['ml']);
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
-      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
+      await esArchiver.loadIfNeeded(
+        'x-pack/platform/test/fixtures/es_archives/ml/categorization_small'
+      );
+      await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -107,32 +97,33 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_categorization_small');
     });
 
-    it('job creation loads the population wizard for the source data', async () => {
+    it('job creation loads the categorization wizard for the source data', async () => {
       await ml.testExecution.logTestStep('job creation loads the job management page');
+      await ml.testExecution.logTestStep('');
       await ml.navigation.navigateToStackManagementMlSection('anomaly_detection', 'ml-jobs-list');
 
       await ml.testExecution.logTestStep('job creation loads the new job source selection page');
       await ml.jobManagement.navigateToNewJobSourceSelection();
 
       await ml.testExecution.logTestStep('job creation loads the job type selection page');
-      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_ecommerce');
+      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_categorization_small');
 
-      await ml.testExecution.logTestStep('job creation loads the population job wizard page');
-      await ml.jobTypeSelection.selectPopulationJob();
+      await ml.testExecution.logTestStep('job creation loads the categorization job wizard page');
+      await ml.jobTypeSelection.selectCategorizationJob();
     });
 
-    it('job creation navigates through the population wizard and sets all needed fields', async () => {
+    it('job creation navigates through the categorization wizard and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job creation displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
       await ml.commonUI.assertDatePickerDataTierOptionsVisible(true);
 
       await ml.testExecution.logTestStep('job creation sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
-        'Jun 12, 2023 @ 00:04:19.000',
-        'Jul 12, 2023 @ 23:45:36.000'
+        'Apr 5, 2019 @ 11:25:35.770',
+        'Nov 21, 2019 @ 00:01:13.923'
       );
 
       await ml.testExecution.logTestStep('job creation displays the event rate chart');
@@ -143,51 +134,29 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
       await ml.testExecution.logTestStep(
-        'job creation opens field stats flyout from population field input'
+        `job creation selects ${detectorTypeIdentifier} detector type`
       );
-      await ml.jobWizardPopulation.assertPopulationFieldInputExists();
-      for (const { fieldName, type: fieldType, expectedValues } of fieldStatsEntries) {
-        await ml.jobWizardPopulation.assertFieldStatFlyoutContentFromPopulationFieldInputTrigger(
+      await ml.jobWizardCategorization.assertCategorizationDetectorTypeSelectionExists();
+      await ml.jobWizardCategorization.selectCategorizationDetectorType(detectorTypeIdentifier);
+
+      await ml.testExecution.logTestStep(
+        'job creation opens field stats flyout from categorization field input'
+      );
+      await ml.jobWizardCategorization.assertCategorizationFieldInputExists();
+      for (const { fieldName, type: fieldType } of fieldStatsEntries) {
+        await ml.jobWizardCategorization.assertFieldStatFlyoutContentFromCategorizationFieldInputTrigger(
           fieldName,
-          fieldType,
-          expectedValues
+          fieldType
         );
       }
 
-      await ml.testExecution.logTestStep('job creation selects the population field');
-      await ml.jobWizardPopulation.selectPopulationField(populationField);
-
-      await ml.testExecution.logTestStep(
-        'job creation selects detectors and displays detector previews'
+      await ml.testExecution.logTestStep(`job creation selects the categorization field`);
+      await ml.jobWizardCategorization.selectCategorizationField(categorizationFieldIdentifier);
+      await ml.jobWizardCategorization.assertCategorizationExamplesCallout(
+        CATEGORY_EXAMPLES_VALIDATION_STATUS.VALID
       );
-      for (const [index, detector] of detectors.entries()) {
-        await ml.jobWizardCommon.assertAggAndFieldInputExists();
-        await ml.jobWizardCommon.selectAggAndField(detector.identifier, false);
-        await ml.jobWizardCommon.assertDetectorPreviewExists(detector.identifier, index, 'SCATTER');
-      }
-
-      await ml.testExecution.logTestStep(
-        'job creation inputs detector split fields and displays split cards'
-      );
-      for (const [index, detector] of detectors.entries()) {
-        await ml.jobWizardPopulation.assertDetectorSplitFieldInputExists(index);
-        await ml.jobWizardPopulation.selectDetectorSplitField(index, detector.splitField);
-
-        await ml.jobWizardPopulation.assertDetectorSplitExists(index);
-        await ml.jobWizardPopulation.assertDetectorSplitFrontCardTitle(
-          index,
-          detector.frontCardTitle
-        );
-        await ml.jobWizardPopulation.assertDetectorSplitNumberOfBackCards(
-          index,
-          detector.numberOfBackCards
-        );
-      }
-
-      await ml.testExecution.logTestStep('job creation displays the influencer field');
-      await ml.jobWizardCommon.assertInfluencerInputExists();
-      await ml.jobWizardCommon.assertInfluencerSelection(
-        [populationField].concat(detectors.map((detector) => detector.splitField))
+      await ml.jobWizardCategorization.assertCategorizationExamplesTable(
+        categorizationExampleCount
       );
 
       await ml.testExecution.logTestStep('job creation inputs the bucket span');
@@ -226,6 +195,8 @@ export default function ({ getService }: FtrProviderContext) {
 
       await ml.testExecution.logTestStep('job creation displays the model plot switch');
       await ml.jobWizardCommon.assertModelPlotSwitchExists();
+      await ml.jobWizardCommon.assertModelPlotSwitchEnabled(false);
+      await ml.jobWizardCommon.assertModelPlotSwitchCheckedState(false);
 
       await ml.testExecution.logTestStep('job creation enables the dedicated index switch');
       await ml.jobWizardCommon.assertDedicatedIndexSwitchExists();
@@ -264,27 +235,25 @@ export default function ({ getService }: FtrProviderContext) {
       );
 
       await ml.testExecution.logTestStep('job creation has detector results');
-      for (let i = 0; i < detectors.length; i++) {
-        await ml.api.assertDetectorResultsExist(jobId, i);
-      }
+      await ml.api.assertDetectorResultsExist(jobId, 0);
     });
 
-    it('job cloning opens the existing job in the population wizard', async () => {
+    it('job cloning opens the existing job in the categorization wizard', async () => {
       await ml.testExecution.logTestStep(
-        'job cloning clicks the clone action and loads the population wizard'
+        'job cloning clicks the clone action and loads the single metric wizard'
       );
       await ml.jobTable.clickCloneJobAction(jobId);
-      await ml.jobTypeSelection.assertPopulationJobWizardOpen();
+      await ml.jobTypeSelection.assertCategorizationJobWizardOpen();
     });
 
-    it('job cloning navigates through the population wizard, checks and sets all needed fields', async () => {
+    it('job cloning navigates through the categorization wizard, checks and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job cloning displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
 
       await ml.testExecution.logTestStep('job cloning sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
-        'Jun 12, 2023 @ 00:04:19.000',
-        'Jul 12, 2023 @ 23:45:36.000'
+        'Apr 5, 2019 @ 11:25:35.770',
+        'Nov 21, 2019 @ 00:01:13.923'
       );
 
       await ml.testExecution.logTestStep('job cloning displays the event rate chart');
@@ -294,35 +263,8 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job cloning displays the pick fields step');
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
-      await ml.testExecution.logTestStep('job cloning pre-fills the population field');
-      await ml.jobWizardPopulation.assertPopulationFieldInputExists();
-      await ml.jobWizardPopulation.assertPopulationFieldSelection([populationField]);
-
-      await ml.testExecution.logTestStep(
-        'job cloning pre-fills detectors and shows preview with split cards'
-      );
-      for (const [index, detector] of detectors.entries()) {
-        await ml.jobWizardCommon.assertDetectorPreviewExists(detector.identifier, index, 'SCATTER');
-
-        await ml.jobWizardPopulation.assertDetectorSplitFieldSelection(index, [
-          detector.splitField,
-        ]);
-        await ml.jobWizardPopulation.assertDetectorSplitExists(index);
-        await ml.jobWizardPopulation.assertDetectorSplitFrontCardTitle(
-          index,
-          detector.frontCardTitle
-        );
-        await ml.jobWizardPopulation.assertDetectorSplitNumberOfBackCards(
-          index,
-          detector.numberOfBackCards
-        );
-      }
-
-      await ml.testExecution.logTestStep('job cloning pre-fills influencers');
-      await ml.jobWizardCommon.assertInfluencerInputExists();
-      await ml.jobWizardCommon.assertInfluencerSelection(
-        [populationField].concat(detectors.map((detector) => detector.splitField))
-      );
+      await ml.testExecution.logTestStep('job cloning pre-fills field and aggregation');
+      await ml.jobWizardCategorization.assertCategorizationDetectorTypeSelectionExists();
 
       await ml.testExecution.logTestStep('job cloning pre-fills the bucket span');
       await ml.jobWizardCommon.assertBucketSpanInputExists();
@@ -365,6 +307,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       await ml.testExecution.logTestStep('job cloning pre-fills the model plot switch');
       await ml.jobWizardCommon.assertModelPlotSwitchExists();
+      await ml.jobWizardCommon.assertModelPlotSwitchEnabled(false);
       await ml.jobWizardCommon.assertModelPlotSwitchCheckedState(false);
 
       await ml.testExecution.logTestStep('job cloning pre-fills the dedicated index switch');
@@ -406,9 +349,29 @@ export default function ({ getService }: FtrProviderContext) {
       );
 
       await ml.testExecution.logTestStep('job cloning has detector results');
-      for (let i = 0; i < detectors.length; i++) {
-        await ml.api.assertDetectorResultsExist(jobId, i);
-      }
+      await ml.api.assertDetectorResultsExist(jobId, 0);
+    });
+
+    it('deletes the cloned job', async () => {
+      await ml.testExecution.logTestStep('job deletion has results for the job before deletion');
+      await ml.api.assertJobResultsExist(jobIdClone);
+
+      await ml.testExecution.logTestStep('job deletion triggers the delete action');
+      await ml.jobTable.clickDeleteJobAction(jobIdClone);
+
+      await ml.testExecution.logTestStep('job deletion confirms the delete modal');
+      await ml.jobTable.confirmDeleteJobModal();
+      await ml.api.waitForAnomalyDetectionJobNotToExist(jobIdClone, 30 * 1000);
+
+      await ml.testExecution.logTestStep(
+        'job deletion does not display the deleted job in the job list any more'
+      );
+      await ml.jobTable.filterWithSearchString(jobIdClone, 0);
+
+      await ml.testExecution.logTestStep(
+        'job deletion does not have results for the deleted job any more'
+      );
+      await ml.api.assertNoJobResultsExist(jobIdClone);
     });
   });
 }

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/config.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/config.ts
@@ -8,13 +8,13 @@
 import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
-  const functionalConfig = await readConfigFile(require.resolve('../../../config.base.ts'));
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
 
   return {
-    ...functionalConfig.getAll(),
+    ...baseConfig.getAll(),
     testFiles: [require.resolve('.')],
     junit: {
-      reportName: 'Chrome X-Pack UI Functional Tests - ML anomaly_detection_jobs',
+      reportName: 'Chrome X-Pack UI Functional Tests - ML anomaly_detection_jobs - group2',
     },
   };
 }

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/custom_urls.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/custom_urls.ts
@@ -11,8 +11,8 @@ import type {
   DiscoverUrlConfig,
   DashboardUrlConfig,
   OtherUrlConfig,
-} from '../../../services/ml/job_table';
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+} from '../../../../services/ml/job_table';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 // @ts-expect-error doesn't implement the full interface
 const JOB_CONFIG: Job = {

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/date_nanos_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/date_nanos_job.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { PickFieldsConfig, DatafeedConfig, Detector } from './types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { PickFieldsConfig, DatafeedConfig, Detector } from '../types';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/geo_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/geo_job.ts
@@ -5,57 +5,62 @@
  * 2.0.
  */
 
-import { CATEGORY_EXAMPLES_VALIDATION_STATUS } from '@kbn/ml-category-validator';
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { FieldStatsType } from '../common/types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  const jobId = `categorization_${Date.now()}`;
+  const jobId = `ec_geo_1_${Date.now()}`;
   const jobIdClone = `${jobId}_clone`;
-  const jobDescription =
-    'Create categorization job based on the ft_categorization dataset with a count rare';
-  const jobGroups = ['automated', 'categorization'];
+  const jobDescription = 'Create geo job based on the ecommerce sample dataset with 15m bucketspan';
+  const jobGroups = ['automated', 'ecommerce', 'geo'];
   const jobGroupsClone = [...jobGroups, 'clone'];
-  const detectorTypeIdentifier = 'Rare';
-  const categorizationFieldIdentifier = 'field1';
-  const categorizationExampleCount = 5;
-  const bucketSpan = '1d';
-  const memoryLimit = '15mb';
+  const geoField = 'geoip.location';
+  const splitField = 'customer_gender';
+  const detectors = [
+    {
+      identifier: 'Lat long(geoip.location)',
+      frontCardTitle: "Men's Clothing",
+      function: 'lat_long',
+      field_name: geoField,
+      numberOfBackCards: 5,
+      splitField,
+    },
+  ];
+  const bucketSpan = '15m';
+  const memoryLimit = '8mb';
 
   function getExpectedRow(expectedJobId: string, expectedJobGroups: string[]) {
     return {
       id: expectedJobId,
       description: jobDescription,
       jobGroups: [...new Set(expectedJobGroups)].sort(),
-      recordCount: '1,000',
+      recordCount: '4,675',
       memoryStatus: 'ok',
       jobState: 'closed',
       datafeedState: 'stopped',
-      latestTimestamp: '2019-11-21 00:01:13',
+      latestTimestamp: '2023-07-12 23:45:36',
     };
   }
 
   function getExpectedCounts(expectedJobId: string) {
     return {
       job_id: expectedJobId,
-      processed_record_count: '1,000',
-      processed_field_count: '1,000',
-      input_bytes: '148.8 KB',
-      input_field_count: '1,000',
+      processed_record_count: '4,675',
+      processed_field_count: '9,350',
+      input_bytes: '504.1 KB',
+      input_field_count: '9,350',
       invalid_date_count: '0',
       missing_field_count: '0',
       out_of_order_timestamp_count: '0',
-      empty_bucket_count: '23',
+      empty_bucket_count: '492',
       sparse_bucket_count: '0',
-      bucket_count: '230',
-      earliest_record_timestamp: '2019-04-05 11:25:35',
-      latest_record_timestamp: '2019-11-21 00:01:13',
-      input_record_count: '1,000',
-      latest_bucket_timestamp: '2019-11-21 00:00:00',
-      latest_empty_bucket_timestamp: '2019-11-17 00:00:00',
+      bucket_count: '2,975',
+      earliest_record_timestamp: '2023-06-12 00:04:19',
+      latest_record_timestamp: '2023-07-12 23:45:36',
+      input_record_count: '4,675',
+      latest_bucket_timestamp: '2023-07-12 23:45:00',
     };
   }
 
@@ -64,31 +69,22 @@ export default function ({ getService }: FtrProviderContext) {
       job_id: expectedJobId,
       result_type: 'model_size_stats',
       model_bytes_exceeded: '0.0 B',
-      // not checking total_by_field_count as the number of categories might change
+      total_by_field_count: '4',
       total_over_field_count: '0',
-      total_partition_field_count: '2',
+      total_partition_field_count: '3',
       bucket_allocation_failures_count: '0',
       memory_status: 'ok',
-      timestamp: '2019-11-20 00:00:00',
+      timestamp: '2023-07-12 23:30:00',
     };
   }
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
 
-  const fieldStatsEntries = [
-    {
-      fieldName: 'field1',
-      type: 'keyword' as FieldStatsType,
-    },
-  ];
-
-  describe('categorization', function () {
+  describe('geo', function () {
     this.tags(['ml']);
     before(async () => {
-      await esArchiver.loadIfNeeded(
-        'x-pack/platform/test/fixtures/es_archives/ml/categorization_small'
-      );
-      await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
+      await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -97,33 +93,31 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteDataViewByTitle('ft_categorization_small');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
-    it('job creation loads the categorization wizard for the source data', async () => {
+    it('job creation loads the geo wizard for the source data', async () => {
       await ml.testExecution.logTestStep('job creation loads the job management page');
-      await ml.testExecution.logTestStep('');
       await ml.navigation.navigateToStackManagementMlSection('anomaly_detection', 'ml-jobs-list');
 
       await ml.testExecution.logTestStep('job creation loads the new job source selection page');
       await ml.jobManagement.navigateToNewJobSourceSelection();
 
       await ml.testExecution.logTestStep('job creation loads the job type selection page');
-      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_categorization_small');
+      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_ecommerce');
 
-      await ml.testExecution.logTestStep('job creation loads the categorization job wizard page');
-      await ml.jobTypeSelection.selectCategorizationJob();
+      await ml.testExecution.logTestStep('job creation loads the geo job wizard page');
+      await ml.jobTypeSelection.selectGeoJob();
     });
 
-    it('job creation navigates through the categorization wizard and sets all needed fields', async () => {
+    it('job creation navigates through the geo wizard and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job creation displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
-      await ml.commonUI.assertDatePickerDataTierOptionsVisible(true);
 
       await ml.testExecution.logTestStep('job creation sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
-        'Apr 5, 2019 @ 11:25:35.770',
-        'Nov 21, 2019 @ 00:01:13.923'
+        'Jun 12, 2023 @ 00:04:19.000',
+        'Jul 12, 2023 @ 23:45:36.000'
       );
 
       await ml.testExecution.logTestStep('job creation displays the event rate chart');
@@ -133,31 +127,28 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job creation displays the pick fields step');
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
-      await ml.testExecution.logTestStep(
-        `job creation selects ${detectorTypeIdentifier} detector type`
-      );
-      await ml.jobWizardCategorization.assertCategorizationDetectorTypeSelectionExists();
-      await ml.jobWizardCategorization.selectCategorizationDetectorType(detectorTypeIdentifier);
+      await ml.testExecution.logTestStep('job creation selects the geo field');
+      await ml.jobWizardGeo.assertGeoFieldInputExists();
+      await ml.jobWizardGeo.selectGeoField(geoField);
+
+      await ml.testExecution.logTestStep('job creation displays detector preview');
+
+      await ml.jobWizardGeo.assertDetectorPreviewExists(detectors[0].identifier);
 
       await ml.testExecution.logTestStep(
-        'job creation opens field stats flyout from categorization field input'
+        'job creation inputs the split field and displays split cards'
       );
-      await ml.jobWizardCategorization.assertCategorizationFieldInputExists();
-      for (const { fieldName, type: fieldType } of fieldStatsEntries) {
-        await ml.jobWizardCategorization.assertFieldStatFlyoutContentFromCategorizationFieldInputTrigger(
-          fieldName,
-          fieldType
-        );
-      }
 
-      await ml.testExecution.logTestStep(`job creation selects the categorization field`);
-      await ml.jobWizardCategorization.selectCategorizationField(categorizationFieldIdentifier);
-      await ml.jobWizardCategorization.assertCategorizationExamplesCallout(
-        CATEGORY_EXAMPLES_VALIDATION_STATUS.VALID
-      );
-      await ml.jobWizardCategorization.assertCategorizationExamplesTable(
-        categorizationExampleCount
-      );
+      await ml.jobWizardMultiMetric.assertSplitFieldInputExists();
+      await ml.jobWizardMultiMetric.selectSplitField(splitField);
+
+      await ml.jobWizardMultiMetric.assertDetectorSplitExists(splitField);
+      await ml.jobWizardMultiMetric.assertDetectorSplitFrontCardTitle('FEMALE');
+      await ml.jobWizardMultiMetric.assertDetectorSplitNumberOfBackCards(1);
+
+      await ml.testExecution.logTestStep('job creation displays the influencer field');
+      await ml.jobWizardCommon.assertInfluencerInputExists();
+      await ml.jobWizardCommon.assertInfluencerSelection([splitField]);
 
       await ml.testExecution.logTestStep('job creation inputs the bucket span');
       await ml.jobWizardCommon.assertBucketSpanInputExists();
@@ -195,8 +186,6 @@ export default function ({ getService }: FtrProviderContext) {
 
       await ml.testExecution.logTestStep('job creation displays the model plot switch');
       await ml.jobWizardCommon.assertModelPlotSwitchExists();
-      await ml.jobWizardCommon.assertModelPlotSwitchEnabled(false);
-      await ml.jobWizardCommon.assertModelPlotSwitchCheckedState(false);
 
       await ml.testExecution.logTestStep('job creation enables the dedicated index switch');
       await ml.jobWizardCommon.assertDedicatedIndexSwitchExists();
@@ -235,25 +224,27 @@ export default function ({ getService }: FtrProviderContext) {
       );
 
       await ml.testExecution.logTestStep('job creation has detector results');
-      await ml.api.assertDetectorResultsExist(jobId, 0);
+      for (let i = 0; i < detectors.length; i++) {
+        await ml.api.assertDetectorResultsExist(jobId, i);
+      }
     });
 
-    it('job cloning opens the existing job in the categorization wizard', async () => {
+    it('job cloning opens the existing job in the geo wizard', async () => {
       await ml.testExecution.logTestStep(
-        'job cloning clicks the clone action and loads the single metric wizard'
+        'job cloning clicks the clone action and loads the geo wizard'
       );
       await ml.jobTable.clickCloneJobAction(jobId);
-      await ml.jobTypeSelection.assertCategorizationJobWizardOpen();
+      await ml.jobTypeSelection.assertGeoJobWizardOpen();
     });
 
-    it('job cloning navigates through the categorization wizard, checks and sets all needed fields', async () => {
+    it('job cloning navigates through the geo wizard, checks and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job cloning displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
 
       await ml.testExecution.logTestStep('job cloning sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
-        'Apr 5, 2019 @ 11:25:35.770',
-        'Nov 21, 2019 @ 00:01:13.923'
+        'Jun 12, 2023 @ 00:04:19.000',
+        'Jul 12, 2023 @ 23:45:36.000'
       );
 
       await ml.testExecution.logTestStep('job cloning displays the event rate chart');
@@ -263,8 +254,18 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job cloning displays the pick fields step');
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
-      await ml.testExecution.logTestStep('job cloning pre-fills field and aggregation');
-      await ml.jobWizardCategorization.assertCategorizationDetectorTypeSelectionExists();
+      await ml.testExecution.logTestStep('job cloning pre-fills the geo field');
+      await ml.jobWizardGeo.assertGeoFieldInputExists();
+      await ml.jobWizardGeo.assertGeoFieldSelection([geoField]);
+
+      await ml.testExecution.logTestStep(
+        'job cloning displays the detector preview with pre-filled geo field'
+      );
+      await ml.jobWizardGeo.assertDetectorPreviewExists(detectors[0].identifier);
+
+      await ml.testExecution.logTestStep('job cloning pre-fills influencers');
+      await ml.jobWizardCommon.assertInfluencerInputExists();
+      await ml.jobWizardCommon.assertInfluencerSelection([splitField]);
 
       await ml.testExecution.logTestStep('job cloning pre-fills the bucket span');
       await ml.jobWizardCommon.assertBucketSpanInputExists();
@@ -307,18 +308,11 @@ export default function ({ getService }: FtrProviderContext) {
 
       await ml.testExecution.logTestStep('job cloning pre-fills the model plot switch');
       await ml.jobWizardCommon.assertModelPlotSwitchExists();
-      await ml.jobWizardCommon.assertModelPlotSwitchEnabled(false);
       await ml.jobWizardCommon.assertModelPlotSwitchCheckedState(false);
 
       await ml.testExecution.logTestStep('job cloning pre-fills the dedicated index switch');
       await ml.jobWizardCommon.assertDedicatedIndexSwitchExists();
       await ml.jobWizardCommon.assertDedicatedIndexSwitchCheckedState(true);
-
-      // MML during clone has changed in #61589
-      // TODO: adjust test code to reflect the new behavior
-      // await ml.testExecution.logTestStep('job cloning pre-fills the model memory limit');
-      // await ml.jobWizardCommon.assertModelMemoryLimitInputExists();
-      // await ml.jobWizardCommon.assertModelMemoryLimitValue(memoryLimit);
 
       await ml.testExecution.logTestStep('job cloning displays the validation step');
       await ml.jobWizardCommon.advanceToValidationSection();
@@ -349,29 +343,9 @@ export default function ({ getService }: FtrProviderContext) {
       );
 
       await ml.testExecution.logTestStep('job cloning has detector results');
-      await ml.api.assertDetectorResultsExist(jobId, 0);
-    });
-
-    it('deletes the cloned job', async () => {
-      await ml.testExecution.logTestStep('job deletion has results for the job before deletion');
-      await ml.api.assertJobResultsExist(jobIdClone);
-
-      await ml.testExecution.logTestStep('job deletion triggers the delete action');
-      await ml.jobTable.clickDeleteJobAction(jobIdClone);
-
-      await ml.testExecution.logTestStep('job deletion confirms the delete modal');
-      await ml.jobTable.confirmDeleteJobModal();
-      await ml.api.waitForAnomalyDetectionJobNotToExist(jobIdClone, 30 * 1000);
-
-      await ml.testExecution.logTestStep(
-        'job deletion does not display the deleted job in the job list any more'
-      );
-      await ml.jobTable.filterWithSearchString(jobIdClone, 0);
-
-      await ml.testExecution.logTestStep(
-        'job deletion does not have results for the deleted job any more'
-      );
-      await ml.api.assertNoJobResultsExist(jobIdClone);
+      for (let i = 0; i < detectors.length; i++) {
+        await ml.api.assertDetectorResultsExist(jobId, i);
+      }
     });
   });
 }

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/index.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getService, loadTestFile }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const ml = getService('ml');
+
+  describe('machine learning - anomaly detection - group2', function () {
+    this.tags(['skipFirefox']);
+
+    before(async () => {
+      await ml.securityCommon.createMlRoles();
+      await ml.securityCommon.createMlUsers();
+      await ml.securityUI.loginAsMlPowerUser();
+    });
+
+    after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await ml.securityUI.logout();
+
+      await ml.securityCommon.cleanMlUsers();
+      await ml.securityCommon.cleanMlRoles();
+
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/categorization_small');
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/event_rate_nanos');
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
+
+      await ml.testResources.resetKibanaTimeZone();
+    });
+
+    loadTestFile(require.resolve('./population_job'));
+    loadTestFile(require.resolve('./geo_job'));
+    loadTestFile(require.resolve('./categorization_job'));
+    loadTestFile(require.resolve('./date_nanos_job'));
+    loadTestFile(require.resolve('./custom_urls'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/population_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/population_job.ts
@@ -5,30 +5,44 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { FieldStatsType } from '../../common/types';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  const jobId = `ec_geo_1_${Date.now()}`;
+  const jobId = `ec_population_1_${Date.now()}`;
   const jobIdClone = `${jobId}_clone`;
-  const jobDescription = 'Create geo job based on the ecommerce sample dataset with 15m bucketspan';
-  const jobGroups = ['automated', 'ecommerce', 'geo'];
+  const jobDescription =
+    'Create population job based on the ecommerce sample dataset with 2h bucketspan over customer_id' +
+    ' - detectors: (Mean(products.base_price) by customer_gender), (Mean(products.quantity) by category.leyword)';
+  const jobGroups = ['automated', 'ecommerce', 'population'];
   const jobGroupsClone = [...jobGroups, 'clone'];
-  const geoField = 'geoip.location';
-  const splitField = 'customer_gender';
+  const populationField = 'customer_id';
   const detectors = [
     {
-      identifier: 'Lat long(geoip.location)',
+      identifier: 'Mean(products.base_price)',
+      splitField: 'customer_gender',
+      frontCardTitle: 'FEMALE',
+      numberOfBackCards: 1,
+    },
+    {
+      identifier: 'Mean(products.quantity)',
+      splitField: 'category.keyword',
       frontCardTitle: "Men's Clothing",
-      function: 'lat_long',
-      field_name: geoField,
       numberOfBackCards: 5,
-      splitField,
     },
   ];
-  const bucketSpan = '15m';
+  const fieldStatsEntries = [
+    {
+      fieldName: 'currency',
+      type: 'keyword' as FieldStatsType,
+      expectedValues: ['EUR'],
+    },
+  ];
+
+  const bucketSpan = '2h';
   const memoryLimit = '8mb';
 
   function getExpectedRow(expectedJobId: string, expectedJobGroups: string[]) {
@@ -48,19 +62,19 @@ export default function ({ getService }: FtrProviderContext) {
     return {
       job_id: expectedJobId,
       processed_record_count: '4,675',
-      processed_field_count: '9,350',
-      input_bytes: '504.1 KB',
-      input_field_count: '9,350',
+      processed_field_count: '23,375',
+      input_bytes: '867.7 KB',
+      input_field_count: '23,375',
       invalid_date_count: '0',
       missing_field_count: '0',
       out_of_order_timestamp_count: '0',
-      empty_bucket_count: '492',
+      empty_bucket_count: '0',
       sparse_bucket_count: '0',
-      bucket_count: '2,975',
+      bucket_count: '371',
       earliest_record_timestamp: '2023-06-12 00:04:19',
       latest_record_timestamp: '2023-07-12 23:45:36',
       input_record_count: '4,675',
-      latest_bucket_timestamp: '2023-07-12 23:45:00',
+      latest_bucket_timestamp: '2023-07-12 22:00:00',
     };
   }
 
@@ -69,18 +83,18 @@ export default function ({ getService }: FtrProviderContext) {
       job_id: expectedJobId,
       result_type: 'model_size_stats',
       model_bytes_exceeded: '0.0 B',
-      total_by_field_count: '4',
-      total_over_field_count: '0',
+      total_by_field_count: '25',
+      total_over_field_count: '92',
       total_partition_field_count: '3',
       bucket_allocation_failures_count: '0',
       memory_status: 'ok',
-      timestamp: '2023-07-12 23:30:00',
+      timestamp: '2023-07-12 20:00:00',
     };
   }
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
 
-  describe('geo', function () {
+  describe('population', function () {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
@@ -96,7 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
-    it('job creation loads the geo wizard for the source data', async () => {
+    it('job creation loads the population wizard for the source data', async () => {
       await ml.testExecution.logTestStep('job creation loads the job management page');
       await ml.navigation.navigateToStackManagementMlSection('anomaly_detection', 'ml-jobs-list');
 
@@ -106,13 +120,14 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job creation loads the job type selection page');
       await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob('ft_ecommerce');
 
-      await ml.testExecution.logTestStep('job creation loads the geo job wizard page');
-      await ml.jobTypeSelection.selectGeoJob();
+      await ml.testExecution.logTestStep('job creation loads the population job wizard page');
+      await ml.jobTypeSelection.selectPopulationJob();
     });
 
-    it('job creation navigates through the geo wizard and sets all needed fields', async () => {
+    it('job creation navigates through the population wizard and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job creation displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
+      await ml.commonUI.assertDatePickerDataTierOptionsVisible(true);
 
       await ml.testExecution.logTestStep('job creation sets the time range');
       await ml.jobWizardCommon.clickUseFullDataButton(
@@ -127,28 +142,53 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job creation displays the pick fields step');
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
-      await ml.testExecution.logTestStep('job creation selects the geo field');
-      await ml.jobWizardGeo.assertGeoFieldInputExists();
-      await ml.jobWizardGeo.selectGeoField(geoField);
+      await ml.testExecution.logTestStep(
+        'job creation opens field stats flyout from population field input'
+      );
+      await ml.jobWizardPopulation.assertPopulationFieldInputExists();
+      for (const { fieldName, type: fieldType, expectedValues } of fieldStatsEntries) {
+        await ml.jobWizardPopulation.assertFieldStatFlyoutContentFromPopulationFieldInputTrigger(
+          fieldName,
+          fieldType,
+          expectedValues
+        );
+      }
 
-      await ml.testExecution.logTestStep('job creation displays detector preview');
-
-      await ml.jobWizardGeo.assertDetectorPreviewExists(detectors[0].identifier);
+      await ml.testExecution.logTestStep('job creation selects the population field');
+      await ml.jobWizardPopulation.selectPopulationField(populationField);
 
       await ml.testExecution.logTestStep(
-        'job creation inputs the split field and displays split cards'
+        'job creation selects detectors and displays detector previews'
       );
+      for (const [index, detector] of detectors.entries()) {
+        await ml.jobWizardCommon.assertAggAndFieldInputExists();
+        await ml.jobWizardCommon.selectAggAndField(detector.identifier, false);
+        await ml.jobWizardCommon.assertDetectorPreviewExists(detector.identifier, index, 'SCATTER');
+      }
 
-      await ml.jobWizardMultiMetric.assertSplitFieldInputExists();
-      await ml.jobWizardMultiMetric.selectSplitField(splitField);
+      await ml.testExecution.logTestStep(
+        'job creation inputs detector split fields and displays split cards'
+      );
+      for (const [index, detector] of detectors.entries()) {
+        await ml.jobWizardPopulation.assertDetectorSplitFieldInputExists(index);
+        await ml.jobWizardPopulation.selectDetectorSplitField(index, detector.splitField);
 
-      await ml.jobWizardMultiMetric.assertDetectorSplitExists(splitField);
-      await ml.jobWizardMultiMetric.assertDetectorSplitFrontCardTitle('FEMALE');
-      await ml.jobWizardMultiMetric.assertDetectorSplitNumberOfBackCards(1);
+        await ml.jobWizardPopulation.assertDetectorSplitExists(index);
+        await ml.jobWizardPopulation.assertDetectorSplitFrontCardTitle(
+          index,
+          detector.frontCardTitle
+        );
+        await ml.jobWizardPopulation.assertDetectorSplitNumberOfBackCards(
+          index,
+          detector.numberOfBackCards
+        );
+      }
 
       await ml.testExecution.logTestStep('job creation displays the influencer field');
       await ml.jobWizardCommon.assertInfluencerInputExists();
-      await ml.jobWizardCommon.assertInfluencerSelection([splitField]);
+      await ml.jobWizardCommon.assertInfluencerSelection(
+        [populationField].concat(detectors.map((detector) => detector.splitField))
+      );
 
       await ml.testExecution.logTestStep('job creation inputs the bucket span');
       await ml.jobWizardCommon.assertBucketSpanInputExists();
@@ -229,15 +269,15 @@ export default function ({ getService }: FtrProviderContext) {
       }
     });
 
-    it('job cloning opens the existing job in the geo wizard', async () => {
+    it('job cloning opens the existing job in the population wizard', async () => {
       await ml.testExecution.logTestStep(
-        'job cloning clicks the clone action and loads the geo wizard'
+        'job cloning clicks the clone action and loads the population wizard'
       );
       await ml.jobTable.clickCloneJobAction(jobId);
-      await ml.jobTypeSelection.assertGeoJobWizardOpen();
+      await ml.jobTypeSelection.assertPopulationJobWizardOpen();
     });
 
-    it('job cloning navigates through the geo wizard, checks and sets all needed fields', async () => {
+    it('job cloning navigates through the population wizard, checks and sets all needed fields', async () => {
       await ml.testExecution.logTestStep('job cloning displays the time range step');
       await ml.jobWizardCommon.assertTimeRangeSectionExists();
 
@@ -254,18 +294,35 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job cloning displays the pick fields step');
       await ml.jobWizardCommon.advanceToPickFieldsSection();
 
-      await ml.testExecution.logTestStep('job cloning pre-fills the geo field');
-      await ml.jobWizardGeo.assertGeoFieldInputExists();
-      await ml.jobWizardGeo.assertGeoFieldSelection([geoField]);
+      await ml.testExecution.logTestStep('job cloning pre-fills the population field');
+      await ml.jobWizardPopulation.assertPopulationFieldInputExists();
+      await ml.jobWizardPopulation.assertPopulationFieldSelection([populationField]);
 
       await ml.testExecution.logTestStep(
-        'job cloning displays the detector preview with pre-filled geo field'
+        'job cloning pre-fills detectors and shows preview with split cards'
       );
-      await ml.jobWizardGeo.assertDetectorPreviewExists(detectors[0].identifier);
+      for (const [index, detector] of detectors.entries()) {
+        await ml.jobWizardCommon.assertDetectorPreviewExists(detector.identifier, index, 'SCATTER');
+
+        await ml.jobWizardPopulation.assertDetectorSplitFieldSelection(index, [
+          detector.splitField,
+        ]);
+        await ml.jobWizardPopulation.assertDetectorSplitExists(index);
+        await ml.jobWizardPopulation.assertDetectorSplitFrontCardTitle(
+          index,
+          detector.frontCardTitle
+        );
+        await ml.jobWizardPopulation.assertDetectorSplitNumberOfBackCards(
+          index,
+          detector.numberOfBackCards
+        );
+      }
 
       await ml.testExecution.logTestStep('job cloning pre-fills influencers');
       await ml.jobWizardCommon.assertInfluencerInputExists();
-      await ml.jobWizardCommon.assertInfluencerSelection([splitField]);
+      await ml.jobWizardCommon.assertInfluencerSelection(
+        [populationField].concat(detectors.map((detector) => detector.splitField))
+      );
 
       await ml.testExecution.logTestStep('job cloning pre-fills the bucket span');
       await ml.jobWizardCommon.assertBucketSpanInputExists();
@@ -313,6 +370,12 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('job cloning pre-fills the dedicated index switch');
       await ml.jobWizardCommon.assertDedicatedIndexSwitchExists();
       await ml.jobWizardCommon.assertDedicatedIndexSwitchCheckedState(true);
+
+      // MML during clone has changed in #61589
+      // TODO: adjust test code to reflect the new behavior
+      // await ml.testExecution.logTestStep('job cloning pre-fills the model memory limit');
+      // await ml.jobWizardCommon.assertModelMemoryLimitInputExists();
+      // await ml.jobWizardCommon.assertModelMemoryLimitValue(memoryLimit);
 
       await ml.testExecution.logTestStep('job cloning displays the validation step');
       await ml.jobWizardCommon.advanceToValidationSection();

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/advanced_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/advanced_job.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
-import type { PickFieldsConfig, DatafeedConfig, Detector } from './types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+import type { PickFieldsConfig, DatafeedConfig, Detector } from '../types';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/config.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('../group1/config.ts'));
+
+  return {
+    ...baseConfig.getAll(),
+    testFiles: [require.resolve('.')],
+    junit: {
+      reportName: 'Chrome X-Pack UI Functional Tests - ML anomaly_detection_jobs - group3',
+    },
+  };
+}

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/convert_jobs_to_advanced_job.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/convert_jobs_to_advanced_job.ts
@@ -6,8 +6,8 @@
  */
 
 import { CATEGORY_EXAMPLES_VALIDATION_STATUS } from '@kbn/ml-category-validator';
-import type { PickFieldsConfig, DatafeedConfig, Detector } from './types';
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { PickFieldsConfig, DatafeedConfig, Detector } from '../types';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/convert_single_metric_job_to_multi_metric.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/convert_single_metric_job_to_multi_metric.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const config = getService('config');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/delete_job_and_delete_annotations.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/delete_job_and_delete_annotations.ts
@@ -9,8 +9,8 @@ import { ANNOTATION_TYPE } from '@kbn/ml-plugin/common/constants/annotations';
 import {
   SINGLE_METRIC_JOB_CONFIG,
   MULTI_METRIC_JOB_CONFIG,
-} from '../../../../api_integration/apis/ml/jobs/common_jobs';
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+} from '../../../../../api_integration/apis/ml/jobs/common_jobs';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const config = getService('config');

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/index.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getService, loadTestFile }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const ml = getService('ml');
+
+  describe('machine learning - anomaly detection - group3', function () {
+    this.tags(['skipFirefox']);
+
+    before(async () => {
+      await ml.securityCommon.createMlRoles();
+      await ml.securityCommon.createMlUsers();
+      await ml.securityUI.loginAsMlPowerUser();
+    });
+
+    after(async () => {
+      // NOTE: Logout needs to happen before anything else to avoid flaky behavior
+      await ml.securityUI.logout();
+
+      await ml.securityCommon.cleanMlUsers();
+      await ml.securityCommon.cleanMlRoles();
+
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/ecommerce');
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/categorization_small');
+      await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/ml/farequote');
+
+      await ml.testResources.resetKibanaTimeZone();
+    });
+
+    loadTestFile(require.resolve('./advanced_job'));
+    loadTestFile(require.resolve('./delete_job_and_delete_annotations'));
+    loadTestFile(require.resolve('./convert_single_metric_job_to_multi_metric'));
+    loadTestFile(require.resolve('./convert_jobs_to_advanced_job'));
+    loadTestFile(require.resolve('./supplied_configurations'));
+  });
+}

--- a/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/supplied_configurations.ts
+++ b/x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/supplied_configurations.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FtrProviderContext } from '../../../ftr_provider_context';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');


### PR DESCRIPTION
## Summary

Split `x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/config.ts` (~31 minutes) into smaller groups targeting 15–20 minutes each.

- Split into 3 groups from the original monolithic config
- Moved 15 test files across `group1/`, `group2/`, `group3/`
- Registered all 3 new configs in `.buildkite/ftr_platform_stateful_configs.yml`

### New configs

* `x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group1/config.ts`
* `x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group2/config.ts`
* `x-pack/platform/test/functional/apps/ml/anomaly_detection_jobs/group3/config.ts`

