### PR TITLE
[Observability:Streams][Streamlang] Add an Enrich processor

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -72902,6 +72902,41 @@ components:
                 - field
                 - extractions
             - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - enrich
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                override:
+                  type: boolean
+                policy_name:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - policy_name
+                - to
+            - additionalProperties: false
               description: Manual ingest pipeline wrapper around native Elasticsearch processors
               type: object
               properties:

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: ['existing_tag'] }];
@@ -52,7 +52,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'a' }];
@@ -94,7 +94,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -120,7 +120,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'a' }];
@@ -150,7 +150,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ tags: ['existing_tag'] }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/append.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: ['existing_tag'] }];
       await testBed.ingest('ingest-append', docs, processors);
@@ -53,7 +53,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'a' }];
       await testBed.ingest('ingest-append-non-existent', docs, processors);
@@ -97,7 +97,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }
@@ -121,7 +121,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'a' }];
         await testBed.ingest('ingest-append-scalar', docs, processors);
@@ -151,7 +151,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ tags: ['existing_tag'] }];
         await testBed.ingest('ingest-append-dedupe', docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/concat.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/concat.spec.ts
@@ -35,7 +35,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -90,7 +90,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com', has_email: true },
@@ -134,7 +134,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -184,7 +184,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/concat.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/concat.spec.ts
@@ -34,7 +34,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -89,7 +89,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -133,7 +133,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -183,7 +183,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest('ingest-convert-value', docs, processors);
@@ -59,7 +59,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
         await testBed.ingest('ingest-convert-value-to-target', docs, processors);
@@ -98,7 +98,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
         await testBed.ingest('ingest-convert-value-to-target-with-where', docs, processors);
@@ -153,7 +153,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/convert.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
@@ -58,7 +58,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
@@ -97,7 +97,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
@@ -150,7 +150,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
@@ -61,7 +61,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -100,7 +100,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
@@ -145,7 +145,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         };
 
         // Both transpilers should throw validation errors for Mustache templates
-        expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+        await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed'
         );
         await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -171,7 +171,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       // Test documents with different formats that should match different patterns in the list
@@ -218,7 +218,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '01-01-2025' } }];
@@ -253,7 +253,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { date: '08 avril 1999' } }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/date.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest('ingest-date-single-format', docs, processors);
@@ -62,7 +62,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { event: { created: '01/01/2025:12:34:56' } },
@@ -101,7 +101,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest('ingest-date-output-format', docs, processors);
@@ -148,7 +148,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
         expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed'
         );
-        expect(() => transpileEsql(streamlangDSL)).toThrow(
+        await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed'
         );
       }
@@ -172,7 +172,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       // Test documents with different formats that should match different patterns in the list
       const docs = [
@@ -219,7 +219,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { time: '01-01-2025' } }];
       const { errors } = await testBed.ingest('ingest-date-fail', docs, processors);
@@ -254,7 +254,7 @@ apiTest.describe('Cross-compatibility - Date Processor', () => {
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ log: { date: '08 avril 1999' } }];
       await testBed.ingest('ingest-date-timezone-locale-format', docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -62,7 +62,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'value1-value2' }];
@@ -109,7 +109,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -132,7 +132,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -179,7 +179,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -228,7 +228,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ case: 'missing', log: { level: 'info' } }];
@@ -262,7 +262,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -308,7 +308,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -363,7 +363,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -418,7 +418,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/dissect.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -63,7 +63,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'value1-value2' }];
         await testBed.ingest('ingest-dissect-append', docs, processors);
@@ -112,7 +112,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }
@@ -133,7 +133,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -180,7 +180,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -229,7 +229,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ case: 'missing', log: { level: 'info' } }];
         const { errors } = await testBed.ingest('ingest-dissect-fail', docs, processors);
@@ -263,7 +263,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { case: 'dissected', attributes: { should_exist: 'YES' }, message: '[info]' },
@@ -309,7 +309,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -364,7 +364,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -419,7 +419,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -78,7 +78,7 @@ apiTest.describe(
       };
 
       // Both transpilers should throw validation errors with no where clause
-      expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+      await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
         'where clause is required in drop_document.'
       );
       await expect(transpileEsql(streamlangDSL)).rejects.toThrow(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/drop_document.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -81,7 +81,7 @@ apiTest.describe(
       expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
         'where clause is required in drop_document.'
       );
-      expect(() => transpileEsql(streamlangDSL)).toThrow(
+      await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
         'where clause is required in drop_document.'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/enrich.spec.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import { tags } from '@kbn/scout';
+import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpileEsql, transpileIngestPipeline } from '@kbn/streamlang';
+import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
+import { streamlangApiTest as apiTest } from '../..';
+import {
+  ENRICH_POLICY_NAME,
+  setupEnrichIndexWithPolicy,
+  teardownEnrichIndexWithPolicy,
+} from '../../utils/enrich_helpers';
+
+const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
+  Promise.resolve({
+    matchField: 'ip',
+    enrichFields: ['city', 'country'],
+  });
+
+const resolverOptions = { enrich: mockEnrichPolicyResolver };
+
+apiTest.describe(
+  'Cross-compatibility - Enrich Processor',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    apiTest.beforeAll(async ({ esClient }) => {
+      await setupEnrichIndexWithPolicy(esClient);
+    });
+
+    apiTest.afterAll(async ({ esClient }) => {
+      await teardownEnrichIndexWithPolicy(esClient);
+    });
+
+    apiTest(
+      'should add matching location fields from policy for each document',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = await transpileIngestPipeline(
+          streamlangDSL,
+          undefined,
+          resolverOptions
+        );
+        const { query } = await transpileEsql(streamlangDSL, undefined, resolverOptions);
+
+        const docs = [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }];
+
+        await testBed.ingest('cross-compat-enrich-basic-ingest', docs, processors);
+        const ingestDocs = await testBed.getFlattenedDocsOrdered(
+          'cross-compat-enrich-basic-ingest'
+        );
+
+        await testBed.ingest('cross-compat-enrich-basic-esql', docs);
+        const esqlResult = await esql.queryOnIndex('cross-compat-enrich-basic-esql', query);
+
+        expect(ingestDocs).toHaveLength(2);
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+
+        expect(ingestDocs[0]?.['location.city']).toBe('New York');
+        expect(ingestDocs[0]?.['location.country']).toBe('US');
+        expect(ingestDocs[1]?.['location.city']).toBe('London');
+        expect(ingestDocs[1]?.['location.country']).toBe('GB');
+
+        expect(esqlResult.documentsOrdered[0]?.['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]?.['location.country']).toBe('US');
+        expect(esqlResult.documentsOrdered[1]?.['location.city']).toBe('London');
+        expect(esqlResult.documentsOrdered[1]?.['location.country']).toBe('GB');
+      }
+    );
+
+    apiTest(
+      'should override existing location fields when override is true',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+              override: true,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = await transpileIngestPipeline(
+          streamlangDSL,
+          undefined,
+          resolverOptions
+        );
+        const { query } = await transpileEsql(streamlangDSL, undefined, resolverOptions);
+
+        const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+
+        await testBed.ingest('cross-compat-enrich-override-ingest', docs, processors);
+        const ingestDocs = await testBed.getFlattenedDocsOrdered(
+          'cross-compat-enrich-override-ingest'
+        );
+
+        await testBed.ingest('cross-compat-enrich-override-esql', docs);
+        const esqlResult = await esql.queryOnIndex('cross-compat-enrich-override-esql', query);
+
+        expect(ingestDocs).toHaveLength(1);
+        expect(esqlResult.documentsOrdered).toHaveLength(1);
+
+        expect(ingestDocs[0]?.['location.city']).toBe('New York');
+        expect(ingestDocs[0]?.['location.country']).toBe('US');
+
+        expect(esqlResult.documentsOrdered[0]?.['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]?.['location.country']).toBe('US');
+      }
+    );
+
+    apiTest(
+      'should preserve existing location fields when override is false',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+              override: false,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = await transpileIngestPipeline(
+          streamlangDSL,
+          undefined,
+          resolverOptions
+        );
+        const { query } = await transpileEsql(streamlangDSL, undefined, resolverOptions);
+
+        const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+
+        await testBed.ingest('cross-compat-enrich-preserve-ingest', docs, processors);
+        const ingestDocs = await testBed.getFlattenedDocsOrdered(
+          'cross-compat-enrich-preserve-ingest'
+        );
+
+        await testBed.ingest('cross-compat-enrich-preserve-esql', docs);
+        const esqlResult = await esql.queryOnIndex('cross-compat-enrich-preserve-esql', query);
+
+        expect(ingestDocs).toHaveLength(1);
+        expect(esqlResult.documentsOrdered).toHaveLength(1);
+
+        expect(ingestDocs[0]?.['location.city']).toBe('Test city');
+        expect(ingestDocs[0]?.['location.country']).toBe('Test country');
+
+        expect(esqlResult.documentsOrdered[0]?.['location.city']).toBe('Test city');
+        expect(esqlResult.documentsOrdered[0]?.['location.country']).toBe('Test country');
+      }
+    );
+
+    apiTest(
+      'with ignore_missing true, should enrich when ip is present and skip enrichment when ip is absent',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+              ignore_missing: true,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = await transpileIngestPipeline(
+          streamlangDSL,
+          undefined,
+          resolverOptions
+        );
+        const { query } = await transpileEsql(streamlangDSL, undefined, resolverOptions);
+
+        const docs = [{ ip: '10.0.0.1', message: 'has ip' }, { message: 'no ip' }];
+
+        await testBed.ingest('cross-compat-enrich-ignore-missing-true-ingest', docs, processors);
+        const ingestDocs = await testBed.getFlattenedDocsOrdered(
+          'cross-compat-enrich-ignore-missing-true-ingest'
+        );
+
+        await testBed.ingest('cross-compat-enrich-ignore-missing-true-esql', docs);
+        const esqlResult = await esql.queryOnIndex(
+          'cross-compat-enrich-ignore-missing-true-esql',
+          query
+        );
+
+        expect(ingestDocs).toHaveLength(2);
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+
+        expect(ingestDocs[0]?.['location.city']).toBe('New York');
+        expect(ingestDocs[0]?.['location.country']).toBe('US');
+
+        expect(ingestDocs[1]?.['location.city']).toBeUndefined();
+        expect(ingestDocs[1]?.['location.country']).toBeUndefined();
+
+        expect(esqlResult.documentsOrdered[0]?.['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]?.['location.country']).toBe('US');
+
+        expect(esqlResult.documentsOrdered[1]?.['location.city']).toBeNull();
+        expect(esqlResult.documentsOrdered[1]?.['location.country']).toBeNull();
+      }
+    );
+
+    apiTest(
+      'with ignore_missing false, should drop documents with missing match field in both ingest outcomes and ES|QL',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+              ignore_missing: false,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = await transpileIngestPipeline(
+          streamlangDSL,
+          undefined,
+          resolverOptions
+        );
+        const { query } = await transpileEsql(streamlangDSL, undefined, resolverOptions);
+
+        const docs = [{ ip: '10.0.0.1', message: 'has ip' }, { message: 'no ip here' }];
+
+        const { errors } = await testBed.ingest(
+          'cross-compat-enrich-ignore-missing-false-ingest',
+          docs,
+          processors
+        );
+        const ingestDocs = await testBed.getFlattenedDocsOrdered(
+          'cross-compat-enrich-ignore-missing-false-ingest'
+        );
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.reason).toContain('field [ip] not present as part of path [ip]');
+
+        await testBed.ingest('cross-compat-enrich-ignore-missing-false-esql', docs);
+        const esqlResult = await esql.queryOnIndex(
+          'cross-compat-enrich-ignore-missing-false-esql',
+          query
+        );
+
+        expect(ingestDocs).toHaveLength(1);
+        expect(esqlResult.documentsOrdered).toHaveLength(1);
+
+        expect(ingestDocs[0]?.['location.city']).toBe('New York');
+        expect(ingestDocs[0]?.['location.country']).toBe('US');
+        expect(ingestDocs[0]?.ip).toBe('10.0.0.1');
+
+        expect(esqlResult.documentsOrdered[0]?.['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]?.['location.country']).toBe('US');
+        expect(esqlResult.documentsOrdered[0]?.ip).toBe('10.0.0.1');
+      }
+    );
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/enrich.spec.ts
@@ -12,10 +12,12 @@ import { transpileEsql, transpileIngestPipeline } from '@kbn/streamlang';
 import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
 import { streamlangApiTest as apiTest } from '../..';
 import {
-  ENRICH_POLICY_NAME,
   setupEnrichIndexWithPolicy,
   teardownEnrichIndexWithPolicy,
 } from '../../utils/enrich_helpers';
+
+const ENRICH_POLICY_NAME = 'test-enrich-cross-compatibility-policy';
+const ENRICH_INDEX_NAME = 'test-enrich-cross-compatibility-index';
 
 const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
   Promise.resolve({
@@ -30,11 +32,11 @@ apiTest.describe(
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     apiTest.beforeAll(async ({ esClient }) => {
-      await setupEnrichIndexWithPolicy(esClient);
+      await setupEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest.afterAll(async ({ esClient }) => {
-      await teardownEnrichIndexWithPolicy(esClient);
+      await teardownEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       // ES|QL needs a mapping doc for the new field
@@ -83,7 +83,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { status: 'null', not_deleted: 'null' } };
@@ -136,7 +136,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { priority: 0, high_priority: 'null' } };
@@ -193,7 +193,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { age: 0, adult: 'null' } };
@@ -244,7 +244,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { quantity: 100, low_stock: 'null' } };
@@ -301,7 +301,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { size: 1000, small_file: 'null' } };
@@ -352,7 +352,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = {
@@ -413,7 +413,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { temperature: 0, in_range: 'null' } };
@@ -473,7 +473,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { service_name: 'null', matched: 'null' } };
@@ -579,7 +579,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { message: 'null', is_error: 'null' } };
@@ -646,7 +646,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { filename: 'null', is_log_file: 'null' } };
@@ -716,7 +716,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = {
@@ -795,7 +795,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { log_level: 'null', not_debug: 'null' } };
@@ -862,7 +862,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { message: 'null', important: 'null' } };
@@ -933,7 +933,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { tags: [''], has_error_tag: 'null' } };
@@ -993,7 +993,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { roles: [''], no_admin: 'null' } };
@@ -1045,7 +1045,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { url_path: 'null', is_api_path: 'null' } };
@@ -1114,7 +1114,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { tag: 'null', matched: 'null' } };

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/filter_conditions.spec.ts
@@ -32,7 +32,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       // ES|QL needs a mapping doc for the new field
       const mappingDoc = { attributes: { status: 'null', is_active: 'null' } };
@@ -84,7 +84,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { status: 'null', not_deleted: 'null' } };
       const docs = [
@@ -137,7 +137,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { priority: 0, high_priority: 'null' } };
       const docs = [
@@ -194,7 +194,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { age: 0, adult: 'null' } };
         const docs = [
@@ -245,7 +245,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { quantity: 100, low_stock: 'null' } };
       const docs = [
@@ -302,7 +302,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { size: 1000, small_file: 'null' } };
         const docs = [
@@ -353,7 +353,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = {
         attributes: { user_email: 'null', user_name: 'null', has_email: 'null' },
@@ -414,7 +414,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { temperature: 0, in_range: 'null' } };
       const docs = [
@@ -474,7 +474,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { service_name: 'null', matched: 'null' } };
       const docs = [
@@ -580,7 +580,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { message: 'null', is_error: 'null' } };
       const docs = [
@@ -647,7 +647,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { filename: 'null', is_log_file: 'null' } };
       const docs = [
@@ -717,7 +717,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = {
         attributes: { service_name: 'null', message: 'null', log_path: 'null', priority: 'null' },
@@ -796,7 +796,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { log_level: 'null', not_debug: 'null' } };
       const docs = [
@@ -863,7 +863,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { message: 'null', important: 'null' } };
       const docs = [
@@ -934,7 +934,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { tags: [''], has_error_tag: 'null' } };
         const docs = [
@@ -994,7 +994,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { roles: [''], no_admin: 'null' } };
       const docs = [
@@ -1046,7 +1046,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const mappingDoc = { attributes: { url_path: 'null', is_api_path: 'null' } };
       const docs = [
@@ -1115,7 +1115,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const mappingDoc = { attributes: { tag: 'null', matched: 'null' } };
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '55.3.244.1 GET /index.html 15824 0.043', client: { ip: null } }]; // Pre-map the field, ES|QL requires it
@@ -62,7 +62,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -118,7 +118,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -141,7 +141,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         // Example log from COMMONAPACHELOG pattern
         const docs = [
@@ -188,7 +188,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 5.6.7.8' }];
         await testBed.ingest('ingest-grok-multi', docs, processors);
@@ -217,7 +217,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 [2025-09-13T12:34:56.789Z] OK' }];
         await testBed.ingest('ingest-grok-special', docs, processors);
@@ -251,7 +251,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4', untouched: 'preserved' }];
         await testBed.ingest('ingest-grok-source', docs, processors);
@@ -284,7 +284,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 This is the extracted message', untouched: 'preserved' }];
 
@@ -323,7 +323,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Pre-map
@@ -405,7 +405,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [
           { id: 1, message: '1.2.3.4', flag: 'yes' },
@@ -443,7 +443,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ log: { level: 'info' } }];
@@ -474,7 +474,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [
           { message: '1.2.3.4 GET' }, // missing size
@@ -517,7 +517,7 @@ apiTest.describe(
             } as GrokProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: 'no match here at all' }];
 
@@ -555,7 +555,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'I love burmese cats!' }];
@@ -591,7 +591,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'I love burmese cats!' }];
@@ -626,7 +626,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '127.0.0.1 [Jan 11, 2011]' }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/grok.spec.ts
@@ -32,7 +32,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '55.3.244.1 GET /index.html 15824 0.043', client: { ip: null } }]; // Pre-map the field, ES|QL requires it
         await testBed.ingest('ingest-grok', docs, processors);
@@ -63,7 +63,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { case: 'groked', attributes: { should_exist: 'YES' }, message: '55.3.244.1' },
@@ -121,7 +121,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }
@@ -142,7 +142,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         // Example log from COMMONAPACHELOG pattern
         const docs = [
           {
@@ -189,7 +189,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 5.6.7.8' }];
         await testBed.ingest('ingest-grok-multi', docs, processors);
         const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-grok-multi');
@@ -218,7 +218,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 [2025-09-13T12:34:56.789Z] OK' }];
         await testBed.ingest('ingest-grok-special', docs, processors);
         const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-grok-special');
@@ -252,7 +252,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4', untouched: 'preserved' }];
         await testBed.ingest('ingest-grok-source', docs, processors);
         const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-grok-source');
@@ -285,7 +285,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: '1.2.3.4 This is the extracted message', untouched: 'preserved' }];
 
         await testBed.ingest('ingest-grok-override', docs, processors);
@@ -324,7 +324,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Pre-map
         const mappingDoc = {
@@ -406,7 +406,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [
           { id: 1, message: '1.2.3.4', flag: 'yes' },
           { id: 2, message: '192.168.1.1' },
@@ -444,7 +444,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ log: { level: 'info' } }];
         const { errors } = await testBed.ingest('ingest-grok-fail', docs, processors);
@@ -475,7 +475,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [
           { message: '1.2.3.4 GET' }, // missing size
         ];
@@ -518,7 +518,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
         const docs = [{ message: 'no match here at all' }];
 
         const { errors } = await testBed.ingest('ingest-grok-nomatch', docs, processors);
@@ -556,7 +556,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'I love burmese cats!' }];
 
@@ -592,7 +592,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'I love burmese cats!' }];
 
@@ -627,7 +627,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '127.0.0.1 [Jan 11, 2011]' }];
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/join.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/join.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -66,7 +66,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -113,7 +113,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -160,7 +160,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/join.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/join.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         {
@@ -67,7 +67,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -114,7 +114,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -161,7 +161,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -29,8 +29,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"user_id": "abc123"}' }];
         await testBed.ingest('ingest-json-extract-basic', docs, processors);
@@ -60,8 +60,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"user_id": "abc123", "status": "active"}' }];
         await testBed.ingest('ingest-json-extract-multi', docs, processors);
@@ -93,8 +93,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"metadata": {"client": {"ip": "192.168.1.1"}}}' }];
         await testBed.ingest('ingest-json-extract-nested', docs, processors);
@@ -127,8 +127,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: '{"user_id": "abc123"}', should_extract: 'yes' },
@@ -179,8 +179,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"count": 42}' }];
       await testBed.ingest('ingest-json-extract-int', docs, processors);
@@ -204,8 +204,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"active": true}' }];
       await testBed.ingest('ingest-json-extract-bool', docs, processors);
@@ -229,8 +229,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"name": "John"}' }];
       await testBed.ingest('ingest-json-extract-default', docs, processors);
@@ -260,8 +260,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"count": 42, "active": true, "name": "Test"}' }];
         await testBed.ingest('ingest-json-extract-multi-types', docs, processors);
@@ -298,8 +298,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const invalidJsonDocs = [{ message: 'not valid json' }];
 
@@ -334,8 +334,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"items": [{"name": "Apple"}, {"name": "Banana"}]}' }];
         await testBed.ingest('ingest-json-extract-array', docs, processors);
@@ -364,8 +364,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"user": {"profile": {"name": "Alice"}}}' }];
         await testBed.ingest('ingest-json-extract-bracket', docs, processors);
@@ -397,8 +397,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -430,8 +430,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"is_active": false}' }];
         await testBed.ingest('ingest-json-extract-false', docs, processors);
@@ -458,8 +458,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"items": ["first", "second", "third"]}' }];
         await testBed.ingest('ingest-json-extract-arr1', docs, processors);
@@ -486,8 +486,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: '{"id": 1}', order: 1 },
@@ -530,8 +530,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"string_num": "42"}' }];
       await testBed.ingest('ingest-json-extract-str2int', docs, processors);
@@ -558,8 +558,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Note: ES|QL requires the column to exist in the index schema, so we include
         // a mapping document with an empty message field. Documents with null/missing
@@ -603,8 +603,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"data": {"nested": {"items": [{"value": "found"}]}}}' }];
         await testBed.ingest('ingest-json-extract-mixed', docs, processors);
@@ -629,8 +629,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"nullable": null}' }];
       await testBed.ingest('ingest-json-extract-null', docs, processors);
@@ -654,8 +654,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"user": {"name": "John"}}' }];
       await testBed.ingest('ingest-json-extract-root', docs, processors);
@@ -681,8 +681,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"user": "test"}' }];
         await testBed.ingest('ingest-json-extract-notfound', docs, processors);
@@ -710,8 +710,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: '{"count": 42}' }];
         await testBed.ingest('ingest-json-extract-overwrite-int', docs, processors);
@@ -745,8 +745,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: '{"data": "processed"}', type: 'process', order: 1 },
@@ -809,8 +809,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: '{"name": "Alice", "age": 30, "active": true}', extract: 'yes', order: 1 },
@@ -870,8 +870,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: '{"simplified": "short_value"}', simplify: 'yes', order: 1 },
@@ -917,8 +917,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"user":{"roles":["admin","viewer"]}}' }];
       await testBed.ingest('ingest-json-extract-array-val', docs, processors);
@@ -945,8 +945,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '{"a":{"b":{"c":"deep"}}}' }];
       await testBed.ingest('ingest-json-extract-obj-val', docs, processors);
@@ -979,8 +979,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -66,7 +66,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
@@ -99,7 +99,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -67,7 +67,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest('ingest-e2e-test-lowercase-basic', docs, processors);
@@ -100,7 +100,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ price: 10, quantity: 5 }];
       await testBed.ingest('ingest-math-multiply', docs, processors);
@@ -54,7 +54,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { price: 25, quantity: 4 } }];
       await testBed.ingest('ingest-math-nested', docs, processors);
@@ -86,7 +86,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Use integer values - both engines will do integer division
         const docs = [{ intVal: 10, divisor: 3.0 }];
@@ -123,7 +123,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       // log(e) = 1
       const docs = [{ value: 2.718281828459045 }];
@@ -156,7 +156,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 3 },
@@ -190,7 +190,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 10, b: 5 },
@@ -224,7 +224,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 5.0 },
@@ -282,7 +282,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Use values that work for all functions:
         // - val: 4 (positive, good for log)
@@ -344,7 +344,7 @@ apiTest.describe(
           expect(errors[0].caused_by?.reason).toMatch(pattern);
 
           // ES|QL: throws during transpilation
-          expect(() => transpileEsql(streamlangDSL)).toThrow(pattern);
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(pattern);
         }
       }
     );
@@ -381,7 +381,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ numerator: 10, denominator: 0 }];
 
@@ -426,7 +426,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ value: 0 }];
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/math.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ price: 10, quantity: 5 }];
@@ -53,7 +53,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { price: 25, quantity: 4 } }];
@@ -85,7 +85,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Use integer values - both engines will do integer division
@@ -122,7 +122,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       // log(e) = 1
@@ -155,7 +155,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -189,7 +189,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -223,7 +223,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -281,7 +281,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Use values that work for all functions:
@@ -338,7 +338,7 @@ apiTest.describe(
           };
 
           // Ingest pipeline: generates error-throwing script, error at runtime
-          const { processors } = transpileIngestPipeline(streamlangDSL);
+          const { processors } = await transpileIngestPipeline(streamlangDSL);
           const { errors } = await testBed.ingest(`cross-reject-${i}`, [doc], processors);
           expect(errors.length).toBeGreaterThan(0);
           expect(errors[0].caused_by?.reason).toMatch(pattern);
@@ -380,7 +380,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ numerator: 10, denominator: 0 }];
@@ -425,7 +425,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ value: 0 }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
@@ -296,7 +296,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Test documents covering different scenarios
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/multi_step.spec.ts
@@ -295,7 +295,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Test documents covering different scenarios

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/network_direction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/network_direction.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -68,7 +68,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
@@ -104,7 +104,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -152,7 +152,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -198,7 +198,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/network_direction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/network_direction.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -69,7 +69,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
         await testBed.ingest('ingest-e2e-test-network-direction-target-field', docs, processors);
@@ -105,7 +105,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -153,7 +153,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1' },
@@ -199,7 +199,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1', event: { kind: 'test' } },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(dsl);
-        const { query } = transpileEsql(dsl);
+        const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { flag: true } }, { attributes: { flag: 'true' } }];
         const mappingDoc = {
@@ -73,7 +73,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(dsl);
-        const { query } = transpileEsql(dsl);
+        const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { val: '450' } }, { attributes: { val: '404' } }];
         const mappingDoc = {
@@ -117,7 +117,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(dsl);
-        const { query } = transpileEsql(dsl);
+        const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { val: 450 } }, { attributes: { val: 404 } }];
         const mappingDoc = {
@@ -154,7 +154,7 @@ apiTest.describe(
         ],
       };
       const { processors } = transpileIngestPipeline(dsl);
-      const { query } = transpileEsql(dsl);
+      const { query } = await transpileEsql(dsl);
 
       const docs = [
         { attributes: { val: '450-abc' } },
@@ -192,7 +192,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(dsl);
-        const { query } = transpileEsql(dsl);
+        const { query } = await transpileEsql(dsl);
 
         const docs = [
           { attributes: { val: 8500 } },
@@ -231,7 +231,7 @@ apiTest.describe(
           ],
         };
         const { processors } = transpileIngestPipeline(dsl);
-        const { query } = transpileEsql(dsl);
+        const { query } = await transpileEsql(dsl);
 
         const docs = [
           { attributes: { val: 8500 } },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/operator_coercions.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
             } as SetProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(dsl);
+        const { processors } = await transpileIngestPipeline(dsl);
         const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { flag: true } }, { attributes: { flag: 'true' } }];
@@ -72,7 +72,7 @@ apiTest.describe(
             } as SetProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(dsl);
+        const { processors } = await transpileIngestPipeline(dsl);
         const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { val: '450' } }, { attributes: { val: '404' } }];
@@ -116,7 +116,7 @@ apiTest.describe(
             } as SetProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(dsl);
+        const { processors } = await transpileIngestPipeline(dsl);
         const { query } = await transpileEsql(dsl);
 
         const docs = [{ attributes: { val: 450 } }, { attributes: { val: 404 } }];
@@ -153,7 +153,7 @@ apiTest.describe(
           } as SetProcessor,
         ],
       };
-      const { processors } = transpileIngestPipeline(dsl);
+      const { processors } = await transpileIngestPipeline(dsl);
       const { query } = await transpileEsql(dsl);
 
       const docs = [
@@ -191,7 +191,7 @@ apiTest.describe(
             } as SetProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(dsl);
+        const { processors } = await transpileIngestPipeline(dsl);
         const { query } = await transpileEsql(dsl);
 
         const docs = [
@@ -230,7 +230,7 @@ apiTest.describe(
             } as SetProcessor,
           ],
         };
-        const { processors } = transpileIngestPipeline(dsl);
+        const { processors } = await transpileIngestPipeline(dsl);
         const { query } = await transpileEsql(dsl);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Connection from 192.168.1.1 established' }];
         await testBed.ingest('ingest-redact-ip', docs, processors);
@@ -60,7 +60,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Contact user at john.doe@example.com for details' }];
         await testBed.ingest('ingest-redact-email', docs, processors);
@@ -90,7 +90,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User john@example.com connected from 10.0.0.1' }];
         await testBed.ingest('ingest-redact-multiple', docs, processors);
@@ -122,7 +122,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Request from 172.16.0.1' }];
         await testBed.ingest('ingest-redact-custom-delim', docs, processors);
@@ -152,7 +152,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Device MAC: 00:1A:2B:3C:4D:5E' }];
         await testBed.ingest('ingest-redact-mac', docs, processors);
@@ -186,7 +186,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: 'Connection from 192.168.1.1', environment: 'production' },
@@ -240,7 +240,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Hello world, no IP here' }];
         await testBed.ingest('ingest-redact-no-match', docs, processors);
@@ -270,7 +270,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User 550e8400-e29b-41d4-a716-446655440000 logged in' }];
         await testBed.ingest('ingest-redact-uuid', docs, processors);
@@ -300,7 +300,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Visited https://example.com/path?query=value today' }];
         await testBed.ingest('ingest-redact-uri', docs, processors);
@@ -343,7 +343,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
         }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Connection from 192.168.1.1 established' }];
@@ -59,7 +59,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Contact user at john.doe@example.com for details' }];
@@ -89,7 +89,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User john@example.com connected from 10.0.0.1' }];
@@ -121,7 +121,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Request from 172.16.0.1' }];
@@ -151,7 +151,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Device MAC: 00:1A:2B:3C:4D:5E' }];
@@ -185,7 +185,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -239,7 +239,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Hello world, no IP here' }];
@@ -269,7 +269,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User 550e8400-e29b-41d4-a716-446655440000 logged in' }];
@@ -299,7 +299,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Visited https://example.com/path?query=value today' }];
@@ -340,7 +340,7 @@ apiTest.describe(
           };
 
           // Both transpilers should reject Mustache template syntax
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          expect(await transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/redact.spec.ts
@@ -340,7 +340,7 @@ apiTest.describe(
           };
 
           // Both transpilers should reject Mustache template syntax
-          expect(await transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -75,7 +75,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -132,7 +132,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }
@@ -152,7 +152,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/remove_by_prefix.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -74,7 +74,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -129,7 +129,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -151,7 +151,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
@@ -61,7 +61,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
@@ -106,7 +106,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -130,7 +130,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'some_value' }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/rename.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
       await testBed.ingest('ingest-rename-override', docs, processors);
@@ -62,7 +62,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
 
@@ -109,7 +109,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }
@@ -131,7 +131,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'some_value' }];
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
         await testBed.ingest('ingest-replace', docs, processors);
@@ -61,7 +61,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
         await testBed.ingest('ingest-replace-target', docs, processors);
@@ -91,7 +91,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Error code 404 found' }];
         await testBed.ingest('ingest-replace-regex', docs, processors);
@@ -120,7 +120,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User alice has 3 new messages' }];
         await testBed.ingest('ingest-replace-capture', docs, processors);
@@ -153,7 +153,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { message: 'An error occurred', event: { kind: 'test' } },
@@ -204,7 +204,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Source field is numeric (non-string)
         const docs = [{ status_code: 404, message: 'test' }];
@@ -243,7 +243,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         // Target field exists as numeric, source field is string
         const docs = [{ message: 'An error occurred', status_code: 404 }];
@@ -292,7 +292,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
         }
@@ -326,7 +326,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: ['An error occurred 01', 'An error occurred 02'] }];
         await testBed.ingest('ingest-replace-single', docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/replace.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
@@ -60,7 +60,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
@@ -90,7 +90,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'Error code 404 found' }];
@@ -119,7 +119,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'User alice has 3 new messages' }];
@@ -152,7 +152,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -203,7 +203,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Source field is numeric (non-string)
@@ -242,7 +242,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         // Target field exists as numeric, source field is string
@@ -289,7 +289,7 @@ apiTest.describe(
           };
 
           // Both transpilers should reject Mustache template syntax
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
@@ -325,7 +325,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: ['An error occurred 01', 'An error occurred 02'] }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
@@ -55,7 +55,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'should-be-copied' }];
@@ -85,7 +85,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { status: 'active' } }];
@@ -116,7 +116,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { status: 'active' } }];
@@ -160,7 +160,7 @@ apiTest.describe(
           };
 
           // Both transpilers should throw validation errors for Mustache templates
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
           await expect(transpileEsql(streamlangDSL)).rejects.toThrow(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/set.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest('ingest-set-value', docs, processors);
@@ -56,7 +56,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'should-be-copied' }];
       await testBed.ingest('ingest-set-copy', docs, processors);
@@ -86,7 +86,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { status: 'active' } }];
         await testBed.ingest('ingest-set-override', docs, processors);
@@ -117,7 +117,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ attributes: { status: 'active' } }];
         await testBed.ingest('ingest-set-no-override', docs, processors);
@@ -163,7 +163,7 @@ apiTest.describe(
           expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed'
           );
         }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/sort.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/sort.spec.ts
@@ -28,8 +28,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
         await testBed.ingest('ingest-sort-asc', docs, processors);
@@ -56,8 +56,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest('ingest-sort-desc', docs, processors);
@@ -84,8 +84,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest('ingest-sort-target', docs, processors);
@@ -120,8 +120,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ numbers: [3, 1, 4, 1, 5, 9, 2, 6] }];
       await testBed.ingest('ingest-sort-numeric', docs, processors);
@@ -146,8 +146,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: ['single'] }];
       await testBed.ingest('ingest-sort-single', docs, processors);
@@ -184,8 +184,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { tags: ['charlie', 'alpha', 'bravo'], should_sort: 'yes' },
@@ -234,8 +234,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           { tags: ['charlie', 'alpha', 'bravo'], status: 'has_tags' },
@@ -301,10 +301,10 @@ apiTest.describe(
           };
 
           // Both transpilers should reject Mustache template syntax
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
         }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/split.spec.ts
@@ -29,8 +29,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ tags: 'foo,bar,baz' }];
         await testBed.ingest('ingest-split-basic', docs, processors);
@@ -58,8 +58,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: 'foo,bar,baz' }];
       await testBed.ingest('ingest-split-target', docs, processors);
@@ -88,8 +88,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ path: 'home/user/documents' }];
       await testBed.ingest('ingest-split-slash', docs, processors);
@@ -115,8 +115,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ tags: 'single' }];
       await testBed.ingest('ingest-split-single', docs, processors);
@@ -153,8 +153,8 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { tags: 'foo,bar,baz', should_split: 'yes' },
@@ -215,10 +215,10 @@ apiTest.describe(
           };
 
           // Both transpilers should reject Mustache template syntax
-          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+          await expect(transpileIngestPipeline(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
-          expect(() => transpileEsql(streamlangDSL)).toThrow(
+          await expect(transpileEsql(streamlangDSL)).rejects.toThrow(
             'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
           );
         }
@@ -248,8 +248,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ message: 'hello world test' }];
         await testBed.ingest('ingest-split-space', docs, processors);
@@ -280,8 +280,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ other_field: 'value' }]; // Missing 'tags' field
 
@@ -315,8 +315,8 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [{ tags: 'A,,B,,' }]; // Has empty trailing elements
         await testBed.ingest('ingest-split-trailing', docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
@@ -25,7 +25,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
@@ -63,7 +63,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
@@ -96,7 +96,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
@@ -26,7 +26,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         {
@@ -64,7 +64,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest('ingest-e2e-test-trim-basic', docs, processors);
@@ -97,7 +97,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { message: '   test message 1   ', should_trim: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         };
 
         const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+        const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
           {
@@ -67,7 +67,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest('ingest-e2e-test-uppercase-basic', docs, processors);
@@ -100,7 +100,7 @@ apiTest.describe(
       };
 
       const { processors } = transpileIngestPipeline(streamlangDSL);
-      const { query } = transpileEsql(streamlangDSL);
+      const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [
         { message: 'test message 1', should_uppercase: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { processors } = await transpileIngestPipeline(streamlangDSL);
         const { query } = await transpileEsql(streamlangDSL);
 
         const docs = [
@@ -66,7 +66,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
@@ -99,7 +99,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { processors } = await transpileIngestPipeline(streamlangDSL);
       const { query } = await transpileEsql(streamlangDSL);
 
       const docs = [

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
           } as AppendProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ tags: ['existing_tag'] }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -46,7 +46,7 @@ apiTest.describe(
           } as AppendProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const mappingDoc = { tags: ['initial_tag'] }; // Needed to satisfy ES|QL which needs all operand columns pre-mapped;
       const docs = [mappingDoc, { message: 'message' }];
       await testBed.ingest(indexName, docs);
@@ -68,7 +68,7 @@ apiTest.describe(
             } as AppendProcessor,
           ],
         };
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag', 'new_tag'] }];
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -90,7 +90,7 @@ apiTest.describe(
             } as AppendProcessor,
           ],
         };
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag'] }];
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -113,7 +113,7 @@ apiTest.describe(
           } as AppendProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         { attributes: { should_exist: 'YES' }, tags: ['existing_tag'] },
         { attributes: { size: 2048 }, tags: ['existing_tag_01', 'existing_tag_02'] },
@@ -141,7 +141,7 @@ apiTest.describe(
             } as AppendProcessor,
           ],
         };
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag'] }];
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -168,7 +168,7 @@ apiTest.describe(
           } as AppendProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         { attributes: { should_exist: 'YES' }, tags: ['existing_tag'] },
         { attributes: { size: 2048 }, tags: ['existing_tag_01', 'existing_tag_02'] },
@@ -195,7 +195,7 @@ apiTest.describe(
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/concat.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/concat.spec.ts
@@ -34,7 +34,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ first_name: 'john', last_name: 'doe', email_domain: 'example.com' }];
       await testBed.ingest(indexName, docs);
@@ -69,7 +69,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com', has_email: true },
@@ -106,7 +106,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },
@@ -143,7 +143,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest(indexName, docs);
@@ -55,7 +55,7 @@ apiTest.describe(
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     });
@@ -76,7 +76,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
         await testBed.ingest(indexName, docs);
@@ -109,7 +109,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrowError(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           /Convert processor must have the .*?to.*? parameter when there is a .*?where.*? condition/
         );
       }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
@@ -26,7 +26,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -50,7 +50,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         { event: { created: '01/01/2025:12:34:56' } },
         { event: { created: '2025-01-02T12:34:56.789Z' } },
@@ -78,7 +78,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -101,7 +101,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -127,7 +127,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const mappingDoc = { '@timestamp': '2025-01-01T12:32:54.123Z' }; // Needed to satisfy ES|QL which needs all operand columns pre-mapped
       const docs = [
@@ -156,7 +156,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
           } as DateProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ log: { time: '01-01-2025' } }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -181,7 +181,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         {
           message: '[2025-01-01T00:00:00.000Z] [info] 127.0.0.1 - - "GET / HTTP/1.1" 200 123',
@@ -65,7 +65,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       // Ingest a doc with all operand fields to satisfy ES|QL requirement that any field used in the query must be pre-mapped (available as a column)
       const mappingDoc = {
@@ -119,7 +119,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const mappingDoc = { message: '[2025-01-01T00:00:00.000Z] [info] 192.168.90.9' };
       const docs = [mappingDoc, { log: { level: 'info' } }];
@@ -146,7 +146,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ message: 'value1-value2' }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -176,7 +176,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const mappingDoc = { log: { level: '' } };
       const docs = [
         mappingDoc,
@@ -229,7 +229,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docsToDissect = [
         { message: '[info] [5] [1024] [50.55]' },
@@ -332,7 +332,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       // Mapping doc to ensure columns exist so pre-cast EVALs don't error
       const mappingDoc = {
@@ -418,7 +418,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const mappingDoc = {
         '@timestamp': '',
@@ -522,7 +522,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           } as DissectProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const mappingDoc = { size: 0, message: '' }; // Ingest size as long type
       const docs = [
         mappingDoc,
@@ -561,7 +561,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { environment: 'production', message: 'keep-this' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpile } from '@kbn/streamlang/src/transpilers/esql';
+import { streamlangApiTest as apiTest } from '../..';
+import {
+  ENRICH_POLICY_NAME,
+  setupEnrichIndexWithPolicy,
+  teardownEnrichIndexWithPolicy,
+} from '../../utils/enrich_helpers';
+
+apiTest.describe(
+  'Streamlang to ES|QL - Enrich Processor',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    apiTest.beforeAll(async ({ esClient }) => {
+      await setupEnrichIndexWithPolicy(esClient);
+    });
+
+    apiTest.afterAll(async ({ esClient }) => {
+      await teardownEnrichIndexWithPolicy(esClient);
+    });
+
+    apiTest(
+      'should enrich a document with location data based on ip',
+      async ({ testBed, esql }) => {
+        const indexName = 'streams-e2e-test-enrich-basic';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              field: 'ip',
+              to: 'location',
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { query } = transpile(streamlangDSL);
+
+        const docs = [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        expect(esqlResult.documents).toHaveLength(2);
+        expect(esqlResult.documents[0].city).toBe('New York');
+        expect(esqlResult.documents[0].country).toBe('US');
+        expect(esqlResult.documents[1].city).toBe('London');
+        expect(esqlResult.documents[1].country).toBe('GB');
+      }
+    );
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -57,5 +57,66 @@ apiTest.describe(
         expect(esqlResult.documents[1].country).toBe('GB');
       }
     );
+
+    apiTest(
+      'should leave the document unchanged if match field is not present and ignore_missing is true',
+      async ({ testBed, esql }) => {
+        const indexName = 'streams-e2e-test-enrich-ignore-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              field: 'ip',
+              to: 'location',
+              ignore_missing: true,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { query } = transpile(streamlangDSL);
+        const docs = [
+          { ip: '10.0.0.1', message: 'some message' },
+          { message: 'some other message' },
+        ];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        expect(esqlResult.documents).toHaveLength(2);
+        expect(esqlResult.documents[0].city).toBe('New York');
+        expect(esqlResult.documents[0].country).toBe('US');
+        expect(esqlResult.documents[1].city).toBeNull();
+        expect(esqlResult.documents[1].country).toBeNull();
+      }
+    );
+
+    apiTest(
+      'should filter out documents where match field is missing when ignore_missing is false',
+      async ({ testBed, esql }) => {
+        const indexName = 'streams-e2e-test-enrich-fail-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              field: 'ip',
+              to: 'location',
+              ignore_missing: false,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { query } = transpile(streamlangDSL);
+        const docs = [{ ip: '10.0.0.1', message: 'has ip' }, { message: 'no ip here' }];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        // Only the doc with ip survives the WHERE filter
+        expect(esqlResult.documents).toHaveLength(1);
+        expect(esqlResult.documents[0].city).toBe('New York');
+      }
+    );
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -60,11 +60,11 @@ apiTest.describe(
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
-        expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0]['location.city']).toBe('New York');
-        expect(esqlResult.documents[0]['location.country']).toBe('US');
-        expect(esqlResult.documents[1]['location.city']).toBe('London');
-        expect(esqlResult.documents[1]['location.country']).toBe('GB');
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+        expect(esqlResult.documentsOrdered[0]['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]['location.country']).toBe('US');
+        expect(esqlResult.documentsOrdered[1]['location.city']).toBe('London');
+        expect(esqlResult.documentsOrdered[1]['location.country']).toBe('GB');
       }
     );
 
@@ -94,11 +94,11 @@ apiTest.describe(
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
-        expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0]['location.city']).toBe('New York');
-        expect(esqlResult.documents[0]['location.country']).toBe('US');
-        expect(esqlResult.documents[1]['location.city']).toBeNull();
-        expect(esqlResult.documents[1]['location.country']).toBeNull();
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+        expect(esqlResult.documentsOrdered[0]['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered[0]['location.country']).toBe('US');
+        expect(esqlResult.documentsOrdered[1]['location.city']).toBeNull();
+        expect(esqlResult.documentsOrdered[1]['location.country']).toBeNull();
       }
     );
 
@@ -126,8 +126,8 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // Only the doc with ip survives the WHERE filter
-        expect(esqlResult.documents).toHaveLength(1);
-        expect(esqlResult.documents[0]['location.city']).toBe('New York');
+        expect(esqlResult.documentsOrdered).toHaveLength(1);
+        expect(esqlResult.documentsOrdered[0]['location.city']).toBe('New York');
       }
     );
 
@@ -153,9 +153,9 @@ apiTest.describe(
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      expect(esqlResult.documents).toHaveLength(1);
-      expect(esqlResult.documents[0]['location.city']).toBe('New York');
-      expect(esqlResult.documents[0]['location.country']).toBe('US');
+      expect(esqlResult.documentsOrdered).toHaveLength(1);
+      expect(esqlResult.documentsOrdered[0]['location.city']).toBe('New York');
+      expect(esqlResult.documentsOrdered[0]['location.country']).toBe('US');
     });
 
     apiTest(
@@ -182,9 +182,9 @@ apiTest.describe(
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
-        expect(esqlResult.documents).toHaveLength(1);
-        expect(esqlResult.documents[0]['location.city']).toBe('Test city');
-        expect(esqlResult.documents[0]['location.country']).toBe('Test country');
+        expect(esqlResult.documentsOrdered).toHaveLength(1);
+        expect(esqlResult.documentsOrdered[0]['location.city']).toBe('Test city');
+        expect(esqlResult.documentsOrdered[0]['location.country']).toBe('Test country');
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -9,12 +9,19 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
 import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/esql';
+import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
 import { streamlangApiTest as apiTest } from '../..';
 import {
   ENRICH_POLICY_NAME,
   setupEnrichIndexWithPolicy,
   teardownEnrichIndexWithPolicy,
 } from '../../utils/enrich_helpers';
+
+const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
+  Promise.resolve({
+    matchField: 'ip',
+    enrichFields: ['city', 'country'],
+  });
 
 apiTest.describe(
   'Streamlang to ES|QL - Enrich Processor',
@@ -44,17 +51,19 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
 
         const docs = [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }];
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0].city).toBe('New York');
-        expect(esqlResult.documents[0].country).toBe('US');
-        expect(esqlResult.documents[1].city).toBe('London');
-        expect(esqlResult.documents[1].country).toBe('GB');
+        expect(esqlResult.documents[0]['location.city']).toBe('New York');
+        expect(esqlResult.documents[0]['location.country']).toBe('US');
+        expect(esqlResult.documents[1]['location.city']).toBe('London');
+        expect(esqlResult.documents[1]['location.country']).toBe('GB');
       }
     );
 
@@ -75,7 +84,9 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
         const docs = [
           { ip: '10.0.0.1', message: 'some message' },
           { message: 'some other message' },
@@ -84,10 +95,10 @@ apiTest.describe(
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0].city).toBe('New York');
-        expect(esqlResult.documents[0].country).toBe('US');
-        expect(esqlResult.documents[1].city).toBeNull();
-        expect(esqlResult.documents[1].country).toBeNull();
+        expect(esqlResult.documents[0]['location.city']).toBe('New York');
+        expect(esqlResult.documents[0]['location.country']).toBe('US');
+        expect(esqlResult.documents[1]['location.city']).toBeNull();
+        expect(esqlResult.documents[1]['location.country']).toBeNull();
       }
     );
 
@@ -108,14 +119,16 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
         const docs = [{ ip: '10.0.0.1', message: 'has ip' }, { message: 'no ip here' }];
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // Only the doc with ip survives the WHERE filter
         expect(esqlResult.documents).toHaveLength(1);
-        expect(esqlResult.documents[0].city).toBe('New York');
+        expect(esqlResult.documents[0]['location.city']).toBe('New York');
       }
     );
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -12,10 +12,12 @@ import { transpile } from '@kbn/streamlang/src/transpilers/esql';
 import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
 import { streamlangApiTest as apiTest } from '../..';
 import {
-  ENRICH_POLICY_NAME,
   setupEnrichIndexWithPolicy,
   teardownEnrichIndexWithPolicy,
 } from '../../utils/enrich_helpers';
+
+const ENRICH_POLICY_NAME = 'test-enrich-esql-policy';
+const ENRICH_INDEX_NAME = 'test-enrich-esql-index';
 
 const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
   Promise.resolve({
@@ -28,11 +30,11 @@ apiTest.describe(
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     apiTest.beforeAll(async ({ esClient }) => {
-      await setupEnrichIndexWithPolicy(esClient);
+      await setupEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest.afterAll(async ({ esClient }) => {
-      await teardownEnrichIndexWithPolicy(esClient);
+      await teardownEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest(

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -45,7 +45,6 @@ apiTest.describe(
             {
               action: 'enrich',
               policy_name: ENRICH_POLICY_NAME,
-              field: 'ip',
               to: 'location',
             } as EnrichProcessor,
           ],
@@ -77,7 +76,6 @@ apiTest.describe(
             {
               action: 'enrich',
               policy_name: ENRICH_POLICY_NAME,
-              field: 'ip',
               to: 'location',
               ignore_missing: true,
             } as EnrichProcessor,
@@ -112,7 +110,6 @@ apiTest.describe(
             {
               action: 'enrich',
               policy_name: ENRICH_POLICY_NAME,
-              field: 'ip',
               to: 'location',
               ignore_missing: false,
             } as EnrichProcessor,

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/enrich.spec.ts
@@ -128,5 +128,62 @@ apiTest.describe(
         expect(esqlResult.documents[0]['location.city']).toBe('New York');
       }
     );
+
+    apiTest('should override the existing value if override is true', async ({ testBed, esql }) => {
+      const indexName = 'streams-e2e-test-enrich-override';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'enrich',
+            policy_name: ENRICH_POLICY_NAME,
+            to: 'location',
+            override: true,
+          } as EnrichProcessor,
+        ],
+      };
+
+      const { query } = await transpile(streamlangDSL, undefined, {
+        enrich: mockEnrichPolicyResolver,
+      });
+
+      const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(1);
+      expect(esqlResult.documents[0]['location.city']).toBe('New York');
+      expect(esqlResult.documents[0]['location.country']).toBe('US');
+    });
+
+    apiTest(
+      'should preserve the existing value if override is false',
+      async ({ testBed, esql }) => {
+        const indexName = 'streams-e2e-test-enrich-preserve-existing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              to: 'location',
+              override: false,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { query } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
+
+        const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        expect(esqlResult.documents).toHaveLength(1);
+        expect(esqlResult.documents[0]['location.city']).toBe('Test city');
+        expect(esqlResult.documents[0]['location.country']).toBe('Test country');
+      }
+    );
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ message: '55.3.244.1 GET /index.html 15824 0.043' }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -59,7 +59,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ message: '8.8.8.8 4.4.4.4' }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -81,7 +81,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ message: 'not_an_ip' }];
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -103,7 +103,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         {
           message:
@@ -146,7 +146,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         { expect: null, log: { level: 'info' }, client: { ip: '192.168.1.1' } }, // Should not grok, but nullifies the field
         { expect: '127.0.0.1', client: { ip: '192.168.1.1' }, message: 'User IP: 127.0.0.1' }, // Should grok
@@ -186,7 +186,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [{ log: { level: 'info' } }];
       await testBed.ingest(indexName, docs);
       await expect(esql.queryOnIndex(indexName, query)).rejects.toThrow('Unknown column [message]');
@@ -211,7 +211,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         {
           expect: '55.3.244.1',
@@ -262,7 +262,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         // Mapping doc to ensure fields exist
         {
@@ -322,7 +322,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         // Mapping doc for pre-cast stability
         {
@@ -395,7 +395,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         // Mapping / schema stabilization doc
         {
@@ -513,7 +513,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const mappingDoc = { size: 0, message: '' }; // Ingest size as long type
       const docs = [
         mappingDoc,
@@ -552,7 +552,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     }
@@ -574,7 +574,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           } as GrokProcessor,
         ],
       };
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
       const docs = [
         {
           message:

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/json_extract.spec.ts
@@ -40,7 +40,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { message: '{"user_id": "abc123"}', status: 'doc1' };
         const docWithoutField = { status: 'doc2' };
@@ -71,7 +71,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { message: '{"user_id": "abc123"}', status: 'doc1' };
         const docWithoutField = { status: 'doc2' };

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/lowercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest(indexName, docs);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest(indexName, docs);
@@ -78,7 +78,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },
@@ -111,7 +111,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
@@ -37,7 +37,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         // Verify that the ES|QL query contains a warning about manual_ingest_pipeline not being supported
         expect(query).toContain('WARNING: Manual ingest pipeline not supported in ES|QL');
@@ -90,7 +90,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         expect(query).toContain('WARNING: Manual ingest pipeline not supported in ES|QL');
 
@@ -150,7 +150,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         // Should contain the warning for manual processor
         expect(query).toContain('WARNING: Manual ingest pipeline not supported in ES|QL');

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ price: 10, quantity: 5 }];
       await testBed.ingest(indexName, docs);
@@ -55,7 +55,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ a: 15, b: 25 }];
       await testBed.ingest(indexName, docs);
@@ -81,7 +81,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ a: 100, b: 30 }];
       await testBed.ingest(indexName, docs);
@@ -107,7 +107,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ total: 100, count: 4 }];
       await testBed.ingest(indexName, docs);
@@ -134,7 +134,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { price: 25, quantity: 4 } }];
       await testBed.ingest(indexName, docs);
@@ -161,7 +161,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       // log(e) = 1, using e ≈ 2.718281828459045
       const docs = [{ value: 2.718281828459045 }];
@@ -187,7 +187,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 3 },
@@ -221,7 +221,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 10, b: 5 },
@@ -251,7 +251,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 3, b: 7 },
@@ -281,7 +281,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 5 },
@@ -316,7 +316,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, price: 0, quantity: 0, active: true, total: 0 }, // Mapping doc
@@ -358,7 +358,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { order_id: 1, price: 0, quantity: 0, total: 0 }, // Mapping doc
@@ -401,7 +401,7 @@ apiTest.describe(
         const streamlangDSL: StreamlangDSL = {
           steps: [{ action: 'math', expression, to: 'result' } as MathProcessor],
         };
-        expect(() => transpile(streamlangDSL)).toThrow(pattern);
+        await expect(transpile(streamlangDSL)).rejects.toThrow(pattern);
       }
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/network_direction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/network_direction.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
       await testBed.ingest(indexName, docs);
@@ -55,7 +55,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -89,7 +89,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1' },
@@ -122,7 +122,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { source_ip: '128.232.110.120', destination_ip: '192.168.1.1', event: { kind: 'test' } },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/redact.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'Connection from 192.168.1.1 established' }];
         await testBed.ingest(indexName, docs);
@@ -56,7 +56,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Contact user at john.doe@example.com for details' }];
       await testBed.ingest(indexName, docs);
@@ -81,7 +81,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User john@example.com connected from 10.0.0.1' }];
       await testBed.ingest(indexName, docs);
@@ -108,7 +108,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Request from 172.16.0.1' }];
       await testBed.ingest(indexName, docs);
@@ -133,7 +133,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Device MAC: 00:1A:2B:3C:4D:5E' }];
       await testBed.ingest(indexName, docs);
@@ -161,7 +161,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { message: 'Connection from 192.168.1.1', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should pass through
@@ -194,7 +194,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { message: 'Connection from 192.168.1.1', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should be filtered out
@@ -227,7 +227,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'Connection from 192.168.1.1', environment: 'production', status: 'doc1' },
@@ -264,7 +264,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User 550e8400-e29b-41d4-a716-446655440000 logged in' }];
       await testBed.ingest(indexName, docs);
@@ -289,7 +289,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Hello world, no IP here' }];
       await testBed.ingest(indexName, docs);
@@ -311,7 +311,7 @@ apiTest.describe(
           } as RedactProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ temp_field: 'to-be-removed', message: 'keep-this' }];
       await testBed.ingest(indexName, docs);
@@ -54,7 +54,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { temp_field: 'to-be-removed', message: 'doc1' };
         const docWithoutField = { message: 'doc2' }; // Should be filtered out
@@ -82,7 +82,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithField = { temp_field: 'to-be-removed', message: 'doc1' };
       const docWithoutField = { message: 'doc2' }; // Should pass through
@@ -114,7 +114,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { temp_data: 'remove-me', event: { kind: 'test' }, message: 'doc1' },
@@ -146,7 +146,7 @@ apiTest.describe(
           } as RemoveProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ temp_field: 'to-be-kept', message: 'keep-this' }];
         await testBed.ingest(indexName, docs);
@@ -56,7 +56,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -101,7 +101,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -134,7 +134,7 @@ apiTest.describe(
           } as RemoveByPrefixProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host' } }];
       await testBed.ingest(indexName, docs);
@@ -56,7 +56,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         // Add `mappingDoc` to address ES|QL limitation that any column used as operand must be available as a column (pre-mapped)
         const mappingDoc = { host: { original: 'new-host-0', renamed: 'old-host-0' } };
@@ -89,7 +89,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithFields = { host: { original: 'new-host-0', renamed: 'old-host-0' } };
       const docWithMissingSource = { host: { renamed: 'old-host-1' } };
@@ -125,7 +125,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithFields = { host: { original: 'test-host', renamed: 'old-host' } };
       const docWithMissingSource = { host: { renamed: 'old-value' } }; // should be dropped
@@ -156,7 +156,7 @@ apiTest.describe(
           } as RenameProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       ); // Should throw validation error for Mustache templates
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
         await testBed.ingest(indexName, docs);
@@ -59,7 +59,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
         await testBed.ingest(indexName, docs);
@@ -85,7 +85,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Error code 404 found' }];
       await testBed.ingest(indexName, docs);
@@ -109,7 +109,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Android.log' }];
       await testBed.ingest(indexName, docs);
@@ -133,7 +133,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User alice has 3 new messages' }];
       await testBed.ingest(indexName, docs);
@@ -159,7 +159,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { message: 'An error occurred', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should be filtered out
@@ -189,7 +189,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithField = { message: 'An error occurred', status: 'doc1' };
       const docWithoutField = { status: 'doc2' }; // Should pass through
@@ -223,7 +223,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'An error occurred', event: { kind: 'test' }, status: 'doc1' },
@@ -266,7 +266,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -312,7 +312,7 @@ apiTest.describe(
           } as ReplaceProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest(indexName, docs);
@@ -54,7 +54,7 @@ apiTest.describe(
       };
 
       // Should throw validation error for Mustache templates
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed'
       );
     });
@@ -77,7 +77,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       // ES|QL errors out when unmapped fields (columns) are read
       // The following docs helps map the fields for which ES|QL has to perform nullability checks
@@ -121,7 +121,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'should-be-copied' }];
       await testBed.ingest(indexName, docs);
@@ -149,7 +149,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
         const docWithStatus = { attributes: { status: 'active' } }; // 'attributes.status' already exists
         const docs = [docWithStatus, { attributes: { size: 1024 } }];
         await testBed.ingest(indexName, docs);
@@ -185,7 +185,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
         const docs = [{ attributes: { status: 'active' } }]; // 'attributes.status' already exists
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
@@ -207,7 +207,7 @@ apiTest.describe(
         ],
       };
 
-      expect(() => transpile(streamlangDSL)).toThrowError(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });
@@ -224,7 +224,7 @@ apiTest.describe(
         ],
       };
 
-      expect(() => transpile(streamlangDSL)).toThrowError(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/sort.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/sort.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
         await testBed.ingest(indexName, docs);
@@ -57,7 +57,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
         await testBed.ingest(indexName, docs);
@@ -86,7 +86,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
         await testBed.ingest(indexName, docs);
@@ -116,7 +116,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ numbers: [3, 1, 4, 1, 5, 9, 2, 6] }];
       await testBed.ingest(indexName, docs);
@@ -140,7 +140,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['single'] }];
       await testBed.ingest(indexName, docs);
@@ -168,7 +168,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { tags: ['charlie', 'alpha', 'bravo'], event: { kind: 'test' }, status: 'doc1' },
@@ -211,7 +211,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         // Use a non-empty placeholder for sorted_tags to ensure a mapping exists in ES|QL
         const docs = [
@@ -266,7 +266,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithField = { tags: ['charlie', 'alpha', 'bravo'], status: 'doc1' };
       const docWithoutField = { status: 'doc2' }; // Should pass through
@@ -291,7 +291,7 @@ apiTest.describe(
           } as SortProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ tags: 'foo,bar,baz' }];
         await testBed.ingest(indexName, docs);
@@ -59,7 +59,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [{ tags: 'foo,bar,baz' }];
         await testBed.ingest(indexName, docs);
@@ -88,7 +88,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ path: 'home/user/documents' }];
       await testBed.ingest(indexName, docs);
@@ -113,7 +113,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ tags: 'single' }];
       await testBed.ingest(indexName, docs);
@@ -139,7 +139,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docWithField = { tags: 'foo,bar,baz', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should be filtered out
@@ -169,7 +169,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docWithField = { tags: 'foo,bar,baz', status: 'doc1' };
       const docWithoutField = { status: 'doc2' }; // Should pass through
@@ -202,7 +202,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { tags: 'foo,bar,baz', event: { kind: 'test' }, status: 'doc1' },
@@ -244,7 +244,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -297,7 +297,7 @@ apiTest.describe(
           } as SplitProcessor,
         ],
       };
-      expect(() => transpile(streamlangDSL)).toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/trim.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest(indexName, docs);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest(indexName, docs);
@@ -78,7 +78,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { message: '   test message 1   ', should_trim: 'yes' },
@@ -111,7 +111,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { message: '   test message 1   ', should_trim: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/uppercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest(indexName, docs);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest(indexName, docs);
@@ -78,7 +78,7 @@ apiTest.describe(
         ],
       };
 
-      const { query } = transpile(streamlangDSL);
+      const { query } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'test message 1', should_uppercase: 'yes' },
@@ -111,7 +111,7 @@ apiTest.describe(
           ],
         };
 
-        const { query } = transpile(streamlangDSL);
+        const { query } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'test message 1', should_uppercase: 'yes' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/append.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['existing_tag'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'a' }];
       await testBed.ingest(indexName, docs, processors);
@@ -77,7 +77,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ tags: ['existing_tag'] }]; // Ingest already existing tag
         await testBed.ingest(indexName, docs, processors);
@@ -102,7 +102,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['existing_tag'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -137,7 +137,7 @@ apiTest.describe(
         };
 
         // Should throw validation error for Mustache templates
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/concat.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/concat.spec.ts
@@ -34,7 +34,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ first_name: 'john', last_name: 'doe', email_domain: 'example.com' }];
       await testBed.ingest(indexName, docs, processors);
@@ -67,7 +67,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { first_name: 'john', last_name: 'doe', email_domain: 'example.com', has_email: true },
@@ -101,7 +101,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },
@@ -137,7 +137,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest(indexName, docs, processors);
@@ -77,9 +77,9 @@ apiTest.describe(
           ],
         };
 
-        expect(() => {
+        await expect(() => {
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
       });
     });
 
@@ -99,7 +99,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
         await testBed.ingest(indexName, docs, processors);
@@ -130,7 +130,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
         await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/convert.spec.ts
@@ -77,9 +77,9 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => {
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
+        );
       });
     });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
@@ -196,20 +196,20 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
       `${description}`,
       { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
       async () => {
-        await expect(() => {
-          const streamlangDSL: StreamlangDSL = {
-            steps: [
-              {
-                action: 'date',
-                from: templateFrom,
-                to: templateTo,
-                formats: ['ISO8601'],
-                output_format: 'yyyy-MM-dd',
-              } as DateProcessor,
-            ],
-          };
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'date',
+              from: templateFrom,
+              to: templateTo,
+              formats: ['ISO8601'],
+              output_format: 'yyyy-MM-dd',
+            } as DateProcessor,
+          ],
+        };
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       }
     );
   });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/date.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -58,7 +58,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -86,7 +86,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '01/01/2025:12:34:56' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -113,7 +113,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
       ],
     };
 
-    const { processors } = transpile(streamlangDSL);
+    const { processors } = await transpile(streamlangDSL);
 
     const docs = [
       { event: { created: '01/01/2025:12:34:56' } },
@@ -145,7 +145,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '2025-01-01T12:34:56.789Z' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -172,7 +172,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '01-01-2025' } }];
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -196,7 +196,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
       `${description}`,
       { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
       async () => {
-        expect(() => {
+        await expect(() => {
           const streamlangDSL: StreamlangDSL = {
             steps: [
               {
@@ -209,7 +209,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
             ],
           };
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
       }
     );
   });
@@ -233,7 +233,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '10 septembre 2025' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -266,7 +266,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '10 septembre 2025' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -296,7 +296,7 @@ apiTest.describe('Streamlang to Ingest Pipeline - Date Processor', () => {
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ event: { created: '10 septembre 2025' } }];
       await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
@@ -131,18 +131,18 @@ apiTest.describe(
       },
     ].forEach(({ templateFrom, description }) => {
       apiTest(`${description}`, async () => {
-        await expect(() => {
-          const streamlangDSL: StreamlangDSL = {
-            steps: [
-              {
-                action: 'dissect',
-                from: templateFrom,
-                pattern: '[%{@timestamp}] [%{log.level}] %{client.ip}',
-              } as DissectProcessor,
-            ],
-          };
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Added error message for Mustache templates
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'dissect',
+              from: templateFrom,
+              pattern: '[%{@timestamp}] [%{log.level}] %{client.ip}',
+            } as DissectProcessor,
+          ],
+        };
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/dissect.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -63,7 +63,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ log: { level: 'info' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -88,7 +88,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ log: { level: 'info' } }];
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -109,7 +109,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'value1-value2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -131,7 +131,7 @@ apiTest.describe(
       },
     ].forEach(({ templateFrom, description }) => {
       apiTest(`${description}`, async () => {
-        expect(() => {
+        await expect(() => {
           const streamlangDSL: StreamlangDSL = {
             steps: [
               {
@@ -142,7 +142,7 @@ apiTest.describe(
             ],
           };
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Added error message for Mustache templates
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Added error message for Mustache templates
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/drop_document.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { environment: 'production', message: 'keep-this' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -10,55 +10,22 @@ import { expect } from '@kbn/scout/api';
 import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import { streamlangApiTest as apiTest } from '../..';
-
-const ENRICH_SOURCE_INDEX = 'streams-e2e-enrich-source-ip-location';
-const ENRICH_POLICY_NAME = 'streams-e2e-ip-location-policy';
+import {
+  ENRICH_POLICY_NAME,
+  setupEnrichIndexWithPolicy,
+  teardownEnrichIndexWithPolicy,
+} from '../../utils/enrich_helpers';
 
 apiTest.describe(
   'Streamlang to Ingest Pipeline - Enrich Processor',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
-    // TODO - all setup/teardown helpers should be in a shared file
     apiTest.beforeAll(async ({ esClient }) => {
-      await esClient.indices.create({
-        index: ENRICH_SOURCE_INDEX,
-        mappings: {
-          properties: {
-            ip: { type: 'keyword' },
-            city: { type: 'keyword' },
-            country: { type: 'keyword' },
-          },
-        },
-      });
-
-      await esClient.bulk({
-        refresh: true,
-        body: [
-          { index: { _index: ENRICH_SOURCE_INDEX } },
-          { ip: '10.0.0.1', city: 'New York', country: 'US' },
-          { index: { _index: ENRICH_SOURCE_INDEX } },
-          { ip: '10.0.0.2', city: 'London', country: 'GB' },
-        ],
-      });
-
-      await esClient.enrich.putPolicy({
-        name: ENRICH_POLICY_NAME,
-        match: {
-          indices: ENRICH_SOURCE_INDEX,
-          match_field: 'ip',
-          enrich_fields: ['city', 'country'],
-        },
-      });
-
-      await esClient.enrich.executePolicy({ name: ENRICH_POLICY_NAME });
+      await setupEnrichIndexWithPolicy(esClient);
     });
 
     apiTest.afterAll(async ({ esClient }) => {
-      await esClient.enrich.deletePolicy({ name: ENRICH_POLICY_NAME });
-      await esClient.indices.delete({
-        index: ENRICH_SOURCE_INDEX,
-        ignore_unavailable: true,
-      });
+      await teardownEnrichIndexWithPolicy(esClient);
     });
 
     apiTest('should enrich a document with location data based on ip', async ({ testBed }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
+import { streamlangApiTest as apiTest } from '../..';
+
+const ENRICH_SOURCE_INDEX = 'streams-e2e-enrich-source-ip-location';
+const ENRICH_POLICY_NAME = 'streams-e2e-ip-location-policy';
+
+apiTest.describe(
+  'Streamlang to Ingest Pipeline - Enrich Processor',
+  { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
+  () => {
+    // TODO - all setup/teardown helpers should be in a shared file
+    apiTest.beforeAll(async ({ esClient }) => {
+      await esClient.indices.create({
+        index: ENRICH_SOURCE_INDEX,
+        mappings: {
+          properties: {
+            ip: { type: 'keyword' },
+            city: { type: 'keyword' },
+            country: { type: 'keyword' },
+          },
+        },
+      });
+
+      await esClient.bulk({
+        refresh: true,
+        body: [
+          { index: { _index: ENRICH_SOURCE_INDEX } },
+          { ip: '10.0.0.1', city: 'New York', country: 'US' },
+          { index: { _index: ENRICH_SOURCE_INDEX } },
+          { ip: '10.0.0.2', city: 'London', country: 'GB' },
+        ],
+      });
+
+      await esClient.enrich.putPolicy({
+        name: ENRICH_POLICY_NAME,
+        match: {
+          indices: ENRICH_SOURCE_INDEX,
+          match_field: 'ip',
+          enrich_fields: ['city', 'country'],
+        },
+      });
+
+      await esClient.enrich.executePolicy({ name: ENRICH_POLICY_NAME });
+    });
+
+    apiTest.afterAll(async ({ esClient }) => {
+      await esClient.enrich.deletePolicy({ name: ENRICH_POLICY_NAME });
+      await esClient.indices.delete({
+        index: ENRICH_SOURCE_INDEX,
+        ignore_unavailable: true,
+      });
+    });
+
+    apiTest('should enrich a document with location data based on ip', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-enrich-basic';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'enrich',
+            policy_name: ENRICH_POLICY_NAME,
+            field: 'ip',
+            to: 'location',
+          } as EnrichProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocsOrdered(indexName);
+      expect(ingestedDocs).toHaveLength(2);
+      expect(ingestedDocs[0]?.['location.city']).toBe('New York');
+      expect(ingestedDocs[0]?.['location.country']).toBe('US');
+      expect(ingestedDocs[1]?.['location.city']).toBe('London');
+      expect(ingestedDocs[1]?.['location.country']).toBe('GB');
+    });
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -54,5 +54,136 @@ apiTest.describe(
       expect(ingestedDocs[1]?.['location.city']).toBe('London');
       expect(ingestedDocs[1]?.['location.country']).toBe('GB');
     });
+
+    apiTest(
+      'should leave the document unchanged if match field is not present and ignore_missing is true',
+      async ({ testBed }) => {
+        const indexName = 'streams-e2e-test-enrich-ignore-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              field: 'ip',
+              to: 'location',
+              ignore_missing: true,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = transpile(streamlangDSL);
+
+        const docs = [{ message: 'some message' }, { message: 'some other message' }];
+        await testBed.ingest(indexName, docs, processors);
+
+        const ingestedDocs = await testBed.getFlattenedDocsOrdered(indexName);
+        expect(ingestedDocs).toHaveLength(2);
+        expect(ingestedDocs[0]?.['location.city']).toBeUndefined();
+        expect(ingestedDocs[0]?.['location.country']).toBeUndefined();
+        expect(ingestedDocs[1]?.['location.city']).toBeUndefined();
+        expect(ingestedDocs[1]?.['location.country']).toBeUndefined();
+      }
+    );
+
+    apiTest(
+      'should fail if match field is not present and ignore_missing is false',
+      async ({ testBed }) => {
+        const indexName = 'streams-e2e-test-enrich-fail-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'enrich',
+              policy_name: ENRICH_POLICY_NAME,
+              field: 'ip',
+              to: 'location',
+              ignore_missing: false,
+            } as EnrichProcessor,
+          ],
+        };
+
+        const { processors } = transpile(streamlangDSL);
+
+        const docs = [{ message: 'some message' }];
+        const { errors } = await testBed.ingest(indexName, docs, processors);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].reason).toContain('field [ip] not present as part of path [ip]');
+      }
+    );
+
+    apiTest('should override the existing value if override is true', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-enrich-override';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'enrich',
+            policy_name: ENRICH_POLICY_NAME,
+            field: 'ip',
+            to: 'location',
+            override: true,
+          } as EnrichProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocsOrdered(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]?.['location.city']).toBe('New York');
+      expect(ingestedDocs[0]?.['location.country']).toBe('US');
+    });
+
+    apiTest('should preserve existing values if override is false', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-enrich-preserve-existing';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'enrich',
+            policy_name: ENRICH_POLICY_NAME,
+            field: 'ip',
+            to: 'location',
+            override: false,
+          } as EnrichProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocsOrdered(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]?.['location.city']).toBe('Test city');
+      expect(ingestedDocs[0]?.['location.country']).toBe('Test country');
+    });
+
+    apiTest('should fail if policy name is not present', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-enrich-fail-policy-name';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'enrich',
+            policy_name: 'invalid-policy-name',
+            field: 'ip',
+            to: 'location',
+          } as EnrichProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ ip: '10.0.0.1' }];
+      await expect(async () => {
+        await testBed.ingest(indexName, docs, processors);
+      }).rejects.toThrow('no enrich index exists for policy with name [invalid-policy-name]');
+    });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -12,10 +12,12 @@ import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
 import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
 import { streamlangApiTest as apiTest } from '../..';
 import {
-  ENRICH_POLICY_NAME,
   setupEnrichIndexWithPolicy,
   teardownEnrichIndexWithPolicy,
 } from '../../utils/enrich_helpers';
+
+const ENRICH_POLICY_NAME = 'test-enrich-ingest-pipeline-policy';
+const ENRICH_INDEX_NAME = 'test-enrich-ingest-pipeline-index';
 
 const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
   Promise.resolve({
@@ -28,11 +30,11 @@ apiTest.describe(
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
     apiTest.beforeAll(async ({ esClient }) => {
-      await setupEnrichIndexWithPolicy(esClient);
+      await setupEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest.afterAll(async ({ esClient }) => {
-      await teardownEnrichIndexWithPolicy(esClient);
+      await teardownEnrichIndexWithPolicy(esClient, ENRICH_INDEX_NAME, ENRICH_POLICY_NAME);
     });
 
     apiTest('should enrich a document with location data based on ip', async ({ testBed }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -43,7 +43,6 @@ apiTest.describe(
           {
             action: 'enrich',
             policy_name: ENRICH_POLICY_NAME,
-            field: 'ip',
             to: 'location',
           } as EnrichProcessor,
         ],
@@ -74,7 +73,6 @@ apiTest.describe(
             {
               action: 'enrich',
               policy_name: ENRICH_POLICY_NAME,
-              field: 'ip',
               to: 'location',
               ignore_missing: true,
             } as EnrichProcessor,
@@ -107,7 +105,6 @@ apiTest.describe(
             {
               action: 'enrich',
               policy_name: ENRICH_POLICY_NAME,
-              field: 'ip',
               to: 'location',
               ignore_missing: false,
             } as EnrichProcessor,
@@ -133,7 +130,6 @@ apiTest.describe(
           {
             action: 'enrich',
             policy_name: ENRICH_POLICY_NAME,
-            field: 'ip',
             to: 'location',
             override: true,
           } as EnrichProcessor,
@@ -161,7 +157,6 @@ apiTest.describe(
           {
             action: 'enrich',
             policy_name: ENRICH_POLICY_NAME,
-            field: 'ip',
             to: 'location',
             override: false,
           } as EnrichProcessor,
@@ -189,7 +184,6 @@ apiTest.describe(
           {
             action: 'enrich',
             policy_name: 'invalid-policy-name',
-            field: 'ip',
             to: 'location',
           } as EnrichProcessor,
         ],

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/enrich.spec.ts
@@ -9,12 +9,19 @@ import { tags } from '@kbn/scout';
 import { expect } from '@kbn/scout/api';
 import type { EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
+import type { EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
 import { streamlangApiTest as apiTest } from '../..';
 import {
   ENRICH_POLICY_NAME,
   setupEnrichIndexWithPolicy,
   teardownEnrichIndexWithPolicy,
 } from '../../utils/enrich_helpers';
+
+const mockEnrichPolicyResolver: EnrichPolicyResolver = () =>
+  Promise.resolve({
+    matchField: 'ip',
+    enrichFields: ['city', 'country'],
+  });
 
 apiTest.describe(
   'Streamlang to Ingest Pipeline - Enrich Processor',
@@ -42,7 +49,9 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL, undefined, {
+        enrich: mockEnrichPolicyResolver,
+      });
 
       const docs = [{ ip: '10.0.0.1' }, { ip: '10.0.0.2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -72,7 +81,9 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
 
         const docs = [{ message: 'some message' }, { message: 'some other message' }];
         await testBed.ingest(indexName, docs, processors);
@@ -103,7 +114,9 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL, undefined, {
+          enrich: mockEnrichPolicyResolver,
+        });
 
         const docs = [{ message: 'some message' }];
         const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -127,7 +140,9 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL, undefined, {
+        enrich: mockEnrichPolicyResolver,
+      });
 
       const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -153,7 +168,9 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL, undefined, {
+        enrich: mockEnrichPolicyResolver,
+      });
 
       const docs = [{ ip: '10.0.0.1', location: { city: 'Test city', country: 'Test country' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -178,7 +195,9 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL, undefined, {
+        enrich: mockEnrichPolicyResolver,
+      });
 
       const docs = [{ ip: '10.0.0.1' }];
       await expect(async () => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/filter_conditions.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/filter_conditions.spec.ts
@@ -33,7 +33,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { attributes: { status_codes: [200, 201, 204] } },
@@ -71,7 +71,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { path: 'C:\\Program Files\\App' },
@@ -102,7 +102,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'He said "hello"' },
@@ -135,7 +135,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { data: 'path: "C:\\Users\\test"' },
@@ -169,7 +169,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { path: 'C:\\Program Files\\App\\bin' },
@@ -203,7 +203,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { path: 'C:\\Windows\\System32' },
@@ -237,7 +237,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { path: 'C:\\Program Files\\bin\\app.exe' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: '55.3.244.1 GET /index.html 15824 0.043' }];
       await testBed.ingest(indexName, docs, processors);
@@ -60,7 +60,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ log: { level: 'info' } }]; // Not including 'message' field
       await testBed.ingest(indexName, docs, processors);
@@ -85,7 +85,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ log: { level: 'info' } }]; // 'message' field is missing
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -105,7 +105,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'not_an_ip' }];
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -123,7 +123,7 @@ apiTest.describe(
       },
     ].forEach(({ templateFrom, description }) => {
       apiTest(`${description}`, async () => {
-        expect(() => {
+        await expect(() => {
           const streamlangDSL: StreamlangDSL = {
             steps: [
               {
@@ -136,7 +136,7 @@ apiTest.describe(
             ],
           };
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/grok.spec.ts
@@ -123,20 +123,20 @@ apiTest.describe(
       },
     ].forEach(({ templateFrom, description }) => {
       apiTest(`${description}`, async () => {
-        await expect(() => {
-          const streamlangDSL: StreamlangDSL = {
-            steps: [
-              {
-                action: 'grok',
-                from: templateFrom,
-                patterns: [
-                  '%{IP:client.ip} %{WORD:http.request.method} %{URIPATHPARAM:url.path} %{NUMBER:http.response.body.bytes} %{NUMBER:event.duration}',
-                ],
-              } as GrokProcessor,
-            ],
-          };
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'grok',
+              from: templateFrom,
+              patterns: [
+                '%{IP:client.ip} %{WORD:http.request.method} %{URIPATHPARAM:url.path} %{NUMBER:http.response.body.bytes} %{NUMBER:event.duration}',
+              ],
+            } as GrokProcessor,
+          ],
+        };
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
@@ -40,7 +40,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'not valid json' }];
         const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -64,7 +64,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'some_value' }];
         await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/lowercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -80,7 +80,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },
@@ -107,7 +107,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ id: 1234 }];
       const { errors } = await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/manual_ingest_pipeline.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/manual_ingest_pipeline.spec.ts
@@ -37,7 +37,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -83,7 +83,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -125,7 +125,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -170,7 +170,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -213,7 +213,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -259,7 +259,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           // Should be processed: status=active AND priority=high
@@ -313,7 +313,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'should process', should_process: true },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/math.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ price: 10, quantity: 5 }];
       await testBed.ingest(indexName, docs, processors);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ a: 15, b: 25 }];
       await testBed.ingest(indexName, docs, processors);
@@ -73,7 +73,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ a: 100, b: 30 }];
       await testBed.ingest(indexName, docs, processors);
@@ -95,7 +95,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ total: 100, count: 4 }];
       await testBed.ingest(indexName, docs, processors);
@@ -118,7 +118,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { price: 25, quantity: 4 } }];
       await testBed.ingest(indexName, docs, processors);
@@ -142,7 +142,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       // log(e) = 1
       const docs = [{ value: 2.718281828459045 }];
@@ -167,7 +167,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 3 },
@@ -193,7 +193,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 10, b: 5 },
@@ -219,7 +219,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 3, b: 7 },
@@ -245,7 +245,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, a: 5, b: 5 },
@@ -276,7 +276,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { order_id: 1, price: 10, quantity: 5, active: true },
@@ -308,7 +308,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { order_id: 1, price: 10, quantity: 5 },
@@ -344,7 +344,7 @@ apiTest.describe(
           const streamlangDSL: StreamlangDSL = {
             steps: [{ action: 'math', expression, to: 'result' } as MathProcessor],
           };
-          const { processors } = transpile(streamlangDSL);
+          const { processors } = await transpile(streamlangDSL);
           const { errors } = await testBed.ingest(`math-reject-${i}`, [doc], processors);
 
           expect(errors.length).toBeGreaterThan(0);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/network_direction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/network_direction.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
       await testBed.ingest(indexName, docs, processors);
@@ -54,7 +54,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -85,7 +85,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
       await testBed.ingest(indexName, docs, processors);
@@ -115,7 +115,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1', event: { kind: 'test' } },
@@ -151,7 +151,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1' },

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/redact.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Connection from 192.168.1.1 established' }];
       await testBed.ingest(indexName, docs, processors);
@@ -53,7 +53,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Contact user at john.doe@example.com for details' }];
       await testBed.ingest(indexName, docs, processors);
@@ -78,7 +78,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User john@example.com connected from 10.0.0.1' }];
       await testBed.ingest(indexName, docs, processors);
@@ -105,7 +105,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Request from 172.16.0.1' }];
       await testBed.ingest(indexName, docs, processors);
@@ -130,7 +130,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Device MAC: 00:1A:2B:3C:4D:5E' }];
       await testBed.ingest(indexName, docs, processors);
@@ -158,7 +158,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
         await testBed.ingest(indexName, docs, processors);
@@ -184,7 +184,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -209,7 +209,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'Connection from 192.168.1.1', environment: 'production' },
@@ -248,7 +248,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User 550e8400-e29b-41d4-a716-446655440000 logged in' }];
       await testBed.ingest(indexName, docs, processors);
@@ -273,7 +273,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Hello world, no IP here' }];
       await testBed.ingest(indexName, docs, processors);
@@ -306,7 +306,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/redact.spec.ts
@@ -306,7 +306,7 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
@@ -164,7 +164,7 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ temp_field: 'to-be-removed', message: 'keep-this' }];
       await testBed.ingest(indexName, docs, processors);
@@ -53,7 +53,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       await testBed.ingest(indexName, docs, processors);
@@ -77,7 +77,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -101,7 +101,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { temp_data: { value: 'remove-me' }, event: { kind: 'test' }, message: 'doc1' },
@@ -135,7 +135,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       // Field missing, should fail (ignore_missing defaults to false)
       const docs = [{ message: 'some_value' }];
@@ -164,7 +164,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
@@ -305,9 +305,9 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => {
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/remove_by_prefix.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ temp_field: 'to-be-removed', message: 'keep-this' }];
       await testBed.ingest(indexName, docs, processors);
@@ -52,7 +52,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -93,7 +93,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       // Create docs with flattened field structure
       const docs = [
@@ -130,7 +130,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -167,7 +167,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -208,7 +208,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         {
@@ -251,7 +251,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           {
@@ -305,9 +305,9 @@ apiTest.describe(
           ],
         };
 
-        expect(() => {
+        await expect(() => {
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
       });
     });
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
@@ -64,9 +64,9 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => {
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       });
     });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/rename.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -64,9 +64,9 @@ apiTest.describe(
           ],
         };
 
-        expect(() => {
+        await expect(() => {
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed');
       });
     });
 
@@ -84,7 +84,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'host.original' field
       await testBed.ingest(indexName, docs, processors);
@@ -109,7 +109,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'host.original' field
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -131,7 +131,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -156,7 +156,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host', renamed: 'old-host' } }];
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -179,7 +179,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         // Case 1: Source field missing, should fail (ignore_missing: false)
         const docsMissingSource = [{ host: { renamed: 'old-host' } }];

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'An error occurred' }];
       await testBed.ingest(indexName, docs, processors);
@@ -55,7 +55,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'An error occurred' }];
       await testBed.ingest(indexName, docs, processors);
@@ -80,7 +80,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'Error code 404 found' }];
       await testBed.ingest(indexName, docs, processors);
@@ -104,7 +104,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'User alice has 3 new messages' }];
       await testBed.ingest(indexName, docs, processors);
@@ -130,7 +130,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
         const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -154,7 +154,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       await testBed.ingest(indexName, docs, processors);
@@ -184,7 +184,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { message: 'An error occurred', event: { kind: 'test' } },
@@ -231,7 +231,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'An error occurred', event: { kind: 'test' } },
@@ -282,7 +282,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/replace.spec.ts
@@ -282,7 +282,7 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
@@ -76,9 +76,9 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => {
-          transpile(streamlangDSL);
-        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed'
+        );
       });
     });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
@@ -160,7 +160,7 @@ apiTest.describe(
         ],
       };
 
-      await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });
@@ -177,7 +177,7 @@ apiTest.describe(
         ],
       };
 
-      await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+      await expect(transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/set.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
       await testBed.ingest(indexName, docs, processors);
@@ -76,9 +76,9 @@ apiTest.describe(
           ],
         };
 
-        expect(() => {
+        await expect(() => {
           transpile(streamlangDSL);
-        }).toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
+        }).rejects.toThrow('Mustache template syntax {{ }} or {{{ }}} is not allowed'); // Should throw validation error for Mustache templates
       });
     });
 
@@ -95,7 +95,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'should-be-copied' }];
       await testBed.ingest(indexName, docs, processors);
@@ -118,7 +118,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { status: 'active' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -141,7 +141,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ attributes: { status: 'active' } }];
       await testBed.ingest(indexName, docs, processors);
@@ -160,7 +160,7 @@ apiTest.describe(
         ],
       };
 
-      expect(() => transpile(streamlangDSL)).toThrowError(
+      await expect(() => transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });
@@ -177,7 +177,7 @@ apiTest.describe(
         ],
       };
 
-      expect(() => transpile(streamlangDSL)).toThrowError(
+      await expect(() => transpile(streamlangDSL)).rejects.toThrow(
         'Set processor must have either value or copy_from, but not both.'
       );
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/sort.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/sort.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -53,7 +53,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -79,7 +79,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -107,7 +107,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ numbers: [3, 1, 4, 1, 5, 9, 2, 6] }];
       await testBed.ingest(indexName, docs, processors);
@@ -132,7 +132,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -155,7 +155,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
         await testBed.ingest(indexName, docs, processors);
@@ -183,7 +183,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
         await testBed.ingest(indexName, docs, processors);
@@ -209,7 +209,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: ['charlie', 'alpha', 'bravo'] }];
       await testBed.ingest(indexName, docs, processors);
@@ -238,7 +238,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { tags: ['charlie', 'alpha', 'bravo'], event: { kind: 'test' } },
@@ -291,7 +291,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { tags: ['charlie', 'alpha', 'bravo'], event: { kind: 'test' } },
@@ -348,7 +348,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/sort.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/sort.spec.ts
@@ -348,7 +348,7 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/split.spec.ts
@@ -328,7 +328,7 @@ apiTest.describe(
           ],
         };
 
-        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
+        await expect(transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/split.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: 'foo,bar,baz' }];
       await testBed.ingest(indexName, docs, processors);
@@ -55,7 +55,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ tags: 'foo,bar,baz' }];
       await testBed.ingest(indexName, docs, processors);
@@ -83,7 +83,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'hello   world  test' }];
       await testBed.ingest(indexName, docs, processors);
@@ -109,7 +109,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       const { errors } = await testBed.ingest(indexName, docs, processors);
@@ -131,7 +131,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'some_value' }]; // Not including 'nonexistent' field
       await testBed.ingest(indexName, docs, processors);
@@ -159,7 +159,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ tags: 'A,,B,,' }];
         await testBed.ingest(indexName, docs, processors);
@@ -188,7 +188,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [{ tags: 'A,,B,,' }];
         await testBed.ingest(indexName, docs, processors);
@@ -216,7 +216,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [
         { tags: 'foo,bar,baz', event: { kind: 'test' } },
@@ -270,7 +270,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { tags: 'foo,bar,baz', event: { kind: 'test' } },
@@ -328,7 +328,7 @@ apiTest.describe(
           ],
         };
 
-        expect(() => transpile(streamlangDSL)).toThrow(
+        await expect(() => transpile(streamlangDSL)).rejects.toThrow(
           'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
         );
       });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/trim.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest(indexName, docs, processors);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest(indexName, docs, processors);
@@ -80,7 +80,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { message: '   test message 1   ', should_trim: 'yes' },
@@ -107,7 +107,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ id: 1234 }];
       const { errors } = await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/uppercase.spec.ts
@@ -27,7 +27,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -51,7 +51,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest(indexName, docs, processors);
@@ -80,7 +80,7 @@ apiTest.describe(
           ],
         };
 
-        const { processors } = transpile(streamlangDSL);
+        const { processors } = await transpile(streamlangDSL);
 
         const docs = [
           { message: 'test message 1', should_uppercase: 'yes' },
@@ -107,7 +107,7 @@ apiTest.describe(
         ],
       };
 
-      const { processors } = transpile(streamlangDSL);
+      const { processors } = await transpile(streamlangDSL);
 
       const docs = [{ id: 1234 }];
       const { errors } = await testBed.ingest(indexName, docs, processors);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EsClient } from '@kbn/scout/src/types/services';
+
+export const ENRICH_SOURCE_INDEX = 'streams-e2e-enrich-source-ip-location';
+export const ENRICH_POLICY_NAME = 'streams-e2e-ip-location-policy';
+
+/**
+ * Sets up an enrich index with an enrich policy with sample data for tests.
+ * @param esClient The Elasticsearch client.
+ */
+export const setupEnrichIndexWithPolicy = async (esClient: EsClient) => {
+  await esClient.indices.create({
+    index: ENRICH_SOURCE_INDEX,
+    mappings: {
+      properties: {
+        ip: { type: 'keyword' },
+        city: { type: 'keyword' },
+        country: { type: 'keyword' },
+      },
+    },
+  });
+
+  await esClient.bulk({
+    refresh: true,
+    body: [
+      { index: { _index: ENRICH_SOURCE_INDEX } },
+      { ip: '10.0.0.1', city: 'New York', country: 'US' },
+      { index: { _index: ENRICH_SOURCE_INDEX } },
+      { ip: '10.0.0.2', city: 'London', country: 'GB' },
+    ],
+  });
+
+  await esClient.enrich.putPolicy({
+    name: ENRICH_POLICY_NAME,
+    match: {
+      indices: ENRICH_SOURCE_INDEX,
+      match_field: 'ip',
+      enrich_fields: ['city', 'country'],
+    },
+  });
+
+  await esClient.enrich.executePolicy({ name: ENRICH_POLICY_NAME });
+};
+
+export const teardownEnrichIndexWithPolicy = async (esClient: EsClient) => {
+  await esClient.enrich.deletePolicy({ name: ENRICH_POLICY_NAME });
+  await esClient.indices.delete({
+    index: ENRICH_SOURCE_INDEX,
+    ignore_unavailable: true,
+  });
+};

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
@@ -48,6 +48,10 @@ export const setupEnrichIndexWithPolicy = async (esClient: EsClient) => {
   await esClient.enrich.executePolicy({ name: ENRICH_POLICY_NAME });
 };
 
+/**
+ * Tears down an enrich index with an enrich policy that were created by the setup function.
+ * @param esClient The Elasticsearch client.
+ */
 export const teardownEnrichIndexWithPolicy = async (esClient: EsClient) => {
   await esClient.enrich.deletePolicy({ name: ENRICH_POLICY_NAME });
   await esClient.indices.delete({

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/utils/enrich_helpers.ts
@@ -7,16 +7,17 @@
 
 import type { EsClient } from '@kbn/scout/src/types/services';
 
-export const ENRICH_SOURCE_INDEX = 'streams-e2e-enrich-source-ip-location';
-export const ENRICH_POLICY_NAME = 'streams-e2e-ip-location-policy';
-
 /**
  * Sets up an enrich index with an enrich policy with sample data for tests.
  * @param esClient The Elasticsearch client.
  */
-export const setupEnrichIndexWithPolicy = async (esClient: EsClient) => {
+export const setupEnrichIndexWithPolicy = async (
+  esClient: EsClient,
+  indexName: string,
+  policyName: string
+) => {
   await esClient.indices.create({
-    index: ENRICH_SOURCE_INDEX,
+    index: indexName,
     mappings: {
       properties: {
         ip: { type: 'keyword' },
@@ -29,33 +30,37 @@ export const setupEnrichIndexWithPolicy = async (esClient: EsClient) => {
   await esClient.bulk({
     refresh: true,
     body: [
-      { index: { _index: ENRICH_SOURCE_INDEX } },
+      { index: { _index: indexName } },
       { ip: '10.0.0.1', city: 'New York', country: 'US' },
-      { index: { _index: ENRICH_SOURCE_INDEX } },
+      { index: { _index: indexName } },
       { ip: '10.0.0.2', city: 'London', country: 'GB' },
     ],
   });
 
   await esClient.enrich.putPolicy({
-    name: ENRICH_POLICY_NAME,
+    name: policyName,
     match: {
-      indices: ENRICH_SOURCE_INDEX,
+      indices: indexName,
       match_field: 'ip',
       enrich_fields: ['city', 'country'],
     },
   });
 
-  await esClient.enrich.executePolicy({ name: ENRICH_POLICY_NAME });
+  await esClient.enrich.executePolicy({ name: policyName });
 };
 
 /**
  * Tears down an enrich index with an enrich policy that were created by the setup function.
  * @param esClient The Elasticsearch client.
  */
-export const teardownEnrichIndexWithPolicy = async (esClient: EsClient) => {
-  await esClient.enrich.deletePolicy({ name: ENRICH_POLICY_NAME });
+export const teardownEnrichIndexWithPolicy = async (
+  esClient: EsClient,
+  indexName: string,
+  policyName: string
+) => {
+  await esClient.enrich.deletePolicy({ name: policyName });
   await esClient.indices.delete({
-    index: ENRICH_SOURCE_INDEX,
+    index: indexName,
     ignore_unavailable: true,
   });
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-streamlang/moon.yml
@@ -24,6 +24,7 @@ dependsOn:
   - '@kbn/datemath'
   - '@kbn/tinymath'
   - '@kbn/grok-ui'
+  - '@kbn/index-management-shared-types'
 tags:
   - shared-common
   - package

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
@@ -854,6 +854,34 @@ export const ACTION_METADATA_MAP: Record<ProcessorType, ActionMetadata> = {
     ],
   },
 
+  enrich: {
+    name: i18n.translate('xpack.streamlang.actionMetadata.enrich.name', {
+      defaultMessage: 'Enrich',
+    }),
+    description: i18n.translate('xpack.streamlang.actionMetadata.enrich.description', {
+      defaultMessage: 'Enrich a field with a policy',
+    }),
+    usage: i18n.translate('xpack.streamlang.actionMetadata.enrich.usage', {
+      defaultMessage: 'Provide a `policy_name` and `field` to enrich the field with the policy.',
+    }),
+    examples: [
+      {
+        description: i18n.translate('xpack.streamlang.actionMetadata.enrich.examples.simple', {
+          defaultMessage: 'Enrich a field with a policy',
+        }),
+        yaml: `- action: enrich
+  policy_name: my_policy
+  field: match_field
+  to: my_enriched_field`,
+      },
+    ],
+    tips: [
+      i18n.translate('xpack.streamlang.actionMetadata.enrich.tips.ignoreMissing', {
+        defaultMessage: 'Ignore missing fields by setting ignore_missing to true',
+      }),
+    ],
+  },
+
   manual_ingest_pipeline: {
     name: i18n.translate('xpack.streamlang.actionMetadata.manualIngestPipeline.name', {
       defaultMessage: 'Manual Ingest Pipeline',

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
@@ -862,16 +862,15 @@ export const ACTION_METADATA_MAP: Record<ProcessorType, ActionMetadata> = {
       defaultMessage: 'Enrich a field with a policy',
     }),
     usage: i18n.translate('xpack.streamlang.actionMetadata.enrich.usage', {
-      defaultMessage: 'Provide a `policy_name` and `field` to enrich the field with the policy.',
+      defaultMessage: 'Provide a `policy_name` to enrich data with the policy.',
     }),
     examples: [
       {
         description: i18n.translate('xpack.streamlang.actionMetadata.enrich.examples.simple', {
-          defaultMessage: 'Enrich a field with a policy',
+          defaultMessage: 'Enrich data with a policy',
         }),
         yaml: `- action: enrich
   policy_name: my_policy
-  field: match_field
   to: my_enriched_field`,
       },
     ],

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
@@ -1659,6 +1659,59 @@ Object {
             },
             Object {
               "additionalProperties": false,
+              "description": "Enrich a field with a policy",
+              "properties": Object {
+                "action": Object {
+                  "const": "enrich",
+                  "type": "string",
+                },
+                "customIdentifier": Object {
+                  "description": "Custom identifier to correlate this processor across outputs",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "description": Object {
+                  "description": "Human-readable notes about this processor step",
+                  "type": "string",
+                },
+                "ignore_failure": Object {
+                  "description": "Continue pipeline execution if this processor fails",
+                  "type": "boolean",
+                },
+                "ignore_missing": Object {
+                  "type": "boolean",
+                },
+                "override": Object {
+                  "type": "boolean",
+                },
+                "policy_name": Object {
+                  "description": "A non-empty string.",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "to": Object {
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "where": Object {
+                  "allOf": Array [
+                    Object {
+                      "$ref": "#/definitions/Condition",
+                    },
+                  ],
+                  "description": "Conditional expression controlling whether this processor runs",
+                },
+              },
+              "required": Array [
+                "action",
+                "policy_name",
+                "to",
+              ],
+              "title": "Enrich",
+              "type": "object",
+            },
+            Object {
+              "additionalProperties": false,
               "description": "Execute raw Elasticsearch ingest processors directly",
               "properties": Object {
                 "action": Object {
@@ -1741,6 +1794,7 @@ Object {
                 "convert",
                 "concat",
                 "json_extract",
+                "enrich",
                 "manual_ingest_pipeline",
               ],
               "type": "string",
@@ -3066,6 +3120,59 @@ Object {
               },
               Object {
                 "additionalProperties": false,
+                "description": "Enrich a field with a policy",
+                "properties": Object {
+                  "action": Object {
+                    "const": "enrich",
+                    "type": "string",
+                  },
+                  "customIdentifier": Object {
+                    "description": "Custom identifier to correlate this processor across outputs",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "description": Object {
+                    "description": "Human-readable notes about this processor step",
+                    "type": "string",
+                  },
+                  "ignore_failure": Object {
+                    "description": "Continue pipeline execution if this processor fails",
+                    "type": "boolean",
+                  },
+                  "ignore_missing": Object {
+                    "type": "boolean",
+                  },
+                  "override": Object {
+                    "type": "boolean",
+                  },
+                  "policy_name": Object {
+                    "description": "A non-empty string.",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "to": Object {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "where": Object {
+                    "allOf": Array [
+                      Object {
+                        "$ref": "#/definitions/Condition",
+                      },
+                    ],
+                    "description": "Conditional expression controlling whether this processor runs",
+                  },
+                },
+                "required": Array [
+                  "action",
+                  "policy_name",
+                  "to",
+                ],
+                "title": "Enrich",
+                "type": "object",
+              },
+              Object {
+                "additionalProperties": false,
                 "description": "Execute raw Elasticsearch ingest processors directly",
                 "properties": Object {
                   "action": Object {
@@ -3148,6 +3255,7 @@ Object {
                   "convert",
                   "concat",
                   "json_extract",
+                  "enrich",
                   "manual_ingest_pipeline",
                 ],
                 "type": "string",

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
@@ -38,7 +38,6 @@ import type {
 import { type StreamlangProcessorDefinition } from '../../../types/processors';
 import {
   getStreamlangResolverForProcessor,
-  type EnrichPolicyResolver,
   type StreamlangResolver,
   type StreamlangResolverOptions,
 } from '../../../types/resolvers';
@@ -139,10 +138,10 @@ async function convertProcessorToESQL(
       return convertJsonExtractProcessorToESQL(processor as JsonExtractProcessor);
 
     case 'enrich':
-      return await convertEnrichProcessorToESQL(
-        processor as EnrichProcessor,
-        resolver as EnrichPolicyResolver
-      );
+      if (!resolver) {
+        throw new Error('Enrich policy resolver is required for enrich processor.');
+      }
+      return await convertEnrichProcessorToESQL(processor as EnrichProcessor, resolver);
 
     case 'manual_ingest_pipeline':
       return [

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { ESQLAstCommand } from '@elastic/esql/types';
 import { BasicPrettyPrinter, Builder } from '@elastic/esql';
+import type { ESQLAstCommand } from '@elastic/esql/types';
 import { conditionToESQLAst } from './condition_to_esql';
 
 import type { ESQLTranspilationOptions } from '.';
@@ -15,15 +15,15 @@ import type {
   ConvertProcessor,
   DateProcessor,
   DissectProcessor,
+  DropDocumentProcessor,
   GrokProcessor,
   MathProcessor,
-  RenameProcessor,
-  SetProcessor,
+  RedactProcessor,
   RemoveByPrefixProcessor,
   RemoveProcessor,
-  DropDocumentProcessor,
+  RenameProcessor,
   ReplaceProcessor,
-  RedactProcessor,
+  SetProcessor,
   UppercaseProcessor,
   LowercaseProcessor,
   TrimProcessor,
@@ -36,29 +36,38 @@ import type {
   EnrichProcessor,
 } from '../../../types/processors';
 import { type StreamlangProcessorDefinition } from '../../../types/processors';
-import { convertRenameProcessorToESQL } from './processors/rename';
-import { convertSetProcessorToESQL } from './processors/set';
+import {
+  getStreamlangResolverForProcessor,
+  type EnrichPolicyResolver,
+  type StreamlangResolver,
+  type StreamlangResolverOptions,
+} from '../../../types/resolvers';
 import { convertAppendProcessorToESQL } from './processors/append';
+import { convertConvertProcessorToESQL } from './processors/convert';
 import { convertDateProcessorToESQL } from './processors/date';
 import { convertDissectProcessorToESQL } from './processors/dissect';
-import { convertGrokProcessorToESQL } from './processors/grok';
-import { convertConvertProcessorToESQL } from './processors/convert';
-import { convertRemoveByPrefixProcessorToESQL } from './processors/remove_by_prefix';
-import { convertRemoveProcessorToESQL } from './processors/remove';
 import { convertDropDocumentProcessorToESQL } from './processors/drop_document';
-import { convertReplaceProcessorToESQL } from './processors/replace';
-import { convertRedactProcessorToESQL } from './processors/redact';
-import { convertMathProcessorToESQL } from './processors/math';
-import { createTransformStringESQL } from './transform_string';
+import { convertGrokProcessorToESQL } from './processors/grok';
 import { convertJoinProcessorToESQL } from './processors/join';
-import { convertSplitProcessorToESQL } from './processors/split';
+import { convertMathProcessorToESQL } from './processors/math';
+import { convertRedactProcessorToESQL } from './processors/redact';
+import { convertRemoveProcessorToESQL } from './processors/remove';
+import { convertRemoveByPrefixProcessorToESQL } from './processors/remove_by_prefix';
+import { convertRenameProcessorToESQL } from './processors/rename';
+import { convertReplaceProcessorToESQL } from './processors/replace';
+import { convertSetProcessorToESQL } from './processors/set';
 import { convertSortProcessorToESQL } from './processors/sort';
+import { convertSplitProcessorToESQL } from './processors/split';
+import { createTransformStringESQL } from './transform_string';
 import { convertConcatProcessorToESQL } from './processors/concat';
 import { convertNetworkDirectionProcessorToESQL } from './processors/network_direction';
 import { convertJsonExtractProcessorToESQL } from './processors/json_extract';
 import { convertEnrichProcessorToESQL } from './processors/enrich';
 
-function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLAstCommand[] | null {
+async function convertProcessorToESQL(
+  processor: StreamlangProcessorDefinition,
+  resolver?: StreamlangResolver
+): Promise<ESQLAstCommand[] | null> {
   switch (processor.action) {
     case 'rename':
       return convertRenameProcessorToESQL(processor as RenameProcessor);
@@ -130,7 +139,10 @@ function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLA
       return convertJsonExtractProcessorToESQL(processor as JsonExtractProcessor);
 
     case 'enrich':
-      return convertEnrichProcessorToESQL(processor as EnrichProcessor);
+      return await convertEnrichProcessorToESQL(
+        processor as EnrichProcessor,
+        resolver as EnrichPolicyResolver
+      );
 
     case 'manual_ingest_pipeline':
       return [
@@ -149,12 +161,21 @@ function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLA
   }
 }
 
-export function convertStreamlangDSLToESQLCommands(
+export async function convertStreamlangDSLToESQLCommands(
   actionSteps: StreamlangProcessorDefinition[],
-  transpilationOptions: ESQLTranspilationOptions
-): string {
-  const esqlAstCommands = actionSteps
-    .map((processor) => convertProcessorToESQL(processor))
+  transpilationOptions: ESQLTranspilationOptions,
+  resolverOptions?: StreamlangResolverOptions
+): Promise<string> {
+  const resolvedEsqlAstCommands = await Promise.all(
+    actionSteps.map((processor) =>
+      convertProcessorToESQL(
+        processor,
+        getStreamlangResolverForProcessor(processor, resolverOptions)
+      )
+    )
+  );
+
+  const esqlAstCommands = resolvedEsqlAstCommands
     .filter((cmds): cmds is ESQLAstCommand[] => cmds !== null)
     .flat();
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
@@ -33,6 +33,7 @@ import type {
   ConcatProcessor,
   NetworkDirectionProcessor,
   JsonExtractProcessor,
+  EnrichProcessor,
 } from '../../../types/processors';
 import { type StreamlangProcessorDefinition } from '../../../types/processors';
 import { convertRenameProcessorToESQL } from './processors/rename';
@@ -55,6 +56,7 @@ import { convertSortProcessorToESQL } from './processors/sort';
 import { convertConcatProcessorToESQL } from './processors/concat';
 import { convertNetworkDirectionProcessorToESQL } from './processors/network_direction';
 import { convertJsonExtractProcessorToESQL } from './processors/json_extract';
+import { convertEnrichProcessorToESQL } from './processors/enrich';
 
 function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLAstCommand[] | null {
   switch (processor.action) {
@@ -126,6 +128,9 @@ function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLA
 
     case 'json_extract':
       return convertJsonExtractProcessorToESQL(processor as JsonExtractProcessor);
+
+    case 'enrich':
+      return convertEnrichProcessorToESQL(processor as EnrichProcessor);
 
     case 'manual_ingest_pipeline':
       return [

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
@@ -7,6 +7,7 @@
 
 import { pipe } from 'fp-ts/function';
 import type { BasicPrettyPrinterOptions } from '@elastic/esql';
+import type { StreamlangResolverOptions } from '../../../types/resolvers';
 import type { StreamlangDSL } from '../../../types/streamlang';
 import { streamlangDSLSchema } from '../../../types/streamlang';
 import { flattenSteps } from '../shared/flatten_steps';
@@ -32,17 +33,18 @@ export const conditionToESQL = (condition: Condition): string => {
   return convertConditionToESQL(condition);
 };
 
-export const transpile = (
+export const transpile = async (
   streamlang: StreamlangDSL,
-  transpilationOptions: ESQLTranspilationOptions = { pipeTab: DEFAULT_PIPE_TAB }
-): ESQLTranspilationResult => {
+  transpilationOptions: ESQLTranspilationOptions = { pipeTab: DEFAULT_PIPE_TAB },
+  resolverOptions?: StreamlangResolverOptions
+): Promise<ESQLTranspilationResult> => {
   const validatedStreamlang = streamlangDSLSchema.parse(streamlang);
 
   const esqlCommandsFromStreamlang = pipe(flattenSteps(validatedStreamlang.steps), (steps) =>
-    convertStreamlangDSLToESQLCommands(steps, transpilationOptions)
+    convertStreamlangDSLToESQLCommands(steps, transpilationOptions, resolverOptions)
   );
 
-  const commandsArray = [esqlCommandsFromStreamlang].filter(Boolean);
+  const commandsArray = [await esqlCommandsFromStreamlang].filter(Boolean);
 
   return {
     query: `  | ${commandsArray.join('\n|')}`,

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Builder } from '@elastic/esql';
+import type { ESQLAstCommand } from '@elastic/esql/types';
+import type { EnrichProcessor } from '../../../../types/processors';
+
+/**
+ * Converts a Streamlang EnrichProcessor into a list of ES|QL AST commands.
+ * @param processor - The EnrichProcessor to convert
+ * @returns A list of ES|QL AST commands
+ * @example
+ * Input:
+ * { action: 'enrich', policy_name: 'ip_location', field: 'ip', to: 'location' }
+ *
+ * Output (basic, without enrich_fields):
+ * | ENRICH ip_location ON ip
+ *
+ * Output (with enrich_fields: ['city', 'country']):
+ * | ENRICH ip_location ON ip WITH location.city = city, location.country = country
+ */
+export const convertEnrichProcessorToESQL = (processor: EnrichProcessor): ESQLAstCommand[] => {
+  const { policy_name, field } = processor;
+
+  const policySource = Builder.expression.source.node({
+    sourceType: 'policy',
+    name: policy_name,
+    index: policy_name,
+  });
+
+  const onOption = Builder.option({
+    name: 'on',
+    args: [Builder.expression.column(field)],
+  });
+
+  const enrichCmd = Builder.command({
+    name: 'enrich',
+    args: [policySource, onOption],
+  });
+
+  // TODO: Add support for to, ignore_missing, and override options
+  return [enrichCmd];
+};

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
@@ -8,6 +8,7 @@
 import { Builder } from '@elastic/esql';
 import type { ESQLAstCommand } from '@elastic/esql/types';
 import type { EnrichProcessor } from '../../../../types/processors';
+import { buildIgnoreMissingFilter } from './common';
 
 /**
  * Converts a Streamlang EnrichProcessor into a list of ES|QL AST commands.
@@ -24,7 +25,13 @@ import type { EnrichProcessor } from '../../../../types/processors';
  * | ENRICH ip_location ON ip WITH location.city = city, location.country = country
  */
 export const convertEnrichProcessorToESQL = (processor: EnrichProcessor): ESQLAstCommand[] => {
-  const { policy_name, field } = processor;
+  const { policy_name, field, ignore_missing = false } = processor;
+  const commands: ESQLAstCommand[] = [];
+
+  const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, field);
+  if (missingFieldFilter) {
+    commands.push(missingFieldFilter);
+  }
 
   const policySource = Builder.expression.source.node({
     sourceType: 'policy',
@@ -42,6 +49,7 @@ export const convertEnrichProcessorToESQL = (processor: EnrichProcessor): ESQLAs
     args: [policySource, onOption],
   });
 
-  // TODO: Add support for to, ignore_missing, and override options
-  return [enrichCmd];
+  // TODO: Add support for "to" and "override" options
+  commands.push(enrichCmd);
+  return commands;
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
@@ -7,28 +7,38 @@
 
 import { Builder } from '@elastic/esql';
 import type { ESQLAstCommand } from '@elastic/esql/types';
+import type { EnrichPolicyResolver } from '../../../../types/resolvers';
 import type { EnrichProcessor } from '../../../../types/processors';
 import { buildIgnoreMissingFilter } from './common';
 
 /**
- * Converts a Streamlang EnrichProcessor into a list of ES|QL AST commands.
- * @param processor - The EnrichProcessor to convert
- * @returns A list of ES|QL AST commands
- * @example
- * Input:
- * { action: 'enrich', policy_name: 'ip_location', field: 'ip', to: 'location' }
- *
- * Output (basic, without enrich_fields):
- * | ENRICH ip_location ON ip
- *
- * Output (with enrich_fields: ['city', 'country']):
- * | ENRICH ip_location ON ip WITH location.city = city, location.country = country
+ * TODO - rewrite this once enrich policy resolver is implemented
+ * TODO - add support for the "override" option
  */
-export const convertEnrichProcessorToESQL = (processor: EnrichProcessor): ESQLAstCommand[] => {
-  const { policy_name, field, ignore_missing = false } = processor;
+export const convertEnrichProcessorToESQL = async (
+  processor: EnrichProcessor,
+  resolver: EnrichPolicyResolver
+): Promise<ESQLAstCommand[]> => {
+  const { policy_name, to, ignore_missing = false } = processor;
   const commands: ESQLAstCommand[] = [];
 
-  const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, field);
+  const policyMetadata = await resolver(policy_name);
+
+  if (!policyMetadata) {
+    throw new Error(`Enrich policy ${policy_name} not found`);
+  }
+
+  if (!policyMetadata.matchField || policyMetadata.enrichFields.length === 0) {
+    throw new Error(`Enrich policy ${policy_name} is invalid`);
+  }
+
+  if (!policyMetadata.enrichFields || policyMetadata.enrichFields.length === 0) {
+    throw new Error(`Enrich policy ${policy_name} has no enrich fields`);
+  }
+
+  const { matchField, enrichFields } = policyMetadata;
+
+  const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, matchField);
   if (missingFieldFilter) {
     commands.push(missingFieldFilter);
   }
@@ -41,15 +51,26 @@ export const convertEnrichProcessorToESQL = (processor: EnrichProcessor): ESQLAs
 
   const onOption = Builder.option({
     name: 'on',
-    args: [Builder.expression.column(field)],
+    args: [Builder.expression.column(matchField)],
+  });
+
+  const withAssignments = enrichFields.map((field) =>
+    Builder.expression.func.binary('=', [
+      Builder.expression.column(`${to}.${field}`),
+      Builder.expression.column(field),
+    ])
+  );
+
+  const withOption = Builder.option({
+    name: 'with',
+    args: withAssignments,
   });
 
   const enrichCmd = Builder.command({
     name: 'enrich',
-    args: [policySource, onOption],
+    args: [policySource, onOption, withOption],
   });
 
-  // TODO: Add support for "to" and "override" options
   commands.push(enrichCmd);
   return commands;
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
@@ -6,10 +6,45 @@
  */
 
 import { Builder } from '@elastic/esql';
-import type { ESQLAstCommand } from '@elastic/esql/types';
+import type { ESQLAstCommand, ESQLAstItem } from '@elastic/esql/types';
 import type { EnrichPolicyResolver } from '../../../../types/resolvers';
 import type { EnrichProcessor } from '../../../../types/processors';
 import { buildIgnoreMissingFilter } from './common';
+
+const internalPrevColumn = (index: number) => `__streamlang_enrich_prev_${index}`;
+const internalNewColumn = (index: number) => `__streamlang_enrich_new_${index}`;
+
+const targetColumnName = (to: string, policyField: string) => `${to}.${policyField}`;
+
+function pushEnrichCommand(
+  commands: ESQLAstCommand[],
+  policy_name: string,
+  matchField: string,
+  withAssignments: ESQLAstItem[]
+): void {
+  const policySource = Builder.expression.source.node({
+    sourceType: 'policy',
+    name: policy_name,
+    index: policy_name,
+  });
+
+  const onOption = Builder.option({
+    name: 'on',
+    args: [Builder.expression.column(matchField)],
+  });
+
+  const withOption = Builder.option({
+    name: 'with',
+    args: withAssignments,
+  });
+
+  commands.push(
+    Builder.command({
+      name: 'enrich',
+      args: [policySource, onOption, withOption],
+    })
+  );
+}
 
 /**
  * Converts a Streamlang EnrichProcessor into a list of ES|QL AST commands.
@@ -33,6 +68,7 @@ import { buildIgnoreMissingFilter } from './common';
  *   matchField: 'ip',
  *   enrichFields: ['city', 'country'],
  * }
+ *
  * Output:
  * | ENRICH ip_location ON ip WITH location.city = city, location.country = country
  */
@@ -40,8 +76,8 @@ export const convertEnrichProcessorToESQL = async (
   processor: EnrichProcessor,
   resolver: EnrichPolicyResolver
 ): Promise<ESQLAstCommand[]> => {
-  // TODO - add support for the "override" option
   const { policy_name, to, ignore_missing = false } = processor;
+  const preserveExistingTargets = processor.override === false;
   const commands: ESQLAstCommand[] = [];
 
   const policyMetadata = await resolver(policy_name);
@@ -65,34 +101,70 @@ export const convertEnrichProcessorToESQL = async (
     commands.push(missingFieldFilter);
   }
 
-  const policySource = Builder.expression.source.node({
-    sourceType: 'policy',
-    name: policy_name,
-    index: policy_name,
-  });
+  if (preserveExistingTargets) {
+    enrichFields.forEach((field, index) => {
+      commands.push(
+        Builder.command({
+          name: 'eval',
+          args: [
+            Builder.expression.func.binary('=', [
+              Builder.expression.column(internalPrevColumn(index)),
+              Builder.expression.column(targetColumnName(to, field)),
+            ]),
+          ],
+        })
+      );
+    });
 
-  const onOption = Builder.option({
-    name: 'on',
-    args: [Builder.expression.column(matchField)],
-  });
+    const withAssignmentsToTemp = enrichFields.map((field, index) =>
+      Builder.expression.func.binary('=', [
+        Builder.expression.column(internalNewColumn(index)),
+        Builder.expression.column(field),
+      ])
+    );
 
-  const withAssignments = enrichFields.map((field) =>
-    Builder.expression.func.binary('=', [
-      Builder.expression.column(`${to}.${field}`),
-      Builder.expression.column(field),
-    ])
-  );
+    pushEnrichCommand(commands, policy_name, matchField, withAssignmentsToTemp);
 
-  const withOption = Builder.option({
-    name: 'with',
-    args: withAssignments,
-  });
+    enrichFields.forEach((field, index) => {
+      commands.push(
+        Builder.command({
+          name: 'eval',
+          args: [
+            Builder.expression.func.binary('=', [
+              Builder.expression.column(targetColumnName(to, field)),
+              Builder.expression.func.call('COALESCE', [
+                Builder.expression.column(internalPrevColumn(index)),
+                Builder.expression.column(internalNewColumn(index)),
+              ]),
+            ]),
+          ],
+        })
+      );
+    });
 
-  const enrichCmd = Builder.command({
-    name: 'enrich',
-    args: [policySource, onOption, withOption],
-  });
+    enrichFields.forEach((_, index) => {
+      commands.push(
+        Builder.command({
+          name: 'drop',
+          args: [Builder.expression.column(internalPrevColumn(index))],
+        })
+      );
+      commands.push(
+        Builder.command({
+          name: 'drop',
+          args: [Builder.expression.column(internalNewColumn(index))],
+        })
+      );
+    });
+  } else {
+    const withAssignments = enrichFields.map((field) =>
+      Builder.expression.func.binary('=', [
+        Builder.expression.column(targetColumnName(to, field)),
+        Builder.expression.column(field),
+      ])
+    );
+    pushEnrichCommand(commands, policy_name, matchField, withAssignments);
+  }
 
-  commands.push(enrichCmd);
   return commands;
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/enrich.ts
@@ -12,28 +12,50 @@ import type { EnrichProcessor } from '../../../../types/processors';
 import { buildIgnoreMissingFilter } from './common';
 
 /**
- * TODO - rewrite this once enrich policy resolver is implemented
- * TODO - add support for the "override" option
+ * Converts a Streamlang EnrichProcessor into a list of ES|QL AST commands.
+ * @param processor - The EnrichProcessor to convert.
+ * @param resolver - The resolver to get the enrich policy metadata.
+ * @returns The list of ES|QL AST commands.
+ * @example
+ * Input:
+ * {
+ *   action: 'enrich',
+ *   policy_name: 'ip_location',
+ *   to: 'location',
+ *   ignore_missing: false,
+ * }
+ *
+ * Resolver:
+ * (policyName: string) => Promise<EnrichPolicyMetadata | null>
+ *
+ * Return:
+ * {
+ *   matchField: 'ip',
+ *   enrichFields: ['city', 'country'],
+ * }
+ * Output:
+ * | ENRICH ip_location ON ip WITH location.city = city, location.country = country
  */
 export const convertEnrichProcessorToESQL = async (
   processor: EnrichProcessor,
   resolver: EnrichPolicyResolver
 ): Promise<ESQLAstCommand[]> => {
+  // TODO - add support for the "override" option
   const { policy_name, to, ignore_missing = false } = processor;
   const commands: ESQLAstCommand[] = [];
 
   const policyMetadata = await resolver(policy_name);
 
   if (!policyMetadata) {
-    throw new Error(`Enrich policy ${policy_name} not found`);
+    throw new Error(`Enrich policy ${policy_name} not found through resolver`);
   }
 
-  if (!policyMetadata.matchField || policyMetadata.enrichFields.length === 0) {
-    throw new Error(`Enrich policy ${policy_name} is invalid`);
+  if (!policyMetadata.matchField) {
+    throw new Error(`Enrich policy ${policy_name} match field is required through resolver`);
   }
 
   if (!policyMetadata.enrichFields || policyMetadata.enrichFields.length === 0) {
-    throw new Error(`Enrich policy ${policy_name} has no enrich fields`);
+    throw new Error(`Enrich policy ${policy_name} has no enrich fields through resolver`);
   }
 
   const { matchField, enrichFields } = policyMetadata;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/streamlang_esql_ast.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/streamlang_esql_ast.test.ts
@@ -72,7 +72,7 @@ describe('ESQL - Wrapping OR within NOT', () => {
     expect(result).toEqual(`EVAL result = NOT (field1 == "value1" OR field2 == "value2")`);
   });
 
-  it('where.and.or should wrap correctly in parenthesis', () => {
+  it('where.and.or should wrap correctly in parenthesis', async () => {
     const dslWithAndOr: StreamlangDSL = {
       steps: [
         {
@@ -94,14 +94,14 @@ describe('ESQL - Wrapping OR within NOT', () => {
       ],
     };
 
-    const result = transpile(dslWithAndOr);
+    const result = await transpile(dslWithAndOr);
 
     expect(result.query).toEqual(
       `  | EVAL result_field = CASE(status == "active" AND (type == "premium" OR category == "gold"), "matched", result_field)`
     );
   });
 
-  it('where.or.and should wrap correctly in parenthesis', () => {
+  it('where.or.and should wrap correctly in parenthesis', async () => {
     const dslWithOrAnd: StreamlangDSL = {
       steps: [
         {
@@ -123,14 +123,14 @@ describe('ESQL - Wrapping OR within NOT', () => {
       ],
     };
 
-    const result = transpile(dslWithOrAnd);
+    const result = await transpile(dslWithOrAnd);
 
     expect(result.query).toEqual(
       `  | EVAL result_field = CASE(status == "active" OR type == "premium" AND category == "gold", "matched", result_field)`
     );
   });
 
-  it('where.not.or should wrap correctly in parenthesis', () => {
+  it('where.not.or should wrap correctly in parenthesis', async () => {
     const dslWithNotOr: StreamlangDSL = {
       steps: [
         {
@@ -149,14 +149,14 @@ describe('ESQL - Wrapping OR within NOT', () => {
       ],
     };
 
-    const result = transpile(dslWithNotOr);
+    const result = await transpile(dslWithNotOr);
 
     expect(result.query).toEqual(
       `  | EVAL result_field = CASE(NOT (status == "active" OR type == "premium"), "matched", result_field)`
     );
   });
 
-  it('where.not.and.or should wrap correctly in parenthesis', () => {
+  it('where.not.and.or should wrap correctly in parenthesis', async () => {
     const dslWithNotAndOr: StreamlangDSL = {
       steps: [
         {
@@ -180,7 +180,7 @@ describe('ESQL - Wrapping OR within NOT', () => {
       ],
     };
 
-    const result = transpile(dslWithNotAndOr);
+    const result = await transpile(dslWithNotAndOr);
 
     expect(result.query).toEqual(
       `  | EVAL result_field = CASE(NOT (status == "active" AND (type == "premium" OR category == "gold")), "matched", result_field)`

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
@@ -35,7 +35,7 @@ describe('transpile - Streamlang DSL to ES|QL)', () => {
     expect(result.query).toMatchSnapshot();
   });
 
-  it('should reject mustache template syntax in json_extract field names', () => {
+  it('should reject mustache template syntax in json_extract field names', async () => {
     const dsl = {
       steps: [
         {
@@ -46,10 +46,10 @@ describe('transpile - Streamlang DSL to ES|QL)', () => {
       ],
     } as unknown as StreamlangDSL;
 
-    expect(() => transpile(dsl)).toThrow();
+    await expect(transpile(dsl)).rejects.toThrow();
   });
 
-  it('should reject invalid json_extract selectors', () => {
+  it('should reject invalid json_extract selectors', async () => {
     const dsl = {
       steps: [
         {
@@ -60,6 +60,6 @@ describe('transpile - Streamlang DSL to ES|QL)', () => {
       ],
     } as unknown as StreamlangDSL;
 
-    expect(() => transpile(dsl)).toThrow('consecutive dots');
+    await expect(transpile(dsl)).rejects.toThrow('consecutive dots');
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/transpiler.test.ts
@@ -15,23 +15,23 @@ import {
 } from '../shared/mocks/test_dsls';
 
 describe('transpile - Streamlang DSL to ES|QL)', () => {
-  it('should transpile a variety of processor steps and where blocks', () => {
-    const result = transpile(comprehensiveTestDSL);
+  it('should transpile a variety of processor steps and where blocks', async () => {
+    const result = await transpile(comprehensiveTestDSL);
     expect(result.query).toMatchSnapshot();
   });
 
-  it('should handle not conditions', () => {
-    const result = transpile(notConditionsTestDSL);
+  it('should handle not conditions', async () => {
+    const result = await transpile(notConditionsTestDSL);
     expect(result.query).toMatchSnapshot();
   });
 
-  it('should handle type coercions', () => {
-    const result = transpile(typeCoercionsTestDSL);
+  it('should handle type coercions', async () => {
+    const result = await transpile(typeCoercionsTestDSL);
     expect(result).toMatchSnapshot();
   });
 
-  it('should warn when manual_ingest_pipeline is used', () => {
-    const result = transpile(manualIngestPipelineTestDSL);
+  it('should warn when manual_ingest_pipeline is used', async () => {
+    const result = await transpile(manualIngestPipelineTestDSL);
     expect(result.query).toMatchSnapshot();
   });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
@@ -6,12 +6,11 @@
  */
 
 import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { IngestPipelineProcessor } from '../../../types/processors/ingest_pipeline_processors';
 import {
   getStreamlangResolverForProcessor,
-  type EnrichPolicyResolver,
   type StreamlangResolverOptions,
 } from '../../../types/resolvers';
-import type { IngestPipelineProcessor } from '../../../types/processors/ingest_pipeline_processors';
 
 import type { StreamlangProcessorDefinition } from '../../../types/processors';
 import { conditionToPainless } from '../../conditions/condition_to_painless';
@@ -26,11 +25,11 @@ import type { ActionToIngestType } from './processors/processor';
 import { processRemoveByPrefixProcessor } from './processors/remove_by_prefix_processor';
 
 import type { IngestPipelineTranspilationOptions } from '.';
-import { processJoinProcessor } from './processors/join_processor';
 import { processConcatProcessor } from './processors/concat_processor';
 import { processSortProcessor } from './processors/sort_processor';
 import { processJsonExtractProcessor } from './processors/json_extract_processor';
 import { processEnrichProcessor } from './processors/enrich_processor';
+import { processJoinProcessor } from './processors/join_processor';
 
 export async function convertStreamlangDSLActionsToIngestPipelineProcessors(
   actionSteps: StreamlangProcessorDefinition[],
@@ -117,9 +116,13 @@ export async function convertStreamlangDSLActionsToIngestPipelineProcessors(
     }
 
     if (action === 'enrich') {
+      const resolver = getStreamlangResolverForProcessor(actionStep, resolverOptions);
+      if (!resolver) {
+        throw new Error('Enrich processor requires an enrich policy resolver.');
+      }
       return processEnrichProcessor(
         processorWithCompiledConditions as Parameters<typeof processEnrichProcessor>[0],
-        getStreamlangResolverForProcessor(actionStep, resolverOptions) as EnrichPolicyResolver
+        resolver
       );
     }
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
@@ -6,6 +6,11 @@
  */
 
 import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import {
+  getStreamlangResolverForProcessor,
+  type EnrichPolicyResolver,
+  type StreamlangResolverOptions,
+} from '../../../types/resolvers';
 import type { IngestPipelineProcessor } from '../../../types/processors/ingest_pipeline_processors';
 
 import type { StreamlangProcessorDefinition } from '../../../types/processors';
@@ -25,12 +30,14 @@ import { processJoinProcessor } from './processors/join_processor';
 import { processConcatProcessor } from './processors/concat_processor';
 import { processSortProcessor } from './processors/sort_processor';
 import { processJsonExtractProcessor } from './processors/json_extract_processor';
+import { processEnrichProcessor } from './processors/enrich_processor';
 
-export function convertStreamlangDSLActionsToIngestPipelineProcessors(
+export async function convertStreamlangDSLActionsToIngestPipelineProcessors(
   actionSteps: StreamlangProcessorDefinition[],
-  transpilationOptions?: IngestPipelineTranspilationOptions
-): IngestProcessorContainer[] {
-  return actionSteps.flatMap((actionStep) => {
+  transpilationOptions?: IngestPipelineTranspilationOptions,
+  resolverOptions?: StreamlangResolverOptions
+): Promise<IngestProcessorContainer[]> {
+  const processors = actionSteps.flatMap((actionStep) => {
     const renames = processorFieldRenames[actionStep.action] || {};
     const { action, ...rest } = actionStep;
 
@@ -109,6 +116,15 @@ export function convertStreamlangDSLActionsToIngestPipelineProcessors(
       ];
     }
 
+    if (action === 'enrich') {
+      return processEnrichProcessor(
+        processorWithCompiledConditions as Parameters<typeof processEnrichProcessor>[0],
+        getStreamlangResolverForProcessor(actionStep, resolverOptions) as EnrichPolicyResolver
+      );
+    }
+
     return applyPreProcessing(action, processorWithCompiledConditions as IngestPipelineProcessor);
   });
+
+  return Promise.all(processors);
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/index.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { pipe } from 'fp-ts/function';
+import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { StreamlangResolverOptions } from '../../../types/resolvers';
 import type { StreamlangDSL } from '../../../types/streamlang';
 import { streamlangDSLSchema } from '../../../types/streamlang';
 import { flattenSteps } from '../shared/flatten_steps';
@@ -17,16 +18,24 @@ export interface IngestPipelineTranspilationOptions {
   traceCustomIdentifiers?: boolean;
 }
 
-export const transpile = (
+export interface IngestPipelineTranspilationResult {
+  processors: IngestProcessorContainer[];
+}
+
+export const transpile = async (
   streamlang: StreamlangDSL,
-  transpilationOptions?: IngestPipelineTranspilationOptions
-) => {
+  transpilationOptions?: IngestPipelineTranspilationOptions,
+  resolverOptions?: StreamlangResolverOptions
+): Promise<IngestPipelineTranspilationResult> => {
   const validatedStreamlang = streamlangDSLSchema.parse(streamlang);
 
-  const processors = pipe(
-    flattenSteps(validatedStreamlang.steps),
-    (steps) => convertStreamlangDSLActionsToIngestPipelineProcessors(steps, transpilationOptions),
-    applyPostProcessing
+  const steps = flattenSteps(validatedStreamlang.steps);
+  const processors = applyPostProcessing(
+    await convertStreamlangDSLActionsToIngestPipelineProcessors(
+      steps,
+      transpilationOptions,
+      resolverOptions
+    )
   );
 
   return {

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/enrich_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/enrich_processor.ts
@@ -19,7 +19,6 @@ import type { EnrichPolicyResolver } from '../../../../types/resolvers';
  * {
  *   action: 'enrich',
  *   policy_name: 'ip_location',
- *   field: 'ip',
  *   to: 'location',
  * }
  *

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/enrich_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/enrich_processor.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { EnrichProcessor } from '../../../../types/processors';
+import type { EnrichPolicyResolver } from '../../../../types/resolvers';
+
+/**
+ * Converts a Streamlang EnrichProcessor into an Ingest Pipeline enrich processor. Uses a resolver to get the enrich policy metadata.
+ * @param processor - The EnrichProcessor to convert.
+ * @param resolver - The resolver to get the enrich policy metadata.
+ * @returns The Ingest Pipeline enrich processor.
+ * @example
+ * Input:
+ * {
+ *   action: 'enrich',
+ *   policy_name: 'ip_location',
+ *   field: 'ip',
+ *   to: 'location',
+ * }
+ *
+ * Resolver:
+ * (policyName: string) => Promise<EnrichPolicyMetadata | null>
+ *
+ * Return:
+ * {
+ *   matchField: 'ip',
+ *   enrichFields: ['city', 'country'],
+ * }
+ *
+ * Output:
+ * {
+ *   enrich: {
+ *     policy_name: 'ip_location',
+ *     field: 'ip',
+ *     target_field: 'location',
+ *   },
+ */
+export const processEnrichProcessor = async (
+  processor: Omit<EnrichProcessor, 'where' | 'action' | 'to'> & {
+    if?: string;
+    target_field: string;
+    tag?: string;
+  },
+  resolver: EnrichPolicyResolver
+): Promise<IngestProcessorContainer> => {
+  const {
+    description,
+    ignore_failure,
+    tag,
+    ignore_missing = false,
+    override = false,
+    policy_name,
+    target_field,
+  } = processor;
+
+  const policyMetadata = await resolver(policy_name);
+
+  if (!policyMetadata) {
+    throw new Error(`Enrich policy ${policy_name} not found through resolver`);
+  }
+
+  if (!policyMetadata.matchField) {
+    throw new Error(`Enrich policy ${policy_name} match field is required through resolver`);
+  }
+
+  const enrichProcessor: IngestProcessorContainer = {
+    enrich: {
+      policy_name,
+      field: policyMetadata.matchField,
+      target_field,
+      ignore_missing,
+      override,
+      if: processor.if,
+      ignore_failure,
+      description,
+      tag,
+    },
+  };
+
+  return enrichProcessor;
+};

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/pre_processing.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/pre_processing.ts
@@ -35,6 +35,7 @@ export const processorFieldRenames: Record<string, Record<string, string>> = {
   concat: { to: 'field', where: 'if' },
   network_direction: { where: 'if' },
   json_extract: { where: 'if' },
+  enrich: { to: 'target_field', where: 'if' },
   manual_ingest_pipeline: { where: 'if' },
 };
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/processor.ts
@@ -29,6 +29,7 @@ import type {
   IngestPipelineConcatProcessor,
   IngestPipelineNetworkDirectionProcessor,
   IngestPipelineJsonExtractProcessor,
+  IngestPipelineEnrichProcessor,
 } from '../../../../types/processors/ingest_pipeline_processors';
 
 type WithOptionalTracingTag<T> = T & { tag?: string };
@@ -56,5 +57,6 @@ export interface ActionToIngestType {
   concat: WithOptionalTracingTag<IngestPipelineConcatProcessor>;
   network_direction: WithOptionalTracingTag<IngestPipelineNetworkDirectionProcessor>;
   json_extract: WithOptionalTracingTag<IngestPipelineJsonExtractProcessor>;
+  enrich: WithOptionalTracingTag<IngestPipelineEnrichProcessor>;
   manual_ingest_pipeline: WithOptionalTracingTag<IngestPipelineManualIngestPipelineProcessor>;
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/transpiler.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/transpiler.test.ts
@@ -35,7 +35,7 @@ describe('transpile (Streamlang DSL to ingest pipeline)', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('should reject mustache template syntax in json_extract field names', () => {
+  it('should reject mustache template syntax in json_extract field names', async () => {
     const dsl = {
       steps: [
         {
@@ -46,10 +46,10 @@ describe('transpile (Streamlang DSL to ingest pipeline)', () => {
       ],
     } as unknown as StreamlangDSL;
 
-    expect(() => transpile(dsl)).toThrow();
+    await expect(transpile(dsl)).rejects.toThrow();
   });
 
-  it('should reject invalid json_extract selectors', () => {
+  it('should reject invalid json_extract selectors', async () => {
     const dsl = {
       steps: [
         {
@@ -60,6 +60,6 @@ describe('transpile (Streamlang DSL to ingest pipeline)', () => {
       ],
     } as unknown as StreamlangDSL;
 
-    expect(() => transpile(dsl)).toThrow('consecutive dots');
+    await expect(transpile(dsl)).rejects.toThrow('consecutive dots');
   });
 });

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/transpiler.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/transpiler.test.ts
@@ -15,23 +15,23 @@ import {
 } from '../shared/mocks/test_dsls';
 
 describe('transpile (Streamlang DSL to ingest pipeline)', () => {
-  it('should transpile a variety of processor steps and where blocks', () => {
-    const result = transpile(comprehensiveTestDSL);
+  it('should transpile a variety of processor steps and where blocks', async () => {
+    const result = await transpile(comprehensiveTestDSL);
     expect(result).toMatchSnapshot();
   });
 
-  it('should handle not conditions', () => {
-    const result = transpile(notConditionsTestDSL);
+  it('should handle not conditions', async () => {
+    const result = await transpile(notConditionsTestDSL);
     expect(result).toMatchSnapshot();
   });
 
-  it('should handle type coercions', () => {
-    const result = transpile(typeCoercionsTestDSL);
+  it('should handle type coercions', async () => {
+    const result = await transpile(typeCoercionsTestDSL);
     expect(result).toMatchSnapshot();
   });
 
-  it('should handle manual_ingest_pipeline with nested and top-level if', () => {
-    const result = transpile(manualIngestPipelineTestDSL);
+  it('should handle manual_ingest_pipeline with nested and top-level if', async () => {
+    const result = await transpile(manualIngestPipelineTestDSL);
     expect(result).toMatchSnapshot();
   });
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
@@ -111,9 +111,12 @@ export function extractAllFieldNames(processor: StreamlangProcessorDefinition): 
         fields.push(extraction.target_field);
       });
       break;
+    case 'enrich':
+      fields.push(processor.field);
+      fields.push(processor.to);
+      break;
     case 'drop_document':
     case 'manual_ingest_pipeline':
-      // No field names to validate
       break;
     default: {
       const _exhaustiveCheck: never = processor;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
@@ -112,7 +112,6 @@ export function extractAllFieldNames(processor: StreamlangProcessorDefinition): 
       });
       break;
     case 'enrich':
-      fields.push(processor.field);
       fields.push(processor.to);
       break;
     case 'drop_document':

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
@@ -69,8 +69,8 @@ export function validateProcessorValues(
     case 'split':
     case 'sort':
     case 'network_direction':
+    case 'enrich':
     case 'manual_ingest_pipeline':
-      // No value validation implemented for these processors yet
       break;
     case 'json_extract': {
       for (let i = 0; i < step.extractions.length; i++) {

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
@@ -479,7 +479,7 @@ export function trackFieldTypesAndValidate(flattenedSteps: StreamlangProcessorDe
         fieldsUsed.push(step.field);
         break;
       case 'enrich':
-        fieldsUsed.push(step.field, step.to);
+        fieldsUsed.push(step.to);
         break;
       case 'append':
       case 'drop_document':

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
@@ -154,6 +154,10 @@ export function extractModifiedFields(processor: StreamlangProcessorDefinition):
       });
       break;
 
+    case 'enrich':
+      fields.push(processor.to);
+      break;
+
     case 'remove':
     case 'remove_by_prefix':
     case 'drop_document':
@@ -299,6 +303,7 @@ export function getProcessorOutputType(
       }
     }
 
+    case 'enrich':
     case 'remove':
     case 'remove_by_prefix':
     case 'drop_document':
@@ -393,6 +398,7 @@ export function getExpectedInputType(
     case 'remove_by_prefix':
     case 'drop_document':
     case 'network_direction':
+    case 'enrich':
     case 'manual_ingest_pipeline':
       return null;
     case 'json_extract':
@@ -471,6 +477,9 @@ export function trackFieldTypesAndValidate(flattenedSteps: StreamlangProcessorDe
         break;
       case 'json_extract':
         fieldsUsed.push(step.field);
+        break;
+      case 'enrich':
+        fieldsUsed.push(step.field, step.to);
         break;
       case 'append':
       case 'drop_document':

--- a/x-pack/platform/packages/shared/kbn-streamlang/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-streamlang/tsconfig.json
@@ -21,5 +21,6 @@
     "@kbn/datemath",
     "@kbn/tinymath",
     "@kbn/grok-ui",
+    "@kbn/index-management-shared-types",
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -725,7 +725,6 @@ export const networkDirectionProcessorSchema = z.intersection(
 export interface EnrichProcessor extends ProcessorBaseWithWhere {
   action: 'enrich';
   policy_name: string;
-  field: string;
   to: string;
   ignore_missing?: boolean;
   override?: boolean;
@@ -734,7 +733,6 @@ export interface EnrichProcessor extends ProcessorBaseWithWhere {
 export const enrichProcessorSchema = processorBaseWithWhereSchema.extend({
   action: z.literal('enrich'),
   policy_name: NonEmptyString,
-  field: StreamlangSourceField,
   to: StreamlangTargetField,
   ignore_missing: z.optional(z.boolean()),
   override: z.optional(z.boolean()),

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -718,6 +718,28 @@ export const networkDirectionProcessorSchema = z.intersection(
   ])
 ) satisfies z.Schema<NetworkDirectionProcessor>;
 
+/**
+ * Enrich processor
+ */
+
+export interface EnrichProcessor extends ProcessorBaseWithWhere {
+  action: 'enrich';
+  policy_name: string;
+  field: string;
+  to: string;
+  ignore_missing?: boolean;
+  override?: boolean;
+}
+
+export const enrichProcessorSchema = processorBaseWithWhereSchema.extend({
+  action: z.literal('enrich'),
+  policy_name: NonEmptyString,
+  field: StreamlangSourceField,
+  to: StreamlangTargetField,
+  ignore_missing: z.optional(z.boolean()),
+  override: z.optional(z.boolean()),
+}) satisfies z.Schema<EnrichProcessor>;
+
 export type StreamlangProcessorDefinition =
   | DateProcessor
   | DissectProcessor
@@ -741,6 +763,7 @@ export type StreamlangProcessorDefinition =
   | ConcatProcessor
   | NetworkDirectionProcessor
   | JsonExtractProcessor
+  | EnrichProcessor
   | ManualIngestPipelineProcessor;
 
 export const streamlangProcessorSchema = z.union([
@@ -766,12 +789,13 @@ export const streamlangProcessorSchema = z.union([
   concatProcessorSchema,
   networkDirectionProcessorSchema,
   jsonExtractProcessorSchema,
+  enrichProcessorSchema,
   manualIngestPipelineProcessorSchema,
 ]);
 
 export const isProcessWithOverrideOption = createIsNarrowSchema(
   processorBaseSchema,
-  z.union([renameProcessorSchema, setProcessorSchema])
+  z.union([renameProcessorSchema, setProcessorSchema, enrichProcessorSchema])
 );
 
 export const isProcessWithIgnoreMissingOption = createIsNarrowSchema(
@@ -786,6 +810,7 @@ export const isProcessWithIgnoreMissingOption = createIsNarrowSchema(
     mathProcessorSchema,
     splitProcessorSchema,
     jsonExtractProcessorSchema,
+    enrichProcessorSchema,
   ])
 );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
@@ -205,4 +205,5 @@ export type IngestPipelineProcessor =
   | IngestPipelineConcatProcessor
   | IngestPipelineNetworkDirectionProcessor
   | IngestPipelineJsonExtractProcessor
+  | IngestPipelineEnrichProcessor
   | IngestPipelineManualIngestPipelineProcessor;

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
@@ -30,6 +30,7 @@ import type {
   ConcatProcessor,
   NetworkDirectionProcessor,
   JsonExtractProcessor,
+  EnrichProcessor,
 } from '.';
 import type { Condition } from '../conditions';
 
@@ -167,6 +168,12 @@ export type IngestPipelineNetworkDirectionProcessor = RenameFieldsAndRemoveActio
 export type IngestPipelineJsonExtractProcessor = RenameFieldsAndRemoveAction<
   JsonExtractProcessor,
   { where: 'if' }
+>;
+
+// Enrich
+export type IngestPipelineEnrichProcessor = RenameFieldsAndRemoveAction<
+  EnrichProcessor,
+  { to: 'target_field'; where: 'if' }
 >;
 
 // Manual Ingest Pipeline (escape hatch)

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/resolvers/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/resolvers/index.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { StreamlangProcessorDefinition } from '../processors';
+
+export interface EnrichPolicyMetadata {
+  matchField: string;
+  enrichFields: readonly string[];
+}
+
+/**
+ * Resolver for enrich policies
+ * @param policyName - The name of the enrich policy
+ * @returns The enrich policy metadata
+ * @example
+ * Input:
+ * 'ip_location'
+ *
+ * Output:
+ * { matchField: 'ip', enrichFields: ['city', 'country'] }
+ */
+export type EnrichPolicyResolver = (policyName: string) => Promise<EnrichPolicyMetadata | null>;
+
+export type StreamlangResolver = EnrichPolicyResolver;
+
+export interface StreamlangResolverOptions {
+  enrich?: EnrichPolicyResolver;
+}
+
+export const getStreamlangResolverForProcessor = (
+  processor: StreamlangProcessorDefinition,
+  opts?: StreamlangResolverOptions
+): StreamlangResolver | undefined => {
+  switch (processor.action) {
+    case 'enrich':
+      return opts?.enrich;
+    default:
+      return undefined;
+  }
+};

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/resolvers/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/resolvers/index.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
+import type { SerializedEnrichPolicy } from '@kbn/index-management-shared-types';
 import type { StreamlangProcessorDefinition } from '../processors';
 
-export interface EnrichPolicyMetadata {
-  matchField: string;
-  enrichFields: readonly string[];
-}
+export type EnrichPolicyResolverMetadata = Pick<
+  SerializedEnrichPolicy,
+  'matchField' | 'enrichFields'
+>;
 
 /**
  * Resolver for enrich policies
@@ -23,7 +24,9 @@ export interface EnrichPolicyMetadata {
  * Output:
  * { matchField: 'ip', enrichFields: ['city', 'country'] }
  */
-export type EnrichPolicyResolver = (policyName: string) => Promise<EnrichPolicyMetadata | null>;
+export type EnrichPolicyResolver = (
+  policyName: string
+) => Promise<EnrichPolicyResolverMetadata | null>;
 
 export type StreamlangResolver = EnrichPolicyResolver;
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IngestSimulateRequest } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import { transpileIngestPipeline } from '@kbn/streamlang';
 import type { FieldDefinition, Streams } from '@kbn/streams-schema';
 import {
@@ -15,7 +16,6 @@ import {
   LOGS_ECS_STREAM_NAME,
   namespacePrefixes,
 } from '@kbn/streams-schema';
-import type { ElasticsearchClient } from '@kbn/core/server';
 import { executePipelineSimulation } from '../../../routes/internal/streams/processing/simulation_handler';
 import { baseMappings } from '../component_templates/logs_layer';
 import { MalformedFieldsError } from '../errors/malformed_fields_error';

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
@@ -16,6 +16,7 @@ import {
   LOGS_ECS_STREAM_NAME,
   namespacePrefixes,
 } from '@kbn/streams-schema';
+import { createStreamlangResolverOptions } from '../resolvers';
 import { executePipelineSimulation } from '../../../routes/internal/streams/processing/simulation_handler';
 import { baseMappings } from '../component_templates/logs_layer';
 import { MalformedFieldsError } from '../errors/malformed_fields_error';
@@ -119,7 +120,13 @@ export async function validateSimulation(
       },
     ],
     pipeline: {
-      processors: (await transpileIngestPipeline(definition.ingest.processing)).processors,
+      processors: (
+        await transpileIngestPipeline(
+          definition.ingest.processing,
+          undefined,
+          createStreamlangResolverOptions(esClient)
+        )
+      ).processors,
     },
   };
   const simulationResult = await executePipelineSimulation(esClient, simulationBody);

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/validate_fields.ts
@@ -119,7 +119,7 @@ export async function validateSimulation(
       },
     ],
     pipeline: {
-      processors: transpileIngestPipeline(definition.ingest.processing).processors,
+      processors: (await transpileIngestPipeline(definition.ingest.processing)).processors,
     },
   };
   const simulationResult = await executePipelineSimulation(esClient, simulationBody);

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
@@ -26,10 +26,10 @@ import {
 } from './logs_default_pipeline';
 import { getProcessingPipelineName } from './name';
 
-export function generateIngestPipeline(
+export async function generateIngestPipeline(
   name: string,
   definition: Streams.all.Definition
-): IngestPutPipelineRequest {
+): Promise<IngestPutPipelineRequest> {
   const isWiredStream = Streams.WiredStream.Definition.is(definition);
   const rootStream = getRoot(definition.name);
 
@@ -77,7 +77,9 @@ export function generateIngestPipeline(
           },
         },
       },
-      ...(isWiredStream ? transpileIngestPipeline(definition.ingest.processing).processors : []),
+      ...(isWiredStream
+        ? (await transpileIngestPipeline(definition.ingest.processing)).processors
+        : []),
       {
         pipeline: {
           name: `${name}@stream.reroutes`,
@@ -99,10 +101,10 @@ export function generateIngestPipeline(
   };
 }
 
-export function generateClassicIngestPipelineBody(
+export async function generateClassicIngestPipelineBody(
   definition: Streams.ingest.all.Definition
-): Partial<IngestPutPipelineRequest> {
-  const transpiledIngestPipeline = transpileIngestPipeline(definition.ingest.processing);
+): Promise<Partial<IngestPutPipelineRequest>> {
+  const transpiledIngestPipeline = await transpileIngestPipeline(definition.ingest.processing);
   return {
     processors: transpiledIngestPipeline.processors,
     _meta: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
@@ -18,7 +18,9 @@ import type {
   IngestPutPipelineRequest,
   IngestProcessorContainer,
 } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import { transpileIngestPipeline } from '@kbn/streamlang';
+import { createStreamlangResolverOptions } from '../resolvers';
 import { ASSET_VERSION } from '../../../../common/constants';
 import {
   getLogsOtelPipelineProcessors,
@@ -28,7 +30,8 @@ import { getProcessingPipelineName } from './name';
 
 export async function generateIngestPipeline(
   name: string,
-  definition: Streams.all.Definition
+  definition: Streams.all.Definition,
+  esClient: ElasticsearchClient
 ): Promise<IngestPutPipelineRequest> {
   const isWiredStream = Streams.WiredStream.Definition.is(definition);
   const rootStream = getRoot(definition.name);
@@ -78,7 +81,13 @@ export async function generateIngestPipeline(
         },
       },
       ...(isWiredStream
-        ? (await transpileIngestPipeline(definition.ingest.processing)).processors
+        ? (
+            await transpileIngestPipeline(
+              definition.ingest.processing,
+              undefined,
+              createStreamlangResolverOptions(esClient)
+            )
+          ).processors
         : []),
       {
         pipeline: {
@@ -102,9 +111,14 @@ export async function generateIngestPipeline(
 }
 
 export async function generateClassicIngestPipelineBody(
-  definition: Streams.ingest.all.Definition
+  definition: Streams.ingest.all.Definition,
+  esClient: ElasticsearchClient
 ): Promise<Partial<IngestPutPipelineRequest>> {
-  const transpiledIngestPipeline = await transpileIngestPipeline(definition.ingest.processing);
+  const transpiledIngestPipeline = await transpileIngestPipeline(
+    definition.ingest.processing,
+    undefined,
+    createStreamlangResolverOptions(esClient)
+  );
   return {
     processors: transpiledIngestPipeline.processors,
     _meta: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/enrich_policy_resolver.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/enrich_policy_resolver.ts
@@ -7,9 +7,14 @@
 
 import type { EnrichSummary } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { EnrichPolicyMetadata, EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
+import type {
+  EnrichPolicyResolverMetadata,
+  EnrichPolicyResolver,
+} from '@kbn/streamlang/types/resolvers';
 
-export const mapEnrichSummaryToMetadata = (summary: EnrichSummary): EnrichPolicyMetadata | null => {
+export const mapEnrichSummaryToMetadata = (
+  summary: EnrichSummary
+): EnrichPolicyResolverMetadata | null => {
   // Each policy has exactly one of match | geo_match | range in the ES response.
   const policy = summary.config.match ?? summary.config.geo_match ?? summary.config.range;
   if (!policy?.match_field || !policy.enrich_fields) {
@@ -33,7 +38,7 @@ export const mapEnrichSummaryToMetadata = (summary: EnrichSummary): EnrichPolicy
  * Resolves enrich policy metadata from Elasticsearch for Streamlang ingest transpilation.
  */
 export const createEnrichPolicyResolver = (esClient: ElasticsearchClient): EnrichPolicyResolver => {
-  return async (policyName: string): Promise<EnrichPolicyMetadata | null> => {
+  return async (policyName: string): Promise<EnrichPolicyResolverMetadata | null> => {
     const response = await esClient.enrich.getPolicy({ name: policyName }, { ignore: [404] });
     const summary = response.policies?.[0];
     if (!summary) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/enrich_policy_resolver.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/enrich_policy_resolver.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EnrichSummary } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { EnrichPolicyMetadata, EnrichPolicyResolver } from '@kbn/streamlang/types/resolvers';
+
+export const mapEnrichSummaryToMetadata = (summary: EnrichSummary): EnrichPolicyMetadata | null => {
+  // Each policy has exactly one of match | geo_match | range in the ES response.
+  const policy = summary.config.match ?? summary.config.geo_match ?? summary.config.range;
+  if (!policy?.match_field || !policy.enrich_fields) {
+    return null;
+  }
+
+  const enrichFields = Array.isArray(policy.enrich_fields)
+    ? policy.enrich_fields
+    : [policy.enrich_fields];
+  if (enrichFields.length === 0) {
+    return null;
+  }
+
+  return {
+    matchField: String(policy.match_field),
+    enrichFields,
+  };
+};
+
+/**
+ * Resolves enrich policy metadata from Elasticsearch for Streamlang ingest transpilation.
+ */
+export const createEnrichPolicyResolver = (esClient: ElasticsearchClient): EnrichPolicyResolver => {
+  return async (policyName: string): Promise<EnrichPolicyMetadata | null> => {
+    const response = await esClient.enrich.getPolicy({ name: policyName }, { ignore: [404] });
+    const summary = response.policies?.[0];
+    if (!summary) {
+      return null;
+    }
+    return mapEnrichSummaryToMetadata(summary);
+  };
+};

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/resolvers/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { StreamlangResolverOptions } from '@kbn/streamlang/types/resolvers';
+import { createEnrichPolicyResolver } from './enrich_policy_resolver';
+
+export const createStreamlangResolverOptions = (
+  esClient: ElasticsearchClient
+): StreamlangResolverOptions => ({
+  enrich: createEnrichPolicyResolver(esClient),
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -575,7 +575,7 @@ export class ClassicStream extends StreamActiveRecord<Streams.ClassicStream.Defi
       stream: this._definition.name,
       request: {
         id: getProcessingPipelineName(this._definition.name),
-        ...(await generateClassicIngestPipelineBody(this._definition)),
+        ...(await generateClassicIngestPipelineBody(this._definition, this.dependencies.esClient)),
       },
     });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -575,7 +575,7 @@ export class ClassicStream extends StreamActiveRecord<Streams.ClassicStream.Defi
       stream: this._definition.name,
       request: {
         id: getProcessingPipelineName(this._definition.name),
-        ...generateClassicIngestPipelineBody(this._definition),
+        ...(await generateClassicIngestPipelineBody(this._definition)),
       },
     });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -747,7 +747,7 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       {
         type: 'upsert_ingest_pipeline',
         stream: this._definition.name,
-        request: generateIngestPipeline(this._definition.name, this._definition),
+        request: await generateIngestPipeline(this._definition.name, this._definition),
       },
       {
         type: 'upsert_ingest_pipeline',
@@ -915,7 +915,7 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       actions.push({
         type: 'upsert_ingest_pipeline',
         stream: this._definition.name,
-        request: generateIngestPipeline(this._definition.name, this._definition),
+        request: await generateIngestPipeline(this._definition.name, this._definition),
       });
     }
     const ancestorsAndSelf = getAncestorsAndSelf(this._definition.name).reverse();

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -747,7 +747,11 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       {
         type: 'upsert_ingest_pipeline',
         stream: this._definition.name,
-        request: await generateIngestPipeline(this._definition.name, this._definition),
+        request: await generateIngestPipeline(
+          this._definition.name,
+          this._definition,
+          this.dependencies.esClient
+        ),
       },
       {
         type: 'upsert_ingest_pipeline',
@@ -915,7 +919,11 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       actions.push({
         type: 'upsert_ingest_pipeline',
         stream: this._definition.name,
-        request: await generateIngestPipeline(this._definition.name, this._definition),
+        request: await generateIngestPipeline(
+          this._definition.name,
+          this._definition,
+          this.dependencies.esClient
+        ),
       });
     }
     const ancestorsAndSelf = getAncestorsAndSelf(this._definition.name).reverse();

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import type { Condition, StreamlangDSL } from '@kbn/streamlang';
+import type { Condition, EnrichProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { conditionToPainless } from '@kbn/streamlang';
+import type { StreamlangResolverOptions } from '@kbn/streamlang/types/resolvers';
 import { buildSimulationProcessorsWithConditionNoops } from './simulation_condition_noops';
 
 describe('buildSimulationProcessorsWithConditionNoops', () => {
@@ -110,5 +111,36 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
 
     const childSetIf = processors[2]!.set?.if;
     expect(childSetIf).toBe(conditionToPainless({ and: [parentCondition, childCondition] }));
+  });
+
+  it('transpiles enrich steps when an enrich policy resolver is provided', async () => {
+    const enrichResolverOptions: StreamlangResolverOptions = {
+      enrich: async () =>
+        Promise.resolve({
+          matchField: 'source.ip',
+          enrichFields: ['city'],
+        }),
+    };
+
+    const dsl: StreamlangDSL = {
+      steps: [
+        {
+          action: 'enrich',
+          policy_name: 'test-policy',
+          to: 'geo',
+        } as EnrichProcessor,
+      ],
+    };
+
+    const processors = await buildSimulationProcessorsWithConditionNoops(
+      dsl,
+      enrichResolverOptions
+    );
+
+    expect(processors).toHaveLength(1);
+    expect(processors[0]).toHaveProperty('enrich');
+    expect(processors[0]!.enrich?.policy_name).toBe('test-policy');
+    expect(processors[0]!.enrich?.field).toBe('source.ip');
+    expect(processors[0]!.enrich?.target_field).toBe('geo');
   });
 });

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.test.ts
@@ -10,7 +10,7 @@ import { conditionToPainless } from '@kbn/streamlang';
 import { buildSimulationProcessorsWithConditionNoops } from './simulation_condition_noops';
 
 describe('buildSimulationProcessorsWithConditionNoops', () => {
-  it('injects a no-op processor for a condition even if it has no descendants', () => {
+  it('injects a no-op processor for a condition even if it has no descendants', async () => {
     const dsl: StreamlangDSL = {
       steps: [
         {
@@ -24,7 +24,7 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
       ],
     };
 
-    const processors = buildSimulationProcessorsWithConditionNoops(dsl);
+    const processors = await buildSimulationProcessorsWithConditionNoops(dsl);
 
     expect(processors).toHaveLength(2);
     expect(processors[0]).toHaveProperty('set');
@@ -36,7 +36,7 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
     expect(processors[1]!.remove?.field).toBe('_streams_condition_noop');
   });
 
-  it('injects condition no-op before its descendants and keeps descendant processor tags', () => {
+  it('injects condition no-op before its descendants and keeps descendant processor tags', async () => {
     const dsl: StreamlangDSL = {
       steps: [
         {
@@ -57,7 +57,7 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
       ],
     };
 
-    const processors = buildSimulationProcessorsWithConditionNoops(dsl);
+    const processors = await buildSimulationProcessorsWithConditionNoops(dsl);
 
     expect(processors).toHaveLength(3);
     expect(processors[0]!.set?.tag).toBe('cond-1');
@@ -67,7 +67,7 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
     expect(typeof processors[2]!.set?.if).toBe('string');
   });
 
-  it('composes nested condition no-ops with parent conditions', () => {
+  it('composes nested condition no-ops with parent conditions', async () => {
     const parentCondition: Condition = { field: 'a', eq: 1 };
     const childCondition: Condition = { field: 'b', eq: 2 };
     const dsl: StreamlangDSL = {
@@ -97,7 +97,7 @@ describe('buildSimulationProcessorsWithConditionNoops', () => {
       ],
     };
 
-    const processors = buildSimulationProcessorsWithConditionNoops(dsl);
+    const processors = await buildSimulationProcessorsWithConditionNoops(dsl);
 
     expect(processors).toHaveLength(5);
     expect(processors[0]!.set?.tag).toBe('cond-parent');

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.ts
@@ -8,6 +8,7 @@
 import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Condition, StreamlangDSL, StreamlangProcessorDefinition } from '@kbn/streamlang';
 import { conditionToPainless, isConditionBlock, transpileIngestPipeline } from '@kbn/streamlang';
+import type { StreamlangResolverOptions } from '@kbn/streamlang/types/resolvers';
 
 type StreamlangStep = StreamlangDSL['steps'][number];
 
@@ -65,9 +66,11 @@ function createConditionNoopProcessor({
 async function buildSimulationProcessorsFromSteps({
   steps,
   parentCondition,
+  resolverOptions,
 }: {
   steps: StreamlangStep[];
   parentCondition?: Condition;
+  resolverOptions?: StreamlangResolverOptions;
 }): Promise<NonNullable<IngestProcessorContainer>[]> {
   const processors: NonNullable<IngestProcessorContainer>[] = [];
 
@@ -90,6 +93,7 @@ async function buildSimulationProcessorsFromSteps({
         ...(await buildSimulationProcessorsFromSteps({
           steps: nestedSteps,
           parentCondition: combinedCondition,
+          resolverOptions,
         }))
       );
 
@@ -111,10 +115,14 @@ async function buildSimulationProcessorsFromSteps({
         : processorStep;
 
     const transpiled = (
-      await transpileIngestPipeline({ steps: [stepWithCombinedWhere] } as StreamlangDSL, {
-        ignoreMalformed: true,
-        traceCustomIdentifiers: true,
-      })
+      await transpileIngestPipeline(
+        { steps: [stepWithCombinedWhere] } as StreamlangDSL,
+        {
+          ignoreMalformed: true,
+          traceCustomIdentifiers: true,
+        },
+        resolverOptions
+      )
     ).processors as NonNullable<IngestProcessorContainer>[];
 
     processors.push(...transpiled);
@@ -137,7 +145,11 @@ async function buildSimulationProcessorsFromSteps({
  * These processors are never exposed as steps in the UI; they exist only in the ES `_simulate` request.
  */
 export async function buildSimulationProcessorsWithConditionNoops(
-  processing: StreamlangDSL
+  processing: StreamlangDSL,
+  resolverOptions?: StreamlangResolverOptions
 ): Promise<NonNullable<IngestProcessorContainer>[]> {
-  return await buildSimulationProcessorsFromSteps({ steps: processing.steps });
+  return await buildSimulationProcessorsFromSteps({
+    steps: processing.steps,
+    resolverOptions,
+  });
 }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_condition_noops.ts
@@ -62,13 +62,13 @@ function createConditionNoopProcessor({
   ];
 }
 
-function buildSimulationProcessorsFromSteps({
+async function buildSimulationProcessorsFromSteps({
   steps,
   parentCondition,
 }: {
   steps: StreamlangStep[];
   parentCondition?: Condition;
-}): NonNullable<IngestProcessorContainer>[] {
+}): Promise<NonNullable<IngestProcessorContainer>[]> {
   const processors: NonNullable<IngestProcessorContainer>[] = [];
 
   for (const step of steps) {
@@ -87,10 +87,10 @@ function buildSimulationProcessorsFromSteps({
       }
 
       processors.push(
-        ...buildSimulationProcessorsFromSteps({
+        ...(await buildSimulationProcessorsFromSteps({
           steps: nestedSteps,
           parentCondition: combinedCondition,
-        })
+        }))
       );
 
       continue;
@@ -110,9 +110,11 @@ function buildSimulationProcessorsFromSteps({
           } as StreamlangProcessorDefinition)
         : processorStep;
 
-    const transpiled = transpileIngestPipeline(
-      { steps: [stepWithCombinedWhere] } as StreamlangDSL,
-      { ignoreMalformed: true, traceCustomIdentifiers: true }
+    const transpiled = (
+      await transpileIngestPipeline({ steps: [stepWithCombinedWhere] } as StreamlangDSL, {
+        ignoreMalformed: true,
+        traceCustomIdentifiers: true,
+      })
     ).processors as NonNullable<IngestProcessorContainer>[];
 
     processors.push(...transpiled);
@@ -134,8 +136,8 @@ function buildSimulationProcessorsFromSteps({
  *
  * These processors are never exposed as steps in the UI; they exist only in the ES `_simulate` request.
  */
-export function buildSimulationProcessorsWithConditionNoops(
+export async function buildSimulationProcessorsWithConditionNoops(
   processing: StreamlangDSL
-): NonNullable<IngestProcessorContainer>[] {
-  return buildSimulationProcessorsFromSteps({ steps: processing.steps });
+): Promise<NonNullable<IngestProcessorContainer>[]> {
+  return await buildSimulationProcessorsFromSteps({ steps: processing.steps });
 }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -47,6 +47,7 @@ import {
   type StreamsMappingProperties,
 } from '@kbn/streams-schema/src/fields';
 import { validateStreamlang, type StreamlangDSL } from '@kbn/streamlang';
+import type { StreamlangResolverOptions } from '@kbn/streamlang/types/resolvers';
 import { mapValues, uniq, uniqBy, omit, isEmpty } from 'lodash';
 import {
   normalizeGeoPointsInObject,
@@ -54,6 +55,7 @@ import {
 } from '../../../../lib/streams/helpers/normalize_geo_points';
 import { getProcessingPipelineName } from '../../../../lib/streams/ingest_pipelines/name';
 import type { StreamsClient } from '../../../../lib/streams/client';
+import { createStreamlangResolverOptions } from '../../../../lib/streams/resolvers';
 import { buildSimulationProcessorsWithConditionNoops } from './simulation_condition_noops';
 
 export interface ProcessingSimulationParams {
@@ -154,8 +156,16 @@ export const simulateProcessing = async ({
     };
   }
 
+  const streamlangResolverOptions: StreamlangResolverOptions =
+    createStreamlangResolverOptions(esClient);
+
   /* 1. Prepare data for either simulation types (ingest, pipeline), prepare simulation body for the mandatory pipeline simulation */
-  const simulationData = await prepareSimulationData(params, stream, streamFields);
+  const simulationData = await prepareSimulationData(
+    params,
+    stream,
+    streamFields,
+    streamlangResolverOptions
+  );
   const pipelineSimulationBody = preparePipelineSimulationBody(simulationData);
   const ingestSimulationBody = prepareIngestSimulationBody(
     simulationData,
@@ -187,7 +197,8 @@ export const simulateProcessing = async ({
     simulationData.docs,
     params.body.processing,
     Streams.WiredStream.Definition.is(stream),
-    streamFields
+    streamFields,
+    streamlangResolverOptions
   );
 
   /* 5. Extract valid detected fields with intelligent type suggestions from fieldsMetadataService */
@@ -216,7 +227,8 @@ const prepareSimulationDocs = (
 };
 
 const prepareSimulationProcessors = async (
-  processing: StreamlangDSL
+  processing: StreamlangDSL,
+  resolverOptions?: StreamlangResolverOptions
 ): Promise<IngestProcessorContainer[]> => {
   //
   /**
@@ -225,7 +237,8 @@ const prepareSimulationProcessors = async (
    * 2. Append the error message to the `_errors` field on failure
    */
   const transpiledIngestPipelineProcessors = await buildSimulationProcessorsWithConditionNoops(
-    processing
+    processing,
+    resolverOptions
   );
 
   return transpiledIngestPipelineProcessors.map((processor) => {
@@ -256,7 +269,8 @@ const prepareSimulationProcessors = async (
 const prepareSimulationData = async (
   params: ProcessingSimulationParams,
   stream: Streams.all.Definition,
-  streamFields: FieldDefinition
+  streamFields: FieldDefinition,
+  resolverOptions?: StreamlangResolverOptions
 ) => {
   const { body } = params;
   const { processing, documents } = body;
@@ -281,7 +295,7 @@ const prepareSimulationData = async (
 
   return {
     docs: prepareSimulationDocs(documents, targetStreamName, geoPointFields),
-    processors: await prepareSimulationProcessors(processing),
+    processors: await prepareSimulationProcessors(processing, resolverOptions),
   };
 };
 
@@ -515,12 +529,16 @@ const computePipelineSimulationResult = async (
   sampleDocs: Array<{ _source: FlattenRecord }>,
   processing: StreamlangDSL,
   isWiredStream: boolean,
-  streamFields: FieldDefinition
+  streamFields: FieldDefinition,
+  resolverOptions?: StreamlangResolverOptions
 ): Promise<{
   docReports: SimulationDocReport[];
   processorsMetrics: Record<string, ProcessorMetrics>;
 }> => {
-  const transpiledProcessors = await buildSimulationProcessorsWithConditionNoops(processing);
+  const transpiledProcessors = await buildSimulationProcessorsWithConditionNoops(
+    processing,
+    resolverOptions
+  );
 
   const processorsMap = initProcessorMetricsMap(transpiledProcessors);
   const conditionProcessorTags = collectConditionBlockIds(processing);

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -155,7 +155,7 @@ export const simulateProcessing = async ({
   }
 
   /* 1. Prepare data for either simulation types (ingest, pipeline), prepare simulation body for the mandatory pipeline simulation */
-  const simulationData = prepareSimulationData(params, stream, streamFields);
+  const simulationData = await prepareSimulationData(params, stream, streamFields);
   const pipelineSimulationBody = preparePipelineSimulationBody(simulationData);
   const ingestSimulationBody = prepareIngestSimulationBody(
     simulationData,
@@ -181,7 +181,7 @@ export const simulateProcessing = async ({
   }
 
   /* 4. Extract all the documents reports and processor metrics from the simulations */
-  const { docReports, processorsMetrics } = computePipelineSimulationResult(
+  const { docReports, processorsMetrics } = await computePipelineSimulationResult(
     pipelineSimulationResult.simulation,
     ingestSimulationResult.simulation,
     simulationData.docs,
@@ -215,15 +215,18 @@ const prepareSimulationDocs = (
   }));
 };
 
-const prepareSimulationProcessors = (processing: StreamlangDSL): IngestProcessorContainer[] => {
+const prepareSimulationProcessors = async (
+  processing: StreamlangDSL
+): Promise<IngestProcessorContainer[]> => {
   //
   /**
    * We want to simulate processors logic and collect data independently from the user config for simulation purposes.
    * 1. Force each processor to not ignore failures to collect all errors
    * 2. Append the error message to the `_errors` field on failure
    */
-  const transpiledIngestPipelineProcessors =
-    buildSimulationProcessorsWithConditionNoops(processing);
+  const transpiledIngestPipelineProcessors = await buildSimulationProcessorsWithConditionNoops(
+    processing
+  );
 
   return transpiledIngestPipelineProcessors.map((processor) => {
     const type = Object.keys(processor)[0];
@@ -250,7 +253,7 @@ const prepareSimulationProcessors = (processing: StreamlangDSL): IngestProcessor
   });
 };
 
-const prepareSimulationData = (
+const prepareSimulationData = async (
   params: ProcessingSimulationParams,
   stream: Streams.all.Definition,
   streamFields: FieldDefinition
@@ -278,12 +281,14 @@ const prepareSimulationData = (
 
   return {
     docs: prepareSimulationDocs(documents, targetStreamName, geoPointFields),
-    processors: prepareSimulationProcessors(processing),
+    processors: await prepareSimulationProcessors(processing),
   };
 };
 
+type PreparedSimulationData = Awaited<ReturnType<typeof prepareSimulationData>>;
+
 const preparePipelineSimulationBody = (
-  simulationData: ReturnType<typeof prepareSimulationData>
+  simulationData: PreparedSimulationData
 ): IngestSimulateRequest => {
   const { docs, processors } = simulationData;
 
@@ -295,7 +300,7 @@ const preparePipelineSimulationBody = (
 };
 
 const prepareIngestSimulationBody = (
-  simulationData: ReturnType<typeof prepareSimulationData>,
+  simulationData: PreparedSimulationData,
   stream: Streams.all.Definition,
   streamIndex: IndicesIndexState,
   params: ProcessingSimulationParams
@@ -504,18 +509,18 @@ const executeIngestSimulation = async (
  * To keep this process at the O(n) complexity, we iterate over the documents and processors only once.
  * This requires a closure on the processor metrics map to keep track of the processor state while iterating over the documents.
  */
-const computePipelineSimulationResult = (
+const computePipelineSimulationResult = async (
   pipelineSimulationResult: SuccessfulPipelineSimulateResponse,
   ingestSimulationResult: SimulateIngestResponse,
   sampleDocs: Array<{ _source: FlattenRecord }>,
   processing: StreamlangDSL,
   isWiredStream: boolean,
   streamFields: FieldDefinition
-): {
+): Promise<{
   docReports: SimulationDocReport[];
   processorsMetrics: Record<string, ProcessorMetrics>;
-} => {
-  const transpiledProcessors = buildSimulationProcessorsWithConditionNoops(processing);
+}> => {
+  const transpiledProcessors = await buildSimulationProcessorsWithConditionNoops(processing);
 
   const processorsMap = initProcessorMetricsMap(transpiledProcessors);
   const conditionProcessorTags = collectConditionBlockIds(processing);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/editor.tsx
@@ -64,6 +64,7 @@ import { ConcatProcessorForm } from './concat';
 import { JoinProcessorForm } from './join';
 import { JsonExtractProcessorForm } from './json_extract';
 import { NetworkDirectionProcessorForm } from './network_direction';
+import { EnrichProcessorForm } from './enrich';
 
 export const ActionBlockEditor = forwardRef<HTMLDivElement, ActionBlockProps>((props, ref) => {
   const { processorMetrics, stepRef } = props;
@@ -169,6 +170,7 @@ export const ActionBlockEditor = forwardRef<HTMLDivElement, ActionBlockProps>((p
                 {type === 'join' && <JoinProcessorForm />}
                 {type === 'json_extract' && <JsonExtractProcessorForm />}
                 {type === 'network_direction' && <NetworkDirectionProcessorForm />}
+                {type === 'enrich' && <EnrichProcessorForm />}
                 {!SPECIALISED_TYPES.includes(type) && (
                   <ConfigDrivenProcessorFields type={type as ConfigDrivenProcessorType} />
                 )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_override_toggle.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_override_toggle.tsx
@@ -8,12 +8,12 @@
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ToggleField } from '../toggle_field';
+import type { ExtractBooleanFields, ProcessorFormState } from '../../../../types';
 
-// TODO - this is not working yet
 export const EnrichOverrideToggle = () => {
   return (
     <ToggleField
-      name="override"
+      name={'override' as ExtractBooleanFields<ProcessorFormState>}
       label={i18n.translate(
         'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichOverrideLabel',
         { defaultMessage: 'Override pre-existing field values.' }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_override_toggle.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_override_toggle.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { ToggleField } from '../toggle_field';
+
+// TODO - this is not working yet
+export const EnrichOverrideToggle = () => {
+  return (
+    <ToggleField
+      name="override"
+      label={i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichOverrideLabel',
+        { defaultMessage: 'Override pre-existing field values.' }
+      )}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { useQuery } from '@kbn/react-query';
+import { useKibana } from '../../../../../../../hooks/use_kibana';
+
+export const useEnrichPolicies = () => {
+  const {
+    dependencies: {
+      start: { indexManagement },
+    },
+  } = useKibana();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['enrichPolicies'],
+    queryFn: async () => {
+      const response = await indexManagement.apiService.getAllEnrichPolicies();
+      return response.data ?? [];
+    },
+  });
+
+  return { policies: data ?? [], isLoading, error };
+};
+
+// TODO - handle errors and prompt to create a policy if no policies are found
+export const EnrichPolicySelector = () => {
+  const { policies, isLoading, error } = useEnrichPolicies();
+
+  return (
+    <EuiFormRow
+      label={i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyLabel',
+        { defaultMessage: 'Enrich policy' }
+      )}
+    >
+      <EuiSelect
+        options={policies.map((policy) => ({
+          text: policy.name,
+        }))}
+        isLoading={isLoading}
+      />
+    </EuiFormRow>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -9,6 +9,7 @@ import { EuiEmptyPrompt, EuiFormRow, EuiLink, EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useQuery } from '@kbn/react-query';
 import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
 import { useKibana } from '../../../../../../../hooks/use_kibana';
 
 // TODO - add return type
@@ -19,7 +20,7 @@ export const useEnrichPolicies = () => {
     },
   } = useKibana();
 
-  const { data, isLoading, error, isFetched } = useQuery({
+  const { data, isLoading, isFetched } = useQuery({
     queryKey: ['enrichPolicies'],
     queryFn: async () => {
       const response = await indexManagement.apiService.getAllEnrichPolicies();
@@ -27,12 +28,13 @@ export const useEnrichPolicies = () => {
     },
   });
 
-  return { policies: data ?? [], isLoading, isFetched, error };
+  return { policies: data ?? [], isLoading, isFetched };
 };
 
 // TODO - handle errors and prompt to create a policy if no policies are found
 export const EnrichPolicySelector = () => {
-  const { policies, isLoading, isFetched, error } = useEnrichPolicies();
+  const { control } = useFormContext();
+  const { policies, isLoading, isFetched } = useEnrichPolicies();
   const { core } = useKibana();
   const createEnrichPolicyUrl = core.application.getUrlForApp('management', {
     path: '/data/index_management/enrich_policies/create',
@@ -60,18 +62,28 @@ export const EnrichPolicySelector = () => {
   }
 
   return (
-    <EuiFormRow
-      label={i18n.translate(
-        'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyLabel',
-        { defaultMessage: 'Enrich policy' }
+    <Controller
+      control={control}
+      name="policy_name"
+      render={({ field }) => (
+        <EuiFormRow
+          label={i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyLabel',
+            { defaultMessage: 'Enrich policy' }
+          )}
+        >
+          <EuiSelect
+            hasNoInitialSelection
+            options={policies.map((policy) => ({
+              text: policy.name,
+              value: policy.name,
+            }))}
+            value={field.value}
+            onChange={field.onChange}
+            isLoading={isLoading}
+          />
+        </EuiFormRow>
       )}
-    >
-      <EuiSelect
-        options={policies.map((policy) => ({
-          text: policy.name,
-        }))}
-        isLoading={isLoading}
-      />
-    </EuiFormRow>
+    />
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -9,19 +9,26 @@ import { EuiFormRow, EuiLink, EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useQuery } from '@kbn/react-query';
-import React, { useMemo } from 'react';
+import React, { type ReactNode, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+import type { SerializedEnrichPolicy } from '@kbn/index-management-shared-types';
 import { useKibana } from '../../../../../../../hooks/use_kibana';
 
-// TODO - add return type
-export const useEnrichPolicies = () => {
+interface UseEnrichPoliciesResponse {
+  policies: SerializedEnrichPolicy[];
+  isLoading: boolean;
+  isFetched: boolean;
+  isError: boolean;
+}
+
+export const useEnrichPolicies = (): UseEnrichPoliciesResponse => {
   const {
     dependencies: {
       start: { indexManagement },
     },
   } = useKibana();
 
-  const { data, isLoading, isFetched } = useQuery({
+  const { data, isLoading, isFetched, isError } = useQuery({
     queryKey: ['enrichPolicies'],
     queryFn: async () => {
       const response = await indexManagement.apiService.getAllEnrichPolicies();
@@ -29,13 +36,48 @@ export const useEnrichPolicies = () => {
     },
   });
 
-  return { policies: data ?? [], isLoading, isFetched };
+  return { policies: data ?? [], isLoading, isFetched, isError };
 };
 
-// TODO - handle errors and prompt to create a policy if no policies are found
+const getErrorMessage = (
+  noPoliciesFound: boolean,
+  isError: boolean,
+  defaultMessage: string | undefined,
+  createEnrichPolicyUrl: string
+): ReactNode => {
+  if (noPoliciesFound) {
+    return (
+      <FormattedMessage
+        id="xpack.streams.enrichPolicySelector.noPoliciesFoundError"
+        defaultMessage="No enrich policies found. {createEnrichPolicyUrl}"
+        values={{
+          createEnrichPolicyUrl: (
+            <EuiLink href={createEnrichPolicyUrl} target="_blank">
+              {i18n.translate('xpack.streams.enrichPolicySelector.createEnrichPolicyLinkLabel', {
+                defaultMessage: 'Create an enrich policy',
+              })}
+            </EuiLink>
+          ),
+        }}
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <FormattedMessage
+        id="xpack.streams.enrichPolicySelector.errorMessage"
+        defaultMessage="Error fetching enrich policies"
+      />
+    );
+  }
+
+  return defaultMessage;
+};
+
 export const EnrichPolicySelector = () => {
   const { control } = useFormContext();
-  const { policies, isLoading, isFetched } = useEnrichPolicies();
+  const { policies, isLoading, isFetched, isError } = useEnrichPolicies();
   const { core } = useKibana();
   const createEnrichPolicyUrl = core.application.getUrlForApp('management', {
     path: '/data/index_management/enrich_policies/create',
@@ -61,26 +103,12 @@ export const EnrichPolicySelector = () => {
             { defaultMessage: 'Enrich policy' }
           )}
           isInvalid={fieldState.invalid || noPoliciesFound}
-          error={
-            noPoliciesFound ? (
-              <FormattedMessage
-                id="xpack.streams.enrichPolicySelector.noPoliciesFoundError"
-                defaultMessage="No enrich policies found. {createEnrichPolicyUrl}"
-                values={{
-                  createEnrichPolicyUrl: (
-                    <EuiLink href={createEnrichPolicyUrl} target="_blank">
-                      {i18n.translate(
-                        'xpack.streams.enrichPolicySelector.createEnrichPolicyLinkLabel',
-                        { defaultMessage: 'Create enrich policy' }
-                      )}
-                    </EuiLink>
-                  ),
-                }}
-              />
-            ) : (
-              fieldState.error?.message
-            )
-          }
+          error={getErrorMessage(
+            noPoliciesFound,
+            isError,
+            fieldState.error?.message,
+            createEnrichPolicyUrl
+          )}
         >
           <EuiSelect
             isInvalid={fieldState.invalid || noPoliciesFound}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { EuiEmptyPrompt, EuiFormRow, EuiLink, EuiSelect } from '@elastic/eui';
+import { EuiFormRow, EuiLink, EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { useQuery } from '@kbn/react-query';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useKibana } from '../../../../../../../hooks/use_kibana';
 
@@ -39,40 +40,50 @@ export const EnrichPolicySelector = () => {
   const createEnrichPolicyUrl = core.application.getUrlForApp('management', {
     path: '/data/index_management/enrich_policies/create',
   });
-
-  if (isFetched && policies.length === 0) {
-    return (
-      <EuiEmptyPrompt
-        title={
-          <h2>
-            {i18n.translate('xpack.streams.enrichPolicySelector.h2.noEnrichPoliciesFoundLabel', {
-              defaultMessage: 'No enrich policies found',
-            })}
-          </h2>
-        }
-        actions={
-          <EuiLink href={createEnrichPolicyUrl} target="_blank">
-            {i18n.translate('xpack.streams.enrichPolicySelector.createEnrichPolicyLinkLabel', {
-              defaultMessage: 'Create enrich policy',
-            })}
-          </EuiLink>
-        }
-      />
-    );
-  }
+  const noPoliciesFound = useMemo(() => {
+    return isFetched && policies.length === 0;
+  }, [isFetched, policies]);
 
   return (
     <Controller
       control={control}
+      rules={{
+        required: i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyRequiredError',
+          { defaultMessage: 'Enrich policy is required' }
+        ),
+      }}
       name="policy_name"
-      render={({ field }) => (
+      render={({ field, fieldState }) => (
         <EuiFormRow
           label={i18n.translate(
             'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyLabel',
             { defaultMessage: 'Enrich policy' }
           )}
+          isInvalid={fieldState.invalid || noPoliciesFound}
+          error={
+            noPoliciesFound ? (
+              <FormattedMessage
+                id="xpack.streams.enrichPolicySelector.noPoliciesFoundError"
+                defaultMessage="No enrich policies found. {createEnrichPolicyUrl}"
+                values={{
+                  createEnrichPolicyUrl: (
+                    <EuiLink href={createEnrichPolicyUrl} target="_blank">
+                      {i18n.translate(
+                        'xpack.streams.enrichPolicySelector.createEnrichPolicyLinkLabel',
+                        { defaultMessage: 'Create enrich policy' }
+                      )}
+                    </EuiLink>
+                  ),
+                }}
+              />
+            ) : (
+              fieldState.error?.message
+            )
+          }
         >
           <EuiSelect
+            isInvalid={fieldState.invalid || noPoliciesFound}
             hasNoInitialSelection
             options={policies.map((policy) => ({
               text: policy.name,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiFormRow, EuiLink, EuiSelect } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
 import { useQuery } from '@kbn/react-query';
+import React from 'react';
 import { useKibana } from '../../../../../../../hooks/use_kibana';
 
+// TODO - add return type
 export const useEnrichPolicies = () => {
   const {
     dependencies: {
@@ -18,7 +19,7 @@ export const useEnrichPolicies = () => {
     },
   } = useKibana();
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, isFetched } = useQuery({
     queryKey: ['enrichPolicies'],
     queryFn: async () => {
       const response = await indexManagement.apiService.getAllEnrichPolicies();
@@ -26,12 +27,37 @@ export const useEnrichPolicies = () => {
     },
   });
 
-  return { policies: data ?? [], isLoading, error };
+  return { policies: data ?? [], isLoading, isFetched, error };
 };
 
 // TODO - handle errors and prompt to create a policy if no policies are found
 export const EnrichPolicySelector = () => {
-  const { policies, isLoading, error } = useEnrichPolicies();
+  const { policies, isLoading, isFetched, error } = useEnrichPolicies();
+  const { core } = useKibana();
+  const createEnrichPolicyUrl = core.application.getUrlForApp('management', {
+    path: '/data/index_management/enrich_policies/create',
+  });
+
+  if (isFetched && policies.length === 0) {
+    return (
+      <EuiEmptyPrompt
+        title={
+          <h2>
+            {i18n.translate('xpack.streams.enrichPolicySelector.h2.noEnrichPoliciesFoundLabel', {
+              defaultMessage: 'No enrich policies found',
+            })}
+          </h2>
+        }
+        actions={
+          <EuiLink href={createEnrichPolicyUrl} target="_blank">
+            {i18n.translate('xpack.streams.enrichPolicySelector.createEnrichPolicyLinkLabel', {
+              defaultMessage: 'Create enrich policy',
+            })}
+          </EuiLink>
+        }
+      />
+    );
+  }
 
   return (
     <EuiFormRow

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/enrich_policy_selector.tsx
@@ -45,6 +45,15 @@ const getErrorMessage = (
   defaultMessage: string | undefined,
   createEnrichPolicyUrl: string
 ): ReactNode => {
+  if (isError) {
+    return (
+      <FormattedMessage
+        id="xpack.streams.enrichPolicySelector.errorMessage"
+        defaultMessage="Error fetching enrich policies"
+      />
+    );
+  }
+
   if (noPoliciesFound) {
     return (
       <FormattedMessage
@@ -63,15 +72,6 @@ const getErrorMessage = (
     );
   }
 
-  if (isError) {
-    return (
-      <FormattedMessage
-        id="xpack.streams.enrichPolicySelector.errorMessage"
-        defaultMessage="Error fetching enrich policies"
-      />
-    );
-  }
-
   return defaultMessage;
 };
 
@@ -83,8 +83,8 @@ export const EnrichPolicySelector = () => {
     path: '/data/index_management/enrich_policies/create',
   });
   const noPoliciesFound = useMemo(() => {
-    return isFetched && policies.length === 0;
-  }, [isFetched, policies]);
+    return isFetched && !isError && policies.length === 0;
+  }, [isFetched, isError, policies]);
 
   return (
     <Controller
@@ -102,7 +102,7 @@ export const EnrichPolicySelector = () => {
             'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichPolicyLabel',
             { defaultMessage: 'Enrich policy' }
           )}
-          isInvalid={fieldState.invalid || noPoliciesFound}
+          isInvalid={fieldState.invalid || noPoliciesFound || isError}
           error={getErrorMessage(
             noPoliciesFound,
             isError,
@@ -111,7 +111,7 @@ export const EnrichPolicySelector = () => {
           )}
         >
           <EuiSelect
-            isInvalid={fieldState.invalid || noPoliciesFound}
+            isInvalid={fieldState.invalid || noPoliciesFound || isError}
             hasNoInitialSelection
             options={policies.map((policy) => ({
               text: policy.name,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiSpacer } from '@elastic/eui';
+import { IgnoreFailureToggle, IgnoreMissingToggle } from '../ignore_toggles';
+import { ProcessorConditionEditor } from '../processor_condition_editor';
+import { FieldsAccordion } from '../optional_fields_accordion';
+import { ProcessorFieldSelector } from '../processor_field_selector';
+
+export const EnrichProcessorForm = () => {
+  return (
+    <>
+      <ProcessorFieldSelector fieldKey="to" />
+      <EuiSpacer size="m" />
+      <FieldsAccordion>
+        <ProcessorConditionEditor />
+      </FieldsAccordion>
+      <EuiSpacer size="m" />
+      <IgnoreMissingToggle />
+      <IgnoreFailureToggle />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
@@ -7,17 +7,43 @@
 
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { IgnoreFailureToggle, IgnoreMissingToggle } from '../ignore_toggles';
 import { ProcessorConditionEditor } from '../processor_condition_editor';
 import { FieldsAccordion } from '../optional_fields_accordion';
 import { ProcessorFieldSelector } from '../processor_field_selector';
 import { EnrichPolicySelector } from './enrich_policy_selector';
+import { EnrichOverrideToggle } from './enrich_override_toggle';
 
 export const EnrichProcessorForm = () => {
   return (
     <>
       <EnrichPolicySelector />
-      <ProcessorFieldSelector fieldKey="to" />
+      <ProcessorFieldSelector
+        fieldKey="field"
+        label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichFieldLabel',
+          { defaultMessage: 'Field' }
+        )}
+        helpText={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichFieldHelpText',
+          {
+            defaultMessage:
+              'The field in the input document that matches the policies match_field used to retrieve the enrichment data',
+          }
+        )}
+      />
+      <ProcessorFieldSelector
+        fieldKey="to"
+        label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichTargetFieldLabel',
+          { defaultMessage: 'Target field' }
+        )}
+        helpText={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichTargetFieldHelpText',
+          { defaultMessage: 'Field added to incoming documents to contain enrich data.' }
+        )}
+      />
       <EuiSpacer size="m" />
       <FieldsAccordion>
         <ProcessorConditionEditor />
@@ -25,6 +51,7 @@ export const EnrichProcessorForm = () => {
       <EuiSpacer size="m" />
       <IgnoreMissingToggle />
       <IgnoreFailureToggle />
+      <EnrichOverrideToggle />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
@@ -11,10 +11,12 @@ import { IgnoreFailureToggle, IgnoreMissingToggle } from '../ignore_toggles';
 import { ProcessorConditionEditor } from '../processor_condition_editor';
 import { FieldsAccordion } from '../optional_fields_accordion';
 import { ProcessorFieldSelector } from '../processor_field_selector';
+import { EnrichPolicySelector } from './enrich_policy_selector';
 
 export const EnrichProcessorForm = () => {
   return (
     <>
+      <EnrichPolicySelector />
       <ProcessorFieldSelector fieldKey="to" />
       <EuiSpacer size="m" />
       <FieldsAccordion>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/enrich/index.tsx
@@ -20,20 +20,6 @@ export const EnrichProcessorForm = () => {
     <>
       <EnrichPolicySelector />
       <ProcessorFieldSelector
-        fieldKey="field"
-        label={i18n.translate(
-          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichFieldLabel',
-          { defaultMessage: 'Field' }
-        )}
-        helpText={i18n.translate(
-          'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichFieldHelpText',
-          {
-            defaultMessage:
-              'The field in the input document that matches the policies match_field used to retrieve the enrichment data',
-          }
-        )}
-      />
-      <ProcessorFieldSelector
         fieldKey="to"
         label={i18n.translate(
           'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichTargetFieldLabel',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
@@ -630,6 +630,37 @@ const getAvailableProcessors: (
       );
     },
   },
+  enrich: {
+    type: 'enrich' as const,
+    inputDisplay: i18n.translate(
+      'xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichInputDisplay',
+      {
+        defaultMessage: 'Enrich',
+      }
+    ),
+    getDocUrl: (docLinks: DocLinksStart) => {
+      return (
+        <FormattedMessage
+          id="xpack.streams.streamDetailView.managementTab.enrichment.processor.enrichHelpText"
+          defaultMessage="{enrichLink} a document with data from another index."
+          values={{
+            enrichLink: (
+              <EuiLink
+                data-test-subj="streamsAppAvailableProcessorsEnrichPolicyLink"
+                external
+                target="_blank"
+                href={docLinks.links.ingest.enrich}
+              >
+                {i18n.translate('xpack.streams.availableProcessors.enrichLinkLabel', {
+                  defaultMessage: 'Enrich',
+                })}
+              </EuiLink>
+            ),
+          }}
+        />
+      );
+    },
+  },
   ...configDrivenProcessors,
   ...(isWired
     ? {}
@@ -680,6 +711,7 @@ const PROCESSOR_GROUP_MAP: Record<
   join: 'set',
   concat: 'set',
   network_direction: 'set',
+  enrich: 'set',
 };
 
 const getProcessorDescription =

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/utils.ts
@@ -200,6 +200,16 @@ export const getStepDescription = (step: StreamlangProcessorDefinitionWithUIAttr
           },
         }
       );
+    } else if (step.action === 'enrich') {
+      return i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.enrichProcessorDescription',
+        {
+          defaultMessage: 'Enrich data with the policy "{policy_name}"',
+          values: {
+            policy_name: step.policy_name,
+          },
+        }
+      );
     } else {
       const { action, parentId, customIdentifier, ignore_failure, ...rest } = step;
       // Remove 'where' if it exists (some processors have it, some don't)

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/types.ts
@@ -26,6 +26,7 @@ import type {
   ConcatProcessor,
   NetworkDirectionProcessor,
   JsonExtractProcessor,
+  EnrichProcessor,
 } from '@kbn/streamlang';
 import type { EnrichmentDataSource } from '../../../../common/url_schema';
 import type { ConfigDrivenProcessorFormState } from './steps/blocks/action/config_driven/types';
@@ -81,6 +82,7 @@ export type NetworkDirectionFormState = Omit<
   internal_networks?: InternalNetworksValue[];
   internal_networks_field?: string;
 };
+export type EnrichFormState = EnrichProcessor;
 
 export type SpecialisedFormState =
   | GrokFormState
@@ -101,7 +103,8 @@ export type SpecialisedFormState =
   | SortFormState
   | ConcatFormState
   | JsonExtractFormState
-  | NetworkDirectionFormState;
+  | NetworkDirectionFormState
+  | EnrichFormState;
 
 export type ProcessorFormState = SpecialisedFormState | ConfigDrivenProcessorFormState;
 export type ConditionBlockFormState = StreamlangConditionBlockWithUIAttributes;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -852,7 +852,7 @@ export const convertFormStateToProcessor = (
     }
 
     if (formState.action === 'enrich') {
-      const { policy_name, field, to, ignore_failure, ignore_missing } = formState;
+      const { policy_name, field, to, ignore_failure, ignore_missing, override } = formState;
       return {
         processorDefinition: {
           action: 'enrich',
@@ -861,6 +861,7 @@ export const convertFormStateToProcessor = (
           to,
           ignore_failure,
           ignore_missing,
+          override,
           description,
           where: 'where' in formState ? formState.where : undefined,
         } as EnrichProcessor,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -358,6 +358,7 @@ const defaultEnrichProcessorFormState = (): EnrichFormState => ({
   to: '',
   ignore_failure: true,
   ignore_missing: true,
+  override: true,
   where: ALWAYS_CONDITION,
 });
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -354,7 +354,6 @@ const defaultNetworkDirectionProcessorFormState = (): NetworkDirectionFormState 
 const defaultEnrichProcessorFormState = (): EnrichFormState => ({
   action: 'enrich' as const,
   policy_name: '',
-  field: '',
   to: '',
   ignore_failure: true,
   ignore_missing: true,
@@ -852,12 +851,11 @@ export const convertFormStateToProcessor = (
     }
 
     if (formState.action === 'enrich') {
-      const { policy_name, field, to, ignore_failure, ignore_missing, override } = formState;
+      const { policy_name, to, ignore_failure, ignore_missing, override } = formState;
       return {
         processorDefinition: {
           action: 'enrich',
           policy_name,
-          field,
           to,
           ignore_failure,
           ignore_missing,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -26,6 +26,7 @@ import type {
   StreamlangProcessorDefinitionWithUIAttributes,
   StreamlangStepWithUIAttributes,
   TrimProcessor,
+  EnrichProcessor,
 } from '@kbn/streamlang';
 import {
   ALWAYS_CONDITION,
@@ -74,6 +75,7 @@ import type {
   SortFormState,
   TrimFormState,
   UppercaseFormState,
+  EnrichFormState,
 } from './types';
 
 /**
@@ -98,6 +100,7 @@ export const SPECIALISED_TYPES = [
   'concat',
   'json_extract',
   'network_direction',
+  'enrich',
 ];
 
 interface FormStateDependencies {
@@ -348,6 +351,16 @@ const defaultNetworkDirectionProcessorFormState = (): NetworkDirectionFormState 
   where: ALWAYS_CONDITION,
 });
 
+const defaultEnrichProcessorFormState = (): EnrichFormState => ({
+  action: 'enrich' as const,
+  policy_name: '',
+  field: '',
+  to: '',
+  ignore_failure: true,
+  ignore_missing: true,
+  where: ALWAYS_CONDITION,
+});
+
 const configDrivenDefaultFormStates = mapValues(
   configDrivenProcessors,
   (config) => () => config.defaultFormState
@@ -378,6 +391,7 @@ const defaultProcessorFormStateByType: Record<
   concat: defaultConcatProcessorFormState,
   json_extract: defaultJsonExtractProcessorFormState,
   network_direction: defaultNetworkDirectionProcessorFormState,
+  enrich: defaultEnrichProcessorFormState,
   ...configDrivenDefaultFormStates,
 };
 
@@ -446,7 +460,8 @@ export const getFormStateFromActionStep = (
     step.action === 'split' ||
     step.action === 'sort' ||
     step.action === 'concat' ||
-    step.action === 'json_extract'
+    step.action === 'json_extract' ||
+    step.action === 'enrich'
   ) {
     const { customIdentifier, parentId, ...restStep } = step;
     return structuredClone({
@@ -832,6 +847,22 @@ export const convertFormStateToProcessor = (
           description,
           where: 'where' in formState ? formState.where : undefined,
         } as NetworkDirectionProcessor,
+      };
+    }
+
+    if (formState.action === 'enrich') {
+      const { policy_name, field, to, ignore_failure, ignore_missing } = formState;
+      return {
+        processorDefinition: {
+          action: 'enrich',
+          policy_name,
+          field,
+          to,
+          ignore_failure,
+          ignore_missing,
+          description,
+          where: 'where' in formState ? formState.where : undefined,
+        } as EnrichProcessor,
       };
     }
 


### PR DESCRIPTION
Closes https://github.com/elastic/streams-program/issues/577

## Summary
This PR introduces an `enrich` action to Streamlang. It uses the ingest pipeline [enrich processor](https://www.elastic.co/docs/reference/enrich-processor/enrich-processor) for ingest pipeline transpilation, and the [ES|QL ENRICH command](https://www.elastic.co/docs/reference/query-languages/esql/commands/enrich) for ES|QL transpilation. A new processor form was added to the processing UI as well which includes inputs for selecting an enrich policy; a target field; an optional where clause; and toggles for ignore missing, ignore failure and override options.

## Callouts
* This PR refactors ingest and ES|QL `transpile` calls to be async in nature and passes an optional resolver object as a new param. This was needed because ES|QL requires manually specifying the `enrich_fields` with `target_field` whereas these are provided by default for ingest pipelines. The new resolver is used to fetch enrich policy details so that the query can be built using match field and enrich field details. See the discussion in the [original issue](https://github.com/elastic/streams-program/issues/577#issuecomment-4033768922) for more details.

## Testing
To properly test this PR, an enrich policy must be created before testing the processing UI. I used these commands in the kibana dev tools to create one programatically:
```
PUT streams-e2e-enrich-source-ip-location
{"mappings":{"properties":{"ip":{"type":"keyword"},"city":{"type":"keyword"},"country":{"type":"keyword"}}}}

POST _bulk?refresh=true
{"index":{"_index":"streams-e2e-enrich-source-ip-location"}}
{"ip":"10.0.0.1","city":"New York","country":"US"}
{"index":{"_index":"streams-e2e-enrich-source-ip-location"}}
{"ip":"10.0.0.2","city":"London","country":"GB"}

PUT _enrich/policy/streams-e2e-ip-location-policy
{"match":{"indices":"streams-e2e-enrich-source-ip-location","match_field":"ip","enrich_fields":["city","country"]}}

PUT _enrich/policy/streams-e2e-ip-location-policy/_execute
```

The UI will prompt a user to create one and link to the UI for it if it detects that no enrich policies exist, so you could use that to test as well. After that simply setup some data that matches the match field on your enrich policy and test that the processor properly adds the new enrich fields in the simulation. 