### PR TITLE
[8.19] [Search][A11y] Fix focus order after Flyout is open (#256510)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/api_call_flyout.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/api_call_flyout.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
+import type { EuiFocusTrapProps } from '@elastic/eui';
 import {
   EuiCodeBlock,
   EuiFlexGroup,
@@ -31,6 +32,7 @@ export interface APICallData {
 }
 
 export interface APICallFlyoutProps {
+  focusButtonRef: React.Ref<HTMLButtonElement>;
   lastAPICall: APICallData;
   onClose: () => void;
   searchApplicationName: string;
@@ -40,13 +42,26 @@ export const APICallFlyout: React.FC<APICallFlyoutProps> = ({
   onClose,
   lastAPICall,
   searchApplicationName,
+  focusButtonRef,
 }) => {
   const [tab, setTab] = useState<'request' | 'response'>('request');
 
+  const focusTrapProps: Pick<EuiFocusTrapProps, 'returnFocus'> = useMemo(
+    () => ({
+      returnFocus() {
+        if (focusButtonRef && 'current' in focusButtonRef && focusButtonRef.current) {
+          focusButtonRef.current.focus();
+          return false;
+        }
+        return true;
+      },
+    }),
+    [focusButtonRef]
+  );
   const contents = JSON.stringify(lastAPICall[tab], null, 2);
 
   return (
-    <EuiFlyout onClose={onClose} size="m">
+    <EuiFlyout onClose={onClose} size="m" focusTrapProps={focusTrapProps}>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle>
           <h2>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/applications/components/search_application/docs_explorer/docs_explorer.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -354,6 +354,7 @@ export const SearchApplicationDocsExplorer: React.FC = () => {
   const { searchApplicationName, isLoadingSearchApplication, hasSchemaConflicts } = useValues(
     SearchApplicationViewLogic
   );
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { resultFields, sortableFields } = useValues(SearchApplicationDocsExplorerLogic);
   const { searchApplicationData } = useValues(SearchApplicationIndicesLogic);
 
@@ -422,6 +423,7 @@ export const SearchApplicationDocsExplorer: React.FC = () => {
                           iconType="eye"
                           onClick={() => setShowAPICallFlyout(true)}
                           isLoading={lastAPICall == null}
+                          buttonRef={buttonRef}
                         >
                           {i18n.translate(
                             'xpack.enterpriseSearch.searchApplications.searchApplication.docsExplorer.inputView.appendButtonLabel',
@@ -458,6 +460,7 @@ export const SearchApplicationDocsExplorer: React.FC = () => {
         {showAPICallFlyout && lastAPICall && (
           <APICallFlyout
             onClose={() => setShowAPICallFlyout(false)}
+            focusButtonRef={buttonRef}
             lastAPICall={lastAPICall}
             searchApplicationName={searchApplicationName}
           />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search][A11y] Fix focus order after Flyout is open (#256510)](https://github.com/elastic/kibana/pull/256510)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-09T15:03:50Z","message":"[Search][A11y] Fix focus order after Flyout is open (#256510)\n\n## Summary\n\nWhen navigated through keyboard, closing view api call flyout losses the\npage focus order and navigated to the page starting.\nTo fix this, added focusTrap in Flyout with view api call buttonRef. So\nthat when flyout is closed the focus is returned to the Search bar of\nview api call button element.\n**Note:** The expected result is to navigate back to view api call\nbutton but I am not able to achieve it. I tried EuiFocusTrap as well.\nBut had no luck. I am open to suggestions\n\n### Screen recording \n\n\nhttps://github.com/user-attachments/assets/81653c0c-3b5a-4319-8b86-7f63ef39b643\n\n\n### Checklist\n\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added automatic focus restoration in the API Call Flyout, returning\nfocus to the triggering button when the flyout closes. This improves\nkeyboard navigation and accessibility.\n\n","sha":"0596213048f6f82e03235e5366633d679a423f29","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Search","backport:all-open","v9.4.0"],"title":"[Search][A11y] Fix focus order after Flyout is open","number":256510,"url":"https://github.com/elastic/kibana/pull/256510","mergeCommit":{"message":"[Search][A11y] Fix focus order after Flyout is open (#256510)\n\n## Summary\n\nWhen navigated through keyboard, closing view api call flyout losses the\npage focus order and navigated to the page starting.\nTo fix this, added focusTrap in Flyout with view api call buttonRef. So\nthat when flyout is closed the focus is returned to the Search bar of\nview api call button element.\n**Note:** The expected result is to navigate back to view api call\nbutton but I am not able to achieve it. I tried EuiFocusTrap as well.\nBut had no luck. I am open to suggestions\n\n### Screen recording \n\n\nhttps://github.com/user-attachments/assets/81653c0c-3b5a-4319-8b86-7f63ef39b643\n\n\n### Checklist\n\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added automatic focus restoration in the API Call Flyout, returning\nfocus to the triggering button when the flyout closes. This improves\nkeyboard navigation and accessibility.\n\n","sha":"0596213048f6f82e03235e5366633d679a423f29"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256510","number":256510,"mergeCommit":{"message":"[Search][A11y] Fix focus order after Flyout is open (#256510)\n\n## Summary\n\nWhen navigated through keyboard, closing view api call flyout losses the\npage focus order and navigated to the page starting.\nTo fix this, added focusTrap in Flyout with view api call buttonRef. So\nthat when flyout is closed the focus is returned to the Search bar of\nview api call button element.\n**Note:** The expected result is to navigate back to view api call\nbutton but I am not able to achieve it. I tried EuiFocusTrap as well.\nBut had no luck. I am open to suggestions\n\n### Screen recording \n\n\nhttps://github.com/user-attachments/assets/81653c0c-3b5a-4319-8b86-7f63ef39b643\n\n\n### Checklist\n\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n\n## Summary by CodeRabbit\n\n* **New Features**\n* Added automatic focus restoration in the API Call Flyout, returning\nfocus to the triggering button when the flyout closes. This improves\nkeyboard navigation and accessibility.\n\n","sha":"0596213048f6f82e03235e5366633d679a423f29"}},{"url":"https://github.com/elastic/kibana/pull/256722","number":256722,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/256723","number":256723,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->