### PR TITLE
[Docs] add xpack.alerting.rules.maxScheduledPerMinute setting description

### DIFF
--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -891,7 +891,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 
     :::{note}
     :applies_to: serverless:
-    In Serverless, the maximum number of rules to run per minute is set to `800` for {{sec-serverless}} project while `400` for other projects. This setting can't be configured.
+    In Serverless, the maximum number of rules to run per minute is set to `800` for Elastic Security project while `400` for other projects. This setting can't be configured.
     :::
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg 'Supported on {{ech}}')

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -891,7 +891,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 
     :::{note}
     :applies_to: serverless:
-    In Serverless, the maximum number of rules to run per minute is set to `400` and can't be configured.
+    In Serverless, the maximum number of rules to run per minute is set to `800` for {{sec-serverless}} project while `400` for other projects. This setting can't be configured.
     :::
 
 `xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg 'Supported on {{ech}}')


### PR DESCRIPTION

## Summary

Background is in https://github.com/elastic/sdh-kibana/issues/6024#issuecomment-4011151616
Per suggestion by @mikecote, I am adding the description to express below:

> it would be worthwhile to carve a note to mention it's 800 for security projects while 400 for other projects.

### Checklist

This is a doc PR. IMHO below conditions are not applicable. 

<details>

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

</details>

## Preview

[docs/reference/configuration-reference/alerting-settings.md](https://docs-v3-preview.elastic.dev/elastic/kibana/pull/257041/reference/configuration-reference/alerting-settings)
