### PR TITLE
[ES|QL] Hide histogram for info commands (METRICS_INFO, TS_INFO)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/commands/registry/metrics_info/index.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/commands/registry/metrics_info/index.ts
@@ -32,6 +32,6 @@ export const metricsInfoCommand: ICommand = {
     examples: ['TS index | METRICS_INFO'],
     preview: true,
     requiresTimeseriesSource: true,
-    hiddenAfterCommands: [Commands.STATS, Commands.INLINE_STATS],
+    hiddenAfterCommands: [Commands.STATS, Commands.INLINE_STATS, Commands.TS_INFO],
   },
 };

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -64,7 +64,7 @@ export {
   getEditorExtensions,
   getProjectRoutingFromEsqlQuery,
   hasOnlySourceCommand,
-  hasInfoCommand,
+  hasTimeseriesInfoCommand,
   isComputedColumn,
   getQuerySummary,
   getEsqlControls,

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -64,6 +64,7 @@ export {
   getEditorExtensions,
   getProjectRoutingFromEsqlQuery,
   hasOnlySourceCommand,
+  hasInfoCommand,
   isComputedColumn,
   getQuerySummary,
   getEsqlControls,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -29,7 +29,7 @@ export {
   getRemoteClustersFromESQLQuery,
   convertTimeseriesCommandToFrom,
   hasOnlySourceCommand,
-  hasInfoCommand,
+  hasTimeseriesInfoCommand,
 } from './utils/query_parsing_helpers';
 export { getIndexPatternFromESQLQuery } from './utils/get_index_pattern_from_query';
 export { queryCannotBeSampled } from './utils/query_cannot_be_sampled';

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -29,6 +29,7 @@ export {
   getRemoteClustersFromESQLQuery,
   convertTimeseriesCommandToFrom,
   hasOnlySourceCommand,
+  hasInfoCommand,
 } from './utils/query_parsing_helpers';
 export { getIndexPatternFromESQLQuery } from './utils/get_index_pattern_from_query';
 export { queryCannotBeSampled } from './utils/query_cannot_be_sampled';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -32,6 +32,7 @@ import {
   hasLimitBeforeAggregate,
   missingSortBeforeLimit,
   hasOnlySourceCommand,
+  hasInfoCommand,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -1093,6 +1094,36 @@ describe('esql query helpers', () => {
           'PROMQL index = index1 step="5m" start=?_tstart end=?_tend avg(bytes) '
         )
       ).toBe(false);
+    });
+  });
+
+  describe('hasInfoCommand', () => {
+    it('should return true when query contains METRICS_INFO command', () => {
+      expect(hasInfoCommand('TS index | METRICS_INFO')).toBe(true);
+    });
+
+    it('should return true when query contains TS_INFO command', () => {
+      expect(hasInfoCommand('TS index | TS_INFO')).toBe(true);
+    });
+
+    it('should return true when METRICS_INFO appears with other commands', () => {
+      expect(hasInfoCommand('TS index | METRICS_INFO | LIMIT 10')).toBe(true);
+    });
+
+    it('should return true when TS_INFO appears with other commands', () => {
+      expect(hasInfoCommand('TS index | TS_INFO | LIMIT 10')).toBe(true);
+    });
+
+    it('should return false when query does not contain METRICS_INFO or TS_INFO', () => {
+      expect(hasInfoCommand('FROM index | STATS count()')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(hasInfoCommand('')).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(hasInfoCommand(undefined)).toBe(false);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -32,7 +32,7 @@ import {
   hasLimitBeforeAggregate,
   missingSortBeforeLimit,
   hasOnlySourceCommand,
-  hasInfoCommand,
+  hasTimeseriesInfoCommand,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -1099,31 +1099,23 @@ describe('esql query helpers', () => {
 
   describe('hasInfoCommand', () => {
     it('should return true when query contains METRICS_INFO command', () => {
-      expect(hasInfoCommand('TS index | METRICS_INFO')).toBe(true);
+      expect(hasTimeseriesInfoCommand('TS index | METRICS_INFO')).toBe(true);
     });
 
     it('should return true when query contains TS_INFO command', () => {
-      expect(hasInfoCommand('TS index | TS_INFO')).toBe(true);
+      expect(hasTimeseriesInfoCommand('TS index | TS_INFO')).toBe(true);
     });
 
     it('should return true when METRICS_INFO appears with other commands', () => {
-      expect(hasInfoCommand('TS index | METRICS_INFO | LIMIT 10')).toBe(true);
+      expect(hasTimeseriesInfoCommand('TS index | METRICS_INFO | LIMIT 10')).toBe(true);
     });
 
     it('should return true when TS_INFO appears with other commands', () => {
-      expect(hasInfoCommand('TS index | TS_INFO | LIMIT 10')).toBe(true);
+      expect(hasTimeseriesInfoCommand('TS index | TS_INFO | LIMIT 10')).toBe(true);
     });
 
     it('should return false when query does not contain METRICS_INFO or TS_INFO', () => {
-      expect(hasInfoCommand('FROM index | STATS count()')).toBe(false);
-    });
-
-    it('should return false for empty string', () => {
-      expect(hasInfoCommand('')).toBe(false);
-    });
-
-    it('should return false for undefined', () => {
-      expect(hasInfoCommand(undefined)).toBe(false);
+      expect(hasTimeseriesInfoCommand('FROM index | STATS count()')).toBe(false);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -16,7 +16,7 @@ import {
   BasicPrettyPrinter,
   isStringLiteral,
 } from '@elastic/esql';
-import { esqlCommandRegistry, TRANSFORMATIONAL_COMMANDS } from '@kbn/esql-language';
+import { CommandNames, esqlCommandRegistry, TRANSFORMATIONAL_COMMANDS } from '@kbn/esql-language';
 
 import type {
   ESQLSource,
@@ -610,5 +610,19 @@ export const hasOnlySourceCommand = (query: string): boolean => {
     root.commands.length > 0 &&
     root.commands.every(({ name }) => name !== 'promql') &&
     root.commands.every((command) => sourceCommands.includes(command.name))
+  );
+};
+
+/**
+ * Determines if an ES|QL query contains the INFO commands.
+ *
+ * @param esql - The ES|QL query string to analyze
+ * @returns true if the query contains the INFO commands, false otherwise
+ */
+export const hasInfoCommand = (esql?: string): boolean => {
+  if (!esql) return false;
+  const { root } = Parser.parse(esql);
+  return root.commands.some(
+    ({ name }) => name === CommandNames.METRICS_INFO || name === CommandNames.TS_INFO
   );
 };

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -614,12 +614,12 @@ export const hasOnlySourceCommand = (query: string): boolean => {
 };
 
 /**
- * Determines if an ES|QL query contains the INFO commands.
+ * Determines if an ES|QL query contains the METRICS_INFO or TS_INFO commands.
  *
  * @param esql - The ES|QL query string to analyze
- * @returns true if the query contains the INFO commands, false otherwise
+ * @returns true if the query contains the METRICS_INFO or TS_INFO commands, false otherwise
  */
-export const hasInfoCommand = (esql?: string): boolean => {
+export const hasTimeseriesInfoCommand = (esql?: string): boolean => {
   if (!esql) return false;
   const { root } = Parser.parse(esql);
   return root.commands.some(

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
@@ -236,6 +236,64 @@ describe('LensVisService suggestions', () => {
     expect(lensVis.currentSuggestionContext?.suggestion).not.toBeDefined();
   });
 
+  test('should not append histogram for METRICS_INFO command queries', async () => {
+    const lensVis = await getLensVisMock({
+      filters: [],
+      query: { esql: 'TS metrics-* | METRICS_INFO | LIMIT 100' },
+      dataView: dataViewMock,
+      timeInterval: 'auto',
+      timeRange: {
+        from: '2023-09-03T08:00:00.000Z',
+        to: '2023-09-04T08:56:28.274Z',
+      },
+      breakdownField: undefined,
+      columns: [
+        {
+          id: 'var0',
+          name: 'var0',
+          meta: {
+            type: 'number',
+          },
+        },
+      ],
+      isPlainRecord: true,
+      allSuggestions: [],
+      isTransformationalESQL: false,
+    });
+
+    expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
+    expect(lensVis.currentSuggestionContext?.suggestion).not.toBeDefined();
+  });
+
+  test('should not append histogram for TS_INFO command queries', async () => {
+    const lensVis = await getLensVisMock({
+      filters: [],
+      query: { esql: 'TS metrics-* | TS_INFO | LIMIT 100' },
+      dataView: dataViewMock,
+      timeInterval: 'auto',
+      timeRange: {
+        from: '2023-09-03T08:00:00.000Z',
+        to: '2023-09-04T08:56:28.274Z',
+      },
+      breakdownField: undefined,
+      columns: [
+        {
+          id: 'var0',
+          name: 'var0',
+          meta: {
+            type: 'number',
+          },
+        },
+      ],
+      isPlainRecord: true,
+      allSuggestions: [],
+      isTransformationalESQL: false,
+    });
+
+    expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
+    expect(lensVis.currentSuggestionContext?.suggestion).not.toBeDefined();
+  });
+
   test('should return histogramSuggestion if no suggestions returned by the api with the breakdown field if it is given', async () => {
     const breakdown = convertDatatableColumnToDataViewFieldSpec({
       name: 'var0',

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -261,16 +261,15 @@ export class LensVisService {
               type: UnifiedHistogramSuggestionType.lensSuggestion,
             });
           }
+        } else if (hasInfoCommand(queryParams.query.esql)) {
+          // skip chart suggestions for info commands
+          return {
+            currentSuggestionContext: {
+              type: UnifiedHistogramSuggestionType.unsupported,
+              suggestion: undefined,
+            },
+          };
         } else {
-          if (hasInfoCommand(queryParams.query.esql)) {
-            return {
-              currentSuggestionContext: {
-                type: UnifiedHistogramSuggestionType.unsupported,
-                suggestion: undefined,
-              },
-            };
-          }
-
           // appends an ES|QL histogram if available
           const histogramSuggestionForESQL = this.getHistogramSuggestionForESQL({
             queryParams,

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -16,7 +16,7 @@ import {
   hasTransformationalCommand,
   getCategorizeField,
   convertTimeseriesCommandToFrom,
-  hasInfoCommand,
+  hasTimeseriesInfoCommand,
 } from '@kbn/esql-utils';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type {
@@ -261,7 +261,7 @@ export class LensVisService {
               type: UnifiedHistogramSuggestionType.lensSuggestion,
             });
           }
-        } else if (hasInfoCommand(queryParams.query.esql)) {
+        } else if (hasTimeseriesInfoCommand(queryParams.query.esql)) {
           // skip chart suggestions for info commands
           return {
             currentSuggestionContext: {

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -16,6 +16,7 @@ import {
   hasTransformationalCommand,
   getCategorizeField,
   convertTimeseriesCommandToFrom,
+  hasInfoCommand,
 } from '@kbn/esql-utils';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type {
@@ -261,6 +262,15 @@ export class LensVisService {
             });
           }
         } else {
+          if (isOfAggregateQueryType(queryParams.query) && hasInfoCommand(queryParams.query.esql)) {
+            return {
+              currentSuggestionContext: {
+                type: UnifiedHistogramSuggestionType.unsupported,
+                suggestion: undefined,
+              },
+            };
+          }
+
           // appends an ES|QL histogram if available
           const histogramSuggestionForESQL = this.getHistogramSuggestionForESQL({
             queryParams,

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -262,7 +262,7 @@ export class LensVisService {
             });
           }
         } else {
-          if (isOfAggregateQueryType(queryParams.query) && hasInfoCommand(queryParams.query.esql)) {
+          if (hasInfoCommand(queryParams.query.esql)) {
             return {
               currentSuggestionContext: {
                 type: UnifiedHistogramSuggestionType.unsupported,


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/255433
closes https://github.com/elastic/kibana/issues/256614

## Summary

This PR doesn't render the histogram when an INFO command is in the query.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
