### PR TITLE
[9.3] [Stack monitoring] Small improvements to marketing banners (#252710)

### DIFF
--- a/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.stories.tsx
+++ b/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.stories.tsx
@@ -17,5 +17,5 @@ export default {
 };
 
 export const AutoOpsPromotionCallout = () => {
-  return <Component learnMoreLink="https://www.elastic.co/blog/elasticsearch-autoops-on-prem" />;
+  return <Component />;
 };

--- a/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.test.tsx
+++ b/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.test.tsx
@@ -19,9 +19,7 @@ const renderWithI18n = (component: React.ReactElement) => {
 };
 
 describe('AutoOpsPromotionCallout', () => {
-  const defaultProps = {
-    learnMoreLink: 'https://www.elastic.co/cloud/autoops',
-  };
+  const defaultProps = {};
 
   beforeEach(() => {
     localStorage.clear();
@@ -37,25 +35,22 @@ describe('AutoOpsPromotionCallout', () => {
       renderWithI18n(<AutoOpsPromotionCallout {...defaultProps} />);
 
       expect(screen.getByTestId('autoOpsPromotionCallout')).toBeInTheDocument();
-      expect(
-        screen.getByText('New! Connect AutoOps to this self-managed cluster')
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('autoOpsPromotionCalloutConnectButton')).toBeInTheDocument();
+      expect(screen.getByText('New! Connect this cluster to AutoOps')).toBeInTheDocument();
+    });
+
+    test('renders Cloud Connect link with default url', () => {
+      renderWithI18n(<AutoOpsPromotionCallout {...defaultProps} />);
+
+      const cloudConnectLink = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      expect(cloudConnectLink).toBeInTheDocument();
+      expect(cloudConnectLink).toHaveAttribute('href', '/app/cloud_connect');
     });
 
     test('renders with custom cloudConnectUrl', () => {
       renderWithI18n(<AutoOpsPromotionCallout {...defaultProps} cloudConnectUrl="/custom/path" />);
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      expect(button).toHaveAttribute('href', '/custom/path');
-    });
-
-    test('renders learn more link', () => {
-      renderWithI18n(<AutoOpsPromotionCallout {...defaultProps} />);
-
-      const learnMoreLink = screen.getByText('Learn more');
-      expect(learnMoreLink).toBeInTheDocument();
-      expect(learnMoreLink.closest('a')).toHaveAttribute('href', defaultProps.learnMoreLink);
+      const cloudConnectLink = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      expect(cloudConnectLink).toHaveAttribute('href', '/custom/path');
     });
   });
 
@@ -79,7 +74,7 @@ describe('AutoOpsPromotionCallout', () => {
     });
   });
 
-  describe('Button behavior with permissions', () => {
+  describe('Cloud Connect link behavior with permissions', () => {
     test('renders internal navigation when hasCloudConnectPermission is true', () => {
       const onConnectClick = jest.fn();
       renderWithI18n(
@@ -91,8 +86,8 @@ describe('AutoOpsPromotionCallout', () => {
         />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      expect(button).toHaveAttribute('href', '/app/cloud_connect');
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      expect(link).toHaveAttribute('href', '/app/cloud_connect');
     });
 
     test('renders internal navigation when hasCloudConnectPermission is undefined (backward compatible)', () => {
@@ -105,8 +100,8 @@ describe('AutoOpsPromotionCallout', () => {
         />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      expect(button).toHaveAttribute('href', '/app/cloud_connect');
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      expect(link).toHaveAttribute('href', '/app/cloud_connect');
     });
 
     test('renders external link when hasCloudConnectPermission is false', () => {
@@ -114,8 +109,8 @@ describe('AutoOpsPromotionCallout', () => {
         <AutoOpsPromotionCallout {...defaultProps} hasCloudConnectPermission={false} />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      expect(button).toHaveAttribute(
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      expect(link).toHaveAttribute(
         'href',
         'https://cloud.elastic.co/connect-cluster-services-portal'
       );
@@ -123,7 +118,7 @@ describe('AutoOpsPromotionCallout', () => {
   });
 
   describe('Click handler', () => {
-    test('calls onConnectClick and preventDefault when user has permission', () => {
+    test('calls onConnectClick when user has permission and clicks Cloud Connect link', () => {
       const onConnectClick = jest.fn();
       renderWithI18n(
         <AutoOpsPromotionCallout
@@ -134,8 +129,8 @@ describe('AutoOpsPromotionCallout', () => {
         />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      fireEvent.click(button);
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      fireEvent.click(link);
 
       expect(onConnectClick).toHaveBeenCalled();
       expect(onConnectClick).toHaveBeenCalledWith(expect.any(Object));
@@ -151,9 +146,9 @@ describe('AutoOpsPromotionCallout', () => {
         />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
 
-      expect(button.onclick).toBeNull();
+      expect(link.onclick).toBeNull();
     });
 
     test('calls onConnectClick when hasCloudConnectPermission is undefined', () => {
@@ -166,8 +161,8 @@ describe('AutoOpsPromotionCallout', () => {
         />
       );
 
-      const button = screen.getByTestId('autoOpsPromotionCalloutConnectButton');
-      fireEvent.click(button);
+      const link = screen.getByTestId('autoOpsPromotionCalloutCloudConnectLink');
+      fireEvent.click(link);
 
       expect(onConnectClick).toHaveBeenCalled();
     });

--- a/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.tsx
+++ b/src/platform/packages/shared/kbn-management/autoops_promotion_callout/src/callout.tsx
@@ -10,10 +10,9 @@
 import React, { useState, useEffect } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiCallOutProps } from '@elastic/eui';
-import { EuiCallOut, EuiButton } from '@elastic/eui';
+import { EuiCallOut, EuiLink } from '@elastic/eui';
 
 export interface AutoOpsPromotionCalloutProps {
-  learnMoreLink: string;
   cloudConnectUrl?: string;
   onConnectClick?: (e: React.MouseEvent) => void;
   hasCloudConnectPermission?: boolean;
@@ -23,7 +22,6 @@ export interface AutoOpsPromotionCalloutProps {
 export const AUTOOPS_CALLOUT_DISMISSED_KEY = 'kibana.autoOpsPromotionCallout.dismissed';
 
 export const AutoOpsPromotionCallout = ({
-  learnMoreLink,
   cloudConnectUrl = '/app/cloud_connect',
   onConnectClick,
   hasCloudConnectPermission,
@@ -47,13 +45,14 @@ export const AutoOpsPromotionCallout = ({
     return null;
   }
 
-  // Determine button behavior based on cloudConnect permission
-  const buttonProps =
+  // Determine Cloud Connect link behavior based on cloudConnect permission
+  const cloudConnectLinkProps =
     hasCloudConnectPermission === false
       ? {
           href: 'https://cloud.elastic.co/connect-cluster-services-portal',
           target: '_blank' as const,
-          rel: 'noopener noreferrer',
+          rel: 'noopener noreferrer' as const,
+          external: true,
         }
       : {
           href: cloudConnectUrl,
@@ -65,11 +64,11 @@ export const AutoOpsPromotionCallout = ({
       title={
         <FormattedMessage
           id="management.autoOpsPromotionCallout.title"
-          defaultMessage="New! Connect AutoOps to this self-managed cluster"
+          defaultMessage="New! Connect this cluster to AutoOps"
         />
       }
-      color="accent"
-      iconType="alert"
+      color="primary"
+      iconType="info"
       data-test-subj="autoOpsPromotionCallout"
       onDismiss={handleDismiss}
       {...overrideCalloutProps}
@@ -77,31 +76,22 @@ export const AutoOpsPromotionCallout = ({
       <p>
         <FormattedMessage
           id="management.autoOpsPromotionCallout.description"
-          defaultMessage="Connect this cluster to AutoOps on Elastic Cloud for simplified monitoring, real-time issue detection, and performance recommendations. {learnMoreLink}"
+          defaultMessage="Unlock advanced monitoring of ECE, ECK, and self-managed clusters with AutoOps, now available for free across all license types. Set it up today using {cloudConnectLink}."
           values={{
-            learnMoreLink: (
-              <a href={learnMoreLink} target="_blank" rel="noopener noreferrer">
+            cloudConnectLink: (
+              <EuiLink
+                {...cloudConnectLinkProps}
+                data-test-subj="autoOpsPromotionCalloutCloudConnectLink"
+              >
                 <FormattedMessage
-                  id="management.autoOpsPromotionCallout.learnMore"
-                  defaultMessage="Learn more"
+                  id="management.autoOpsPromotionCallout.cloudConnectLink"
+                  defaultMessage="Cloud Connect"
                 />
-              </a>
+              </EuiLink>
             ),
           }}
         />
       </p>
-      <EuiButton
-        color="accent"
-        fill
-        size="s"
-        {...buttonProps}
-        data-test-subj="autoOpsPromotionCalloutConnectButton"
-      >
-        <FormattedMessage
-          id="management.autoOpsPromotionCallout.openButton"
-          defaultMessage="Connect this cluster"
-        />
-      </EuiButton>
     </EuiCallOut>
   );
 };

--- a/src/platform/plugins/shared/management/kibana.jsonc
+++ b/src/platform/plugins/shared/management/kibana.jsonc
@@ -16,8 +16,10 @@
     "optionalPlugins": [
       "home",
       "serverless",
-      "cloud",
-      "licensing"
+      "cloud"
+    ],
+    "runtimePluginDependencies": [
+      "fleet"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/src/platform/plugins/shared/management/moon.yml
+++ b/src/platform/plugins/shared/management/moon.yml
@@ -37,7 +37,6 @@ dependsOn:
   - '@kbn/react-kibana-context-render'
   - '@kbn/core-chrome-browser'
   - '@kbn/autoops-promotion-callout'
-  - '@kbn/licensing-plugin'
 tags:
   - plugin
   - prod

--- a/src/platform/plugins/shared/management/public/components/landing/landing.test.tsx
+++ b/src/platform/plugins/shared/management/public/components/landing/landing.test.tsx
@@ -49,7 +49,7 @@ const renderLandingPage = async (overrides: Partial<AppDependencies> = {}) => {
     sections: sectionsMock,
     chromeStyle: 'classic',
     coreStart,
-    hasEnterpriseLicense: false,
+    isAirGapped: false,
     getAutoOpsStatusHook: () => () => ({ isCloudConnectAutoopsEnabled: false, isLoading: false }),
     ...overrides,
   };
@@ -115,12 +115,11 @@ describe('Landing Page', () => {
   });
 
   describe('AutoOps Promotion Callout', () => {
-    test('Shows AutoOps callout when not in cloud and has enterprise license', async () => {
+    test('Shows AutoOps callout when not in cloud', async () => {
       await renderLandingPage({
         chromeStyle: 'classic',
         cardsNavigationConfig: { enabled: false },
         cloud: { isCloudEnabled: false },
-        hasEnterpriseLicense: true,
       });
 
       expect(screen.getByTestId('autoOpsPromotionCallout')).toBeInTheDocument();
@@ -131,43 +130,30 @@ describe('Landing Page', () => {
         chromeStyle: 'classic',
         cardsNavigationConfig: { enabled: false },
         cloud: { isCloudEnabled: true },
-        hasEnterpriseLicense: true,
       });
 
       expect(screen.queryByTestId('autoOpsPromotionCallout')).not.toBeInTheDocument();
     });
 
-    test('Hides AutoOps callout when not having enterprise license', async () => {
+    test('Shows AutoOps callout when cloud service is not available', async () => {
       await renderLandingPage({
         chromeStyle: 'classic',
         cardsNavigationConfig: { enabled: false },
-        cloud: { isCloudEnabled: false },
-        hasEnterpriseLicense: false,
-      });
-
-      expect(screen.queryByTestId('autoOpsPromotionCallout')).not.toBeInTheDocument();
-    });
-
-    test('Hides AutoOps callout when in cloud and without enterprise license', async () => {
-      await renderLandingPage({
-        chromeStyle: 'classic',
-        cardsNavigationConfig: { enabled: false },
-        cloud: { isCloudEnabled: true },
-        hasEnterpriseLicense: false,
-      });
-
-      expect(screen.queryByTestId('autoOpsPromotionCallout')).not.toBeInTheDocument();
-    });
-
-    test('Shows AutoOps callout when cloud service is not available but has enterprise license', async () => {
-      await renderLandingPage({
-        chromeStyle: 'classic',
-        cardsNavigationConfig: { enabled: false },
-        hasEnterpriseLicense: true,
         // cloud service not provided - defaults to isCloudEnabled: false
       });
 
       expect(screen.getByTestId('autoOpsPromotionCallout')).toBeInTheDocument();
+    });
+
+    test('Hides AutoOps callout when in air-gapped environment', async () => {
+      await renderLandingPage({
+        chromeStyle: 'classic',
+        cardsNavigationConfig: { enabled: false },
+        cloud: { isCloudEnabled: false },
+        isAirGapped: true,
+      });
+
+      expect(screen.queryByTestId('autoOpsPromotionCallout')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/platform/plugins/shared/management/public/components/landing/landing.tsx
+++ b/src/platform/plugins/shared/management/public/components/landing/landing.tsx
@@ -36,7 +36,7 @@ export const ManagementLandingPage = ({
     chromeStyle,
     coreStart,
     cloud,
-    hasEnterpriseLicense,
+    isAirGapped,
     getAutoOpsStatusHook,
   } = useAppContext();
   setBreadcrumbs();
@@ -47,12 +47,13 @@ export const ManagementLandingPage = ({
 
   // Check if cloud services are available
   const isCloudEnabled = cloud?.isCloudEnabled || false;
-  // AutoOps promotion callout should only be shown for self-managed instances with an enterprise license
+  // AutoOps promotion callout should only be shown for self-managed, non-air-gapped instances
   // and not already connected to AutoOps
-  const isAutoOpsEligible = !isCloudEnabled && hasEnterpriseLicense;
   const shouldShowAutoOpsPromotion =
-    isAutoOpsEligible && !autoOpsStatus.isLoading && !autoOpsStatus.isCloudConnectAutoopsEnabled;
-  const learnMoreLink = coreStart.docLinks.links.cloud.connectToAutoops;
+    !isCloudEnabled &&
+    !isAirGapped &&
+    !autoOpsStatus.isLoading &&
+    !autoOpsStatus.isCloudConnectAutoopsEnabled;
   const cloudConnectUrl = coreStart.application.getUrlForApp('cloud_connect');
   const handleConnectClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -97,7 +98,6 @@ export const ManagementLandingPage = ({
               `}
             >
               <AutoOpsPromotionCallout
-                learnMoreLink={learnMoreLink}
                 cloudConnectUrl={cloudConnectUrl}
                 onConnectClick={handleConnectClick}
                 hasCloudConnectPermission={hasCloudConnectPermission}

--- a/src/platform/plugins/shared/management/public/components/management_app/management_app.tsx
+++ b/src/platform/plugins/shared/management/public/components/management_app/management_app.tsx
@@ -44,7 +44,7 @@ export interface ManagementAppDependencies {
   kibanaVersion: string;
   coreStart: CoreStart;
   cloud?: { isCloudEnabled: boolean; baseUrl?: string };
-  hasEnterpriseLicense: boolean;
+  isAirGapped: boolean;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;
   isSidebarEnabled$: BehaviorSubject<boolean>;
   cardsNavigationConfig$: BehaviorSubject<NavigationCardsSubject>;
@@ -118,7 +118,7 @@ export const ManagementApp = ({ dependencies, history, appBasePath }: Management
     coreStart,
     chromeStyle,
     cloud: dependencies.cloud,
-    hasEnterpriseLicense: dependencies.hasEnterpriseLicense,
+    isAirGapped: dependencies.isAirGapped,
     getAutoOpsStatusHook: dependencies.getAutoOpsStatusHook,
   };
 

--- a/src/platform/plugins/shared/management/public/plugin.tsx
+++ b/src/platform/plugins/shared/management/public/plugin.tsx
@@ -8,11 +8,10 @@
  */
 
 import { i18n as kbnI18n } from '@kbn/i18n';
-import { BehaviorSubject, take } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
-import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type {
   CoreSetup,
   CoreStart,
@@ -57,7 +56,6 @@ interface ManagementStartDependencies {
   share: SharePluginStart;
   serverless?: ServerlessPluginStart;
   cloud?: { isCloudEnabled: boolean; baseUrl?: string };
-  licensing?: LicensingPluginStart;
 }
 
 export class ManagementPlugin
@@ -150,18 +148,21 @@ export class ManagementPlugin
         const [coreStart, deps] = await core.getStartServices();
         const chromeStyle$ = coreStart.chrome.getChromeStyle$();
 
-        // Check if user has enterprise license
-        const license = deps.licensing
-          ? await deps.licensing.license$.pipe(take(1)).toPromise()
-          : null;
-        const hasEnterpriseLicense = license?.hasAtLeast('enterprise') || false;
+        // Resolve fleet at runtime via `core.plugins.onStart` instead of declaring it
+        // as a plugin dependency to avoid massive circular dependency issues in the plugin graph.
+        const fleetResult = await coreStart.plugins.onStart<{
+          fleet: { config: { isAirGapped?: boolean } };
+        }>('fleet');
+        const isAirGapped =
+          Boolean(fleetResult.fleet.found && fleetResult.fleet.contract.config.isAirGapped) &&
+          !Boolean(deps.cloud?.isCloudEnabled);
 
         return renderApp(params, {
           sections: getSectionsServiceStartPrivate(),
           kibanaVersion,
           coreStart,
           cloud: deps.cloud,
-          hasEnterpriseLicense,
+          isAirGapped,
           setBreadcrumbs: (newBreadcrumbs) => {
             if (deps.serverless) {
               // drop the root management breadcrumb in serverless because it comes from the navigation tree

--- a/src/platform/plugins/shared/management/public/types.ts
+++ b/src/platform/plugins/shared/management/public/types.ts
@@ -127,7 +127,7 @@ export interface AppDependencies {
   chromeStyle?: ChromeStyle;
   coreStart: CoreStart;
   cloud?: { isCloudEnabled: boolean; baseUrl?: string };
-  hasEnterpriseLicense: boolean;
+  isAirGapped: boolean;
   getAutoOpsStatusHook: () => AutoOpsStatusHook;
 }
 

--- a/src/platform/plugins/shared/management/tsconfig.json
+++ b/src/platform/plugins/shared/management/tsconfig.json
@@ -29,7 +29,6 @@
     "@kbn/react-kibana-context-render",
     "@kbn/core-chrome-browser",
     "@kbn/autoops-promotion-callout",
-    "@kbn/licensing-plugin",
   ],
   "exclude": [
     "target/**/*"

--- a/x-pack/platform/plugins/private/monitoring/public/application/pages/page_template.tsx
+++ b/x-pack/platform/plugins/private/monitoring/public/application/pages/page_template.tsx
@@ -67,7 +67,6 @@ export const PageTemplate: FC<PropsWithChildren<PageTemplateProps>> = ({
   const handleRequestError = useRequestErrorHandler();
   const { setHeaderActionMenu, theme$ } = useContext(HeaderActionMenuContext);
   const { services } = useKibana<MonitoringStartServices>();
-  const learnMoreLink = services.docLinks.links.cloud.connectToAutoops;
   const cloudConnectUrl = services.application.getUrlForApp('cloud_connect');
   const handleConnectClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -128,12 +127,11 @@ export const PageTemplate: FC<PropsWithChildren<PageTemplateProps>> = ({
 
   const { supported, enabled } = getSetupModeState();
 
-  // Check AutoOps connection status
   const cloudConnectStatus = Legacy.shims.useCloudConnectStatus();
   const shouldShowAutoOpsPromotion =
     showAutoOpsPromotion &&
     !Legacy.shims.isCloud &&
-    Legacy.shims.hasEnterpriseLicense &&
+    !Legacy.shims.isAirGapped &&
     !cloudConnectStatus.isLoading &&
     !cloudConnectStatus.isCloudConnectAutoopsEnabled;
 
@@ -157,7 +155,6 @@ export const PageTemplate: FC<PropsWithChildren<PageTemplateProps>> = ({
         <EuiSpacer size="m" />
         {shouldShowAutoOpsPromotion && (
           <AutoOpsPromotionCallout
-            learnMoreLink={learnMoreLink}
             cloudConnectUrl={cloudConnectUrl}
             onConnectClick={handleConnectClick}
             hasCloudConnectPermission={hasCloudConnectPermission}

--- a/x-pack/platform/plugins/private/monitoring/public/components/no_data/__snapshots__/no_data.test.js.snap
+++ b/x-pack/platform/plugins/private/monitoring/public/components/no_data/__snapshots__/no_data.test.js.snap
@@ -14,6 +14,58 @@ exports[`NoData should show a default message if reason is unknown 1`] = `
     class="euiPageBody emotion-euiPageBody-restrictWidth"
     style="max-width:600px"
   >
+    <div
+      class="euiPanel euiPanel--primary euiPanel--paddingMedium euiCallOut euiCallOut--primary emotion-euiPanel-none-m-primary-euiCallOut-hasDimissButton-m"
+      data-test-subj="autoOpsPromotionCallout"
+      style="margin:0 24px"
+    >
+      <p
+        class="euiTitle euiCallOutHeader__title emotion-euiTitle-xs-euiCallOutHeader-primary"
+      >
+        <span
+          aria-hidden="true"
+          class="emotion-euiCallOut__icon"
+          color="inherit"
+          data-euiicon-type="info"
+        />
+        New! Connect this cluster to AutoOps
+      </p>
+      <button
+        aria-label="Dismiss this callout"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary-euiCallOut__dismissButton-m"
+        data-test-subj="euiDismissCalloutButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
+      <div
+        class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
+      />
+      <div
+        class="euiText emotion-euiText-s-euiTextColor-default"
+      >
+        <p>
+          Unlock advanced monitoring of ECE, ECK, and self-managed clusters with AutoOps, now available for free across all license types. Set it up today using 
+          <a
+            class="euiLink emotion-euiLink-primary"
+            data-test-subj="autoOpsPromotionCalloutCloudConnectLink"
+            href="/app/cloud_connect"
+            rel="noreferrer"
+          >
+            Cloud Connect
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+    />
     <section
       class="emotion-euiPageSection-grow-l-center-transparent"
     >
@@ -125,6 +177,58 @@ exports[`NoData should show text next to the spinner while checking a setting 1`
     class="euiPageBody emotion-euiPageBody-restrictWidth"
     style="max-width:600px"
   >
+    <div
+      class="euiPanel euiPanel--primary euiPanel--paddingMedium euiCallOut euiCallOut--primary emotion-euiPanel-none-m-primary-euiCallOut-hasDimissButton-m"
+      data-test-subj="autoOpsPromotionCallout"
+      style="margin:0 24px"
+    >
+      <p
+        class="euiTitle euiCallOutHeader__title emotion-euiTitle-xs-euiCallOutHeader-primary"
+      >
+        <span
+          aria-hidden="true"
+          class="emotion-euiCallOut__icon"
+          color="inherit"
+          data-euiicon-type="info"
+        />
+        New! Connect this cluster to AutoOps
+      </p>
+      <button
+        aria-label="Dismiss this callout"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary-euiCallOut__dismissButton-m"
+        data-test-subj="euiDismissCalloutButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
+      <div
+        class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
+      />
+      <div
+        class="euiText emotion-euiText-s-euiTextColor-default"
+      >
+        <p>
+          Unlock advanced monitoring of ECE, ECK, and self-managed clusters with AutoOps, now available for free across all license types. Set it up today using 
+          <a
+            class="euiLink emotion-euiLink-primary"
+            data-test-subj="autoOpsPromotionCalloutCloudConnectLink"
+            href="/app/cloud_connect"
+            rel="noreferrer"
+          >
+            Cloud Connect
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
+    />
     <section
       class="emotion-euiPageSection-grow-l-center-transparent"
     >

--- a/x-pack/platform/plugins/private/monitoring/public/components/no_data/no_data.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/no_data/no_data.js
@@ -55,9 +55,7 @@ export function NoData(props) {
   const isCloudEnabled = props.isCloudEnabled;
   const { services } = useKibana();
 
-  // Check AutoOps connection status
   const cloudConnectStatus = Legacy.shims.useCloudConnectStatus();
-  const learnMoreLink = services.docLinks.links.cloud.connectToAutoops;
   const cloudConnectUrl = services.application.getUrlForApp('cloud_connect');
   const handleConnectClick = (e) => {
     e.preventDefault();
@@ -134,12 +132,11 @@ export function NoData(props) {
           </h1>
         </EuiScreenReaderOnly>
         <EuiPageBody restrictWidth={600}>
-          {Legacy.shims.hasEnterpriseLicense &&
+          {!Legacy.shims.isAirGapped &&
             !cloudConnectStatus.isLoading &&
             !cloudConnectStatus.isCloudConnectAutoopsEnabled && (
               <>
                 <AutoOpsPromotionCallout
-                  learnMoreLink={learnMoreLink}
                   cloudConnectUrl={cloudConnectUrl}
                   onConnectClick={handleConnectClick}
                   hasCloudConnectPermission={hasCloudConnectPermission}
@@ -191,12 +188,11 @@ export function NoData(props) {
         </h1>
       </EuiScreenReaderOnly>
       <EuiPageBody restrictWidth={600}>
-        {Legacy.shims.hasEnterpriseLicense &&
+        {!Legacy.shims.isAirGapped &&
           !cloudConnectStatus.isLoading &&
           !cloudConnectStatus.isCloudConnectAutoopsEnabled && (
             <>
               <AutoOpsPromotionCallout
-                learnMoreLink={learnMoreLink}
                 cloudConnectUrl={cloudConnectUrl}
                 onConnectClick={handleConnectClick}
                 hasCloudConnectPermission={hasCloudConnectPermission}

--- a/x-pack/platform/plugins/private/monitoring/public/components/no_data/no_data.test.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/no_data/no_data.test.js
@@ -12,7 +12,7 @@ import { NoData } from '.';
 jest.mock('../../legacy_shims', () => ({
   Legacy: {
     shims: {
-      hasEnterpriseLicense: false,
+      isAirGapped: false,
       useCloudConnectStatus: () => ({ isCloudConnectAutoopsEnabled: false, isLoading: false }),
     },
   },
@@ -21,13 +21,6 @@ jest.mock('../../legacy_shims', () => ({
 jest.mock('@kbn/kibana-react-plugin/public', () => ({
   useKibana: () => ({
     services: {
-      docLinks: {
-        links: {
-          cloud: {
-            connectToAutoops: 'https://docs.elastic.co/cloud/connect',
-          },
-        },
-      },
       application: {
         getUrlForApp: jest.fn(() => '/app/cloud_connect'),
         navigateToApp: jest.fn(),

--- a/x-pack/platform/plugins/private/monitoring/public/legacy_shims.ts
+++ b/x-pack/platform/plugins/private/monitoring/public/legacy_shims.ts
@@ -79,7 +79,7 @@ export interface IShims {
   ) => Promise<any>;
   isCloud: boolean;
   cloudBaseUrl?: string;
-  hasEnterpriseLicense: boolean;
+  isAirGapped: boolean;
   useCloudConnectStatus: UseCloudConnectStatusHook;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
   usageCollection: UsageCollectionSetup;
@@ -95,7 +95,7 @@ export class Legacy {
     data,
     isCloud,
     cloudBaseUrl,
-    hasEnterpriseLicense,
+    isAirGapped,
     triggersActionsUi,
     usageCollection,
     appMountParameters,
@@ -152,7 +152,7 @@ export class Legacy {
         }),
       isCloud,
       cloudBaseUrl,
-      hasEnterpriseLicense,
+      isAirGapped,
       useCloudConnectStatus:
         cloudConnect?.hooks.useCloudConnectStatus ?? defaultCloudConnectStatusHook,
       triggersActionsUi,

--- a/x-pack/platform/plugins/private/monitoring/public/plugin.ts
+++ b/x-pack/platform/plugins/private/monitoring/public/plugin.ts
@@ -6,7 +6,6 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { take } from 'rxjs';
 import type {
   App,
   AppMountParameters,
@@ -19,7 +18,6 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import type { TriggersAndActionsUIPublicPluginSetup } from '@kbn/triggers-actions-ui-plugin/public';
-import type { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
 import {
   CCS_REMOTE_PATTERN,
   RULE_DETAILS,
@@ -48,7 +46,6 @@ interface MonitoringSetupPluginDependencies {
   cloud?: { isCloudEnabled: boolean; baseUrl?: string };
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
   usageCollection: UsageCollectionSetup;
-  licensing: LicensingPluginSetup;
 }
 
 export class MonitoringPlugin
@@ -61,7 +58,7 @@ export class MonitoringPlugin
     core: CoreSetup<MonitoringStartPluginDependencies>,
     plugins: MonitoringSetupPluginDependencies
   ) {
-    const { home, licensing } = plugins;
+    const { home } = plugins;
     const id = 'monitoring';
     const icon = 'monitoringApp';
     const title = i18n.translate('xpack.monitoring.stackMonitoringTitle', {
@@ -101,9 +98,6 @@ export class MonitoringPlugin
       mount: async (params: AppMountParameters) => {
         const [coreStart, pluginsStart] = await core.getStartServices();
         const externalConfig = this.getExternalConfig();
-        // Check if user has enterprise license
-        const license = await licensing.license$.pipe(take(1)).toPromise();
-        const hasEnterpriseLicense = license?.hasAtLeast('enterprise') || false;
 
         const deps: LegacyMonitoringStartPluginDependencies = {
           navigation: pluginsStart.navigation,
@@ -113,7 +107,9 @@ export class MonitoringPlugin
           share: pluginsStart.share,
           isCloud: Boolean(plugins.cloud?.isCloudEnabled),
           cloudBaseUrl: plugins.cloud?.baseUrl,
-          hasEnterpriseLicense,
+          isAirGapped:
+            Boolean(pluginsStart.fleet?.config?.isAirGapped) &&
+            !Boolean(plugins.cloud?.isCloudEnabled),
           pluginInitializerContext: this.initializerContext,
           externalConfig,
           triggersActionsUi: pluginsStart.triggersActionsUi,
@@ -131,7 +127,7 @@ export class MonitoringPlugin
           navigation: deps.navigation,
           isCloud: deps.isCloud,
           cloudBaseUrl: deps.cloudBaseUrl,
-          hasEnterpriseLicense: deps.hasEnterpriseLicense,
+          isAirGapped: deps.isAirGapped,
           pluginInitializerContext: deps.pluginInitializerContext,
           externalConfig: deps.externalConfig,
           triggersActionsUi: deps.triggersActionsUi,

--- a/x-pack/platform/plugins/private/monitoring/public/types.ts
+++ b/x-pack/platform/plugins/private/monitoring/public/types.ts
@@ -38,7 +38,7 @@ interface LegacyStartDependencies {
   core: CoreStart;
   isCloud: boolean;
   cloudBaseUrl?: string;
-  hasEnterpriseLicense: boolean;
+  isAirGapped: boolean;
   pluginInitializerContext: PluginInitializerContext;
   externalConfig: Array<Array<string | number> | Array<string | boolean>>;
   appMountParameters: AppMountParameters;

--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -56,6 +56,7 @@ export const config: PluginConfigDescriptor = {
     integrationsHomeOverride: true,
     prereleaseEnabledByDefault: true,
     hideDashboards: true,
+    isAirGapped: true,
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
     // Unused settings before Fleet server exists


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Stack monitoring] Small improvements to marketing banners (#252710)](https://github.com/elastic/kibana/pull/252710)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2026-03-10T15:34:51Z","message":"[Stack monitoring] Small improvements to marketing banners (#252710)","sha":"41f68eaf1d9ce6af2ac1c8c83a2ff20b8416bbf5","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.3.2"],"title":"[Stack monitoring] Small improvements to marketing banners","number":252710,"url":"https://github.com/elastic/kibana/pull/252710","mergeCommit":{"message":"[Stack monitoring] Small improvements to marketing banners (#252710)","sha":"41f68eaf1d9ce6af2ac1c8c83a2ff20b8416bbf5"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252710","number":252710,"mergeCommit":{"message":"[Stack monitoring] Small improvements to marketing banners (#252710)","sha":"41f68eaf1d9ce6af2ac1c8c83a2ff20b8416bbf5"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->