### PR TITLE
[Security Solution] fix alerts page infinite loading state due to data view error

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -72,6 +72,7 @@ jest.mock('@kbn/unified-search-plugin/public', () => ({
 
 describe('DataViewPicker', () => {
   let mockDispatch = jest.fn();
+  const mockAddDanger = jest.fn();
 
   beforeEach(() => {
     jest.mocked(useUpdateUrlParam).mockReturnValue(jest.fn());
@@ -83,6 +84,11 @@ describe('DataViewPicker', () => {
     jest.mocked(useKibana).mockReturnValue({
       services: {
         ...mockUseKibana().services,
+        notifications: {
+          toasts: {
+            addDanger: mockAddDanger,
+          },
+        },
         dataViewFieldEditor: { openEditor: jest.fn() },
         dataViewEditor: {
           userPermissions: { editDataView: jest.fn().mockReturnValue(true) },
@@ -174,6 +180,27 @@ describe('DataViewPicker', () => {
         'security-solution-default'
       );
       expect(jest.mocked(useKibana().services.dataViewFieldEditor.openEditor)).toHaveBeenCalled();
+    });
+  });
+
+  it('shows a danger toast when adding field fails to load data view', async () => {
+    jest
+      .mocked(useKibana().services.data.dataViews.get)
+      .mockRejectedValue(new Error('conflict loading data view'));
+
+    render(
+      <TestProviders>
+        <DataViewPicker scope={PageScope.default} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('addField'));
+
+    await waitFor(() => {
+      expect(mockAddDanger).toHaveBeenCalledWith({
+        title: 'Error retrieving data view',
+        text: 'Error: conflict loading data view',
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -44,7 +44,7 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
   const selectDataView = useSelectDataView();
 
   const {
-    services: { dataViewEditor, data, dataViewFieldEditor, fieldFormats },
+    services: { dataViewEditor, data, dataViewFieldEditor, fieldFormats, notifications },
   } = useKibana();
 
   const canEditDataView = useMemo(
@@ -117,27 +117,35 @@ export const DataViewPicker = memo(({ scope, onClosePopover, disabled }: DataVie
         return;
       }
 
-      const dataViewInstance = await data.dataViews.get(dataViewId);
-      // Modifications to the fields do not trigger cache invalidation, but should as `fields` will be stale.
-      if (dataViewInstance.isPersisted?.()) {
-        data.dataViews.clearInstanceCache(dataViewId);
+      // We wrap dataViews.get within a try catch because we've seen errors happening with conflicting ids in the saved object api
+      try {
+        const dataViewInstance = await data.dataViews.get(dataViewId);
+        // Modifications to the fields do not trigger cache invalidation, but should as `fields` will be stale.
+        if (dataViewInstance.isPersisted?.()) {
+          data.dataViews.clearInstanceCache(dataViewId);
+        }
+
+        closeFieldEditor.current = await dataViewFieldEditor.openEditor({
+          ctx: {
+            dataView: dataViewInstance,
+          },
+          fieldName,
+          onSave: async () => {
+            if (!dataViewInstance.id) {
+              return;
+            }
+
+            handleChangeDataView(dataViewInstance.id, dataViewInstance.getIndexPattern());
+          },
+        });
+      } catch (error) {
+        notifications.toasts.addDanger({
+          title: 'Error retrieving data view',
+          text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+        });
       }
-
-      closeFieldEditor.current = await dataViewFieldEditor.openEditor({
-        ctx: {
-          dataView: dataViewInstance,
-        },
-        fieldName,
-        onSave: async () => {
-          if (!dataViewInstance.id) {
-            return;
-          }
-
-          handleChangeDataView(dataViewInstance.id, dataViewInstance.getIndexPattern());
-        },
-      });
     },
-    [dataViewId, data.dataViews, dataViewFieldEditor, handleChangeDataView]
+    [dataViewId, data.dataViews, dataViewFieldEditor, handleChangeDataView, notifications]
   );
 
   const getDataViewHelpText = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_init_data_view_manager.ts
@@ -98,6 +98,7 @@ export const useInitDataViewManager = () => {
         dataViews: services.dataViews,
         http: services.http,
         uiSettings: services.uiSettings,
+        notifications: services.notifications,
         application: services.application,
         spaces: services.spaces,
         storage: services.storage,
@@ -122,6 +123,7 @@ export const useInitDataViewManager = () => {
       createDataViewSelectedListener({
         scope,
         dataViews: services.dataViews,
+        notifications: services.notifications,
         storage: services.storage,
         logger: createDataViewSelectedListenerLogger,
       })
@@ -151,6 +153,7 @@ export const useInitDataViewManager = () => {
     services.application,
     services.dataViews,
     services.http,
+    services.notifications,
     createInitListenerLogger,
     services.spaces,
     services.storage,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.test.ts
@@ -14,6 +14,7 @@ import type { RootState } from '../reducer';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, PageScope } from '../../constants';
 import { DEFAULT_ALERT_DATA_VIEW_ID } from '../../../../common/constants';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { CoreStart } from '@kbn/core/public';
 
 const mockDataViewsService = {
   getDataViewLazy: jest.fn(),
@@ -92,6 +93,7 @@ const mockStorage = {
   remove: jest.fn(),
   clear: jest.fn(),
 } as unknown as Storage;
+const mockToastsDanger = jest.fn();
 
 const mockListenerApi = {
   dispatch: mockDispatch,
@@ -107,6 +109,11 @@ describe('createDataViewSelectedListener', () => {
     jest.clearAllMocks();
     listener = createDataViewSelectedListener({
       dataViews: mockDataViewsService,
+      notifications: {
+        toasts: {
+          addDanger: mockToastsDanger,
+        },
+      } as unknown as CoreStart['notifications'],
       logger: mockLogger,
       scope: PageScope.default,
       storage: mockStorage,
@@ -185,6 +192,11 @@ describe('createDataViewSelectedListener', () => {
     it('should store data view ID in storage when scope is analyzer', async () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
+        notifications: {
+          toasts: {
+            addDanger: mockToastsDanger,
+          },
+        } as unknown as CoreStart['notifications'],
         scope: PageScope.analyzer,
         logger: mockLogger,
         storage: mockStorage,
@@ -213,6 +225,11 @@ describe('createDataViewSelectedListener', () => {
     it('should store resolved data view ID from cached view when scope is analyzer', async () => {
       const analyzerListener = createDataViewSelectedListener({
         dataViews: mockDataViewsService,
+        notifications: {
+          toasts: {
+            addDanger: mockToastsDanger,
+          },
+        } as unknown as CoreStart['notifications'],
         scope: PageScope.analyzer,
         logger: mockLogger,
         storage: mockStorage,
@@ -228,5 +245,50 @@ describe('createDataViewSelectedListener', () => {
         'persisted_test-*'
       );
     });
+  });
+
+  it('should show toast and fallback to default when getDataViewLazy fails without fallback patterns', async () => {
+    jest.mocked(mockDataViewsService.getDataViewLazy).mockRejectedValue(new Error('conflict'));
+
+    await listener.effect(
+      selectDataViewAsync({ id: 'conflicted-id', scope: PageScope.default }),
+      mockListenerApi
+    );
+
+    expect(mockToastsDanger).toHaveBeenCalledWith({
+      title: 'Selected data view is unavailable',
+      text: 'Unable to load data view "conflicted-id". Using fallback selection when possible.',
+    });
+    expect(mockDataViewsService.create).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
+        type: 'x-pack/security_solution/dataViewManager/default/setSelectedDataView',
+      })
+    );
+  });
+
+  it('should clear stale analyzer storage value when getDataViewLazy fails for analyzer scope', async () => {
+    const analyzerListener = createDataViewSelectedListener({
+      dataViews: mockDataViewsService,
+      notifications: {
+        toasts: {
+          addDanger: mockToastsDanger,
+        },
+      } as unknown as CoreStart['notifications'],
+      scope: PageScope.analyzer,
+      logger: mockLogger,
+      storage: mockStorage,
+    });
+    jest.mocked(mockDataViewsService.getDataViewLazy).mockRejectedValue(new Error('conflict'));
+
+    await analyzerListener.effect(
+      selectDataViewAsync({ id: 'conflicted-id', scope: PageScope.analyzer }),
+      mockListenerApi
+    );
+
+    expect(mockStorage.remove).toHaveBeenCalledWith(
+      'securitySolution.dataViewManager.selectedDataView.analyzer'
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/data_view_selected.ts
@@ -12,6 +12,7 @@ import type { AnyAction, Dispatch, ListenerEffectAPI } from '@reduxjs/toolkit';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { isEmpty } from 'lodash';
 import type { Logger } from '@kbn/logging';
+import type { CoreStart } from '@kbn/core/public';
 import type { RootState } from '../reducer';
 import { scopes } from '../reducer';
 import { selectDataViewAsync } from '../actions';
@@ -37,6 +38,7 @@ import { PageScope } from '../../constants';
 export const createDataViewSelectedListener = (dependencies: {
   scope: PageScope;
   dataViews: DataViewsServicePublic;
+  notifications: CoreStart['notifications'];
   storage: Storage;
   logger: Logger;
 }) => {
@@ -103,6 +105,8 @@ export const createDataViewSelectedListener = (dependencies: {
         }`
       );
 
+      // If the data view is not found in the cache, attempt to fetch it by ID from the DataViews service.
+      // We wrap the dataViews.getDataViewLazy within a try catch because we've seen errors happening with conflicting ids in the saved object api
       if (!cachedDataViewSpec) {
         try {
           if (action.payload.id) {
@@ -110,11 +114,25 @@ export const createDataViewSelectedListener = (dependencies: {
           }
         } catch (error: unknown) {
           logger.error(`Error fetching data view by id ${action.payload.id}: ${error}`);
+          dependencies.notifications.toasts.addDanger({
+            title: 'Selected data view is unavailable',
+            text: `Unable to load data view ${
+              action.payload.id ? `"${action.payload.id}"` : ''
+            }. Using fallback selection when possible.`,
+          });
+
+          // This cleans local storage for the analyzer data view to prevent the error from happening again on page refresh.
+          if (action.payload.scope === PageScope.analyzer && action.payload.id) {
+            dependencies.storage.remove(
+              `securitySolution.dataViewManager.selectedDataView.${action.payload.scope}`
+            );
+          }
           dataViewByIdError = error;
         }
       }
 
-      if (!dataViewById) {
+      // We attempt to create an ad-hoc data view if the data view by id lookup fails, and fallback patterns are provided.
+      if (!dataViewById && action.payload.fallbackPatterns?.length) {
         logger.debug(`Data view by id lookup failed for id: ${action.payload.id}`);
         try {
           const title = action.payload.fallbackPatterns?.join(',') ?? '';
@@ -134,6 +152,11 @@ export const createDataViewSelectedListener = (dependencies: {
           logger.error(`Error creating ad-hoc data view: ${error}`);
           adhocDataViewCreationError = error;
         }
+      } else if (!dataViewById && !action.payload.fallbackPatterns?.length) {
+        // No need to create an ad-hoc data view if there are no fallback patterns
+        logger.debug(
+          `Skipping ad-hoc data view creation for scope ${dependencies.scope} because no fallback patterns were provided`
+        );
       }
 
       const resolvedIdToUse =

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.test.ts
@@ -34,13 +34,14 @@ const mockDataViewsService = {
     isPersisted: () => false,
     toSpec: () => ({ id: 'adhoc_test-*', title: 'test-*' }),
   }),
-  getAllDataViewLazy: jest.fn().mockReturnValue([]),
+  getIdsWithTitle: jest.fn().mockReturnValue([]),
 } as unknown as DataViewsServicePublic;
 
 const http = {} as unknown as CoreStart['http'];
 const application = {} as unknown as CoreStart['application'];
 const uiSettings = {} as unknown as CoreStart['uiSettings'];
 const spaces = { getActiveSpace: async () => ({ id: 'default' }) } as unknown as SpacesPluginStart;
+const mockToastsDanger = jest.fn();
 
 const mockDispatch = jest.fn();
 const mockGetState = jest.fn(() => {
@@ -82,6 +83,11 @@ describe('createInitListener', () => {
         http,
         application,
         uiSettings,
+        notifications: {
+          toasts: {
+            addDanger: mockToastsDanger,
+          },
+        } as unknown as CoreStart['notifications'],
         spaces,
         storage: {
           get: jest.fn(),
@@ -94,15 +100,34 @@ describe('createInitListener', () => {
     );
   });
 
-  it('should load the data views and dispatch further actions', async () => {
+  it('should load the data views from getIdsWithTitle and dispatch further actions', async () => {
+    jest.mocked(mockDataViewsService.getIdsWithTitle).mockResolvedValue([
+      {
+        id: 'logs-*',
+        title: 'logs-*',
+        name: 'logs',
+        managed: false,
+      },
+    ]);
+
     await listener.effect(sharedDataViewManagerSlice.actions.init([]), mockListenerApi);
 
     expect(jest.mocked(createDefaultDataView)).toHaveBeenCalled();
 
-    expect(jest.mocked(mockDataViewsService.getAllDataViewLazy)).toHaveBeenCalled();
+    expect(jest.mocked(mockDataViewsService.getIdsWithTitle)).toHaveBeenCalled();
 
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
-      sharedDataViewManagerSlice.actions.setDataViews([])
+      sharedDataViewManagerSlice.actions.setDataViews([
+        {
+          id: 'logs-*',
+          title: 'logs-*',
+          name: 'logs',
+          managed: false,
+          timeFieldName: undefined,
+          type: undefined,
+          typeMeta: undefined,
+        },
+      ])
     );
     expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
       sharedDataViewManagerSlice.actions.setDataViewId({
@@ -141,12 +166,13 @@ describe('createInitListener', () => {
         scope: PageScope.analyzer,
       })
     );
+    expect(mockToastsDanger).not.toHaveBeenCalled();
   });
 
-  describe('when data views fetch returns an error', () => {
+  describe('when getIdsWithTitle fetch returns an error', () => {
     beforeEach(() => {
       jest
-        .mocked(mockDataViewsService.getAllDataViewLazy)
+        .mocked(mockDataViewsService.getIdsWithTitle)
         .mockRejectedValue(new Error('some loading error'));
     });
 
@@ -156,6 +182,10 @@ describe('createInitListener', () => {
       expect(jest.mocked(mockListenerApi.dispatch)).toBeCalledWith(
         sharedDataViewManagerSlice.actions.error()
       );
+      expect(mockToastsDanger).toHaveBeenCalledWith({
+        title: 'Error initializing data views',
+        text: 'Error: some loading error',
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/redux/listeners/init_listener.ts
@@ -17,6 +17,7 @@ import { PageScope } from '../../constants';
 import { selectDataViewAsync } from '../actions';
 import { createDefaultDataView } from '../../utils/create_default_data_view';
 import { createExploreDataView } from '../../utils/create_explore_data_view';
+import type { DataViewSpec } from '../types';
 
 /**
  * Creates a Redux listener for initializing the Data View Manager state.
@@ -41,6 +42,7 @@ export const createInitListener = (
     http: CoreStart['http'];
     application: CoreStart['application'];
     uiSettings: CoreStart['uiSettings'];
+    notifications: CoreStart['notifications'];
     dataViews: DataViewsServicePublic;
     spaces: SpacesPluginStart;
     storage: Storage;
@@ -91,19 +93,24 @@ export const createInitListener = (
         listenerApi.dispatch(sharedDataViewManagerSlice.actions.addDataView(exploreDataView));
 
         // NOTE: This is later used in the data view manager drop-down selector
-        const dataViews = await dependencies.dataViews.getAllDataViewLazy();
+        // We're using getIdsWithTitle instead of getAllDataViewLazy because to avoid a bug that happens in the savedObject api where id conflicts can happen between documents
+        const dataViews = await dependencies.dataViews.getIdsWithTitle();
 
         logger.debug(
-          `Fetched ${
-            dataViews.length
-          } data views from the Data Views service. Data View Names: ${dataViews
-            .map((dv) => dv.getName())
+          `Fetched ${dataViews.length} data views from getIdsWithTitle. Data View Names: ${dataViews
+            .map((dv) => dv.name ?? dv.title)
             .join(', ')}`
         );
 
-        const dataViewSpecs = await Promise.all(dataViews.map((dataView) => dataView.toSpec()));
-
-        logger.debug(`Converted ${dataViewSpecs.length} data views to specs`);
+        const dataViewSpecs: DataViewSpec[] = dataViews.map((dataView) => ({
+          id: dataView.id,
+          title: dataView.title,
+          name: dataView.name,
+          managed: dataView.managed,
+          timeFieldName: dataView.timeFieldName,
+          type: dataView.type,
+          typeMeta: dataView.typeMeta,
+        }));
 
         listenerApi.dispatch(sharedDataViewManagerSlice.actions.setDataViews(dataViewSpecs));
 
@@ -189,6 +196,10 @@ export const createInitListener = (
         });
       } catch (error: unknown) {
         dependencies.logger.error(`Error initializing Data View Manager: ${error}`);
+        dependencies.notifications.toasts.addDanger({
+          title: 'Error initializing data views',
+          text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+        });
         listenerApi.dispatch(sharedDataViewManagerSlice.actions.error());
       }
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -84,12 +84,15 @@ const fieldItem: BrowserFieldItem = {
 };
 
 describe('useFieldBrowserOptions', () => {
+  const mockAddDanger = jest.fn();
+
   beforeEach(() => {
     mockIndexPatternFieldEditor = indexPatternFieldEditorPluginMock.createStartContract();
     mockIndexPatternFieldEditor.userPermissions.editIndexPattern = () => true;
     useKibanaMock().services.dataViewFieldEditor = mockIndexPatternFieldEditor;
     useKibanaMock().services.data.dataViews.get = () => new Promise(() => undefined);
     useKibanaMock().services.data.dataViews.clearInstanceCache = () => undefined;
+    useKibanaMock().services.notifications.toasts.addDanger = mockAddDanger;
 
     useKibanaMock().services.application.capabilities = {
       ...useKibanaMock().services.application.capabilities,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/fields_browser/index.tsx
@@ -63,6 +63,7 @@ export const useFieldBrowserOptions: UseFieldBrowserOptions = ({
   const { indexFieldsSearch } = useDataViewOld();
   const {
     dataViewFieldEditor,
+    notifications,
     data: { dataViews },
   } = useKibana().services;
   const missingPatterns = useSelector((state: State) => {
@@ -83,9 +84,17 @@ export const useFieldBrowserOptions: UseFieldBrowserOptions = ({
         if (experimentalDataView) setDataView(experimentalDataView);
         return;
       }
-      const aDatView = await dataViews.get(dataViewId);
-      if (ignore) return;
-      setDataView(aDatView);
+      // We wrap dataViews.get within a try catch because we've seen errors happening with conflicting ids in the saved object api
+      try {
+        const aDatView = await dataViews.get(dataViewId);
+        if (ignore) return;
+        setDataView(aDatView);
+      } catch (error) {
+        notifications.toasts.addDanger({
+          title: 'Error retrieving data view',
+          text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+        });
+      }
     };
     if (selectedDataViewId != null && !missingPatterns.length) {
       fetchAndSetDataView(selectedDataViewId);
@@ -98,6 +107,7 @@ export const useFieldBrowserOptions: UseFieldBrowserOptions = ({
     selectedDataViewId,
     missingPatterns,
     dataViews,
+    notifications,
     newDataViewPickerEnabled,
     experimentalDataView,
   ]);


### PR DESCRIPTION
## Summary

This PR fixed an issue that we've had for a while now with the new data view manager logic.

> [!WARNING]
> This PR should not introduce any logic changes or visual changes (other than the added toast when we encounter errors

### Reason

Some customer see an issue with the alerts page stuck in an infinite loading state. The issue happens because something is failing within the platform dataview service, which we rely on. In our code, we were wrapping the entire logic of data view initialization within a `try/catch`. When the error was happening in the dataview service, we would not complete the initialization of all dataview, and some of them were staying in a `pristine` status, instead of being changed to `error` or `ready`, which is what the different pages (including the alerts page) is expecting

### Fix

We're performing 2 types of fixes:
- we're not using the `getAllDataViewLazy` function dataview service anymore as it has some code that communicates with the saved object client, and we noticed some of our customers having errors with conflicting ids in their saved objects, which triggered the flow mentioned above. Instead we're leveraging the `getAllDataViewLazy` function from the dataview service, which returns from the cache.
- we're wrapping everywhere we use the `get` function from the dataview service with a `try/catch` to prevent other potential issue
- we're adding a UI toast to all those places to let the user know about the error, which will facilitate debugging for us if this was to happen again

> [!NOTE]
> We're trying to make this available in `9.2.7`, we'll be doing a follow up PR shortly for other try catches we found in the `detection_engine` folder

## What/How to test

- add data to a local instance and navigate through the app
- make sure the happy path works
  - load main the Security Solution pages
  - alerts page
  - timeline
  - analyzer
- verify interaction with new spaces

### Checklist
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->