### PR TITLE
[Streams] Add json_extract processor to Streamlang

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -762,7 +762,7 @@ apiTest.describe(
     });
 
     apiTest(
-      'should handle ignore_missing: true when field is missing',
+      'should handle ignore_missing: true when field value is null',
       async ({ testBed, esql }) => {
         const streamlangDSL: StreamlangDSL = {
           steps: [
@@ -778,16 +778,30 @@ apiTest.describe(
         const { processors } = transpileIngestPipeline(streamlangDSL);
         const { query } = transpileEsql(streamlangDSL);
 
+        // Note: ES|QL requires the column to exist in the index schema, so we include
+        // a mapping document with an empty message field. Documents with null/missing
+        // message values should be handled by ignore_missing: true.
+        const mappingDoc = { message: '{}' };
         const docs = [{ other_field: 'no message field here' }];
         await testBed.ingest('ingest-json-extract-ignmiss', docs, processors);
         const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-ignmiss');
 
-        await testBed.ingest('esql-json-extract-ignmiss', docs);
+        await testBed.ingest('esql-json-extract-ignmiss', [mappingDoc, ...docs]);
         const esqlResult = await esql.queryOnIndex('esql-json-extract-ignmiss', query);
 
-        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        // Filter out the mapping document from ES|QL results
+        const esqlDocsWithoutMapping = esqlResult.documentsWithoutKeywords.filter(
+          (d: any) => d.other_field
+        );
+
+        // Behavioral difference: Ingest Pipeline doesn't add fields that don't exist,
+        // while ES|QL returns null for columns that exist in schema but have no value.
+        // Both preserve the original document content (other_field) and don't add the
+        // extracted value when the source field is missing/null.
+        expect(ingestResult[0].other_field).toStrictEqual(esqlDocsWithoutMapping[0].other_field);
         expect(ingestResult[0].value).toBeUndefined();
-        expect(esqlResult.documentsWithoutKeywords[0].value).toBeUndefined();
+        // ES|QL returns null for the value column (schema exists but extraction returns null)
+        expect(esqlDocsWithoutMapping[0].value).toBeNull();
       }
     );
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -197,117 +197,105 @@ apiTest.describe(
 
     // *** Type Casting Tests ***
 
-    apiTest(
-      'should correctly cast extracted values to integer type',
-      async ({ testBed, esql }) => {
-        const streamlangDSL: StreamlangDSL = {
-          steps: [
-            {
-              action: 'json_extract',
-              field: 'message',
-              extractions: [{ selector: 'count', target_field: 'count', type: 'integer' }],
-            } as JsonExtractProcessor,
-          ],
-        };
+    apiTest('should correctly cast extracted values to integer type', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'count', target_field: 'count', type: 'integer' }],
+          } as JsonExtractProcessor,
+        ],
+      };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
 
-        const docs = [{ message: '{"count": 42}' }];
-        await testBed.ingest('ingest-json-extract-int', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-int');
+      const docs = [{ message: '{"count": 42}' }];
+      await testBed.ingest('ingest-json-extract-int', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-int');
 
-        await testBed.ingest('esql-json-extract-int', docs);
-        const esqlResult = await esql.queryOnIndex('esql-json-extract-int', query);
+      await testBed.ingest('esql-json-extract-int', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-int', query);
 
-        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 42 }));
-      }
-    );
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 42 }));
+    });
 
-    apiTest(
-      'should correctly cast extracted values to boolean type',
-      async ({ testBed, esql }) => {
-        const streamlangDSL: StreamlangDSL = {
-          steps: [
-            {
-              action: 'json_extract',
-              field: 'message',
-              extractions: [{ selector: 'active', target_field: 'active', type: 'boolean' }],
-            } as JsonExtractProcessor,
-          ],
-        };
+    apiTest('should correctly cast extracted values to boolean type', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'active', target_field: 'active', type: 'boolean' }],
+          } as JsonExtractProcessor,
+        ],
+      };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
 
-        const docs = [{ message: '{"active": true}' }];
-        await testBed.ingest('ingest-json-extract-bool', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-bool');
+      const docs = [{ message: '{"active": true}' }];
+      await testBed.ingest('ingest-json-extract-bool', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-bool');
 
-        await testBed.ingest('esql-json-extract-bool', docs);
-        const esqlResult = await esql.queryOnIndex('esql-json-extract-bool', query);
+      await testBed.ingest('esql-json-extract-bool', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-bool', query);
 
-        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ active: true }));
-      }
-    );
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ active: true }));
+    });
 
-    apiTest(
-      'should correctly cast extracted values to double type',
-      async ({ testBed, esql }) => {
-        const streamlangDSL: StreamlangDSL = {
-          steps: [
-            {
-              action: 'json_extract',
-              field: 'message',
-              extractions: [{ selector: 'price', target_field: 'price', type: 'double' }],
-            } as JsonExtractProcessor,
-          ],
-        };
+    apiTest('should correctly cast extracted values to double type', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'price', target_field: 'price', type: 'double' }],
+          } as JsonExtractProcessor,
+        ],
+      };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
 
-        const docs = [{ message: '{"price": 19.99}' }];
-        await testBed.ingest('ingest-json-extract-double', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-double');
+      const docs = [{ message: '{"price": 19.99}' }];
+      await testBed.ingest('ingest-json-extract-double', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-double');
 
-        await testBed.ingest('esql-json-extract-double', docs);
-        const esqlResult = await esql.queryOnIndex('esql-json-extract-double', query);
+      await testBed.ingest('esql-json-extract-double', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-double', query);
 
-        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ price: 19.99 }));
-      }
-    );
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ price: 19.99 }));
+    });
 
-    apiTest(
-      'should default to keyword type when no type specified',
-      async ({ testBed, esql }) => {
-        const streamlangDSL: StreamlangDSL = {
-          steps: [
-            {
-              action: 'json_extract',
-              field: 'message',
-              extractions: [{ selector: 'name', target_field: 'name' }],
-            } as JsonExtractProcessor,
-          ],
-        };
+    apiTest('should default to keyword type when no type specified', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'name', target_field: 'name' }],
+          } as JsonExtractProcessor,
+        ],
+      };
 
-        const { processors } = transpileIngestPipeline(streamlangDSL);
-        const { query } = transpileEsql(streamlangDSL);
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
 
-        const docs = [{ message: '{"name": "John"}' }];
-        await testBed.ingest('ingest-json-extract-default', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-default');
+      const docs = [{ message: '{"name": "John"}' }];
+      await testBed.ingest('ingest-json-extract-default', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-default');
 
-        await testBed.ingest('esql-json-extract-default', docs);
-        const esqlResult = await esql.queryOnIndex('esql-json-extract-default', query);
+      await testBed.ingest('esql-json-extract-default', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-default', query);
 
-        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
-        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ name: 'John' }));
-      }
-    );
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ name: 'John' }));
+    });
 
     apiTest(
       'should correctly cast multiple extractions with different types',
@@ -331,7 +319,9 @@ apiTest.describe(
 
         const docs = [{ message: '{"count": 42, "active": true, "name": "Test"}' }];
         await testBed.ingest('ingest-json-extract-multi-types', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-multi-types');
+        const ingestResult = await testBed.getFlattenedDocsOrdered(
+          'ingest-json-extract-multi-types'
+        );
 
         await testBed.ingest('esql-json-extract-multi-types', docs);
         const esqlResult = await esql.queryOnIndex('esql-json-extract-multi-types', query);
@@ -381,7 +371,7 @@ apiTest.describe(
         await testBed.ingest('esql-json-extract-fail', [validJsonDoc, ...invalidJsonDocs]);
         const esqlResult = await esql.queryOnIndex('esql-json-extract-fail', query);
         // ES|QL query should include both documents but only the valid one has a value
-        expect(esqlResult.documents.length >= 1).toBe(true);
+        expect(esqlResult.documents.length).toBeGreaterThan(0);
       }
     );
 
@@ -412,5 +402,473 @@ apiTest.describe(
         expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ first_item: 'Apple' }));
       }
     );
+
+    // *** Additional Edge Case Tests ***
+
+    apiTest('should correctly cast extracted values to long type', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'big_number', target_field: 'big_number', type: 'long' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"big_number": 9007199254740992}' }];
+      await testBed.ingest('ingest-json-extract-long', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-long');
+
+      await testBed.ingest('esql-json-extract-long', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-long', query);
+
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(
+        expect.objectContaining({ big_number: 9007199254740992 })
+      );
+    });
+
+    apiTest(
+      'should correctly extract using bracket notation selectors',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: "['user']['profile']['name']", target_field: 'user_name' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"user": {"profile": {"name": "Alice"}}}' }];
+        await testBed.ingest('ingest-json-extract-bracket', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-bracket');
+
+        await testBed.ingest('esql-json-extract-bracket', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-bracket', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ user_name: 'Alice' }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract deeply nested fields (5+ levels)',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [
+                {
+                  selector: 'level1.level2.level3.level4.level5.value',
+                  target_field: 'deep_value',
+                },
+              ],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [
+          {
+            message:
+              '{"level1": {"level2": {"level3": {"level4": {"level5": {"value": "found"}}}}}}',
+          },
+        ];
+        await testBed.ingest('ingest-json-extract-deep', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-deep');
+
+        await testBed.ingest('esql-json-extract-deep', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-deep', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ deep_value: 'found' }));
+      }
+    );
+
+    apiTest('should correctly extract empty string values', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'empty_field', target_field: 'empty_field' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"empty_field": ""}' }];
+      await testBed.ingest('ingest-json-extract-empty', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-empty');
+
+      await testBed.ingest('esql-json-extract-empty', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-empty', query);
+
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ empty_field: '' }));
+    });
+
+    apiTest(
+      'should correctly extract boolean false without converting to null',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'is_active', target_field: 'is_active', type: 'boolean' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"is_active": false}' }];
+        await testBed.ingest('ingest-json-extract-false', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-false');
+
+        await testBed.ingest('esql-json-extract-false', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-false', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ is_active: false }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract zero integer without treating as falsy',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'count', target_field: 'count', type: 'integer' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"count": 0}' }];
+        await testBed.ingest('ingest-json-extract-zero', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-zero');
+
+        await testBed.ingest('esql-json-extract-zero', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-zero', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 0 }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract negative numbers with double type',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [
+                { selector: 'temperature', target_field: 'temperature', type: 'double' },
+              ],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"temperature": -42.5}' }];
+        await testBed.ingest('ingest-json-extract-neg', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-neg');
+
+        await testBed.ingest('esql-json-extract-neg', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-neg', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ temperature: -42.5 }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract second array element with [1] selector',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'items[1]', target_field: 'second_item' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"items": ["first", "second", "third"]}' }];
+        await testBed.ingest('ingest-json-extract-arr1', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-arr1');
+
+        await testBed.ingest('esql-json-extract-arr1', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-arr1', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ second_item: 'second' }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract values with unicode characters',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'greeting', target_field: 'greeting' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"greeting": "こんにちは世界 🌍"}' }];
+        await testBed.ingest('ingest-json-extract-unicode', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-unicode');
+
+        await testBed.ingest('esql-json-extract-unicode', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-unicode', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(
+          expect.objectContaining({ greeting: 'こんにちは世界 🌍' })
+        );
+      }
+    );
+
+    apiTest(
+      'should correctly extract from multiple documents in batch',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'id', target_field: 'extracted_id', type: 'integer' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [
+          { message: '{"id": 1}', order: 1 },
+          { message: '{"id": 2}', order: 2 },
+          { message: '{"id": 3}', order: 3 },
+        ];
+        await testBed.ingest('ingest-json-extract-batch', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-batch');
+
+        await testBed.ingest('esql-json-extract-batch', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-batch', query);
+
+        expect(ingestResult).toHaveLength(3);
+        expect(esqlResult.documentsWithoutKeywords).toHaveLength(3);
+
+        const ingestSorted = [...ingestResult].sort((a: any, b: any) => a.order - b.order);
+        const esqlSorted = [...esqlResult.documentsWithoutKeywords].sort(
+          (a: any, b: any) => a.order - b.order
+        );
+
+        expect(ingestSorted).toStrictEqual(esqlSorted);
+        expect(ingestSorted[0]).toStrictEqual(expect.objectContaining({ extracted_id: 1 }));
+        expect(ingestSorted[1]).toStrictEqual(expect.objectContaining({ extracted_id: 2 }));
+        expect(ingestSorted[2]).toStrictEqual(expect.objectContaining({ extracted_id: 3 }));
+      }
+    );
+
+    apiTest('should correctly coerce string number to integer', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'string_num', target_field: 'parsed_num', type: 'integer' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"string_num": "42"}' }];
+      await testBed.ingest('ingest-json-extract-str2int', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-str2int');
+
+      await testBed.ingest('esql-json-extract-str2int', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-str2int', query);
+
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ parsed_num: 42 }));
+    });
+
+    apiTest('should correctly coerce string "true" to boolean', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'string_bool', target_field: 'parsed_bool', type: 'boolean' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"string_bool": "true"}' }];
+      await testBed.ingest('ingest-json-extract-str2bool', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-str2bool');
+
+      await testBed.ingest('esql-json-extract-str2bool', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-str2bool', query);
+
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ parsed_bool: true }));
+    });
+
+    apiTest(
+      'should handle ignore_missing: true when field is missing',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'value', target_field: 'value' }],
+              ignore_missing: true,
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ other_field: 'no message field here' }];
+        await testBed.ingest('ingest-json-extract-ignmiss', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-ignmiss');
+
+        await testBed.ingest('esql-json-extract-ignmiss', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-ignmiss', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0].value).toBeUndefined();
+        expect(esqlResult.documentsWithoutKeywords[0].value).toBeUndefined();
+      }
+    );
+
+    apiTest(
+      'should correctly extract with mixed bracket and dot notation',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [
+                { selector: "data['nested'].items[0].value", target_field: 'extracted' },
+              ],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"data": {"nested": {"items": [{"value": "found"}]}}}' }];
+        await testBed.ingest('ingest-json-extract-mixed', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-mixed');
+
+        await testBed.ingest('esql-json-extract-mixed', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-mixed', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ extracted: 'found' }));
+      }
+    );
+
+    apiTest('should correctly extract null JSON value', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'nullable', target_field: 'nullable' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"nullable": null}' }];
+      await testBed.ingest('ingest-json-extract-null', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-null');
+
+      await testBed.ingest('esql-json-extract-null', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-null', query);
+
+      expect(ingestResult[0].nullable).toBeUndefined();
+      expect(esqlResult.documentsWithoutKeywords[0].nullable).toBeNull();
+    });
+
+    apiTest('should correctly extract scientific notation numbers', async ({ testBed, esql }) => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'scientific', target_field: 'scientific', type: 'double' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpileIngestPipeline(streamlangDSL);
+      const { query } = transpileEsql(streamlangDSL);
+
+      const docs = [{ message: '{"scientific": 1.23e4}' }];
+      await testBed.ingest('ingest-json-extract-sci', docs, processors);
+      const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-sci');
+
+      await testBed.ingest('esql-json-extract-sci', docs);
+      const esqlResult = await esql.queryOnIndex('esql-json-extract-sci', query);
+
+      expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+      expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ scientific: 12300 }));
+    });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -1,0 +1,300 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import type { JsonExtractProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpileIngestPipeline, transpileEsql } from '@kbn/streamlang';
+import { streamlangApiTest as apiTest } from '../..';
+
+apiTest.describe(
+  'Cross-compatibility - JsonExtract Processor',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    // *** Compatible Cases ***
+    apiTest(
+      'should correctly extract a simple field from JSON string',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"user_id": "abc123"}' }];
+        await testBed.ingest('ingest-json-extract-basic', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-basic');
+
+        await testBed.ingest('esql-json-extract-basic', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-basic', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ user_id: 'abc123' }));
+      }
+    );
+
+    apiTest(
+      'should correctly extract multiple fields from JSON string',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [
+                { selector: 'user_id', target_field: 'user_id' },
+                { selector: 'status', target_field: 'event_status' },
+              ],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"user_id": "abc123", "status": "active"}' }];
+        await testBed.ingest('ingest-json-extract-multi', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-multi');
+
+        await testBed.ingest('esql-json-extract-multi', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-multi', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(
+          expect.objectContaining({
+            user_id: 'abc123',
+            event_status: 'active',
+          })
+        );
+      }
+    );
+
+    apiTest(
+      'should correctly extract nested fields using dot notation',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'metadata.client.ip', target_field: 'client_ip' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"metadata": {"client": {"ip": "192.168.1.1"}}}' }];
+        await testBed.ingest('ingest-json-extract-nested', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-nested');
+
+        await testBed.ingest('esql-json-extract-nested', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-nested', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(
+          expect.objectContaining({ client_ip: '192.168.1.1' })
+        );
+      }
+    );
+
+    apiTest(
+      'should support conditional extraction with where clause',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+              where: {
+                field: 'should_extract',
+                eq: 'yes',
+              },
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [
+          { message: '{"user_id": "abc123"}', should_extract: 'yes' },
+          { message: '{"user_id": "xyz789"}', should_extract: 'no' },
+        ];
+        await testBed.ingest('ingest-json-extract-conditional', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered(
+          'ingest-json-extract-conditional'
+        );
+
+        await testBed.ingest('esql-json-extract-conditional', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-conditional', query);
+
+        expect(ingestResult).toHaveLength(2);
+        expect(esqlResult.documents).toHaveLength(2);
+
+        const ingestDoc1 = ingestResult.find((d: any) => d.should_extract === 'yes');
+        const ingestDoc2 = ingestResult.find((d: any) => d.should_extract === 'no');
+        const esqlDoc1 = esqlResult.documentsWithoutKeywords.find(
+          (d: any) => d.should_extract === 'yes'
+        );
+        const esqlDoc2 = esqlResult.documentsWithoutKeywords.find(
+          (d: any) => d.should_extract === 'no'
+        );
+
+        expect(ingestDoc1).toStrictEqual(esqlDoc1);
+        expect(ingestDoc1).toStrictEqual(expect.objectContaining({ user_id: 'abc123' }));
+
+        expect(ingestDoc2?.user_id).toBeUndefined();
+        expect(esqlDoc2?.user_id).toBeNull();
+      }
+    );
+
+    // *** Template validation tests ***
+    [
+      {
+        templateType: '{{ }}',
+        field: '{{template_field}}',
+      },
+      {
+        templateType: '{{{ }}}',
+        field: '{{{template_field}}}',
+      },
+    ].forEach(({ templateType, field }) => {
+      apiTest(
+        `should consistently reject ${templateType} template syntax in both Ingest Pipeline and ES|QL transpilers`,
+        async () => {
+          const streamlangDSL: StreamlangDSL = {
+            steps: [
+              {
+                action: 'json_extract',
+                field,
+                extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+              } as JsonExtractProcessor,
+            ],
+          };
+
+          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(
+            'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
+          );
+          expect(() => transpileEsql(streamlangDSL)).toThrow(
+            'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
+          );
+        }
+      );
+    });
+
+    // *** Incompatible / Partially Compatible Cases ***
+
+    apiTest(
+      'should document type preservation difference: Ingest Pipeline preserves types, ES|QL returns keywords',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [
+                { selector: 'count', target_field: 'count' },
+                { selector: 'active', target_field: 'active' },
+              ],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"count": 42, "active": true}' }];
+        await testBed.ingest('ingest-json-extract-types', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-types');
+
+        await testBed.ingest('esql-json-extract-types', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-types', query);
+
+        // NOTE: BEHAVIORAL DIFFERENCE - Type preservation
+        // Ingest Pipeline: Preserves original JSON types (number, boolean)
+        // ES|QL: JSON_EXTRACT returns keyword type (strings)
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 42, active: true }));
+        expect(esqlResult.documents[0]).toStrictEqual(
+          expect.objectContaining({ count: '42', active: 'true' })
+        );
+      }
+    );
+
+    apiTest(
+      'should handle invalid JSON differently between transpilers',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const invalidJsonDocs = [{ message: 'not valid json' }];
+
+        // NOTE: BEHAVIORAL DIFFERENCE - Invalid JSON handling
+        // Ingest Pipeline: Script throws error when JSON parsing fails
+        // ES|QL: JSON_EXTRACT returns null for invalid JSON
+        const { errors } = await testBed.ingest(
+          'ingest-json-extract-fail',
+          invalidJsonDocs,
+          processors
+        );
+        expect(errors.length).toBeGreaterThan(0);
+
+        const validJsonDoc = { message: '{"user_id": "abc"}' };
+        await testBed.ingest('esql-json-extract-fail', [validJsonDoc, ...invalidJsonDocs]);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-fail', query);
+        // ES|QL query should include both documents but only the valid one has a value
+        expect(esqlResult.documents.length >= 1).toBe(true);
+      }
+    );
+
+    apiTest(
+      'should handle array index extraction in both transpilers',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'items[0].name', target_field: 'first_item' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"items": [{"name": "Apple"}, {"name": "Banana"}]}' }];
+        await testBed.ingest('ingest-json-extract-array', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-array');
+
+        await testBed.ingest('esql-json-extract-array', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-array', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ first_item: 'Apple' }));
+      }
+    );
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -195,6 +195,35 @@ apiTest.describe(
       );
     });
 
+    // *** JSON path validation tests ***
+    [
+      { selector: 'a..b', error: 'consecutive dots' },
+      { selector: 'a.', error: 'path cannot end with a dot' },
+      { selector: '.a', error: 'path cannot start with a dot' },
+      { selector: 'a[]', error: 'empty brackets' },
+      { selector: '$.....xyz', error: 'path cannot start with a dot' },
+      { selector: "$['unclosed", error: 'unterminated quoted key' },
+      { selector: 'a[01]', error: 'leading zeros are not allowed' },
+    ].forEach(({ selector, error }) => {
+      apiTest(
+        `should consistently reject invalid selector "${selector}" in both transpilers`,
+        async () => {
+          const streamlangDSL: StreamlangDSL = {
+            steps: [
+              {
+                action: 'json_extract',
+                field: 'message',
+                extractions: [{ selector, target_field: 'extracted' }],
+              } as JsonExtractProcessor,
+            ],
+          };
+
+          expect(() => transpileIngestPipeline(streamlangDSL)).toThrow(error);
+          expect(() => transpileEsql(streamlangDSL)).toThrow(error);
+        }
+      );
+    });
+
     // *** Type Casting Tests ***
 
     apiTest('should correctly cast extracted values to integer type', async ({ testBed, esql }) => {

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/json_extract.spec.ts
@@ -195,10 +195,122 @@ apiTest.describe(
       );
     });
 
-    // *** Incompatible / Partially Compatible Cases ***
+    // *** Type Casting Tests ***
 
     apiTest(
-      'should document type preservation difference: Ingest Pipeline preserves types, ES|QL returns keywords',
+      'should correctly cast extracted values to integer type',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'count', target_field: 'count', type: 'integer' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"count": 42}' }];
+        await testBed.ingest('ingest-json-extract-int', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-int');
+
+        await testBed.ingest('esql-json-extract-int', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-int', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 42 }));
+      }
+    );
+
+    apiTest(
+      'should correctly cast extracted values to boolean type',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'active', target_field: 'active', type: 'boolean' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"active": true}' }];
+        await testBed.ingest('ingest-json-extract-bool', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-bool');
+
+        await testBed.ingest('esql-json-extract-bool', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-bool', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ active: true }));
+      }
+    );
+
+    apiTest(
+      'should correctly cast extracted values to double type',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'price', target_field: 'price', type: 'double' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"price": 19.99}' }];
+        await testBed.ingest('ingest-json-extract-double', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-double');
+
+        await testBed.ingest('esql-json-extract-double', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-double', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ price: 19.99 }));
+      }
+    );
+
+    apiTest(
+      'should default to keyword type when no type specified',
+      async ({ testBed, esql }) => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'name', target_field: 'name' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpileIngestPipeline(streamlangDSL);
+        const { query } = transpileEsql(streamlangDSL);
+
+        const docs = [{ message: '{"name": "John"}' }];
+        await testBed.ingest('ingest-json-extract-default', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-default');
+
+        await testBed.ingest('esql-json-extract-default', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-default', query);
+
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ name: 'John' }));
+      }
+    );
+
+    apiTest(
+      'should correctly cast multiple extractions with different types',
       async ({ testBed, esql }) => {
         const streamlangDSL: StreamlangDSL = {
           steps: [
@@ -206,8 +318,9 @@ apiTest.describe(
               action: 'json_extract',
               field: 'message',
               extractions: [
-                { selector: 'count', target_field: 'count' },
-                { selector: 'active', target_field: 'active' },
+                { selector: 'count', target_field: 'count', type: 'integer' },
+                { selector: 'active', target_field: 'active', type: 'boolean' },
+                { selector: 'name', target_field: 'name', type: 'keyword' },
               ],
             } as JsonExtractProcessor,
           ],
@@ -216,22 +329,25 @@ apiTest.describe(
         const { processors } = transpileIngestPipeline(streamlangDSL);
         const { query } = transpileEsql(streamlangDSL);
 
-        const docs = [{ message: '{"count": 42, "active": true}' }];
-        await testBed.ingest('ingest-json-extract-types', docs, processors);
-        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-types');
+        const docs = [{ message: '{"count": 42, "active": true, "name": "Test"}' }];
+        await testBed.ingest('ingest-json-extract-multi-types', docs, processors);
+        const ingestResult = await testBed.getFlattenedDocsOrdered('ingest-json-extract-multi-types');
 
-        await testBed.ingest('esql-json-extract-types', docs);
-        const esqlResult = await esql.queryOnIndex('esql-json-extract-types', query);
+        await testBed.ingest('esql-json-extract-multi-types', docs);
+        const esqlResult = await esql.queryOnIndex('esql-json-extract-multi-types', query);
 
-        // NOTE: BEHAVIORAL DIFFERENCE - Type preservation
-        // Ingest Pipeline: Preserves original JSON types (number, boolean)
-        // ES|QL: JSON_EXTRACT returns keyword type (strings)
-        expect(ingestResult[0]).toStrictEqual(expect.objectContaining({ count: 42, active: true }));
-        expect(esqlResult.documents[0]).toStrictEqual(
-          expect.objectContaining({ count: '42', active: 'true' })
+        expect(ingestResult[0]).toStrictEqual(esqlResult.documentsWithoutKeywords[0]);
+        expect(ingestResult[0]).toStrictEqual(
+          expect.objectContaining({
+            count: 42,
+            active: true,
+            name: 'Test',
+          })
         );
       }
     );
+
+    // *** Incompatible / Partially Compatible Cases ***
 
     apiTest(
       'should handle invalid JSON differently between transpilers',

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/json_extract.spec.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import type { JsonExtractProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpileEsql as transpile } from '@kbn/streamlang';
+import { streamlangApiTest as apiTest } from '../..';
+
+apiTest.describe(
+  'Streamlang to ES|QL - JsonExtract Processor',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    apiTest(
+      'should extract a simple field from JSON string with JSON_EXTRACT',
+      async ({ testBed, esql }) => {
+        const indexName = 'stream-e2e-test-json-extract-basic';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { query } = transpile(streamlangDSL);
+
+        const docs = [{ message: '{"user_id": "abc123"}' }];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        expect(esqlResult.documents).toHaveLength(1);
+        expect(esqlResult.documents[0]).toStrictEqual(
+          expect.objectContaining({ user_id: 'abc123' })
+        );
+      }
+    );
+
+    apiTest('should extract multiple fields from JSON string', async ({ testBed, esql }) => {
+      const indexName = 'stream-e2e-test-json-extract-multiple';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'user_id', target_field: 'user_id' },
+              { selector: 'status', target_field: 'event_status' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { query } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user_id": "abc123", "status": "active"}' }];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(1);
+      expect(esqlResult.documents[0]).toStrictEqual(
+        expect.objectContaining({
+          user_id: 'abc123',
+          event_status: 'active',
+        })
+      );
+    });
+
+    apiTest('should extract nested fields using dot notation', async ({ testBed, esql }) => {
+      const indexName = 'stream-e2e-test-json-extract-nested';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'metadata.client.ip', target_field: 'client_ip' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { query } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"metadata": {"client": {"ip": "192.168.1.1"}}}' }];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(1);
+      expect(esqlResult.documents[0]).toStrictEqual(
+        expect.objectContaining({ client_ip: '192.168.1.1' })
+      );
+    });
+
+    apiTest(
+      'should handle ignore_missing: false (default) with WHERE filter',
+      async ({ testBed, esql }) => {
+        const indexName = 'stream-e2e-test-json-extract-no-ignore-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'message',
+              extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { query } = transpile(streamlangDSL);
+
+        const docWithField = { message: '{"user_id": "abc123"}', status: 'doc1' };
+        const docWithoutField = { status: 'doc2' };
+        const docs = [docWithField, docWithoutField];
+        await testBed.ingest(indexName, docs);
+        const esqlResult = await esql.queryOnIndex(indexName, query);
+
+        expect(esqlResult.documents).toHaveLength(1);
+        expect(esqlResult.documents[0]).toStrictEqual(
+          expect.objectContaining({ status: 'doc1', user_id: 'abc123' })
+        );
+      }
+    );
+
+    apiTest('should handle ignore_missing: true', async ({ testBed, esql }) => {
+      const indexName = 'stream-e2e-test-json-extract-ignore-missing';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            ignore_missing: true,
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { query } = transpile(streamlangDSL);
+
+      const docWithField = { message: '{"user_id": "abc123"}', status: 'doc1' };
+      const docWithoutField = { status: 'doc2' };
+      const docs = [docWithField, docWithoutField];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(2);
+      const doc1 = esqlResult.documents.find((d: any) => d.status === 'doc1');
+      const doc2 = esqlResult.documents.find((d: any) => d.status === 'doc2');
+      expect(doc1).toStrictEqual(expect.objectContaining({ user_id: 'abc123' }));
+      expect(doc2).toStrictEqual(expect.objectContaining({ user_id: null }));
+    });
+
+    apiTest('should extract conditionally with EVAL CASE', async ({ testBed, esql }) => {
+      const indexName = 'stream-e2e-test-json-extract-conditional';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            where: {
+              field: 'event.kind',
+              eq: 'test',
+            },
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { query } = transpile(streamlangDSL);
+
+      const docs = [
+        { message: '{"user_id": "abc123"}', event: { kind: 'test' }, status: 'doc1' },
+        { message: '{"user_id": "xyz789"}', event: { kind: 'production' }, status: 'doc2' },
+      ];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(2);
+
+      const doc1 = esqlResult.documents.find((d: any) => d.status === 'doc1');
+      expect(doc1).toStrictEqual(expect.objectContaining({ user_id: 'abc123' }));
+      expect(doc1?.['event.kind']).toBe('test');
+
+      const doc2 = esqlResult.documents.find((d: any) => d.status === 'doc2');
+      expect(doc2).toStrictEqual(expect.objectContaining({ user_id: null }));
+      expect(doc2?.['event.kind']).toBe('production');
+    });
+
+    apiTest('should extract using selector with $ root prefix', async ({ testBed, esql }) => {
+      const indexName = 'stream-e2e-test-json-extract-root-prefix';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: '$.user.name', target_field: 'username' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { query } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user": {"name": "John"}}' }];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+
+      expect(esqlResult.documents).toHaveLength(1);
+      expect(esqlResult.documents[0]).toStrictEqual(expect.objectContaining({ username: 'John' }));
+    });
+
+    apiTest('should reject Mustache template syntax {{ and {{{ in field names', async () => {
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: '{{field.name}}',
+            extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+      expect(() => transpile(streamlangDSL)).toThrow(
+        'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
+      );
+    });
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
@@ -162,7 +162,7 @@ apiTest.describe(
       expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ city: 'Seattle' }));
     });
 
-    apiTest('should preserve numeric types from JSON', async ({ testBed }) => {
+    apiTest('should cast numeric types from JSON when type is specified', async ({ testBed }) => {
       const indexName = 'streams-e2e-test-json-extract-numeric';
 
       const streamlangDSL: StreamlangDSL = {
@@ -171,8 +171,8 @@ apiTest.describe(
             action: 'json_extract',
             field: 'message',
             extractions: [
-              { selector: 'count', target_field: 'count' },
-              { selector: 'price', target_field: 'price' },
+              { selector: 'count', target_field: 'count', type: 'integer' },
+              { selector: 'price', target_field: 'price', type: 'double' },
             ],
           } as JsonExtractProcessor,
         ],
@@ -188,7 +188,7 @@ apiTest.describe(
       expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ count: 42, price: 19.99 }));
     });
 
-    apiTest('should preserve boolean types from JSON', async ({ testBed }) => {
+    apiTest('should cast boolean types from JSON when type is specified', async ({ testBed }) => {
       const indexName = 'streams-e2e-test-json-extract-boolean';
 
       const streamlangDSL: StreamlangDSL = {
@@ -197,8 +197,8 @@ apiTest.describe(
             action: 'json_extract',
             field: 'message',
             extractions: [
-              { selector: 'active', target_field: 'is_active' },
-              { selector: 'verified', target_field: 'is_verified' },
+              { selector: 'active', target_field: 'is_active', type: 'boolean' },
+              { selector: 'verified', target_field: 'is_verified', type: 'boolean' },
             ],
           } as JsonExtractProcessor,
         ],
@@ -325,7 +325,7 @@ apiTest.describe(
       expect((doc2 as Record<string, unknown>).user_id).toBeUndefined();
     });
 
-    apiTest('should handle complex JSON with mixed types', async ({ testBed }) => {
+    apiTest('should handle complex JSON with mixed types (type casting)', async ({ testBed }) => {
       const indexName = 'streams-e2e-test-json-extract-complex';
 
       const streamlangDSL: StreamlangDSL = {
@@ -336,7 +336,7 @@ apiTest.describe(
             extractions: [
               { selector: 'user.name', target_field: 'username' },
               { selector: 'tags[1]', target_field: 'second_tag' },
-              { selector: 'metadata.count', target_field: 'count' },
+              { selector: 'metadata.count', target_field: 'count', type: 'integer' },
             ],
           } as JsonExtractProcessor,
         ],

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/ingest_pipeline/json_extract.spec.ts
@@ -1,0 +1,393 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout/api';
+import type { JsonExtractProcessor, StreamlangDSL } from '@kbn/streamlang';
+import { transpile } from '@kbn/streamlang/src/transpilers/ingest_pipeline';
+import { streamlangApiTest as apiTest } from '../..';
+
+apiTest.describe(
+  'Streamlang to Ingest Pipeline - JsonExtract Processor',
+  { tag: ['@ess', '@svlOblt'] },
+  () => {
+    apiTest('should extract a simple field from JSON string', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-basic';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user_id": "abc123"}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(
+        expect.objectContaining({ 'user.id': 'abc123', message: '{"user_id": "abc123"}' })
+      );
+    });
+
+    apiTest('should extract multiple fields from JSON string', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-multiple';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'user_id', target_field: 'user.id' },
+              { selector: 'status', target_field: 'event.status' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user_id": "abc123", "status": "active"}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(
+        expect.objectContaining({
+          'user.id': 'abc123',
+          'event.status': 'active',
+        })
+      );
+    });
+
+    apiTest('should extract nested fields using dot notation', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-nested';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'metadata.client.ip', target_field: 'client_ip' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"metadata": {"client": {"ip": "192.168.1.1"}}}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ client_ip: '192.168.1.1' }));
+    });
+
+    apiTest('should extract using $ root selector', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-root';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: '$.user.name', target_field: 'username' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user": {"name": "John"}}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ username: 'John' }));
+    });
+
+    apiTest('should extract array element by index', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-array';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'items[0].name', target_field: 'first_item' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"items": [{"name": "Apple"}, {"name": "Banana"}]}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ first_item: 'Apple' }));
+    });
+
+    apiTest('should extract using bracket notation', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-bracket';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: "['user']['address']['city']", target_field: 'city' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user": {"address": {"city": "Seattle"}}}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ city: 'Seattle' }));
+    });
+
+    apiTest('should preserve numeric types from JSON', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-numeric';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'count', target_field: 'count' },
+              { selector: 'price', target_field: 'price' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"count": 42, "price": 19.99}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(expect.objectContaining({ count: 42, price: 19.99 }));
+    });
+
+    apiTest('should preserve boolean types from JSON', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-boolean';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'active', target_field: 'is_active' },
+              { selector: 'verified', target_field: 'is_verified' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"active": true, "verified": false}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(
+        expect.objectContaining({ is_active: true, is_verified: false })
+      );
+    });
+
+    apiTest('should fail if JSON parsing fails on invalid JSON', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-fail-invalid';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: 'not valid json' }];
+      const { errors } = await testBed.ingest(indexName, docs, processors);
+      expect(errors).toHaveLength(1);
+    });
+
+    apiTest(
+      'should ignore missing source field when ignore_missing is true',
+      async ({ testBed }) => {
+        const indexName = 'streams-e2e-test-json-extract-ignore-missing';
+
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: 'nonexistent',
+              extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+              ignore_missing: true,
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        const { processors } = transpile(streamlangDSL);
+
+        const docs = [{ message: 'some_value' }];
+        await testBed.ingest(indexName, docs, processors);
+
+        const ingestedDocs = await testBed.getDocs(indexName);
+        expect(ingestedDocs).toHaveLength(1);
+        const source = ingestedDocs[0];
+        expect(source).toStrictEqual(expect.objectContaining({ message: 'some_value' }));
+        expect((source as Record<string, unknown>).user).toBeUndefined();
+      }
+    );
+
+    apiTest('should not set target field when selector path not found', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-not-found';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'nonexistent.path', target_field: 'result' }],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [{ message: '{"user": "test"}' }];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect((ingestedDocs[0] as Record<string, unknown>).result).toBeUndefined();
+    });
+
+    apiTest('should extract conditionally with where condition', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-conditional';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [{ selector: 'user_id', target_field: 'user_id' }],
+            where: {
+              field: 'event.kind',
+              eq: 'test',
+            },
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [
+        { message: '{"user_id": "abc123"}', event: { kind: 'test' } },
+        { message: '{"user_id": "xyz789"}', event: { kind: 'production' } },
+      ];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getFlattenedDocs(indexName);
+      expect(ingestedDocs).toHaveLength(2);
+
+      const doc1 = ingestedDocs.find((d: any) => d['event.kind'] === 'test');
+      expect(doc1).toStrictEqual(
+        expect.objectContaining({ user_id: 'abc123', 'event.kind': 'test' })
+      );
+
+      const doc2 = ingestedDocs.find((d: any) => d['event.kind'] === 'production');
+      expect((doc2 as Record<string, unknown>).user_id).toBeUndefined();
+    });
+
+    apiTest('should handle complex JSON with mixed types', async ({ testBed }) => {
+      const indexName = 'streams-e2e-test-json-extract-complex';
+
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'json_extract',
+            field: 'message',
+            extractions: [
+              { selector: 'user.name', target_field: 'username' },
+              { selector: 'tags[1]', target_field: 'second_tag' },
+              { selector: 'metadata.count', target_field: 'count' },
+            ],
+          } as JsonExtractProcessor,
+        ],
+      };
+
+      const { processors } = transpile(streamlangDSL);
+
+      const docs = [
+        {
+          message:
+            '{"user": {"name": "Alice"}, "tags": ["a", "b", "c"], "metadata": {"count": 100}}',
+        },
+      ];
+      await testBed.ingest(indexName, docs, processors);
+
+      const ingestedDocs = await testBed.getDocs(indexName);
+      expect(ingestedDocs).toHaveLength(1);
+      expect(ingestedDocs[0]).toStrictEqual(
+        expect.objectContaining({
+          username: 'Alice',
+          second_tag: 'b',
+          count: 100,
+        })
+      );
+    });
+
+    [
+      {
+        templateField: 'host.{{field_name}}',
+        description: 'should reject {{ }} template syntax in field names',
+      },
+      {
+        templateField: 'host.{{{field_name}}}',
+        description: 'should reject {{{ }}} template syntax in field names',
+      },
+    ].forEach(({ templateField, description }) => {
+      apiTest(`${description}`, async () => {
+        const streamlangDSL: StreamlangDSL = {
+          steps: [
+            {
+              action: 'json_extract',
+              field: templateField,
+              extractions: [{ selector: 'user_id', target_field: 'user.id' }],
+            } as JsonExtractProcessor,
+          ],
+        };
+
+        expect(() => transpile(streamlangDSL)).toThrow(
+          'Mustache template syntax {{ }} or {{{ }}} is not allowed in field names'
+        );
+      });
+    });
+  }
+);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/actions/action_metadata.ts
@@ -808,6 +808,52 @@ export const ACTION_METADATA_MAP: Record<ProcessorType, ActionMetadata> = {
     ],
   },
 
+  json_extract: {
+    name: i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.name', {
+      defaultMessage: 'JSON Extract',
+    }),
+    description: i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.description', {
+      defaultMessage: 'Extract values from JSON strings using JSONPath-like selectors',
+    }),
+    usage: i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.usage', {
+      defaultMessage:
+        'Provide a `field` containing the JSON string and an array of `extractions` with `selector` (JSONPath-like path) and `target_field` pairs to extract specific values.',
+    }),
+    examples: [
+      {
+        description: i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.examples.simple', {
+          defaultMessage: 'Extract a simple top-level field',
+        }),
+        yaml: `- action: json_extract
+  field: message
+  extractions:
+    - selector: user_id
+      target_field: user.id`,
+      },
+      {
+        description: i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.examples.nested', {
+          defaultMessage: 'Extract nested values using dot notation',
+        }),
+        yaml: `- action: json_extract
+  field: message
+  extractions:
+    - selector: "$.metadata.client.ip"
+      target_field: client_ip
+    - selector: "items[0].name"
+      target_field: first_item_name`,
+      },
+    ],
+    tips: [
+      i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.tips.selector', {
+        defaultMessage:
+          "Selectors support dot notation (user.name), bracket notation (['user']['name']), and array indices (items[0])",
+      }),
+      i18n.translate('xpack.streamlang.actionMetadata.jsonExtract.tips.root', {
+        defaultMessage: 'The $ root selector is optional and can be omitted',
+      }),
+    ],
+  },
+
   manual_ingest_pipeline: {
     name: i18n.translate('xpack.streamlang.actionMetadata.manualIngestPipeline.name', {
       defaultMessage: 'Manual Ingest Pipeline',

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
@@ -1257,6 +1257,17 @@ Object {
                         "minLength": 1,
                         "type": "string",
                       },
+                      "type": Object {
+                        "description": "Data type for the extracted value. Defaults to \\"keyword\\". Ensures consistent types across transpilers.",
+                        "enum": Array [
+                          "keyword",
+                          "integer",
+                          "long",
+                          "double",
+                          "boolean",
+                        ],
+                        "type": "string",
+                      },
                     },
                     "required": Array [
                       "selector",
@@ -3510,6 +3521,17 @@ Object {
                         "target_field": Object {
                           "description": "Target field to store the extracted value",
                           "minLength": 1,
+                          "type": "string",
+                        },
+                        "type": Object {
+                          "description": "Data type for the extracted value. Defaults to \\"keyword\\". Ensures consistent types across transpilers.",
+                          "enum": Array [
+                            "keyword",
+                            "integer",
+                            "long",
+                            "double",
+                            "boolean",
+                          ],
                           "type": "string",
                         },
                       },

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
@@ -1226,6 +1226,79 @@ Object {
             },
             Object {
               "additionalProperties": false,
+              "description": "Extract values from JSON strings using JSONPath-like selectors",
+              "properties": Object {
+                "action": Object {
+                  "const": "json_extract",
+                  "type": "string",
+                },
+                "customIdentifier": Object {
+                  "description": "Custom identifier to correlate this processor across outputs",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "description": Object {
+                  "description": "Human-readable notes about this processor step",
+                  "type": "string",
+                },
+                "extractions": Object {
+                  "description": "List of extraction specifications",
+                  "items": Object {
+                    "additionalProperties": false,
+                    "description": "A single extraction specification",
+                    "properties": Object {
+                      "selector": Object {
+                        "description": "JSONPath-like selector to extract value (e.g., \\"user.id\\", \\"$.metadata.client.ip\\", \\"items[0].name\\")",
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                      "target_field": Object {
+                        "description": "Target field to store the extracted value",
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "selector",
+                      "target_field",
+                    ],
+                    "type": "object",
+                  },
+                  "minItems": 1,
+                  "type": "array",
+                },
+                "field": Object {
+                  "description": "Source field containing the JSON string to parse",
+                  "minLength": 1,
+                  "type": "string",
+                },
+                "ignore_failure": Object {
+                  "description": "Continue pipeline execution if this processor fails",
+                  "type": "boolean",
+                },
+                "ignore_missing": Object {
+                  "description": "Skip processing when source field is missing",
+                  "type": "boolean",
+                },
+                "where": Object {
+                  "allOf": Array [
+                    Object {
+                      "$ref": "#/definitions/__schema1",
+                    },
+                  ],
+                  "description": "Conditional expression controlling whether this processor runs",
+                },
+              },
+              "required": Array [
+                "action",
+                "field",
+                "extractions",
+              ],
+              "title": "JSON Extract",
+              "type": "object",
+            },
+            Object {
+              "additionalProperties": false,
               "description": "Execute raw Elasticsearch ingest processors directly",
               "properties": Object {
                 "action": Object {
@@ -1307,6 +1380,7 @@ Object {
                 "sort",
                 "convert",
                 "concat",
+                "json_extract",
                 "manual_ingest_pipeline",
               ],
               "type": "string",
@@ -3407,6 +3481,79 @@ Object {
               },
               Object {
                 "additionalProperties": false,
+                "description": "Extract values from JSON strings using JSONPath-like selectors",
+                "properties": Object {
+                  "action": Object {
+                    "const": "json_extract",
+                    "type": "string",
+                  },
+                  "customIdentifier": Object {
+                    "description": "Custom identifier to correlate this processor across outputs",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "description": Object {
+                    "description": "Human-readable notes about this processor step",
+                    "type": "string",
+                  },
+                  "extractions": Object {
+                    "description": "List of extraction specifications",
+                    "items": Object {
+                      "additionalProperties": false,
+                      "description": "A single extraction specification",
+                      "properties": Object {
+                        "selector": Object {
+                          "description": "JSONPath-like selector to extract value (e.g., \\"user.id\\", \\"$.metadata.client.ip\\", \\"items[0].name\\")",
+                          "minLength": 1,
+                          "type": "string",
+                        },
+                        "target_field": Object {
+                          "description": "Target field to store the extracted value",
+                          "minLength": 1,
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "selector",
+                        "target_field",
+                      ],
+                      "type": "object",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                  },
+                  "field": Object {
+                    "description": "Source field containing the JSON string to parse",
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "ignore_failure": Object {
+                    "description": "Continue pipeline execution if this processor fails",
+                    "type": "boolean",
+                  },
+                  "ignore_missing": Object {
+                    "description": "Skip processing when source field is missing",
+                    "type": "boolean",
+                  },
+                  "where": Object {
+                    "allOf": Array [
+                      Object {
+                        "$ref": "#/definitions/__schema1",
+                      },
+                    ],
+                    "description": "Conditional expression controlling whether this processor runs",
+                  },
+                },
+                "required": Array [
+                  "action",
+                  "field",
+                  "extractions",
+                ],
+                "title": "JSON Extract",
+                "type": "object",
+              },
+              Object {
+                "additionalProperties": false,
                 "description": "Execute raw Elasticsearch ingest processors directly",
                 "properties": Object {
                   "action": Object {
@@ -3488,6 +3635,7 @@ Object {
                   "sort",
                   "convert",
                   "concat",
+                  "json_extract",
                   "manual_ingest_pipeline",
                 ],
                 "type": "string",

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/conversions.ts
@@ -32,6 +32,7 @@ import type {
   SortProcessor,
   ConcatProcessor,
   NetworkDirectionProcessor,
+  JsonExtractProcessor,
 } from '../../../types/processors';
 import { type StreamlangProcessorDefinition } from '../../../types/processors';
 import { convertRenameProcessorToESQL } from './processors/rename';
@@ -53,6 +54,7 @@ import { convertSplitProcessorToESQL } from './processors/split';
 import { convertSortProcessorToESQL } from './processors/sort';
 import { convertConcatProcessorToESQL } from './processors/concat';
 import { convertNetworkDirectionProcessorToESQL } from './processors/network_direction';
+import { convertJsonExtractProcessorToESQL } from './processors/json_extract';
 
 function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLAstCommand[] | null {
   switch (processor.action) {
@@ -121,6 +123,9 @@ function convertProcessorToESQL(processor: StreamlangProcessorDefinition): ESQLA
 
     case 'network_direction':
       return convertNetworkDirectionProcessorToESQL(processor as NetworkDirectionProcessor);
+
+    case 'json_extract':
+      return convertJsonExtractProcessorToESQL(processor as JsonExtractProcessor);
 
     case 'manual_ingest_pipeline':
       return [

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
@@ -6,30 +6,100 @@
  */
 
 import { Builder } from '@elastic/esql';
-import type { ESQLAstCommand } from '@elastic/esql/types';
-import type { JsonExtractProcessor } from '../../../../types/processors';
+import type { ESQLAstCommand, ESQLAstExpression } from '@elastic/esql/types';
+import type {
+  JsonExtractProcessor,
+  JsonExtraction,
+  JsonExtractType,
+} from '../../../../types/processors';
 import { buildIgnoreMissingFilter } from './common';
 import { conditionToESQLAst } from '../condition_to_esql';
+
+/**
+ * Resolves the ES|QL type conversion function name for a given JsonExtractType.
+ * Since JSON_EXTRACT returns keyword, we need to cast to the desired type.
+ *
+ * @param type - The target type for the extraction
+ * @returns The ES|QL function name for type conversion, or null for keyword (no conversion needed)
+ */
+function resolveTypeConversionFunction(type: JsonExtractType): string | null {
+  switch (type) {
+    case 'integer':
+      return 'TO_INTEGER';
+    case 'long':
+      return 'TO_LONG';
+    case 'double':
+      return 'TO_DOUBLE';
+    case 'boolean':
+      return 'TO_BOOLEAN';
+    case 'keyword':
+    default:
+      return null;
+  }
+}
+
+/**
+ * Wraps a JSON_EXTRACT expression with type conversion if needed.
+ *
+ * @param jsonExtractExpr - The JSON_EXTRACT function expression
+ * @param type - The target type (defaults to 'keyword')
+ * @returns The expression, optionally wrapped in a type conversion function
+ */
+function applyTypeConversion(
+  jsonExtractExpr: ESQLAstExpression,
+  type: JsonExtractType = 'keyword'
+): ESQLAstExpression {
+  const conversionFunc = resolveTypeConversionFunction(type);
+  if (!conversionFunc) {
+    return jsonExtractExpr;
+  }
+  return Builder.expression.func.call(conversionFunc, [jsonExtractExpr]);
+}
+
+/**
+ * Builds the extraction expression for a single extraction configuration.
+ *
+ * @param fromColumn - The source column containing the JSON string
+ * @param extraction - The extraction specification
+ * @returns The expression for extracting and optionally casting the value
+ */
+function buildExtractionExpression(
+  fromColumn: ESQLAstExpression,
+  extraction: JsonExtraction
+): ESQLAstExpression {
+  const selectorLiteral = Builder.expression.literal.string(extraction.selector);
+  const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
+    fromColumn,
+    selectorLiteral,
+  ]);
+  return applyTypeConversion(jsonExtractFunction, extraction.type ?? 'keyword');
+}
 
 /**
  * Converts a Streamlang JsonExtractProcessor into a list of ES|QL AST commands.
  *
  * For unconditional extraction (no 'where' or 'where: always'):
- *   Uses EVAL with JSON_EXTRACT() function for each extraction:
- *   EVAL target_field1 = JSON_EXTRACT(field, "selector1"), target_field2 = JSON_EXTRACT(field, "selector2")
+ *   Uses EVAL with JSON_EXTRACT() function for each extraction, wrapped in type conversion:
+ *   EVAL target_field1 = TO_INTEGER(JSON_EXTRACT(field, "selector1")), target_field2 = JSON_EXTRACT(field, "selector2")
  *
  * For conditional extraction (with 'where' condition):
  *   Uses EVAL with CASE for each extraction:
- *   EVAL target_field = CASE(<condition>, JSON_EXTRACT(field, "selector"), NULL)
+ *   EVAL target_field = CASE(<condition>, TO_INTEGER(JSON_EXTRACT(field, "selector")), NULL)
+ *
+ * Type conversion:
+ * - keyword (default): No conversion needed (JSON_EXTRACT returns keyword)
+ * - integer: TO_INTEGER(JSON_EXTRACT(...))
+ * - long: TO_LONG(JSON_EXTRACT(...))
+ * - double: TO_DOUBLE(JSON_EXTRACT(...))
+ * - boolean: TO_BOOLEAN(JSON_EXTRACT(...))
  *
  * Filters applied for Ingest Pipeline parity:
  * - When `ignore_missing: false`: `WHERE NOT(field IS NULL)` filters missing fields
  *
  * Limitations:
- * - ES|QL's JSON_EXTRACT returns keyword type, while Ingest Pipeline preserves types
  * - JSON_EXTRACT does not support wildcards, recursive descent, array slicing, filter expressions, or negative array indices
  *
- * @example Unconditional:
+ * @example Unconditional with type:
  *    ```typescript
  *    const streamlangDSL: StreamlangDSL = {
  *      steps: [
@@ -38,7 +108,7 @@ import { conditionToESQLAst } from '../condition_to_esql';
  *          field: 'message',
  *          extractions: [
  *            { selector: 'user.id', target_field: 'user_id' },
- *            { selector: 'metadata.client.ip', target_field: 'client_ip' },
+ *            { selector: 'count', target_field: 'event_count', type: 'integer' },
  *          ],
  *        } as JsonExtractProcessor,
  *      ],
@@ -47,7 +117,7 @@ import { conditionToESQLAst } from '../condition_to_esql';
  *
  *    Generates:
  *    ```txt
- *    | EVAL `user_id` = JSON_EXTRACT(`message`, "user.id"), `client_ip` = JSON_EXTRACT(`message`, "metadata.client.ip")
+ *    | EVAL `user_id` = JSON_EXTRACT(`message`, "user.id"), `event_count` = TO_INTEGER(JSON_EXTRACT(`message`, "count"))
  *    ```
  *
  * @example Conditional:
@@ -58,7 +128,7 @@ import { conditionToESQLAst } from '../condition_to_esql';
  *          action: 'json_extract',
  *          field: 'message',
  *          extractions: [
- *            { selector: 'user.id', target_field: 'user_id' },
+ *            { selector: 'user.id', target_field: 'user_id', type: 'keyword' },
  *          ],
  *          where: { field: 'status', eq: 'active' },
  *        } as JsonExtractProcessor,
@@ -90,15 +160,11 @@ export function convertJsonExtractProcessorToESQL(
 
     const assignments = extractions.map((extraction) => {
       const targetColumn = Builder.expression.column(extraction.target_field);
-      const selectorLiteral = Builder.expression.literal.string(extraction.selector);
-      const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
-        fromColumn,
-        selectorLiteral,
-      ]);
+      const extractionExpr = buildExtractionExpression(fromColumn, extraction);
 
       const caseExpression = Builder.expression.func.call('CASE', [
         conditionExpression,
-        jsonExtractFunction,
+        extractionExpr,
         Builder.expression.literal.nil(),
       ]);
 
@@ -114,13 +180,9 @@ export function convertJsonExtractProcessorToESQL(
   } else {
     const assignments = extractions.map((extraction) => {
       const targetColumn = Builder.expression.column(extraction.target_field);
-      const selectorLiteral = Builder.expression.literal.string(extraction.selector);
-      const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
-        fromColumn,
-        selectorLiteral,
-      ]);
+      const extractionExpr = buildExtractionExpression(fromColumn, extraction);
 
-      return Builder.expression.func.binary('=', [targetColumn, jsonExtractFunction]);
+      return Builder.expression.func.binary('=', [targetColumn, extractionExpr]);
     });
 
     const evalCommand = Builder.command({

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../../types/processors';
 import { buildIgnoreMissingFilter } from './common';
 import { conditionToESQLAst } from '../condition_to_esql';
+import { validateJsonPath } from '../../shared/json_path_parser';
 
 /**
  * Resolves the ES|QL type conversion function name for a given JsonExtractType.
@@ -58,15 +59,18 @@ function applyTypeConversion(
 
 /**
  * Builds the extraction expression for a single extraction configuration.
+ * Validates the selector syntax before building the expression.
  *
  * @param fromColumn - The source column containing the JSON string
  * @param extraction - The extraction specification
  * @returns The expression for extracting and optionally casting the value
+ * @throws {JsonPathParseError} If the selector has invalid syntax
  */
 function buildExtractionExpression(
   fromColumn: ESQLAstExpression,
   extraction: JsonExtraction
 ): ESQLAstExpression {
+  validateJsonPath(extraction.selector);
   const selectorLiteral = Builder.expression.literal.string(extraction.selector);
   const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
     fromColumn,

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Builder } from '@elastic/esql';
+import type { ESQLAstCommand } from '@elastic/esql/types';
+import type { JsonExtractProcessor } from '../../../../types/processors';
+import { buildIgnoreMissingFilter } from './common';
+import { conditionToESQLAst } from '../condition_to_esql';
+
+/**
+ * Converts a Streamlang JsonExtractProcessor into a list of ES|QL AST commands.
+ *
+ * For unconditional extraction (no 'where' or 'where: always'):
+ *   Uses EVAL with JSON_EXTRACT() function for each extraction:
+ *   EVAL target_field1 = JSON_EXTRACT(field, "selector1"), target_field2 = JSON_EXTRACT(field, "selector2")
+ *
+ * For conditional extraction (with 'where' condition):
+ *   Uses EVAL with CASE for each extraction:
+ *   EVAL target_field = CASE(<condition>, JSON_EXTRACT(field, "selector"), NULL)
+ *
+ * Filters applied for Ingest Pipeline parity:
+ * - When `ignore_missing: false`: `WHERE NOT(field IS NULL)` filters missing fields
+ *
+ * Limitations:
+ * - ES|QL's JSON_EXTRACT returns keyword type, while Ingest Pipeline preserves types
+ * - JSON_EXTRACT does not support wildcards, recursive descent, array slicing, filter expressions, or negative array indices
+ *
+ * @example Unconditional:
+ *    ```typescript
+ *    const streamlangDSL: StreamlangDSL = {
+ *      steps: [
+ *        {
+ *          action: 'json_extract',
+ *          field: 'message',
+ *          extractions: [
+ *            { selector: 'user.id', target_field: 'user_id' },
+ *            { selector: 'metadata.client.ip', target_field: 'client_ip' },
+ *          ],
+ *        } as JsonExtractProcessor,
+ *      ],
+ *    };
+ *    ```
+ *
+ *    Generates:
+ *    ```txt
+ *    | EVAL `user_id` = JSON_EXTRACT(`message`, "user.id"), `client_ip` = JSON_EXTRACT(`message`, "metadata.client.ip")
+ *    ```
+ *
+ * @example Conditional:
+ *    ```typescript
+ *    const streamlangDSL: StreamlangDSL = {
+ *      steps: [
+ *        {
+ *          action: 'json_extract',
+ *          field: 'message',
+ *          extractions: [
+ *            { selector: 'user.id', target_field: 'user_id' },
+ *          ],
+ *          where: { field: 'status', eq: 'active' },
+ *        } as JsonExtractProcessor,
+ *      ],
+ *    };
+ *    ```
+ *
+ *    Generates:
+ *    ```txt
+ *    | EVAL `user_id` = CASE(status == "active", JSON_EXTRACT(`message`, "user.id"), NULL)
+ *    ```
+ */
+export function convertJsonExtractProcessorToESQL(
+  processor: JsonExtractProcessor
+): ESQLAstCommand[] {
+  const { field, extractions, ignore_missing = false } = processor;
+
+  const commands: ESQLAstCommand[] = [];
+
+  const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, field);
+  if (missingFieldFilter) {
+    commands.push(missingFieldFilter);
+  }
+
+  const fromColumn = Builder.expression.column(field);
+
+  if ('where' in processor && processor.where && !('always' in processor.where)) {
+    const conditionExpression = conditionToESQLAst(processor.where);
+
+    const assignments = extractions.map((extraction) => {
+      const targetColumn = Builder.expression.column(extraction.target_field);
+      const selectorLiteral = Builder.expression.literal.string(extraction.selector);
+      const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
+        fromColumn,
+        selectorLiteral,
+      ]);
+
+      const caseExpression = Builder.expression.func.call('CASE', [
+        conditionExpression,
+        jsonExtractFunction,
+        Builder.expression.literal.nil(),
+      ]);
+
+      return Builder.expression.func.binary('=', [targetColumn, caseExpression]);
+    });
+
+    const evalCommand = Builder.command({
+      name: 'eval',
+      args: assignments,
+    });
+
+    commands.push(evalCommand);
+  } else {
+    const assignments = extractions.map((extraction) => {
+      const targetColumn = Builder.expression.column(extraction.target_field);
+      const selectorLiteral = Builder.expression.literal.string(extraction.selector);
+      const jsonExtractFunction = Builder.expression.func.call('JSON_EXTRACT', [
+        fromColumn,
+        selectorLiteral,
+      ]);
+
+      return Builder.expression.func.binary('=', [targetColumn, jsonExtractFunction]);
+    });
+
+    const evalCommand = Builder.command({
+      name: 'eval',
+      args: assignments,
+    });
+
+    commands.push(evalCommand);
+  }
+
+  return commands;
+}

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/json_extract.ts
@@ -152,15 +152,12 @@ export function convertJsonExtractProcessorToESQL(
 
   const commands: ESQLAstCommand[] = [];
 
-  const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, field);
-  if (missingFieldFilter) {
-    commands.push(missingFieldFilter);
-  }
-
   const fromColumn = Builder.expression.column(field);
+  const hasConditionalWhere =
+    'where' in processor && processor.where && !('always' in processor.where);
 
-  if ('where' in processor && processor.where && !('always' in processor.where)) {
-    const conditionExpression = conditionToESQLAst(processor.where);
+  if (hasConditionalWhere) {
+    const conditionExpression = conditionToESQLAst(processor.where!);
 
     const assignments = extractions.map((extraction) => {
       const targetColumn = Builder.expression.column(extraction.target_field);
@@ -182,6 +179,11 @@ export function convertJsonExtractProcessorToESQL(
 
     commands.push(evalCommand);
   } else {
+    const missingFieldFilter = buildIgnoreMissingFilter(ignore_missing, field);
+    if (missingFieldFilter) {
+      commands.push(missingFieldFilter);
+    }
+
     const assignments = extractions.map((extraction) => {
       const targetColumn = Builder.expression.column(extraction.target_field);
       const extractionExpr = buildExtractionExpression(fromColumn, extraction);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/conversions.ts
@@ -24,6 +24,7 @@ import type { IngestPipelineTranspilationOptions } from '.';
 import { processJoinProcessor } from './processors/join_processor';
 import { processConcatProcessor } from './processors/concat_processor';
 import { processSortProcessor } from './processors/sort_processor';
+import { processJsonExtractProcessor } from './processors/json_extract_processor';
 
 export function convertStreamlangDSLActionsToIngestPipelineProcessors(
   actionSteps: StreamlangProcessorDefinition[],
@@ -98,6 +99,14 @@ export function convertStreamlangDSLActionsToIngestPipelineProcessors(
       return processSortProcessor(
         processorWithCompiledConditions as Parameters<typeof processSortProcessor>[0]
       );
+    }
+
+    if (action === 'json_extract') {
+      return [
+        processJsonExtractProcessor(
+          processorWithCompiledConditions as Parameters<typeof processJsonExtractProcessor>[0]
+        ),
+      ];
     }
 
     return applyPreProcessing(action, processorWithCompiledConditions as IngestPipelineProcessor);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
@@ -6,7 +6,11 @@
  */
 
 import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
-import type { JsonExtractProcessor, JsonExtraction } from '../../../../types/processors';
+import type {
+  JsonExtractProcessor,
+  JsonExtraction,
+  JsonExtractType,
+} from '../../../../types/processors';
 import { painlessFieldAccessor, painlessFieldAssignment } from '../../../../types/utils';
 
 /**
@@ -114,8 +118,33 @@ function generateTraversalExpression(varName: string, parts: string[]): string {
 }
 
 /**
+ * Generates Painless code to cast a value to the specified type.
+ * Returns an expression that converts the extracted value to the target type.
+ *
+ * @param varName - The variable name holding the extracted value
+ * @param type - The target type (keyword, integer, long, double, boolean)
+ * @returns Painless expression that casts the value
+ */
+function generateTypeCast(varName: string, type: JsonExtractType): string {
+  switch (type) {
+    case 'integer':
+      return `(${varName} instanceof Number ? ((Number)${varName}).intValue() : Integer.parseInt(${varName}.toString()))`;
+    case 'long':
+      return `(${varName} instanceof Number ? ((Number)${varName}).longValue() : Long.parseLong(${varName}.toString()))`;
+    case 'double':
+      return `(${varName} instanceof Number ? ((Number)${varName}).doubleValue() : Double.parseDouble(${varName}.toString()))`;
+    case 'boolean':
+      return `(${varName} instanceof Boolean ? (Boolean)${varName} : Boolean.parseBoolean(${varName}.toString()))`;
+    case 'keyword':
+    default:
+      return `${varName}.toString()`;
+  }
+}
+
+/**
  * Generates the Painless script source for JSON extraction.
  * Uses `Processors.json()` which is available in Painless ingest pipeline context.
+ * Applies type casting to ensure consistent output types.
  */
 function generateJsonExtractScript(
   field: string,
@@ -142,17 +171,13 @@ function generateJsonExtractScript(
     const parts = parseSelector(extraction.selector);
     const traversalExpr = generateTraversalExpression('parsed', parts);
     const targetAssignment = painlessFieldAssignment(extraction.target_field);
+    const varName = `extracted_${parts.join('_').replace(/[^a-zA-Z0-9_]/g, '_')}`;
+    const targetType = extraction.type ?? 'keyword';
 
-    lines.push(
-      `def extracted_${parts.join('_').replace(/[^a-zA-Z0-9_]/g, '_')} = ${traversalExpr};`
-    );
-    lines.push(
-      `if (extracted_${parts
-        .join('_')
-        .replace(/[^a-zA-Z0-9_]/g, '_')} != null) { ${targetAssignment} = extracted_${parts
-        .join('_')
-        .replace(/[^a-zA-Z0-9_]/g, '_')}; }`
-    );
+    lines.push(`def ${varName} = ${traversalExpr};`);
+
+    const typeCastExpr = generateTypeCast(varName, targetType);
+    lines.push(`if (${varName} != null) { ${targetAssignment} = ${typeCastExpr}; }`);
   }
 
   return lines.join('\n');

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { JsonExtractProcessor, JsonExtraction } from '../../../../types/processors';
+import { painlessFieldAccessor, painlessFieldAssignment } from '../../../../types/utils';
+
+/**
+ * Normalizes a JSONPath-like selector to a format suitable for Painless traversal.
+ * Supports:
+ * - Dot notation: user.address.city
+ * - Bracket notation: ['user']['address']['city']
+ * - Array indices: items[0]
+ * - Optional $ root selector (ignored)
+ *
+ * @example
+ * "$.user.address" -> ["user", "address"]
+ * "user.address.city" -> ["user", "address", "city"]
+ * "items[0].name" -> ["items", "0", "name"]
+ * "['user']['name']" -> ["user", "name"]
+ */
+function parseSelector(selector: string): string[] {
+  let s = selector.trim();
+
+  // Remove leading $ if present
+  if (s.startsWith('$.')) {
+    s = s.slice(2);
+  } else if (s.startsWith('$')) {
+    s = s.slice(1);
+  }
+
+  const parts: string[] = [];
+  let current = '';
+  let i = 0;
+
+  while (i < s.length) {
+    const char = s[i];
+
+    if (char === '.') {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      i++;
+    } else if (char === '[') {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      i++;
+      // Find closing bracket
+      const start = i;
+      while (i < s.length && s[i] !== ']') {
+        i++;
+      }
+      let key = s.slice(start, i);
+      // Remove quotes if present (bracket notation like ['key'])
+      if (
+        (key.startsWith("'") && key.endsWith("'")) ||
+        (key.startsWith('"') && key.endsWith('"'))
+      ) {
+        key = key.slice(1, -1);
+      }
+      parts.push(key);
+      i++; // Skip closing bracket
+    } else {
+      current += char;
+      i++;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+/**
+ * Generates Painless code to traverse a parsed JSON object and extract a value.
+ * Uses defensive null checks at each level.
+ *
+ * @param varName - The variable name holding the parsed JSON
+ * @param parts - The path parts to traverse
+ * @returns Painless expression that evaluates to the value or null
+ */
+function generateTraversalExpression(varName: string, parts: string[]): string {
+  if (parts.length === 0) {
+    return varName;
+  }
+
+  // Build a chain of safe navigation
+  // For each part, we check if current is a Map (object) or List (array)
+  // and access accordingly
+  let expr = varName;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const isNumeric = /^\d+$/.test(part);
+
+    if (isNumeric) {
+      // Array index access
+      expr = `(${expr} instanceof List && ((List)${expr}).size() > ${part} ? ((List)${expr}).get(${part}) : null)`;
+    } else {
+      // Object key access
+      expr = `(${expr} instanceof Map ? ((Map)${expr}).get("${part}") : null)`;
+    }
+  }
+
+  return expr;
+}
+
+/**
+ * Generates the Painless script source for JSON extraction.
+ * Uses `Processors.json()` which is available in Painless ingest pipeline context.
+ */
+function generateJsonExtractScript(
+  field: string,
+  extractions: JsonExtraction[],
+  ignoreMissing: boolean
+): string {
+  const lines: string[] = [];
+
+  // Read the source field
+  const sourceAccess = painlessFieldAccessor(field);
+
+  // Start with null check for the source field
+  lines.push(`def jsonStr = ${sourceAccess};`);
+
+  if (ignoreMissing) {
+    lines.push('if (jsonStr == null) { return; }');
+  }
+
+  // Parse JSON using Painless Processors.json() method available in ingest pipeline context
+  lines.push('def parsed = Processors.json(jsonStr);');
+
+  // Generate extraction for each selector
+  for (const extraction of extractions) {
+    const parts = parseSelector(extraction.selector);
+    const traversalExpr = generateTraversalExpression('parsed', parts);
+    const targetAssignment = painlessFieldAssignment(extraction.target_field);
+
+    lines.push(
+      `def extracted_${parts.join('_').replace(/[^a-zA-Z0-9_]/g, '_')} = ${traversalExpr};`
+    );
+    lines.push(
+      `if (extracted_${parts
+        .join('_')
+        .replace(/[^a-zA-Z0-9_]/g, '_')} != null) { ${targetAssignment} = extracted_${parts
+        .join('_')
+        .replace(/[^a-zA-Z0-9_]/g, '_')}; }`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Converts a JsonExtractProcessor to an Ingest Pipeline script processor.
+ *
+ * @example
+ * Input:
+ *   {
+ *     action: 'json_extract',
+ *     field: 'message',
+ *     extractions: [
+ *       { selector: 'user_id', target_field: 'user.id' },
+ *       { selector: '$.metadata.client.ip', target_field: 'client_ip' }
+ *     ]
+ *   }
+ *
+ * Output:
+ *   { script: { lang: 'painless', source: '...' } }
+ */
+export function processJsonExtractProcessor(
+  processor: Omit<JsonExtractProcessor, 'where' | 'action'> & { if?: string; tag?: string }
+): IngestProcessorContainer {
+  const { field, extractions, ignore_missing = false } = processor;
+
+  const source = generateJsonExtractScript(field, extractions, ignore_missing);
+
+  const scriptProcessor: IngestProcessorContainer = {
+    script: {
+      lang: 'painless',
+      source,
+    },
+  };
+
+  if (scriptProcessor.script) {
+    (
+      scriptProcessor.script as Record<string, unknown>
+    ).description = `JsonExtract processor: extract from ${field}`;
+  }
+
+  if (processor.tag && scriptProcessor.script) {
+    (scriptProcessor.script as Record<string, unknown>).tag = processor.tag;
+  }
+
+  if (processor.if && scriptProcessor.script) {
+    (scriptProcessor.script as Record<string, unknown>).if = processor.if;
+  }
+
+  if (processor.ignore_failure === true && scriptProcessor.script) {
+    (scriptProcessor.script as Record<string, unknown>).ignore_failure = true;
+  }
+
+  return scriptProcessor;
+}

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
@@ -12,77 +12,7 @@ import type {
   JsonExtractType,
 } from '../../../../types/processors';
 import { painlessFieldAccessor, painlessFieldAssignment } from '../../../../types/utils';
-
-/**
- * Normalizes a JSONPath-like selector to a format suitable for Painless traversal.
- * Supports:
- * - Dot notation: user.address.city
- * - Bracket notation: ['user']['address']['city']
- * - Array indices: items[0]
- * - Optional $ root selector (ignored)
- *
- * @example
- * "$.user.address" -> ["user", "address"]
- * "user.address.city" -> ["user", "address", "city"]
- * "items[0].name" -> ["items", "0", "name"]
- * "['user']['name']" -> ["user", "name"]
- */
-function parseSelector(selector: string): string[] {
-  let s = selector.trim();
-
-  // Remove leading $ if present
-  if (s.startsWith('$.')) {
-    s = s.slice(2);
-  } else if (s.startsWith('$')) {
-    s = s.slice(1);
-  }
-
-  const parts: string[] = [];
-  let current = '';
-  let i = 0;
-
-  while (i < s.length) {
-    const char = s[i];
-
-    if (char === '.') {
-      if (current) {
-        parts.push(current);
-        current = '';
-      }
-      i++;
-    } else if (char === '[') {
-      if (current) {
-        parts.push(current);
-        current = '';
-      }
-      i++;
-      // Find closing bracket
-      const start = i;
-      while (i < s.length && s[i] !== ']') {
-        i++;
-      }
-      let key = s.slice(start, i);
-      // Remove quotes if present (bracket notation like ['key'])
-      if (
-        (key.startsWith("'") && key.endsWith("'")) ||
-        (key.startsWith('"') && key.endsWith('"'))
-      ) {
-        key = key.slice(1, -1);
-      }
-      parts.push(key);
-      i++; // Skip closing bracket
-    } else {
-      current += char;
-      i++;
-    }
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
-}
+import { parseJsonPath, segmentsToStrings } from '../../shared/json_path_parser';
 
 /**
  * Generates Painless code to traverse a parsed JSON object and extract a value.
@@ -168,7 +98,7 @@ function generateJsonExtractScript(
 
   // Generate extraction for each selector
   for (const extraction of extractions) {
-    const parts = parseSelector(extraction.selector);
+    const parts = segmentsToStrings(parseJsonPath(extraction.selector).segments);
     const traversalExpr = generateTraversalExpression('parsed', parts);
     const targetAssignment = painlessFieldAssignment(extraction.target_field);
     const varName = `extracted_${parts.join('_').replace(/[^a-zA-Z0-9_]/g, '_')}`;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/json_extract_processor.ts
@@ -97,11 +97,12 @@ function generateJsonExtractScript(
   lines.push('def parsed = Processors.json(jsonStr);');
 
   // Generate extraction for each selector
-  for (const extraction of extractions) {
+  for (let i = 0; i < extractions.length; i++) {
+    const extraction = extractions[i];
     const parts = segmentsToStrings(parseJsonPath(extraction.selector).segments);
     const traversalExpr = generateTraversalExpression('parsed', parts);
     const targetAssignment = painlessFieldAssignment(extraction.target_field);
-    const varName = `extracted_${parts.join('_').replace(/[^a-zA-Z0-9_]/g, '_')}`;
+    const varName = `extracted_${i}`;
     const targetType = extraction.type ?? 'keyword';
 
     lines.push(`def ${varName} = ${traversalExpr};`);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/pre_processing.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/pre_processing.ts
@@ -34,6 +34,7 @@ export const processorFieldRenames: Record<string, Record<string, string>> = {
   sort: { from: 'field', to: 'target_field', where: 'if' },
   concat: { to: 'field', where: 'if' },
   network_direction: { where: 'if' },
+  json_extract: { where: 'if' },
   manual_ingest_pipeline: { where: 'if' },
 };
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/processor.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/ingest_pipeline/processors/processor.ts
@@ -28,6 +28,7 @@ import type {
   IngestPipelineSortProcessor,
   IngestPipelineConcatProcessor,
   IngestPipelineNetworkDirectionProcessor,
+  IngestPipelineJsonExtractProcessor,
 } from '../../../../types/processors/ingest_pipeline_processors';
 
 type WithOptionalTracingTag<T> = T & { tag?: string };
@@ -54,5 +55,6 @@ export interface ActionToIngestType {
   redact: WithOptionalTracingTag<IngestPipelineRedactProcessor>;
   concat: WithOptionalTracingTag<IngestPipelineConcatProcessor>;
   network_direction: WithOptionalTracingTag<IngestPipelineNetworkDirectionProcessor>;
+  json_extract: WithOptionalTracingTag<IngestPipelineJsonExtractProcessor>;
   manual_ingest_pipeline: WithOptionalTracingTag<IngestPipelineManualIngestPipelineProcessor>;
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.test.ts
@@ -287,6 +287,8 @@ describe('parseJsonPath', () => {
     it('rejects unsupported JSONPath features - wildcards', () => {
       expect(() => parseJsonPath('a[*]')).toThrow(JsonPathParseError);
       expect(() => parseJsonPath('a[*]')).toThrow('expected integer array index');
+      expect(() => parseJsonPath('a.*')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a.*')).toThrow('unsupported character');
     });
 
     it('rejects unsupported JSONPath features - array slicing', () => {

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.test.ts
@@ -1,0 +1,352 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  parseJsonPath,
+  segmentsToStrings,
+  validateJsonPath,
+  JsonPathParseError,
+  type JsonPathSegment,
+} from './json_path_parser';
+
+describe('parseJsonPath', () => {
+  const key = (name: string): JsonPathSegment => ({ type: 'key', name });
+  const index = (i: number): JsonPathSegment => ({ type: 'index', index: i });
+
+  describe('dot notation', () => {
+    it('parses a simple key', () => {
+      const result = parseJsonPath('name');
+      expect(result.segments).toEqual([key('name')]);
+    });
+
+    it('parses nested dot notation', () => {
+      const result = parseJsonPath('user.address.city');
+      expect(result.segments).toEqual([key('user'), key('address'), key('city')]);
+    });
+
+    it('parses two-level dot notation', () => {
+      const result = parseJsonPath('a.b');
+      expect(result.segments).toEqual([key('a'), key('b')]);
+    });
+  });
+
+  describe('array index bracket notation', () => {
+    it('parses array index', () => {
+      const result = parseJsonPath('items[0]');
+      expect(result.segments).toEqual([key('items'), index(0)]);
+    });
+
+    it('parses nested array index', () => {
+      const result = parseJsonPath('orders[1].item');
+      expect(result.segments).toEqual([key('orders'), index(1), key('item')]);
+    });
+
+    it('parses multiple array indices', () => {
+      const result = parseJsonPath('a[0][1]');
+      expect(result.segments).toEqual([key('a'), index(0), index(1)]);
+    });
+
+    it('parses array index in middle of path', () => {
+      const result = parseJsonPath('a[0].b.c');
+      expect(result.segments).toEqual([key('a'), index(0), key('b'), key('c')]);
+    });
+
+    it('allows whitespace inside brackets', () => {
+      const result = parseJsonPath('items[ 0 ]');
+      expect(result.segments).toEqual([key('items'), index(0)]);
+    });
+  });
+
+  describe('$ prefix', () => {
+    it('parses $. prefix', () => {
+      const result = parseJsonPath('$.name');
+      expect(result.segments).toEqual([key('name')]);
+    });
+
+    it('parses $. with nested path', () => {
+      const result = parseJsonPath('$.user.address.city');
+      expect(result.segments).toEqual([key('user'), key('address'), key('city')]);
+    });
+
+    it('parses $. with array index', () => {
+      const result = parseJsonPath('$.tags[0]');
+      expect(result.segments).toEqual([key('tags'), index(0)]);
+    });
+
+    it('parses $. with mixed nesting', () => {
+      const result = parseJsonPath('$.orders[1].id');
+      expect(result.segments).toEqual([key('orders'), index(1), key('id')]);
+    });
+
+    it('parses bare $ as root accessor', () => {
+      const result = parseJsonPath('$');
+      expect(result.segments).toEqual([]);
+    });
+
+    it('parses $. alone as root accessor', () => {
+      const result = parseJsonPath('$.');
+      expect(result.segments).toEqual([]);
+    });
+
+    it('parses empty string as root accessor', () => {
+      const result = parseJsonPath('');
+      expect(result.segments).toEqual([]);
+    });
+
+    it('parses $[ prefix with array index', () => {
+      const result = parseJsonPath('$[1]');
+      expect(result.segments).toEqual([index(1)]);
+    });
+
+    it('parses $[ prefix with quoted key', () => {
+      const result = parseJsonPath("$['user.name']");
+      expect(result.segments).toEqual([key('user.name')]);
+    });
+
+    it('parses $[ with nested path', () => {
+      const result = parseJsonPath("$['a'].b");
+      expect(result.segments).toEqual([key('a'), key('b')]);
+    });
+  });
+
+  describe('bare leading bracket', () => {
+    it('parses bare leading bracket with array index', () => {
+      const result = parseJsonPath('[0]');
+      expect(result.segments).toEqual([index(0)]);
+    });
+
+    it('parses bare leading bracket with quoted key', () => {
+      const result = parseJsonPath("['name']");
+      expect(result.segments).toEqual([key('name')]);
+    });
+  });
+
+  describe('quoted bracket notation for named keys', () => {
+    it('parses single-quoted key', () => {
+      const result = parseJsonPath("['name']");
+      expect(result.segments).toEqual([key('name')]);
+    });
+
+    it('parses double-quoted key', () => {
+      const result = parseJsonPath('["name"]');
+      expect(result.segments).toEqual([key('name')]);
+    });
+
+    it('parses quoted key with dot', () => {
+      const result = parseJsonPath("['user.name']");
+      expect(result.segments).toEqual([key('user.name')]);
+    });
+
+    it('parses quoted key with space', () => {
+      const result = parseJsonPath("['first name']");
+      expect(result.segments).toEqual([key('first name')]);
+    });
+
+    it('parses quoted key with brackets', () => {
+      const result = parseJsonPath("['items[0]']");
+      expect(result.segments).toEqual([key('items[0]')]);
+    });
+
+    it('parses empty quoted key (single quote)', () => {
+      const result = parseJsonPath("['']");
+      expect(result.segments).toEqual([key('')]);
+    });
+
+    it('parses empty quoted key (double quote)', () => {
+      const result = parseJsonPath('[""]');
+      expect(result.segments).toEqual([key('')]);
+    });
+
+    it('parses quoted key nested after dot notation', () => {
+      const result = parseJsonPath("a['b.c']");
+      expect(result.segments).toEqual([key('a'), key('b.c')]);
+    });
+
+    it('parses mixed dot and bracket notation', () => {
+      const result = parseJsonPath("store['user.name']");
+      expect(result.segments).toEqual([key('store'), key('user.name')]);
+    });
+
+    it('parses consecutive bracket notation', () => {
+      const result = parseJsonPath("a['b.c']['d']");
+      expect(result.segments).toEqual([key('a'), key('b.c'), key('d')]);
+    });
+
+    it('parses bracket notation after array index', () => {
+      const result = parseJsonPath("arr[0]['a.b']");
+      expect(result.segments).toEqual([key('arr'), index(0), key('a.b')]);
+    });
+
+    it('parses complex mixed path', () => {
+      const result = parseJsonPath("$.store['items'][0].name");
+      expect(result.segments).toEqual([key('store'), key('items'), index(0), key('name')]);
+    });
+
+    it('allows whitespace inside brackets with quoted keys', () => {
+      const result = parseJsonPath("[ 'key' ]");
+      expect(result.segments).toEqual([key('key')]);
+    });
+  });
+
+  describe('escape sequences', () => {
+    it('parses escaped single quote in single-quoted key', () => {
+      const result = parseJsonPath("['it\\'s']");
+      expect(result.segments).toEqual([key("it's")]);
+    });
+
+    it('parses escaped double quote in double-quoted key', () => {
+      const result = parseJsonPath('["say \\"hi\\""]');
+      expect(result.segments).toEqual([key('say "hi"')]);
+    });
+
+    it('parses escaped backslash', () => {
+      const result = parseJsonPath("['a\\\\b']");
+      expect(result.segments).toEqual([key('a\\b')]);
+    });
+
+    it('passes through unrecognized escape sequences', () => {
+      const result = parseJsonPath("['a\\nb']");
+      expect(result.segments).toEqual([key('anb')]);
+    });
+  });
+
+  describe('dot / bracket equivalence (RFC 9535)', () => {
+    it('dot and single-quoted bracket are equivalent', () => {
+      expect(parseJsonPath('a.b').segments).toEqual(parseJsonPath("a['b']").segments);
+    });
+
+    it('dot and double-quoted bracket are equivalent', () => {
+      expect(parseJsonPath('a.b').segments).toEqual(parseJsonPath('a["b"]').segments);
+    });
+
+    it('nested dot and bracket are equivalent', () => {
+      expect(parseJsonPath('a.b.c').segments).toEqual(parseJsonPath("a['b']['c']").segments);
+    });
+  });
+
+  describe('error cases', () => {
+    it('rejects consecutive dots', () => {
+      expect(() => parseJsonPath('a..b')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a..b')).toThrow('consecutive dots');
+    });
+
+    it('rejects trailing dot', () => {
+      expect(() => parseJsonPath('a.')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a.')).toThrow('path cannot end with a dot');
+    });
+
+    it('rejects leading dot', () => {
+      expect(() => parseJsonPath('.a')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('.a')).toThrow('path cannot start with a dot');
+    });
+
+    it('rejects empty brackets', () => {
+      expect(() => parseJsonPath('a[]')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[]')).toThrow('empty brackets');
+    });
+
+    it('rejects unterminated quoted key', () => {
+      expect(() => parseJsonPath("a['unclosed")).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath("a['unclosed")).toThrow('unterminated quoted key');
+    });
+
+    it('rejects missing closing bracket', () => {
+      expect(() => parseJsonPath('a[0')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[0')).toThrow('missing closing bracket');
+    });
+
+    it('rejects invalid $ prefix', () => {
+      expect(() => parseJsonPath('$name')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('$name')).toThrow('expected [.] or [[] after [$]');
+    });
+
+    it('rejects non-numeric array index', () => {
+      expect(() => parseJsonPath('a[abc]')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[abc]')).toThrow('expected integer array index');
+    });
+
+    it('rejects leading zeros in array index', () => {
+      expect(() => parseJsonPath('a[01]')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[01]')).toThrow('leading zeros are not allowed');
+    });
+
+    it('rejects multiple consecutive dots like $.....dsfsd', () => {
+      expect(() => parseJsonPath('$.....dsfsd')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('$.....dsfsd')).toThrow('path cannot start with a dot');
+    });
+
+    it('rejects consecutive dots in middle of path', () => {
+      expect(() => parseJsonPath('a...b')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a...b')).toThrow('consecutive dots');
+    });
+
+    it('rejects unsupported JSONPath features - wildcards', () => {
+      expect(() => parseJsonPath('a[*]')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[*]')).toThrow('expected integer array index');
+    });
+
+    it('rejects unsupported JSONPath features - array slicing', () => {
+      expect(() => parseJsonPath('a[0:3]')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[0:3]')).toThrow('expected integer array index');
+    });
+
+    it('rejects unsupported JSONPath features - filter expressions', () => {
+      expect(() => parseJsonPath('a[?(@.price<10)]')).toThrow(JsonPathParseError);
+    });
+
+    it('rejects unterminated bracket', () => {
+      expect(() => parseJsonPath('a[')).toThrow(JsonPathParseError);
+      expect(() => parseJsonPath('a[')).toThrow('unterminated bracket');
+    });
+  });
+
+  describe('error position offset', () => {
+    it('shifts position in error message', () => {
+      try {
+        parseJsonPath('a..b', 10);
+        fail('Expected error');
+      } catch (e) {
+        expect(e).toBeInstanceOf(JsonPathParseError);
+        expect((e as JsonPathParseError).message).toContain('position 11');
+      }
+    });
+
+    it('accounts for $ prefix when calculating position', () => {
+      try {
+        parseJsonPath('$.a..b', 10);
+        fail('Expected error');
+      } catch (e) {
+        expect(e).toBeInstanceOf(JsonPathParseError);
+        expect((e as JsonPathParseError).message).toContain('position 13');
+      }
+    });
+  });
+});
+
+describe('segmentsToStrings', () => {
+  it('converts keys and indices to strings', () => {
+    const segments = parseJsonPath('user[0].name').segments;
+    expect(segmentsToStrings(segments)).toEqual(['user', '0', 'name']);
+  });
+
+  it('returns empty array for root path', () => {
+    const segments = parseJsonPath('$').segments;
+    expect(segmentsToStrings(segments)).toEqual([]);
+  });
+});
+
+describe('validateJsonPath', () => {
+  it('does not throw for valid paths', () => {
+    expect(() => validateJsonPath('user.name')).not.toThrow();
+    expect(() => validateJsonPath("$['key']")).not.toThrow();
+    expect(() => validateJsonPath('items[0].value')).not.toThrow();
+  });
+
+  it('throws for invalid paths', () => {
+    expect(() => validateJsonPath('a..b')).toThrow(JsonPathParseError);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.ts
@@ -94,7 +94,13 @@ function normalizePath(
 }
 
 /**
+ * Characters that are not allowed in bare keys (unsupported JSONPath features).
+ */
+const INVALID_KEY_CHARS = ['*', '?', ':', '@', '!', '&', '|', '(', ')', ','];
+
+/**
  * Reads a bare key using dot notation until a delimiter is found.
+ * Validates that keys don't contain unsupported characters like wildcards.
  */
 function readKey(
   path: string,
@@ -108,6 +114,13 @@ function readKey(
     const c = path[end];
     if (c === DOT || c === OPEN_BRACKET || c === CLOSE_BRACKET) {
       break;
+    }
+    if (INVALID_KEY_CHARS.includes(c)) {
+      throw new JsonPathParseError(
+        originalPath,
+        `unsupported character [${c}] in key name`,
+        baseOffset + end
+      );
     }
     end++;
   }

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/shared/json_path_parser.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * A segment in a parsed JSON path. Either a key (object field name) or an index (array position).
+ */
+export type JsonPathSegment = { type: 'key'; name: string } | { type: 'index'; index: number };
+
+/**
+ * Result of parsing a JSON path.
+ */
+export interface ParsedJsonPath {
+  segments: JsonPathSegment[];
+  originalPath: string;
+}
+
+/**
+ * Error thrown when a JSON path is malformed.
+ */
+export class JsonPathParseError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly reason: string,
+    public readonly position?: number
+  ) {
+    const positionSuffix = position !== undefined ? ` at position ${position}` : '';
+    super(`Invalid JSON path [${path}]: ${reason}${positionSuffix}`);
+    this.name = 'JsonPathParseError';
+  }
+}
+
+/**
+ * Characters used by the parser.
+ */
+const DOLLAR = '$';
+const DOT = '.';
+const OPEN_BRACKET = '[';
+const CLOSE_BRACKET = ']';
+const BACKSLASH = '\\';
+const SINGLE_QUOTE = "'";
+const DOUBLE_QUOTE = '"';
+
+/**
+ * Returns true if the character is whitespace per RFC 9535:
+ * space (%x20), horizontal tab (%x09), newline (%x0A), or carriage return (%x0D).
+ */
+function isBlank(c: string): boolean {
+  return c === ' ' || c === '\t' || c === '\n' || c === '\r';
+}
+
+/**
+ * Skips optional blank space starting at pos.
+ */
+function skipBlankSpace(path: string, pos: number): number {
+  while (pos < path.length && isBlank(path[pos])) {
+    pos++;
+  }
+  return pos;
+}
+
+/**
+ * Normalizes the path by stripping the optional $ prefix.
+ * Returns null if the path represents the root accessor (empty path or bare $).
+ */
+function normalizePath(
+  path: string,
+  originalPath: string,
+  errorPositionOffset: number
+): string | null {
+  if (path.length === 0 || (path[0] === DOLLAR && path.length === 1)) {
+    return null;
+  }
+
+  if (path.length >= 2 && path[0] === DOLLAR) {
+    const second = path[1];
+    if (second === DOT) {
+      path = path.slice(2);
+    } else if (second === OPEN_BRACKET) {
+      path = path.slice(1);
+    } else {
+      throw new JsonPathParseError(
+        originalPath,
+        'expected [.] or [[] after [$]',
+        errorPositionOffset + 1
+      );
+    }
+  }
+
+  return path.length === 0 ? null : path;
+}
+
+/**
+ * Reads a bare key using dot notation until a delimiter is found.
+ */
+function readKey(
+  path: string,
+  originalPath: string,
+  start: number,
+  baseOffset: number,
+  segments: JsonPathSegment[]
+): number {
+  let end = start;
+  while (end < path.length) {
+    const c = path[end];
+    if (c === DOT || c === OPEN_BRACKET || c === CLOSE_BRACKET) {
+      break;
+    }
+    end++;
+  }
+
+  if (end === start) {
+    throw new JsonPathParseError(originalPath, 'empty key name', baseOffset + start);
+  }
+
+  segments.push({ type: 'key', name: path.slice(start, end) });
+  return end;
+}
+
+/**
+ * Reads a quoted key inside brackets, handling escape sequences.
+ */
+function readQuotedKey(
+  path: string,
+  originalPath: string,
+  pos: number,
+  bracketOffset: number,
+  segments: JsonPathSegment[]
+): number {
+  const quote = path[pos];
+  pos++;
+  let key = '';
+
+  while (pos < path.length) {
+    const c = path[pos];
+
+    if (c === BACKSLASH && pos + 1 < path.length) {
+      key += path[pos + 1];
+      pos += 2;
+    } else if (c === quote) {
+      const afterQuote = skipBlankSpace(path, pos + 1);
+      if (afterQuote >= path.length || path[afterQuote] !== CLOSE_BRACKET) {
+        throw new JsonPathParseError(
+          originalPath,
+          'expected closing bracket after quoted key',
+          bracketOffset
+        );
+      }
+      segments.push({ type: 'key', name: key });
+      return afterQuote + 1;
+    } else {
+      key += c;
+      pos++;
+    }
+  }
+
+  throw new JsonPathParseError(originalPath, 'unterminated quoted key', bracketOffset);
+}
+
+/**
+ * Reads a numeric array index inside brackets.
+ */
+function readIndex(
+  path: string,
+  originalPath: string,
+  pos: number,
+  bracketOffset: number,
+  segments: JsonPathSegment[]
+): number {
+  const end = path.indexOf(CLOSE_BRACKET, pos);
+  if (end === -1) {
+    throw new JsonPathParseError(
+      originalPath,
+      'missing closing bracket for array index',
+      bracketOffset
+    );
+  }
+
+  let contentEnd = end;
+  while (contentEnd > pos && isBlank(path[contentEnd - 1])) {
+    contentEnd--;
+  }
+
+  const content = path.slice(pos, contentEnd);
+  if (content.length === 0) {
+    throw new JsonPathParseError(originalPath, 'empty array index', bracketOffset);
+  }
+
+  const index = parseInt(content, 10);
+  if (isNaN(index) || !/^\d+$/.test(content)) {
+    throw new JsonPathParseError(
+      originalPath,
+      `expected integer array index, got [${content}]`,
+      bracketOffset
+    );
+  }
+
+  if (content.length > 1 && content[0] === '0') {
+    throw new JsonPathParseError(
+      originalPath,
+      `leading zeros are not allowed in array index [${content}]`,
+      bracketOffset
+    );
+  }
+
+  if (index < 0) {
+    throw new JsonPathParseError(originalPath, 'array index out of bounds', bracketOffset);
+  }
+
+  segments.push({ type: 'index', index });
+  return end + 1;
+}
+
+/**
+ * Dispatches bracket content to the appropriate reader.
+ */
+function readBracket(
+  path: string,
+  originalPath: string,
+  pos: number,
+  bracketOffset: number,
+  segments: JsonPathSegment[]
+): number {
+  pos = skipBlankSpace(path, pos);
+
+  if (pos >= path.length) {
+    throw new JsonPathParseError(originalPath, 'unterminated bracket', bracketOffset);
+  }
+
+  const c = path[pos];
+  if (c === SINGLE_QUOTE || c === DOUBLE_QUOTE) {
+    return readQuotedKey(path, originalPath, pos, bracketOffset, segments);
+  } else if (c === CLOSE_BRACKET) {
+    throw new JsonPathParseError(originalPath, 'empty brackets', bracketOffset);
+  } else {
+    return readIndex(path, originalPath, pos, bracketOffset, segments);
+  }
+}
+
+/**
+ * Internal parsing implementation.
+ */
+function doParse(path: string, errorPositionOffset: number): JsonPathSegment[] {
+  const originalPath = path;
+  const segments: JsonPathSegment[] = [];
+
+  let dollarPrefixLength = 0;
+  if (path.startsWith('$.')) {
+    dollarPrefixLength = 2;
+  } else if (path.startsWith('$[')) {
+    dollarPrefixLength = 1;
+  } else if (path === '$') {
+    dollarPrefixLength = 1;
+  }
+
+  const normalized = normalizePath(path, originalPath, errorPositionOffset);
+  if (normalized === null) {
+    return segments;
+  }
+
+  path = normalized;
+  const baseOffset = errorPositionOffset + dollarPrefixLength;
+
+  let pos = 0;
+
+  if (path[0] === DOT) {
+    throw new JsonPathParseError(originalPath, 'path cannot start with a dot', baseOffset);
+  }
+
+  while (pos < path.length) {
+    const c = path[pos];
+
+    if (c === DOT) {
+      pos++;
+      if (pos >= path.length) {
+        throw new JsonPathParseError(
+          originalPath,
+          'path cannot end with a dot',
+          baseOffset + pos - 1
+        );
+      }
+      if (path[pos] === DOT) {
+        throw new JsonPathParseError(originalPath, 'consecutive dots', baseOffset + pos - 1);
+      }
+      if (path[pos] === OPEN_BRACKET) {
+        continue;
+      }
+      pos = readKey(path, originalPath, pos, baseOffset, segments);
+    } else if (c === OPEN_BRACKET) {
+      const bracketOffset = baseOffset + pos;
+      pos++;
+      pos = readBracket(path, originalPath, pos, bracketOffset, segments);
+    } else {
+      pos = readKey(path, originalPath, pos, baseOffset, segments);
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Parses a JSON path string into typed segments.
+ *
+ * This implementation follows a subset of JSONPath (RFC 9535) syntax:
+ * - Dot notation: user.address.city
+ * - Bracket notation for array indices: items[0]
+ * - Quoted bracket notation for special keys: ['user.name'], ["key with spaces"]
+ * - Optional $ root selector: $.name and name are equivalent
+ * - Mixed notation: $.store['items'][0].name
+ * - Escape sequences in quoted keys: \', \", \\
+ * - Optional whitespace inside brackets: [ 0 ], [ 'key' ]
+ *
+ * @param path - The JSON path string to parse
+ * @param errorPositionOffset - Optional offset for error positions (useful when path comes from a larger query)
+ * @throws {JsonPathParseError} If the path is malformed
+ */
+export function parseJsonPath(path: string, errorPositionOffset = 0): ParsedJsonPath {
+  const trimmed = path.trim();
+  return {
+    segments: doParse(trimmed, errorPositionOffset),
+    originalPath: trimmed,
+  };
+}
+
+/**
+ * Converts parsed segments to a simple string array for backward compatibility.
+ * Keys become their names, indices become their string representation.
+ */
+export function segmentsToStrings(segments: JsonPathSegment[]): string[] {
+  return segments.map((seg) => (seg.type === 'key' ? seg.name : String(seg.index)));
+}
+
+/**
+ * Validates a JSON path without returning the full parsed result.
+ * Throws JsonPathParseError if the path is invalid.
+ */
+export function validateJsonPath(path: string, errorPositionOffset = 0): void {
+  parseJsonPath(path, errorPositionOffset);
+}

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_field_names.ts
@@ -105,6 +105,12 @@ export function extractAllFieldNames(processor: StreamlangProcessorDefinition): 
         fields.push(processor.internal_networks_field);
       }
       break;
+    case 'json_extract':
+      fields.push(processor.field);
+      processor.extractions.forEach((extraction) => {
+        fields.push(extraction.target_field);
+      });
+      break;
     case 'drop_document':
     case 'manual_ingest_pipeline':
       // No field names to validate

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import type { StreamlangProcessorDefinition } from '../../types/processors';
 import { validateMathExpression } from '../transpilers/shared/math';
+import { validateJsonPath, JsonPathParseError } from '../transpilers/shared/json_path_parser';
 import type { StreamlangValidationError } from './types';
 
 /**
@@ -68,10 +69,38 @@ export function validateProcessorValues(
     case 'split':
     case 'sort':
     case 'network_direction':
-    case 'json_extract':
     case 'manual_ingest_pipeline':
       // No value validation implemented for these processors yet
       break;
+    case 'json_extract': {
+      for (let i = 0; i < step.extractions.length; i++) {
+        const extraction = step.extractions[i];
+        try {
+          validateJsonPath(extraction.selector);
+        } catch (e) {
+          if (e instanceof JsonPathParseError) {
+            errors.push({
+              type: 'invalid_value',
+              message: i18n.translate('xpack.streamlang.validation.invalidJsonPathSelector', {
+                defaultMessage:
+                  'Processor #{processorNumber} ({processorAction}) has an invalid selector in extraction #{extractionNumber}: {error}',
+                values: {
+                  processorNumber,
+                  processorAction: step.action,
+                  extractionNumber: i + 1,
+                  error: e.reason,
+                },
+              }),
+              processorId,
+              field: `extractions[${i}].selector`,
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
+      break;
+    }
     default: {
       const _exhaustiveCheck: never = step;
       return _exhaustiveCheck;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_processor_values.ts
@@ -68,6 +68,7 @@ export function validateProcessorValues(
     case 'split':
     case 'sort':
     case 'network_direction':
+    case 'json_extract':
     case 'manual_ingest_pipeline':
       // No value validation implemented for these processors yet
       break;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
@@ -148,6 +148,12 @@ export function extractModifiedFields(processor: StreamlangProcessorDefinition):
       }
       break;
 
+    case 'json_extract':
+      processor.extractions.forEach((extraction) => {
+        fields.push(extraction.target_field);
+      });
+      break;
+
     case 'remove':
     case 'remove_by_prefix':
     case 'drop_document':
@@ -275,6 +281,9 @@ export function getProcessorOutputType(
     case 'network_direction':
       return 'string';
 
+    case 'json_extract':
+      return 'unknown';
+
     case 'remove':
     case 'remove_by_prefix':
     case 'drop_document':
@@ -369,6 +378,7 @@ export function getExpectedInputType(
     case 'remove_by_prefix':
     case 'drop_document':
     case 'network_direction':
+    case 'json_extract':
     case 'manual_ingest_pipeline':
       return null;
     default: {
@@ -439,6 +449,9 @@ export function trackFieldTypesAndValidate(flattenedSteps: StreamlangProcessorDe
         if ('internal_networks_field' in step && step.internal_networks_field) {
           fieldsUsed.push(step.internal_networks_field);
         }
+        break;
+      case 'json_extract':
+        fieldsUsed.push(step.field);
         break;
       case 'append':
       case 'drop_document':

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/validation/validate_types.ts
@@ -281,8 +281,23 @@ export function getProcessorOutputType(
     case 'network_direction':
       return 'string';
 
-    case 'json_extract':
-      return 'unknown';
+    case 'json_extract': {
+      const extraction = processor.extractions.find(
+        ({ target_field }) => target_field === fieldName
+      );
+      switch (extraction?.type ?? 'keyword') {
+        case 'keyword':
+          return 'string';
+        case 'integer':
+        case 'long':
+        case 'double':
+          return 'number';
+        case 'boolean':
+          return 'boolean';
+        default:
+          return 'unknown';
+      }
+    }
 
     case 'remove':
     case 'remove_by_prefix':
@@ -378,8 +393,12 @@ export function getExpectedInputType(
     case 'remove_by_prefix':
     case 'drop_document':
     case 'network_direction':
-    case 'json_extract':
     case 'manual_ingest_pipeline':
+      return null;
+    case 'json_extract':
+      if (processor.field === fieldName) {
+        return ['string'];
+      }
       return null;
     default: {
       const _exhaustiveCheck: never = processor;

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -591,9 +591,13 @@ export const sortProcessorSchema = processorBaseWithWhereSchema.extend({
  * Extracts values from JSON strings using JSONPath-like selectors.
  */
 
+export const jsonExtractTypes = ['keyword', 'integer', 'long', 'double', 'boolean'] as const;
+export type JsonExtractType = (typeof jsonExtractTypes)[number];
+
 export interface JsonExtraction {
   selector: string;
   target_field: string;
+  type?: JsonExtractType;
 }
 
 const jsonExtractionSchema = z
@@ -602,6 +606,11 @@ const jsonExtractionSchema = z
       'JSONPath-like selector to extract value (e.g., "user.id", "$.metadata.client.ip", "items[0].name")'
     ),
     target_field: StreamlangTargetField.describe('Target field to store the extracted value'),
+    type: z
+      .optional(z.enum(jsonExtractTypes))
+      .describe(
+        'Data type for the extracted value. Defaults to "keyword". Ensures consistent types across transpilers.'
+      ),
   })
   .describe('A single extraction specification') satisfies z.Schema<JsonExtraction>;
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/index.ts
@@ -586,6 +586,49 @@ export const sortProcessorSchema = processorBaseWithWhereSchema.extend({
 }) satisfies z.Schema<SortProcessor>;
 
 /**
+ * JsonExtract processor
+ *
+ * Extracts values from JSON strings using JSONPath-like selectors.
+ */
+
+export interface JsonExtraction {
+  selector: string;
+  target_field: string;
+}
+
+const jsonExtractionSchema = z
+  .object({
+    selector: NonEmptyString.describe(
+      'JSONPath-like selector to extract value (e.g., "user.id", "$.metadata.client.ip", "items[0].name")'
+    ),
+    target_field: StreamlangTargetField.describe('Target field to store the extracted value'),
+  })
+  .describe('A single extraction specification') satisfies z.Schema<JsonExtraction>;
+
+export interface JsonExtractProcessor extends ProcessorBaseWithWhere {
+  action: 'json_extract';
+  field: string;
+  extractions: JsonExtraction[];
+  ignore_missing?: boolean;
+}
+
+export const jsonExtractProcessorSchema = processorBaseWithWhereSchema
+  .extend({
+    action: z.literal('json_extract'),
+    field: StreamlangSourceField.describe('Source field containing the JSON string to parse'),
+    extractions: z
+      .array(jsonExtractionSchema)
+      .nonempty()
+      .describe('List of extraction specifications'),
+    ignore_missing: z
+      .optional(z.boolean())
+      .describe('Skip processing when source field is missing'),
+  })
+  .describe(
+    'JsonExtract processor - Extract values from JSON strings using JSONPath-like selectors'
+  ) satisfies z.Schema<JsonExtractProcessor>;
+
+/**
  * Concat processor
  */
 
@@ -699,6 +742,7 @@ export type StreamlangProcessorDefinition =
   | SortProcessor
   | ConcatProcessor
   | NetworkDirectionProcessor
+  | JsonExtractProcessor
   | ManualIngestPipelineProcessor;
 
 export const streamlangProcessorSchema = z.union([
@@ -723,6 +767,7 @@ export const streamlangProcessorSchema = z.union([
   convertProcessorSchema,
   concatProcessorSchema,
   networkDirectionProcessorSchema,
+  jsonExtractProcessorSchema,
   manualIngestPipelineProcessorSchema,
 ]);
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/processors/ingest_pipeline_processors.ts
@@ -29,6 +29,7 @@ import type {
   SortProcessor,
   ConcatProcessor,
   NetworkDirectionProcessor,
+  JsonExtractProcessor,
 } from '.';
 import type { Condition } from '../conditions';
 
@@ -162,6 +163,12 @@ export type IngestPipelineNetworkDirectionProcessor = RenameFieldsAndRemoveActio
   { where: 'if' }
 >;
 
+// JsonExtract (uses script processor internally)
+export type IngestPipelineJsonExtractProcessor = RenameFieldsAndRemoveAction<
+  JsonExtractProcessor,
+  { where: 'if' }
+>;
+
 // Manual Ingest Pipeline (escape hatch)
 export type IngestPipelineManualIngestPipelineProcessor = RenameFieldsAndRemoveAction<
   ManualIngestPipelineProcessor,
@@ -190,4 +197,5 @@ export type IngestPipelineProcessor =
   | IngestPipelineSortProcessor
   | IngestPipelineConcatProcessor
   | IngestPipelineNetworkDirectionProcessor
+  | IngestPipelineJsonExtractProcessor
   | IngestPipelineManualIngestPipelineProcessor;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/editor.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/editor.tsx
@@ -62,6 +62,7 @@ import { SortProcessorForm } from './sort';
 import { TransformStringProcessorForm } from './transform_string';
 import { ConcatProcessorForm } from './concat';
 import { JoinProcessorForm } from './join';
+import { JsonExtractProcessorForm } from './json_extract';
 import { NetworkDirectionProcessorForm } from './network_direction';
 
 export const ActionBlockEditor = forwardRef<HTMLDivElement, ActionBlockProps>((props, ref) => {
@@ -166,6 +167,7 @@ export const ActionBlockEditor = forwardRef<HTMLDivElement, ActionBlockProps>((p
                 {type === 'sort' && <SortProcessorForm />}
                 {type === 'concat' && <ConcatProcessorForm />}
                 {type === 'join' && <JoinProcessorForm />}
+                {type === 'json_extract' && <JsonExtractProcessorForm />}
                 {type === 'network_direction' && <NetworkDirectionProcessorForm />}
                 {!SPECIALISED_TYPES.includes(type) && (
                   <ConfigDrivenProcessorFields type={type as ConfigDrivenProcessorType} />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -21,8 +21,8 @@ import {
   EuiSuperSelect,
   EuiText,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
-import { FieldNameWithIcon } from '@kbn/react-field';
 import { capitalize } from 'lodash';
 import { jsonExtractTypes } from '@kbn/streamlang';
 import { ProcessorFieldSelector } from '../processor_field_selector';
@@ -33,8 +33,15 @@ import type { JsonExtractFormState } from '../../../../types';
 
 const typeOptions = jsonExtractTypes.map((type) => ({
   value: type,
-  inputDisplay: <FieldNameWithIcon name={capitalize(type)} type={type} />,
+  inputDisplay: capitalize(type),
 }));
+
+const extractionGridStyles = css`
+  display: grid;
+  grid-template-columns: 4fr 4fr 2fr auto;
+  gap: 8px;
+  align-items: start;
+`;
 
 export const JsonExtractProcessorForm = () => {
   const { control } = useFormContext<JsonExtractFormState>();
@@ -100,20 +107,20 @@ export const JsonExtractProcessorForm = () => {
                 </EuiFlexItem>
               ))}
             </EuiFlexGroup>
-            <EuiSpacer size="s" />
-            <EuiButtonEmpty
-              iconType="plus"
-              onClick={() => append({ selector: '', target_field: '', type: 'keyword' })}
-              size="xs"
-              flush="both"
-              data-test-subj="streamsAppJsonExtractAddExtractionButton"
-            >
-              {i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractAddExtraction',
-                { defaultMessage: 'Add extraction' }
-              )}
-            </EuiButtonEmpty>
           </EuiPanel>
+          <EuiSpacer size="s" />
+          <EuiButtonEmpty
+            iconType="plus"
+            onClick={() => append({ selector: '', target_field: '', type: 'keyword' })}
+            size="xs"
+            flush="both"
+            data-test-subj="streamsAppJsonExtractAddExtractionButton"
+          >
+            {i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractAddExtraction',
+              { defaultMessage: 'Add extraction' }
+            )}
+          </EuiButtonEmpty>
         </div>
       </EuiFormRow>
       <EuiSpacer size="m" />
@@ -215,69 +222,60 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
     : undefined;
 
   return (
-    <EuiFlexGroup gutterSize="s" alignItems="flexStart">
-      <EuiFlexItem grow={4}>
-        <EuiFormRow
-          label={selectorLabel}
-          isInvalid={selectorFieldState.invalid}
-          error={selectorFieldState.error?.message}
-          fullWidth
-        >
-          <EuiFieldText
-            placeholder={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorPlaceholder',
-              { defaultMessage: 'e.g., user.id or $.data[0].value' }
-            )}
-            isInvalid={selectorFieldState.invalid}
-            {...selectorInputProps}
-            inputRef={selectorRef}
-            fullWidth
-            compressed
-            data-test-subj={`streamsAppJsonExtractSelectorInput-${index}`}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem grow={4}>
-        <EuiFormRow
-          label={targetLabel}
-          isInvalid={targetFieldState.invalid}
-          error={targetFieldState.error?.message}
-          fullWidth
-        >
-          <EuiFieldText
-            placeholder={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldPlaceholder',
-              { defaultMessage: 'e.g., extracted.user_id' }
-            )}
-            isInvalid={targetFieldState.invalid}
-            {...targetInputProps}
-            inputRef={targetRef}
-            fullWidth
-            compressed
-            data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem grow={2}>
-        <EuiFormRow label={typeLabel} fullWidth>
-          <EuiSuperSelect
-            options={typeOptions}
-            valueOfSelected={typeField.value ?? 'keyword'}
-            onChange={typeField.onChange}
-            compressed
-            fullWidth
-            data-test-subj={`streamsAppJsonExtractTypeSelect-${index}`}
-            aria-label={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeAriaLabel',
-              { defaultMessage: 'Extraction type' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-        css={showLabels ? { alignSelf: 'flex-end', marginBottom: 4 } : { alignSelf: 'center' }}
+    <div css={extractionGridStyles}>
+      <EuiFormRow
+        label={selectorLabel}
+        isInvalid={selectorFieldState.invalid}
+        error={selectorFieldState.error?.message}
+        fullWidth
       >
+        <EuiFieldText
+          placeholder={i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorPlaceholder',
+            { defaultMessage: 'e.g., user.id or $.data[0].value' }
+          )}
+          isInvalid={selectorFieldState.invalid}
+          {...selectorInputProps}
+          inputRef={selectorRef}
+          fullWidth
+          compressed
+          data-test-subj={`streamsAppJsonExtractSelectorInput-${index}`}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label={targetLabel}
+        isInvalid={targetFieldState.invalid}
+        error={targetFieldState.error?.message}
+        fullWidth
+      >
+        <EuiFieldText
+          placeholder={i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldPlaceholder',
+            { defaultMessage: 'e.g., extracted.user_id' }
+          )}
+          isInvalid={targetFieldState.invalid}
+          {...targetInputProps}
+          inputRef={targetRef}
+          fullWidth
+          compressed
+          data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
+        />
+      </EuiFormRow>
+      <EuiFormRow label={typeLabel} fullWidth>
+        <EuiSuperSelect
+          options={typeOptions}
+          valueOfSelected={typeField.value ?? 'keyword'}
+          onChange={typeField.onChange}
+          compressed
+          fullWidth
+          data-test-subj={`streamsAppJsonExtractTypeSelect-${index}`}
+          aria-label={i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeAriaLabel',
+            { defaultMessage: 'Extraction type' }
+          )}
+        />
+      </EuiFormRow>
+      <div css={showLabels ? { alignSelf: 'end', marginBottom: 4 } : { alignSelf: 'center' }}>
         <EuiButtonIcon
           iconType="trash"
           color="danger"
@@ -289,7 +287,7 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
           )}
           data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
         />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </div>
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -19,6 +19,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiSuperSelect,
+  EuiText,
 } from '@elastic/eui';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
 import { FieldNameWithIcon } from '@kbn/react-field';
@@ -61,9 +62,9 @@ export const JsonExtractProcessorForm = () => {
     <>
       <ProcessorFieldSelector
         fieldKey="field"
-        helpText={i18n.translate(
-          'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractFieldHelpText',
-          { defaultMessage: 'The field containing the JSON string to parse.' }
+        label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractFieldLabel',
+          { defaultMessage: 'Field with JSON string' }
         )}
       />
       <EuiFormRow
@@ -71,39 +72,48 @@ export const JsonExtractProcessorForm = () => {
           'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsLabel',
           { defaultMessage: 'Extractions' }
         )}
-        helpText={
-          <FormattedMessage
-            id="xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsHelpText"
-            defaultMessage="Define which values to extract using JSONPath-like selectors. Examples: {example1}, {example2}, {example3}"
-            values={{
-              example1: <EuiCode>user.id</EuiCode>,
-              example2: <EuiCode>$.metadata.client.ip</EuiCode>,
-              example3: <EuiCode>items[0].name</EuiCode>,
-            }}
-          />
-        }
         fullWidth
       >
         <div>
-          {fields.map((field, index) => (
-            <ExtractionField
-              key={field.id}
-              index={index}
-              onRemove={() => remove(index)}
-              canRemove={fields.length > 1}
+          <EuiText size="xs" color="subdued">
+            <FormattedMessage
+              id="xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsHelpText"
+              defaultMessage="Define which values to extract using JSONPath-like selectors. Examples: {example1}, {example2}, {example3}"
+              values={{
+                example1: <EuiCode>user.id</EuiCode>,
+                example2: <EuiCode>$.metadata.client.ip</EuiCode>,
+                example3: <EuiCode>items[0].name</EuiCode>,
+              }}
             />
-          ))}
-          <EuiButtonEmpty
-            iconType="plusInCircle"
-            onClick={() => append({ selector: '', target_field: '', type: 'keyword' })}
-            size="xs"
-            data-test-subj="streamsAppJsonExtractAddExtractionButton"
-          >
-            {i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractAddExtraction',
-              { defaultMessage: 'Add extraction' }
-            )}
-          </EuiButtonEmpty>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiPanel color="subdued" paddingSize="s" hasShadow={false} hasBorder={false}>
+            <EuiFlexGroup direction="column" gutterSize="s">
+              {fields.map((field, index) => (
+                <EuiFlexItem key={field.id}>
+                  <ExtractionField
+                    index={index}
+                    onRemove={() => remove(index)}
+                    canRemove={fields.length > 1}
+                    showLabels={index === 0}
+                  />
+                </EuiFlexItem>
+              ))}
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+            <EuiButtonEmpty
+              iconType="plus"
+              onClick={() => append({ selector: '', target_field: '', type: 'keyword' })}
+              size="xs"
+              flush="both"
+              data-test-subj="streamsAppJsonExtractAddExtractionButton"
+            >
+              {i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractAddExtraction',
+                { defaultMessage: 'Add extraction' }
+              )}
+            </EuiButtonEmpty>
+          </EuiPanel>
         </div>
       </EuiFormRow>
       <EuiSpacer size="m" />
@@ -121,9 +131,10 @@ interface ExtractionFieldProps {
   index: number;
   onRemove: () => void;
   canRemove: boolean;
+  showLabels: boolean;
 }
 
-const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) => {
+const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionFieldProps) => {
   const { field: selectorField, fieldState: selectorFieldState } = useController<
     JsonExtractFormState,
     `extractions.${number}.selector`
@@ -182,94 +193,103 @@ const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) =
   const { ref: selectorRef, ...selectorInputProps } = selectorField;
   const { ref: targetRef, ...targetInputProps } = targetField;
 
+  const selectorLabel = showLabels
+    ? i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
+        { defaultMessage: 'Selector' }
+      )
+    : undefined;
+
+  const targetLabel = showLabels
+    ? i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetLabel',
+        { defaultMessage: 'Target' }
+      )
+    : undefined;
+
+  const typeLabel = showLabels
+    ? i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeLabel',
+        { defaultMessage: 'Type' }
+      )
+    : undefined;
+
   return (
-    <EuiPanel paddingSize="s" hasShadow={false} hasBorder style={{ marginBottom: 8 }}>
-      <EuiFlexGroup gutterSize="s" alignItems="flexStart">
-        <EuiFlexItem grow={4}>
-          <EuiFormRow
-            label={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
-              { defaultMessage: 'Selector' }
+    <EuiFlexGroup gutterSize="s" alignItems="flexStart">
+      <EuiFlexItem grow={4}>
+        <EuiFormRow
+          label={selectorLabel}
+          isInvalid={selectorFieldState.invalid}
+          error={selectorFieldState.error?.message}
+          fullWidth
+        >
+          <EuiFieldText
+            placeholder={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorPlaceholder',
+              { defaultMessage: 'e.g., user.id or $.data[0].value' }
             )}
             isInvalid={selectorFieldState.invalid}
-            error={selectorFieldState.error?.message}
+            {...selectorInputProps}
+            inputRef={selectorRef}
             fullWidth
-          >
-            <EuiFieldText
-              placeholder={i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorPlaceholder',
-                { defaultMessage: 'e.g., user.id or $.data[0].value' }
-              )}
-              isInvalid={selectorFieldState.invalid}
-              {...selectorInputProps}
-              inputRef={selectorRef}
-              fullWidth
-              compressed
-              data-test-subj={`streamsAppJsonExtractSelectorInput-${index}`}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={4}>
-          <EuiFormRow
-            label={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldLabel',
-              { defaultMessage: 'Target field' }
+            compressed
+            data-test-subj={`streamsAppJsonExtractSelectorInput-${index}`}
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={4}>
+        <EuiFormRow
+          label={targetLabel}
+          isInvalid={targetFieldState.invalid}
+          error={targetFieldState.error?.message}
+          fullWidth
+        >
+          <EuiFieldText
+            placeholder={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldPlaceholder',
+              { defaultMessage: 'e.g., extracted.user_id' }
             )}
             isInvalid={targetFieldState.invalid}
-            error={targetFieldState.error?.message}
+            {...targetInputProps}
+            inputRef={targetRef}
             fullWidth
-          >
-            <EuiFieldText
-              placeholder={i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldPlaceholder',
-                { defaultMessage: 'e.g., extracted.user_id' }
-              )}
-              isInvalid={targetFieldState.invalid}
-              {...targetInputProps}
-              inputRef={targetRef}
-              fullWidth
-              compressed
-              data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow
-            label={i18n.translate(
-              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeLabel',
-              { defaultMessage: 'Type' }
+            compressed
+            data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={2}>
+        <EuiFormRow label={typeLabel} fullWidth>
+          <EuiSuperSelect
+            options={typeOptions}
+            valueOfSelected={typeField.value ?? 'keyword'}
+            onChange={typeField.onChange}
+            compressed
+            fullWidth
+            data-test-subj={`streamsAppJsonExtractTypeSelect-${index}`}
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeAriaLabel',
+              { defaultMessage: 'Extraction type' }
             )}
-            fullWidth
-          >
-            <EuiSuperSelect
-              options={typeOptions}
-              valueOfSelected={typeField.value ?? 'keyword'}
-              onChange={typeField.onChange}
-              compressed
-              fullWidth
-              data-test-subj={`streamsAppJsonExtractTypeSelect-${index}`}
-              aria-label={i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeAriaLabel',
-                { defaultMessage: 'Extraction type' }
-              )}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        {canRemove && (
-          <EuiFlexItem grow={false} style={{ alignSelf: 'flex-end', marginBottom: 4 }}>
-            <EuiButtonIcon
-              iconType="trash"
-              color="danger"
-              onClick={onRemove}
-              aria-label={i18n.translate(
-                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractRemoveExtraction',
-                { defaultMessage: 'Remove extraction' }
-              )}
-              data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
-            />
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-    </EuiPanel>
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+        css={showLabels ? { alignSelf: 'flex-end', marginBottom: 4 } : { alignSelf: 'center' }}
+      >
+        <EuiButtonIcon
+          iconType="trash"
+          color="danger"
+          onClick={onRemove}
+          disabled={!canRemove}
+          aria-label={i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractRemoveExtraction',
+            { defaultMessage: 'Remove extraction' }
+          )}
+          data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -13,8 +13,7 @@ import {
   EuiButtonIcon,
   EuiCode,
   EuiFieldText,
-  EuiFlexGroup,
-  EuiFlexItem,
+  EuiFormLabel,
   EuiFormRow,
   EuiPanel,
   EuiSpacer,
@@ -38,9 +37,17 @@ const typeOptions = jsonExtractTypes.map((type) => ({
 
 const extractionGridStyles = css`
   display: grid;
-  grid-template-columns: 4fr 4fr 2fr auto;
+  grid-template-columns: 1fr 1fr 1fr auto;
   gap: 8px;
   align-items: start;
+
+  & > * {
+    min-width: 0;
+  }
+
+  & > .euiFormRow {
+    margin-block-start: 0;
+  }
 `;
 
 export const JsonExtractProcessorForm = () => {
@@ -95,18 +102,35 @@ export const JsonExtractProcessorForm = () => {
           </EuiText>
           <EuiSpacer size="s" />
           <EuiPanel color="subdued" paddingSize="s" hasShadow={false} hasBorder={false}>
-            <EuiFlexGroup direction="column" gutterSize="s">
+            <div css={extractionGridStyles}>
+              <EuiFormLabel>
+                {i18n.translate(
+                  'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
+                  { defaultMessage: 'Selector' }
+                )}
+              </EuiFormLabel>
+              <EuiFormLabel>
+                {i18n.translate(
+                  'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetLabel',
+                  { defaultMessage: 'Target' }
+                )}
+              </EuiFormLabel>
+              <EuiFormLabel>
+                {i18n.translate(
+                  'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeLabel',
+                  { defaultMessage: 'Type' }
+                )}
+              </EuiFormLabel>
+              <div />
               {fields.map((field, index) => (
-                <EuiFlexItem key={field.id}>
-                  <ExtractionField
-                    index={index}
-                    onRemove={() => remove(index)}
-                    canRemove={fields.length > 1}
-                    showLabels={index === 0}
-                  />
-                </EuiFlexItem>
+                <ExtractionField
+                  key={field.id}
+                  index={index}
+                  onRemove={() => remove(index)}
+                  canRemove={fields.length > 1}
+                />
               ))}
-            </EuiFlexGroup>
+            </div>
           </EuiPanel>
           <EuiSpacer size="s" />
           <EuiButtonEmpty
@@ -138,10 +162,9 @@ interface ExtractionFieldProps {
   index: number;
   onRemove: () => void;
   canRemove: boolean;
-  showLabels: boolean;
 }
 
-const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionFieldProps) => {
+const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) => {
   const { field: selectorField, fieldState: selectorFieldState } = useController<
     JsonExtractFormState,
     `extractions.${number}.selector`
@@ -200,31 +223,9 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
   const { ref: selectorRef, ...selectorInputProps } = selectorField;
   const { ref: targetRef, ...targetInputProps } = targetField;
 
-  const selectorLabel = showLabels
-    ? i18n.translate(
-        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
-        { defaultMessage: 'Selector' }
-      )
-    : undefined;
-
-  const targetLabel = showLabels
-    ? i18n.translate(
-        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetLabel',
-        { defaultMessage: 'Target' }
-      )
-    : undefined;
-
-  const typeLabel = showLabels
-    ? i18n.translate(
-        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeLabel',
-        { defaultMessage: 'Type' }
-      )
-    : undefined;
-
   return (
-    <div css={extractionGridStyles}>
+    <>
       <EuiFormRow
-        label={selectorLabel}
         isInvalid={selectorFieldState.invalid}
         error={selectorFieldState.error?.message}
         fullWidth
@@ -243,7 +244,6 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
         />
       </EuiFormRow>
       <EuiFormRow
-        label={targetLabel}
         isInvalid={targetFieldState.invalid}
         error={targetFieldState.error?.message}
         fullWidth
@@ -261,7 +261,7 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
           data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
         />
       </EuiFormRow>
-      <EuiFormRow label={typeLabel} fullWidth>
+      <EuiFormRow fullWidth>
         <EuiSuperSelect
           options={typeOptions}
           valueOfSelected={typeField.value ?? 'keyword'}
@@ -275,7 +275,7 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
           )}
         />
       </EuiFormRow>
-      <div css={showLabels ? { alignSelf: 'end', marginBottom: 4 } : { alignSelf: 'center' }}>
+      <div css={{ alignSelf: 'center' }}>
         <EuiButtonIcon
           iconType="trash"
           color="danger"
@@ -288,6 +288,6 @@ const ExtractionField = ({ index, onRemove, canRemove, showLabels }: ExtractionF
           data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
         />
       </div>
-    </div>
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -18,13 +18,22 @@ import {
   EuiFormRow,
   EuiPanel,
   EuiSpacer,
+  EuiSuperSelect,
 } from '@elastic/eui';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
+import { FieldNameWithIcon } from '@kbn/react-field';
+import { capitalize } from 'lodash';
+import { jsonExtractTypes } from '@kbn/streamlang';
 import { ProcessorFieldSelector } from '../processor_field_selector';
 import { FieldsAccordion } from '../optional_fields_accordion';
 import { IgnoreFailureToggle, IgnoreMissingToggle } from '../ignore_toggles';
 import { ProcessorConditionEditor } from '../processor_condition_editor';
 import type { JsonExtractFormState } from '../../../../types';
+
+const typeOptions = jsonExtractTypes.map((type) => ({
+  value: type,
+  inputDisplay: <FieldNameWithIcon name={capitalize(type)} type={type} />,
+}));
 
 export const JsonExtractProcessorForm = () => {
   const { control } = useFormContext<JsonExtractFormState>();
@@ -44,7 +53,7 @@ export const JsonExtractProcessorForm = () => {
 
   useEffect(() => {
     if (fields.length === 0) {
-      append({ selector: '', target_field: '' });
+      append({ selector: '', target_field: '', type: 'keyword' });
     }
   }, [fields.length, append]);
 
@@ -86,7 +95,7 @@ export const JsonExtractProcessorForm = () => {
           ))}
           <EuiButtonEmpty
             iconType="plusInCircle"
-            onClick={() => append({ selector: '', target_field: '' })}
+            onClick={() => append({ selector: '', target_field: '', type: 'keyword' })}
             size="xs"
             data-test-subj="streamsAppJsonExtractAddExtractionButton"
           >
@@ -165,13 +174,18 @@ const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) =
     },
   });
 
+  const { field: typeField } = useController<JsonExtractFormState, `extractions.${number}.type`>({
+    name: `extractions.${index}.type`,
+    defaultValue: 'keyword',
+  });
+
   const { ref: selectorRef, ...selectorInputProps } = selectorField;
   const { ref: targetRef, ...targetInputProps } = targetField;
 
   return (
     <EuiPanel paddingSize="s" hasShadow={false} hasBorder style={{ marginBottom: 8 }}>
       <EuiFlexGroup gutterSize="s" alignItems="flexStart">
-        <EuiFlexItem grow={5}>
+        <EuiFlexItem grow={4}>
           <EuiFormRow
             label={i18n.translate(
               'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
@@ -195,7 +209,7 @@ const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) =
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem grow={5}>
+        <EuiFlexItem grow={4}>
           <EuiFormRow
             label={i18n.translate(
               'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldLabel',
@@ -216,6 +230,28 @@ const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) =
               fullWidth
               compressed
               data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeLabel',
+              { defaultMessage: 'Type' }
+            )}
+            fullWidth
+          >
+            <EuiSuperSelect
+              options={typeOptions}
+              valueOfSelected={typeField.value ?? 'keyword'}
+              onChange={typeField.onChange}
+              compressed
+              fullWidth
+              data-test-subj={`streamsAppJsonExtractTypeSelect-${index}`}
+              aria-label={i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTypeAriaLabel',
+                { defaultMessage: 'Extraction type' }
+              )}
             />
           </EuiFormRow>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/json_extract/index.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCode,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+} from '@elastic/eui';
+import { useController, useFieldArray, useFormContext } from 'react-hook-form';
+import { ProcessorFieldSelector } from '../processor_field_selector';
+import { FieldsAccordion } from '../optional_fields_accordion';
+import { IgnoreFailureToggle, IgnoreMissingToggle } from '../ignore_toggles';
+import { ProcessorConditionEditor } from '../processor_condition_editor';
+import type { JsonExtractFormState } from '../../../../types';
+
+export const JsonExtractProcessorForm = () => {
+  const { control } = useFormContext<JsonExtractFormState>();
+  const { fields, append, remove } = useFieldArray<JsonExtractFormState, 'extractions'>({
+    control,
+    name: 'extractions',
+    rules: {
+      minLength: {
+        value: 1,
+        message: i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsMinLengthError',
+          { defaultMessage: 'At least one extraction is required.' }
+        ),
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      append({ selector: '', target_field: '' });
+    }
+  }, [fields.length, append]);
+
+  return (
+    <>
+      <ProcessorFieldSelector
+        fieldKey="field"
+        helpText={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractFieldHelpText',
+          { defaultMessage: 'The field containing the JSON string to parse.' }
+        )}
+      />
+      <EuiFormRow
+        label={i18n.translate(
+          'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsLabel',
+          { defaultMessage: 'Extractions' }
+        )}
+        helpText={
+          <FormattedMessage
+            id="xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractExtractionsHelpText"
+            defaultMessage="Define which values to extract using JSONPath-like selectors. Examples: {example1}, {example2}, {example3}"
+            values={{
+              example1: <EuiCode>user.id</EuiCode>,
+              example2: <EuiCode>$.metadata.client.ip</EuiCode>,
+              example3: <EuiCode>items[0].name</EuiCode>,
+            }}
+          />
+        }
+        fullWidth
+      >
+        <div>
+          {fields.map((field, index) => (
+            <ExtractionField
+              key={field.id}
+              index={index}
+              onRemove={() => remove(index)}
+              canRemove={fields.length > 1}
+            />
+          ))}
+          <EuiButtonEmpty
+            iconType="plusInCircle"
+            onClick={() => append({ selector: '', target_field: '' })}
+            size="xs"
+            data-test-subj="streamsAppJsonExtractAddExtractionButton"
+          >
+            {i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractAddExtraction',
+              { defaultMessage: 'Add extraction' }
+            )}
+          </EuiButtonEmpty>
+        </div>
+      </EuiFormRow>
+      <EuiSpacer size="m" />
+      <FieldsAccordion>
+        <ProcessorConditionEditor />
+      </FieldsAccordion>
+      <EuiSpacer size="m" />
+      <IgnoreFailureToggle />
+      <IgnoreMissingToggle />
+    </>
+  );
+};
+
+interface ExtractionFieldProps {
+  index: number;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+const ExtractionField = ({ index, onRemove, canRemove }: ExtractionFieldProps) => {
+  const { field: selectorField, fieldState: selectorFieldState } = useController<
+    JsonExtractFormState,
+    `extractions.${number}.selector`
+  >({
+    name: `extractions.${index}.selector`,
+    rules: {
+      required: i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorRequiredError',
+        { defaultMessage: 'Selector is required.' }
+      ),
+      validate: (value: string) => {
+        if (value.includes('{{')) {
+          return i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorMustacheError',
+            {
+              defaultMessage:
+                "Mustache template syntax '{{' '}}' or '{{{' '}}}' is not allowed in selectors",
+            }
+          );
+        }
+        return true;
+      },
+    },
+  });
+
+  const { field: targetField, fieldState: targetFieldState } = useController<
+    JsonExtractFormState,
+    `extractions.${number}.target_field`
+  >({
+    name: `extractions.${index}.target_field`,
+    rules: {
+      required: i18n.translate(
+        'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldRequiredError',
+        { defaultMessage: 'Target field is required.' }
+      ),
+      validate: (value: string) => {
+        if (value.includes('{{')) {
+          return i18n.translate(
+            'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldMustacheError',
+            {
+              defaultMessage:
+                "Mustache template syntax '{{' '}}' or '{{{' '}}}' is not allowed in target fields",
+            }
+          );
+        }
+        return true;
+      },
+    },
+  });
+
+  const { ref: selectorRef, ...selectorInputProps } = selectorField;
+  const { ref: targetRef, ...targetInputProps } = targetField;
+
+  return (
+    <EuiPanel paddingSize="s" hasShadow={false} hasBorder style={{ marginBottom: 8 }}>
+      <EuiFlexGroup gutterSize="s" alignItems="flexStart">
+        <EuiFlexItem grow={5}>
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorLabel',
+              { defaultMessage: 'Selector' }
+            )}
+            isInvalid={selectorFieldState.invalid}
+            error={selectorFieldState.error?.message}
+            fullWidth
+          >
+            <EuiFieldText
+              placeholder={i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractSelectorPlaceholder',
+                { defaultMessage: 'e.g., user.id or $.data[0].value' }
+              )}
+              isInvalid={selectorFieldState.invalid}
+              {...selectorInputProps}
+              inputRef={selectorRef}
+              fullWidth
+              compressed
+              data-test-subj={`streamsAppJsonExtractSelectorInput-${index}`}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={5}>
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldLabel',
+              { defaultMessage: 'Target field' }
+            )}
+            isInvalid={targetFieldState.invalid}
+            error={targetFieldState.error?.message}
+            fullWidth
+          >
+            <EuiFieldText
+              placeholder={i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractTargetFieldPlaceholder',
+                { defaultMessage: 'e.g., extracted.user_id' }
+              )}
+              isInvalid={targetFieldState.invalid}
+              {...targetInputProps}
+              inputRef={targetRef}
+              fullWidth
+              compressed
+              data-test-subj={`streamsAppJsonExtractTargetFieldInput-${index}`}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        {canRemove && (
+          <EuiFlexItem grow={false} style={{ alignSelf: 'flex-end', marginBottom: 4 }}>
+            <EuiButtonIcon
+              iconType="trash"
+              color="danger"
+              onClick={onRemove}
+              aria-label={i18n.translate(
+                'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractRemoveExtraction',
+                { defaultMessage: 'Remove extraction' }
+              )}
+              data-test-subj={`streamsAppJsonExtractRemoveExtractionButton-${index}`}
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
@@ -625,11 +625,7 @@ const getAvailableProcessors: (
       return (
         <FormattedMessage
           id="xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractHelpText"
-          defaultMessage="Extract values from JSON strings using JSONPath-like selectors (e.g., {example1}, {example2})."
-          values={{
-            example1: <EuiCode>user.id</EuiCode>,
-            example2: <EuiCode>items[0].name</EuiCode>,
-          }}
+          defaultMessage="Extract values from JSON strings."
         />
       );
     },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/steps/blocks/action/processor_type_selector.tsx
@@ -613,6 +613,27 @@ const getAvailableProcessors: (
       );
     },
   },
+  json_extract: {
+    type: 'json_extract' as const,
+    inputDisplay: i18n.translate(
+      'xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractInputDisplay',
+      {
+        defaultMessage: 'JSON extract',
+      }
+    ),
+    getDocUrl: () => {
+      return (
+        <FormattedMessage
+          id="xpack.streams.streamDetailView.managementTab.enrichment.processor.jsonExtractHelpText"
+          defaultMessage="Extract values from JSON strings using JSONPath-like selectors (e.g., {example1}, {example2})."
+          values={{
+            example1: <EuiCode>user.id</EuiCode>,
+            example2: <EuiCode>items[0].name</EuiCode>,
+          }}
+        />
+      );
+    },
+  },
   ...configDrivenProcessors,
   ...(isWired
     ? {}
@@ -645,6 +666,7 @@ const PROCESSOR_GROUP_MAP: Record<
   drop_document: 'remove',
   grok: 'extract',
   dissect: 'extract',
+  json_extract: 'extract',
   convert: 'convert',
   date: 'convert',
   replace: 'convert',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/types.ts
@@ -25,6 +25,7 @@ import type {
   SortProcessor,
   ConcatProcessor,
   NetworkDirectionProcessor,
+  JsonExtractProcessor,
 } from '@kbn/streamlang';
 import type { EnrichmentDataSource } from '../../../../common/url_schema';
 import type { ConfigDrivenProcessorFormState } from './steps/blocks/action/config_driven/types';
@@ -72,6 +73,7 @@ export type JoinFormState = JoinProcessor;
 export type SplitFormState = SplitProcessor;
 export type SortFormState = SortProcessor;
 export type ConcatFormState = ConcatProcessor;
+export type JsonExtractFormState = JsonExtractProcessor;
 export type NetworkDirectionFormState = Omit<
   NetworkDirectionProcessor,
   'internal_networks' | 'internal_networks_field'
@@ -98,6 +100,7 @@ export type SpecialisedFormState =
   | SplitFormState
   | SortFormState
   | ConcatFormState
+  | JsonExtractFormState
   | NetworkDirectionFormState;
 
 export type ProcessorFormState = SpecialisedFormState | ConfigDrivenProcessorFormState;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -11,6 +11,7 @@ import type {
   ConvertProcessor,
   GrokProcessor,
   JoinProcessor,
+  JsonExtractProcessor,
   LowercaseProcessor,
   MathProcessor,
   NetworkDirectionProcessor,
@@ -60,6 +61,7 @@ import type {
   EnrichmentDataSourceWithUIAttributes,
   GrokFormState,
   JoinFormState,
+  JsonExtractFormState,
   LowercaseFormState,
   ManualIngestPipelineFormState,
   MathFormState,
@@ -94,6 +96,7 @@ export const SPECIALISED_TYPES = [
   'split',
   'sort',
   'concat',
+  'json_extract',
   'network_direction',
 ];
 
@@ -323,6 +326,17 @@ const defaultConcatProcessorFormState = (): ConcatFormState => ({
   where: ALWAYS_CONDITION,
 });
 
+const defaultJsonExtractProcessorFormState = (
+  sampleDocs: FlattenRecord[]
+): JsonExtractFormState => ({
+  action: 'json_extract' as const,
+  field: getDefaultTextField(sampleDocs, PRIORITIZED_CONTENT_FIELDS),
+  extractions: [{ selector: '', target_field: '' }],
+  ignore_failure: true,
+  ignore_missing: true,
+  where: ALWAYS_CONDITION,
+});
+
 const defaultNetworkDirectionProcessorFormState = (): NetworkDirectionFormState => ({
   action: 'network_direction' as const,
   source_ip: '',
@@ -362,6 +376,7 @@ const defaultProcessorFormStateByType: Record<
   split: defaultSplitProcessorFormState,
   sort: defaultSortProcessorFormState,
   concat: defaultConcatProcessorFormState,
+  json_extract: defaultJsonExtractProcessorFormState,
   network_direction: defaultNetworkDirectionProcessorFormState,
   ...configDrivenDefaultFormStates,
 };
@@ -430,7 +445,8 @@ export const getFormStateFromActionStep = (
     step.action === 'join' ||
     step.action === 'split' ||
     step.action === 'sort' ||
-    step.action === 'concat'
+    step.action === 'concat' ||
+    step.action === 'json_extract'
   ) {
     const { customIdentifier, parentId, ...restStep } = step;
     return structuredClone({
@@ -773,6 +789,26 @@ export const convertFormStateToProcessor = (
           description,
           where: 'where' in formState ? formState.where : undefined,
         } as ConcatProcessor,
+      };
+    }
+
+    if (formState.action === 'json_extract') {
+      const { field, extractions, ignore_failure, ignore_missing } = formState;
+
+      const filteredExtractions = extractions.filter(
+        (e) => !isEmpty(e.selector) && !isEmpty(e.target_field)
+      );
+
+      return {
+        processorDefinition: {
+          action: 'json_extract',
+          field,
+          extractions: filteredExtractions.length > 0 ? filteredExtractions : extractions,
+          ignore_failure,
+          ignore_missing,
+          description,
+          where: 'where' in formState ? formState.where : undefined,
+        } as JsonExtractProcessor,
       };
     }
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.ts
@@ -803,7 +803,7 @@ export const convertFormStateToProcessor = (
         processorDefinition: {
           action: 'json_extract',
           field,
-          extractions: filteredExtractions.length > 0 ? filteredExtractions : extractions,
+          extractions: filteredExtractions,
           ignore_failure,
           ignore_missing,
           description,


### PR DESCRIPTION
## Summary

Adds a new `json_extract` action/processor to Streamlang that extracts values from JSON strings using JSONPath-like selectors.

### Features
- Support for dot notation (`user.address.city`), bracket notation (`['user']['name']`), and array indices (`items[0]`)
- Optional `$` root selector
- Multiple extractions per processor
- `ignore_missing` and `ignore_failure` options
- Conditional extraction with `where` clause
- **Type casting support**: Each extraction can specify a target type (`keyword`, `integer`, `long`, `double`, `boolean`) to ensure consistent output types across transpilers

### Implementation
- **Ingest Pipeline**: Uses Painless script with `Processors.json()` for JSON parsing and traversal, with type casting via Painless type conversion methods
- **ES|QL**: Uses `JSON_EXTRACT` function wrapped in type conversion functions (`TO_INTEGER`, `TO_LONG`, `TO_DOUBLE`, `TO_BOOLEAN`) when a non-keyword type is specified

### Type Casting
The `type` field in each extraction specification controls the output data type:
- `keyword` (default): String output, no conversion needed
- `integer`: Converts to integer (Painless: `intValue()`, ES|QL: `TO_INTEGER`)
- `long`: Converts to long (Painless: `longValue()`, ES|QL: `TO_LONG`)
- `double`: Converts to double (Painless: `doubleValue()`, ES|QL: `TO_DOUBLE`)
- `boolean`: Converts to boolean (Painless: `Boolean.parseBoolean()`, ES|QL: `TO_BOOLEAN`)

This ensures consistent types between Ingest Pipeline and ES|QL transpilers, eliminating the previous behavioral difference where Ingest Pipeline preserved JSON types while ES|QL returned keywords.

### Test Coverage
- 15 ingest pipeline tests
- 8 ES|QL tests
- 14 cross-compatibility tests (including type casting tests)
- UI form component for streams_app with type selector dropdown

## Test plan
- [ ] Run streamlang tests: `yarn test:jest x-pack/platform/packages/shared/kbn-streamlang`
- [ ] Run Scout API tests: `node scripts/scout run-tests --arch stateful --domain classic --config x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/config/stateful/classic.config.ts`
- [ ] Verify UI in streams_app data management enrichment page

Closes #256676

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON extraction processor to extract values from JSON strings.
  * Support for nested field extraction using dot notation and bracket notation.
  * Type casting for extracted values: integer, long, double, boolean, and keyword.
  * Conditional extraction with filtering capabilities.
  * Multiple field extraction from a single JSON source.
  * Configurable behavior for handling missing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->