### PR TITLE
[Security Solution] fix potential issues with loading data views in detection engine

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_about_rule/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_about_rule/index.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { EuiAccordion, EuiFlexItem, EuiSpacer, EuiFormRow, EuiToolTip } from '@elastic/eui';
+import { EuiAccordion, EuiFlexItem, EuiFormRow, EuiSpacer, EuiToolTip } from '@elastic/eui';
 import type { FC } from 'react';
-import React, { memo, useCallback, useEffect, useState, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import type { DataViewBase } from '@kbn/es-query';
@@ -15,8 +15,8 @@ import type { Severity, Type } from '@kbn/securitysolution-io-ts-alerting-types'
 
 import { defaultRiskScoreBySeverity } from '../../../../../common/detection_engine/constants';
 import type { RuleSource } from '../../../../../common/api/detection_engine';
-import { isThreatMatchRule, isEsqlRule } from '../../../../../common/detection_engine/utils';
-import type { RuleStepProps, AboutStepRule } from '../../../common/types';
+import { isEsqlRule, isThreatMatchRule } from '../../../../../common/detection_engine/utils';
+import type { AboutStepRule, RuleStepProps } from '../../../common/types';
 import { AddItem } from '../add_item_form';
 import { StepRuleDescription } from '../description_step';
 import { AddMitreAttackThreat } from '../mitre';
@@ -86,7 +86,7 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   esqlQuery,
   ruleSource,
 }) => {
-  const { data } = useKibana().services;
+  const { data, notifications } = useKibana().services;
 
   const isThreatMatchRuleValue = useMemo(() => isThreatMatchRule(ruleType), [ruleType]);
   const isEsqlRuleValue = useMemo(() => isEsqlRule(ruleType), [ruleType]);
@@ -116,13 +116,21 @@ const StepAboutRuleComponent: FC<StepAboutRuleProps> = ({
   useEffect(() => {
     const fetchSingleDataView = async () => {
       if (dataViewId != null && dataViewId !== '') {
-        const dv = await data.dataViews.get(dataViewId);
-        setIndexPattern(dv);
+        // We wrap dataViews.get within a try catch because we've seen errors happening with conflicting ids in the saved object api
+        try {
+          const dv = await data.dataViews.get(dataViewId);
+          setIndexPattern(dv);
+        } catch (error) {
+          notifications.toasts.addDanger({
+            title: 'Error retrieving data view',
+            text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+          });
+        }
       }
     };
 
     fetchSingleDataView();
-  }, [data.dataViews, dataViewId, indexIndexPattern, setIndexPattern]);
+  }, [data.dataViews, dataViewId, indexIndexPattern, setIndexPattern, notifications]);
 
   const { getFields } = form;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/form.tsx
@@ -132,7 +132,7 @@ export const useRuleIndexPattern = ({
   index,
   dataViewId,
 }: UseRuleIndexPatternProps) => {
-  const { data } = useKibana().services;
+  const { data, notifications } = useKibana().services;
   const [isIndexPatternLoading, { browserFields, indexPatterns: initIndexPattern }] =
     useFetchIndex(index);
   const [indexPattern, setIndexPattern] = useState<DataViewBase>(initIndexPattern);
@@ -148,14 +148,22 @@ export const useRuleIndexPattern = ({
     if (dataSourceType === DataSourceType.DataView) {
       const fetchDataView = async () => {
         if (dataViewId != null && dataViewId !== '') {
-          const dv = await data.dataViews.get(dataViewId);
-          setIndexPattern(dv);
+          // We wrap dataViews.get within a try catch because we've seen errors happening with conflicting ids in the saved object api
+          try {
+            const dv = await data.dataViews.get(dataViewId);
+            setIndexPattern(dv);
+          } catch (error) {
+            notifications.toasts.addDanger({
+              title: 'Error retrieving data view',
+              text: `Error: ${error instanceof Error ? error.message : 'unknown'}`,
+            });
+          }
         }
       };
 
       fetchDataView();
     }
-  }, [dataSourceType, isIndexPatternLoading, data, dataViewId, initIndexPattern]);
+  }, [dataSourceType, isIndexPatternLoading, data, dataViewId, initIndexPattern, notifications]);
   return { indexPattern, isIndexPatternLoading, browserFields };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/logic/use_exception_flyout_data.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/logic/use_exception_flyout_data.tsx
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { DataViewBase } from '@kbn/es-query';
 import { getIndexListFromEsqlQuery } from '@kbn/securitysolution-utils';
 
-import type { FieldSpec, DataViewSpec } from '@kbn/data-views-plugin/common';
+import type { DataViewSpec, FieldSpec } from '@kbn/data-views-plugin/common';
 
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import type { Rule } from '../../rule_management/logic/types';
@@ -110,15 +110,21 @@ export const useFetchIndexPatterns = (rules: Rule[] | null): ReturnUseFetchExcep
       // throw an error here.
       if (activeSpaceId !== '' && memoDataViewId) {
         setDataViewLoading(true);
-        const dv = await data.dataViews.get(memoDataViewId);
-        setDataViewLoading(false);
-        setDataViewIndexPatterns(dv);
-        setDataViewSpec(dv.toSpec());
+        // We wrap dataViews.get within a try catch because we've seen errors happening with conflicting ids in the saved object api
+        try {
+          const dv = await data.dataViews.get(memoDataViewId);
+          setDataViewIndexPatterns(dv);
+          setDataViewSpec(dv.toSpec());
+        } catch (error) {
+          addWarning(error, { title: 'Failed to load data view for exceptions flyout' });
+        } finally {
+          setDataViewLoading(false);
+        }
       }
     };
 
     fetchSingleDataView();
-  }, [memoDataViewId, data.dataViews, setDataViewIndexPatterns, activeSpaceId]);
+  }, [memoDataViewId, data.dataViews, setDataViewIndexPatterns, activeSpaceId, addWarning]);
 
   // Fetch extended fields information
   const getExtendedFields = useCallback(


### PR DESCRIPTION
## Summary

A recent SDH made us realize that we have a potential issue in our code, when the platform dataview service throws errors.
This previous [PR](https://github.com/elastic/kibana/pull/256983) fixes the issue in the @elastic/security-threat-hunting-investigations codebase and we want to merge it for `9.2.7`.

This PR applies similar changes to the code owned by the @elastic/security-detection-engine team:
- wrap the `dataview.get` calls within a `try/catch` and show a toast if an error happens

This will facilitate debugging if we ever need. (more info in the PR mentioned above).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->