### PR TITLE
[Fleet] Skip routing transforms for dynamic_signal_types otelcol packages

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -787,117 +787,39 @@ describe('generateOtelcolConfig', () => {
       ],
     ]);
 
-    it('should generate transform with multiple signal type statements when dynamic_signal_types is true', () => {
+    it('should not generate routing transform when dynamic_signal_types is true', () => {
       const inputs: FullAgentPolicyInput[] = [otelInputWithMultipleSignalTypes];
       const result = generateOtelcolConfig(inputs, defaultOutput, packageInfoCache);
 
-      expect(result.processors?.['transform/test-multi-signal-stream-id-1-routing']).toEqual({
-        log_statements: [
-          {
-            context: 'log',
-            statements: [
-              'set(attributes["data_stream.type"], "logs")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        metric_statements: [
-          {
-            context: 'datapoint',
-            statements: [
-              'set(attributes["data_stream.type"], "metrics")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        trace_statements: [
-          {
-            context: 'span',
-            statements: [
-              'set(attributes["data_stream.type"], "traces")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-          {
-            context: 'spanevent',
-            statements: [
-              'set(attributes["data_stream.type"], "logs")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        profile_statements: [
-          {
-            context: 'profile',
-            statements: [
-              'set(attributes["data_stream.type"], "profiles")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
+      // No routing transform processor should be present
+      expect(
+        result.processors?.['transform/test-multi-signal-stream-id-1-routing']
+      ).toBeUndefined();
+
+      // Pipeline processors should not include routing transform
+      Object.values(result.service?.pipelines ?? {}).forEach((pipeline) => {
+        expect(pipeline.processors ?? []).not.toContain(
+          'transform/test-multi-signal-stream-id-1-routing'
+        );
       });
     });
 
-    it('should generate transform with multiple signal type statements when dynamic_signal_types is true and pipelines have simple names', () => {
+    it('should not generate routing transform when dynamic_signal_types is true and pipelines have simple names', () => {
       const inputs: FullAgentPolicyInput[] = [otelInputWithMultipleSignalTypes2];
       const result = generateOtelcolConfig(inputs, defaultOutput, packageInfoCache);
 
-      expect(result.processors?.['transform/test-multi-signal-stream-id-1-routing']).toEqual({
-        log_statements: [
-          {
-            context: 'log',
-            statements: [
-              'set(attributes["data_stream.type"], "logs")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        metric_statements: [
-          {
-            context: 'datapoint',
-            statements: [
-              'set(attributes["data_stream.type"], "metrics")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        trace_statements: [
-          {
-            context: 'span',
-            statements: [
-              'set(attributes["data_stream.type"], "traces")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-          {
-            context: 'spanevent',
-            statements: [
-              'set(attributes["data_stream.type"], "logs")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        profile_statements: [
-          {
-            context: 'profile',
-            statements: [
-              'set(attributes["data_stream.type"], "profiles")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
+      expect(
+        result.processors?.['transform/test-multi-signal-stream-id-1-routing']
+      ).toBeUndefined();
+
+      Object.values(result.service?.pipelines ?? {}).forEach((pipeline) => {
+        expect(pipeline.processors ?? []).not.toContain(
+          'transform/test-multi-signal-stream-id-1-routing'
+        );
       });
     });
 
-    it('should generate transform with only specified signal types when pipelines have subset', () => {
+    it('should not generate routing transform when dynamic_signal_types is true with subset of pipelines', () => {
       const baseStream = otelInputWithMultipleSignalTypes.streams?.[0];
       if (!baseStream) {
         throw new Error('Test data is invalid');
@@ -925,32 +847,15 @@ describe('generateOtelcolConfig', () => {
       const inputs: FullAgentPolicyInput[] = [otelInputWithSubsetSignalTypes];
       const result = generateOtelcolConfig(inputs, defaultOutput, packageInfoCache);
 
-      expect(result.processors?.['transform/test-multi-signal-stream-id-1-routing']).toEqual({
-        log_statements: [
-          {
-            context: 'log',
-            statements: [
-              'set(attributes["data_stream.type"], "logs")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-        metric_statements: [
-          {
-            context: 'datapoint',
-            statements: [
-              'set(attributes["data_stream.type"], "metrics")',
-              'set(attributes["data_stream.dataset"], "multidataset")',
-              'set(attributes["data_stream.namespace"], "default")',
-            ],
-          },
-        ],
-      });
-      // Should not have trace_statements
       expect(
-        result.processors?.['transform/test-multi-signal-stream-id-1-routing']?.trace_statements
+        result.processors?.['transform/test-multi-signal-stream-id-1-routing']
       ).toBeUndefined();
+
+      Object.values(result.service?.pipelines ?? {}).forEach((pipeline) => {
+        expect(pipeline.processors ?? []).not.toContain(
+          'transform/test-multi-signal-stream-id-1-routing'
+        );
+      });
     });
 
     it('should fall back to single signal type when dynamic_signal_types is false', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -87,7 +87,9 @@ export function generateOtelcolConfig(
             : {}),
         };
 
-        otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
+        if (Object.keys(attributesTransform).length > 0) {
+          otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
+        }
 
         if (stream.data_stream.type === dataTypes.Traces && stream[USE_APM_VAR_NAME] === true) {
           if (!otelConfig?.connectors) {
@@ -215,15 +217,10 @@ function generateOTelAttributesTransform(
   let transformStatements: Record<string, any> = {};
 
   if (dynamicSignalTypes && streamPipelines) {
-    // When dynamic_signal_types is true, extract signal types from pipeline IDs
-    // and generate transforms for each. This allows the collector to route data
-    // to the appropriate datastreams based on the pipelines configured in the policy.
-    const signalTypes = extractSignalTypesFromPipelines(streamPipelines);
-    // Generate transforms for each signal type found in pipelines
-    signalTypes.forEach((signalType) => {
-      const typeTransforms = generateOtelTypeTransforms(signalType, dataset, namespace);
-      Object.assign(transformStatements, typeTransforms);
-    });
+    // When dynamic_signal_types is true, skip routing transforms entirely.
+    // The ES exporter handles routing based on scope.name, explicit data_stream.*
+    // payload attributes, and signal type.
+    return {};
   } else {
     // Default: single signal type from stream.data_stream.type
     transformStatements = generateOtelTypeTransforms(type, dataset, namespace);


### PR DESCRIPTION
## Summary

OTel input packages with `dynamic_signal_types: true` (e.g. `otlp`, `kafka`) incorrectly route data using the `policy_template` name as the dataset via `transform/*-routing` processors. Data lands in e.g. `logs-otlpreceiver.otel-default` instead of `logs-generic.otel-default`.

This PR makes Fleet skip generating routing transforms for these packages entirely - the ES exporter handles routing based on `scope.name`, explicit `data_stream.*` payload attributes, and signal type.

### Changes

**`otel_collector.ts`**
- `generateOTelAttributesTransform()`: returns `{}` when `dynamicSignalTypes` is true, instead of generating per-signal-type routing transforms
- `generateOtelcolConfig()`: guards `appendOtelComponents` call so empty transforms don't produce empty processor entries or pipeline references

**`otel_collector.test.ts`**
- Updated 3 existing `dynamic_signal_types: true` tests to assert no `transform/*-routing` processor is generated and no routing entry appears in pipeline processor arrays
- Existing tests for `dynamic_signal_types: false` and `undefined` are unchanged, confirming routing transforms still work for non-dynamic packages

### Related issues

Closes https://github.com/elastic/ingest-dev/issues/7132

## Test plan

- [x] Existing unit tests updated and passing (`otel_collector.test.ts`)
- [x] Verify `dynamic_signal_types: true` packages (otlp, kafka) no longer get `transform/*-routing` processors in generated agent policy
- [x] Verify non-dynamic packages (e.g. receiver-specific) still get routing transforms as before
- [x] Verify ES exporter correctly routes data to `{signal}-generic.otel-default` for dynamic packages

## Screenshots + examples

After removing the routing transforms, here's a sample of documents generated with `telemetrygen` ingested by the OTLP package: 

<img width="1418" height="637" alt="image" src="https://github.com/user-attachments/assets/e1cd3144-92c5-45ad-ad46-aa7134bfcc91" />

<details>
<summary>Relevant agent policy chunk after these changes</summary>

```yml
receivers:
  otlp/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:4318
processors:
  resourcedetection/system/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b:
    detectors:
      - system
service:
  pipelines:
    logs/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b:
      receivers:
        - >-
          otlp/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      processors:
        - >-
          resourcedetection/system/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      exporters:
        - forward
    metrics/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b:
      receivers:
        - >-
          otlp/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      processors:
        - >-
          resourcedetection/system/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      exporters:
        - forward
    traces/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b:
      receivers:
        - >-
          otlp/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      processors:
        - >-
          resourcedetection/system/otelcol-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b-otelcol-otlp_input_otel-otlpreceiver-6f9bf8cb-c2da-4d56-983c-a0a5160dfc2b
      exporters:
        - forward
    logs:
      receivers:
        - forward
      exporters:
        - elasticsearch/default
    metrics:
      receivers:
        - forward
      exporters:
        - elasticsearch/default
    traces:
      receivers:
        - forward
      exporters:
        - elasticsearch/default
connectors:
  forward: {}
exporters:
  elasticsearch/default:
    endpoints:
      - http://host.docker.internal:9200
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)