### PR TITLE
[9.3] [APM] Add kibana.alert.grouping to error count threshold alerts (#254894)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
@@ -164,6 +164,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -195,6 +196,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: env-foo-2. Alert when > 2.',
         'processor.event': 'error',
@@ -226,6 +228,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -327,6 +330,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo, name: tx-name-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -363,6 +367,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: env-foo-2, name: tx-name-foo-2. Alert when > 2.',
         'processor.event': 'error',
@@ -399,6 +404,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar, name: tx-name-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -503,6 +509,7 @@ describe('Error count alert', () => {
         'error.grouping_key': 'error-key-foo',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo, error key: error-key-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -537,6 +544,7 @@ describe('Error count alert', () => {
         'error.grouping_key': 'error-key-foo-2',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: env-foo-2, error key: error-key-foo-2. Alert when > 2.',
         'processor.event': 'error',
@@ -571,6 +579,7 @@ describe('Error count alert', () => {
         'error.grouping_key': 'error-key-bar',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar, error key: error-key-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -667,6 +676,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -698,6 +708,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: env-foo-2. Alert when > 2.',
         'processor.event': 'error',
@@ -729,6 +740,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -827,6 +839,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: Not defined. Alert when > 2.',
         'processor.event': 'error',
@@ -859,6 +872,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: Not defined. Alert when > 2.',
         'processor.event': 'error',
@@ -890,6 +904,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -996,6 +1011,7 @@ describe('Error count alert', () => {
         'error.grouping_name': 'error-name-foo',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo, error key: error-key-foo, error name: error-name-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -1033,6 +1049,7 @@ describe('Error count alert', () => {
         'error.grouping_name': 'error-name-foo2',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 4,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 4 in the last 5 mins for service: foo, env: env-foo-2, error key: error-key-foo-2, error name: error-name-foo2. Alert when > 2.',
         'processor.event': 'error',
@@ -1070,6 +1087,7 @@ describe('Error count alert', () => {
         'error.grouping_name': 'error-name-bar',
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 3,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 3 in the last 5 mins for service: bar, env: env-bar, error key: error-key-bar, error name: error-name-bar. Alert when > 2.',
         'processor.event': 'error',
@@ -1161,6 +1179,7 @@ describe('Error count alert', () => {
         'error.grouping_key': undefined,
         'kibana.alert.evaluation.threshold': 2,
         'kibana.alert.evaluation.value': 5,
+        'kibana.alert.grouping': expect.anything(),
         'kibana.alert.reason':
           'Error count is 5 in the last 5 mins for service: foo, env: env-foo. Alert when > 2.',
         'processor.event': 'error',
@@ -1218,6 +1237,15 @@ describe('Error count alert', () => {
           'processor.event': 'error',
           'kibana.alert.evaluation.value': 60568922,
           'kibana.alert.evaluation.threshold': 24999998,
+          'kibana.alert.grouping': {
+            service: {
+              environment: 'Synthtrace: many_errors',
+              name: 'synthtrace-high-cardinality-0',
+            },
+            transaction: {
+              name: 'from-recovered-hit',
+            },
+          },
           'kibana.alert.reason':
             'Error count is 60568922 in the last 5 days for service: synthtrace-high-cardinality-0, env: Synthtrace: many_errors. Alert when > 24999998.',
           'agent.name': 'java',
@@ -1272,6 +1300,9 @@ describe('Error count alert', () => {
           service: {
             environment: 'Synthtrace: many_errors',
             name: 'synthtrace-high-cardinality-0',
+          },
+          transaction: {
+            name: 'from-recovered-hit',
           },
         },
         interval: '5 mins',

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
@@ -26,6 +26,7 @@ import {
 import {
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
+  ALERT_GROUPING,
   ALERT_REASON,
   ALERT_RULE_PARAMETERS,
   ApmRuleType,
@@ -249,6 +250,7 @@ export function registerErrorCountRuleType({
             [PROCESSOR_EVENT]: ProcessorEvent.error,
             [ALERT_EVALUATION_VALUE]: errorCount,
             [ALERT_EVALUATION_THRESHOLD]: ruleParams.threshold,
+            [ALERT_GROUPING]: groupingObject,
             [ERROR_GROUP_ID]: ruleParams.errorGroupingKey,
             [ALERT_REASON]: alertReason,
             ...sourceFields,
@@ -312,7 +314,8 @@ export function registerErrorCountRuleType({
           relativeViewInAppUrl
         );
         const groupByActionVariables = getGroupByActionVariables(groupByFields);
-        const groupingObject = unflattenObject(groupByFields);
+        const groupingObjectFromRecoveredAlert =
+          alertHits?.[ALERT_GROUPING] ?? unflattenObject(groupByFields);
 
         const recoveredContext = {
           alertDetailsUrl,
@@ -326,7 +329,7 @@ export function registerErrorCountRuleType({
           threshold: ruleParams.threshold,
           triggerValue: alertHits?.[ALERT_EVALUATION_VALUE],
           viewInAppUrl,
-          grouping: groupingObject,
+          grouping: groupingObjectFromRecoveredAlert,
           ...groupByActionVariables,
         };
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/error_count_threshold.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/apm/alerts/error_count_threshold.spec.ts
@@ -272,6 +272,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             transactionName: alert!['transaction.name'],
             errorGroupingKey: alert!['error.grouping_key'],
             errorGroupingName: alert!['error.grouping_name'],
+            grouping: alert!['kibana.alert.grouping'],
           };
         });
 
@@ -282,6 +283,19 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             transactionName: 'tx-php',
             errorGroupingKey: '000000000000000000000a php error',
             errorGroupingName: phpErrorMessage,
+            grouping: {
+              service: {
+                name: 'opbeans-php',
+                environment: 'production',
+              },
+              transaction: {
+                name: 'tx-php',
+              },
+              error: {
+                grouping_key: '000000000000000000000a php error',
+                grouping_name: phpErrorMessage,
+              },
+            },
           },
           {
             serviceName: 'opbeans-java',
@@ -289,6 +303,19 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             transactionName: 'tx-java',
             errorGroupingKey: '00000000000000000000a java error',
             errorGroupingName: javaErrorMessage,
+            grouping: {
+              service: {
+                name: 'opbeans-java',
+                environment: 'production',
+              },
+              transaction: {
+                name: 'tx-java',
+              },
+              error: {
+                grouping_key: '00000000000000000000a java error',
+                grouping_name: javaErrorMessage,
+              },
+            },
           },
         ]);
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[APM] Add kibana.alert.grouping to error count threshold alerts (#254894)](https://github.com/elastic/kibana/pull/254894)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Faisal Kanout","email":"faisal.kanout@elastic.co"},"sourceCommit":{"committedDate":"2026-03-10T12:01:16Z","message":"[APM] Add kibana.alert.grouping to error count threshold alerts (#254894)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/224901\n\n\nImplements `kibana.alert.grouping` for the APM Error count threshold\nrule (`apm.error_rate`) as part of the Observability grouping\ninitiative.\n\n### What changed\n\n- Added `kibana.alert.grouping` to active alert payloads in the error\ncount executor.\n- Updated recovered alert context to prefer `kibana.alert.grouping` from\nthe recovered alert document, with a backward-compatible fallback to\nreconstructed grouping for older alerts.\n- Added dynamic template mapping for `kibana.alert.grouping.*` (string\nfields as `keyword`) in APM rule alert mappings.\n- Updated unit and deployment-agnostic API integration tests to validate\ngrouping behavior.\n<img width=\"1547\" height=\"1496\" alt=\"Screenshot 2026-02-25 at 12 33 43\"\nsrc=\"https://github.com/user-attachments/assets/74e6644f-f751-43f2-b9a2-00035c587676\"\n/>\n\n## Why\n\nThis makes grouping first-class in alert documents for\nfiltering/search/autocomplete and aligns recovered `context.grouping`\nbehavior with the expected source of truth (`kibana.alert.grouping`).\n\n## Test plan\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts`\n- `yarn test:ftr --config\nx-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts\n--grep \"error count threshold alert\"`\n\n## Validation results\n\n- Unit test suite: **PASS** (9/9)\n- Deployment-agnostic APM API integration scenario: **PASS** (11\npassing)\n\n## Notes\n\n- No saved object migration required.\n- Mapping change is additive and scoped to `kibana.alert.grouping.*`.","sha":"69af56ca0fc95aea38326bcab8a029026a9a5994","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:actionable-obs","backport:version","v9.3.0","v9.4.0","author:actionable-obs","Team:obs-presentation"],"title":"[APM] Add kibana.alert.grouping to error count threshold alerts","number":254894,"url":"https://github.com/elastic/kibana/pull/254894","mergeCommit":{"message":"[APM] Add kibana.alert.grouping to error count threshold alerts (#254894)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/224901\n\n\nImplements `kibana.alert.grouping` for the APM Error count threshold\nrule (`apm.error_rate`) as part of the Observability grouping\ninitiative.\n\n### What changed\n\n- Added `kibana.alert.grouping` to active alert payloads in the error\ncount executor.\n- Updated recovered alert context to prefer `kibana.alert.grouping` from\nthe recovered alert document, with a backward-compatible fallback to\nreconstructed grouping for older alerts.\n- Added dynamic template mapping for `kibana.alert.grouping.*` (string\nfields as `keyword`) in APM rule alert mappings.\n- Updated unit and deployment-agnostic API integration tests to validate\ngrouping behavior.\n<img width=\"1547\" height=\"1496\" alt=\"Screenshot 2026-02-25 at 12 33 43\"\nsrc=\"https://github.com/user-attachments/assets/74e6644f-f751-43f2-b9a2-00035c587676\"\n/>\n\n## Why\n\nThis makes grouping first-class in alert documents for\nfiltering/search/autocomplete and aligns recovered `context.grouping`\nbehavior with the expected source of truth (`kibana.alert.grouping`).\n\n## Test plan\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts`\n- `yarn test:ftr --config\nx-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts\n--grep \"error count threshold alert\"`\n\n## Validation results\n\n- Unit test suite: **PASS** (9/9)\n- Deployment-agnostic APM API integration scenario: **PASS** (11\npassing)\n\n## Notes\n\n- No saved object migration required.\n- Mapping change is additive and scoped to `kibana.alert.grouping.*`.","sha":"69af56ca0fc95aea38326bcab8a029026a9a5994"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254894","number":254894,"mergeCommit":{"message":"[APM] Add kibana.alert.grouping to error count threshold alerts (#254894)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/224901\n\n\nImplements `kibana.alert.grouping` for the APM Error count threshold\nrule (`apm.error_rate`) as part of the Observability grouping\ninitiative.\n\n### What changed\n\n- Added `kibana.alert.grouping` to active alert payloads in the error\ncount executor.\n- Updated recovered alert context to prefer `kibana.alert.grouping` from\nthe recovered alert document, with a backward-compatible fallback to\nreconstructed grouping for older alerts.\n- Added dynamic template mapping for `kibana.alert.grouping.*` (string\nfields as `keyword`) in APM rule alert mappings.\n- Updated unit and deployment-agnostic API integration tests to validate\ngrouping behavior.\n<img width=\"1547\" height=\"1496\" alt=\"Screenshot 2026-02-25 at 12 33 43\"\nsrc=\"https://github.com/user-attachments/assets/74e6644f-f751-43f2-b9a2-00035c587676\"\n/>\n\n## Why\n\nThis makes grouping first-class in alert documents for\nfiltering/search/autocomplete and aligns recovered `context.grouping`\nbehavior with the expected source of truth (`kibana.alert.grouping`).\n\n## Test plan\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts`\n- `yarn test:ftr --config\nx-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts\n--grep \"error count threshold alert\"`\n\n## Validation results\n\n- Unit test suite: **PASS** (9/9)\n- Deployment-agnostic APM API integration scenario: **PASS** (11\npassing)\n\n## Notes\n\n- No saved object migration required.\n- Mapping change is additive and scoped to `kibana.alert.grouping.*`.","sha":"69af56ca0fc95aea38326bcab8a029026a9a5994"}}]}] BACKPORT-->