### PR TITLE
[9.3] Resolve issue with spaces list displaying "no match" text on load (#255654)

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/spaces/public/space_selector/__snapshots__/space_selector.test.tsx.snap
@@ -1,110 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`it renders with custom logo 1`] = `
-<_KibanaPageTemplate
-  css="unknown styles"
+<div
+  class="euiPageTemplate kbnPageTemplate emotion-euiPageOuter-row-grow-pageTemplateStyles"
   data-test-subj="kibanaSpaceSelector"
+  style="min-block-size: max(0, 100vh); padding-block-start: 0;"
 >
-  <Memo(BackgroundPortal) />
-  <_EuiPageSection
-    color="transparent"
-    paddingSize="xl"
+  <main
+    class="emotion-euiPageInner"
+    id="EuiPageTemplateInner_generated-id"
   >
-    <EuiText
-      size="s"
-      textAlign="center"
+    <section
+      class="emotion-euiPageSection-grow-xl-top-transparent"
     >
-      <EuiSpacer
-        size="xxl"
-      />
-      <EuiImage
-        alt="Custom logo"
-        size={64}
-        src="img.jpg"
-      />
-      <EuiSpacer
-        size="xxl"
-      />
-      <EuiTextColor
-        color="subdued"
+      <div
+        class="emotion-euiPageSection__content-xl-restrictWidth"
+        style="max-width: 1200px;"
       >
-        <h1
-          css="unknown styles"
-          tabIndex={-1}
+        <div
+          class="euiText emotion-euiText-s-euiTextAlign-center"
         >
-          <MemoizedFormattedMessage
-            defaultMessage="Select your space"
-            id="xpack.spaces.spaceSelector.selectSpacesTitle"
+          <div
+            class="euiSpacer euiSpacer--xxl emotion-euiSpacer-xxl"
           />
-        </h1>
-        <p>
-          <MemoizedFormattedMessage
-            defaultMessage="You can change your space at anytime."
-            id="xpack.spaces.spaceSelector.changeSpaceAnytimeAvailabilityText"
+          <figure
+            class="euiImageWrapper emotion-euiImageWrapper"
+          >
+            <img
+              alt="Custom logo"
+              class="euiImage emotion-euiImage-customSize"
+              src="img.jpg"
+              style="max-width: 64px; max-height: 64px;"
+            />
+          </figure>
+          <div
+            class="euiSpacer euiSpacer--xxl emotion-euiSpacer-xxl"
           />
-        </p>
-      </EuiTextColor>
-    </EuiText>
-    <EuiSpacer
-      size="xl"
-    />
-    <EuiLoadingSpinner
-      size="xl"
-    />
-  </_EuiPageSection>
-</_KibanaPageTemplate>
-`;
-
-exports[`it renders without crashing 1`] = `
-<_KibanaPageTemplate
-  css="unknown styles"
-  data-test-subj="kibanaSpaceSelector"
->
-  <Memo(BackgroundPortal) />
-  <_EuiPageSection
-    color="transparent"
-    paddingSize="xl"
-  >
-    <EuiText
-      size="s"
-      textAlign="center"
-    >
-      <EuiSpacer
-        size="xxl"
-      />
-      <KibanaSolutionAvatar
-        name="Elastic"
-        size="xl"
-      />
-      <EuiSpacer
-        size="xxl"
-      />
-      <EuiTextColor
-        color="subdued"
-      >
-        <h1
-          css="unknown styles"
-          tabIndex={-1}
+          <span
+            class="emotion-euiTextColor-subdued"
+          >
+            <h1
+              class="css-aruir-headerStyles"
+              tabindex="-1"
+            >
+              Select your space
+            </h1>
+            <p>
+              You can change your space at anytime.
+            </p>
+          </span>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--xl emotion-euiSpacer-xl"
+        />
+        <div
+          class="css-9yumq1-spacesLoadingSpinnerStyles"
+          data-test-subj="spacesLoadingSpinner"
         >
-          <MemoizedFormattedMessage
-            defaultMessage="Select your space"
-            id="xpack.spaces.spaceSelector.selectSpacesTitle"
+          <span
+            aria-label="Loading"
+            class="euiLoadingSpinner emotion-euiLoadingSpinner-xl"
+            role="progressbar"
           />
-        </h1>
-        <p>
-          <MemoizedFormattedMessage
-            defaultMessage="You can change your space at anytime."
-            id="xpack.spaces.spaceSelector.changeSpaceAnytimeAvailabilityText"
-          />
-        </p>
-      </EuiTextColor>
-    </EuiText>
-    <EuiSpacer
-      size="xl"
-    />
-    <EuiLoadingSpinner
-      size="xl"
-    />
-  </_EuiPageSection>
-</_KibanaPageTemplate>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
 `;

--- a/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.styles.ts
+++ b/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.styles.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { css } from '@emotion/react';
+
+export const panelStyles = css`
+  text-align: center;
+  margin-inline: auto;
+  max-width: 700px;
+`;
+
+export const pageTemplateStyles = css`
+  background-color: transparent;
+`;
+
+export const headerStyles = css`
+  &:focus {
+    outline: none;
+    text-decoration: underline;
+  }
+`;
+
+export const spacesLoadingSpinnerStyles = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;

--- a/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.test.tsx
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import { EuiImage } from '@elastic/eui';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { of } from 'rxjs';
 
 import { customBrandingServiceMock } from '@kbn/core-custom-branding-browser-mocks';
-import { KibanaSolutionAvatar } from '@kbn/shared-ux-avatar-solution';
-import { shallowWithIntl } from '@kbn/test-jest-helpers';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 
-import { SpaceSelector } from './space_selector';
+import { SpaceSelector, type SpaceSelectorProps, VIEW_MODE_THRESHOLD } from './space_selector';
 import type { Space } from '../../common';
 import { spacesManagerMock } from '../spaces_manager/mocks';
 
@@ -23,35 +24,42 @@ function getSpacesManager(spaces: Space[] = []) {
   return manager;
 }
 
+const renderScreen = (props: SpaceSelectorProps) => {
+  const queryClient = new QueryClient();
+
+  return renderWithI18n(
+    <QueryClientProvider client={queryClient}>
+      <SpaceSelector {...props} />
+    </QueryClientProvider>
+  );
+};
+
 test('it renders without crashing', () => {
   const spacesManager = getSpacesManager();
   const customBranding$ = of({});
-  const component = shallowWithIntl(
-    <SpaceSelector
-      spacesManager={spacesManager as any}
-      serverBasePath={'/server-base-path'}
-      customBranding$={customBranding$}
-    />
-  );
-  expect(component).toMatchSnapshot();
+  renderScreen({
+    spacesManager,
+    serverBasePath: '/server-base-path',
+    customBranding$,
+  });
+
+  expect(screen.getByTestId('kibanaSpaceSelector')).toBeInTheDocument();
 });
 
 test('it renders with custom logo', () => {
   const spacesManager = getSpacesManager();
   const customBranding$ = of({ logo: 'img.jpg' });
-  const component = shallowWithIntl(
-    <SpaceSelector
-      spacesManager={spacesManager as any}
-      serverBasePath={'/server-base-path'}
-      customBranding$={customBranding$}
-    />
-  );
-  expect(component).toMatchSnapshot();
-  expect(component.find(KibanaSolutionAvatar).length).toBe(0);
-  expect(component.find(EuiImage).length).toBe(1);
+  renderScreen({
+    spacesManager,
+    serverBasePath: '/server-base-path',
+    customBranding$,
+  });
+
+  expect(screen.getByTestId('kibanaSpaceSelector')).toMatchSnapshot();
+  expect(screen.getByAltText('Custom logo')).toBeInTheDocument();
 });
 
-test('it queries for spaces when loaded', () => {
+test('it queries for spaces when loaded', async () => {
   const spaces = [
     {
       id: 'space-1',
@@ -63,15 +71,68 @@ test('it queries for spaces when loaded', () => {
 
   const spacesManager = getSpacesManager(spaces);
 
-  shallowWithIntl(
-    <SpaceSelector
-      spacesManager={spacesManager as any}
-      serverBasePath={'/server-base-path'}
-      customBranding$={customBrandingServiceMock.createStartContract().customBranding$}
-    />
-  );
+  renderScreen({
+    spacesManager,
+    serverBasePath: '/server-base-path',
+    customBranding$: customBrandingServiceMock.createStartContract().customBranding$,
+  });
 
-  return Promise.resolve().then(() => {
+  expect(screen.queryByRole('progressbar')).toBeInTheDocument();
+
+  await waitFor(() => {
     expect(spacesManager.getSpaces).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('it renders the list filter controls when the spaces list exceeds the threshold', async () => {
+  const spaces = Array.from({ length: VIEW_MODE_THRESHOLD + 1 }, (_, index) => ({
+    id: `space-${index}`,
+    name: `Space ${index}`,
+    description: `This is the ${index} space`,
+    disabledFeatures: [],
+  }));
+
+  const spacesManager = getSpacesManager(spaces);
+
+  renderScreen({
+    spacesManager,
+    serverBasePath: '/server-base-path',
+    customBranding$: customBrandingServiceMock.createStartContract().customBranding$,
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('kibanaSpaceSelectorSearchField')).toBeInTheDocument();
+    expect(screen.getByTestId('kibanaSpaceSelectorViewToggle')).toBeInTheDocument();
+  });
+});
+
+test('it displays only spaces matching the search term', async () => {
+  const spaces = Array.from({ length: VIEW_MODE_THRESHOLD + 1 }, (_, index) => ({
+    id: `space-${index}`,
+    name: `Space ${index}`,
+    description: `This is the ${index} space`,
+    disabledFeatures: [],
+  }));
+
+  const spacesManager = getSpacesManager(spaces);
+
+  const user = userEvent.setup();
+
+  renderScreen({
+    spacesManager,
+    serverBasePath: '/server-base-path',
+    customBranding$: customBrandingServiceMock.createStartContract().customBranding$,
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('kibanaSpaceSelectorSearchField')).toBeInTheDocument();
+    expect(screen.getByTestId('kibanaSpaceSelectorViewToggle')).toBeInTheDocument();
+  });
+
+  await user.type(screen.getByTestId('kibanaSpaceSelectorSearchField'), 'Space 1');
+
+  await waitFor(() => {
+    expect(screen.getByText('Space 1')).toBeInTheDocument();
+    expect(screen.getByText('Space 10')).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/space_selector/space_selector.tsx
@@ -20,310 +20,139 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
-import type { Observable, Subscription } from 'rxjs';
+import type { Observable } from 'rxjs';
 
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import { useKbnFullScreenBgCss } from '@kbn/css-utils/public/full_screen_bg_css';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { QueryClient, QueryClientProvider, useQuery } from '@kbn/react-query';
 import { KibanaSolutionAvatar } from '@kbn/shared-ux-avatar-solution';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import { euiThemeVars } from '@kbn/ui-theme';
 
 import { SpaceCards, SpaceTable } from './components';
+import * as styles from './space_selector.styles';
 import type { Space } from '../../common';
 import { SPACE_SEARCH_COUNT_THRESHOLD } from '../../common/constants';
 import type { SpacesManager } from '../spaces_manager';
 
 // Number of spaces above which the selector defaults to table view for better scalability
-const VIEW_MODE_THRESHOLD = 20;
+export const VIEW_MODE_THRESHOLD = 20;
 
 type ViewMode = 'grid' | 'table';
-
-interface Props {
+export interface SpaceSelectorProps {
   spacesManager: SpacesManager;
   serverBasePath: string;
   customBranding$: Observable<CustomBranding>;
 }
 
-interface State {
-  loading: boolean;
-  searchTerm: string;
-  spaces: Space[];
-  error?: Error;
-  customLogo?: string;
+const ViewToggle = ({
+  viewMode,
+  onChange,
+}: {
   viewMode: ViewMode;
-}
+  onChange: (viewMode: ViewMode) => void;
+}) => {
+  const toggleOptions = [
+    {
+      id: 'grid',
+      label: i18n.translate('xpack.spaces.spaceSelector.gridViewLabel', {
+        defaultMessage: 'Grid view',
+      }),
+      iconType: 'apps',
+    },
+    {
+      id: 'table',
+      label: i18n.translate('xpack.spaces.spaceSelector.tableViewLabel', {
+        defaultMessage: 'Table view',
+      }),
+      iconType: 'list',
+    },
+  ];
 
-export class SpaceSelector extends Component<Props, State> {
-  private headerRef?: HTMLElement | null;
-  private customBrandingSubscription?: Subscription;
+  return (
+    <EuiButtonGroup
+      data-test-subj="kibanaSpaceSelectorViewToggle"
+      css={css`
+        .euiButtonGroup__buttons .euiButtonGroupButton {
+          min-width: 40px;
+          width: 40px;
+        }
+      `}
+      legend={i18n.translate('xpack.spaces.spaceSelector.viewToggleLegend', {
+        defaultMessage: 'View options',
+      })}
+      options={toggleOptions}
+      idSelected={viewMode}
+      onChange={(id) => onChange(id as ViewMode)}
+      buttonSize="m"
+      isIconOnly
+    />
+  );
+};
 
-  constructor(props: Props) {
-    super(props);
+export const SpaceSelector = ({
+  spacesManager,
+  serverBasePath,
+  customBranding$,
+}: SpaceSelectorProps) => {
+  const [currentViewMode, setCurrentViewMode] = useState<ViewMode>('grid');
+  const [customLogo, setCustomLogo] = useState<string | undefined>(undefined);
+  const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
+  const headerRef = useRef<HTMLHeadingElement | null>(null);
+  const { euiTheme } = useEuiTheme();
 
-    this.state = {
-      loading: false,
-      searchTerm: '',
-      spaces: [],
-      viewMode: 'grid',
-    };
-  }
+  const {
+    data: spaces,
+    isLoading,
+    error,
+  } = useQuery<Space[], Error>({
+    queryKey: ['spaces_list'],
+    queryFn: () => spacesManager.getSpaces(),
+    enabled: !searchTerm,
+  });
 
-  public setHeaderRef = (ref: HTMLElement | null) => {
-    this.headerRef = ref;
-    // forcing focus of header for screen readers to announce on page load
-    if (this.headerRef) {
-      this.headerRef.focus();
+  useEffect(() => {
+    setCurrentViewMode((spaces?.length ?? 0) > VIEW_MODE_THRESHOLD ? 'table' : 'grid');
+  }, [spaces]);
+
+  const filteredSpaces = useMemo(() => {
+    if (!spaces) {
+      return [];
     }
-  };
-
-  public componentDidMount() {
-    if (this.state.spaces.length === 0) {
-      this.loadSpaces();
-    }
-    this.customBrandingSubscription = this.props.customBranding$.subscribe((next) => {
-      this.setState({ ...this.state, customLogo: next.logo });
-    });
-  }
-
-  public componentWillUnmount() {
-    this.customBrandingSubscription?.unsubscribe();
-  }
-
-  public loadSpaces() {
-    this.setState({ loading: true });
-    const { spacesManager } = this.props;
-
-    spacesManager
-      .getSpaces()
-      .then((spaces) => {
-        this.setState({
-          loading: false,
-          spaces,
-          viewMode: spaces.length > VIEW_MODE_THRESHOLD ? 'table' : 'grid',
-        });
-      })
-      .catch((err) => {
-        this.setState({
-          loading: false,
-          error: err,
-        });
-      });
-  }
-
-  public render() {
-    const { spaces, searchTerm } = this.state;
-
-    const panelStyles = css`
-      text-align: center;
-      margin-inline: auto;
-      max-width: 700px;
-    `;
-
-    let filteredSpaces = spaces;
-    if (searchTerm) {
-      filteredSpaces = spaces.filter(
-        (space) =>
-          space.name.toLowerCase().indexOf(searchTerm) >= 0 ||
-          (space.description || '').toLowerCase().indexOf(searchTerm) >= 0
+    return spaces.filter((space) => {
+      return (
+        space.name.toLowerCase().includes(searchTerm?.toLowerCase() || '') ||
+        space.description?.toLowerCase().includes(searchTerm?.toLowerCase() || '')
       );
-    }
+    });
+  }, [spaces, searchTerm]);
 
-    return (
-      <KibanaPageTemplate
-        css={css`
-          background-color: transparent;
-        `}
-        data-test-subj="kibanaSpaceSelector"
-      >
-        <BackgroundPortal />
-        <KibanaPageTemplate.Section color="transparent" paddingSize="xl">
-          <EuiText textAlign="center" size="s">
-            <EuiSpacer size="xxl" />
-            {this.state.customLogo ? (
-              <EuiImage
-                src={this.state.customLogo}
-                size={64}
-                alt={i18n.translate('xpack.spaces.spaceSelector.customLogoAlt', {
-                  defaultMessage: 'Custom logo',
-                })}
-              />
-            ) : (
-              <KibanaSolutionAvatar name="Elastic" size="xl" />
-            )}
-            <EuiSpacer size="xxl" />
-            <EuiTextColor color="subdued">
-              <h1
-                css={css`
-                  &:focus {
-                    outline: none;
-                    text-decoration: underline;
-                  }
-                `}
-                tabIndex={-1}
-                ref={this.setHeaderRef}
-              >
-                <FormattedMessage
-                  id="xpack.spaces.spaceSelector.selectSpacesTitle"
-                  defaultMessage="Select your space"
-                />
-              </h1>
-              <p>
-                <FormattedMessage
-                  id="xpack.spaces.spaceSelector.changeSpaceAnytimeAvailabilityText"
-                  defaultMessage="You can change your space at anytime."
-                />
-              </p>
-            </EuiTextColor>
-          </EuiText>
-          <EuiSpacer size="xl" />
-
-          {this.getSearchAndToggle()}
-
-          {this.state.loading && <EuiLoadingSpinner size="xl" />}
-
-          {!this.state.loading &&
-            (this.state.viewMode === 'grid' ? (
-              <SpaceCards spaces={filteredSpaces} serverBasePath={this.props.serverBasePath} />
-            ) : (
-              <SpaceTable spaces={filteredSpaces} serverBasePath={this.props.serverBasePath} />
-            ))}
-
-          {!this.state.loading && !this.state.error && filteredSpaces.length === 0 && (
-            <Fragment>
-              <EuiSpacer />
-              <EuiPanel css={panelStyles} color="subdued">
-                <EuiTitle size="xs">
-                  <h2>
-                    {i18n.translate(
-                      'xpack.spaces.spaceSelector.noSpacesMatchSearchCriteriaDescription',
-                      {
-                        defaultMessage: 'No spaces match {searchTerm}',
-                        values: { searchTerm: `"${this.state.searchTerm}"` },
-                      }
-                    )}
-                  </h2>
-                </EuiTitle>
-              </EuiPanel>
-            </Fragment>
-          )}
-
-          {!this.state.loading && this.state.error && (
-            <Fragment>
-              <EuiSpacer />
-              <EuiPanel css={panelStyles} color="danger">
-                <EuiText size="s" color="danger">
-                  <h2>
-                    <FormattedMessage
-                      id="xpack.spaces.spaceSelector.errorLoadingSpacesDescription"
-                      defaultMessage="Error loading spaces ({message})"
-                      values={{ message: this.state.error.message }}
-                    />
-                  </h2>
-                  <p>
-                    <FormattedMessage
-                      id="xpack.spaces.spaceSelector.contactSysAdminDescription"
-                      defaultMessage="Contact your system administrator."
-                    />
-                  </p>
-                </EuiText>
-              </EuiPanel>
-            </Fragment>
-          )}
-        </KibanaPageTemplate.Section>
-      </KibanaPageTemplate>
-    );
-  }
-
-  public getSearchField = () => {
-    if (!this.state.spaces || this.state.spaces.length < SPACE_SEARCH_COUNT_THRESHOLD) {
-      return null;
-    }
-
-    const inputLabel = i18n.translate('xpack.spaces.spaceSelector.findSpacePlaceholder', {
-      defaultMessage: 'Find a space',
+  useEffect(() => {
+    const subscription = customBranding$.subscribe((next) => {
+      setCustomLogo(next.logo);
     });
 
-    return (
-      <>
-        <div
-          css={css`
-            width: ${euiThemeVars.euiFormMaxWidth};
-            max-width: 100%;
-            margin-inline: auto;
-          `}
-        >
-          <EuiFieldSearch
-            placeholder={inputLabel}
-            aria-label={inputLabel}
-            incremental={true}
-            onSearch={this.onSearch}
-          />
-        </div>
-        <EuiSpacer size="xl" />
-      </>
-    );
-  };
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [customBranding$]);
 
-  public onSearch = (searchTerm = '') => {
-    this.setState({
-      searchTerm: searchTerm.trim().toLowerCase(),
-    });
-  };
+  const onViewModeChange = useCallback((viewMode: ViewMode) => {
+    setCurrentViewMode(viewMode);
+  }, []);
 
-  public onViewModeChange = (viewMode: ViewMode) => {
-    this.setState({ viewMode });
-  };
+  const onSearch = useCallback((term: string) => {
+    setSearchTerm(term.trim().toLowerCase());
+  }, []);
 
-  public getViewToggle = () => {
-    const { viewMode } = this.state;
-
-    const toggleOptions = [
-      {
-        id: 'grid',
-        label: i18n.translate('xpack.spaces.spaceSelector.gridViewLabel', {
-          defaultMessage: 'Grid view',
-        }),
-        iconType: 'apps',
-      },
-      {
-        id: 'table',
-        label: i18n.translate('xpack.spaces.spaceSelector.tableViewLabel', {
-          defaultMessage: 'Table view',
-        }),
-        iconType: 'list',
-      },
-    ];
-
-    return (
-      <EuiButtonGroup
-        css={css`
-          .euiButtonGroup__buttons .euiButtonGroupButton {
-            min-width: 40px;
-            width: 40px;
-          }
-        `}
-        legend={i18n.translate('xpack.spaces.spaceSelector.viewToggleLegend', {
-          defaultMessage: 'View options',
-        })}
-        options={toggleOptions}
-        idSelected={viewMode}
-        onChange={(id) => this.onViewModeChange(id as ViewMode)}
-        buttonSize="m"
-        isIconOnly
-      />
-    );
-  };
-
-  public getSearchAndToggle = () => {
-    const { spaces } = this.state;
-
+  const renderListFilterControls = useCallback(() => {
     // Show search field and toggle if we have enough spaces to warrant them
     const showSearchAndToggle = spaces && spaces.length >= SPACE_SEARCH_COUNT_THRESHOLD;
 
@@ -338,37 +167,158 @@ export class SpaceSelector extends Component<Props, State> {
     return (
       <>
         <EuiFlexGroup gutterSize="m" alignItems="center" justifyContent="center">
-          {showSearchAndToggle && (
-            <EuiFlexItem grow={false}>
-              <div
-                css={css`
-                  width: ${euiThemeVars.euiFormMaxWidth};
-                  max-width: 100%;
-                `}
-              >
-                <EuiFieldSearch
-                  placeholder={inputLabel}
-                  aria-label={inputLabel}
-                  incremental={true}
-                  onSearch={this.onSearch}
-                />
-              </div>
-            </EuiFlexItem>
-          )}
-          {showSearchAndToggle && <EuiFlexItem grow={false}>{this.getViewToggle()}</EuiFlexItem>}
+          <EuiFlexItem grow={false}>
+            <div
+              css={css`
+                width: ${euiTheme.components.forms.maxWidth};
+                max-width: 100%;
+              `}
+              data-test-subj="kibanaSpaceSelectorSearchField"
+            >
+              <EuiFieldSearch
+                placeholder={inputLabel}
+                aria-label={inputLabel}
+                incremental={true}
+                onSearch={onSearch}
+              />
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <ViewToggle viewMode={currentViewMode} onChange={onViewModeChange} />
+          </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="xl" />
       </>
     );
-  };
-}
+  }, [currentViewMode, euiTheme.components.forms.maxWidth, onSearch, onViewModeChange, spaces]);
+
+  const focusHeaderOnMount = useCallback(
+    (node: HTMLHeadingElement | null) => {
+      headerRef.current = node;
+      // forcing focus of header for screen readers to announce on page load
+      headerRef.current?.focus();
+    },
+    [headerRef]
+  );
+
+  return (
+    <KibanaPageTemplate css={styles.pageTemplateStyles} data-test-subj="kibanaSpaceSelector">
+      <BackgroundPortal />
+      <KibanaPageTemplate.Section color="transparent" paddingSize="xl">
+        <EuiText textAlign="center" size="s">
+          <EuiSpacer size="xxl" />
+          {customLogo ? (
+            <EuiImage
+              src={customLogo}
+              size={64}
+              alt={i18n.translate('xpack.spaces.spaceSelector.customLogoAlt', {
+                defaultMessage: 'Custom logo',
+              })}
+            />
+          ) : (
+            <KibanaSolutionAvatar name="Elastic" size="xl" />
+          )}
+          <EuiSpacer size="xxl" />
+          <EuiTextColor color="subdued">
+            <h1 css={styles.headerStyles} tabIndex={-1} ref={focusHeaderOnMount}>
+              <FormattedMessage
+                id="xpack.spaces.spaceSelector.selectSpacesTitle"
+                defaultMessage="Select your space"
+              />
+            </h1>
+            <p>
+              <FormattedMessage
+                id="xpack.spaces.spaceSelector.changeSpaceAnytimeAvailabilityText"
+                defaultMessage="You can change your space at anytime."
+              />
+            </p>
+          </EuiTextColor>
+        </EuiText>
+        <EuiSpacer size="xl" />
+        <Fragment>
+          {renderListFilterControls()}
+          <Fragment>
+            {isLoading ? (
+              <div css={styles.spacesLoadingSpinnerStyles} data-test-subj="spacesLoadingSpinner">
+                <EuiLoadingSpinner size="xl" />
+              </div>
+            ) : (
+              <Fragment>
+                {!error ? (
+                  <Fragment>
+                    {filteredSpaces.length > 0 ? (
+                      <Fragment>
+                        {currentViewMode === 'grid' ? (
+                          <SpaceCards spaces={filteredSpaces} serverBasePath={serverBasePath} />
+                        ) : (
+                          <SpaceTable spaces={filteredSpaces} serverBasePath={serverBasePath} />
+                        )}
+                      </Fragment>
+                    ) : (
+                      <Fragment>
+                        <EuiSpacer />
+                        <EuiPanel css={styles.panelStyles} color="subdued">
+                          <EuiTitle size="xs">
+                            <h2>
+                              {i18n.translate(
+                                'xpack.spaces.spaceSelector.noSpacesMatchSearchCriteriaDescription',
+                                {
+                                  defaultMessage: 'No spaces match "{searchTerm}"',
+                                  values: { searchTerm },
+                                }
+                              )}
+                            </h2>
+                          </EuiTitle>
+                        </EuiPanel>
+                      </Fragment>
+                    )}
+                  </Fragment>
+                ) : (
+                  <Fragment>
+                    <EuiSpacer />
+                    <EuiPanel css={styles.panelStyles} color="danger">
+                      <EuiText size="s" color="danger">
+                        <h2>
+                          <FormattedMessage
+                            id="xpack.spaces.spaceSelector.errorLoadingSpacesDescription"
+                            defaultMessage="Error loading spaces ({message})"
+                            values={{ message: error.message }}
+                          />
+                        </h2>
+                        <p>
+                          <FormattedMessage
+                            id="xpack.spaces.spaceSelector.contactSysAdminDescription"
+                            defaultMessage="Contact your system administrator."
+                          />
+                        </p>
+                      </EuiText>
+                    </EuiPanel>
+                  </Fragment>
+                )}
+              </Fragment>
+            )}
+          </Fragment>
+        </Fragment>
+      </KibanaPageTemplate.Section>
+    </KibanaPageTemplate>
+  );
+};
 
 export const renderSpaceSelectorApp = (
   services: Pick<CoreStart, 'analytics' | 'i18n' | 'theme' | 'userProfile' | 'rendering'>,
   { element }: Pick<AppMountParameters, 'element'>,
-  props: Props
+  props: SpaceSelectorProps
 ) => {
-  ReactDOM.render(services.rendering.addContext(<SpaceSelector {...props} />), element);
+  const queryClient = new QueryClient();
+
+  ReactDOM.render(
+    services.rendering.addContext(
+      <QueryClientProvider client={queryClient}>
+        <SpaceSelector {...props} />
+      </QueryClientProvider>
+    ),
+    element
+  );
   return () => ReactDOM.unmountComponentAtNode(element);
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Resolve issue with spaces list displaying "no match" text on load (#255654)](https://github.com/elastic/kibana/pull/255654)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-09T13:33:16Z","message":"Resolve issue with spaces list displaying \"no match\" text on load (#255654)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/255554\n\nFixes the issue where on loading the spaces selector, the user would get\npresented the text \"No spaces match\". This happened because of how the\nspace selector component was structured.\n\nNow all content is gated behind a loading state, since we want to\ndefinitely display the available space if this screen is presented to\nthe user, and it's only till the request to get the user's space\nresolves that we will display any content, this approach prevents the\nsituation where the user is presented some false message that they have\nno spaces initially.\n\n_Note for reviewers_\n\n- The space selector component has been refactored from class component\nto functional component\n- This change adopts react query for fetching the space list for the\nuser.\n- Unit tests for the space selector component has been migrated from\nenzyme to RTL\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1be1053112521429480a79b4eba6029bad7164a3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:SharedUX","backport:all-open","v9.4.0"],"title":"Resolve issue with spaces list displaying \"no match\" text on load","number":255654,"url":"https://github.com/elastic/kibana/pull/255654","mergeCommit":{"message":"Resolve issue with spaces list displaying \"no match\" text on load (#255654)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/255554\n\nFixes the issue where on loading the spaces selector, the user would get\npresented the text \"No spaces match\". This happened because of how the\nspace selector component was structured.\n\nNow all content is gated behind a loading state, since we want to\ndefinitely display the available space if this screen is presented to\nthe user, and it's only till the request to get the user's space\nresolves that we will display any content, this approach prevents the\nsituation where the user is presented some false message that they have\nno spaces initially.\n\n_Note for reviewers_\n\n- The space selector component has been refactored from class component\nto functional component\n- This change adopts react query for fetching the space list for the\nuser.\n- Unit tests for the space selector component has been migrated from\nenzyme to RTL\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1be1053112521429480a79b4eba6029bad7164a3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255654","number":255654,"mergeCommit":{"message":"Resolve issue with spaces list displaying \"no match\" text on load (#255654)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/255554\n\nFixes the issue where on loading the spaces selector, the user would get\npresented the text \"No spaces match\". This happened because of how the\nspace selector component was structured.\n\nNow all content is gated behind a loading state, since we want to\ndefinitely display the available space if this screen is presented to\nthe user, and it's only till the request to get the user's space\nresolves that we will display any content, this approach prevents the\nsituation where the user is presented some false message that they have\nno spaces initially.\n\n_Note for reviewers_\n\n- The space selector component has been refactored from class component\nto functional component\n- This change adopts react query for fetching the space list for the\nuser.\n- Unit tests for the space selector component has been migrated from\nenzyme to RTL\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1be1053112521429480a79b4eba6029bad7164a3"}}]}] BACKPORT-->