### PR TITLE
[Lens] Refactor string literal use of `formBased`/`textBased`

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
@@ -439,13 +439,19 @@ export interface ExpressionWrapperProps {
 
 export type GetStateType = () => LensRuntimeState;
 
-export interface StructuredDatasourceStates {
-  formBased?: FormBasedPersistedState;
-  textBased?: TextBasedPersistedState;
-}
+export const SupportedDatasourceId = {
+  FormBased: 'formBased',
+  TextBased: 'textBased',
+} as const;
 
 /** The supported datasource identifiers */
-export type SupportedDatasourceId = keyof StructuredDatasourceStates;
+export type SupportedDatasourceId =
+  (typeof SupportedDatasourceId)[keyof typeof SupportedDatasourceId];
+
+export interface StructuredDatasourceStates {
+  [SupportedDatasourceId.FormBased]?: FormBasedPersistedState;
+  [SupportedDatasourceId.TextBased]?: TextBasedPersistedState;
+}
 
 /** Utility type to build typed version for each chart */
 type TypedLensAttributes<TVisType, TVisState> = Simplify<

--- a/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/embeddable/types.ts
@@ -439,18 +439,17 @@ export interface ExpressionWrapperProps {
 
 export type GetStateType = () => LensRuntimeState;
 
-export const SupportedDatasourceId = {
-  FormBased: 'formBased',
-  TextBased: 'textBased',
+export const LENS_DATASOURCE_ID = {
+  FORM_BASED: 'formBased',
+  TEXT_BASED: 'textBased',
 } as const;
 
 /** The supported datasource identifiers */
-export type SupportedDatasourceId =
-  (typeof SupportedDatasourceId)[keyof typeof SupportedDatasourceId];
+export type LensDatasourceId = (typeof LENS_DATASOURCE_ID)[keyof typeof LENS_DATASOURCE_ID];
 
 export interface StructuredDatasourceStates {
-  [SupportedDatasourceId.FormBased]?: FormBasedPersistedState;
-  [SupportedDatasourceId.TextBased]?: TextBasedPersistedState;
+  [LENS_DATASOURCE_ID.FORM_BASED]?: FormBasedPersistedState;
+  [LENS_DATASOURCE_ID.TEXT_BASED]?: TextBasedPersistedState;
 }
 
 /** Utility type to build typed version for each chart */

--- a/src/platform/packages/shared/kbn-lens-common/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common/index.ts
@@ -277,7 +277,6 @@ export type {
   ExpressionWrapperProps,
   GetStateType,
   StructuredDatasourceStates,
-  SupportedDatasourceId,
   LensByValueInput,
   TypedLensSerializedState,
   ESQLVariablesCompatibleDashboardApi,
@@ -401,3 +400,4 @@ export {
 } from './datasources/form_based/helpers';
 
 export { DRAG_DROP_EXTRA_TARGETS_WIDTH, DRAG_DROP_EXTRA_TARGETS_PADDING } from './editor/constants';
+export { SupportedDatasourceId } from './embeddable/types';

--- a/src/platform/packages/shared/kbn-lens-common/index.ts
+++ b/src/platform/packages/shared/kbn-lens-common/index.ts
@@ -400,4 +400,5 @@ export {
 } from './datasources/form_based/helpers';
 
 export { DRAG_DROP_EXTRA_TARGETS_WIDTH, DRAG_DROP_EXTRA_TARGETS_PADDING } from './editor/constants';
-export { SupportedDatasourceId } from './embeddable/types';
+export { LENS_DATASOURCE_ID } from './embeddable/types';
+export type { LensDatasourceId } from './embeddable/types';

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -6,6 +6,9 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { SavedObjectReference } from '@kbn/core-saved-objects-common/src/server_types';
 import type {
   FormBasedLayer,
@@ -288,7 +291,7 @@ function buildDatasourceStatesLayer(
     index: { index: string; timeFieldName: string | undefined }
   ) => FormBasedPersistedState['layers'] | PersistedIndexPatternLayer | undefined,
   getValueColumns: (layer: unknown, i: number) => TextBasedLayerColumn[] // ValueBasedLayerColumn[]
-): ['textBased' | 'formBased', DataSourceStateLayer | undefined] {
+): [SupportedDatasourceId, DataSourceStateLayer | undefined] {
   function buildValueLayer(
     config: unknown,
     ds: NarrowByType<DatasetType, 'table'>
@@ -326,12 +329,12 @@ function buildDatasourceStatesLayer(
   }
 
   if (dataset.type === 'esql') {
-    return ['textBased', buildESQLLayer(layer, dataset)];
+    return [SupportedDatasourceId.TextBased, buildESQLLayer(layer, dataset)];
   }
   if (dataset.type === 'table') {
-    return ['textBased', buildValueLayer(layer, dataset)];
+    return [SupportedDatasourceId.TextBased, buildValueLayer(layer, dataset)];
   }
-  return ['formBased', buildDataLayer(layer, i, datasetIndex)];
+  return [SupportedDatasourceId.FormBased, buildDataLayer(layer, i, datasetIndex)];
 }
 
 /**

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import type { SavedObjectReference } from '@kbn/core-saved-objects-common/src/server_types';
 import type {
@@ -18,6 +18,7 @@ import type {
   TextBasedLayer,
   TextBasedLayerColumn,
   TextBasedPersistedState,
+  LensDatasourceId,
 } from '@kbn/lens-common';
 import { cleanupFormulaReferenceColumns } from '@kbn/lens-common';
 import { getIndexPatternFromESQLQuery, getTimeFieldFromESQLQuery } from '@kbn/esql-utils';
@@ -291,7 +292,7 @@ function buildDatasourceStatesLayer(
     index: { index: string; timeFieldName: string | undefined }
   ) => FormBasedPersistedState['layers'] | PersistedIndexPatternLayer | undefined,
   getValueColumns: (layer: unknown, i: number) => TextBasedLayerColumn[] // ValueBasedLayerColumn[]
-): [SupportedDatasourceId, DataSourceStateLayer | undefined] {
+): [LensDatasourceId, DataSourceStateLayer | undefined] {
   function buildValueLayer(
     config: unknown,
     ds: NarrowByType<DatasetType, 'table'>
@@ -329,12 +330,12 @@ function buildDatasourceStatesLayer(
   }
 
   if (dataset.type === 'esql') {
-    return [SupportedDatasourceId.TextBased, buildESQLLayer(layer, dataset)];
+    return [LENS_DATASOURCE_ID.TEXT_BASED, buildESQLLayer(layer, dataset)];
   }
   if (dataset.type === 'table') {
-    return [SupportedDatasourceId.TextBased, buildValueLayer(layer, dataset)];
+    return [LENS_DATASOURCE_ID.TEXT_BASED, buildValueLayer(layer, dataset)];
   }
-  return [SupportedDatasourceId.FormBased, buildDataLayer(layer, i, datasetIndex)];
+  return [LENS_DATASOURCE_ID.FORM_BASED, buildDataLayer(layer, i, datasetIndex)];
 }
 
 /**

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import { v4 as uuidv4 } from 'uuid';
 import type { SavedObjectReference } from '@kbn/core-saved-objects-common/src/server_types';
 import type { DataViewSpec, DataView } from '@kbn/data-views-plugin/public';
@@ -193,7 +195,7 @@ function buildDatasourceStatesLayer(
     dataView: DataView
   ) => FormBasedPersistedState['layers'] | PersistedIndexPatternLayer | undefined,
   getValueColumns: (config: unknown, i: number) => TextBasedLayerColumn[] // ValueBasedLayerColumn[]
-): ['textBased' | 'formBased', DataSourceStateLayer | undefined] {
+): [SupportedDatasourceId, DataSourceStateLayer | undefined] {
   function buildValueLayer(
     config: LensBaseLayer | LensBaseXYLayer
   ): TextBasedPersistedState['layers'][0] {
@@ -233,11 +235,11 @@ function buildDatasourceStatesLayer(
   }
 
   if (isESQLDataset(dataset)) {
-    return ['textBased', buildESQLLayer(layer)];
+    return [SupportedDatasourceId.TextBased, buildESQLLayer(layer)];
   } else if ('type' in dataset) {
-    return ['textBased', buildValueLayer(layer)];
+    return [SupportedDatasourceId.TextBased, buildValueLayer(layer)];
   }
-  return ['formBased', buildFormulaLayers(layer, i, dataView!)];
+  return [SupportedDatasourceId.FormBased, buildFormulaLayers(layer, i, dataView!)];
 }
 export const buildDatasourceStates = async (
   config: (LensBaseConfig & { layers: LensBaseXYLayer[] }) | (LensBaseLayer & LensBaseConfig),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import { v4 as uuidv4 } from 'uuid';
 import type { SavedObjectReference } from '@kbn/core-saved-objects-common/src/server_types';
@@ -18,6 +18,7 @@ import type {
   PersistedIndexPatternLayer,
   TextBasedLayerColumn,
   TextBasedPersistedState,
+  LensDatasourceId,
 } from '@kbn/lens-common';
 import type { AggregateQuery } from '@kbn/es-query';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
@@ -195,7 +196,7 @@ function buildDatasourceStatesLayer(
     dataView: DataView
   ) => FormBasedPersistedState['layers'] | PersistedIndexPatternLayer | undefined,
   getValueColumns: (config: unknown, i: number) => TextBasedLayerColumn[] // ValueBasedLayerColumn[]
-): [SupportedDatasourceId, DataSourceStateLayer | undefined] {
+): [LensDatasourceId, DataSourceStateLayer | undefined] {
   function buildValueLayer(
     config: LensBaseLayer | LensBaseXYLayer
   ): TextBasedPersistedState['layers'][0] {
@@ -235,11 +236,11 @@ function buildDatasourceStatesLayer(
   }
 
   if (isESQLDataset(dataset)) {
-    return [SupportedDatasourceId.TextBased, buildESQLLayer(layer)];
+    return [LENS_DATASOURCE_ID.TEXT_BASED, buildESQLLayer(layer)];
   } else if ('type' in dataset) {
-    return [SupportedDatasourceId.TextBased, buildValueLayer(layer)];
+    return [LENS_DATASOURCE_ID.TEXT_BASED, buildValueLayer(layer)];
   }
-  return [SupportedDatasourceId.FormBased, buildFormulaLayers(layer, i, dataView!)];
+  return [LENS_DATASOURCE_ID.FORM_BASED, buildFormulaLayers(layer, i, dataView!)];
 }
 export const buildDatasourceStates = async (
   config: (LensBaseConfig & { layers: LensBaseXYLayer[] }) | (LensBaseLayer & LensBaseConfig),

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import { isEqual, noop } from 'lodash';
 import { i18n } from '@kbn/i18n';
@@ -926,7 +926,7 @@ export const LensTopNavMenu = ({
           if (isOfAggregateQueryType(newQuery) && !isOnTextBasedMode) {
             dispatch(
               switchAndCleanDatasource({
-                newDatasourceId: SupportedDatasourceId.TextBased,
+                newDatasourceId: LENS_DATASOURCE_ID.TEXT_BASED,
                 visualizationId: visualization?.activeId,
                 currentIndexPatternId: currentIndexPattern?.id,
               })
@@ -1052,7 +1052,7 @@ export const LensTopNavMenu = ({
         if (isOnTextBasedMode) {
           dispatch(
             switchAndCleanDatasource({
-              newDatasourceId: SupportedDatasourceId.FormBased,
+              newDatasourceId: LENS_DATASOURCE_ID.FORM_BASED,
               visualizationId: visualization?.activeId,
               currentIndexPatternId: dataView?.id,
             })
@@ -1074,7 +1074,7 @@ export const LensTopNavMenu = ({
       if (isOnTextBasedMode) {
         dispatch(
           switchAndCleanDatasource({
-            newDatasourceId: SupportedDatasourceId.FormBased,
+            newDatasourceId: LENS_DATASOURCE_ID.FORM_BASED,
             visualizationId: visualization?.activeId,
             currentIndexPatternId: dataView?.id,
           })
@@ -1110,7 +1110,7 @@ export const LensTopNavMenu = ({
       if (isOnTextBasedMode) {
         dispatch(
           switchAndCleanDatasource({
-            newDatasourceId: SupportedDatasourceId.FormBased,
+            newDatasourceId: LENS_DATASOURCE_ID.FORM_BASED,
             visualizationId: visualization?.activeId,
             currentIndexPatternId: newIndexPatternId,
           })

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/lens_top_nav.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import { isEqual, noop } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
@@ -924,7 +926,7 @@ export const LensTopNavMenu = ({
           if (isOfAggregateQueryType(newQuery) && !isOnTextBasedMode) {
             dispatch(
               switchAndCleanDatasource({
-                newDatasourceId: 'textBased',
+                newDatasourceId: SupportedDatasourceId.TextBased,
                 visualizationId: visualization?.activeId,
                 currentIndexPatternId: currentIndexPattern?.id,
               })
@@ -1050,7 +1052,7 @@ export const LensTopNavMenu = ({
         if (isOnTextBasedMode) {
           dispatch(
             switchAndCleanDatasource({
-              newDatasourceId: 'formBased',
+              newDatasourceId: SupportedDatasourceId.FormBased,
               visualizationId: visualization?.activeId,
               currentIndexPatternId: dataView?.id,
             })
@@ -1072,7 +1074,7 @@ export const LensTopNavMenu = ({
       if (isOnTextBasedMode) {
         dispatch(
           switchAndCleanDatasource({
-            newDatasourceId: 'formBased',
+            newDatasourceId: SupportedDatasourceId.FormBased,
             visualizationId: visualization?.activeId,
             currentIndexPatternId: dataView?.id,
           })
@@ -1108,7 +1110,7 @@ export const LensTopNavMenu = ({
       if (isOnTextBasedMode) {
         dispatch(
           switchAndCleanDatasource({
-            newDatasourceId: 'formBased',
+            newDatasourceId: SupportedDatasourceId.FormBased,
             visualizationId: visualization?.activeId,
             currentIndexPatternId: newIndexPatternId,
           })

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -22,8 +22,8 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import type { TypedLensSerializedState } from '@kbn/lens-common';
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import type { TypedLensSerializedState, LensDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 import { buildExpression } from '../../../editor_frame_service/editor_frame/expression_helpers';
 import type { TextBasedQueryState } from '../../../editor_frame_service/editor_frame/config_panel/types';
 import { getLensFeatureFlags } from '../../../get_feature_flags';
@@ -84,7 +84,7 @@ export function LensEditConfigurationFlyout({
   const { datasourceMap, visualizationMap } = useEditorFrameService();
 
   // Derive datasourceId from attributes - this updates when converting between formBased and textBased
-  const datasourceId = getActiveDatasourceIdFromDoc(attributes) as SupportedDatasourceId;
+  const datasourceId = getActiveDatasourceIdFromDoc(attributes) as LensDatasourceId;
 
   const [isInlineFlyoutVisible, setIsInlineFlyoutVisible] = useState(true);
   const [isLayerAccordionOpen, setIsLayerAccordionOpen] = useState(true);
@@ -122,7 +122,7 @@ export function LensEditConfigurationFlyout({
     let previousPersistable: typeof currentPersistable = null;
     if (previousDsState) {
       previousPersistable =
-        datasourceId === SupportedDatasourceId.TextBased
+        datasourceId === LENS_DATASOURCE_ID.TEXT_BASED
           ? datasource.getPersistableState(previousDsState)
           : {
               state: previousDsState,
@@ -177,9 +177,7 @@ export function LensEditConfigurationFlyout({
     if (attributesChanged) {
       // Use the datasourceId from the previous attributes, not the current one
       // This is important when canceling after a datasource conversion (e.g., formBased -> textBased)
-      const previousDatasourceId = getActiveDatasourceIdFromDoc(
-        previousAttrs
-      ) as SupportedDatasourceId;
+      const previousDatasourceId = getActiveDatasourceIdFromDoc(previousAttrs) as LensDatasourceId;
       if (previousAttrs.visualizationType === visualization.activeId) {
         const currentDatasourceState = datasourceMap[previousDatasourceId].injectReferencesToLayers
           ? datasourceMap[previousDatasourceId]?.injectReferencesToLayers?.(
@@ -407,7 +405,7 @@ export function LensEditConfigurationFlyout({
     if (!esqlConvertAttributes) return;
 
     // Update local attributes state - this triggers re-render of get_edit_lens_configuration
-    // which will derive the new datasourceId (SupportedDatasourceId.TextBased) from the updated attributes
+    // which will derive the new datasourceId (LENS_DATASOURCE_ID.TEXT_BASED) from the updated attributes
     // and recreate the Redux store with the correct datasource
     setCurrentAttributes?.(esqlConvertAttributes);
 

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -22,7 +22,8 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import type { TypedLensSerializedState, SupportedDatasourceId } from '@kbn/lens-common';
+import type { TypedLensSerializedState } from '@kbn/lens-common';
+import { SupportedDatasourceId } from '@kbn/lens-common';
 import { buildExpression } from '../../../editor_frame_service/editor_frame/expression_helpers';
 import type { TextBasedQueryState } from '../../../editor_frame_service/editor_frame/config_panel/types';
 import { getLensFeatureFlags } from '../../../get_feature_flags';
@@ -121,7 +122,7 @@ export function LensEditConfigurationFlyout({
     let previousPersistable: typeof currentPersistable = null;
     if (previousDsState) {
       previousPersistable =
-        datasourceId === 'textBased'
+        datasourceId === SupportedDatasourceId.TextBased
           ? datasource.getPersistableState(previousDsState)
           : {
               state: previousDsState,
@@ -406,7 +407,7 @@ export function LensEditConfigurationFlyout({
     if (!esqlConvertAttributes) return;
 
     // Update local attributes state - this triggers re-render of get_edit_lens_configuration
-    // which will derive the new datasourceId ('textBased') from the updated attributes
+    // which will derive the new datasourceId (SupportedDatasourceId.TextBased) from the updated attributes
     // and recreate the Redux store with the correct datasource
     setCurrentAttributes?.(esqlConvertAttributes);
 

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
@@ -12,7 +12,7 @@ import type {
   UserMessagesGetter,
   LensDocument,
   LensInspector,
-  SupportedDatasourceId,
+  LensDatasourceId,
 } from '@kbn/lens-common';
 import type { TextBasedQueryState } from '../../../editor_frame_service/editor_frame/config_panel/types';
 import type { LensPluginStartDependencies } from '../../../plugin';
@@ -46,7 +46,7 @@ export interface EditConfigPanelProps {
     visualizationState: unknown,
     visualizationId?: string,
     /** When restoring state (e.g. on cancel), pass the datasource the state belongs to. */
-    datasourceId?: SupportedDatasourceId
+    datasourceId?: LensDatasourceId
   ) => void;
   updateSuggestion?: (attrs: TypedLensSerializedState['attributes']) => void;
   /** Set the attributes state */

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_conversion_check.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_conversion_check.tsx
@@ -13,7 +13,7 @@ import type {
   FormBasedPrivateState,
   FramePublicAPI,
   VisualizationState,
-  SupportedDatasourceId,
+  LensDatasourceId,
   TypedLensSerializedState,
   LensDocument,
 } from '@kbn/lens-common';
@@ -61,7 +61,7 @@ export const useEsqlConversionCheck = (
     activeVisualization,
   }: {
     attributes: TypedLensSerializedState['attributes'] | undefined;
-    datasourceId: SupportedDatasourceId;
+    datasourceId: LensDatasourceId;
     layerIds: string[];
     visualization: VisualizationState;
     activeVisualization: unknown;

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import React from 'react';
 import type { Reference } from '@kbn/content-management-utils';
@@ -241,7 +241,7 @@ export function getFormBasedDatasource({
 }) {
   const { uiSettings } = core;
 
-  const DATASOURCE_ID = SupportedDatasourceId.FormBased;
+  const DATASOURCE_ID = LENS_DATASOURCE_ID.FORM_BASED;
   const ALIAS_IDS = ['indexpattern'];
 
   // Not stateful. State is persisted to the frame

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import React from 'react';
 import type { Reference } from '@kbn/content-management-utils';
 import type { CoreStart } from '@kbn/core/public';
@@ -239,7 +241,7 @@ export function getFormBasedDatasource({
 }) {
   const { uiSettings } = core;
 
-  const DATASOURCE_ID = 'formBased';
+  const DATASOURCE_ID = SupportedDatasourceId.FormBased;
   const ALIAS_IDS = ['indexpattern'];
 
   // Not stateful. State is persisted to the frame

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import React from 'react';
 
@@ -307,7 +307,7 @@ export function getTextBasedDatasource({
     return [];
   };
   const TextBasedDatasource: Datasource<TextBasedPrivateState, TextBasedPersistedState> = {
-    id: SupportedDatasourceId.TextBased,
+    id: LENS_DATASOURCE_ID.TEXT_BASED,
 
     checkIntegrity: () => {
       return [];
@@ -526,7 +526,7 @@ export function getTextBasedDatasource({
     onDrop,
     getPublicAPI({ state, layerId, indexPatterns }: PublicAPIProps<TextBasedPrivateState>) {
       return {
-        datasourceId: SupportedDatasourceId.TextBased,
+        datasourceId: LENS_DATASOURCE_ID.TEXT_BASED,
 
         getTableSpec: () => {
           const layerColumns = state.layers[layerId]?.columns ?? [];

--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/text_based_languages.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import React from 'react';
 
 import type { CoreStart } from '@kbn/core/public';
@@ -305,7 +307,7 @@ export function getTextBasedDatasource({
     return [];
   };
   const TextBasedDatasource: Datasource<TextBasedPrivateState, TextBasedPersistedState> = {
-    id: 'textBased',
+    id: SupportedDatasourceId.TextBased,
 
     checkIntegrity: () => {
       return [];
@@ -524,7 +526,7 @@ export function getTextBasedDatasource({
     onDrop,
     getPublicAPI({ state, layerId, indexPatterns }: PublicAPIProps<TextBasedPrivateState>) {
       return {
-        datasourceId: 'textBased',
+        datasourceId: SupportedDatasourceId.TextBased,
 
         getTableSpec: () => {
           const layerColumns = state.layers[layerId]?.columns ?? [];

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SupportedDatasourceId } from '@kbn/lens-common';
+
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   EuiSpacer,
@@ -136,7 +138,7 @@ export function LayerPanel(props: LayerPanelProps) {
   };
 
   const datasourcePublicAPI = framePublicAPI.datasourceLayers?.[layerId];
-  const datasourceId = datasourcePublicAPI?.datasourceId! as 'formBased' | 'textBased';
+  const datasourceId = datasourcePublicAPI?.datasourceId! as SupportedDatasourceId;
   let layerDatasourceState = datasourceStates?.[datasourceId]?.state;
   // try again with aliases
   if (!layerDatasourceState && datasourcePublicAPI?.datasourceAliasIds && datasourceStates) {

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SupportedDatasourceId } from '@kbn/lens-common';
+import type { LensDatasourceId } from '@kbn/lens-common';
 
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
@@ -138,7 +138,7 @@ export function LayerPanel(props: LayerPanelProps) {
   };
 
   const datasourcePublicAPI = framePublicAPI.datasourceLayers?.[layerId];
-  const datasourceId = datasourcePublicAPI?.datasourceId! as SupportedDatasourceId;
+  const datasourceId = datasourcePublicAPI?.datasourceId! as LensDatasourceId;
   let layerDatasourceState = datasourceStates?.[datasourceId]?.state;
   // try again with aliases
   if (!layerDatasourceState && datasourcePublicAPI?.datasourceAliasIds && datasourceStates) {

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { AggregateQuery } from '@kbn/es-query';
@@ -221,7 +221,7 @@ export function getVisualizeFieldSuggestions({
   // suggestions for visualizing textbased languages
   if (visualizeTriggerFieldContext && 'query' in visualizeTriggerFieldContext) {
     if (visualizeTriggerFieldContext.query) {
-      return suggestions.find((s) => s.datasourceId === SupportedDatasourceId.TextBased);
+      return suggestions.find((s) => s.datasourceId === LENS_DATASOURCE_ID.TEXT_BASED);
     }
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/suggestion_helpers.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { AggregateQuery } from '@kbn/es-query';
 import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
@@ -219,7 +221,7 @@ export function getVisualizeFieldSuggestions({
   // suggestions for visualizing textbased languages
   if (visualizeTriggerFieldContext && 'query' in visualizeTriggerFieldContext) {
     if (visualizeTriggerFieldContext.query) {
-      return suggestions.find((s) => s.datasourceId === 'textBased');
+      return suggestions.find((s) => s.datasourceId === SupportedDatasourceId.TextBased);
     }
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
@@ -4,6 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import { getDatasourceId } from '@kbn/visualization-utils';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
@@ -42,7 +45,7 @@ export const injectESQLQueryIntoLensLayers = (
   const datasourceId = getDatasourceId(attributes.state.datasourceStates);
 
   // if the datasource is formBased, we should not fix the query
-  if (!datasourceId || datasourceId === 'formBased') {
+  if (!datasourceId || datasourceId === SupportedDatasourceId.FormBased) {
     return attributes;
   }
 
@@ -107,11 +110,11 @@ export function mergeSuggestionWithVisContext({
     return suggestion;
   }
 
-  // it should be one of 'formBased'/'textBased' and have value
+  // it should be one of SupportedDatasourceId.FormBased/SupportedDatasourceId.TextBased and have value
   const datasourceId = getDatasourceId(visAttributes.state.datasourceStates);
 
   // if the datasource is formBased, we should not merge
-  if (!datasourceId || datasourceId === 'formBased') {
+  if (!datasourceId || datasourceId === SupportedDatasourceId.FormBased) {
     return suggestion;
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import type { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import { getDatasourceId } from '@kbn/visualization-utils';
@@ -45,7 +45,7 @@ export const injectESQLQueryIntoLensLayers = (
   const datasourceId = getDatasourceId(attributes.state.datasourceStates);
 
   // if the datasource is formBased, we should not fix the query
-  if (!datasourceId || datasourceId === SupportedDatasourceId.FormBased) {
+  if (!datasourceId || datasourceId === LENS_DATASOURCE_ID.FORM_BASED) {
     return attributes;
   }
 
@@ -110,11 +110,11 @@ export function mergeSuggestionWithVisContext({
     return suggestion;
   }
 
-  // it should be one of SupportedDatasourceId.FormBased/SupportedDatasourceId.TextBased and have value
+  // it should be one of LENS_DATASOURCE_ID.FORM_BASED/LENS_DATASOURCE_ID.TEXT_BASED and have value
   const datasourceId = getDatasourceId(visAttributes.state.datasourceStates);
 
   // if the datasource is formBased, we should not merge
-  if (!datasourceId || datasourceId === SupportedDatasourceId.FormBased) {
+  if (!datasourceId || datasourceId === LENS_DATASOURCE_ID.FORM_BASED) {
     return suggestion;
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/variables.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/variables.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { TextBasedPersistedState, LensRuntimeState } from '@kbn/lens-common';
@@ -13,7 +13,7 @@ import type { LensApi } from '@kbn/lens-common-2';
 
 function getInternalTables(states: Record<string, unknown>) {
   const result: Record<string, Datatable> = {};
-  if (SupportedDatasourceId.TextBased in states) {
+  if (LENS_DATASOURCE_ID.TEXT_BASED in states) {
     const layers = (states.textBased as TextBasedPersistedState).layers;
     for (const layer in layers) {
       if (layers[layer]?.table) {

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/variables.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/variables.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { Datatable } from '@kbn/expressions-plugin/common';
 import type { TextBasedPersistedState, LensRuntimeState } from '@kbn/lens-common';
 import type { LensApi } from '@kbn/lens-common-2';
 
 function getInternalTables(states: Record<string, unknown>) {
   const result: Record<string, Datatable> = {};
-  if ('textBased' in states) {
+  if (SupportedDatasourceId.TextBased in states) {
     const layers = (states.textBased as TextBasedPersistedState).layers;
     for (const layer in layers) {
       if (layers[layer]?.table) {

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
@@ -71,7 +71,7 @@ export function prepareInlineEditPanel(
       saveUserChartTypeToSessionStorage(attributes.visualizationType);
     }
     const activeDatasourceId = (getActiveDatasourceIdFromDoc(attributes) ||
-      'formBased') as SupportedDatasourceId;
+      SupportedDatasourceId.FormBased) as SupportedDatasourceId;
 
     const { updatePanelState, updateSuggestion } = getStateManagementForInlineEditing(
       activeDatasourceId,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
@@ -13,8 +13,9 @@ import type {
   LensInternalApi,
   LensRuntimeState,
   TypedLensSerializedState,
-  SupportedDatasourceId,
+  LensDatasourceId,
 } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 import type { EditConfigPanelProps } from '../../app_plugin/shared/edit_on_the_fly/types';
 import { getActiveDatasourceIdFromDoc } from '../../utils';
 import { isTextBasedLanguage } from '../helper';
@@ -71,7 +72,7 @@ export function prepareInlineEditPanel(
       saveUserChartTypeToSessionStorage(attributes.visualizationType);
     }
     const activeDatasourceId = (getActiveDatasourceIdFromDoc(attributes) ||
-      SupportedDatasourceId.FormBased) as SupportedDatasourceId;
+      LENS_DATASOURCE_ID.FORM_BASED) as LensDatasourceId;
 
     const { updatePanelState, updateSuggestion } = getStateManagementForInlineEditing(
       activeDatasourceId,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { FilterManager } from '@kbn/data-plugin/public';
 import type {
   DatasourceStates,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
@@ -5,15 +5,13 @@
  * 2.0.
  */
 
-import type { LensDatasourceId } from '@kbn/lens-common';
-
 import type { FilterManager } from '@kbn/data-plugin/public';
 import type {
   DatasourceStates,
   VisualizationMap,
   DatasourceMap,
   TypedLensSerializedState,
-  SupportedDatasourceId,
+  LensDatasourceId,
 } from '@kbn/lens-common';
 import { mergeToNewDoc } from '../../state_management/shared_logic';
 import { getActiveDatasourceIdFromDoc } from '../../utils';
@@ -29,7 +27,7 @@ export function getStateManagementForInlineEditing(
   datasourceMap: DatasourceMap,
   extractFilterReferences: FilterManager['extract']
 ) {
-  const resolveActiveDatasourceId = (explicit?: SupportedDatasourceId): SupportedDatasourceId => {
+  const resolveActiveDatasourceId = (explicit?: LensDatasourceId): LensDatasourceId => {
     return explicit ?? getActiveDatasourceIdFromDoc(getAttributes()) ?? initialDatasourceId;
   };
 
@@ -37,7 +35,7 @@ export function getStateManagementForInlineEditing(
     datasourceState: unknown,
     visualizationState: unknown,
     visualizationType?: string,
-    datasourceId?: 'formBased' | 'textBased'
+    datasourceId?: LensDatasourceId
   ) => {
     const viz = getAttributes();
     const activeDatasourceId = resolveActiveDatasourceId(datasourceId);

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/state_management.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SupportedDatasourceId } from '@kbn/lens-common';
+import type { LensDatasourceId } from '@kbn/lens-common';
 
 import type { FilterManager } from '@kbn/data-plugin/public';
 import type {
@@ -19,7 +19,7 @@ import { mergeToNewDoc } from '../../state_management/shared_logic';
 import { getActiveDatasourceIdFromDoc } from '../../utils';
 
 export function getStateManagementForInlineEditing(
-  initialDatasourceId: SupportedDatasourceId,
+  initialDatasourceId: LensDatasourceId,
   getAttributes: () => TypedLensSerializedState['attributes'],
   updateAttributes: (
     newAttributes: TypedLensSerializedState['attributes'],

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
 import type { History } from 'history';
@@ -375,7 +377,7 @@ export async function loadInitial(
 
   let activeDatasourceId: string | undefined;
   if (initialContext && 'query' in initialContext) {
-    activeDatasourceId = 'textBased';
+    activeDatasourceId = SupportedDatasourceId.TextBased;
   }
   if (initialStateFromLocator) {
     const newFilters = initialStateFromLocator.filters

--- a/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
+++ b/x-pack/platform/plugins/shared/lens/public/state_management/init_middleware/load_initial.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import type { MiddlewareAPI } from '@reduxjs/toolkit';
 import { i18n } from '@kbn/i18n';
@@ -377,7 +377,7 @@ export async function loadInitial(
 
   let activeDatasourceId: string | undefined;
   if (initialContext && 'query' in initialContext) {
-    activeDatasourceId = SupportedDatasourceId.TextBased;
+    activeDatasourceId = LENS_DATASOURCE_ID.TEXT_BASED;
   }
   if (initialStateFromLocator) {
     const newFilters = initialStateFromLocator.filters

--- a/x-pack/platform/plugins/shared/lens/public/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/utils.ts
@@ -33,9 +33,10 @@ import type {
   UserMessage,
   DatasourceStates,
   VisualizationState,
-  SupportedDatasourceId,
   TriggerEvent,
 } from '@kbn/lens-common';
+import type { LensDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 import {
   isOperation,
   isLensBrushEvent,
@@ -94,17 +95,17 @@ export function getTimeZone(uiSettings: IUiSettingsClient) {
   return configuredTimeZone;
 }
 
-export function getActiveDatasourceIdFromDoc(doc?: LensDocument): SupportedDatasourceId | null {
+export function getActiveDatasourceIdFromDoc(doc?: LensDocument): LensDatasourceId | null {
   if (!doc) {
     return null;
   }
 
   const [firstDatasourceFromDoc] = Object.keys(doc.state.datasourceStates);
   if (
-    firstDatasourceFromDoc === SupportedDatasourceId.FormBased ||
-    firstDatasourceFromDoc === SupportedDatasourceId.TextBased
+    firstDatasourceFromDoc === LENS_DATASOURCE_ID.FORM_BASED ||
+    firstDatasourceFromDoc === LENS_DATASOURCE_ID.TEXT_BASED
   ) {
-    return firstDatasourceFromDoc;
+    return firstDatasourceFromDoc as LensDatasourceId;
   }
   return null;
 }

--- a/x-pack/platform/plugins/shared/lens/public/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/utils.ts
@@ -100,7 +100,10 @@ export function getActiveDatasourceIdFromDoc(doc?: LensDocument): SupportedDatas
   }
 
   const [firstDatasourceFromDoc] = Object.keys(doc.state.datasourceStates);
-  if (firstDatasourceFromDoc === 'formBased' || firstDatasourceFromDoc === 'textBased') {
+  if (
+    firstDatasourceFromDoc === SupportedDatasourceId.FormBased ||
+    firstDatasourceFromDoc === SupportedDatasourceId.TextBased
+  ) {
     return firstDatasourceFromDoc;
   }
   return null;

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
@@ -183,7 +183,7 @@ export const getLegacyMetricVisualization = ({
   ],
   hideFromChartSwitch(frame: FramePublicAPI) {
     return Object.values(frame.datasourceLayers).some(
-      (datasource) => datasource && datasource.datasourceId === SupportedDatasourceId.TextBased
+      (datasource) => datasource && datasource.datasourceId === LENS_DATASOURCE_ID.TEXT_BASED
     );
   },
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -3,7 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- */ import React from 'react';
+ */
+
+import { SupportedDatasourceId } from '@kbn/lens-common';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { euiThemeVars } from '@kbn/ui-theme';
 import type { Ast } from '@kbn/interpreter';
@@ -180,7 +183,7 @@ export const getLegacyMetricVisualization = ({
   ],
   hideFromChartSwitch(frame: FramePublicAPI) {
     return Object.values(frame.datasourceLayers).some(
-      (datasource) => datasource && datasource.datasourceId === 'textBased'
+      (datasource) => datasource && datasource.datasourceId === SupportedDatasourceId.TextBased
     );
   },
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_suggestions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_suggestions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SupportedDatasourceId } from '@kbn/lens-common';
+import { LENS_DATASOURCE_ID } from '@kbn/lens-common';
 
 import { i18n } from '@kbn/i18n';
 import { partition } from 'lodash';
@@ -140,7 +140,7 @@ function getSuggestionForColumns(
     query,
   };
 
-  const isEsql = datasourceId === SupportedDatasourceId.TextBased;
+  const isEsql = datasourceId === LENS_DATASOURCE_ID.TEXT_BASED;
   // we have 2 different suggestion: with DSL we can split by only when we have a max of 2 buckets (one for the X and the other for the breakdown)
   // in ESQL we instead suggest split by with more then 1 buckets always.
   const whenToSuggestSplitBy = isEsql
@@ -280,7 +280,7 @@ function getSuggestionsForLayer({
   if (
     changeType === 'initial' &&
     xValue?.operation.dataType === 'date' &&
-    datasourceId === SupportedDatasourceId.FormBased
+    datasourceId === LENS_DATASOURCE_ID.FORM_BASED
   ) {
     return buildSuggestion({ ...options, seriesType: 'line' });
   }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_suggestions.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/xy/xy_suggestions.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { SupportedDatasourceId } from '@kbn/lens-common';
+
 import { i18n } from '@kbn/i18n';
 import { partition } from 'lodash';
 import { Position } from '@elastic/charts';
@@ -138,7 +140,7 @@ function getSuggestionForColumns(
     query,
   };
 
-  const isEsql = datasourceId === 'textBased';
+  const isEsql = datasourceId === SupportedDatasourceId.TextBased;
   // we have 2 different suggestion: with DSL we can split by only when we have a max of 2 buckets (one for the X and the other for the breakdown)
   // in ESQL we instead suggest split by with more then 1 buckets always.
   const whenToSuggestSplitBy = isEsql
@@ -278,7 +280,7 @@ function getSuggestionsForLayer({
   if (
     changeType === 'initial' &&
     xValue?.operation.dataType === 'date' &&
-    datasourceId === 'formBased'
+    datasourceId === SupportedDatasourceId.FormBased
   ) {
     return buildSuggestion({ ...options, seriesType: 'line' });
   }

--- a/x-pack/platform/plugins/shared/lens/server/migrations/common_migrations.ts
+++ b/x-pack/platform/plugins/shared/lens/server/migrations/common_migrations.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import type { SupportedDatasourceId } from '@kbn/lens-common';
-
 import { cloneDeep, mapValues } from 'lodash';
 import type { PaletteOutput, CustomPaletteParams } from '@kbn/coloring';
 import { LayerTypes } from '@kbn/expression-xy-plugin/common';
@@ -583,8 +581,7 @@ export const commonMigrateMetricFormatter = (attributes: LensDocShape860<unknown
     return attributes as LensDocShape860<unknown>;
   }
 
-  type LayersType =
-    LensDocShape860['state']['datasourceStates'][SupportedDatasourceId.FormBased]['layers'];
+  type LayersType = LensDocShape860['state']['datasourceStates']['formBased']['layers'];
 
   const updatedLayersWithCompactFormatters: LayersType = {};
   for (const [layerId, layer] of Object.entries(

--- a/x-pack/platform/plugins/shared/lens/server/migrations/common_migrations.ts
+++ b/x-pack/platform/plugins/shared/lens/server/migrations/common_migrations.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SupportedDatasourceId } from '@kbn/lens-common';
+
 import { cloneDeep, mapValues } from 'lodash';
 import type { PaletteOutput, CustomPaletteParams } from '@kbn/coloring';
 import { LayerTypes } from '@kbn/expression-xy-plugin/common';
@@ -581,7 +583,8 @@ export const commonMigrateMetricFormatter = (attributes: LensDocShape860<unknown
     return attributes as LensDocShape860<unknown>;
   }
 
-  type LayersType = LensDocShape860['state']['datasourceStates']['formBased']['layers'];
+  type LayersType =
+    LensDocShape860['state']['datasourceStates'][SupportedDatasourceId.FormBased]['layers'];
 
   const updatedLayersWithCompactFormatters: LayersType = {};
   for (const [layerId, layer] of Object.entries(


### PR DESCRIPTION
## Summary

Part of #255571.

Refactors hardcoded `'formBased'` and `'textBased'` strings to a structured constant and union type.

- Introduces `LENS_DATASOURCE_ID.FORM_BASED` and `LENS_DATASOURCE_ID.TEXT_BASED` constants.
- Renames `SupportedDatasourceId` to `LensDatasourceId` union type.

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
- [x] Used `pi-coding-agent` with `gemini-3.1-pro-preview-customtools` 

### Identify risks

Low Risk: Refactoring could potentially break runtime checks if the string literal replacement missed a dynamic assignment, but TypeScript compiler checks pass across the shared packages and tests should catch any regressions.
