### PR TITLE
[SharedUX] Add solution side nav footer slot

### DIFF
--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
@@ -36,6 +36,101 @@ exports[`SolutionNav accepts EuiSideNavProps 1`] = `
       color="transparent"
       paddingSize="s"
     >
+      <div
+        css="unknown styles"
+      >
+        <EuiSideNavClass
+          aria-hidden={true}
+          aria-labelledby="SolutionNav_generated-id_heading"
+          data-test-subj="DTS"
+          items={
+            Array [
+              Object {
+                "id": "1",
+                "items": Array [
+                  Object {
+                    "id": "1.1",
+                    "items": undefined,
+                    "name": "Ingest Node Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.2",
+                    "items": undefined,
+                    "name": "Logstash Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.3",
+                    "items": undefined,
+                    "name": "Beats Central Management",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Ingest",
+                "tabIndex": -1,
+              },
+              Object {
+                "id": "2",
+                "items": Array [
+                  Object {
+                    "id": "2.1",
+                    "items": undefined,
+                    "name": "Index Management",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.2",
+                    "items": undefined,
+                    "name": "Index Lifecycle Policies",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.3",
+                    "items": undefined,
+                    "name": "Snapshot and Restore",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Data",
+                "tabIndex": -1,
+              },
+            ]
+          }
+          mobileBreakpoints={Array []}
+        />
+      </div>
+    </EuiPanel>
+  </EuiCollapsibleNavGroup>
+  <div
+    css="unknown styles"
+  >
+    <EuiTitle
+      css="unknown styles"
+      id="SolutionNav_generated-id_heading"
+      size="xs"
+    >
+      <h2>
+        <strong>
+          <MemoizedFormattedMessage
+            defaultMessage="{solutionName} {menuText}"
+            id="sharedUXPackages.solutionNav.mobileTitleText"
+            values={
+              Object {
+                "menuText": "menu",
+                "solutionName": "Solution",
+              }
+            }
+          />
+        </strong>
+      </h2>
+    </EuiTitle>
+    <EuiSpacer
+      size="l"
+    />
+    <div
+      css="unknown styles"
+    >
       <EuiSideNavClass
         aria-hidden={true}
         aria-labelledby="SolutionNav_generated-id_heading"
@@ -96,94 +191,7 @@ exports[`SolutionNav accepts EuiSideNavProps 1`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
-  <div
-    css="unknown styles"
-  >
-    <EuiTitle
-      css="unknown styles"
-      id="SolutionNav_generated-id_heading"
-      size="xs"
-    >
-      <h2>
-        <strong>
-          <MemoizedFormattedMessage
-            defaultMessage="{solutionName} {menuText}"
-            id="sharedUXPackages.solutionNav.mobileTitleText"
-            values={
-              Object {
-                "menuText": "menu",
-                "solutionName": "Solution",
-              }
-            }
-          />
-        </strong>
-      </h2>
-    </EuiTitle>
-    <EuiSpacer
-      size="l"
-    />
-    <EuiSideNavClass
-      aria-hidden={true}
-      aria-labelledby="SolutionNav_generated-id_heading"
-      data-test-subj="DTS"
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "items": Array [
-              Object {
-                "id": "1.1",
-                "items": undefined,
-                "name": "Ingest Node Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.2",
-                "items": undefined,
-                "name": "Logstash Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.3",
-                "items": undefined,
-                "name": "Beats Central Management",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Ingest",
-            "tabIndex": -1,
-          },
-          Object {
-            "id": "2",
-            "items": Array [
-              Object {
-                "id": "2.1",
-                "items": undefined,
-                "name": "Index Management",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.2",
-                "items": undefined,
-                "name": "Index Lifecycle Policies",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.3",
-                "items": undefined,
-                "name": "Snapshot and Restore",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Data",
-            "tabIndex": -1,
-          },
-        ]
-      }
-      mobileBreakpoints={Array []}
-    />
+    </div>
   </div>
   <SolutionNavCollapseButton
     isCollapsed={true}
@@ -226,6 +234,100 @@ exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
     <EuiPanel
       color="transparent"
       paddingSize="s"
+    >
+      <div
+        css="unknown styles"
+      >
+        <EuiSideNavClass
+          aria-hidden={true}
+          aria-labelledby="SolutionNav_generated-id_heading"
+          items={
+            Array [
+              Object {
+                "id": "1",
+                "items": Array [
+                  Object {
+                    "id": "1.1",
+                    "items": undefined,
+                    "name": "Ingest Node Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.2",
+                    "items": undefined,
+                    "name": "Logstash Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.3",
+                    "items": undefined,
+                    "name": "Beats Central Management",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Ingest",
+                "tabIndex": -1,
+              },
+              Object {
+                "id": "2",
+                "items": Array [
+                  Object {
+                    "id": "2.1",
+                    "items": undefined,
+                    "name": "Index Management",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.2",
+                    "items": undefined,
+                    "name": "Index Lifecycle Policies",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.3",
+                    "items": undefined,
+                    "name": "Snapshot and Restore",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Data",
+                "tabIndex": -1,
+              },
+            ]
+          }
+          mobileBreakpoints={Array []}
+        />
+      </div>
+    </EuiPanel>
+  </EuiCollapsibleNavGroup>
+  <div
+    css="unknown styles"
+  >
+    <EuiTitle
+      css="unknown styles"
+      id="SolutionNav_generated-id_heading"
+      size="xs"
+    >
+      <h2>
+        <strong>
+          <MemoizedFormattedMessage
+            defaultMessage="{solutionName} {menuText}"
+            id="sharedUXPackages.solutionNav.mobileTitleText"
+            values={
+              Object {
+                "menuText": "menu",
+                "solutionName": "Solution",
+              }
+            }
+          />
+        </strong>
+      </h2>
+    </EuiTitle>
+    <EuiSpacer
+      size="l"
+    />
+    <div
+      css="unknown styles"
     >
       <EuiSideNavClass
         aria-hidden={true}
@@ -286,93 +388,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
-  <div
-    css="unknown styles"
-  >
-    <EuiTitle
-      css="unknown styles"
-      id="SolutionNav_generated-id_heading"
-      size="xs"
-    >
-      <h2>
-        <strong>
-          <MemoizedFormattedMessage
-            defaultMessage="{solutionName} {menuText}"
-            id="sharedUXPackages.solutionNav.mobileTitleText"
-            values={
-              Object {
-                "menuText": "menu",
-                "solutionName": "Solution",
-              }
-            }
-          />
-        </strong>
-      </h2>
-    </EuiTitle>
-    <EuiSpacer
-      size="l"
-    />
-    <EuiSideNavClass
-      aria-hidden={true}
-      aria-labelledby="SolutionNav_generated-id_heading"
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "items": Array [
-              Object {
-                "id": "1.1",
-                "items": undefined,
-                "name": "Ingest Node Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.2",
-                "items": undefined,
-                "name": "Logstash Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.3",
-                "items": undefined,
-                "name": "Beats Central Management",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Ingest",
-            "tabIndex": -1,
-          },
-          Object {
-            "id": "2",
-            "items": Array [
-              Object {
-                "id": "2.1",
-                "items": undefined,
-                "name": "Index Management",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.2",
-                "items": undefined,
-                "name": "Index Lifecycle Policies",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.3",
-                "items": undefined,
-                "name": "Snapshot and Restore",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Data",
-            "tabIndex": -1,
-          },
-        ]
-      }
-      mobileBreakpoints={Array []}
-    />
+    </div>
   </div>
   <SolutionNavCollapseButton
     isCollapsed={true}
@@ -415,6 +431,100 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
     <EuiPanel
       color="transparent"
       paddingSize="s"
+    >
+      <div
+        css="unknown styles"
+      >
+        <EuiSideNavClass
+          aria-hidden={false}
+          aria-labelledby="SolutionNav_generated-id_heading"
+          items={
+            Array [
+              Object {
+                "id": "1",
+                "items": Array [
+                  Object {
+                    "id": "1.1",
+                    "items": undefined,
+                    "name": "Ingest Node Pipelines",
+                    "tabIndex": undefined,
+                  },
+                  Object {
+                    "id": "1.2",
+                    "items": undefined,
+                    "name": "Logstash Pipelines",
+                    "tabIndex": undefined,
+                  },
+                  Object {
+                    "id": "1.3",
+                    "items": undefined,
+                    "name": "Beats Central Management",
+                    "tabIndex": undefined,
+                  },
+                ],
+                "name": "Ingest",
+                "tabIndex": undefined,
+              },
+              Object {
+                "id": "2",
+                "items": Array [
+                  Object {
+                    "id": "2.1",
+                    "items": undefined,
+                    "name": "Index Management",
+                    "tabIndex": undefined,
+                  },
+                  Object {
+                    "id": "2.2",
+                    "items": undefined,
+                    "name": "Index Lifecycle Policies",
+                    "tabIndex": undefined,
+                  },
+                  Object {
+                    "id": "2.3",
+                    "items": undefined,
+                    "name": "Snapshot and Restore",
+                    "tabIndex": undefined,
+                  },
+                ],
+                "name": "Data",
+                "tabIndex": undefined,
+              },
+            ]
+          }
+          mobileBreakpoints={Array []}
+        />
+      </div>
+    </EuiPanel>
+  </EuiCollapsibleNavGroup>
+  <div
+    css="unknown styles"
+  >
+    <EuiTitle
+      css="unknown styles"
+      id="SolutionNav_generated-id_heading"
+      size="xs"
+    >
+      <h2>
+        <strong>
+          <MemoizedFormattedMessage
+            defaultMessage="{solutionName} {menuText}"
+            id="sharedUXPackages.solutionNav.mobileTitleText"
+            values={
+              Object {
+                "menuText": "menu",
+                "solutionName": "Solution",
+              }
+            }
+          />
+        </strong>
+      </h2>
+    </EuiTitle>
+    <EuiSpacer
+      size="l"
+    />
+    <div
+      css="unknown styles"
     >
       <EuiSideNavClass
         aria-hidden={false}
@@ -475,93 +585,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
-  <div
-    css="unknown styles"
-  >
-    <EuiTitle
-      css="unknown styles"
-      id="SolutionNav_generated-id_heading"
-      size="xs"
-    >
-      <h2>
-        <strong>
-          <MemoizedFormattedMessage
-            defaultMessage="{solutionName} {menuText}"
-            id="sharedUXPackages.solutionNav.mobileTitleText"
-            values={
-              Object {
-                "menuText": "menu",
-                "solutionName": "Solution",
-              }
-            }
-          />
-        </strong>
-      </h2>
-    </EuiTitle>
-    <EuiSpacer
-      size="l"
-    />
-    <EuiSideNavClass
-      aria-hidden={false}
-      aria-labelledby="SolutionNav_generated-id_heading"
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "items": Array [
-              Object {
-                "id": "1.1",
-                "items": undefined,
-                "name": "Ingest Node Pipelines",
-                "tabIndex": undefined,
-              },
-              Object {
-                "id": "1.2",
-                "items": undefined,
-                "name": "Logstash Pipelines",
-                "tabIndex": undefined,
-              },
-              Object {
-                "id": "1.3",
-                "items": undefined,
-                "name": "Beats Central Management",
-                "tabIndex": undefined,
-              },
-            ],
-            "name": "Ingest",
-            "tabIndex": undefined,
-          },
-          Object {
-            "id": "2",
-            "items": Array [
-              Object {
-                "id": "2.1",
-                "items": undefined,
-                "name": "Index Management",
-                "tabIndex": undefined,
-              },
-              Object {
-                "id": "2.2",
-                "items": undefined,
-                "name": "Index Lifecycle Policies",
-                "tabIndex": undefined,
-              },
-              Object {
-                "id": "2.3",
-                "items": undefined,
-                "name": "Snapshot and Restore",
-                "tabIndex": undefined,
-              },
-            ],
-            "name": "Data",
-            "tabIndex": undefined,
-          },
-        ]
-      }
-      mobileBreakpoints={Array []}
-    />
+    </div>
   </div>
 </Fragment>
 `;
@@ -672,6 +696,100 @@ exports[`SolutionNav renders 1`] = `
       color="transparent"
       paddingSize="s"
     >
+      <div
+        css="unknown styles"
+      >
+        <EuiSideNavClass
+          aria-hidden={true}
+          aria-labelledby="SolutionNav_generated-id_heading"
+          items={
+            Array [
+              Object {
+                "id": "1",
+                "items": Array [
+                  Object {
+                    "id": "1.1",
+                    "items": undefined,
+                    "name": "Ingest Node Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.2",
+                    "items": undefined,
+                    "name": "Logstash Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.3",
+                    "items": undefined,
+                    "name": "Beats Central Management",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Ingest",
+                "tabIndex": -1,
+              },
+              Object {
+                "id": "2",
+                "items": Array [
+                  Object {
+                    "id": "2.1",
+                    "items": undefined,
+                    "name": "Index Management",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.2",
+                    "items": undefined,
+                    "name": "Index Lifecycle Policies",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.3",
+                    "items": undefined,
+                    "name": "Snapshot and Restore",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Data",
+                "tabIndex": -1,
+              },
+            ]
+          }
+          mobileBreakpoints={Array []}
+        />
+      </div>
+    </EuiPanel>
+  </EuiCollapsibleNavGroup>
+  <div
+    css="unknown styles"
+  >
+    <EuiTitle
+      css="unknown styles"
+      id="SolutionNav_generated-id_heading"
+      size="xs"
+    >
+      <h2>
+        <strong>
+          <MemoizedFormattedMessage
+            defaultMessage="{solutionName} {menuText}"
+            id="sharedUXPackages.solutionNav.mobileTitleText"
+            values={
+              Object {
+                "menuText": "menu",
+                "solutionName": "Solution",
+              }
+            }
+          />
+        </strong>
+      </h2>
+    </EuiTitle>
+    <EuiSpacer
+      size="l"
+    />
+    <div
+      css="unknown styles"
+    >
       <EuiSideNavClass
         aria-hidden={true}
         aria-labelledby="SolutionNav_generated-id_heading"
@@ -731,93 +849,7 @@ exports[`SolutionNav renders 1`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
-  <div
-    css="unknown styles"
-  >
-    <EuiTitle
-      css="unknown styles"
-      id="SolutionNav_generated-id_heading"
-      size="xs"
-    >
-      <h2>
-        <strong>
-          <MemoizedFormattedMessage
-            defaultMessage="{solutionName} {menuText}"
-            id="sharedUXPackages.solutionNav.mobileTitleText"
-            values={
-              Object {
-                "menuText": "menu",
-                "solutionName": "Solution",
-              }
-            }
-          />
-        </strong>
-      </h2>
-    </EuiTitle>
-    <EuiSpacer
-      size="l"
-    />
-    <EuiSideNavClass
-      aria-hidden={true}
-      aria-labelledby="SolutionNav_generated-id_heading"
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "items": Array [
-              Object {
-                "id": "1.1",
-                "items": undefined,
-                "name": "Ingest Node Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.2",
-                "items": undefined,
-                "name": "Logstash Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.3",
-                "items": undefined,
-                "name": "Beats Central Management",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Ingest",
-            "tabIndex": -1,
-          },
-          Object {
-            "id": "2",
-            "items": Array [
-              Object {
-                "id": "2.1",
-                "items": undefined,
-                "name": "Index Management",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.2",
-                "items": undefined,
-                "name": "Index Lifecycle Policies",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.3",
-                "items": undefined,
-                "name": "Snapshot and Restore",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Data",
-            "tabIndex": -1,
-          },
-        ]
-      }
-      mobileBreakpoints={Array []}
-    />
+    </div>
   </div>
   <SolutionNavCollapseButton
     isCollapsed={true}
@@ -866,6 +898,105 @@ exports[`SolutionNav renders with icon 1`] = `
       color="transparent"
       paddingSize="s"
     >
+      <div
+        css="unknown styles"
+      >
+        <EuiSideNavClass
+          aria-hidden={true}
+          aria-labelledby="SolutionNav_generated-id_heading"
+          items={
+            Array [
+              Object {
+                "id": "1",
+                "items": Array [
+                  Object {
+                    "id": "1.1",
+                    "items": undefined,
+                    "name": "Ingest Node Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.2",
+                    "items": undefined,
+                    "name": "Logstash Pipelines",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "1.3",
+                    "items": undefined,
+                    "name": "Beats Central Management",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Ingest",
+                "tabIndex": -1,
+              },
+              Object {
+                "id": "2",
+                "items": Array [
+                  Object {
+                    "id": "2.1",
+                    "items": undefined,
+                    "name": "Index Management",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.2",
+                    "items": undefined,
+                    "name": "Index Lifecycle Policies",
+                    "tabIndex": -1,
+                  },
+                  Object {
+                    "id": "2.3",
+                    "items": undefined,
+                    "name": "Snapshot and Restore",
+                    "tabIndex": -1,
+                  },
+                ],
+                "name": "Data",
+                "tabIndex": -1,
+              },
+            ]
+          }
+          mobileBreakpoints={Array []}
+        />
+      </div>
+    </EuiPanel>
+  </EuiCollapsibleNavGroup>
+  <div
+    css="unknown styles"
+  >
+    <EuiTitle
+      css="unknown styles"
+      id="SolutionNav_generated-id_heading"
+      size="xs"
+    >
+      <h2>
+        <KibanaSolutionAvatar
+          css="unknown styles"
+          iconType="logoElastic"
+          name="Solution"
+        />
+        <strong>
+          <MemoizedFormattedMessage
+            defaultMessage="{solutionName} {menuText}"
+            id="sharedUXPackages.solutionNav.mobileTitleText"
+            values={
+              Object {
+                "menuText": "menu",
+                "solutionName": "Solution",
+              }
+            }
+          />
+        </strong>
+      </h2>
+    </EuiTitle>
+    <EuiSpacer
+      size="l"
+    />
+    <div
+      css="unknown styles"
+    >
       <EuiSideNavClass
         aria-hidden={true}
         aria-labelledby="SolutionNav_generated-id_heading"
@@ -925,98 +1056,7 @@ exports[`SolutionNav renders with icon 1`] = `
         }
         mobileBreakpoints={Array []}
       />
-    </EuiPanel>
-  </EuiCollapsibleNavGroup>
-  <div
-    css="unknown styles"
-  >
-    <EuiTitle
-      css="unknown styles"
-      id="SolutionNav_generated-id_heading"
-      size="xs"
-    >
-      <h2>
-        <KibanaSolutionAvatar
-          css="unknown styles"
-          iconType="logoElastic"
-          name="Solution"
-        />
-        <strong>
-          <MemoizedFormattedMessage
-            defaultMessage="{solutionName} {menuText}"
-            id="sharedUXPackages.solutionNav.mobileTitleText"
-            values={
-              Object {
-                "menuText": "menu",
-                "solutionName": "Solution",
-              }
-            }
-          />
-        </strong>
-      </h2>
-    </EuiTitle>
-    <EuiSpacer
-      size="l"
-    />
-    <EuiSideNavClass
-      aria-hidden={true}
-      aria-labelledby="SolutionNav_generated-id_heading"
-      items={
-        Array [
-          Object {
-            "id": "1",
-            "items": Array [
-              Object {
-                "id": "1.1",
-                "items": undefined,
-                "name": "Ingest Node Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.2",
-                "items": undefined,
-                "name": "Logstash Pipelines",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "1.3",
-                "items": undefined,
-                "name": "Beats Central Management",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Ingest",
-            "tabIndex": -1,
-          },
-          Object {
-            "id": "2",
-            "items": Array [
-              Object {
-                "id": "2.1",
-                "items": undefined,
-                "name": "Index Management",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.2",
-                "items": undefined,
-                "name": "Index Lifecycle Policies",
-                "tabIndex": -1,
-              },
-              Object {
-                "id": "2.3",
-                "items": undefined,
-                "name": "Snapshot and Restore",
-                "tabIndex": -1,
-              },
-            ],
-            "name": "Data",
-            "tabIndex": -1,
-          },
-        ]
-      }
-      mobileBreakpoints={Array []}
-    />
+    </div>
   </div>
   <SolutionNavCollapseButton
     isCollapsed={true}

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.stories.tsx
@@ -9,6 +9,15 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  useEuiMinBreakpoint,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { SolutionNavProps } from './solution_nav';
 import { SolutionNav as Component } from './solution_nav';
 
@@ -17,7 +26,29 @@ export default {
   description: 'Solution-specific navigation for the sidebar',
 };
 
-type Params = Pick<SolutionNavProps, 'name' | 'icon'>;
+type Params = Pick<SolutionNavProps, 'name' | 'icon'> & { showFooter?: boolean };
+
+const FooterContent = () => {
+  return (
+    <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiText size="s">
+          <strong>Solution Nav Footer</strong>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiText size="s">
+          This is a footer for the solution nav. You can use it to add additional content to the
+          solution nav.
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton size="s" fullWidth onClick={action('click')}>
+          Click me
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
 
 const items: SolutionNavProps['items'] = [
   {
@@ -56,16 +87,67 @@ const items: SolutionNavProps['items'] = [
       },
     ],
   },
+  {
+    name: 'Settings',
+    id: '3',
+    items: [
+      {
+        name: 'Cluster Settings',
+        id: '3.1',
+      },
+      {
+        name: 'Node Settings',
+        id: '3.2',
+      },
+      {
+        name: 'Index Settings',
+        id: '3.3',
+      },
+      {
+        name: 'Index Templates',
+        id: '3.4',
+      },
+      {
+        name: 'Node Templates',
+        id: '3.5',
+      },
+      {
+        name: 'Component Templates',
+        id: '3.6',
+      },
+    ],
+  },
 ];
 
 export const SolutionNav = {
+  args: {
+    showFooter: true,
+  },
+  decorators: [
+    (storyFn: Function) => {
+      return (
+        <div
+          css={css`
+            height: 100vh;
+            ${useEuiMinBreakpoint('m')} {
+              display: flex;
+            }
+          `}
+        >
+          {storyFn()}
+        </div>
+      );
+    },
+  ],
   render: (params: Params) => {
+    const { showFooter, ...rest } = params;
     return (
       <Component
         items={items}
         isOpenOnDesktop={true}
-        {...params}
+        {...rest}
         onCollapse={action('onCollapse')}
+        footer={showFooter ? <FooterContent /> : undefined}
       />
     );
   },
@@ -88,8 +170,11 @@ export const SolutionNav = {
       control: 'boolean',
       defaultValue: true,
     },
+    showFooter: {
+      control: 'boolean',
+      defaultValue: true,
+    },
   },
-
   parameters: {
     layout: 'fullscreen',
   },

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.test.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.test.tsx
@@ -106,4 +106,30 @@ describe('SolutionNav', () => {
     );
     expect(noCollapse).toMatchSnapshot();
   });
+
+  describe('footer', () => {
+    test('renders footer when provided', () => {
+      const component = shallow(
+        <SolutionNav
+          name="Solution"
+          items={items}
+          footer={<div id="test-footer">Footer content</div>}
+        />
+      );
+      expect(component.find('#test-footer').exists()).toBeTruthy();
+    });
+    test('does not render footer wrapper when footer is not provided', () => {
+      const component = shallow(<SolutionNav name="Solution" items={items} />);
+      expect(component.find('[data-test-subj="solutionNavFooter"]').exists()).toBeFalsy();
+    });
+    test('renders footer with custom children', () => {
+      const component = shallow(
+        <SolutionNav name="Solution" footer={<div id="test-footer">Footer</div>}>
+          <span id="custom-nav" />
+        </SolutionNav>
+      );
+      expect(component.find('#test-footer').exists()).toBeTruthy();
+      expect(component.find('#custom-nav').exists()).toBeTruthy();
+    });
+  });
 });

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
@@ -31,9 +31,9 @@ import {
   useEuiTheme,
   useEuiThemeCSSVariables,
   EuiPageSidebar,
-  useEuiOverflowScroll,
   useEuiMinBreakpoint,
   euiCanAnimate,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -79,6 +79,11 @@ export type SolutionNavProps = Omit<EuiSideNavProps<{}>, 'children' | 'items' | 
    * If false, forces all breakpoint versions into the open state without the ability to hide.
    */
   canBeCollapsed?: boolean;
+  /**
+   * Optional content to render at the bottom of the nav, pinned below the scrollable nav items.
+   * Hidden when the nav is collapsed.
+   */
+  footer?: React.ReactNode;
 };
 
 const FLYOUT_SIZE = 248;
@@ -109,6 +114,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
   name,
   onCollapse,
   canBeCollapsed = true,
+  footer,
   ...rest
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -223,11 +229,10 @@ export const SolutionNav: FC<SolutionNavProps> = ({
       display: flex;
       flex-direction: column;
 
-      ${useEuiOverflowScroll('y')};
-
       ${useEuiMinBreakpoint('m')} {
         width: ${FLYOUT_SIZE_CSS};
         padding: ${euiTheme.size.l};
+        height: 100%;
       }
     `,
     solutionNavHidden: css`
@@ -238,7 +243,30 @@ export const SolutionNav: FC<SolutionNavProps> = ({
         transition: opacity ${euiTheme.animation.fast} ${euiTheme.animation.resistance};
       }
     `,
+    solutionNavScrollable: css`
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      margin-right: -${euiTheme.size.l};
+      padding-right: ${euiTheme.size.l};
+    `,
+    solutionNavFooter: css`
+      flex-shrink: 0;
+      margin-top: auto;
+    `,
   };
+
+  const footerContent = footer && (
+    <div css={styles.solutionNavFooter} data-test-subj="solutionNavFooter">
+      <EuiHorizontalRule margin="m" />
+      {footer}
+    </div>
+  );
+
+  const solutionNavContent = sideNavContent && (
+    <div css={styles.solutionNavScrollable}>{sideNavContent}</div>
+  );
+
   return (
     <>
       {isSmallerBreakpoint && (
@@ -254,7 +282,8 @@ export const SolutionNav: FC<SolutionNavProps> = ({
           initialIsOpen={false}
         >
           <EuiPanel color="transparent" paddingSize="s">
-            {sideNavContent}
+            {solutionNavContent}
+            {footerContent}
           </EuiPanel>
         </EuiCollapsibleNavGroup>
       )}
@@ -286,7 +315,8 @@ export const SolutionNav: FC<SolutionNavProps> = ({
               >
                 {titleText}
                 <EuiSpacer size="l" />
-                {sideNavContent}
+                {solutionNavContent}
+                {footerContent}
               </EuiPageSidebar>
             </EuiFlyout>
           )}
@@ -303,7 +333,8 @@ export const SolutionNav: FC<SolutionNavProps> = ({
           >
             {titleText}
             <EuiSpacer size="l" />
-            {sideNavContent}
+            {solutionNavContent}
+            {footerContent}
           </div>
           {canBeCollapsed && (
             <SolutionNavCollapseButton isCollapsed={!isOpenOnDesktop} onClick={onCollapse} />

--- a/x-pack/solutions/security/packages/side-nav/src/solution_side_nav.tsx
+++ b/x-pack/solutions/security/packages/side-nav/src/solution_side_nav.tsx
@@ -23,6 +23,7 @@ import classNames from 'classnames';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
 import type { SeparatorLinkCategory } from '@kbn/security-solution-navigation';
+import { css } from '@emotion/react';
 import { SolutionSideNavPanel } from './solution_side_nav_panel';
 import { SolutionSideNavItemPosition } from './types';
 import type { SolutionSideNavItem, Tracker } from './types';
@@ -103,7 +104,13 @@ export const SolutionSideNav: React.FC<SolutionSideNavProps> = React.memo(functi
 
   return (
     <TelemetryContextProvider tracker={tracker}>
-      <EuiFlexGroup gutterSize="none" direction="column">
+      <EuiFlexGroup
+        gutterSize="none"
+        direction="column"
+        css={css`
+          height: 100%;
+        `}
+      >
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="none" direction="column">
             <EuiFlexItem grow={false}>
@@ -271,7 +278,7 @@ const SolutionSideNavItem: React.FC<SolutionSideNavItemProps> = React.memo(
         <EuiFlexGroup alignItems="center" gutterSize="none">
           <EuiFlexItem>{label}</EuiFlexItem>
           <EuiFlexItem grow={0} id={`solutionSideNavCustomIconItem-${id}`}>
-            <EuiIcon type={iconType} color="text" />
+            <EuiIcon type={iconType} color="text" aria-hidden={true} />
           </EuiFlexItem>
         </EuiFlexGroup>
       );


### PR DESCRIPTION
## Summary

- Added a new optional `footer` prop to the solution nav to accommodate for the new [Solution side nav space callout](https://github.com/elastic/kibana-team/issues/2873) we will include on the 3 solution navs to highlight switching to solution view spaces.
- Footer remains pinned at the bottom and the scrollable area is now for the nav items only.

Closes https://github.com/elastic/kibana/issues/256671

### Testing

You can test in Storybook with mocked footer content. Solution navs are not yet using this prop so there should be no footer nor horizontal rule nor major style changes on the solution navs at this point.

**Storybook:**

<img width="172" height="436" alt="Screenshot 2026-03-11 at 14 29 41" src="https://github.com/user-attachments/assets/c61f059b-bf0f-4131-990b-e0b4ac3dcb1c" />

**Before/after solution navs (no noticeable changes):**

| Before | After |
|----------|----------|
| <img width="150" height="600" alt="Screenshot 2026-03-11 at 11 24 59" src="https://github.com/user-attachments/assets/7e77e344-271f-4fed-bdeb-bc3bb9eb4607" />    | <img width="150" height="550" alt="Screenshot 2026-03-11 at 11 46 39" src="https://github.com/user-attachments/assets/5caf3d0c-2080-4238-9fbc-0cc55de9e075" />  |
| <img width="140" height="500" alt="Screenshot 2026-03-11 at 11 24 38" src="https://github.com/user-attachments/assets/dc8d3c16-d771-46c2-af9b-aa0eeea09593" />    | <img width="140" height="550" alt="Screenshot 2026-03-11 at 11 41 07" src="https://github.com/user-attachments/assets/7a07a61a-ad33-401f-8a70-6305e9824d92" />
   |
| <img width="137" height="495" alt="Screenshot 2026-03-11 at 11 24 23" src="https://github.com/user-attachments/assets/bfe76f46-d016-49d9-8a0b-6db6d25105ac" />   | <img width="140" height="550" alt="Screenshot 2026-03-11 at 11 40 52" src="https://github.com/user-attachments/assets/6e37e83a-a0dc-421e-9522-e7055d1aed08" />
  |
| <img width="140" height="550" alt="Screenshot 2026-03-11 at 11 25 18" src="https://github.com/user-attachments/assets/9f26945c-00f9-486d-a384-bbe5c433fbdd" />    | <img width="140" height="590" alt="Screenshot 2026-03-11 at 11 40 39" src="https://github.com/user-attachments/assets/0ed51cfd-b691-4fa3-b3ab-2928247378b7" />   |
