### PR TITLE
[TSVB] Link annotation marker tooltips for screen readers

### DIFF
--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/annotation_tooltip_aria_description.test.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/annotation_tooltip_aria_description.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  syncAnnotationTooltipAriaDescription,
+  ANNOTATION_MARKER_SELECTOR,
+} from './annotation_tooltip_aria_description';
+
+const createMarker = (): HTMLButtonElement => {
+  const marker = document.createElement('button');
+  marker.className = ANNOTATION_MARKER_SELECTOR.slice(1);
+  marker.type = 'button';
+  marker.textContent = 'annotation';
+  return marker;
+};
+
+const createTooltipPortal = ({ hidden = false }: { hidden?: boolean } = {}): HTMLElement => {
+  const portal = document.createElement('div');
+  portal.className = hidden ? 'echTooltipPortal__invisible' : 'echTooltipPortal';
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'echTooltip echAnnotation';
+  tooltip.textContent = 'Tooltip details';
+  portal.appendChild(tooltip);
+
+  document.body.appendChild(portal);
+
+  return tooltip;
+};
+
+describe('annotation_tooltip_aria_description', () => {
+  const tooltipId = 'tsvbAnnotationTooltip';
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('links the focused marker to the visible annotation tooltip', () => {
+    const chartContainer = document.createElement('div');
+    const marker = createMarker();
+
+    chartContainer.appendChild(marker);
+    document.body.appendChild(chartContainer);
+    const tooltip = createTooltipPortal();
+
+    marker.focus();
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(marker).toHaveAttribute('aria-describedby', tooltipId);
+    expect(tooltip).toHaveAttribute('id', tooltipId);
+  });
+
+  it('removes the generated description from markers that are no longer focused', () => {
+    const chartContainer = document.createElement('div');
+    const previousMarker = createMarker();
+    const focusedMarker = createMarker();
+
+    previousMarker.setAttribute('aria-describedby', `existing ${tooltipId}`);
+    focusedMarker.setAttribute('aria-describedby', 'existing');
+
+    chartContainer.appendChild(previousMarker);
+    chartContainer.appendChild(focusedMarker);
+    document.body.appendChild(chartContainer);
+    createTooltipPortal();
+
+    focusedMarker.focus();
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(previousMarker).toHaveAttribute('aria-describedby', 'existing');
+    expect(focusedMarker).toHaveAttribute('aria-describedby', `existing ${tooltipId}`);
+  });
+
+  it('adds aria-describedby when tooltip appears after marker is already focused', () => {
+    const chartContainer = document.createElement('div');
+    const marker = createMarker();
+
+    chartContainer.appendChild(marker);
+    document.body.appendChild(chartContainer);
+
+    marker.focus();
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(marker).not.toHaveAttribute('aria-describedby');
+
+    const tooltip = createTooltipPortal();
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(marker).toHaveAttribute('aria-describedby', tooltipId);
+    expect(tooltip).toHaveAttribute('id', tooltipId);
+  });
+
+  it('cleans up aria-describedby from all markers when focus leaves', () => {
+    const chartContainer = document.createElement('div');
+    const marker1 = createMarker();
+    const marker2 = createMarker();
+
+    marker1.setAttribute('aria-describedby', tooltipId);
+    marker2.setAttribute('aria-describedby', `existing ${tooltipId}`);
+
+    chartContainer.appendChild(marker1);
+    chartContainer.appendChild(marker2);
+    document.body.appendChild(chartContainer);
+    createTooltipPortal();
+
+    // Focus is on document.body (no marker focused)
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(marker1).not.toHaveAttribute('aria-describedby');
+    expect(marker2).toHaveAttribute('aria-describedby', 'existing');
+  });
+
+  it('does not attach aria-describedby when the annotation tooltip is hidden', () => {
+    const chartContainer = document.createElement('div');
+    const marker = createMarker();
+
+    chartContainer.appendChild(marker);
+    document.body.appendChild(chartContainer);
+    createTooltipPortal({ hidden: true });
+
+    marker.focus();
+    syncAnnotationTooltipAriaDescription(chartContainer, tooltipId);
+
+    expect(marker).not.toHaveAttribute('aria-describedby');
+  });
+});

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/annotation_tooltip_aria_description.ts
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/annotation_tooltip_aria_description.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const ANNOTATION_MARKER_SELECTOR = '.echAnnotation__marker';
+export const ANNOTATION_TOOLTIP_SELECTOR = '.echTooltip.echAnnotation';
+
+const getAriaDescribedByIds = (element: HTMLElement): string[] =>
+  element.getAttribute('aria-describedby')?.split(/\s+/).filter(Boolean) ?? [];
+
+const updateAriaDescribedBy = (
+  element: HTMLElement,
+  tooltipId: string,
+  operation: 'add' | 'remove'
+): void => {
+  const describedByIds = getAriaDescribedByIds(element);
+  const nextIds =
+    operation === 'add'
+      ? Array.from(new Set([...describedByIds, tooltipId]))
+      : describedByIds.filter((value) => value !== tooltipId);
+
+  if (nextIds.length > 0) {
+    element.setAttribute('aria-describedby', nextIds.join(' '));
+    return;
+  }
+
+  element.removeAttribute('aria-describedby');
+};
+
+const getFocusedAnnotationMarker = (chartContainer: HTMLElement): HTMLButtonElement | null => {
+  const { activeElement } = chartContainer.ownerDocument;
+
+  if (
+    !(activeElement instanceof HTMLButtonElement) ||
+    !chartContainer.contains(activeElement) ||
+    !activeElement.matches(ANNOTATION_MARKER_SELECTOR)
+  ) {
+    return null;
+  }
+
+  return activeElement;
+};
+
+const getVisibleAnnotationTooltip = (document: Document): HTMLElement | null =>
+  Array.from(document.querySelectorAll<HTMLElement>(ANNOTATION_TOOLTIP_SELECTOR)).find(
+    (tooltip) => !tooltip.closest('.echTooltipPortal__invisible')
+  ) ?? null;
+
+export const syncAnnotationTooltipAriaDescription = (
+  chartContainer: HTMLElement,
+  tooltipId: string
+): void => {
+  const markers = Array.from(
+    chartContainer.querySelectorAll<HTMLButtonElement>(ANNOTATION_MARKER_SELECTOR)
+  );
+  const focusedMarker = getFocusedAnnotationMarker(chartContainer);
+
+  markers.forEach((marker) => {
+    if (marker !== focusedMarker) {
+      updateAriaDescribedBy(marker, tooltipId, 'remove');
+    }
+  });
+
+  if (!focusedMarker) {
+    return;
+  }
+
+  const tooltip = getVisibleAnnotationTooltip(chartContainer.ownerDocument);
+
+  if (!tooltip) {
+    updateAriaDescribedBy(focusedMarker, tooltipId, 'remove');
+    return;
+  }
+
+  tooltip.id = tooltipId;
+  updateAriaDescribedBy(focusedMarker, tooltipId, 'add');
+};

--- a/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/platform/plugins/shared/vis_types/timeseries/public/application/visualizations/views/timeseries/index.js
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useRef, useCallback, useMemo } from 'react';
+import React, { useRef, useCallback, useEffect, useId, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { i18n } from '@kbn/i18n';
@@ -38,6 +38,7 @@ import { getValueOrEmpty } from '../../../../../common/empty_label';
 import { getSplitByTermsColor } from '../../../lib/get_split_by_terms_color';
 import { getAxisLabelString } from '../../../components/lib/get_axis_label_string';
 import { calculateDomainForSeries } from './utils/series_domain_calculation';
+import { syncAnnotationTooltipAriaDescription } from './annotation_tooltip_aria_description';
 
 const generateAnnotationData = (values, formatter) =>
   values.map(({ key, docs }) => ({
@@ -85,6 +86,7 @@ export const TimeSeries = ({
   const { theme: themeService, activeCursor: activeCursorService } = getCharts();
 
   const chartRef = useRef();
+  const annotationTooltipId = useId();
   const chartBaseTheme = getBaseTheme(themeService.useChartsBaseTheme(), backgroundColor);
 
   const handleCursorUpdate = useActiveCursor(activeCursorService, chartRef, {
@@ -104,6 +106,72 @@ export const TimeSeries = ({
     },
     [initialRender]
   );
+
+  // Links focused annotation markers to their tooltip via aria-describedby so
+  // screen readers announce tooltip content (timestamp, airline, message).
+  useEffect(() => {
+    if (!hasVisibleAnnotations) {
+      return;
+    }
+
+    const chartContainer = chartRef.current?.getChartContainerRef?.().current;
+
+    if (!chartContainer) {
+      return;
+    }
+
+    let animationFrame = null;
+
+    const syncAriaDescription = () => {
+      syncAnnotationTooltipAriaDescription(chartContainer, annotationTooltipId);
+    };
+
+    const scheduleSync = () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+      }
+
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null;
+        syncAriaDescription();
+      });
+    };
+
+    // Annotation tooltips render in portals on document.body, outside the chart
+    // container, so we observe body and filter for tooltip-related mutations.
+    const tooltipObserver = new MutationObserver((mutations) => {
+      const isRelevant = mutations.some(
+        (m) =>
+          m.target instanceof HTMLElement &&
+          (m.target.matches(
+            '.echTooltipPortal, .echTooltipPortal__invisible, .echTooltip.echAnnotation'
+          ) ||
+            m.target.closest('.echTooltipPortal, .echTooltipPortal__invisible'))
+      );
+      if (isRelevant) scheduleSync();
+    });
+
+    chartContainer.addEventListener('focusin', scheduleSync);
+    chartContainer.addEventListener('focusout', scheduleSync);
+    tooltipObserver.observe(chartContainer.ownerDocument.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    scheduleSync();
+
+    return () => {
+      chartContainer.removeEventListener('focusin', scheduleSync);
+      chartContainer.removeEventListener('focusout', scheduleSync);
+      tooltipObserver.disconnect();
+
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [annotationTooltipId, hasVisibleAnnotations]);
 
   let tooltipFormatter = decorateFormatter(xAxisFormatter);
   if (!isLastBucketDropped) {
@@ -228,7 +296,9 @@ export const TimeSeries = ({
             id={id}
             domainType={AnnotationDomainType.XDomain}
             dataValues={dataValues}
-            marker={<EuiIcon type={ICON_TYPES_MAP[icon] || 'asterisk'} />}
+            // aria-hidden: the marker button provides its own accessible label;
+            // the decorative icon should not be announced separately.
+            marker={<EuiIcon type={ICON_TYPES_MAP[icon] || 'asterisk'} aria-hidden={true} />}
             hideLinesTooltips={true}
             style={style}
           />


### PR DESCRIPTION
Closes #148685

TSVB annotation markers exposed an accessible name but did not link the visible tooltip to the focused marker, so screen readers would not read the tooltip contents.

Add a small DOM sync in the time series chart to attach 	taria-describedbyfrom the focused annotation marker button to the visible annotation tooltip, and mark the marker icon as decorative. Include unit coverage for the tooltip/marker association behavior.

Prompt:

> You have access to `gh`. Take a look at the issue outlined in https://github.com/elastic/kibana/issues/148685. You
  will need to inspect the image within the description for required context. Resolve the issue if you are able to
  confidently identify the exact problem mentioned.
