### PR TITLE
[Lens as code] Casing convention cleanup

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.test.ts
@@ -19,7 +19,7 @@ test('generates metric chart config', async () => {
         esql: 'from test | count=count() by @timestamp, category',
       },
       breakdown: 'category',
-      xAxis: '@timestamp',
+      x_axis: '@timestamp',
       value: 'count',
     },
     {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/heatmap.ts
@@ -28,7 +28,7 @@ function buildVisualizationState(config: LensHeatmapConfig): HeatmapVisualizatio
     layerType: 'data',
     shape: 'heatmap',
     valueAccessor: ACCESSOR,
-    ...(layer.xAxis
+    ...(layer.x_axis
       ? {
           xAccessor: getAccessorName('x'),
         }
@@ -64,10 +64,10 @@ function buildFormulaLayer(
     ...getFormulaColumn(ACCESSOR, mapToFormula(layer), dataView),
   };
 
-  if (layer.xAxis) {
+  if (layer.x_axis) {
     const columnName = getAccessorName('x');
     const breakdownColumn = getBreakdownColumn({
-      options: layer.xAxis,
+      options: layer.x_axis,
       dataView,
     });
     addLayerColumn(defaultLayer, columnName, breakdownColumn, true);
@@ -89,12 +89,12 @@ function getValueColumns(layer: LensHeatmapConfig) {
   if (layer.breakdown && typeof layer.breakdown !== 'string') {
     throw new Error('breakdown must be a field name when not using index source');
   }
-  if (typeof layer.xAxis !== 'string') {
-    throw new Error('xAxis must be a field name when not using index source');
+  if (typeof layer.x_axis !== 'string') {
+    throw new Error('x_axis must be a field name when not using index source');
   }
   return [
     ...(layer.breakdown ? [getValueColumn(getAccessorName('y'), layer.breakdown as string)] : []),
-    getValueColumn(getAccessorName('x'), layer.xAxis as string),
+    getValueColumn(getAccessorName('x'), layer.x_axis as string),
     getValueColumn(ACCESSOR, layer.value),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/table.ts
@@ -75,7 +75,7 @@ function getValueColumns(layer: LensTableConfig) {
     throw new Error('breakdown must be a field name when not using index source');
   }
   if (layer.splitBy && layer.splitBy.filter((s) => typeof s !== 'string').length) {
-    throw new Error('xAxis must be a field name when not using index source');
+    throw new Error('x_axis must be a field name when not using index source');
   }
   return [
     ...(layer.breakdown

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.test.ts
@@ -24,8 +24,8 @@ test('generates xy chart config', async () => {
         {
           type: 'series',
           seriesType: 'bar',
-          xAxis: '@timestamp',
-          yAxis: [
+          x_axis: '@timestamp',
+          y_axis: [
             {
               label: 'test',
               value: 'count',
@@ -169,8 +169,8 @@ test('generates xy chart config with legend stats', async () => {
         {
           type: 'series',
           seriesType: 'bar',
-          xAxis: '@timestamp',
-          yAxis: [
+          x_axis: '@timestamp',
+          y_axis: [
             {
               label: 'test',
               value: 'count',
@@ -211,11 +211,11 @@ test('it generates xy chart with multiple reference lines', async () => {
         {
           type: 'series',
           seriesType: 'bar',
-          xAxis: {
+          x_axis: {
             type: 'dateHistogram',
             field: '@timestamp',
           },
-          yAxis: [
+          y_axis: [
             {
               label: 'test',
               value: 'count()',
@@ -224,7 +224,7 @@ test('it generates xy chart with multiple reference lines', async () => {
         },
         {
           type: 'reference',
-          yAxis: [
+          y_axis: [
             {
               seriesColor: 'red',
               lineThickness: 2,
@@ -241,7 +241,7 @@ test('it generates xy chart with multiple reference lines', async () => {
         },
         {
           type: 'reference',
-          yAxis: [
+          y_axis: [
             {
               seriesColor: 'yellow',
               fill: 'none',
@@ -312,8 +312,8 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'line',
-            xAxis: '@timestamp',
-            yAxis: [
+            x_axis: '@timestamp',
+            y_axis: [
               {
                 label: 'test',
                 value: 'count',
@@ -345,9 +345,9 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'line',
-            xAxis: '@timestamp',
+            x_axis: '@timestamp',
             breakdown: 'service.name',
-            yAxis: [
+            y_axis: [
               {
                 label: 'test',
                 value: 'count',
@@ -379,9 +379,9 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'line',
-            xAxis: '@timestamp',
+            x_axis: '@timestamp',
             breakdown: ['host.name'],
-            yAxis: [
+            y_axis: [
               {
                 label: 'test',
                 value: 'count',
@@ -413,9 +413,9 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'line',
-            xAxis: '@timestamp',
+            x_axis: '@timestamp',
             breakdown: ['host.name', 'service.name', 'container.id'],
-            yAxis: [
+            y_axis: [
               {
                 label: 'test',
                 value: 'count',
@@ -451,9 +451,9 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'line',
-            xAxis: '@timestamp',
+            x_axis: '@timestamp',
             breakdown: 'service.name',
-            yAxis: [
+            y_axis: [
               {
                 label: 'test',
                 value: 'count',
@@ -463,9 +463,9 @@ describe('breakdown handling', () => {
           {
             type: 'series',
             seriesType: 'bar',
-            xAxis: '@timestamp',
+            x_axis: '@timestamp',
             breakdown: ['host.name', 'container.id'],
-            yAxis: [
+            y_axis: [
               {
                 label: 'test2',
                 value: 'count',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -119,13 +119,13 @@ function buildVisualizationState(config: LensXYConfig): XYState {
           return {
             layerId: `layer_${i}`,
             layerType: 'referenceLine',
-            accessors: layer.yAxis.map((_, index) => `${ACCESSOR}${i}_${index}`),
-            yConfig: layer.yAxis.map((yAxis, index) => ({
+            accessors: layer.y_axis.map((_, index) => `${ACCESSOR}${i}_${index}`),
+            yConfig: layer.y_axis.map((y_axis, index) => ({
               forAccessor: `${ACCESSOR}${i}_${index}`,
               axisMode: 'left',
-              color: yAxis.seriesColor,
-              ...(yAxis.fill ? { fill: yAxis.fill } : {}),
-              ...(yAxis.lineThickness ? { lineWidth: yAxis.lineThickness } : {}),
+              color: y_axis.seriesColor,
+              ...(y_axis.fill ? { fill: y_axis.fill } : {}),
+              ...(y_axis.lineThickness ? { lineWidth: y_axis.lineThickness } : {}),
             })),
           } satisfies XYReferenceLineLayerConfig;
         case 'series': {
@@ -141,11 +141,11 @@ function buildVisualizationState(config: LensXYConfig): XYState {
                   ),
                 }
               : {}),
-            accessors: layer.yAxis.map((_, index) => `${ACCESSOR}${i}_${index}`),
+            accessors: layer.y_axis.map((_, index) => `${ACCESSOR}${i}_${index}`),
             seriesType: layer.seriesType || 'line',
-            yConfig: layer.yAxis.map((yAxis, index) => ({
+            yConfig: layer.y_axis.map((y_axis, index) => ({
               forAccessor: `${ACCESSOR}${i}_${index}`,
-              color: yAxis.seriesColor,
+              color: y_axis.seriesColor,
             })),
           } as XYDataLayerConfig;
         }
@@ -154,10 +154,10 @@ function buildVisualizationState(config: LensXYConfig): XYState {
   };
 }
 
-function hasFormatParams(yAxis: LensSeriesLayer['yAxis'][number]) {
+function hasFormatParams(y_axis: LensSeriesLayer['y_axis'][number]) {
   return (
-    yAxis.format &&
-    (yAxis.suffix || yAxis.compactValues || yAxis.decimals || yAxis.fromUnit || yAxis.toUnit)
+    y_axis.format &&
+    (y_axis.suffix || y_axis.compactValues || y_axis.decimals || y_axis.fromUnit || y_axis.toUnit)
   );
 }
 
@@ -173,22 +173,22 @@ function getValueColumns(layer: LensSeriesLayer, i: number) {
     ...layerBreakdown.map((bd, breakdownIndex) =>
       getValueColumn(`${ACCESSOR}${i}_breakdown_${breakdownIndex}`, bd as string)
     ),
-    ...getXValueColumn(layer.xAxis, i),
-    ...layer.yAxis.map((yAxis, index) => {
-      const params = hasFormatParams(yAxis)
+    ...getXValueColumn(layer.x_axis, i),
+    ...layer.y_axis.map((y_axis, index) => {
+      const params = hasFormatParams(y_axis)
         ? {
-            id: yAxis.format as string,
+            id: y_axis.format as string,
             params: {
-              compact: yAxis.compactValues,
-              decimals: yAxis.decimals ?? 0,
-              suffix: yAxis.suffix,
-              fromUnit: yAxis.fromUnit,
-              toUnit: yAxis.toUnit,
+              compact: y_axis.compactValues,
+              decimals: y_axis.decimals ?? 0,
+              suffix: y_axis.suffix,
+              fromUnit: y_axis.fromUnit,
+              toUnit: y_axis.toUnit,
             },
           }
         : undefined;
 
-      return getValueColumn(`${ACCESSOR}${i}_${index}`, yAxis.value, 'number', params);
+      return getValueColumn(`${ACCESSOR}${i}_${index}`, y_axis.value, 'number', params);
     }),
   ];
 }
@@ -222,7 +222,7 @@ function buildAllFormulasInLayer(
   i: number,
   dataView: DataView
 ): PersistedIndexPatternLayer {
-  return layer.yAxis.reduce((acc, curr, valueIndex) => {
+  return layer.y_axis.reduce((acc, curr, valueIndex) => {
     const formulaColumn = getFormulaColumn(
       `${ACCESSOR}${i}_${valueIndex}`,
       mapToFormula(curr),
@@ -241,10 +241,10 @@ function buildFormulaLayer(
   if (layer.type === 'series') {
     const resultLayer = buildAllFormulasInLayer(layer, i, dataView);
 
-    if (layer.xAxis) {
+    if (layer.x_axis) {
       const columnName = `x_${ACCESSOR}${i}`;
       const breakdownColumn = getBreakdownColumn({
-        options: layer.xAxis,
+        options: layer.x_axis,
         dataView,
       });
       addLayerColumn(resultLayer, columnName, breakdownColumn, true);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/charts/xy.ts
@@ -174,21 +174,21 @@ function getValueColumns(layer: LensSeriesLayer, i: number) {
       getValueColumn(`${ACCESSOR}${i}_breakdown_${breakdownIndex}`, bd as string)
     ),
     ...getXValueColumn(layer.x_axis, i),
-    ...layer.y_axis.map((y_axis, index) => {
-      const params = hasFormatParams(y_axis)
+    ...layer.y_axis.map((yAxis, index) => {
+      const params = hasFormatParams(yAxis)
         ? {
-            id: y_axis.format as string,
+            id: yAxis.format as string,
             params: {
-              compact: y_axis.compactValues,
-              decimals: y_axis.decimals ?? 0,
-              suffix: y_axis.suffix,
-              fromUnit: y_axis.fromUnit,
-              toUnit: y_axis.toUnit,
+              compact: yAxis.compactValues,
+              decimals: yAxis.decimals ?? 0,
+              suffix: yAxis.suffix,
+              fromUnit: yAxis.fromUnit,
+              toUnit: yAxis.toUnit,
             },
           }
         : undefined;
 
-      return getValueColumn(`${ACCESSOR}${i}_${index}`, y_axis.value, 'number', params);
+      return getValueColumn(`${ACCESSOR}${i}_${index}`, yAxis.value, 'number', params);
     }),
   ];
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/datatable.test.ts
@@ -723,7 +723,7 @@ describe('Datatable Schema', () => {
                 {
                   values: ['value1', 'value2', 'value3'],
                   color: {
-                    type: 'colorCode',
+                    type: 'color_code',
                     value: '#000000',
                   },
                 },
@@ -819,7 +819,7 @@ describe('Datatable Schema', () => {
                 {
                   values: ['value1', 'value2', 'value3'],
                   color: {
-                    type: 'colorCode',
+                    type: 'color_code',
                     value: '#000000',
                   },
                 },
@@ -864,7 +864,7 @@ describe('Datatable Schema', () => {
                 {
                   values: ['value1', 'value2', 'value3'],
                   color: {
-                    type: 'colorCode',
+                    type: 'color_code',
                     value: '#000000',
                   },
                 },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/heatmap.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/heatmap.ts
@@ -129,13 +129,13 @@ const heatmapSharedStateSchema = {
 };
 
 const heatmapAxesStateSchemaProps = {
-  xAxis: bucketOperationDefinitionSchema,
-  yAxis: schema.maybe(bucketOperationDefinitionSchema),
+  x_axis: bucketOperationDefinitionSchema,
+  y_axis: schema.maybe(bucketOperationDefinitionSchema),
 };
 
 const heatmapAxesStateESQLSchemaProps = {
-  xAxis: esqlColumnSchema,
-  yAxis: schema.maybe(esqlColumnSchema),
+  x_axis: esqlColumnSchema,
+  y_axis: schema.maybe(esqlColumnSchema),
 };
 
 const heatmapStateMetricOptionsSchemaProps = {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/pie.test.ts
@@ -185,7 +185,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['success'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 6,
                     },
@@ -193,7 +193,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['info'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 9,
                     },
@@ -201,7 +201,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['security'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 4,
                     },
@@ -209,7 +209,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['__other__'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 5,
                     },
@@ -788,7 +788,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['success'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 6,
                     },
@@ -796,7 +796,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['info'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 9,
                     },
@@ -804,7 +804,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['security'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 4,
                     },
@@ -812,7 +812,7 @@ describe('Pie/Donut Schema', () => {
                   {
                     values: ['__other__'],
                     color: {
-                      type: 'from_palette',
+                      type: 'color_from_palette',
                       palette: 'default',
                       index: 5,
                     },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
@@ -90,7 +90,7 @@ describe('Tagcloud Schema', () => {
                 color: { type: 'from_palette', palette: 'default', index: 0 },
               },
             ],
-            unassignedColor: { type: 'colorCode', value: '#cccccc' },
+            unassigned_color: { type: 'color_code', value: '#cccccc' },
           },
         },
       };
@@ -386,8 +386,8 @@ describe('Tagcloud Schema', () => {
               mode: 'gradient',
               palette: 'kibana_palette',
               gradient: [
-                { type: 'colorCode', value: '#ff0000' },
-                { type: 'colorCode', value: '#00ff00' },
+                { type: 'color_code', value: '#ff0000' },
+                { type: 'color_code', value: '#00ff00' },
               ],
             },
           },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
@@ -87,7 +87,7 @@ describe('Tagcloud Schema', () => {
             mapping: [
               {
                 values: ['value1', 'value2', 'value3'],
-                color: { type: 'from_palette', palette: 'default', index: 0 },
+                color: { type: 'color_from_palette', palette: 'default', index: 0 },
               },
             ],
             unassigned_color: { type: 'color_code', value: '#cccccc' },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/treemap.test.ts
@@ -152,7 +152,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['success'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 6,
                   },
@@ -160,7 +160,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['info'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 9,
                   },
@@ -168,7 +168,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['security'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 4,
                   },
@@ -176,7 +176,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['__other__'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 5,
                   },
@@ -626,7 +626,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['success'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 6,
                   },
@@ -634,7 +634,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['info'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 9,
                   },
@@ -642,7 +642,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['security'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 4,
                   },
@@ -650,7 +650,7 @@ describe('Treemap Schema', () => {
                 {
                   values: ['__other__'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 5,
                   },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/waffle.test.ts
@@ -146,7 +146,7 @@ describe('Waffle Schema', () => {
                 {
                   values: ['success'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 6,
                   },
@@ -154,7 +154,7 @@ describe('Waffle Schema', () => {
                 {
                   values: ['info'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 9,
                   },
@@ -162,7 +162,7 @@ describe('Waffle Schema', () => {
                 {
                   values: ['security'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 4,
                   },
@@ -170,7 +170,7 @@ describe('Waffle Schema', () => {
                 {
                   values: ['__other__'],
                   color: {
-                    type: 'from_palette',
+                    type: 'color_from_palette',
                     palette: 'default',
                     index: 5,
                   },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
@@ -368,7 +368,7 @@ const xySharedSettings = {
       },
       {
         meta: {
-          id: 'xyAxis',
+          id: 'xy_axis',
           title: 'Axis',
           description: 'Axis configuration for X, left Y, and right Y axes',
         },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
@@ -235,10 +235,10 @@ describe('Color Schema', () => {
         mapping: [
           {
             values: ['value1', 'value2', 'value3'],
-            color: { type: 'colorCode', value: 'red' },
+            color: { type: 'color_code', value: 'red' },
           },
         ],
-        unassignedColor: { type: 'colorCode', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);
@@ -252,7 +252,7 @@ describe('Color Schema', () => {
         mapping: [
           {
             values: ['value1', 'value2', 'value3'],
-            color: { type: 'colorCode', value: 'red' },
+            color: { type: 'color_code', value: 'red' },
           },
         ],
       };
@@ -271,7 +271,7 @@ describe('Color Schema', () => {
             color: { type: 'from_palette', palette: 'default', index: 0 },
           },
         ],
-        unassignedColor: { type: 'colorCode', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);
@@ -305,7 +305,7 @@ describe('Color Schema', () => {
           },
           {
             values: ['value4', 'value5', 'value6'],
-            color: { type: 'colorCode', value: 'green' },
+            color: { type: 'color_code', value: 'green' },
           },
         ],
       };
@@ -354,7 +354,7 @@ describe('Color Schema', () => {
             palette: 'default',
           },
         ],
-        unassignedColor: { type: 'colorCode', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
@@ -268,7 +268,7 @@ describe('Color Schema', () => {
         mapping: [
           {
             values: ['value1', 'value2', 'value3'],
-            color: { type: 'from_palette', palette: 'default', index: 0 },
+            color: { type: 'color_from_palette', palette: 'default', index: 0 },
           },
         ],
         unassigned_color: { type: 'color_code', value: 'green' },
@@ -285,7 +285,7 @@ describe('Color Schema', () => {
         mapping: [
           {
             values: ['value1', 'value2', 'value3'],
-            color: { type: 'from_palette', palette: 'default', index: 0 },
+            color: { type: 'color_from_palette', palette: 'default', index: 0 },
           },
         ],
       };
@@ -301,7 +301,7 @@ describe('Color Schema', () => {
         mapping: [
           {
             values: ['value1', 'value2', 'value3'],
-            color: { type: 'from_palette', palette: 'default', index: 0 },
+            color: { type: 'color_from_palette', palette: 'default', index: 0 },
           },
           {
             values: ['value4', 'value5', 'value6'],
@@ -321,12 +321,12 @@ describe('Color Schema', () => {
         mapping: [{ values: ['low', 'medium', 'high'] }],
         gradient: [
           {
-            type: 'from_palette',
+            type: 'color_from_palette',
             index: 0,
             palette: 'default',
           },
           {
-            type: 'from_palette',
+            type: 'color_from_palette',
             index: 2,
             palette: 'default',
           },
@@ -344,12 +344,12 @@ describe('Color Schema', () => {
         mapping: [{ values: ['low', 'medium', 'high'] }],
         gradient: [
           {
-            type: 'from_palette',
+            type: 'color_from_palette',
             index: 0,
             palette: 'default',
           },
           {
-            type: 'from_palette',
+            type: 'color_from_palette',
             index: 2,
             palette: 'default',
           },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
@@ -214,7 +214,7 @@ export const staticColorSchema = schema.object(
 
 const colorFromPaletteSchema = schema.object(
   {
-    type: schema.literal('from_palette'),
+    type: schema.literal('color_from_palette'),
     index: schema.number({ meta: { description: 'The index of the color in the palette.' } }),
     palette: schema.maybe(schema.string({ meta: { description: 'The palette name to use.' } })),
   },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
@@ -218,15 +218,15 @@ const colorFromPaletteSchema = schema.object(
     index: schema.number({ meta: { description: 'The index of the color in the palette.' } }),
     palette: schema.maybe(schema.string({ meta: { description: 'The palette name to use.' } })),
   },
-  { meta: { id: 'colorFromPalette', title: 'Color From Palette' } }
+  { meta: { id: 'color_from_palette', title: 'Color From Palette' } }
 );
 
 const colorCodeSchema = schema.object(
   {
-    type: schema.literal('colorCode'),
+    type: schema.literal('color_code'),
     value: schema.string({ meta: { description: 'The static color value to use.' } }),
   },
-  { meta: { id: 'colorCode', title: 'Color Code' } }
+  { meta: { id: 'color_code', title: 'Color Code' } }
 );
 
 const colorDefSchema = schema.oneOf([colorFromPaletteSchema, colorCodeSchema]);
@@ -244,9 +244,9 @@ const categoricalColorMappingSchema = schema.object(
       }),
       { maxSize: 1000 }
     ),
-    unassignedColor: schema.maybe(colorDefSchema),
+    unassigned_color: schema.maybe(colorDefSchema),
   },
-  { meta: { id: 'categoricalColorMapping', title: 'Categorical Color Mapping' } }
+  { meta: { id: 'categorical_color_mapping', title: 'Categorical Color Mapping' } }
 );
 
 const gradientColorMappingSchema = schema.object(
@@ -269,9 +269,9 @@ const gradientColorMappingSchema = schema.object(
       )
     ),
     gradient: schema.maybe(schema.arrayOf(colorDefSchema, { maxSize: 3 })),
-    unassignedColor: schema.maybe(colorDefSchema),
+    unassigned_color: schema.maybe(colorDefSchema),
   },
-  { meta: { id: 'gradientColorMapping', title: 'Gradient Color Mapping' } }
+  { meta: { id: 'gradient_color_mapping', title: 'Gradient Color Mapping' } }
 );
 
 export const colorMappingSchema = schema.oneOf(
@@ -285,7 +285,7 @@ export const colorMappingSchema = schema.oneOf(
      */
     gradientColorMappingSchema,
   ],
-  { meta: { id: 'colorMapping', title: 'Color Mapping' } }
+  { meta: { id: 'color_mapping', title: 'Color Mapping' } }
 );
 
 export const allColoringTypeSchema = schema.oneOf([

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
@@ -833,7 +833,7 @@ export const esqlCharts = [
             {
               values: ['success'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 6,
               },
@@ -841,7 +841,7 @@ export const esqlCharts = [
             {
               values: ['info'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 9,
               },
@@ -849,7 +849,7 @@ export const esqlCharts = [
             {
               values: ['security'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 4,
               },
@@ -857,7 +857,7 @@ export const esqlCharts = [
             {
               values: ['__other__'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 5,
               },
@@ -1005,7 +1005,7 @@ export const esqlCharts = [
             {
               values: ['success'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 6,
               },
@@ -1013,7 +1013,7 @@ export const esqlCharts = [
             {
               values: ['info'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 9,
               },
@@ -1021,7 +1021,7 @@ export const esqlCharts = [
             {
               values: ['security'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 4,
               },
@@ -1029,7 +1029,7 @@ export const esqlCharts = [
             {
               values: ['__other__'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 5,
               },
@@ -1111,7 +1111,7 @@ export const esqlCharts = [
             {
               values: ['success'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 6,
               },
@@ -1119,7 +1119,7 @@ export const esqlCharts = [
             {
               values: ['info'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 9,
               },
@@ -1127,7 +1127,7 @@ export const esqlCharts = [
             {
               values: ['security'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 4,
               },
@@ -1135,7 +1135,7 @@ export const esqlCharts = [
             {
               values: ['__other__'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 5,
               },
@@ -1202,7 +1202,7 @@ export const esqlCharts = [
             {
               values: ['success'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 6,
               },
@@ -1210,7 +1210,7 @@ export const esqlCharts = [
             {
               values: ['info'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 9,
               },
@@ -1218,7 +1218,7 @@ export const esqlCharts = [
             {
               values: ['security'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 4,
               },
@@ -1226,7 +1226,7 @@ export const esqlCharts = [
             {
               values: ['__other__'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 5,
               },
@@ -1295,7 +1295,7 @@ export const esqlCharts = [
             {
               values: ['success'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 6,
               },
@@ -1303,7 +1303,7 @@ export const esqlCharts = [
             {
               values: ['info'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 9,
               },
@@ -1311,7 +1311,7 @@ export const esqlCharts = [
             {
               values: ['security'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 4,
               },
@@ -1319,7 +1319,7 @@ export const esqlCharts = [
             {
               values: ['__other__'],
               color: {
-                type: 'from_palette',
+                type: 'color_from_palette',
                 palette: 'default',
                 index: 5,
               },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/tagcloud/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/tagcloud/lens_api_config.mock.ts
@@ -117,7 +117,7 @@ export const comprehensiveTagcloudWithAdHocDataView = {
         {
           values: ['CN'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 0,
           },
@@ -125,7 +125,7 @@ export const comprehensiveTagcloudWithAdHocDataView = {
         {
           values: ['IN'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 1,
           },
@@ -133,7 +133,7 @@ export const comprehensiveTagcloudWithAdHocDataView = {
         {
           values: ['ID'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 2,
           },
@@ -180,7 +180,7 @@ export const comprehensiveTagcloudWithDataView = {
         {
           values: ['CN'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 0,
           },
@@ -188,7 +188,7 @@ export const comprehensiveTagcloudWithDataView = {
         {
           values: ['IN'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 1,
           },
@@ -196,7 +196,7 @@ export const comprehensiveTagcloudWithDataView = {
         {
           values: ['ID'],
           color: {
-            type: 'from_palette',
+            type: 'color_from_palette',
             palette: 'default',
             index: 2,
           },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
@@ -116,8 +116,8 @@ function reverseBuildVisualizationState(
         ...getValueApiColumn(valueAccessor, layer),
         ...paletteProps,
       },
-      xAxis: getValueApiColumn(visualization.xAccessor, layer),
-      ...(visualization.yAccessor && { yAxis: getValueApiColumn(visualization.yAccessor, layer) }),
+      x_axis: getValueApiColumn(visualization.xAccessor, layer),
+      ...(visualization.yAccessor && { y_axis: getValueApiColumn(visualization.yAccessor, layer) }),
     } satisfies HeatmapStateESQL;
   }
 
@@ -136,8 +136,8 @@ function reverseBuildVisualizationState(
       ...operationFromColumn(valueAccessor, layer),
       ...paletteProps,
     } as LensApiAllMetricOperations,
-    xAxis: operationFromColumn(visualization.xAccessor!, layer),
-    yAxis: visualization.yAccessor && operationFromColumn(visualization.yAccessor, layer),
+    x_axis: operationFromColumn(visualization.xAccessor!, layer),
+    y_axis: visualization.yAccessor && operationFromColumn(visualization.yAccessor, layer),
   } as HeatmapStateNoESQL;
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
@@ -556,7 +556,10 @@ describe('Color util transforms', () => {
         mapping: [
           { color: { type: 'colorCode', value: '#ff0000' }, values: ['value1'] },
           { color: { type: 'colorCode', value: '#00ff00' }, values: ['value2', 'value3'] },
-          { color: { type: 'from_palette', palette: 'no_default', index: 1 }, values: ['value1'] },
+          {
+            color: { type: 'color_from_palette', palette: 'no_default', index: 1 },
+            values: ['value1'],
+          },
         ],
       });
     });
@@ -839,7 +842,7 @@ describe('Color util transforms', () => {
           },
           {
             values: ['value4', 'value5'],
-            color: { type: 'from_palette', index: 2, palette: 'no_default' },
+            color: { type: 'color_from_palette', index: 2, palette: 'no_default' },
           },
         ],
       };
@@ -868,7 +871,7 @@ describe('Color util transforms', () => {
         ],
         gradient: [
           { type: 'colorCode', value: '#ff0000' },
-          { type: 'from_palette', index: 2, palette: 'no_default' },
+          { type: 'color_from_palette', index: 2, palette: 'no_default' },
         ],
         sort: 'asc',
         unassignedColor: { type: 'from_palette', palette: 'kibana_palette', index: 2 },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
@@ -228,7 +228,7 @@ function fromColorLensStateToAPI(
     };
   }
   return {
-    type: 'from_palette',
+    type: 'color_from_palette',
     palette: color.paletteId,
     index: color.colorIndex,
   };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/types.ts
@@ -85,7 +85,7 @@ export interface LensBaseLayer {
 
 export interface LensBaseXYLayer {
   dataset?: LensDataset;
-  yAxis: LensBaseLayer[];
+  y_axis: LensBaseLayer[];
 }
 
 export type LensConfig =
@@ -243,7 +243,7 @@ export interface LensHeatmapConfigBase {
   chartType: 'heatmap';
   /** field name to apply breakdown based on field type or full breakdown configuration */
   breakdown?: LensBreakdownConfig;
-  xAxis: LensBreakdownConfig;
+  x_axis: LensBreakdownConfig;
   legend?: Identity<LensLegendConfig>;
 }
 
@@ -251,7 +251,7 @@ export type LensHeatmapConfig = Identity<LensBaseConfig & LensBaseLayer & LensHe
 
 export interface LensReferenceLineLayerBase {
   type: 'reference';
-  yAxis: Array<
+  y_axis: Array<
     LensBaseLayer & {
       lineThickness?: number;
       color?: string;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/utils.test.ts
@@ -210,7 +210,7 @@ describe('buildDatasourceStates', () => {
             dataset: {
               esql: 'from test | limit 10',
             },
-            yAxis: [{ label: 'test', value: 'test' }],
+            y_axis: [{ label: 'test', value: 'test' }],
           },
         ],
       },


### PR DESCRIPTION
## Summary

Fixes #257034.

- Updates API payload properties (e.g., `perPage` -> `per_page`, `colorMapping` -> `color_mapping`, `unassignedColor` -> `unassigned_color`) to follow the `snake_case` convention.
- Updates API string values (e.g., `type: 'colorCode'` -> `type: 'color_code'`, `from_palette` -> `color_from_palette`) to `snake_case`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
- [x] Used `pi-coding-agent` with `gemini-3.1-pro-preview-customtools` 

### Identify risks

Low Risk: API is not released yet.

