### PR TITLE
[Security Solution] Implement single execution result per rule execution logging

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -166,6 +166,7 @@ enabled:
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group3/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/config_with_schedule_circuit_breaker.ts
+  - x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/action_task_params/config.ts
   - x-pack/platform/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email_recipient_allowlist/config.ts

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/create/create_rule.test.ts
@@ -517,6 +517,7 @@ describe('create()', () => {
               "metrics": Object {
                 "duration": 0,
                 "gap_duration_s": null,
+                "gap_range": null,
                 "total_alerts_created": null,
                 "total_alerts_detected": null,
                 "total_indexing_duration_ms": null,
@@ -754,6 +755,7 @@ describe('create()', () => {
               "metrics": Object {
                 "duration": 0,
                 "gap_duration_s": null,
+                "gap_range": null,
                 "total_alerts_created": null,
                 "total_alerts_detected": null,
                 "total_indexing_duration_ms": null,
@@ -1489,8 +1491,7 @@ describe('create()', () => {
               metrics: {
                 duration: 0,
                 gap_duration_s: null,
-                // TODO: uncomment after intermidiate release
-                // gap_range: null,
+                gap_range: null,
                 total_alerts_created: null,
                 total_alerts_detected: null,
                 total_indexing_duration_ms: null,
@@ -2642,8 +2643,7 @@ describe('create()', () => {
               metrics: {
                 duration: 0,
                 gap_duration_s: null,
-                // TODO: uncomment after intermidiate release
-                // gap_range: null,
+                gap_range: null,
                 total_alerts_created: null,
                 total_alerts_detected: null,
                 total_indexing_duration_ms: null,

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -13,7 +13,11 @@ import { EVENT_LOG_ACTIONS } from '../../plugin';
 import type { UntypedNormalizedRuleType } from '../../rule_type_registry';
 import { RULE_SAVED_OBJECT_TYPE } from '../../saved_objects';
 import type { TaskRunnerTimings } from '../../task_runner/task_runner_timer';
-import type { AlertInstanceState, RuleExecutionStatus } from '../../types';
+import type {
+  AlertInstanceState,
+  ConsumerExecutionMetrics,
+  RuleExecutionStatus,
+} from '../../types';
 import { createAlertEventLogRecordObject } from '../create_alert_event_log_record_object';
 import type { RuleRunMetrics } from '../rule_run_metrics_store';
 import { Gap } from '../rule_gaps/gap';
@@ -58,6 +62,7 @@ interface DoneOpts {
   timings?: TaskRunnerTimings;
   status?: RuleExecutionStatus;
   metrics?: RuleRunMetrics | null;
+  consumerMetrics?: Partial<ConsumerExecutionMetrics> | null;
   backfill?: BackfillOpts;
 }
 
@@ -345,7 +350,7 @@ export class AlertingEventLogger {
     );
   }
 
-  public done({ status, metrics, timings, backfill }: DoneOpts) {
+  public done({ status, metrics, consumerMetrics, timings, backfill }: DoneOpts) {
     if (!this.isInitialized || !this.event || !this.context) {
       throw new Error('AlertingEventLogger not initialized');
     }
@@ -383,6 +388,10 @@ export class AlertingEventLogger {
 
     if (metrics) {
       updateEvent(this.event, { metrics });
+    }
+
+    if (consumerMetrics) {
+      updateEvent(this.event, { consumerMetrics });
     }
 
     if (timings) {
@@ -607,6 +616,7 @@ interface UpdateEventOpts {
   status?: string;
   reason?: string;
   metrics?: RuleRunMetrics;
+  consumerMetrics?: Partial<ConsumerExecutionMetrics>;
   timings?: TaskRunnerTimings;
   backfill?: BackfillOpts;
   maintenanceWindowIds?: string[];
@@ -700,6 +710,7 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     status,
     reason,
     metrics,
+    consumerMetrics,
     timings,
     alertingOutcome,
     backfill,
@@ -761,6 +772,17 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
       number_of_searches: metrics.numSearches ? metrics.numSearches : 0,
       es_search_duration_ms: metrics.esSearchDurationMs ? metrics.esSearchDurationMs : 0,
       total_search_duration_ms: metrics.totalSearchDurationMs ? metrics.totalSearchDurationMs : 0,
+    };
+  }
+
+  if (consumerMetrics) {
+    event.kibana = event.kibana || {};
+    event.kibana.alert = event.kibana.alert || {};
+    event.kibana.alert.rule = event.kibana.alert.rule || {};
+    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
+    event.kibana.alert.rule.execution.metrics = {
+      ...event.kibana.alert.rule.execution.metrics,
+      ...consumerMetrics,
     };
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -22,6 +22,7 @@ import { createAlertEventLogRecordObject } from '../create_alert_event_log_recor
 import type { RuleRunMetrics } from '../rule_run_metrics_store';
 import { Gap } from '../rule_gaps/gap';
 import type { GapBase } from '../../application/gaps/types';
+import { RuleResultServiceResults } from '../../monitoring/rule_result_service';
 
 // 1,000,000 nanoseconds in 1 millisecond
 const Millis2Nanos = 1000 * 1000;
@@ -64,6 +65,8 @@ interface DoneOpts {
   metrics?: RuleRunMetrics | null;
   consumerMetrics?: Partial<ConsumerExecutionMetrics> | null;
   backfill?: BackfillOpts;
+  errors?: RuleResultServiceResults['errors'];
+  warnings?: RuleResultServiceResults['warnings'];
 }
 
 interface LogTimeoutOpts {
@@ -350,7 +353,7 @@ export class AlertingEventLogger {
     );
   }
 
-  public done({ status, metrics, consumerMetrics, timings, backfill }: DoneOpts) {
+  public done({ status, metrics, consumerMetrics, timings, backfill, errors, warnings }: DoneOpts) {
     if (!this.isInitialized || !this.event || !this.context) {
       throw new Error('AlertingEventLogger not initialized');
     }
@@ -392,6 +395,14 @@ export class AlertingEventLogger {
 
     if (consumerMetrics) {
       updateEvent(this.event, { consumerMetrics });
+    }
+
+    if (errors) {
+      updateEvent(this.event, { errors });
+    }
+
+    if (warnings) {
+      updateEvent(this.event, { warnings });
     }
 
     if (timings) {
@@ -620,6 +631,8 @@ interface UpdateEventOpts {
   timings?: TaskRunnerTimings;
   backfill?: BackfillOpts;
   maintenanceWindowIds?: string[];
+  errors?: RuleResultServiceResults['errors'];
+  warnings?: RuleResultServiceResults['warnings'];
 }
 
 interface UpdateRuleOpts {
@@ -715,6 +728,8 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     alertingOutcome,
     backfill,
     maintenanceWindowIds,
+    errors,
+    warnings,
   } = opts;
   if (!event) {
     throw new Error('Cannot update event because it is not initialized.');
@@ -784,6 +799,24 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
       ...event.kibana.alert.rule.execution.metrics,
       ...consumerMetrics,
     };
+  }
+
+  if (errors) {
+    event.kibana = event.kibana || {};
+    event.kibana.alert = event.kibana.alert || {};
+    event.kibana.alert.rule = event.kibana.alert.rule || {};
+    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
+    event.kibana.alert.rule.execution.errors = errors;
+  }
+
+  if (warnings) {
+    event.kibana = event.kibana || {};
+    event.kibana.alert = event.kibana.alert || {};
+    event.kibana.alert.rule = event.kibana.alert.rule || {};
+    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
+    event.kibana.alert.rule.execution.warnings = warnings.map((warning) => ({
+      message: warning,
+    }));
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -6,7 +6,6 @@
  */
 
 import * as uuid from 'uuid';
-import { isUndefined, omitBy } from 'lodash';
 import { set } from '@kbn/safer-lodash-set';
 import type { IEvent, IEventLogger, InternalFields } from '@kbn/event-log-plugin/server';
 import { millisToNanos, SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
@@ -795,32 +794,16 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
   }
 
   if (consumerMetrics) {
-    set(
-      event,
-      'kibana.alert.rule.execution.metrics',
-      omitBy(
-        {
-          ...event.kibana?.alert?.rule?.execution?.metrics,
-          alert_counts: omitBy(
-            {
-              ...event.kibana?.alert?.rule?.execution?.metrics?.alert_counts,
-              // "candidates" and "suppressed" fields have mappings added
-              // uncomment the two following lines after https://github.com/elastic/kibana/pull/257203
-              // is merged
-              // candidates: consumerMetrics.candidate_alerts_count,
-              // suppressed: consumerMetrics.suppressed_alerts,
-            },
-            isUndefined
-          ),
-          frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
-          total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
-          total_enrichment_duration_ms: consumerMetrics.total_enrichment_duration_ms,
-          execution_gap_duration_s: consumerMetrics.gap_duration_s,
-          gap_range: consumerMetrics.gap_range,
-        },
-        isUndefined
-      )
-    );
+    set(event, 'kibana.alert.rule.execution.metrics', {
+      ...event.kibana?.alert?.rule?.execution?.metrics,
+      alerts_candidate_count: consumerMetrics.candidate_alerts_count,
+      alerts_suppressed_count: consumerMetrics.suppressed_alerts,
+      frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
+      total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
+      total_enrichment_duration_ms: consumerMetrics.total_enrichment_duration_ms,
+      execution_gap_duration_s: consumerMetrics.gap_duration_s,
+      gap_range: consumerMetrics.gap_range,
+    });
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -17,6 +17,7 @@ import type { TaskRunnerTimings } from '../../task_runner/task_runner_timer';
 import type {
   AlertInstanceState,
   ConsumerExecutionMetrics,
+  ConsumerRuleExecutionContext,
   RuleExecutionStatus,
 } from '../../types';
 import { createAlertEventLogRecordObject } from '../create_alert_event_log_record_object';
@@ -64,6 +65,7 @@ interface DoneOpts {
   status?: RuleExecutionStatus;
   metrics?: RuleRunMetrics | null;
   consumerMetrics?: Partial<ConsumerExecutionMetrics> | null;
+  consumerContext?: Partial<ConsumerRuleExecutionContext> | null;
   backfill?: BackfillOpts;
 }
 
@@ -351,7 +353,7 @@ export class AlertingEventLogger {
     );
   }
 
-  public done({ status, metrics, consumerMetrics, timings, backfill }: DoneOpts) {
+  public done({ status, metrics, consumerMetrics, consumerContext, timings, backfill }: DoneOpts) {
     if (!this.isInitialized || !this.event || !this.context) {
       throw new Error('AlertingEventLogger not initialized');
     }
@@ -393,6 +395,10 @@ export class AlertingEventLogger {
 
     if (consumerMetrics) {
       updateEvent(this.event, { consumerMetrics });
+    }
+
+    if (consumerContext) {
+      updateEvent(this.event, { consumerContext });
     }
 
     if (timings) {
@@ -618,6 +624,7 @@ interface UpdateEventOpts {
   reason?: string;
   metrics?: RuleRunMetrics;
   consumerMetrics?: Partial<ConsumerExecutionMetrics>;
+  consumerContext?: Partial<ConsumerRuleExecutionContext>;
   timings?: TaskRunnerTimings;
   backfill?: BackfillOpts;
   maintenanceWindowIds?: string[];
@@ -712,6 +719,7 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     reason,
     metrics,
     consumerMetrics,
+    consumerContext,
     timings,
     alertingOutcome,
     backfill,
@@ -796,6 +804,14 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
         isUndefined
       )
     );
+  }
+
+  if (consumerContext?.ruleUuid) {
+    set(event, 'rule.uuid', consumerContext.ruleUuid);
+  }
+
+  if (consumerContext?.ruleRevision !== undefined) {
+    set(event, 'kibana.alert.rule.revision', consumerContext.ruleRevision);
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -691,7 +691,8 @@ export function updateEventWithRuleData(event: IEvent, opts: UpdateRuleOpts) {
     }
   }
 
-  if (revision) {
+  // revision is a non-negative integer. We'd like to capture 0 as well.
+  if (revision !== undefined) {
     event.kibana = event.kibana || {};
     event.kibana.alert = event.kibana.alert || {};
     event.kibana.alert.rule = event.kibana.alert.rule || {};
@@ -808,10 +809,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
 
   if (consumerContext?.ruleUuid) {
     set(event, 'rule.uuid', consumerContext.ruleUuid);
-  }
-
-  if (consumerContext?.ruleRevision !== undefined) {
-    set(event, 'kibana.alert.rule.revision', consumerContext.ruleRevision);
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -6,6 +6,7 @@
  */
 
 import * as uuid from 'uuid';
+import { isUndefined, omitBy } from 'lodash';
 import type { IEvent, IEventLogger, InternalFields } from '@kbn/event-log-plugin/server';
 import { millisToNanos, SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { BulkResponse } from '@elastic/elasticsearch/lib/api/types';
@@ -795,10 +796,23 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     event.kibana.alert = event.kibana.alert || {};
     event.kibana.alert.rule = event.kibana.alert.rule || {};
     event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
-    event.kibana.alert.rule.execution.metrics = {
-      ...event.kibana.alert.rule.execution.metrics,
-      ...consumerMetrics,
-    };
+    event.kibana.alert.rule.execution.metrics = omitBy(
+      {
+        ...event.kibana.alert.rule.execution.metrics,
+        alert_counts: omitBy(
+          {
+            ...event.kibana.alert.rule.execution.metrics?.alert_counts,
+            candidates: consumerMetrics.candidate_alerts_count,
+            suppressed: consumerMetrics.suppressed_alerts,
+          },
+          isUndefined
+        ),
+        events_found_count: consumerMetrics.events_found_count,
+        unaccounted_events: consumerMetrics.unaccounted_events,
+        frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
+      },
+      isUndefined
+    );
   }
 
   if (errors) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -814,6 +814,7 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
           ),
           frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
           total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
+          total_enrichment_duration_ms: consumerMetrics.total_enrichment_duration_ms,
           execution_gap_duration_s: consumerMetrics.gap_duration_s,
           gap_range: consumerMetrics.gap_range,
         },

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -791,8 +791,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
             },
             isUndefined
           ),
-          events_found_count: consumerMetrics.events_found_count,
-          unaccounted_events: consumerMetrics.unaccounted_events,
           frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
         },
         isUndefined

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -23,7 +23,6 @@ import { createAlertEventLogRecordObject } from '../create_alert_event_log_recor
 import type { RuleRunMetrics } from '../rule_run_metrics_store';
 import { Gap } from '../rule_gaps/gap';
 import type { GapBase } from '../../application/gaps/types';
-import { RuleResultServiceResults } from '../../monitoring/rule_result_service';
 
 // 1,000,000 nanoseconds in 1 millisecond
 const Millis2Nanos = 1000 * 1000;
@@ -66,8 +65,6 @@ interface DoneOpts {
   metrics?: RuleRunMetrics | null;
   consumerMetrics?: Partial<ConsumerExecutionMetrics> | null;
   backfill?: BackfillOpts;
-  errors?: RuleResultServiceResults['errors'];
-  warnings?: RuleResultServiceResults['warnings'];
 }
 
 interface LogTimeoutOpts {
@@ -354,7 +351,7 @@ export class AlertingEventLogger {
     );
   }
 
-  public done({ status, metrics, consumerMetrics, timings, backfill, errors, warnings }: DoneOpts) {
+  public done({ status, metrics, consumerMetrics, timings, backfill }: DoneOpts) {
     if (!this.isInitialized || !this.event || !this.context) {
       throw new Error('AlertingEventLogger not initialized');
     }
@@ -396,14 +393,6 @@ export class AlertingEventLogger {
 
     if (consumerMetrics) {
       updateEvent(this.event, { consumerMetrics });
-    }
-
-    if (errors) {
-      updateEvent(this.event, { errors });
-    }
-
-    if (warnings) {
-      updateEvent(this.event, { warnings });
     }
 
     if (timings) {
@@ -632,8 +621,6 @@ interface UpdateEventOpts {
   timings?: TaskRunnerTimings;
   backfill?: BackfillOpts;
   maintenanceWindowIds?: string[];
-  errors?: RuleResultServiceResults['errors'];
-  warnings?: RuleResultServiceResults['warnings'];
 }
 
 interface UpdateRuleOpts {
@@ -729,8 +716,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     alertingOutcome,
     backfill,
     maintenanceWindowIds,
-    errors,
-    warnings,
   } = opts;
   if (!event) {
     throw new Error('Cannot update event because it is not initialized.');
@@ -813,24 +798,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
       },
       isUndefined
     );
-  }
-
-  if (errors) {
-    event.kibana = event.kibana || {};
-    event.kibana.alert = event.kibana.alert || {};
-    event.kibana.alert.rule = event.kibana.alert.rule || {};
-    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
-    event.kibana.alert.rule.execution.errors = errors;
-  }
-
-  if (warnings) {
-    event.kibana = event.kibana || {};
-    event.kibana.alert = event.kibana.alert || {};
-    event.kibana.alert.rule = event.kibana.alert.rule || {};
-    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
-    event.kibana.alert.rule.execution.warnings = warnings.map((warning) => ({
-      message: warning,
-    }));
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -796,13 +796,14 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
   if (consumerMetrics) {
     set(event, 'kibana.alert.rule.execution.metrics', {
       ...event.kibana?.alert?.rule?.execution?.metrics,
-      alerts_candidate_count: consumerMetrics.candidate_alerts_count,
-      alerts_suppressed_count: consumerMetrics.suppressed_alerts,
+      alerts_candidate_count: consumerMetrics.alerts_candidate_count,
+      alerts_suppressed_count: consumerMetrics.alerts_suppressed_count,
       frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
       total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
       total_enrichment_duration_ms: consumerMetrics.total_enrichment_duration_ms,
       execution_gap_duration_s: consumerMetrics.gap_duration_s,
-      gap_range: consumerMetrics.gap_range,
+      // Event Log schema doesn't expect null for gap_range
+      gap_range: consumerMetrics.gap_range ?? undefined,
     });
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -6,7 +6,8 @@
  */
 
 import * as uuid from 'uuid';
-import { isUndefined, omitBy, set } from 'lodash';
+import { isUndefined, omitBy } from 'lodash';
+import { set } from '@kbn/safer-lodash-set';
 import type { IEvent, IEventLogger, InternalFields } from '@kbn/event-log-plugin/server';
 import { millisToNanos, SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { BulkResponse } from '@elastic/elasticsearch/lib/api/types';

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -6,7 +6,7 @@
  */
 
 import * as uuid from 'uuid';
-import { isUndefined, omitBy } from 'lodash';
+import { isUndefined, omitBy, set } from 'lodash';
 import type { IEvent, IEventLogger, InternalFields } from '@kbn/event-log-plugin/server';
 import { millisToNanos, SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { BulkResponse } from '@elastic/elasticsearch/lib/api/types';
@@ -777,26 +777,26 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
   }
 
   if (consumerMetrics) {
-    event.kibana = event.kibana || {};
-    event.kibana.alert = event.kibana.alert || {};
-    event.kibana.alert.rule = event.kibana.alert.rule || {};
-    event.kibana.alert.rule.execution = event.kibana.alert.rule.execution || {};
-    event.kibana.alert.rule.execution.metrics = omitBy(
-      {
-        ...event.kibana.alert.rule.execution.metrics,
-        alert_counts: omitBy(
-          {
-            ...event.kibana.alert.rule.execution.metrics?.alert_counts,
-            candidates: consumerMetrics.candidate_alerts_count,
-            suppressed: consumerMetrics.suppressed_alerts,
-          },
-          isUndefined
-        ),
-        events_found_count: consumerMetrics.events_found_count,
-        unaccounted_events: consumerMetrics.unaccounted_events,
-        frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
-      },
-      isUndefined
+    set(
+      event,
+      'kibana.alert.rule.execution.metrics',
+      omitBy(
+        {
+          ...event.kibana?.alert?.rule?.execution?.metrics,
+          alert_counts: omitBy(
+            {
+              ...event.kibana?.alert?.rule?.execution?.metrics?.alert_counts,
+              candidates: consumerMetrics.candidate_alerts_count,
+              suppressed: consumerMetrics.suppressed_alerts,
+            },
+            isUndefined
+          ),
+          events_found_count: consumerMetrics.events_found_count,
+          unaccounted_events: consumerMetrics.unaccounted_events,
+          frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
+        },
+        isUndefined
+      )
     );
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -813,6 +813,9 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
             isUndefined
           ),
           frozen_indices_queried_count: consumerMetrics.frozen_indices_queried_count,
+          total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
+          execution_gap_duration_s: consumerMetrics.gap_duration_s,
+          gap_range: consumerMetrics.gap_range,
         },
         isUndefined
       )

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -17,7 +17,6 @@ import type { TaskRunnerTimings } from '../../task_runner/task_runner_timer';
 import type {
   AlertInstanceState,
   ConsumerExecutionMetrics,
-  ConsumerRuleExecutionContext,
   RuleExecutionStatus,
 } from '../../types';
 import { createAlertEventLogRecordObject } from '../create_alert_event_log_record_object';
@@ -30,6 +29,7 @@ const Millis2Nanos = 1000 * 1000;
 
 export interface RuleContext {
   id: string;
+  uuid?: string;
   type: UntypedNormalizedRuleType;
   consumer?: string;
   name?: string;
@@ -65,7 +65,6 @@ interface DoneOpts {
   status?: RuleExecutionStatus;
   metrics?: RuleRunMetrics | null;
   consumerMetrics?: Partial<ConsumerExecutionMetrics> | null;
-  consumerContext?: Partial<ConsumerRuleExecutionContext> | null;
   backfill?: BackfillOpts;
 }
 
@@ -222,12 +221,14 @@ export class AlertingEventLogger {
   public addOrUpdateRuleData({
     name,
     id,
+    uuid: ruleUuid,
     consumer,
     type,
     revision,
   }: {
     name?: string;
     id?: string;
+    uuid?: string;
     consumer?: string;
     revision?: number;
     type?: UntypedNormalizedRuleType;
@@ -242,6 +243,10 @@ export class AlertingEventLogger {
         id,
         type,
       };
+    }
+
+    if (ruleUuid) {
+      this.ruleData.uuid = ruleUuid;
     }
 
     if (name) {
@@ -274,6 +279,7 @@ export class AlertingEventLogger {
     updateEventWithRuleData(this.event, {
       ruleName: name,
       ruleId: id,
+      ruleUuid,
       ruleType: type,
       consumer,
       revision,
@@ -353,7 +359,7 @@ export class AlertingEventLogger {
     );
   }
 
-  public done({ status, metrics, consumerMetrics, consumerContext, timings, backfill }: DoneOpts) {
+  public done({ status, metrics, consumerMetrics, timings, backfill }: DoneOpts) {
     if (!this.isInitialized || !this.event || !this.context) {
       throw new Error('AlertingEventLogger not initialized');
     }
@@ -395,10 +401,6 @@ export class AlertingEventLogger {
 
     if (consumerMetrics) {
       updateEvent(this.event, { consumerMetrics });
-    }
-
-    if (consumerContext) {
-      updateEvent(this.event, { consumerContext });
     }
 
     if (timings) {
@@ -624,7 +626,6 @@ interface UpdateEventOpts {
   reason?: string;
   metrics?: RuleRunMetrics;
   consumerMetrics?: Partial<ConsumerExecutionMetrics>;
-  consumerContext?: Partial<ConsumerRuleExecutionContext>;
   timings?: TaskRunnerTimings;
   backfill?: BackfillOpts;
   maintenanceWindowIds?: string[];
@@ -633,6 +634,7 @@ interface UpdateEventOpts {
 interface UpdateRuleOpts {
   ruleName?: string;
   ruleId?: string;
+  ruleUuid?: string;
   consumer?: string;
   ruleType?: UntypedNormalizedRuleType;
   revision?: number;
@@ -640,7 +642,7 @@ interface UpdateRuleOpts {
 }
 
 export function updateEventWithRuleData(event: IEvent, opts: UpdateRuleOpts) {
-  const { ruleName, ruleId, consumer, ruleType, revision, savedObjects } = opts;
+  const { ruleName, ruleId, ruleUuid, consumer, ruleType, revision, savedObjects } = opts;
   if (!event) {
     throw new Error('Cannot update event because it is not initialized.');
   }
@@ -656,6 +658,13 @@ export function updateEventWithRuleData(event: IEvent, opts: UpdateRuleOpts) {
     event.rule = {
       ...event.rule,
       id: ruleId,
+    };
+  }
+
+  if (ruleUuid) {
+    event.rule = {
+      ...event.rule,
+      uuid: ruleUuid,
     };
   }
 
@@ -720,7 +729,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
     reason,
     metrics,
     consumerMetrics,
-    consumerContext,
     timings,
     alertingOutcome,
     backfill,
@@ -805,10 +813,6 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
         isUndefined
       )
     );
-  }
-
-  if (consumerContext?.ruleUuid) {
-    set(event, 'rule.uuid', consumerContext.ruleUuid);
   }
 
   if (backfill) {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -802,8 +802,7 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
       total_indexing_duration_ms: consumerMetrics.total_indexing_duration_ms,
       total_enrichment_duration_ms: consumerMetrics.total_enrichment_duration_ms,
       execution_gap_duration_s: consumerMetrics.gap_duration_s,
-      // Event Log schema doesn't expect null for gap_range
-      gap_range: consumerMetrics.gap_range ?? undefined,
+      gap_range: consumerMetrics.gap_range,
     });
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts
@@ -803,8 +803,11 @@ export function updateEvent(event: IEvent, opts: UpdateEventOpts) {
           alert_counts: omitBy(
             {
               ...event.kibana?.alert?.rule?.execution?.metrics?.alert_counts,
-              candidates: consumerMetrics.candidate_alerts_count,
-              suppressed: consumerMetrics.suppressed_alerts,
+              // "candidates" and "suppressed" fields have mappings added
+              // uncomment the two following lines after https://github.com/elastic/kibana/pull/257203
+              // is merged
+              // candidates: consumerMetrics.candidate_alerts_count,
+              // suppressed: consumerMetrics.suppressed_alerts,
             },
             isUndefined
           ),

--- a/x-pack/platform/plugins/shared/alerting/server/lib/last_run_status.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/last_run_status.ts
@@ -14,11 +14,16 @@ import type { RawRuleLastRun, RuleLastRun } from '../types';
 import { RuleLastRunOutcomeValues, RuleExecutionStatusWarningReasons } from '../types';
 import { translations } from '../constants/translations';
 import type { RuleRunMetrics } from './rule_run_metrics_store';
-import type { RuleResultService } from '../monitoring/rule_result_service';
+import type {
+  RuleResultService,
+  RuleResultServiceResults,
+} from '../monitoring/rule_result_service';
 
 export interface ILastRun {
   lastRun: RuleLastRun;
   metrics: RuleRunMetrics | null;
+  errors?: RuleResultServiceResults['errors'];
+  warnings?: RuleResultServiceResults['warnings'];
 }
 
 export const lastRunFromState = (
@@ -77,6 +82,8 @@ export const lastRunFromState = (
       },
     },
     metrics,
+    errors,
+    warnings,
   };
 };
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/last_run_status.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/last_run_status.ts
@@ -14,16 +14,11 @@ import type { RawRuleLastRun, RuleLastRun } from '../types';
 import { RuleLastRunOutcomeValues, RuleExecutionStatusWarningReasons } from '../types';
 import { translations } from '../constants/translations';
 import type { RuleRunMetrics } from './rule_run_metrics_store';
-import type {
-  RuleResultService,
-  RuleResultServiceResults,
-} from '../monitoring/rule_result_service';
+import type { RuleResultService } from '../monitoring/rule_result_service';
 
 export interface ILastRun {
   lastRun: RuleLastRun;
   metrics: RuleRunMetrics | null;
-  errors?: RuleResultServiceResults['errors'];
-  warnings?: RuleResultServiceResults['warnings'];
 }
 
 export const lastRunFromState = (
@@ -82,8 +77,6 @@ export const lastRunFromState = (
       },
     },
     metrics,
-    errors,
-    warnings,
   };
 };
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/monitoring.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/monitoring.test.ts
@@ -107,8 +107,7 @@ describe('resetMonitoringLastRun', () => {
       total_alerts_detected: null,
       total_alerts_created: null,
       gap_duration_s: null,
-      // TODO: uncomment after intermidiate release
-      // gap_range: null,
+      gap_range: null,
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/monitoring.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/monitoring.ts
@@ -21,8 +21,7 @@ const INITIAL_LAST_RUN_METRICS: RuleMonitoringLastRunMetrics = {
   total_alerts_detected: null,
   total_alerts_created: null,
   gap_duration_s: null,
-  // TODO: uncomment after intermidiate release
-  // gap_range: null,
+  gap_range: null,
 };
 
 export const getDefaultMonitoring = (timestamp: string): RawRuleMonitoring => {

--- a/x-pack/platform/plugins/shared/alerting/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/mocks.ts
@@ -133,11 +133,9 @@ const createAbortableSearchServiceMock = () => {
 
 const createRuleMonitoringServiceMock = () => {
   const mock = lazyObject({
-    setLastRunMetricsTotalSearchDurationMs: jest.fn(),
-    setLastRunMetricsTotalIndexingDurationMs: jest.fn(),
-    setLastRunMetricsTotalAlertsDetected: jest.fn(),
-    setLastRunMetricsTotalAlertsCreated: jest.fn(),
-    setLastRunMetricsGapDurationS: jest.fn(),
+    setMetric: jest.fn(),
+    setMetrics: jest.fn(),
+    clearGapRange: jest.fn(),
   }) as unknown as jest.Mocked<PublicRuleMonitoringService>;
 
   return mock;

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
@@ -20,12 +20,8 @@ function createRuleMonitoringServiceMock() {
 function createPublicRuleMonitoringServiceMock() {
   return jest.fn().mockImplementation(() => {
     return {
-      setLastRunMetricsGapDurationS: jest.fn(),
-      setLastRunMetricsTotalAlertsCreated: jest.fn(),
-      setLastRunMetricsTotalAlertsDetected: jest.fn(),
-      setLastRunMetricsTotalIndexingDurationMs: jest.fn(),
-      setLastRunMetricsTotalSearchDurationMs: jest.fn(),
-      setLastRunMetricsGapRange: jest.fn(),
+      setMetric: jest.fn(),
+      setMetrics: jest.fn(),
     };
   });
 }

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
@@ -8,8 +8,9 @@
 function createRuleMonitoringServiceMock() {
   return jest.fn().mockImplementation(() => {
     return {
+      addFrameworkMetrics: jest.fn(),
       addHistory: jest.fn(),
-      getLastRunMetricsSetters: jest.fn(),
+      getSetters: jest.fn(),
       getMonitoring: jest.fn(),
       setLastRunMetricsDuration: jest.fn(),
       setMonitoring: jest.fn(),

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.mock.ts
@@ -22,6 +22,7 @@ function createPublicRuleMonitoringServiceMock() {
     return {
       setMetric: jest.fn(),
       setMetrics: jest.fn(),
+      clearGapRange: jest.fn(),
     };
   });
 }

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -212,35 +212,5 @@ describe('RuleMonitoringService', () => {
       expect(metrics.total_search_duration_ms).toBe(42);
       expect(metrics.total_indexing_duration_ms).toBe(99);
     });
-
-    it('overwrites total_search_duration_ms from setMonitoring when addFrameworkMetrics runs', () => {
-      const ruleMonitoringService = new RuleMonitoringService();
-      ruleMonitoringService.setMonitoring({
-        run: {
-          history: [],
-          calculated_metrics: { success_ratio: 1, p50: 1, p95: 1, p99: 1 },
-          last_run: {
-            timestamp: mockNow,
-            metrics: {
-              duration: 1,
-              gap_duration_s: null,
-              gap_range: null,
-              total_indexing_duration_ms: null,
-              total_search_duration_ms: 100,
-            },
-          },
-        },
-      });
-
-      expect(
-        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
-      ).toBe(100);
-
-      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 200 });
-
-      expect(
-        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
-      ).toBe(200);
-    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -181,4 +181,66 @@ describe('RuleMonitoringService', () => {
       expect(metricsAfterClearing.gap_range).toBeNull();
     });
   });
+
+  describe('addFrameworkMetrics', () => {
+    it('exposes total_search_duration_ms via getMonitoring() for the rule saved object', () => {
+      const ruleMonitoringService = new RuleMonitoringService();
+      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 42 });
+
+      expect(
+        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
+      ).toBe(42);
+    });
+
+    it('replaces prior framework total_search_duration_ms', () => {
+      const ruleMonitoringService = new RuleMonitoringService();
+      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 10 });
+      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 20 });
+
+      expect(
+        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
+      ).toBe(20);
+    });
+
+    it('preserves executor metrics when addFrameworkMetrics sets total_search_duration_ms', () => {
+      const ruleMonitoringService = new RuleMonitoringService();
+      const { setMetric } = ruleMonitoringService.getSetters();
+      setMetric('total_indexing_duration_ms', 99);
+      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 42 });
+
+      const { metrics } = ruleMonitoringService.getMonitoring().run.last_run;
+      expect(metrics.total_search_duration_ms).toBe(42);
+      expect(metrics.total_indexing_duration_ms).toBe(99);
+    });
+
+    it('overwrites total_search_duration_ms from setMonitoring when addFrameworkMetrics runs', () => {
+      const ruleMonitoringService = new RuleMonitoringService();
+      ruleMonitoringService.setMonitoring({
+        run: {
+          history: [],
+          calculated_metrics: { success_ratio: 1, p50: 1, p95: 1, p99: 1 },
+          last_run: {
+            timestamp: mockNow,
+            metrics: {
+              duration: 1,
+              gap_duration_s: null,
+              gap_range: null,
+              total_indexing_duration_ms: null,
+              total_search_duration_ms: 100,
+            },
+          },
+        },
+      });
+
+      expect(
+        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
+      ).toBe(100);
+
+      ruleMonitoringService.addFrameworkMetrics({ total_search_duration_ms: 200 });
+
+      expect(
+        ruleMonitoringService.getMonitoring().run.last_run.metrics.total_search_duration_ms
+      ).toBe(200);
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -103,20 +103,6 @@ describe('RuleMonitoringService', () => {
       expect(ruleMonitoringService.getMonitoring()).toEqual(customMonitoring);
     });
 
-    it('should set totalSearchDurationMs', () => {
-      const ruleMonitoringService = new RuleMonitoringService();
-      const { setMetric } = ruleMonitoringService.getSetters();
-
-      setMetric('total_search_duration_ms', 123);
-
-      const {
-        run: {
-          last_run: { metrics },
-        },
-      } = ruleMonitoringService.getMonitoring();
-      expect(metrics.total_search_duration_ms).toEqual(123);
-    });
-
     it('should set totalIndexDurationMs', () => {
       const ruleMonitoringService = new RuleMonitoringService();
       const { setMetric } = ruleMonitoringService.getSetters();
@@ -129,34 +115,6 @@ describe('RuleMonitoringService', () => {
         },
       } = ruleMonitoringService.getMonitoring();
       expect(metrics.total_indexing_duration_ms).toEqual(234);
-    });
-
-    it('should set totalAlertsDetected', () => {
-      const ruleMonitoringService = new RuleMonitoringService();
-      const { setMetric } = ruleMonitoringService.getSetters();
-
-      setMetric('total_alerts_detected', 345);
-
-      const {
-        run: {
-          last_run: { metrics },
-        },
-      } = ruleMonitoringService.getMonitoring();
-      expect(metrics.total_alerts_detected).toEqual(345);
-    });
-
-    it('should set totalAlertsCreated', () => {
-      const ruleMonitoringService = new RuleMonitoringService();
-      const { setMetric } = ruleMonitoringService.getSetters();
-
-      setMetric('total_alerts_created', 456);
-
-      const {
-        run: {
-          last_run: { metrics },
-        },
-      } = ruleMonitoringService.getMonitoring();
-      expect(metrics.total_alerts_created).toEqual(456);
     });
 
     it('should set gapDurationS', () => {

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -190,5 +190,33 @@ describe('RuleMonitoringService', () => {
       expect(metrics.gap_range?.gte).toEqual('2020-01-01T00:00:00.000Z');
       expect(metrics.gap_range?.lte).toEqual('2020-01-01T01:00:00.000Z');
     });
+
+    it('should clear the previously set gapRange', () => {
+      const ruleMonitoringService = new RuleMonitoringService();
+      const { setMetric, clearGapRange } = ruleMonitoringService.getSetters();
+
+      setMetric('gap_range', {
+        gte: '2020-01-01T00:00:00.000Z',
+        lte: '2020-01-01T01:00:00.000Z',
+      });
+
+      const {
+        run: {
+          last_run: { metrics: metricBeforeClearing },
+        },
+      } = ruleMonitoringService.getMonitoring();
+
+      expect(metricBeforeClearing.gap_range).toBeDefined();
+
+      clearGapRange();
+
+      const {
+        run: {
+          last_run: { metrics: metricsAfterClearing },
+        },
+      } = ruleMonitoringService.getMonitoring();
+
+      expect(metricsAfterClearing.gap_range).toBeUndefined();
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -95,6 +95,10 @@ describe('RuleMonitoringService', () => {
             timestamp: mockNow,
             metrics: {
               duration: 100000,
+              gap_duration_s: null,
+              gap_range: null,
+              total_indexing_duration_ms: null,
+              total_search_duration_ms: null,
             },
           },
         },
@@ -174,7 +178,7 @@ describe('RuleMonitoringService', () => {
         },
       } = ruleMonitoringService.getMonitoring();
 
-      expect(metricsAfterClearing.gap_range).toBeUndefined();
+      expect(metricsAfterClearing.gap_range).toBeNull();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.test.ts
@@ -105,9 +105,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set totalSearchDurationMs', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsTotalSearchDurationMs } =
-        ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsTotalSearchDurationMs(123);
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('total_search_duration_ms', 123);
 
       const {
         run: {
@@ -119,9 +119,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set totalIndexDurationMs', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsTotalIndexingDurationMs } =
-        ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsTotalIndexingDurationMs(234);
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('total_indexing_duration_ms', 234);
 
       const {
         run: {
@@ -133,9 +133,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set totalAlertsDetected', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsTotalAlertsDetected } =
-        ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsTotalAlertsDetected(345);
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('total_alerts_detected', 345);
 
       const {
         run: {
@@ -147,9 +147,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set totalAlertsCreated', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsTotalAlertsCreated } =
-        ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsTotalAlertsCreated(456);
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('total_alerts_created', 456);
 
       const {
         run: {
@@ -161,8 +161,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set gapDurationS', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsGapDurationS } = ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsGapDurationS(567);
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('gap_duration_s', 567);
 
       const {
         run: {
@@ -174,8 +175,9 @@ describe('RuleMonitoringService', () => {
 
     it('should set gapRange', () => {
       const ruleMonitoringService = new RuleMonitoringService();
-      const { setLastRunMetricsGapRange } = ruleMonitoringService.getLastRunMetricsSetters();
-      setLastRunMetricsGapRange({
+      const { setMetric } = ruleMonitoringService.getSetters();
+
+      setMetric('gap_range', {
         gte: '2020-01-01T00:00:00.000Z',
         lte: '2020-01-01T01:00:00.000Z',
       });

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -6,10 +6,17 @@
  */
 
 import { getDefaultMonitoring, getExecutionDurationPercentiles } from '../lib/monitoring';
-import type { RuleMonitoring, RuleMonitoringHistory, PublicRuleMonitoringService } from '../types';
+import type {
+  RuleMonitoring,
+  RuleMonitoringHistory,
+  PublicRuleMonitoringService,
+  ConsumerExecutionMetrics,
+} from '../types';
 
 export class RuleMonitoringService {
   private monitoring: RuleMonitoring = getDefaultMonitoring(new Date().toISOString());
+  // Metrics added inside the rule executor
+  private metrics: Partial<ConsumerExecutionMetrics> = {};
 
   public setLastRunMetricsDuration(duration: number) {
     this.monitoring.run.last_run.metrics.duration = duration;
@@ -23,6 +30,12 @@ export class RuleMonitoringService {
 
   public getMonitoring(): RuleMonitoring {
     return this.monitoring;
+  }
+
+  public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> {
+    return {
+      ...this.metrics,
+    };
   }
 
   public addHistory({
@@ -64,6 +77,8 @@ export class RuleMonitoringService {
       setLastRunMetricsTotalAlertsCreated: this.setLastRunMetricsTotalAlertsCreated.bind(this),
       setLastRunMetricsGapDurationS: this.setLastRunMetricsGapDurationS.bind(this),
       setLastRunMetricsGapRange: this.setLastRunMetricsGapRange.bind(this),
+      setMetric: this.setMetric.bind(this),
+      setMetrics: this.setMetrics.bind(this),
     };
   }
 
@@ -99,5 +114,56 @@ export class RuleMonitoringService {
   private buildExecutionDurationPercentiles = () => {
     const { history } = this.monitoring.run;
     return getExecutionDurationPercentiles(history);
+  };
+
+  private setMetric = <MetricName extends keyof ConsumerExecutionMetrics>(
+    metricName: MetricName,
+    value: ConsumerExecutionMetrics[MetricName]
+  ) => {
+    if (metricName === 'total_search_duration_ms') {
+      this.setLastRunMetricsTotalSearchDurationMs(
+        value as ConsumerExecutionMetrics['total_search_duration_ms']
+      );
+      return;
+    }
+
+    if (metricName === 'total_indexing_duration_ms') {
+      this.setLastRunMetricsTotalIndexingDurationMs(
+        value as ConsumerExecutionMetrics['total_indexing_duration_ms']
+      );
+      return;
+    }
+
+    if (metricName === 'total_alerts_detected') {
+      this.setLastRunMetricsTotalAlertsDetected(
+        value as ConsumerExecutionMetrics['total_alerts_detected']
+      );
+      return;
+    }
+
+    if (metricName === 'total_alerts_created') {
+      this.setLastRunMetricsTotalAlertsCreated(
+        value as ConsumerExecutionMetrics['total_alerts_created']
+      );
+      return;
+    }
+
+    if (metricName === 'gap_duration_s') {
+      this.setLastRunMetricsGapDurationS(value as ConsumerExecutionMetrics['gap_duration_s']);
+      return;
+    }
+
+    if (metricName === 'gap_range') {
+      this.setLastRunMetricsGapRange(value as ConsumerExecutionMetrics['gap_range']);
+      return;
+    }
+
+    this.metrics[metricName] = value;
+  };
+
+  private setMetrics = (metrics: Partial<ConsumerExecutionMetrics>) => {
+    for (const [metricName, value] of Object.entries(metrics)) {
+      this.setMetric(metricName as keyof ConsumerExecutionMetrics, value);
+    }
   };
 }

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -14,9 +14,15 @@ import type {
   ConsumerExecutionMetrics,
 } from '../types';
 
+interface FrameworkMetrics {
+  total_search_duration_ms: number;
+}
+
 export class RuleMonitoringService {
   // Mirrors rule's SO state
   private monitoring: RuleMonitoring = getDefaultMonitoring(new Date().toISOString());
+  // Metrics calculated by the framework
+  private frameworkMetrics: Partial<FrameworkMetrics> = {};
   // Rule executor metrics. Essential metrics get written to rule's SO.
   private metrics: Partial<ConsumerExecutionMetrics> = {};
 
@@ -27,6 +33,7 @@ export class RuleMonitoringService {
   public setMonitoring(monitoringFromSO: RuleMonitoring | undefined) {
     if (monitoringFromSO) {
       this.monitoring = monitoringFromSO;
+      Object.assign(this.metrics, monitoringFromSO.run.last_run.metrics);
     }
   }
 
@@ -37,10 +44,8 @@ export class RuleMonitoringService {
       result.run.last_run.metrics,
       omitBy(
         {
-          total_search_duration_ms: this.metrics.total_search_duration_ms,
+          total_search_duration_ms: this.frameworkMetrics.total_search_duration_ms,
           total_indexing_duration_ms: this.metrics.total_indexing_duration_ms,
-          total_alerts_detected: this.metrics.total_alerts_detected,
-          total_alerts_created: this.metrics.total_alerts_created,
           gap_duration_s: this.metrics.gap_duration_s,
           gap_range: this.metrics.gap_range,
         },
@@ -55,6 +60,10 @@ export class RuleMonitoringService {
     return {
       ...this.metrics,
     };
+  }
+
+  public addFrameworkMetrics(fwkMetrics: Partial<FrameworkMetrics>): void {
+    this.frameworkMetrics = fwkMetrics;
   }
 
   public addHistory({

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -12,7 +12,6 @@ import type {
   RuleMonitoringHistory,
   PublicRuleMonitoringService,
   ConsumerExecutionMetrics,
-  ConsumerRuleExecutionContext,
 } from '../types';
 
 export class RuleMonitoringService {
@@ -20,8 +19,6 @@ export class RuleMonitoringService {
   private monitoring: RuleMonitoring = getDefaultMonitoring(new Date().toISOString());
   // Rule executor metrics. Essential metrics get written to rule's SO.
   private metrics: Partial<ConsumerExecutionMetrics> = {};
-  // Rule info to be logged like correlation ids
-  private context: Partial<ConsumerRuleExecutionContext> = {};
 
   public setLastRunMetricsDuration(duration: number) {
     this.monitoring.run.last_run.metrics.duration = duration;
@@ -52,10 +49,6 @@ export class RuleMonitoringService {
     );
 
     return result;
-  }
-
-  public getConsumerContext(): Partial<ConsumerRuleExecutionContext> {
-    return { ...this.context };
   }
 
   public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> {
@@ -95,15 +88,10 @@ export class RuleMonitoringService {
 
   public getSetters(): PublicRuleMonitoringService {
     return {
-      setContext: this.setConsumerContext.bind(this),
       setMetric: this.setMetric.bind(this),
       setMetrics: this.setMetrics.bind(this),
       clearGapRange: this.clearGapRange.bind(this),
     };
-  }
-
-  private setConsumerContext(ctx: Partial<ConsumerRuleExecutionContext>): void {
-    Object.assign(this.context, ctx);
   }
 
   private clearGapRange(): void {

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -117,7 +117,7 @@ export class RuleMonitoringService {
   }
 
   private clearGapRange(): void {
-    delete this.metrics['gap_range'];
+    delete this.metrics.gap_range;
   }
 
   private buildExecutionSuccessRatio() {

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -33,17 +33,6 @@ export class RuleMonitoringService {
   public setMonitoring(monitoringFromSO: RuleMonitoring | undefined) {
     if (monitoringFromSO) {
       this.monitoring = monitoringFromSO;
-
-      const metricsSO = monitoringFromSO.run.last_run.metrics;
-
-      Object.assign(this.frameworkMetrics, {
-        total_search_duration_ms: metricsSO.total_search_duration_ms ?? undefined,
-      });
-      Object.assign(this.metrics, {
-        total_indexing_duration_ms: metricsSO.total_indexing_duration_ms ?? undefined,
-        gap_duration_s: metricsSO.gap_duration_s ?? undefined,
-        gap_range: metricsSO.gap_range ?? undefined,
-      });
     }
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -37,13 +37,12 @@ export class RuleMonitoringService {
       const metricsSO = monitoringFromSO.run.last_run.metrics;
 
       Object.assign(this.frameworkMetrics, {
-        total_search_duration_ms: metricsSO.total_search_duration_ms,
+        total_search_duration_ms: metricsSO.total_search_duration_ms ?? undefined,
       });
-
       Object.assign(this.metrics, {
-        total_indexing_duration_ms: metricsSO.total_indexing_duration_ms,
-        gap_duration_s: metricsSO.gap_duration_s,
-        gap_range: metricsSO.gap_range,
+        total_indexing_duration_ms: metricsSO.total_indexing_duration_ms ?? undefined,
+        gap_duration_s: metricsSO.gap_duration_s ?? undefined,
+        gap_range: metricsSO.gap_range ?? undefined,
       });
     }
   }

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { cloneDeep, isUndefined, omitBy } from 'lodash';
 import { getDefaultMonitoring, getExecutionDurationPercentiles } from '../lib/monitoring';
 import type {
   RuleMonitoring,
@@ -14,8 +15,9 @@ import type {
 } from '../types';
 
 export class RuleMonitoringService {
+  // Mirrors rule's SO state
   private monitoring: RuleMonitoring = getDefaultMonitoring(new Date().toISOString());
-  // Metrics added inside the rule executor
+  // Rule executor metrics. Essential metrics get written to rule's SO.
   private metrics: Partial<ConsumerExecutionMetrics> = {};
 
   public setLastRunMetricsDuration(duration: number) {
@@ -29,7 +31,24 @@ export class RuleMonitoringService {
   }
 
   public getMonitoring(): RuleMonitoring {
-    return this.monitoring;
+    const result = cloneDeep(this.monitoring);
+
+    Object.assign(
+      result.run.last_run.metrics,
+      omitBy(
+        {
+          total_search_duration_ms: this.metrics.total_search_duration_ms,
+          total_indexing_duration_ms: this.metrics.total_indexing_duration_ms,
+          total_alerts_detected: this.metrics.total_alerts_detected,
+          total_alerts_created: this.metrics.total_alerts_created,
+          gap_duration_s: this.metrics.gap_duration_s,
+          gap_range: this.metrics.gap_range,
+        },
+        isUndefined
+      )
+    );
+
+    return result;
   }
 
   public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> {
@@ -67,43 +86,16 @@ export class RuleMonitoringService {
     };
   }
 
-  public getLastRunMetricsSetters(): PublicRuleMonitoringService {
+  public getSetters(): PublicRuleMonitoringService {
     return {
-      setLastRunMetricsTotalSearchDurationMs:
-        this.setLastRunMetricsTotalSearchDurationMs.bind(this),
-      setLastRunMetricsTotalIndexingDurationMs:
-        this.setLastRunMetricsTotalIndexingDurationMs.bind(this),
-      setLastRunMetricsTotalAlertsDetected: this.setLastRunMetricsTotalAlertsDetected.bind(this),
-      setLastRunMetricsTotalAlertsCreated: this.setLastRunMetricsTotalAlertsCreated.bind(this),
-      setLastRunMetricsGapDurationS: this.setLastRunMetricsGapDurationS.bind(this),
-      setLastRunMetricsGapRange: this.setLastRunMetricsGapRange.bind(this),
       setMetric: this.setMetric.bind(this),
       setMetrics: this.setMetrics.bind(this),
+      clearGapRange: this.clearGapRange.bind(this),
     };
   }
 
-  private setLastRunMetricsTotalSearchDurationMs(totalSearchDurationMs: number) {
-    this.monitoring.run.last_run.metrics.total_search_duration_ms = totalSearchDurationMs;
-  }
-
-  private setLastRunMetricsTotalIndexingDurationMs(totalIndexingDurationMs: number) {
-    this.monitoring.run.last_run.metrics.total_indexing_duration_ms = totalIndexingDurationMs;
-  }
-
-  private setLastRunMetricsTotalAlertsDetected(totalAlertDetected: number) {
-    this.monitoring.run.last_run.metrics.total_alerts_detected = totalAlertDetected;
-  }
-
-  private setLastRunMetricsTotalAlertsCreated(totalAlertCreated: number) {
-    this.monitoring.run.last_run.metrics.total_alerts_created = totalAlertCreated;
-  }
-
-  private setLastRunMetricsGapDurationS(gapDurationS: number) {
-    this.monitoring.run.last_run.metrics.gap_duration_s = gapDurationS;
-  }
-
-  private setLastRunMetricsGapRange(gap: { lte: string; gte: string } | null) {
-    this.monitoring.run.last_run.metrics.gap_range = gap;
+  private clearGapRange(): void {
+    delete this.metrics['gap_range'];
   }
 
   private buildExecutionSuccessRatio() {
@@ -120,44 +112,6 @@ export class RuleMonitoringService {
     metricName: MetricName,
     value: ConsumerExecutionMetrics[MetricName]
   ) => {
-    if (metricName === 'total_search_duration_ms') {
-      this.setLastRunMetricsTotalSearchDurationMs(
-        value as ConsumerExecutionMetrics['total_search_duration_ms']
-      );
-      return;
-    }
-
-    if (metricName === 'total_indexing_duration_ms') {
-      this.setLastRunMetricsTotalIndexingDurationMs(
-        value as ConsumerExecutionMetrics['total_indexing_duration_ms']
-      );
-      return;
-    }
-
-    if (metricName === 'total_alerts_detected') {
-      this.setLastRunMetricsTotalAlertsDetected(
-        value as ConsumerExecutionMetrics['total_alerts_detected']
-      );
-      return;
-    }
-
-    if (metricName === 'total_alerts_created') {
-      this.setLastRunMetricsTotalAlertsCreated(
-        value as ConsumerExecutionMetrics['total_alerts_created']
-      );
-      return;
-    }
-
-    if (metricName === 'gap_duration_s') {
-      this.setLastRunMetricsGapDurationS(value as ConsumerExecutionMetrics['gap_duration_s']);
-      return;
-    }
-
-    if (metricName === 'gap_range') {
-      this.setLastRunMetricsGapRange(value as ConsumerExecutionMetrics['gap_range']);
-      return;
-    }
-
     this.metrics[metricName] = value;
   };
 

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -12,6 +12,7 @@ import type {
   RuleMonitoringHistory,
   PublicRuleMonitoringService,
   ConsumerExecutionMetrics,
+  ConsumerRuleExecutionContext,
 } from '../types';
 
 export class RuleMonitoringService {
@@ -19,6 +20,8 @@ export class RuleMonitoringService {
   private monitoring: RuleMonitoring = getDefaultMonitoring(new Date().toISOString());
   // Rule executor metrics. Essential metrics get written to rule's SO.
   private metrics: Partial<ConsumerExecutionMetrics> = {};
+  // Rule info to be logged like correlation ids
+  private context: Partial<ConsumerRuleExecutionContext> = {};
 
   public setLastRunMetricsDuration(duration: number) {
     this.monitoring.run.last_run.metrics.duration = duration;
@@ -49,6 +52,10 @@ export class RuleMonitoringService {
     );
 
     return result;
+  }
+
+  public getConsumerContext(): Partial<ConsumerRuleExecutionContext> {
+    return { ...this.context };
   }
 
   public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> {
@@ -88,10 +95,15 @@ export class RuleMonitoringService {
 
   public getSetters(): PublicRuleMonitoringService {
     return {
+      setContext: this.setConsumerContext.bind(this),
       setMetric: this.setMetric.bind(this),
       setMetrics: this.setMetrics.bind(this),
       clearGapRange: this.clearGapRange.bind(this),
     };
+  }
+
+  private setConsumerContext(ctx: Partial<ConsumerRuleExecutionContext>): void {
+    Object.assign(this.context, ctx);
   }
 
   private clearGapRange(): void {

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -68,10 +68,10 @@ export class RuleMonitoringService {
   }
 
   public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> | undefined {
-    if (Object.values(this.metrics).some((value) => value != null)) {
-      return {
-        ...this.metrics,
-      };
+    const result = omitBy(this.metrics, (value) => value == null);
+
+    if (Object.keys(result).length === 0) {
+      return;
     }
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -33,7 +33,18 @@ export class RuleMonitoringService {
   public setMonitoring(monitoringFromSO: RuleMonitoring | undefined) {
     if (monitoringFromSO) {
       this.monitoring = monitoringFromSO;
-      Object.assign(this.metrics, monitoringFromSO.run.last_run.metrics);
+
+      const metricsSO = monitoringFromSO.run.last_run.metrics;
+
+      Object.assign(this.frameworkMetrics, {
+        total_search_duration_ms: metricsSO.total_search_duration_ms,
+      });
+
+      Object.assign(this.metrics, {
+        total_indexing_duration_ms: metricsSO.total_indexing_duration_ms,
+        gap_duration_s: metricsSO.gap_duration_s,
+        gap_range: metricsSO.gap_range,
+      });
     }
   }
 
@@ -56,10 +67,12 @@ export class RuleMonitoringService {
     return result;
   }
 
-  public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> {
-    return {
-      ...this.metrics,
-    };
+  public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> | undefined {
+    if (Object.values(this.metrics).some((value) => value != null)) {
+      return {
+        ...this.metrics,
+      };
+    }
   }
 
   public addFrameworkMetrics(fwkMetrics: Partial<FrameworkMetrics>): void {

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { cloneDeep, isUndefined, omitBy } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { getDefaultMonitoring, getExecutionDurationPercentiles } from '../lib/monitoring';
 import type {
   RuleMonitoring,
@@ -51,27 +51,19 @@ export class RuleMonitoringService {
   public getMonitoring(): RuleMonitoring {
     const result = cloneDeep(this.monitoring);
 
-    Object.assign(
-      result.run.last_run.metrics,
-      omitBy(
-        {
-          total_search_duration_ms: this.frameworkMetrics.total_search_duration_ms,
-          total_indexing_duration_ms: this.metrics.total_indexing_duration_ms,
-          gap_duration_s: this.metrics.gap_duration_s,
-          gap_range: this.metrics.gap_range,
-        },
-        isUndefined
-      )
-    );
+    Object.assign(result.run.last_run.metrics, {
+      total_search_duration_ms: this.frameworkMetrics.total_search_duration_ms ?? null,
+      total_indexing_duration_ms: this.metrics.total_indexing_duration_ms ?? null,
+      gap_duration_s: this.metrics.gap_duration_s ?? null,
+      gap_range: this.metrics.gap_range ?? null,
+    });
 
     return result;
   }
 
   public getExecutorMetrics(): Partial<ConsumerExecutionMetrics> | undefined {
-    const result = omitBy(this.metrics, (value) => value == null);
-
-    if (Object.keys(result).length === 0) {
-      return;
+    if (Object.values(this.metrics).some((v) => v != null)) {
+      return this.metrics;
     }
   }
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -29,6 +29,7 @@ import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { TaskPriority, TaskStatus } from '@kbn/task-manager-plugin/server';
 import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/usage_counters/usage_counters_service.mock';
 import { AdHocTaskRunner } from './ad_hoc_task_runner';
+import { RuleMonitoringService } from '../monitoring/rule_monitoring_service';
 import type { TaskRunnerContext } from './types';
 import { ApiKeyType } from './types';
 import { backfillClientMock } from '../backfill_client/backfill_client.mock';
@@ -415,6 +416,10 @@ describe('Ad Hoc Task Runner', () => {
   afterAll(() => fakeTimer.restore());
 
   test('successfully executes the task', async () => {
+    const addFrameworkMetricsSpy = jest.spyOn(
+      RuleMonitoringService.prototype,
+      'addFrameworkMetrics'
+    );
     ruleTypeWithAlerts.executor.mockImplementation(
       async ({
         services: executorServices,
@@ -444,6 +449,10 @@ describe('Ad Hoc Task Runner', () => {
 
     const runnerResult = await taskRunner.run();
     expect(runnerResult).toEqual({ state: {}, runAt: new Date('1970-01-01T00:00:00.000Z') });
+    expect(addFrameworkMetricsSpy).toHaveBeenCalledWith({
+      total_search_duration_ms: 23423,
+    });
+    addFrameworkMetricsSpy.mockRestore();
     await taskRunner.cleanup();
 
     // Verify all the expected calls were made before calling the rule executor
@@ -582,6 +591,48 @@ describe('Ad Hoc Task Runner', () => {
       `rule test:rule-id: 'test' has 1 active alerts: [{"instanceId":"1","actionGroup":"default"}]`
     );
     expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  test('passes consumer metrics to AlertingEventLogger', async () => {
+    const consumerMetrics = {
+      alerts_candidate_count: 100,
+      total_enrichment_duration_ms: 50,
+    };
+    ruleTypeWithAlerts.executor.mockImplementation(
+      async ({
+        services: executorServices,
+      }: RuleExecutorOptions<
+        RuleTypeParams,
+        RuleTypeState,
+        AlertInstanceState,
+        AlertInstanceContext,
+        string,
+        RuleAlertData
+      >) => {
+        executorServices.ruleMonitoringService?.setMetrics(consumerMetrics);
+        return { state: {} };
+      }
+    );
+
+    const taskRunner = new AdHocTaskRunner({
+      context: taskRunnerFactoryInitializerParams,
+      internalSavedObjectsRepository,
+      taskInstance: mockedTaskInstance,
+    });
+
+    await taskRunner.run();
+    await taskRunner.cleanup();
+
+    expect(alertingEventLogger.done).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumerMetrics,
+        backfill: {
+          id: mockedAdHocRunSO.id,
+          start: schedule1.runAt,
+          interval: schedule1.interval,
+        },
+      })
+    );
   });
 
   test('should schedule actions for rule with actions', async () => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -1672,7 +1672,6 @@ describe('Ad Hoc Task Runner', () => {
         name: mockedAdHocRunSO.attributes.rule.name,
         consumer: mockedAdHocRunSO.attributes.rule.consumer,
         revision: mockedAdHocRunSO.attributes.rule.revision,
-        uuid: expect.any(String),
       });
     }
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -1672,6 +1672,7 @@ describe('Ad Hoc Task Runner', () => {
         name: mockedAdHocRunSO.attributes.rule.name,
         consumer: mockedAdHocRunSO.attributes.rule.consumer,
         revision: mockedAdHocRunSO.attributes.rule.revision,
+        uuid: expect.any(String),
       });
     }
 

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -396,7 +396,10 @@ export class AdHocTaskRunner implements CancellableTask {
       this.ruleId = rule.id;
       this.alertingEventLogger.addOrUpdateRuleData({
         id: rule.id,
-        uuid: typeof rule.params.ruleId === 'string' ? rule.params.ruleId : undefined,
+        uuid:
+          ruleType.solution === 'security' && typeof rule.params.ruleId === 'string'
+            ? rule.params.ruleId
+            : undefined,
         type: ruleType,
         name: rule.name,
         consumer: rule.consumer,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -511,6 +511,13 @@ export class AdHocTaskRunner implements CancellableTask {
 
       if (apm.currentTransaction) {
         apm.currentTransaction.setOutcome(outcome);
+        apm.setCustomContext({
+          execution_outcome: {
+            ...this.ruleMonitoring.getExecutorMetrics(),
+            error: executionStatus.error,
+            warning: executionStatus.warning,
+          },
+        });
       }
 
       // set start and duration based on event log

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -484,83 +484,93 @@ export class AdHocTaskRunner implements CancellableTask {
     } = this.taskInstance;
     const namespace = this.context.spaceIdToNamespace(spaceId);
 
-    const { executionStatus: execStatus, executionMetrics: execMetrics } =
-      await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
-        const { executionStatus, executionMetrics, outcome } = processRunResults({
-          result: this.ruleResult,
-          runDate: this.runDate,
-          runRuleResult,
-        });
-
-        if (!isOk(runRuleResult)) {
-          const error = this.stackTraceLog ? this.stackTraceLog.message : runRuleResult.error;
-          const stack = this.stackTraceLog
-            ? this.stackTraceLog.stackTrace
-            : runRuleResult.error.stack;
-          const message = `Executing ad hoc run with id "${adHocRunParamsId}" has resulted in Error: ${getEsErrorMessage(
-            error
-          )} - ${stack ?? ''}`;
-          const tags = [adHocRunParamsId, 'rule-ad-hoc-run-failed'];
-          if (this.ruleTypeId.length > 0) {
-            tags.push(this.ruleTypeId);
-          }
-          if (this.ruleId.length > 0) {
-            tags.push(this.ruleId);
-          }
-          this.logger.error(message, { tags, error: { stack_trace: stack } });
-        }
-
-        if (apm.currentTransaction) {
-          apm.currentTransaction.setOutcome(outcome);
-        }
-
-        // set start and duration based on event log
-        const { start, duration } = this.alertingEventLogger.getStartAndDuration();
-        if (null != start) {
-          executionStatus.lastExecutionDate = start;
-        }
-        if (null != duration) {
-          executionStatus.lastDuration = nanosToMillis(duration);
-        }
-
-        if (this.scheduleToRunIndex > -1) {
-          let updatedStatus: AdHocRunStatus = adHocRunStatus.COMPLETE;
-          if (this.cancelled) {
-            updatedStatus = adHocRunStatus.TIMEOUT;
-          } else if (outcome === 'failure') {
-            updatedStatus = adHocRunStatus.ERROR;
-          }
-          this.adHocRunSchedule[this.scheduleToRunIndex].status = updatedStatus;
-        }
-
-        // If execution failed due to decrypt error, we should stop running the task
-        // If the user wants to rerun it, they can reschedule
-        // In the future, we can consider saving the task in an error state when we
-        // have one or both of the following abilities
-        // - ability to rerun a failed ad hoc run
-        // - ability to clean up failed ad hoc runs (either manually or automatically)
-        this.shouldDeleteTask =
-          executionStatus.status === 'error' &&
-          (executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Decrypt ||
-            executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Read ||
-            executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.License ||
-            executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Validate);
-
-        await this.updateAdHocRunSavedObjectPostRun(adHocRunParamsId, namespace, {
-          ...(this.shouldDeleteTask ? { status: adHocRunStatus.ERROR } : {}),
-          ...(this.scheduleToRunIndex > -1 ? { schedule: this.adHocRunSchedule } : {}),
-        });
-
-        if (startedAt) {
-          // Capture how long it took for the rule to run after being claimed
-          this.timer.setDuration(TaskRunnerTimerSpan.TotalRunDuration, startedAt);
-        }
-
-        return { executionStatus, executionMetrics };
+    const result = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
+      const { executionStatus, executionMetrics, outcome } = processRunResults({
+        result: this.ruleResult,
+        runDate: this.runDate,
+        runRuleResult,
       });
+
+      if (!isOk(runRuleResult)) {
+        const error = this.stackTraceLog ? this.stackTraceLog.message : runRuleResult.error;
+        const stack = this.stackTraceLog
+          ? this.stackTraceLog.stackTrace
+          : runRuleResult.error.stack;
+        const message = `Executing ad hoc run with id "${adHocRunParamsId}" has resulted in Error: ${getEsErrorMessage(
+          error
+        )} - ${stack ?? ''}`;
+        const tags = [adHocRunParamsId, 'rule-ad-hoc-run-failed'];
+        if (this.ruleTypeId.length > 0) {
+          tags.push(this.ruleTypeId);
+        }
+        if (this.ruleId.length > 0) {
+          tags.push(this.ruleId);
+        }
+        this.logger.error(message, { tags, error: { stack_trace: stack } });
+      }
+
+      if (apm.currentTransaction) {
+        apm.currentTransaction.setOutcome(outcome);
+      }
+
+      // set start and duration based on event log
+      const { start, duration } = this.alertingEventLogger.getStartAndDuration();
+      if (null != start) {
+        executionStatus.lastExecutionDate = start;
+      }
+      if (null != duration) {
+        executionStatus.lastDuration = nanosToMillis(duration);
+      }
+
+      if (executionMetrics) {
+        this.ruleMonitoring.addFrameworkMetrics({
+          total_search_duration_ms: executionMetrics.totalSearchDurationMs,
+        });
+      }
+
+      if (this.scheduleToRunIndex > -1) {
+        let updatedStatus: AdHocRunStatus = adHocRunStatus.COMPLETE;
+        if (this.cancelled) {
+          updatedStatus = adHocRunStatus.TIMEOUT;
+        } else if (outcome === 'failure') {
+          updatedStatus = adHocRunStatus.ERROR;
+        }
+        this.adHocRunSchedule[this.scheduleToRunIndex].status = updatedStatus;
+      }
+
+      // If execution failed due to decrypt error, we should stop running the task
+      // If the user wants to rerun it, they can reschedule
+      // In the future, we can consider saving the task in an error state when we
+      // have one or both of the following abilities
+      // - ability to rerun a failed ad hoc run
+      // - ability to clean up failed ad hoc runs (either manually or automatically)
+      this.shouldDeleteTask =
+        executionStatus.status === 'error' &&
+        (executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Decrypt ||
+          executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Read ||
+          executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.License ||
+          executionStatus?.error?.reason === RuleExecutionStatusErrorReasons.Validate);
+
+      await this.updateAdHocRunSavedObjectPostRun(adHocRunParamsId, namespace, {
+        ...(this.shouldDeleteTask ? { status: adHocRunStatus.ERROR } : {}),
+        ...(this.scheduleToRunIndex > -1 ? { schedule: this.adHocRunSchedule } : {}),
+      });
+
+      if (startedAt) {
+        // Capture how long it took for the rule to run after being claimed
+        this.timer.setDuration(TaskRunnerTimerSpan.TotalRunDuration, startedAt);
+      }
+
+      return {
+        executionStatus,
+        executionMetrics,
+        consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
+      };
+    });
     this.alertingEventLogger.done({
-      status: execStatus,
-      metrics: execMetrics,
+      status: result.executionStatus,
+      metrics: result.executionMetrics,
+      consumerMetrics: result.consumerExecutionMetrics,
       // in the future if we have other types of ad hoc runs (like preview)
       // we can differentiate and pass in different info
       backfill: {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -396,6 +396,7 @@ export class AdHocTaskRunner implements CancellableTask {
       this.ruleId = rule.id;
       this.alertingEventLogger.addOrUpdateRuleData({
         id: rule.id,
+        uuid: typeof rule.params.ruleId === 'string' ? rule.params.ruleId : undefined,
         type: ruleType,
         name: rule.name,
         consumer: rule.consumer,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/fixtures.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/fixtures.ts
@@ -102,8 +102,7 @@ export const generateRuleUpdateParams = ({
               metrics: {
                 duration: 0,
                 gap_duration_s: null,
-                // TODO: uncomment after intermidiate release
-                // gap_range: null,
+                gap_range: null,
                 total_alerts_created: null,
                 total_alerts_detected: null,
                 total_indexing_duration_ms: null,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/fixtures.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/fixtures.ts
@@ -74,6 +74,7 @@ export const generateRuleUpdateParams = ({
   successRatio = 1,
   history = defaultHistory,
   alertsCount,
+  metrics,
 }: {
   error?: null | { reason: string; message: string };
   warning?: null | { reason: string; message: string };
@@ -83,6 +84,7 @@ export const generateRuleUpdateParams = ({
   successRatio?: number;
   history?: RuleMonitoring['run']['history'];
   alertsCount?: Record<string, number>;
+  metrics?: Record<string, unknown>;
 }) => [
   {
     id: `alert:1`,
@@ -106,6 +108,7 @@ export const generateRuleUpdateParams = ({
                 total_alerts_detected: null,
                 total_indexing_duration_ms: null,
                 total_search_duration_ms: null,
+                ...metrics,
               },
             },
           },

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.test.ts
@@ -76,7 +76,7 @@ describe('getExecutorServices', () => {
   };
   const ruleMonitoringService = ruleMonitoringServiceMock.create();
   const ruleResultService = ruleResultServiceMock.create();
-  (ruleMonitoringService.getLastRunMetricsSetters as jest.Mock).mockReturnValue({});
+  (ruleMonitoringService.getSetters as jest.Mock).mockReturnValue({});
   (ruleResultService.getLastRunSetters as jest.Mock).mockReturnValue({});
 
   beforeEach(() => {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/get_executor_services.ts
@@ -87,7 +87,7 @@ export const getExecutorServices = (opts: GetExecutorServicesOpts): ExecutorServ
   const uiSettingsClient = context.uiSettings.asScopedToClient(savedObjectsClient);
 
   return {
-    ruleMonitoringService: opts.ruleMonitoringService.getLastRunMetricsSetters(),
+    ruleMonitoringService: opts.ruleMonitoringService.getSetters(),
     ruleResultService: opts.ruleResultService.getLastRunSetters(),
     savedObjectsClient,
     uiSettingsClient,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/process_run_result.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/process_run_result.ts
@@ -19,7 +19,10 @@ import {
   executionStatusFromState,
 } from '../../lib/rule_execution_status';
 import type { RuleRunMetrics } from '../../lib/rule_run_metrics_store';
-import type { RuleResultService } from '../../monitoring/rule_result_service';
+import type {
+  RuleResultService,
+  RuleResultServiceResults,
+} from '../../monitoring/rule_result_service';
 import type { RunRuleResult } from '../types';
 
 interface ProcessRuleRunOpts {
@@ -35,6 +38,8 @@ interface ProcessRuleRunResult {
   executionMetrics: RuleRunMetrics | null;
   lastRun: RuleLastRun;
   outcome: Outcome;
+  errors?: RuleResultServiceResults['errors'];
+  warnings?: RuleResultServiceResults['warnings'];
 }
 
 export function processRunResults({
@@ -61,7 +66,12 @@ export function processRunResults({
   );
 
   // New consolidated statuses for lastRun
-  const { lastRun, metrics: executionMetrics } = map<RunRuleResult, ElasticsearchError, ILastRun>(
+  const {
+    lastRun,
+    metrics: executionMetrics,
+    errors,
+    warnings,
+  } = map<RunRuleResult, ElasticsearchError, ILastRun>(
     runRuleResult,
     ({ metrics }) => lastRunFromState(metrics, result),
     (err: ElasticsearchError) => lastRunFromError(err)
@@ -86,5 +96,5 @@ export function processRunResults({
     outcome = 'failure';
   }
 
-  return { executionStatus, executionMetrics, lastRun, outcome };
+  return { executionStatus, executionMetrics, lastRun, outcome, errors, warnings };
 }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/process_run_result.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/lib/process_run_result.ts
@@ -19,10 +19,7 @@ import {
   executionStatusFromState,
 } from '../../lib/rule_execution_status';
 import type { RuleRunMetrics } from '../../lib/rule_run_metrics_store';
-import type {
-  RuleResultService,
-  RuleResultServiceResults,
-} from '../../monitoring/rule_result_service';
+import type { RuleResultService } from '../../monitoring/rule_result_service';
 import type { RunRuleResult } from '../types';
 
 interface ProcessRuleRunOpts {
@@ -38,8 +35,6 @@ interface ProcessRuleRunResult {
   executionMetrics: RuleRunMetrics | null;
   lastRun: RuleLastRun;
   outcome: Outcome;
-  errors?: RuleResultServiceResults['errors'];
-  warnings?: RuleResultServiceResults['warnings'];
 }
 
 export function processRunResults({
@@ -66,12 +61,7 @@ export function processRunResults({
   );
 
   // New consolidated statuses for lastRun
-  const {
-    lastRun,
-    metrics: executionMetrics,
-    errors,
-    warnings,
-  } = map<RunRuleResult, ElasticsearchError, ILastRun>(
+  const { lastRun, metrics: executionMetrics } = map<RunRuleResult, ElasticsearchError, ILastRun>(
     runRuleResult,
     ({ metrics }) => lastRunFromState(metrics, result),
     (err: ElasticsearchError) => lastRunFromError(err)
@@ -96,5 +86,5 @@ export function processRunResults({
     outcome = 'failure';
   }
 
-  return { executionStatus, executionMetrics, lastRun, outcome, errors, warnings };
+  return { executionStatus, executionMetrics, lastRun, outcome };
 }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -2923,7 +2923,7 @@ describe('Task Runner', () => {
         warning,
         alertsCount: { active: 1, new: 1 },
         metrics: {
-          total_search_duration_ms: 23423,
+          total_search_duration_ms: null,
         },
       })
     );
@@ -3099,7 +3099,7 @@ describe('Task Runner', () => {
         warning,
         alertsCount: { active: 2, new: 2 },
         metrics: {
-          total_search_duration_ms: 23423,
+          total_search_duration_ms: null,
         },
       })
     );

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -339,7 +339,11 @@ describe('Task Runner', () => {
     testAlertingEventLogCalls({ status: 'ok' });
 
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-      ...generateRuleUpdateParams({})
+      ...generateRuleUpdateParams({
+        metrics: {
+          total_search_duration_ms: 23423,
+        },
+      })
     );
 
     expect(taskRunnerFactoryInitializerParams.executionContext.withContext).toBeCalledTimes(1);
@@ -2756,7 +2760,10 @@ describe('Task Runner', () => {
 
     await taskRunner.run();
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-      ...generateRuleUpdateParams({ nextRun: '1970-01-01T00:00:10.000Z' })
+      ...generateRuleUpdateParams({
+        nextRun: '1970-01-01T00:00:10.000Z',
+        metrics: { total_search_duration_ms: 23423 },
+      })
     );
   });
 
@@ -2915,6 +2922,9 @@ describe('Task Runner', () => {
         outcome: 'warning',
         warning,
         alertsCount: { active: 1, new: 1 },
+        metrics: {
+          total_search_duration_ms: 23423,
+        },
       })
     );
 
@@ -3088,6 +3098,9 @@ describe('Task Runner', () => {
         outcome: 'warning',
         warning,
         alertsCount: { active: 2, new: 2 },
+        metrics: {
+          total_search_duration_ms: 23423,
+        },
       })
     );
 
@@ -3690,6 +3703,7 @@ describe('Task Runner', () => {
           triggeredActionsStatus: 'complete',
           hasReachedQueuedActionsLimit,
         },
+        consumerMetrics: undefined,
         status: {
           lastExecutionDate: new Date('1970-01-01T00:00:00.000Z'),
           status,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -362,6 +362,73 @@ describe('Task Runner', () => {
     ).toHaveBeenCalled();
   });
 
+  test('passes total_search_duration_ms from execution metrics into rule monitoring via addFrameworkMetrics', async () => {
+    const addFrameworkMetricsSpy = jest.spyOn(
+      RuleMonitoringService.prototype,
+      'addFrameworkMetrics'
+    );
+    const taskRunner = new TaskRunner({
+      ruleType,
+      taskInstance: {
+        ...mockedTaskInstance,
+        state: {
+          ...mockedTaskInstance.state,
+          previousStartedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+      },
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+      internalSavedObjectsRepository,
+    });
+
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    await taskRunner.run();
+
+    expect(addFrameworkMetricsSpy).toHaveBeenCalledWith({
+      total_search_duration_ms: 23423,
+    });
+    addFrameworkMetricsSpy.mockRestore();
+  });
+
+  test('passes consumer metrics to AlertingEventLogger', async () => {
+    const consumerMetrics = {
+      alerts_candidate_count: 42,
+      alerts_suppressed_count: 7,
+      frozen_indices_queried_count: 3,
+    };
+    ruleType.executor.mockImplementation(async ({ services: { ruleMonitoringService } }) => {
+      ruleMonitoringService?.setMetrics(consumerMetrics);
+      return { state: {} };
+    });
+
+    const taskRunner = new TaskRunner({
+      ruleType,
+      taskInstance: {
+        ...mockedTaskInstance,
+        state: {
+          ...mockedTaskInstance.state,
+          previousStartedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+      },
+      context: taskRunnerFactoryInitializerParams,
+      inMemoryMetrics,
+      internalSavedObjectsRepository,
+    });
+
+    mockGetRuleFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+
+    await taskRunner.run();
+
+    expect(alertingEventLogger.done).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumerMetrics,
+      })
+    );
+  });
+
   test('should update the persisted alerts', async () => {
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(true);
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(true);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -612,6 +612,8 @@ export class TaskRunner<
       executionStatus: execStatus,
       executionMetrics: execMetrics,
       consumerExecutionMetrics: consumerExecMetrics,
+      errors: executionErrors,
+      warnings: executionWarnings,
     } = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
       const {
         params: { alertId: ruleId },
@@ -627,13 +629,14 @@ export class TaskRunner<
         nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
       }
 
-      const { executionStatus, executionMetrics, lastRun, outcome } = processRunResults({
-        logger: this.logger,
-        logPrefix: `${this.ruleType.id}:${ruleId}`,
-        result: this.ruleResult,
-        runDate: this.runDate,
-        runRuleResult,
-      });
+      const { executionStatus, executionMetrics, lastRun, outcome, errors, warnings } =
+        processRunResults({
+          logger: this.logger,
+          logPrefix: `${this.ruleType.id}:${ruleId}`,
+          result: this.ruleResult,
+          runDate: this.runDate,
+          runRuleResult,
+        });
 
       if (apm.currentTransaction) {
         apm.currentTransaction.setOutcome(outcome);
@@ -692,6 +695,8 @@ export class TaskRunner<
         executionStatus,
         executionMetrics: executionMetrics,
         consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
+        errors,
+        warnings,
       };
     });
 
@@ -699,6 +704,8 @@ export class TaskRunner<
       status: execStatus,
       metrics: execMetrics,
       consumerMetrics: consumerExecMetrics,
+      errors: executionErrors,
+      warnings: executionWarnings,
       timings: this.timer.toJson(),
     });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -608,89 +608,97 @@ export class TaskRunner<
     schedule: Result<IntervalSchedule, Error>;
     runRuleResult: Result<RunRuleResult, Error>;
   }) {
-    const { executionStatus: execStatus, executionMetrics: execMetrics } =
-      await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
-        const {
-          params: { alertId: ruleId },
-          startedAt,
-          schedule: taskSchedule,
-        } = this.taskInstance;
+    const {
+      executionStatus: execStatus,
+      executionMetrics: execMetrics,
+      consumerExecutionMetrics: consumerExecMetrics,
+    } = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
+      const {
+        params: { alertId: ruleId },
+        startedAt,
+        schedule: taskSchedule,
+      } = this.taskInstance;
 
-        let nextRun: string | null = null;
-        if (isOk(schedule)) {
-          nextRun = getNextRun({ startDate: startedAt, interval: schedule.value.interval });
-        } else if (taskSchedule) {
-          // rules cannot use rrule for scheduling yet
-          nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
-        }
+      let nextRun: string | null = null;
+      if (isOk(schedule)) {
+        nextRun = getNextRun({ startDate: startedAt, interval: schedule.value.interval });
+      } else if (taskSchedule) {
+        // rules cannot use rrule for scheduling yet
+        nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
+      }
 
-        const { executionStatus, executionMetrics, lastRun, outcome } = processRunResults({
-          logger: this.logger,
-          logPrefix: `${this.ruleType.id}:${ruleId}`,
-          result: this.ruleResult,
-          runDate: this.runDate,
-          runRuleResult,
-        });
-
-        if (apm.currentTransaction) {
-          apm.currentTransaction.setOutcome(outcome);
-        }
-
-        // set start and duration based on event log
-        const { start, duration } = this.alertingEventLogger.getStartAndDuration();
-        if (null != start) {
-          executionStatus.lastExecutionDate = start;
-        }
-        if (null != duration) {
-          executionStatus.lastDuration = nanosToMillis(duration);
-        }
-
-        // if executionStatus indicates an error, fill in fields in
-        this.ruleMonitoring.addHistory({
-          duration: executionStatus.lastDuration,
-          hasError: executionStatus.error != null,
-          runDate: this.runDate,
-        });
-
-        const gap = this.ruleMonitoring.getMonitoring()?.run?.last_run?.metrics?.gap_range;
-        if (gap) {
-          this.alertingEventLogger.reportGap({
-            gap,
-          });
-        }
-
-        if (!this.cancelled) {
-          this.inMemoryMetrics.increment(IN_MEMORY_METRICS.RULE_EXECUTIONS);
-          if (outcome === 'failure') {
-            this.inMemoryMetrics.increment(IN_MEMORY_METRICS.RULE_FAILURES);
-          }
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              `Updating rule task for ${this.ruleType.id} rule with id ${ruleId} - ${JSON.stringify(
-                executionStatus
-              )} - ${JSON.stringify(lastRun)}`
-            );
-          }
-
-          await this.updateRuleSavedObjectPostRun(ruleId, {
-            executionStatus: ruleExecutionStatusToRaw(executionStatus),
-            nextRun,
-            lastRun: lastRunToRaw(lastRun),
-            monitoring: this.ruleMonitoring.getMonitoring() as RawRuleMonitoring,
-          });
-        }
-
-        if (startedAt) {
-          // Capture how long it took for the rule to run after being claimed
-          this.timer.setDuration(TaskRunnerTimerSpan.TotalRunDuration, startedAt);
-        }
-
-        return { executionStatus, executionMetrics };
+      const { executionStatus, executionMetrics, lastRun, outcome } = processRunResults({
+        logger: this.logger,
+        logPrefix: `${this.ruleType.id}:${ruleId}`,
+        result: this.ruleResult,
+        runDate: this.runDate,
+        runRuleResult,
       });
+
+      if (apm.currentTransaction) {
+        apm.currentTransaction.setOutcome(outcome);
+      }
+
+      // set start and duration based on event log
+      const { start, duration } = this.alertingEventLogger.getStartAndDuration();
+      if (null != start) {
+        executionStatus.lastExecutionDate = start;
+      }
+      if (null != duration) {
+        executionStatus.lastDuration = nanosToMillis(duration);
+      }
+
+      // if executionStatus indicates an error, fill in fields in
+      this.ruleMonitoring.addHistory({
+        duration: executionStatus.lastDuration,
+        hasError: executionStatus.error != null,
+        runDate: this.runDate,
+      });
+
+      const gap = this.ruleMonitoring.getMonitoring()?.run?.last_run?.metrics?.gap_range;
+      if (gap) {
+        this.alertingEventLogger.reportGap({
+          gap,
+        });
+      }
+
+      if (!this.cancelled) {
+        this.inMemoryMetrics.increment(IN_MEMORY_METRICS.RULE_EXECUTIONS);
+        if (outcome === 'failure') {
+          this.inMemoryMetrics.increment(IN_MEMORY_METRICS.RULE_FAILURES);
+        }
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(
+            `Updating rule task for ${this.ruleType.id} rule with id ${ruleId} - ${JSON.stringify(
+              executionStatus
+            )} - ${JSON.stringify(lastRun)}`
+          );
+        }
+
+        await this.updateRuleSavedObjectPostRun(ruleId, {
+          executionStatus: ruleExecutionStatusToRaw(executionStatus),
+          nextRun,
+          lastRun: lastRunToRaw(lastRun),
+          monitoring: this.ruleMonitoring.getMonitoring() as RawRuleMonitoring,
+        });
+      }
+
+      if (startedAt) {
+        // Capture how long it took for the rule to run after being claimed
+        this.timer.setDuration(TaskRunnerTimerSpan.TotalRunDuration, startedAt);
+      }
+
+      return {
+        executionStatus,
+        executionMetrics: executionMetrics,
+        consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
+      };
+    });
 
     this.alertingEventLogger.done({
       status: execStatus,
       metrics: execMetrics,
+      consumerMetrics: consumerExecMetrics,
       timings: this.timer.toJson(),
     });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -608,11 +608,7 @@ export class TaskRunner<
     schedule: Result<IntervalSchedule, Error>;
     runRuleResult: Result<RunRuleResult, Error>;
   }) {
-    const {
-      executionStatus: execStatus,
-      executionMetrics: execMetrics,
-      consumerExecutionMetrics: consumerExecMetrics,
-    } = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
+    const result = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
       const {
         params: { alertId: ruleId },
         startedAt,
@@ -692,13 +688,15 @@ export class TaskRunner<
         executionStatus,
         executionMetrics: executionMetrics,
         consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
+        consumerContext: this.ruleMonitoring.getConsumerContext(),
       };
     });
 
     this.alertingEventLogger.done({
-      status: execStatus,
-      metrics: execMetrics,
-      consumerMetrics: consumerExecMetrics,
+      status: result.executionStatus,
+      metrics: result.executionMetrics,
+      consumerMetrics: result.consumerExecutionMetrics,
+      consumerContext: result.consumerContext,
       timings: this.timer.toJson(),
     });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -574,6 +574,10 @@ export class TaskRunner<
         name: runRuleParams.rule.name,
         consumer: runRuleParams.rule.consumer,
         revision: runRuleParams.rule.revision,
+        uuid:
+          typeof runRuleParams.rule.params.ruleId === 'string'
+            ? runRuleParams.rule.params.ruleId
+            : undefined,
       });
 
       // Set rule monitoring data
@@ -688,7 +692,6 @@ export class TaskRunner<
         executionStatus,
         executionMetrics: executionMetrics,
         consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
-        consumerContext: this.ruleMonitoring.getConsumerContext(),
       };
     });
 
@@ -696,7 +699,6 @@ export class TaskRunner<
       status: result.executionStatus,
       metrics: result.executionMetrics,
       consumerMetrics: result.consumerExecutionMetrics,
-      consumerContext: result.consumerContext,
       timings: this.timer.toJson(),
     });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -612,8 +612,6 @@ export class TaskRunner<
       executionStatus: execStatus,
       executionMetrics: execMetrics,
       consumerExecutionMetrics: consumerExecMetrics,
-      errors: executionErrors,
-      warnings: executionWarnings,
     } = await this.timer.runWithTimer(TaskRunnerTimerSpan.ProcessRuleRun, async () => {
       const {
         params: { alertId: ruleId },
@@ -629,14 +627,13 @@ export class TaskRunner<
         nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
       }
 
-      const { executionStatus, executionMetrics, lastRun, outcome, errors, warnings } =
-        processRunResults({
-          logger: this.logger,
-          logPrefix: `${this.ruleType.id}:${ruleId}`,
-          result: this.ruleResult,
-          runDate: this.runDate,
-          runRuleResult,
-        });
+      const { executionStatus, executionMetrics, lastRun, outcome } = processRunResults({
+        logger: this.logger,
+        logPrefix: `${this.ruleType.id}:${ruleId}`,
+        result: this.ruleResult,
+        runDate: this.runDate,
+        runRuleResult,
+      });
 
       if (apm.currentTransaction) {
         apm.currentTransaction.setOutcome(outcome);
@@ -695,8 +692,6 @@ export class TaskRunner<
         executionStatus,
         executionMetrics: executionMetrics,
         consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
-        errors,
-        warnings,
       };
     });
 
@@ -704,8 +699,6 @@ export class TaskRunner<
       status: execStatus,
       metrics: execMetrics,
       consumerMetrics: consumerExecMetrics,
-      errors: executionErrors,
-      warnings: executionWarnings,
       timings: this.timer.toJson(),
     });
   }

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -581,7 +581,7 @@ export class TaskRunner<
 
       // Clear gap range that was persisted in the rule SO
       if (this.ruleMonitoring.getMonitoring()?.run?.last_run?.metrics?.gap_range) {
-        this.ruleMonitoring.getLastRunMetricsSetters().setLastRunMetricsGapRange(null);
+        this.ruleMonitoring.getSetters().clearGapRange();
       }
       (async () => {
         try {

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -575,6 +575,7 @@ export class TaskRunner<
         consumer: runRuleParams.rule.consumer,
         revision: runRuleParams.rule.revision,
         uuid:
+          this.ruleType.solution === 'security' &&
           typeof runRuleParams.rule.params.ruleId === 'string'
             ? runRuleParams.rule.params.ruleId
             : undefined,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -662,7 +662,9 @@ export class TaskRunner<
         runDate: this.runDate,
       });
 
-      if (executionMetrics) {
+      // In case of non-success outcome framework calculated metrics could be incomplete
+      // Instead of including numbers without clear interpretation omit them
+      if (executionMetrics && lastRun.outcome === 'succeeded') {
         this.ruleMonitoring.addFrameworkMetrics({
           total_search_duration_ms: executionMetrics.totalSearchDurationMs,
         });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -655,6 +655,12 @@ export class TaskRunner<
         runDate: this.runDate,
       });
 
+      if (executionMetrics) {
+        this.ruleMonitoring.addFrameworkMetrics({
+          total_search_duration_ms: executionMetrics.totalSearchDurationMs,
+        });
+      }
+
       const gap = this.ruleMonitoring.getMonitoring()?.run?.last_run?.metrics?.gap_range;
       if (gap) {
         this.alertingEventLogger.reportGap({

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -705,7 +705,7 @@ export class TaskRunner<
 
       return {
         executionStatus,
-        executionMetrics: executionMetrics,
+        executionMetrics,
         consumerExecutionMetrics: this.ruleMonitoring.getExecutorMetrics(),
       };
     });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -637,6 +637,13 @@ export class TaskRunner<
 
       if (apm.currentTransaction) {
         apm.currentTransaction.setOutcome(outcome);
+        apm.setCustomContext({
+          execution_outcome: {
+            ...this.ruleMonitoring.getExecutorMetrics(),
+            error: executionStatus.error,
+            warning: executionStatus.warning,
+          },
+        });
       }
 
       // set start and duration based on event log

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
@@ -399,7 +399,11 @@ describe('Task Runner', () => {
         );
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-          ...generateRuleUpdateParams({})
+          ...generateRuleUpdateParams({
+            metrics: {
+              total_search_duration_ms: 23423,
+            },
+          })
         );
 
         expect(taskRunnerFactoryInitializerParams.executionContext.withContext).toBeCalledTimes(1);
@@ -534,7 +538,11 @@ describe('Task Runner', () => {
           { tags: ['1', 'test'] }
         );
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-          ...generateRuleUpdateParams({})
+          ...generateRuleUpdateParams({
+            metrics: {
+              total_search_duration_ms: 23423,
+            },
+          })
         );
         expect(taskRunnerFactoryInitializerParams.executionContext.withContext).toBeCalledTimes(1);
         expect(
@@ -736,7 +744,11 @@ describe('Task Runner', () => {
         });
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-          ...generateRuleUpdateParams({})
+          ...generateRuleUpdateParams({
+            metrics: {
+              total_search_duration_ms: 23423,
+            },
+          })
         );
 
         expect(taskRunnerFactoryInitializerParams.executionContext.withContext).toBeCalledTimes(1);
@@ -827,7 +839,11 @@ describe('Task Runner', () => {
         });
 
         expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledWith(
-          ...generateRuleUpdateParams({})
+          ...generateRuleUpdateParams({
+            metrics: {
+              total_search_duration_ms: 23423,
+            },
+          })
         );
 
         expect(taskRunnerFactoryInitializerParams.executionContext.withContext).toBeCalledTimes(1);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -279,8 +279,7 @@ describe('Task Runner Cancel', () => {
                   metrics: {
                     duration: 0,
                     gap_duration_s: null,
-                    // TODO: uncomment after intermidiate release
-                    // gap_range: null,
+                    gap_range: null,
                     total_alerts_created: null,
                     total_alerts_detected: null,
                     total_indexing_duration_ms: null,

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -451,6 +451,20 @@ export type RulesSettingsClientApi = PublicMethodsOf<RulesSettingsClient>;
 export type RulesSettingsFlappingClientApi = PublicMethodsOf<RulesSettingsFlappingClient>;
 export type RulesSettingsQueryDelayClientApi = PublicMethodsOf<RulesSettingsQueryDelayClient>;
 
+export interface ConsumerExecutionMetrics {
+  total_search_duration_ms: number;
+  total_indexing_duration_ms: number;
+  total_alerts_detected: number;
+  total_alerts_created: number;
+  gap_duration_s: number;
+  gap_range: { lte: string; gte: string };
+  events_found_count: number;
+  candidate_alerts_count: number;
+  unaccounted_events: number;
+  suppressed_alerts: number;
+  frozen_indices_queried_count: number;
+}
+
 export interface PublicMetricsSetters {
   setLastRunMetricsTotalSearchDurationMs: (totalSearchDurationMs: number) => void;
   setLastRunMetricsTotalIndexingDurationMs: (totalIndexingDurationMs: number) => void;
@@ -458,6 +472,11 @@ export interface PublicMetricsSetters {
   setLastRunMetricsTotalAlertsCreated: (totalAlertCreated: number) => void;
   setLastRunMetricsGapDurationS: (gapDurationS: number) => void;
   setLastRunMetricsGapRange: (gapRange: { lte: string; gte: string } | null) => void;
+  setMetric: <MetricName extends keyof ConsumerExecutionMetrics>(
+    metricName: MetricName,
+    value: ConsumerExecutionMetrics[MetricName]
+  ) => void;
+  setMetrics: (metrics: Partial<ConsumerExecutionMetrics>) => void;
 }
 
 export interface PublicLastRunSetters {

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -464,12 +464,7 @@ export interface ConsumerExecutionMetrics {
   indices_found_count: number;
 }
 
-export interface ConsumerRuleExecutionContext {
-  ruleUuid: string;
-}
-
 export interface PublicRuleMonitoringService {
-  setContext: (context: Partial<ConsumerRuleExecutionContext>) => void;
   setMetric: <MetricName extends keyof ConsumerExecutionMetrics>(
     metricName: MetricName,
     value: ConsumerExecutionMetrics[MetricName]

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -458,9 +458,7 @@ export interface ConsumerExecutionMetrics {
   total_alerts_created: number;
   gap_duration_s: number;
   gap_range: { lte: string; gte: string };
-  events_found_count: number;
   candidate_alerts_count: number;
-  unaccounted_events: number;
   suppressed_alerts: number;
   frozen_indices_queried_count: number;
   indices_found_count: number;

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -453,6 +453,7 @@ export type RulesSettingsQueryDelayClientApi = PublicMethodsOf<RulesSettingsQuer
 
 export interface ConsumerExecutionMetrics {
   total_indexing_duration_ms: number;
+  total_enrichment_duration_ms: number;
   gap_duration_s: number;
   gap_range: { lte: string; gte: string };
   candidate_alerts_count: number;

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -464,7 +464,13 @@ export interface ConsumerExecutionMetrics {
   indices_found_count: number;
 }
 
+export interface ConsumerRuleExecutionContext {
+  ruleUuid: string;
+  ruleRevision: number;
+}
+
 export interface PublicRuleMonitoringService {
+  setContext: (context: Partial<ConsumerRuleExecutionContext>) => void;
   setMetric: <MetricName extends keyof ConsumerExecutionMetrics>(
     metricName: MetricName,
     value: ConsumerExecutionMetrics[MetricName]

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -456,8 +456,8 @@ export interface ConsumerExecutionMetrics {
   total_enrichment_duration_ms: number;
   gap_duration_s: number;
   gap_range: { lte: string; gte: string };
-  candidate_alerts_count: number;
-  suppressed_alerts: number;
+  alerts_candidate_count: number;
+  alerts_suppressed_count: number;
   frozen_indices_queried_count: number;
 }
 

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -466,18 +466,13 @@ export interface ConsumerExecutionMetrics {
   indices_found_count: number;
 }
 
-export interface PublicMetricsSetters {
-  setLastRunMetricsTotalSearchDurationMs: (totalSearchDurationMs: number) => void;
-  setLastRunMetricsTotalIndexingDurationMs: (totalIndexingDurationMs: number) => void;
-  setLastRunMetricsTotalAlertsDetected: (totalAlertDetected: number) => void;
-  setLastRunMetricsTotalAlertsCreated: (totalAlertCreated: number) => void;
-  setLastRunMetricsGapDurationS: (gapDurationS: number) => void;
-  setLastRunMetricsGapRange: (gapRange: { lte: string; gte: string } | null) => void;
+export interface PublicRuleMonitoringService {
   setMetric: <MetricName extends keyof ConsumerExecutionMetrics>(
     metricName: MetricName,
     value: ConsumerExecutionMetrics[MetricName]
   ) => void;
   setMetrics: (metrics: Partial<ConsumerExecutionMetrics>) => void;
+  clearGapRange: () => void;
 }
 
 export interface PublicLastRunSetters {
@@ -485,8 +480,6 @@ export interface PublicLastRunSetters {
   addLastRunWarning: (outcomeMsg: string) => void;
   setLastRunOutcomeMessage: (warning: string) => void;
 }
-
-export type PublicRuleMonitoringService = PublicMetricsSetters;
 
 export type PublicRuleResultService = PublicLastRunSetters;
 

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -466,7 +466,6 @@ export interface ConsumerExecutionMetrics {
 
 export interface ConsumerRuleExecutionContext {
   ruleUuid: string;
-  ruleRevision: number;
 }
 
 export interface PublicRuleMonitoringService {

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -452,16 +452,12 @@ export type RulesSettingsFlappingClientApi = PublicMethodsOf<RulesSettingsFlappi
 export type RulesSettingsQueryDelayClientApi = PublicMethodsOf<RulesSettingsQueryDelayClient>;
 
 export interface ConsumerExecutionMetrics {
-  total_search_duration_ms: number;
   total_indexing_duration_ms: number;
-  total_alerts_detected: number;
-  total_alerts_created: number;
   gap_duration_s: number;
   gap_range: { lte: string; gte: string };
   candidate_alerts_count: number;
   suppressed_alerts: number;
   frozen_indices_queried_count: number;
-  indices_found_count: number;
 }
 
 export interface PublicRuleMonitoringService {

--- a/x-pack/platform/plugins/shared/alerting/server/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/types.ts
@@ -463,6 +463,7 @@ export interface ConsumerExecutionMetrics {
   unaccounted_events: number;
   suppressed_alerts: number;
   frozen_indices_queried_count: number;
+  indices_found_count: number;
 }
 
 export interface PublicMetricsSetters {

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -489,6 +489,40 @@
                                                 },
                                                 "update_alerts_duration_ms": {
                                                     "type": "long"
+                                                },
+                                                "events_found_count": {
+                                                    "type": "long"
+                                                },
+                                                "candidate_alerts_count": {
+                                                    "type": "long"
+                                                },
+                                                "unaccounted_events": {
+                                                    "type": "long"
+                                                },
+                                                "suppressed_alerts": {
+                                                    "type": "long"
+                                                }
+                                            }
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "@timestamp": {
+                                                    "type": "date"
+                                                },
+                                                "message": {
+                                                    "norms": false,
+                                                    "type": "text"
+                                                }
+                                            }
+                                        },
+                                        "warnings": {
+                                            "properties": {
+                                                "@timestamp": {
+                                                    "type": "date"
+                                                },
+                                                "message": {
+                                                    "norms": false,
+                                                    "type": "text"
                                                 }
                                             }
                                         }

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -505,10 +505,8 @@
                                             }
                                         },
                                         "errors": {
+                                            "type": "nested",
                                             "properties": {
-                                                "@timestamp": {
-                                                    "type": "date"
-                                                },
                                                 "message": {
                                                     "norms": false,
                                                     "type": "text"
@@ -516,10 +514,8 @@
                                             }
                                         },
                                         "warnings": {
+                                            "type": "nested",
                                             "properties": {
-                                                "@timestamp": {
-                                                    "type": "date"
-                                                },
                                                 "message": {
                                                     "norms": false,
                                                     "type": "text"

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -432,6 +432,12 @@
                                                         },
                                                         "recovered": {
                                                             "type": "long"
+                                                        },
+                                                        "candidates": {
+                                                            "type": "long"
+                                                        },
+                                                        "suppressed": {
+                                                            "type": "long"
                                                         }
                                                     }
                                                 },
@@ -493,13 +499,7 @@
                                                 "events_found_count": {
                                                     "type": "long"
                                                 },
-                                                "candidate_alerts_count": {
-                                                    "type": "long"
-                                                },
                                                 "unaccounted_events": {
-                                                    "type": "long"
-                                                },
-                                                "suppressed_alerts": {
                                                     "type": "long"
                                                 }
                                             }

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -432,12 +432,6 @@
                                                         },
                                                         "recovered": {
                                                             "type": "long"
-                                                        },
-                                                        "candidates": {
-                                                            "type": "long"
-                                                        },
-                                                        "suppressed": {
-                                                            "type": "long"
                                                         }
                                                     }
                                                 },
@@ -494,6 +488,12 @@
                                                     "type": "long"
                                                 },
                                                 "update_alerts_duration_ms": {
+                                                    "type": "long"
+                                                },
+                                                "alerts_candidate_count": {
+                                                    "type": "long"
+                                                },
+                                                "alerts_suppressed_count": {
                                                     "type": "long"
                                                 }
                                             }

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -495,12 +495,6 @@
                                                 },
                                                 "update_alerts_duration_ms": {
                                                     "type": "long"
-                                                },
-                                                "events_found_count": {
-                                                    "type": "long"
-                                                },
-                                                "unaccounted_events": {
-                                                    "type": "long"
                                                 }
                                             }
                                         }

--- a/x-pack/platform/plugins/shared/event_log/generated/mappings.json
+++ b/x-pack/platform/plugins/shared/event_log/generated/mappings.json
@@ -503,24 +503,6 @@
                                                     "type": "long"
                                                 }
                                             }
-                                        },
-                                        "errors": {
-                                            "type": "nested",
-                                            "properties": {
-                                                "message": {
-                                                    "norms": false,
-                                                    "type": "text"
-                                                }
-                                            }
-                                        },
-                                        "warnings": {
-                                            "type": "nested",
-                                            "properties": {
-                                                "message": {
-                                                    "norms": false,
-                                                    "type": "text"
-                                                }
-                                            }
                                         }
                                     }
                                 },

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -216,16 +216,18 @@ export const EventSchema = schema.maybe(
                       })
                     ),
                     errors: schema.maybe(
-                      schema.object({
-                        '@timestamp': ecsDate(),
-                        message: ecsString(),
-                      })
+                      schema.arrayOf(
+                        schema.object({
+                          message: ecsString(),
+                        })
+                      )
                     ),
                     warnings: schema.maybe(
-                      schema.object({
-                        '@timestamp': ecsDate(),
-                        message: ecsString(),
-                      })
+                      schema.arrayOf(
+                        schema.object({
+                          message: ecsString(),
+                        })
+                      )
                     ),
                   })
                 ),

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -213,7 +213,7 @@ export const EventSchema = schema.maybe(
                         candidate_alerts_count: ecsStringOrNumber(),
                         unaccounted_events: ecsStringOrNumber(),
                         suppressed_alerts: ecsStringOrNumber(),
-                      }, { unknowns: 'allow' })
+                      })
                     ),
                     errors: schema.maybe(
                       schema.object({

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -209,6 +209,22 @@ export const EventSchema = schema.maybe(
                         total_run_duration_ms: ecsStringOrNumber(),
                         total_enrichment_duration_ms: ecsStringOrNumber(),
                         update_alerts_duration_ms: ecsStringOrNumber(),
+                        events_found_count: ecsStringOrNumber(),
+                        candidate_alerts_count: ecsStringOrNumber(),
+                        unaccounted_events: ecsStringOrNumber(),
+                        suppressed_alerts: ecsStringOrNumber(),
+                      }, { unknowns: 'allow' })
+                    ),
+                    errors: schema.maybe(
+                      schema.object({
+                        '@timestamp': ecsDate(),
+                        message: ecsString(),
+                      })
+                    ),
+                    warnings: schema.maybe(
+                      schema.object({
+                        '@timestamp': ecsDate(),
+                        message: ecsString(),
                       })
                     ),
                   })

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -189,6 +189,8 @@ export const EventSchema = schema.maybe(
                             active: ecsStringOrNumber(),
                             new: ecsStringOrNumber(),
                             recovered: ecsStringOrNumber(),
+                            candidates: ecsStringOrNumber(),
+                            suppressed: ecsStringOrNumber(),
                           })
                         ),
                         number_of_delayed_alerts: ecsStringOrNumber(),
@@ -210,9 +212,7 @@ export const EventSchema = schema.maybe(
                         total_enrichment_duration_ms: ecsStringOrNumber(),
                         update_alerts_duration_ms: ecsStringOrNumber(),
                         events_found_count: ecsStringOrNumber(),
-                        candidate_alerts_count: ecsStringOrNumber(),
                         unaccounted_events: ecsStringOrNumber(),
-                        suppressed_alerts: ecsStringOrNumber(),
                       })
                     ),
                     errors: schema.maybe(

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -211,8 +211,6 @@ export const EventSchema = schema.maybe(
                         total_run_duration_ms: ecsStringOrNumber(),
                         total_enrichment_duration_ms: ecsStringOrNumber(),
                         update_alerts_duration_ms: ecsStringOrNumber(),
-                        events_found_count: ecsStringOrNumber(),
-                        unaccounted_events: ecsStringOrNumber(),
                       })
                     ),
                   })

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -215,20 +215,6 @@ export const EventSchema = schema.maybe(
                         unaccounted_events: ecsStringOrNumber(),
                       })
                     ),
-                    errors: schema.maybe(
-                      schema.arrayOf(
-                        schema.object({
-                          message: ecsString(),
-                        })
-                      )
-                    ),
-                    warnings: schema.maybe(
-                      schema.arrayOf(
-                        schema.object({
-                          message: ecsString(),
-                        })
-                      )
-                    ),
                   })
                 ),
                 revision: ecsStringOrNumber(),

--- a/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
+++ b/x-pack/platform/plugins/shared/event_log/generated/schemas.ts
@@ -189,8 +189,6 @@ export const EventSchema = schema.maybe(
                             active: ecsStringOrNumber(),
                             new: ecsStringOrNumber(),
                             recovered: ecsStringOrNumber(),
-                            candidates: ecsStringOrNumber(),
-                            suppressed: ecsStringOrNumber(),
                           })
                         ),
                         number_of_delayed_alerts: ecsStringOrNumber(),
@@ -211,6 +209,8 @@ export const EventSchema = schema.maybe(
                         total_run_duration_ms: ecsStringOrNumber(),
                         total_enrichment_duration_ms: ecsStringOrNumber(),
                         update_alerts_duration_ms: ecsStringOrNumber(),
+                        alerts_candidate_count: ecsStringOrNumber(),
+                        alerts_suppressed_count: ecsStringOrNumber(),
                       })
                     ),
                   })

--- a/x-pack/platform/plugins/shared/event_log/scripts/create_schemas.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/create_schemas.js
@@ -203,8 +203,7 @@ function generateSchemaLines(lineWriter, prop, mappings) {
   }
   lineWriter.dedent();
 
-  // Allow custom unmapped metrics
-  lineWriter.addLine(prop === 'metrics' ? "}, { unknowns: 'allow' })" : '})');
+  lineWriter.addLine('})');
   if (mappings.type === 'nested') {
     lineWriter.dedent();
     lineWriter.addLine(')');

--- a/x-pack/platform/plugins/shared/event_log/scripts/create_schemas.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/create_schemas.js
@@ -203,7 +203,8 @@ function generateSchemaLines(lineWriter, prop, mappings) {
   }
   lineWriter.dedent();
 
-  lineWriter.addLine('})');
+  // Allow custom unmapped metrics
+  lineWriter.addLine(prop === 'metrics' ? "}, { unknowns: 'allow' })" : '})');
   if (mappings.type === 'nested') {
     lineWriter.dedent();
     lineWriter.addLine(')');

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -256,6 +256,40 @@ exports.EcsCustomPropertyMappings = {
                       update_alerts_duration_ms: {
                         type: 'long',
                       },
+                      events_found_count: {
+                        type: 'long',
+                      },
+                      candidate_alerts_count: {
+                        type: 'long',
+                      },
+                      unaccounted_events: {
+                        type: 'long',
+                      },
+                      suppressed_alerts: {
+                        type: 'long',
+                      },
+                    },
+                  },
+                  errors: {
+                    properties: {
+                      '@timestamp': {
+                        type: 'date',
+                      },
+                      message: {
+                        norms: false,
+                        type: 'text',
+                      },
+                    },
+                  },
+                  warnings: {
+                    properties: {
+                      '@timestamp': {
+                        type: 'date',
+                      },
+                      message: {
+                        norms: false,
+                        type: 'text',
+                      },
                     },
                   },
                 },

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -271,10 +271,8 @@ exports.EcsCustomPropertyMappings = {
                     },
                   },
                   errors: {
+                    type: 'nested',
                     properties: {
-                      '@timestamp': {
-                        type: 'date',
-                      },
                       message: {
                         norms: false,
                         type: 'text',
@@ -282,10 +280,8 @@ exports.EcsCustomPropertyMappings = {
                     },
                   },
                   warnings: {
+                    type: 'nested',
                     properties: {
-                      '@timestamp': {
-                        type: 'date',
-                      },
                       message: {
                         norms: false,
                         type: 'text',

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -199,12 +199,6 @@ exports.EcsCustomPropertyMappings = {
                           recovered: {
                             type: 'long',
                           },
-                          candidates: {
-                            type: 'long',
-                          },
-                          suppressed: {
-                            type: 'long',
-                          },
                         },
                       },
                       number_of_delayed_alerts: {
@@ -260,6 +254,12 @@ exports.EcsCustomPropertyMappings = {
                         type: 'long',
                       },
                       update_alerts_duration_ms: {
+                        type: 'long',
+                      },
+                      alerts_candidate_count: {
+                        type: 'long',
+                      },
+                      alerts_suppressed_count: {
                         type: 'long',
                       },
                     },

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -262,12 +262,6 @@ exports.EcsCustomPropertyMappings = {
                       update_alerts_duration_ms: {
                         type: 'long',
                       },
-                      events_found_count: {
-                        type: 'long',
-                      },
-                      unaccounted_events: {
-                        type: 'long',
-                      },
                     },
                   },
                 },

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -270,24 +270,6 @@ exports.EcsCustomPropertyMappings = {
                       },
                     },
                   },
-                  errors: {
-                    type: 'nested',
-                    properties: {
-                      message: {
-                        norms: false,
-                        type: 'text',
-                      },
-                    },
-                  },
-                  warnings: {
-                    type: 'nested',
-                    properties: {
-                      message: {
-                        norms: false,
-                        type: 'text',
-                      },
-                    },
-                  },
                 },
               },
               revision: {

--- a/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
+++ b/x-pack/platform/plugins/shared/event_log/scripts/mappings.js
@@ -199,6 +199,12 @@ exports.EcsCustomPropertyMappings = {
                           recovered: {
                             type: 'long',
                           },
+                          candidates: {
+                            type: 'long',
+                          },
+                          suppressed: {
+                            type: 'long',
+                          },
                         },
                       },
                       number_of_delayed_alerts: {
@@ -259,13 +265,7 @@ exports.EcsCustomPropertyMappings = {
                       events_found_count: {
                         type: 'long',
                       },
-                      candidate_alerts_count: {
-                        type: 'long',
-                      },
                       unaccounted_events: {
-                        type: 'long',
-                      },
-                      suppressed_alerts: {
                         type: 'long',
                       },
                     },

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
@@ -59,6 +59,7 @@ export interface FixtureStartDeps {
 const testRuleTypes = [
   'test.always-firing',
   'test.cumulative-firing',
+  'test.consumer-metrics',
   'test.never-firing',
   'test.failing',
   'test.authorization',

--- a/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+++ b/x-pack/platform/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
@@ -195,6 +195,48 @@ function getCumulativeFiringRuleType() {
   return result;
 }
 
+function getConsumerMetricsRuleType() {
+  const paramsSchema = schema.object({
+    index: schema.string(),
+    reference: schema.string(),
+  });
+  type ParamsType = TypeOf<typeof paramsSchema>;
+  const result: RuleType<ParamsType, never, {}, {}, {}, 'default'> = {
+    id: 'test.consumer-metrics',
+    name: 'Test: Consumer metrics',
+    actionGroups: [{ id: 'default', name: 'Default' }],
+    category: 'kibana',
+    producer: 'alertsFixture',
+    solution: 'stack',
+    defaultActionGroupId: 'default',
+    minimumLicenseRequired: 'basic',
+    isExportable: true,
+    autoRecoverAlerts: false,
+    async executor({ services, params }) {
+      services.ruleMonitoringService?.setMetrics({
+        alerts_candidate_count: 90357,
+        alerts_suppressed_count: 42,
+        total_indexing_duration_ms: 987,
+        total_enrichment_duration_ms: 654,
+        frozen_indices_queried_count: 3,
+      });
+      await services.scopedClusterClient.asCurrentUser.index({
+        index: params.index,
+        refresh: 'wait_for',
+        document: {
+          reference: params.reference,
+          source: 'alert:test.consumer-metrics',
+        },
+      });
+      return { state: {} };
+    },
+    validate: {
+      params: paramsSchema,
+    },
+  };
+  return result;
+}
+
 function getNeverFiringRuleType() {
   const paramsSchema = schema.object({
     index: schema.string(),
@@ -1750,6 +1792,7 @@ export function defineRuleTypes(
 
   alerting.registerType(getAlwaysFiringRuleType());
   alerting.registerType(getCumulativeFiringRuleType());
+  alerting.registerType(getConsumerMetricsRuleType());
   alerting.registerType(getNeverFiringRuleType());
   alerting.registerType(getFailingRuleType());
   alerting.registerType(getValidationRuleType());

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/consumer_metrics_backfill.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/consumer_metrics_backfill.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import moment from 'moment';
+import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
+import { waitForEventLogDocs } from './test_utils';
+import { SuperuserAtSpace1 } from '../../../../scenarios';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+
+const EXPECTED_CONSUMER_METRICS = {
+  alerts_candidate_count: 90357,
+  alerts_suppressed_count: 42,
+  total_indexing_duration_ms: 987,
+  total_enrichment_duration_ms: 654,
+  frozen_indices_queried_count: 3,
+} as const;
+
+export default function consumerMetricsBackfillTests({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const retry = getService('retry');
+  const esTestIndexTool = new ESTestIndexTool(es, retry);
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const supertest = getService('supertest');
+  const objectRemover = new ObjectRemover(supertest);
+
+  describe('consumer metrics on execute-backfill events', () => {
+    let backfillId: string | undefined;
+
+    beforeEach(async () => {
+      backfillId = undefined;
+      await esTestIndexTool.destroy();
+      await esTestIndexTool.setup();
+    });
+
+    afterEach(async () => {
+      if (backfillId) {
+        await supertest
+          .delete(
+            `${getUrlPrefix(
+              SuperuserAtSpace1.space.id
+            )}/internal/alerting/rules/backfill/${backfillId}`
+          )
+          .set('kbn-xsrf', 'foo');
+      }
+      await objectRemover.removeAll();
+      await esTestIndexTool.destroy();
+    });
+
+    it('writes consumer metrics from the rule executor to execute-backfill events', async () => {
+      const spaceId = SuperuserAtSpace1.space.id;
+
+      const response1 = await supertestWithoutAuth
+        .post(`${getUrlPrefix(spaceId)}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .auth(SuperuserAtSpace1.user.username, SuperuserAtSpace1.user.password)
+        .send({
+          enabled: true,
+          name: 'consumer metrics backfill rule',
+          tags: [],
+          rule_type_id: 'test.consumer-metrics',
+          consumer: 'alertsFixture',
+          schedule: { interval: '24h' },
+          actions: [],
+          params: {
+            index: ES_TEST_INDEX_NAME,
+            reference: 'backfill-ref',
+          },
+        })
+        .expect(200);
+
+      const ruleId = response1.body.id;
+      objectRemover.add(spaceId, ruleId, 'rule', 'alerting');
+
+      const start = moment().utc().startOf('day').subtract(7, 'days').toISOString();
+      const end = moment().utc().startOf('day').subtract(1, 'day').toISOString();
+
+      const response2 = await supertestWithoutAuth
+        .post(`${getUrlPrefix(spaceId)}/internal/alerting/rules/backfill/_schedule`)
+        .set('kbn-xsrf', 'foo')
+        .auth(SuperuserAtSpace1.user.username, SuperuserAtSpace1.user.password)
+        .send([{ rule_id: ruleId, ranges: [{ start, end }] }])
+        .expect(200);
+
+      backfillId = response2.body[0].id;
+
+      const events: IValidatedEvent[] = await waitForEventLogDocs(
+        retry,
+        getService,
+        backfillId as string,
+        spaceId,
+        new Map([['execute-backfill', { gte: 1 }]])
+      );
+
+      const backfillEvents = events.filter((e) => e?.event?.action === 'execute-backfill');
+      expect(backfillEvents.length > 0).to.be(true);
+
+      for (const e of backfillEvents) {
+        const metrics = e?.kibana?.alert?.rule?.execution?.metrics;
+        expect(metrics?.alerts_candidate_count).to.eql(
+          EXPECTED_CONSUMER_METRICS.alerts_candidate_count
+        );
+        expect(metrics?.alerts_suppressed_count).to.eql(
+          EXPECTED_CONSUMER_METRICS.alerts_suppressed_count
+        );
+        expect(metrics?.total_indexing_duration_ms).to.eql(
+          EXPECTED_CONSUMER_METRICS.total_indexing_duration_ms
+        );
+        expect(metrics?.total_enrichment_duration_ms).to.eql(
+          EXPECTED_CONSUMER_METRICS.total_enrichment_duration_ms
+        );
+        expect(metrics?.frozen_indices_queried_count).to.eql(
+          EXPECTED_CONSUMER_METRICS.frozen_indices_queried_count
+        );
+      }
+    });
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/index.ts
@@ -16,5 +16,6 @@ export default function backfillTests({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./delete'));
     loadTestFile(require.resolve('./delete_rule'));
     loadTestFile(require.resolve('./public_api'));
+    loadTestFile(require.resolve('./consumer_metrics_backfill'));
   });
 }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/clone.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/clone.ts
@@ -169,8 +169,7 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
                         total_alerts_detected: null,
                         total_alerts_created: null,
                         gap_duration_s: null,
-                        // TODO: uncomment after intermidiate release
-                        // gap_range: null,
+                        gap_range: null,
                       },
                     },
                   },

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/user_managed_api_key.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/user_managed_api_key.ts
@@ -257,8 +257,7 @@ export default function userManagedApiKeyTest({ getService }: FtrProviderContext
                   total_alerts_detected: null,
                   total_alerts_created: null,
                   gap_duration_s: null,
-                  // TODO: uncomment after intermidiate release
-                  // gap_range: null,
+                  gap_range: null,
                 },
               },
             },
@@ -342,8 +341,7 @@ export default function userManagedApiKeyTest({ getService }: FtrProviderContext
                   total_alerts_detected: null,
                   total_alerts_created: null,
                   gap_duration_s: null,
-                  // TODO: uncomment after intermidiate release
-                  // gap_range: null,
+                  gap_range: null,
                 },
               },
             },

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring.ts
@@ -6,13 +6,16 @@
  */
 
 import expect from '@kbn/expect';
+import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { createEsDocuments } from '../create_test_data';
 
 export default function monitoringAlertTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const retry = getService('retry');
+  const es = getService('es');
 
   describe('monitoring', () => {
     const objectRemover = new ObjectRemover(supertest);
@@ -142,6 +145,63 @@ export default function monitoringAlertTests({ getService }: FtrProviderContext)
 
       getResponse.body.monitoring.run.history.forEach((history: any) => {
         expect(history.duration).to.be.a('number');
+      });
+    });
+
+    describe('last run framework metrics', () => {
+      const esTestIndexTool = new ESTestIndexTool(es, retry);
+      const RULE_INTERVAL_SECONDS = 6;
+      const RULE_INTERVALS_TO_WRITE = 5;
+      const RULE_INTERVAL_MILLIS = RULE_INTERVAL_SECONDS * 1000;
+      const ES_GROUPS_TO_WRITE = 3;
+
+      afterEach(async () => {
+        await esTestIndexTool.destroy();
+      });
+
+      it('persists total_search_duration_ms on the rule after successful rule tun', async () => {
+        await esTestIndexTool.destroy();
+        await esTestIndexTool.setup();
+
+        const endDateMillis = Date.now() + (RULE_INTERVALS_TO_WRITE - 1) * RULE_INTERVAL_MILLIS;
+        const endDate = new Date(endDateMillis).toISOString();
+
+        await createEsDocuments(
+          es,
+          esTestIndexTool,
+          endDate,
+          RULE_INTERVALS_TO_WRITE,
+          RULE_INTERVAL_MILLIS,
+          ES_GROUPS_TO_WRITE
+        );
+
+        const createResponse = await supertest
+          .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
+          .set('kbn-xsrf', 'foo')
+          .send(
+            getTestRuleData({
+              rule_type_id: 'test.cancellableRule',
+              schedule: { interval: '1h' },
+              params: {
+                doLongSearch: false,
+                doLongPostProcessing: false,
+              },
+            })
+          )
+          .expect(200);
+
+        objectRemover.add(Spaces.space1.id, createResponse.body.id, 'rule', 'alerting');
+
+        await waitForExecutionCount(1, createResponse.body.id);
+
+        const getResponse = await supertest
+          .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createResponse.body.id}`)
+          .expect(200);
+
+        const totalSearchMs =
+          getResponse.body.monitoring.run.last_run.metrics.total_search_duration_ms;
+
+        expect(totalSearchMs).to.be.greaterThan(0);
       });
     });
   });

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createTestConfig } from '../../../../common/config';
+
+export const EmailDomainsAllowed = ['example.org', 'test.com'];
+
+export default createTestConfig('spaces_only', {
+  disabledPlugins: ['security'],
+  license: 'trial',
+  enableActionsProxy: false,
+  verificationMode: 'none',
+  customizeLocalHostSsl: true,
+  preconfiguredAlertHistoryEsIndex: true,
+  emailDomainsAllowed: EmailDomainsAllowed,
+  useDedicatedTaskRunner: true,
+  testFiles: [require.resolve('.')],
+  reportName: 'X-Pack Alerting API Integration Tests - Alerting - group5',
+});

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/consumer_metrics.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/consumer_metrics.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import { Spaces } from '../../../scenarios';
+import {
+  getUrlPrefix,
+  getTestRuleData,
+  ObjectRemover,
+  getEventLog,
+  resetRulesSettings,
+} from '../../../../common/lib';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+const EXPECTED_CONSUMER_METRICS = {
+  alerts_candidate_count: 90357,
+  alerts_suppressed_count: 42,
+  total_indexing_duration_ms: 987,
+  total_enrichment_duration_ms: 654,
+  frozen_indices_queried_count: 3,
+} as const;
+
+export default function consumerMetricsEventLogTests({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const es = getService('es');
+  const esTestIndexTool = new ESTestIndexTool(es, retry);
+  const objectRemover = new ObjectRemover(supertest);
+
+  describe('consumer metrics on rule execute event', () => {
+    beforeEach(async () => {
+      await resetRulesSettings(supertest, Spaces.default.id);
+      await resetRulesSettings(supertest, Spaces.space1.id);
+      await esTestIndexTool.destroy();
+      await esTestIndexTool.setup();
+    });
+
+    afterEach(async () => {
+      await objectRemover.removeAll();
+    });
+
+    it('writes consumer metrics from the rule executor to the execute event', async () => {
+      const spaceId = Spaces.default.id;
+      const response = await supertest
+        .post(`${getUrlPrefix(spaceId)}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send(
+          getTestRuleData({
+            rule_type_id: 'test.consumer-metrics',
+            schedule: { interval: '24h' },
+            throttle: null,
+            notify_when: undefined,
+            params: {
+              index: ES_TEST_INDEX_NAME,
+              reference: 'consumer-metrics-ref',
+            },
+            actions: [],
+          })
+        )
+        .expect(200);
+
+      const ruleId = response.body.id;
+      objectRemover.add(spaceId, ruleId, 'rule', 'alerting');
+
+      const events = await retry.try(async () => {
+        return await getEventLog({
+          getService,
+          spaceId,
+          type: 'alert',
+          id: ruleId,
+          provider: 'alerting',
+          actions: new Map([
+            ['execute-start', { equal: 1 }],
+            ['execute', { equal: 1 }],
+          ]),
+        });
+      });
+
+      const executeEvent = events.find((e) => e?.event?.action === 'execute');
+      expect(executeEvent).to.be.ok();
+      const metrics = executeEvent?.kibana?.alert?.rule?.execution?.metrics;
+      expect(metrics?.alerts_candidate_count).to.eql(
+        EXPECTED_CONSUMER_METRICS.alerts_candidate_count
+      );
+      expect(metrics?.alerts_suppressed_count).to.eql(
+        EXPECTED_CONSUMER_METRICS.alerts_suppressed_count
+      );
+      expect(metrics?.total_indexing_duration_ms).to.eql(
+        EXPECTED_CONSUMER_METRICS.total_indexing_duration_ms
+      );
+      expect(metrics?.total_enrichment_duration_ms).to.eql(
+        EXPECTED_CONSUMER_METRICS.total_enrichment_duration_ms
+      );
+      expect(metrics?.frozen_indices_queried_count).to.eql(
+        EXPECTED_CONSUMER_METRICS.frozen_indices_queried_count
+      );
+    });
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group5/index.ts
@@ -12,6 +12,7 @@ export default function alertingTests({ loadTestFile, getService }: FtrProviderC
   describe('Alerting', () => {
     before(async () => await buildUp(getService));
     after(async () => await tearDown(getService));
+    loadTestFile(require.resolve('./consumer_metrics'));
     // the next file takes ~37 min to run
     loadTestFile(require.resolve('./event_log'));
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/__mocks__/index.ts
@@ -53,7 +53,6 @@ const ruleExecutionLogForExecutorsMock = {
 
     logMetric: jest.fn(),
     logMetrics: jest.fn(),
-    logExecutionResult: jest.fn(),
 
     closed: jest.fn(),
     close: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/__mocks__/index.ts
@@ -51,7 +51,12 @@ const ruleExecutionLogForExecutorsMock = {
     warn: jest.fn(),
     error: jest.fn(),
 
-    logStatusChange: jest.fn(),
+    logMetric: jest.fn(),
+    logMetrics: jest.fn(),
+    logExecutionResult: jest.fn(),
+
+    closed: jest.fn(),
+    close: jest.fn(),
   }),
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -7,10 +7,8 @@
 
 import agent from 'elastic-apm-node';
 import type { Logger } from '@kbn/core/server';
-import { sum } from 'lodash';
-import type { Duration } from 'moment';
-
 import type {
+  ConsumerExecutionMetrics,
   PublicRuleMonitoringService,
   PublicRuleResultService,
 } from '@kbn/alerting-plugin/server/types';
@@ -21,111 +19,201 @@ import type {
 } from '../../../../../../../common/api/detection_engine/rule_monitoring';
 import {
   consoleLogLevelFromExecutionStatus,
-  LogLevelSetting,
-  logLevelToNumber,
   RuleExecutionStatusEnum,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-
 import { assertUnreachable } from '../../../../../../../common/utility_types';
 import { withSecuritySpan } from '../../../../../../utils/with_security_span';
 import type { ExtMeta } from '../../utils/console_logging';
 import { truncateValue } from '../../utils/normalization';
+import type { ExecutionResultLogEntry, IEventLogWriter } from '../event_log/event_log_writer';
+import type { RuleExecutionMetrics } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
+import {
+  LogLevelEnum,
+  LogLevelSetting,
+  logLevelToNumber,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
+import { SECURITY_RULE_STATUS } from '../../../../rule_types/utils/apm_field_names';
+import type { IRuleExecutionLogForExecutors, RuleExecutionContext } from './client_interface';
 import { getCorrelationIds } from './correlation_ids';
 
-import type { IEventLogWriter } from '../event_log/event_log_writer';
-import type {
-  IRuleExecutionLogForExecutors,
-  LogMessageOptions,
-  RuleExecutionContext,
-  StatusChangeArgs,
-} from './client_interface';
-import type { RuleExecutionMetrics } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
-import { LogLevelEnum } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
-import { SECURITY_RULE_STATUS } from '../../../../rule_types/utils/apm_field_names';
-
-export const createRuleExecutionLogClientForExecutors = (
+export function createRuleExecutionLogClientForExecutors(
   settings: RuleExecutionSettings,
   eventLog: IEventLogWriter,
   logger: Logger,
   context: RuleExecutionContext,
   ruleMonitoringService: PublicRuleMonitoringService,
   ruleResultService: PublicRuleResultService
-): IRuleExecutionLogForExecutors => {
+): IRuleExecutionLogForExecutors {
   const baseCorrelationIds = getCorrelationIds(context);
   const baseLogSuffix = baseCorrelationIds.getLogSuffix();
-  const baseLogMeta = baseCorrelationIds.getLogMeta();
-
   const { executionId, ruleId, ruleUuid, ruleName, ruleRevision, ruleType, spaceId } = context;
 
-  const client: IRuleExecutionLogForExecutors = {
+  // Buffers the execution related data
+  const executionResultBuffer: ExecutionResultBuffer = {
+    errors: [],
+    warnings: [],
+    executionResult: undefined,
+    closed: false,
+  };
+
+  const ruleExecutionLogClient: IRuleExecutionLogForExecutors = {
     get context() {
       return context;
     },
 
-    trace(message: string, options?: LogMessageOptions): void {
-      writeMessage(message, {
-        eventLogLevel: LogLevelEnum.trace,
-        consoleLogLevel: options?.consoleLogLevel ?? LogLevelEnum.trace,
+    trace(message: string): void {
+      writeMessageToEventLog(message, LogLevelEnum.trace);
+    },
+
+    debug(message: string): void {
+      writeMessageToEventLog(message, LogLevelEnum.debug);
+    },
+
+    info(message: string): void {
+      writeMessageToEventLog(message, LogLevelEnum.info);
+    },
+
+    warn(message: string): void {
+      if (this.closed()) {
+        throw new Error('The logger has been closed');
+      }
+
+      executionResultBuffer.warnings.push({
+        timestamp: new Date().toISOString(),
+        message,
       });
     },
 
-    debug(message: string, options?: LogMessageOptions): void {
-      writeMessage(message, {
-        eventLogLevel: LogLevelEnum.debug,
-        consoleLogLevel: options?.consoleLogLevel ?? LogLevelEnum.debug,
+    error(message: string): void {
+      if (this.closed()) {
+        throw new Error('The logger has been closed');
+      }
+
+      executionResultBuffer.warnings.push({
+        timestamp: new Date().toISOString(),
+        message,
       });
     },
 
-    info(message: string, options?: LogMessageOptions): void {
-      writeMessage(message, {
-        eventLogLevel: LogLevelEnum.info,
-        consoleLogLevel: options?.consoleLogLevel,
-      });
+    logMetric<Metric extends keyof ConsumerExecutionMetrics>(
+      metricName: Metric,
+      value: ConsumerExecutionMetrics[Metric]
+    ): void {
+      if (this.closed() || value === undefined) {
+        return;
+      }
+
+      ruleMonitoringService.setMetric(metricName, value);
     },
 
-    warn(message: string, options?: LogMessageOptions): void {
-      writeMessage(message, {
-        eventLogLevel: LogLevelEnum.warn,
-        consoleLogLevel: options?.consoleLogLevel,
-      });
+    logMetrics(metrics: Partial<ConsumerExecutionMetrics>): void {
+      if (this.closed()) {
+        return;
+      }
+
+      ruleMonitoringService.setMetrics(metrics);
     },
 
-    error(message: string, options?: LogMessageOptions): void {
-      writeMessage(message, {
-        eventLogLevel: LogLevelEnum.error,
-        consoleLogLevel: options?.consoleLogLevel,
-      });
+    logExecutionResult(args: ExecutionOutcome): void {
+      executionResultBuffer.executionResult = args;
     },
 
-    async logStatusChange(args: StatusChangeArgs): Promise<void> {
-      await withSecuritySpan('IRuleExecutionLogForExecutors.logStatusChange', async () => {
-        const correlationIds = baseCorrelationIds.withStatus(args.newStatus);
+    closed(): boolean {
+      return executionResultBuffer.closed;
+    },
+
+    async close(): Promise<void> {
+      const executionResult = executionResultBuffer.executionResult;
+
+      if (!executionResult) {
+        throw new Error(
+          'Rule execution result must be set before closing the rule execution log client'
+        );
+      }
+
+      if (this.closed()) {
+        throw new Error('The logger has been closed');
+      }
+
+      executionResultBuffer.closed = true;
+
+      await withSecuritySpan('IRuleExecutionLogForExecutors.close', async () => {
+        const correlationIds = baseCorrelationIds.withStatus(executionResult.outcome);
         const logMeta = correlationIds.getLogMeta();
 
-        agent.addLabels({ [SECURITY_RULE_STATUS]: args.newStatus });
+        agent.addLabels({ [SECURITY_RULE_STATUS]: executionResult.outcome });
 
         try {
-          const normalizedArgs = normalizeStatusChangeArgs(args);
+          const executionOutcome: ExecutionOutcome = {
+            outcome: executionResult.outcome,
+            message: truncateValue(executionResult.message) ?? '',
+            userError: executionResult.userError,
+          };
 
           await Promise.all([
-            writeStatusChangeToConsole(normalizedArgs, logMeta),
-            writeStatusChangeToRuleObject(normalizedArgs),
-            writeStatusChangeToEventLog(normalizedArgs),
+            writeExecutionResultToConsole(executionOutcome, logMeta),
+            writeExecutionResultToRuleObject(executionOutcome),
           ]);
         } catch (e) {
-          const logMessage = `Error changing rule status to "${args.newStatus}"`;
+          const logMessage = `Error logging execution result with outcome "${executionResult.outcome}"`;
           writeExceptionToConsole(e, logMessage, logMeta);
         }
       });
     },
   };
 
-  const writeMessage = (
-    message: string,
-    levels: { eventLogLevel: LogLevel; consoleLogLevel?: LogLevel }
-  ): void => {
-    writeMessageToConsole(message, levels.consoleLogLevel ?? LogLevelEnum.debug, baseLogMeta);
-    writeMessageToEventLog(message, levels.eventLogLevel);
+  const writeExceptionToConsole = (e: unknown, message: string, logMeta: ExtMeta): void => {
+    const logReason = e instanceof Error ? e.stack ?? e.message : String(e);
+    writeMessageToConsole(`${message}. Reason: ${logReason}`, LogLevelEnum.error, logMeta);
+  };
+
+  const writeExecutionResultToConsole = (args: ExecutionOutcome, logMeta: ExtMeta): void => {
+    const messageParts: string[] = [`Changing rule status to "${args.outcome}"`, args.message];
+    const logMessage = messageParts.filter(Boolean).join('. ');
+    const logLevel = consoleLogLevelFromExecutionStatus(args.outcome, args.userError);
+
+    writeMessageToConsole(logMessage, logLevel, logMeta);
+  };
+
+  const writeExecutionResultToRuleObject = async (args: ExecutionOutcome): Promise<void> => {
+    const { outcome, message, userError } = args;
+
+    if (outcome === RuleExecutionStatusEnum.running) {
+      return;
+    }
+
+    if (outcome === RuleExecutionStatusEnum.failed) {
+      ruleResultService.addLastRunError(message, userError ?? false);
+    } else if (outcome === RuleExecutionStatusEnum['partial failure']) {
+      ruleResultService.addLastRunWarning(message);
+    }
+
+    ruleResultService.setLastRunOutcomeMessage(message);
+  };
+
+  const writeMessageToEventLog = (message: string, logLevel: LogLevel): void => {
+    const { isEnabled, minLevel } = settings.extendedLogging;
+
+    if (!isEnabled || minLevel === LogLevelSetting.off) {
+      return;
+    }
+    if (logLevelToNumber(logLevel) < logLevelToNumber(minLevel)) {
+      return;
+    }
+
+    eventLog.logMessage({
+      ruleInfo: {
+        ruleId,
+        ruleUuid,
+        ruleName,
+        ruleRevision,
+        ruleType,
+        spaceId,
+        executionId,
+      },
+      message,
+      logLevel,
+    });
   };
 
   const writeMessageToConsole = (message: string, logLevel: LogLevel, logMeta: ExtMeta): void => {
@@ -150,154 +238,19 @@ export const createRuleExecutionLogClientForExecutors = (
     }
   };
 
-  const writeMessageToEventLog = (message: string, logLevel: LogLevel): void => {
-    const { isEnabled, minLevel } = settings.extendedLogging;
+  return ruleExecutionLogClient;
+}
 
-    if (!isEnabled || minLevel === LogLevelSetting.off) {
-      return;
-    }
-    if (logLevelToNumber(logLevel) < logLevelToNumber(minLevel)) {
-      return;
-    }
-
-    eventLog.logMessage({
-      ruleId,
-      ruleUuid,
-      ruleName,
-      ruleRevision,
-      ruleType,
-      spaceId,
-      executionId,
-      message,
-      logLevel,
-    });
-  };
-
-  const writeExceptionToConsole = (e: unknown, message: string, logMeta: ExtMeta): void => {
-    const logReason = e instanceof Error ? e.stack ?? e.message : String(e);
-    writeMessageToConsole(`${message}. Reason: ${logReason}`, LogLevelEnum.error, logMeta);
-  };
-
-  const writeStatusChangeToConsole = (args: NormalizedStatusChangeArgs, logMeta: ExtMeta): void => {
-    const messageParts: string[] = [`Changing rule status to "${args.newStatus}"`, args.message];
-    const logMessage = messageParts.filter(Boolean).join('. ');
-    const logLevel = consoleLogLevelFromExecutionStatus(args.newStatus, args.userError);
-    writeMessageToConsole(logMessage, logLevel, logMeta);
-  };
-
-  const writeStatusChangeToRuleObject = async (args: NormalizedStatusChangeArgs): Promise<void> => {
-    const { newStatus, message, metrics, userError } = args;
-
-    if (newStatus === RuleExecutionStatusEnum.running) {
-      return;
-    }
-
-    const {
-      total_search_duration_ms: totalSearchDurationMs,
-      total_indexing_duration_ms: totalIndexingDurationMs,
-      execution_gap_duration_s: executionGapDurationS,
-      gap_range: gapRange,
-    } = metrics ?? {};
-
-    if (totalSearchDurationMs) {
-      ruleMonitoringService.setLastRunMetricsTotalSearchDurationMs(totalSearchDurationMs);
-    }
-
-    if (totalIndexingDurationMs) {
-      ruleMonitoringService.setLastRunMetricsTotalIndexingDurationMs(totalIndexingDurationMs);
-    }
-
-    if (executionGapDurationS) {
-      ruleMonitoringService.setLastRunMetricsGapDurationS(executionGapDurationS);
-    }
-
-    if (gapRange) {
-      ruleMonitoringService.setLastRunMetricsGapRange(gapRange);
-    }
-
-    if (newStatus === RuleExecutionStatusEnum.failed) {
-      ruleResultService.addLastRunError(message, userError ?? false);
-    } else if (newStatus === RuleExecutionStatusEnum['partial failure']) {
-      ruleResultService.addLastRunWarning(message);
-    }
-
-    ruleResultService.setLastRunOutcomeMessage(message);
-  };
-
-  const writeStatusChangeToEventLog = (args: NormalizedStatusChangeArgs): void => {
-    const { newStatus, message, metrics } = args;
-
-    if (metrics) {
-      eventLog.logExecutionMetrics({
-        ruleId,
-        ruleUuid,
-        ruleName,
-        ruleRevision,
-        ruleType,
-        spaceId,
-        executionId,
-        metrics,
-      });
-    }
-
-    eventLog.logStatusChange({
-      ruleId,
-      ruleUuid,
-      ruleName,
-      ruleRevision,
-      ruleType,
-      spaceId,
-      executionId,
-      newStatus,
-      message,
-    });
-  };
-
-  return client;
-};
-
-interface NormalizedStatusChangeArgs {
-  newStatus: RuleExecutionStatus;
+interface ExecutionOutcome {
+  outcome: RuleExecutionStatus;
   message: string;
-  metrics?: RuleExecutionMetrics;
+  metrics?: Partial<RuleExecutionMetrics>;
   userError?: boolean;
 }
 
-const normalizeStatusChangeArgs = (args: StatusChangeArgs): NormalizedStatusChangeArgs => {
-  if (args.newStatus === RuleExecutionStatusEnum.running) {
-    return {
-      newStatus: args.newStatus,
-      message: '',
-    };
-  }
-  const { newStatus, message, metrics, userError } = args;
-
-  return {
-    newStatus,
-    message: truncateValue(message) ?? '',
-    metrics: metrics
-      ? {
-          total_search_duration_ms: normalizeDurations(metrics.searchDurations),
-          total_indexing_duration_ms: normalizeDurations(metrics.indexingDurations),
-          total_enrichment_duration_ms: normalizeDurations(metrics.enrichmentDurations),
-          execution_gap_duration_s: normalizeGap(metrics.executionGap),
-          gap_range: metrics.gapRange ?? undefined,
-          frozen_indices_queried_count: metrics.frozenIndicesQueriedCount,
-        }
-      : undefined,
-    userError,
-  };
-};
-
-const normalizeDurations = (durations?: string[]): number | undefined => {
-  if (durations == null) {
-    return undefined;
-  }
-
-  const sumAsFloat = sum(durations.map(Number));
-  return Math.round(sumAsFloat);
-};
-
-const normalizeGap = (duration?: Duration): number | undefined => {
-  return duration ? Math.round(duration.asSeconds()) : undefined;
-};
+interface ExecutionResultBuffer {
+  errors: ExecutionResultLogEntry[];
+  warnings: ExecutionResultLogEntry[];
+  executionResult: ExecutionOutcome | undefined;
+  closed: boolean;
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -26,14 +26,18 @@ import { withSecuritySpan } from '../../../../../../utils/with_security_span';
 import type { ExtMeta } from '../../utils/console_logging';
 import { truncateValue } from '../../utils/normalization';
 import type { ExecutionResultLogEntry, IEventLogWriter } from '../event_log/event_log_writer';
-import type { RuleExecutionMetrics } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import {
   LogLevelEnum,
   LogLevelSetting,
   logLevelToNumber,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import { SECURITY_RULE_STATUS } from '../../../../rule_types/utils/apm_field_names';
-import type { IRuleExecutionLogForExecutors, RuleExecutionContext } from './client_interface';
+import type {
+  ExecutionResult,
+  IRuleExecutionLogForExecutors,
+  LogMessageOptions,
+  RuleExecutionContext,
+} from './client_interface';
 import { getCorrelationIds } from './correlation_ids';
 
 export function createRuleExecutionLogClientForExecutors(
@@ -46,6 +50,7 @@ export function createRuleExecutionLogClientForExecutors(
 ): IRuleExecutionLogForExecutors {
   const baseCorrelationIds = getCorrelationIds(context);
   const baseLogSuffix = baseCorrelationIds.getLogSuffix();
+  const baseLogMeta = baseCorrelationIds.getLogMeta();
   const { executionId, ruleId, ruleUuid, ruleName, ruleRevision, ruleType, spaceId } = context;
 
   // Buffers the execution related data
@@ -61,24 +66,39 @@ export function createRuleExecutionLogClientForExecutors(
       return context;
     },
 
-    trace(message: string): void {
-      writeMessageToEventLog(message, LogLevelEnum.trace);
+    trace(message: string, options?: LogMessageOptions): void {
+      writeMessage(message, {
+        eventLogLevel: LogLevelEnum.trace,
+        consoleLogLevel: options?.consoleLogLevel ?? LogLevelEnum.trace,
+      });
     },
 
-    debug(message: string): void {
-      writeMessageToEventLog(message, LogLevelEnum.debug);
+    debug(message: string, options?: LogMessageOptions): void {
+      writeMessage(message, {
+        eventLogLevel: LogLevelEnum.debug,
+        consoleLogLevel: options?.consoleLogLevel ?? LogLevelEnum.debug,
+      });
     },
 
-    info(message: string): void {
-      writeMessageToEventLog(message, LogLevelEnum.info);
+    info(message: string, options?: LogMessageOptions): void {
+      writeMessage(message, {
+        eventLogLevel: LogLevelEnum.info,
+        consoleLogLevel: options?.consoleLogLevel,
+      });
     },
 
-    warn(message: string): void {
-      writeMessageToEventLog(message, LogLevelEnum.warn);
+    warn(message: string, options?: LogMessageOptions): void {
+      writeMessage(message, {
+        eventLogLevel: LogLevelEnum.warn,
+        consoleLogLevel: options?.consoleLogLevel,
+      });
     },
 
-    error(message: string): void {
-      writeMessageToEventLog(message, LogLevelEnum.error);
+    error(message: string, options?: LogMessageOptions): void {
+      writeMessage(message, {
+        eventLogLevel: LogLevelEnum.error,
+        consoleLogLevel: options?.consoleLogLevel,
+      });
     },
 
     logMetric<Metric extends keyof ConsumerExecutionMetrics>(
@@ -100,7 +120,7 @@ export function createRuleExecutionLogClientForExecutors(
       ruleMonitoringService.setMetrics(metrics);
     },
 
-    logExecutionResult(args: ExecutionOutcome): void {
+    logExecutionResult(args: ExecutionResult): void {
       executionResultBuffer.executionResult = args;
     },
 
@@ -124,24 +144,24 @@ export function createRuleExecutionLogClientForExecutors(
       executionResultBuffer.closed = true;
 
       await withSecuritySpan('IRuleExecutionLogForExecutors.close', async () => {
-        const correlationIds = baseCorrelationIds.withStatus(executionResult.outcome);
+        const correlationIds = baseCorrelationIds.withStatus(executionResult.status);
         const logMeta = correlationIds.getLogMeta();
 
-        agent.addLabels({ [SECURITY_RULE_STATUS]: executionResult.outcome });
+        agent.addLabels({ [SECURITY_RULE_STATUS]: executionResult.status });
 
         try {
-          const executionOutcome: ExecutionOutcome = {
-            outcome: executionResult.outcome,
+          const normalizedExecutionResult: ExecutionResult = {
+            status: executionResult.status,
             message: truncateValue(executionResult.message) ?? '',
             userError: executionResult.userError,
           };
 
           await Promise.all([
-            writeExecutionResultToConsole(executionOutcome, logMeta),
-            writeExecutionResultToRuleObject(executionOutcome),
+            writeExecutionResultToConsole(normalizedExecutionResult, logMeta),
+            writeExecutionResultToRuleObject(normalizedExecutionResult),
           ]);
         } catch (e) {
-          const logMessage = `Error logging execution result with outcome "${executionResult.outcome}"`;
+          const logMessage = `Error writing execution result with status "${executionResult.status}"`;
           writeExceptionToConsole(e, logMessage, logMeta);
         }
       });
@@ -153,28 +173,32 @@ export function createRuleExecutionLogClientForExecutors(
     writeMessageToConsole(`${message}. Reason: ${logReason}`, LogLevelEnum.error, logMeta);
   };
 
-  const writeExecutionResultToConsole = (args: ExecutionOutcome, logMeta: ExtMeta): void => {
-    const messageParts: string[] = [`Changing rule status to "${args.outcome}"`, args.message];
+  const writeExecutionResultToConsole = (args: ExecutionResult, logMeta: ExtMeta): void => {
+    const messageParts: string[] = [`Changing rule status to "${args.status}"`, args.message];
     const logMessage = messageParts.filter(Boolean).join('. ');
-    const logLevel = consoleLogLevelFromExecutionStatus(args.outcome, args.userError);
+    const logLevel = consoleLogLevelFromExecutionStatus(args.status, args.userError);
 
     writeMessageToConsole(logMessage, logLevel, logMeta);
   };
 
-  const writeExecutionResultToRuleObject = async (args: ExecutionOutcome): Promise<void> => {
-    const { outcome, message, userError } = args;
+  const writeExecutionResultToRuleObject = async (args: ExecutionResult): Promise<void> => {
+    const { status, message, userError } = args;
 
-    if (outcome === RuleExecutionStatusEnum.running) {
-      return;
-    }
-
-    if (outcome === RuleExecutionStatusEnum.failed) {
+    if (status === RuleExecutionStatusEnum.failed) {
       ruleResultService.addLastRunError(message, userError ?? false);
-    } else if (outcome === RuleExecutionStatusEnum['partial failure']) {
+    } else if (status === RuleExecutionStatusEnum['partial failure']) {
       ruleResultService.addLastRunWarning(message);
     }
 
     ruleResultService.setLastRunOutcomeMessage(message);
+  };
+
+  const writeMessage = (
+    message: string,
+    levels: { eventLogLevel: LogLevel; consoleLogLevel?: LogLevel }
+  ): void => {
+    writeMessageToConsole(message, levels.consoleLogLevel ?? LogLevelEnum.debug, baseLogMeta);
+    writeMessageToEventLog(message, levels.eventLogLevel);
   };
 
   const writeMessageToEventLog = (message: string, logLevel: LogLevel): void => {
@@ -227,16 +251,9 @@ export function createRuleExecutionLogClientForExecutors(
   return ruleExecutionLogClient;
 }
 
-interface ExecutionOutcome {
-  outcome: RuleExecutionStatus;
-  message: string;
-  metrics?: Partial<RuleExecutionMetrics>;
-  userError?: boolean;
-}
-
 interface ExecutionResultBuffer {
   errors: ExecutionResultLogEntry[];
   warnings: ExecutionResultLogEntry[];
-  executionResult: ExecutionOutcome | undefined;
+  executionResult: ExecutionResult | undefined;
   closed: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -74,18 +74,10 @@ export function createRuleExecutionLogClientForExecutors(
     },
 
     warn(message: string): void {
-      if (this.closed()) {
-        throw new Error('The logger has been closed');
-      }
-
       writeMessageToEventLog(message, LogLevelEnum.warn);
     },
 
     error(message: string): void {
-      if (this.closed()) {
-        throw new Error('The logger has been closed');
-      }
-
       writeMessageToEventLog(message, LogLevelEnum.error);
     },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -78,10 +78,7 @@ export function createRuleExecutionLogClientForExecutors(
         throw new Error('The logger has been closed');
       }
 
-      executionResultBuffer.warnings.push({
-        timestamp: new Date().toISOString(),
-        message,
-      });
+      writeMessageToEventLog(message, LogLevelEnum.warn);
     },
 
     error(message: string): void {
@@ -89,10 +86,7 @@ export function createRuleExecutionLogClientForExecutors(
         throw new Error('The logger has been closed');
       }
 
-      executionResultBuffer.warnings.push({
-        timestamp: new Date().toISOString(),
-        message,
-      });
+      writeMessageToEventLog(message, LogLevelEnum.error);
     },
 
     logMetric<Metric extends keyof ConsumerExecutionMetrics>(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -9,7 +9,6 @@ import { omitBy } from 'lodash';
 import agent from 'elastic-apm-node';
 import type { Logger } from '@kbn/core/server';
 import type {
-  ConsumerExecutionMetrics,
   PublicRuleMonitoringService,
   PublicRuleResultService,
 } from '@kbn/alerting-plugin/server/types';
@@ -25,7 +24,7 @@ import { assertUnreachable } from '../../../../../../../common/utility_types';
 import { withSecuritySpan } from '../../../../../../utils/with_security_span';
 import type { ExtMeta } from '../../utils/console_logging';
 import { truncateValue } from '../../utils/normalization';
-import type { ExecutionResultLogEntry, IEventLogWriter } from '../event_log/event_log_writer';
+import type { IEventLogWriter } from '../event_log/event_log_writer';
 import {
   LogLevelEnum,
   LogLevelSetting,
@@ -37,6 +36,7 @@ import type {
   IRuleExecutionLogForExecutors,
   LogMessageOptions,
   RuleExecutionContext,
+  RuleExecutionLogMetrics,
 } from './client_interface';
 import { getCorrelationIds } from './correlation_ids';
 
@@ -55,9 +55,8 @@ export function createRuleExecutionLogClientForExecutors(
 
   // Buffers the execution related data
   const executionResultBuffer: ExecutionResultBuffer = {
-    errors: [],
-    warnings: [],
     executionResult: undefined,
+    metrics: {},
     closed: false,
   };
 
@@ -101,23 +100,33 @@ export function createRuleExecutionLogClientForExecutors(
       });
     },
 
-    logMetric<Metric extends keyof ConsumerExecutionMetrics>(
+    logMetric<Metric extends keyof RuleExecutionLogMetrics>(
       metricName: Metric,
-      value: ConsumerExecutionMetrics[Metric]
+      value: RuleExecutionLogMetrics[Metric]
     ): void {
       if (this.closed() || !value) {
         return;
       }
 
-      ruleMonitoringService.setMetric(metricName, value);
+      executionResultBuffer.metrics[metricName] = value;
+
+      // total_search_duration_ms gets calculated and logged at the Alerting Framework level
+      if (metricName !== 'total_search_duration_ms') {
+        ruleMonitoringService.setMetric(metricName, value);
+      }
     },
 
-    logMetrics(metrics: Partial<ConsumerExecutionMetrics>): void {
+    logMetrics(metrics: Partial<RuleExecutionLogMetrics>): void {
       if (this.closed()) {
         return;
       }
 
-      ruleMonitoringService.setMetrics(omitBy(metrics, (value) => !value));
+      Object.assign(executionResultBuffer.metrics, metrics);
+
+      // total_search_duration_ms gets calculated and logged at the Alerting Framework level
+      ruleMonitoringService.setMetrics(
+        omitBy(metrics, (value, key) => !value || key === 'total_search_duration_ms')
+      );
     },
 
     logExecutionResult(args: ExecutionResult): void {
@@ -155,6 +164,9 @@ export function createRuleExecutionLogClientForExecutors(
             message: truncateValue(executionResult.message) ?? '',
             userError: executionResult.userError,
           };
+
+          writeStatusChangeToEventLog(normalizedExecutionResult);
+          writeMetricsToEventLog(executionResultBuffer.metrics);
 
           await Promise.all([
             writeExecutionResultToConsole(normalizedExecutionResult, logMeta),
@@ -199,6 +211,52 @@ export function createRuleExecutionLogClientForExecutors(
   ): void => {
     writeMessageToConsole(message, levels.consoleLogLevel ?? LogLevelEnum.debug, baseLogMeta);
     writeMessageToEventLog(message, levels.eventLogLevel);
+  };
+
+  /**
+   * @deprecated To be removed in favor of Alerting Framework's "execute" event
+   */
+  const writeStatusChangeToEventLog = (args: ExecutionResult): void => {
+    const { status, message } = args;
+
+    eventLog.logStatusChange({
+      status,
+      message,
+      ruleInfo: {
+        ruleId,
+        ruleUuid,
+        ruleName,
+        ruleRevision,
+        ruleType,
+        spaceId,
+        executionId,
+      },
+    });
+  };
+
+  /**
+   * @deprecated To be removed in favor of Alerting Framework's "execute" event
+   */
+  const writeMetricsToEventLog = (metrics: RuleExecutionLogMetrics): void => {
+    eventLog.logExecutionMetrics({
+      metrics: {
+        total_search_duration_ms: metrics.total_search_duration_ms,
+        total_indexing_duration_ms: metrics.total_indexing_duration_ms,
+        total_enrichment_duration_ms: metrics.total_enrichment_duration_ms,
+        frozen_indices_queried_count: metrics.frozen_indices_queried_count,
+        execution_gap_duration_s: metrics.gap_duration_s,
+        gap_range: metrics.gap_range,
+      },
+      ruleInfo: {
+        ruleId,
+        ruleUuid,
+        ruleName,
+        ruleRevision,
+        ruleType,
+        spaceId,
+        executionId,
+      },
+    });
   };
 
   const writeMessageToEventLog = (message: string, logLevel: LogLevel): void => {
@@ -252,8 +310,7 @@ export function createRuleExecutionLogClientForExecutors(
 }
 
 interface ExecutionResultBuffer {
-  errors: ExecutionResultLogEntry[];
-  warnings: ExecutionResultLogEntry[];
   executionResult: ExecutionResult | undefined;
+  metrics: RuleExecutionLogMetrics;
   closed: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -52,10 +52,6 @@ export function createRuleExecutionLogClientForExecutors(
   const baseLogMeta = baseCorrelationIds.getLogMeta();
   const { executionId, ruleId, ruleUuid, ruleName, ruleRevision, ruleType, spaceId } = context;
 
-  ruleMonitoringService.setContext({
-    ruleUuid: ruleUuid,
-  });
-
   // Buffers the execution related data
   const executionResultBuffer: ExecutionResultBuffer = {
     errors: [],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -54,7 +54,6 @@ export function createRuleExecutionLogClientForExecutors(
 
   ruleMonitoringService.setContext({
     ruleUuid: ruleUuid,
-    ruleRevision: ruleRevision,
   });
 
   // Buffers the execution related data

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { omitBy } from 'lodash';
 import agent from 'elastic-apm-node';
 import type { Logger } from '@kbn/core/server';
 import type {
@@ -104,7 +105,7 @@ export function createRuleExecutionLogClientForExecutors(
       metricName: Metric,
       value: ConsumerExecutionMetrics[Metric]
     ): void {
-      if (this.closed() || value === undefined) {
+      if (this.closed() || !value) {
         return;
       }
 
@@ -116,7 +117,7 @@ export function createRuleExecutionLogClientForExecutors(
         return;
       }
 
-      ruleMonitoringService.setMetrics(metrics);
+      ruleMonitoringService.setMetrics(omitBy(metrics, (value) => !value));
     },
 
     logExecutionResult(args: ExecutionResult): void {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -14,7 +14,6 @@ import type {
 } from '@kbn/alerting-plugin/server/types';
 import type {
   RuleExecutionSettings,
-  RuleExecutionStatus,
   LogLevel,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring';
 import {
@@ -52,6 +51,11 @@ export function createRuleExecutionLogClientForExecutors(
   const baseLogSuffix = baseCorrelationIds.getLogSuffix();
   const baseLogMeta = baseCorrelationIds.getLogMeta();
   const { executionId, ruleId, ruleUuid, ruleName, ruleRevision, ruleType, spaceId } = context;
+
+  ruleMonitoringService.setContext({
+    ruleUuid: ruleUuid,
+    ruleRevision: ruleRevision,
+  });
 
   // Buffers the execution related data
   const executionResultBuffer: ExecutionResultBuffer = {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   RuleExecutionSettings,
   LogLevel,
+  RuleExecutionStatus,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring';
 import {
   consoleLogLevelFromExecutionStatus,
@@ -23,7 +24,7 @@ import {
 import { assertUnreachable } from '../../../../../../../common/utility_types';
 import { withSecuritySpan } from '../../../../../../utils/with_security_span';
 import type { ExtMeta } from '../../utils/console_logging';
-import { truncateValue } from '../../utils/normalization';
+import { truncateList, truncateValue } from '../../utils/normalization';
 import type { IEventLogWriter } from '../event_log/event_log_writer';
 import {
   LogLevelEnum,
@@ -34,11 +35,13 @@ import { SECURITY_RULE_STATUS } from '../../../../rule_types/utils/apm_field_nam
 import type {
   ExecutionResult,
   IRuleExecutionLogForExecutors,
+  LogErrorMessageOptions,
   LogMessageOptions,
   RuleExecutionContext,
   RuleExecutionLogMetrics,
 } from './client_interface';
 import { getCorrelationIds } from './correlation_ids';
+import { checkErrorDetails } from '../../../../rule_types/utils/check_error_details';
 
 export function createRuleExecutionLogClientForExecutors(
   settings: RuleExecutionSettings,
@@ -55,7 +58,8 @@ export function createRuleExecutionLogClientForExecutors(
 
   // Buffers the execution related data
   const executionResultBuffer: ExecutionResultBuffer = {
-    executionResult: undefined,
+    errors: [],
+    warnings: [],
     metrics: {},
     closed: false,
   };
@@ -87,13 +91,20 @@ export function createRuleExecutionLogClientForExecutors(
     },
 
     warn(message: string, options?: LogMessageOptions): void {
+      executionResultBuffer.warnings.push(message);
+
       writeMessage(message, {
         eventLogLevel: LogLevelEnum.warn,
         consoleLogLevel: options?.consoleLogLevel,
       });
     },
 
-    error(message: string, options?: LogMessageOptions): void {
+    error(message: string, options?: LogErrorMessageOptions): void {
+      executionResultBuffer.errors.push({
+        message,
+        userError: options?.userError ?? false,
+      });
+
       writeMessage(message, {
         eventLogLevel: LogLevelEnum.error,
         consoleLogLevel: options?.consoleLogLevel,
@@ -129,23 +140,11 @@ export function createRuleExecutionLogClientForExecutors(
       );
     },
 
-    logExecutionResult(args: ExecutionResult): void {
-      executionResultBuffer.executionResult = args;
-    },
-
     closed(): boolean {
       return executionResultBuffer.closed;
     },
 
     async close(): Promise<void> {
-      const executionResult = executionResultBuffer.executionResult;
-
-      if (!executionResult) {
-        throw new Error(
-          'Rule execution result must be set before closing the rule execution log client'
-        );
-      }
-
       if (this.closed()) {
         throw new Error('The logger has been closed');
       }
@@ -153,6 +152,8 @@ export function createRuleExecutionLogClientForExecutors(
       executionResultBuffer.closed = true;
 
       await withSecuritySpan('IRuleExecutionLogForExecutors.close', async () => {
+        const executionResult: ExecutionResult = determineExecutionResult(executionResultBuffer);
+
         const correlationIds = baseCorrelationIds.withStatus(executionResult.status);
         const logMeta = correlationIds.getLogMeta();
 
@@ -178,6 +179,31 @@ export function createRuleExecutionLogClientForExecutors(
         }
       });
     },
+  };
+
+  const determineExecutionResult = ({
+    errors,
+    warnings,
+  }: ExecutionResultBuffer): ExecutionResult => {
+    let status: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;
+    let message = 'Rule execution completed successfully';
+
+    if (errors.length > 0) {
+      status = RuleExecutionStatusEnum.failed;
+      message = truncateList(errors.map((e) => e.message)).join(', ');
+    } else if (warnings.length > 0) {
+      status = RuleExecutionStatusEnum['partial failure'];
+      message = truncateList(warnings).join('\n\n');
+    }
+
+    return {
+      status,
+      message,
+      userError: errors.every(
+        ({ message: errorMessage, userError }) =>
+          userError || checkErrorDetails(new Error(errorMessage)).isUserError
+      ),
+    };
   };
 
   const writeExceptionToConsole = (e: unknown, message: string, logMeta: ExtMeta): void => {
@@ -310,7 +336,8 @@ export function createRuleExecutionLogClientForExecutors(
 }
 
 interface ExecutionResultBuffer {
-  executionResult: ExecutionResult | undefined;
+  errors: Array<{ message: string; userError: boolean }>;
+  warnings: string[];
   metrics: RuleExecutionLogMetrics;
   closed: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -102,9 +102,9 @@ export function createRuleExecutionLogClientForExecutors(
 
     logMetric<Metric extends keyof RuleExecutionLogMetrics>(
       metricName: Metric,
-      value: RuleExecutionLogMetrics[Metric]
+      value: NonNullable<RuleExecutionLogMetrics[Metric]>
     ): void {
-      if (this.closed() || !value) {
+      if (this.closed()) {
         return;
       }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -125,7 +125,7 @@ export function createRuleExecutionLogClientForExecutors(
 
       // total_search_duration_ms gets calculated and logged at the Alerting Framework level
       ruleMonitoringService.setMetrics(
-        omitBy(metrics, (value, key) => !value || key === 'total_search_duration_ms')
+        omitBy(metrics, (value, key) => value == null || key === 'total_search_duration_ms')
       );
     },
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import type { Duration } from 'moment';
+import type { ConsumerExecutionMetrics } from '@kbn/alerting-plugin/server/types';
 import type {
-  LogLevel,
   RuleExecutionStatus,
   RuleExecutionStatusEnum,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring';
@@ -31,40 +30,62 @@ export interface IRuleExecutionLogForExecutors {
   /**
    * Writes a trace message to the event log and console at TRACE level.
    */
-  trace(message: string, options?: LogMessageOptions): void;
+  trace(message: string): void;
 
   /**
    * Writes a debug message to the event log and console at DEBUG level.
    */
-  debug(message: string, options?: LogMessageOptions): void;
+  debug(message: string): void;
 
   /**
    * Writes an info message to the event log at INFO level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  info(message: string, options?: LogMessageOptions): void;
+  info(message: string): void;
 
   /**
    * Writes a warning message to the event log at WARN level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  warn(message: string, options?: LogMessageOptions): void;
+  warn(message: string): void;
 
   /**
    * Writes an error message to the event log at ERROR level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  error(message: string, options?: LogMessageOptions): void;
+  error(message: string): void;
 
   /**
-   * Writes information about new rule statuses and measured execution metrics:
-   *   1. To .kibana-* index as a custom `siem-detection-engine-rule-execution-info` saved object.
-   *      This SO is used for fast access to last execution info of a large amount of rules.
-   *   2. To .kibana-event-log-* index in order to track history of rule executions.
-   *   3. To console logs.
-   * @param args Information about the status change event.
+   * Logs a rule execution metric like a number of source events found and a number of generated alerts.
+   * Metric names are type-checked against RuleExecutionMetrics.
    */
-  logStatusChange(args: StatusChangeArgs): Promise<void>;
+  logMetric<Metric extends keyof ConsumerExecutionMetrics>(
+    metricName: Metric,
+    value: ConsumerExecutionMetrics[Metric]
+  ): void;
+
+  /**
+   * Convenience method to log multiple rule execution metrics like a number of source events
+   * found and a number of generated alerts.
+   * Metric names are type-checked against RuleExecutionMetrics.
+   */
+  logMetrics(metrics: Partial<ConsumerExecutionMetrics>): void;
+
+  /**
+   * Logs rule execution result at the end of rule execution. This includes the final rule outcome (failed, partial failure, succeeded)
+   * and an optional message describing the outcome.
+   */
+  logExecutionResult(args: ExecutionResultArgs): void;
+
+  /**
+   * Whether the logger is closed
+   */
+  closed(): boolean;
+
+  /**
+   * Closes the logger and writes the logged data to the event log
+   */
+  close(): Promise<void>;
 }
 
 /**
@@ -117,25 +138,11 @@ export interface LogMessageOptions {
   consoleLogLevel?: LogLevel;
 }
 
-export interface RunningStatusChangeArgs {
-  newStatus: RuleExecutionStatusEnum['running'];
-}
-
 /**
- * Information about the status change event.
+ * Arguments for logging the final execution result. The outcome must not be 'running'.
  */
-export interface StatusChangeArgs {
-  newStatus: RuleExecutionStatus;
-  message?: string;
-  metrics?: MetricsArgs;
+export interface ExecutionResultArgs {
+  outcome: Exclude<RuleExecutionStatus, RuleExecutionStatusEnum['running']>;
+  message: string;
   userError?: boolean;
-}
-
-export interface MetricsArgs {
-  searchDurations?: string[];
-  indexingDurations?: string[];
-  enrichmentDurations?: string[];
-  executionGap?: Duration;
-  gapRange?: { gte: string; lte: string };
-  frozenIndicesQueriedCount?: number;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -30,30 +30,30 @@ export interface IRuleExecutionLogForExecutors {
   /**
    * Writes a trace message to the event log and console at TRACE level.
    */
-  trace(message: string): void;
+  trace(message: string, options?: LogMessageOptions): void;
 
   /**
    * Writes a debug message to the event log and console at DEBUG level.
    */
-  debug(message: string): void;
+  debug(message: string, options?: LogMessageOptions): void;
 
   /**
    * Writes an info message to the event log at INFO level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  info(message: string): void;
+  info(message: string, options?: LogMessageOptions): void;
 
   /**
    * Writes a warning message to the event log at WARN level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  warn(message: string): void;
+  warn(message: string, options?: LogMessageOptions): void;
 
   /**
    * Writes an error message to the event log at ERROR level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  error(message: string): void;
+  error(message: string, options?: LogMessageOptions): void;
 
   /**
    * Logs a rule execution metric like a number of source events found and a number of generated alerts.
@@ -139,7 +139,7 @@ export interface LogMessageOptions {
 }
 
 /**
- * Arguments for logging the final execution result. The outcome must not be 'running'.
+ * Arguments for logging the final execution result. The status must not be 'running'.
  */
 export interface ExecutionResult {
   status: Exclude<RuleExecutionStatus, RuleExecutionStatusEnum['running']>;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -59,9 +59,9 @@ export interface IRuleExecutionLogForExecutors {
    * Logs a rule execution metric like a number of source events found and a number of generated alerts.
    * Metric names are type-checked against RuleExecutionMetrics.
    */
-  logMetric<Metric extends keyof ConsumerExecutionMetrics>(
+  logMetric<Metric extends keyof RuleExecutionLogMetrics>(
     metricName: Metric,
-    value: ConsumerExecutionMetrics[Metric]
+    value: RuleExecutionLogMetrics[Metric]
   ): void;
 
   /**
@@ -69,7 +69,7 @@ export interface IRuleExecutionLogForExecutors {
    * found and a number of generated alerts.
    * Metric names are type-checked against RuleExecutionMetrics.
    */
-  logMetrics(metrics: Partial<ConsumerExecutionMetrics>): void;
+  logMetrics(metrics: Partial<RuleExecutionLogMetrics>): void;
 
   /**
    * Logs rule execution result at the end of rule execution. This includes the final rule outcome (failed, partial failure, succeeded)
@@ -137,6 +137,19 @@ export interface LogMessageOptions {
    */
   consoleLogLevel?: LogLevel;
 }
+
+/**
+ * @deprecated To be removed in favor of Alerting Framework's "execute" event
+ *
+ * We have to accept total_search_duration_ms in the rule execution logger as
+ * it's difficult to extract this value from the Alerting Framework
+ *
+ * After fully migrating to the AF's execute event RuleExecutionLogMetrics should
+ * be removed.
+ */
+export type RuleExecutionLogMetrics = Partial<
+  ConsumerExecutionMetrics & { total_search_duration_ms: number }
+>;
 
 /**
  * Arguments for logging the final execution result. The status must not be 'running'.

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -75,7 +75,7 @@ export interface IRuleExecutionLogForExecutors {
    * Logs rule execution result at the end of rule execution. This includes the final rule outcome (failed, partial failure, succeeded)
    * and an optional message describing the outcome.
    */
-  logExecutionResult(args: ExecutionResultArgs): void;
+  logExecutionResult(args: ExecutionResult): void;
 
   /**
    * Whether the logger is closed
@@ -141,8 +141,8 @@ export interface LogMessageOptions {
 /**
  * Arguments for logging the final execution result. The outcome must not be 'running'.
  */
-export interface ExecutionResultArgs {
-  outcome: Exclude<RuleExecutionStatus, RuleExecutionStatusEnum['running']>;
+export interface ExecutionResult {
+  status: Exclude<RuleExecutionStatus, RuleExecutionStatusEnum['running']>;
   message: string;
   userError?: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -53,7 +53,7 @@ export interface IRuleExecutionLogForExecutors {
    * Writes an error message to the event log at ERROR level.
    * Writes to console at DEBUG level by default (override via options.consoleLogLevel).
    */
-  error(message: string, options?: LogMessageOptions): void;
+  error(message: string, options?: LogErrorMessageOptions): void;
 
   /**
    * Logs a rule execution metric like a number of source events found and a number of generated alerts.
@@ -70,12 +70,6 @@ export interface IRuleExecutionLogForExecutors {
    * Metric names are type-checked against RuleExecutionMetrics.
    */
   logMetrics(metrics: Partial<RuleExecutionLogMetrics>): void;
-
-  /**
-   * Logs rule execution result at the end of rule execution. This includes the final rule outcome (failed, partial failure, succeeded)
-   * and an optional message describing the outcome.
-   */
-  logExecutionResult(args: ExecutionResult): void;
 
   /**
    * Whether the logger is closed
@@ -136,6 +130,13 @@ export interface LogMessageOptions {
    * Override the console log level. Defaults to DEBUG when not specified.
    */
   consoleLogLevel?: LogLevel;
+}
+
+export interface LogErrorMessageOptions extends LogMessageOptions {
+  /**
+   * Whether this is a user side error.
+   */
+  userError?: boolean;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
@@ -9,19 +9,12 @@ import { SavedObjectsUtils } from '@kbn/core/server';
 import type { IEventLogService } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { LogLevel } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-import {
-  eventLogLevelFromExecutionStatus,
-  logLevelToNumber,
-  ruleExecutionStatusToNumber,
-} from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import { logLevelToNumber } from '../../../../../../../common/api/detection_engine/rule_monitoring';
 import type {
   RuleExecutionMetrics,
   RuleExecutionStatus,
 } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
-import {
-  LogLevelEnum,
-  RuleExecutionEventTypeEnum,
-} from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
+import { RuleExecutionEventTypeEnum } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import {
   RULE_SAVED_OBJECT_TYPE,
   RULE_EXECUTION_LOG_PROVIDER,
@@ -29,11 +22,9 @@ import {
 
 export interface IEventLogWriter {
   logMessage(args: MessageArgs): void;
-  logStatusChange(args: StatusChangeArgs): void;
-  logExecutionMetrics(args: ExecutionMetricsArgs): void;
 }
 
-export interface BaseArgs {
+export interface RuleInfo {
   ruleId: string;
   ruleUuid: string;
   ruleName: string;
@@ -43,18 +34,24 @@ export interface BaseArgs {
   executionId: string;
 }
 
-export interface MessageArgs extends BaseArgs {
+export interface MessageArgs {
   logLevel: LogLevel;
+  message: string;
+  ruleInfo: RuleInfo;
+}
+
+export interface ExecutionResultLogEntry {
+  timestamp: string;
   message: string;
 }
 
-export interface StatusChangeArgs extends BaseArgs {
-  newStatus: RuleExecutionStatus;
+export interface ExecutionResultArgs {
+  ruleInfo: RuleInfo;
+  outcome: RuleExecutionStatus;
   message?: string;
-}
-
-export interface ExecutionMetricsArgs extends BaseArgs {
   metrics: RuleExecutionMetrics;
+  errors: ExecutionResultLogEntry[];
+  warnings: ExecutionResultLogEntry[];
 }
 
 export const createEventLogWriter = (eventLogService: IEventLogService): IEventLogWriter => {
@@ -70,10 +67,10 @@ export const createEventLogWriter = (eventLogService: IEventLogService): IEventL
         '@timestamp': nowISO(),
         message: args.message,
         rule: {
-          id: args.ruleId,
-          uuid: args.ruleUuid,
-          name: args.ruleName,
-          category: args.ruleType,
+          id: args.ruleInfo.ruleId,
+          uuid: args.ruleInfo.ruleUuid,
+          name: args.ruleInfo.ruleName,
+          category: args.ruleInfo.ruleType,
         },
         event: {
           kind: 'event',
@@ -88,104 +85,18 @@ export const createEventLogWriter = (eventLogService: IEventLogService): IEventL
           alert: {
             rule: {
               execution: {
-                uuid: args.executionId,
+                uuid: args.ruleInfo.executionId,
               },
-              revision: args.ruleRevision,
+              revision: args.ruleInfo.ruleRevision,
             },
           },
-          space_ids: [args.spaceId],
+          space_ids: [args.ruleInfo.spaceId],
           saved_objects: [
             {
               rel: SAVED_OBJECT_REL_PRIMARY,
               type: RULE_SAVED_OBJECT_TYPE,
-              id: args.ruleId,
-              namespace: spaceIdToNamespace(args.spaceId),
-            },
-          ],
-        },
-      });
-    },
-
-    logStatusChange: (args: StatusChangeArgs): void => {
-      const logLevel = eventLogLevelFromExecutionStatus(args.newStatus);
-      eventLogger.logEvent({
-        '@timestamp': nowISO(),
-        message: args.message,
-        rule: {
-          id: args.ruleId,
-          uuid: args.ruleUuid,
-          name: args.ruleName,
-          category: args.ruleType,
-        },
-        event: {
-          kind: 'event',
-          action: RuleExecutionEventTypeEnum['status-change'],
-          sequence: sequence++,
-          severity: logLevelToNumber(logLevel),
-        },
-        log: {
-          level: logLevel,
-        },
-        kibana: {
-          alert: {
-            rule: {
-              execution: {
-                uuid: args.executionId,
-                status: args.newStatus,
-                status_order: ruleExecutionStatusToNumber(args.newStatus),
-              },
-              revision: args.ruleRevision,
-            },
-          },
-          space_ids: [args.spaceId],
-          saved_objects: [
-            {
-              rel: SAVED_OBJECT_REL_PRIMARY,
-              type: RULE_SAVED_OBJECT_TYPE,
-              id: args.ruleId,
-              namespace: spaceIdToNamespace(args.spaceId),
-            },
-          ],
-        },
-      });
-    },
-
-    logExecutionMetrics: (args: ExecutionMetricsArgs): void => {
-      const logLevel = LogLevelEnum.info;
-      eventLogger.logEvent({
-        '@timestamp': nowISO(),
-        rule: {
-          id: args.ruleId,
-          uuid: args.ruleUuid,
-          name: args.ruleName,
-          category: args.ruleType,
-        },
-        event: {
-          kind: 'metric',
-          action: RuleExecutionEventTypeEnum['execution-metrics'],
-          sequence: sequence++,
-          severity: logLevelToNumber(logLevel),
-        },
-        log: {
-          level: logLevel,
-        },
-        kibana: {
-          alert: {
-            rule: {
-              execution: {
-                uuid: args.executionId,
-                metrics: args.metrics,
-              },
-              revision: args.ruleRevision,
-            },
-          },
-          space_ids: [args.spaceId],
-          saved_objects: [
-            {
-              rel: SAVED_OBJECT_REL_PRIMARY,
-              type: RULE_SAVED_OBJECT_TYPE,
-              id: args.ruleId,
-              namespace: spaceIdToNamespace(args.spaceId),
+              id: args.ruleInfo.ruleId,
+              namespace: spaceIdToNamespace(args.ruleInfo.spaceId),
             },
           ],
         },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
@@ -8,9 +8,20 @@
 import { SavedObjectsUtils } from '@kbn/core/server';
 import type { IEventLogService } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
-import type { LogLevel } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-import { logLevelToNumber } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-import { RuleExecutionEventTypeEnum } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
+import type {
+  LogLevel,
+  RuleExecutionMetrics,
+  RuleExecutionStatus,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import {
+  logLevelToNumber,
+  ruleExecutionStatusToNumber,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import {
+  eventLogLevelFromExecutionStatus,
+  LogLevelEnum,
+  RuleExecutionEventTypeEnum,
+} from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import {
   RULE_SAVED_OBJECT_TYPE,
   RULE_EXECUTION_LOG_PROVIDER,
@@ -18,6 +29,8 @@ import {
 
 export interface IEventLogWriter {
   logMessage(args: MessageArgs): void;
+  logStatusChange(args: StatusChangeArgs): void;
+  logExecutionMetrics(args: ExecutionMetricsArgs): void;
 }
 
 export interface RuleInfo {
@@ -33,6 +46,17 @@ export interface RuleInfo {
 export interface MessageArgs {
   logLevel: LogLevel;
   message: string;
+  ruleInfo: RuleInfo;
+}
+
+export interface StatusChangeArgs {
+  status: RuleExecutionStatus;
+  message?: string;
+  ruleInfo: RuleInfo;
+}
+
+export interface ExecutionMetricsArgs {
+  metrics: RuleExecutionMetrics;
   ruleInfo: RuleInfo;
 }
 
@@ -73,6 +97,92 @@ export const createEventLogWriter = (eventLogService: IEventLogService): IEventL
             rule: {
               execution: {
                 uuid: args.ruleInfo.executionId,
+              },
+              revision: args.ruleInfo.ruleRevision,
+            },
+          },
+          space_ids: [args.ruleInfo.spaceId],
+          saved_objects: [
+            {
+              rel: SAVED_OBJECT_REL_PRIMARY,
+              type: RULE_SAVED_OBJECT_TYPE,
+              id: args.ruleInfo.ruleId,
+              namespace: spaceIdToNamespace(args.ruleInfo.spaceId),
+            },
+          ],
+        },
+      });
+    },
+
+    logStatusChange: (args: StatusChangeArgs): void => {
+      const logLevel = eventLogLevelFromExecutionStatus(args.status);
+      eventLogger.logEvent({
+        '@timestamp': nowISO(),
+        message: args.message,
+        rule: {
+          id: args.ruleInfo.ruleId,
+          uuid: args.ruleInfo.ruleUuid,
+          name: args.ruleInfo.ruleName,
+          category: args.ruleInfo.ruleType,
+        },
+        event: {
+          kind: 'event',
+          action: RuleExecutionEventTypeEnum['status-change'],
+          sequence: sequence++,
+          severity: logLevelToNumber(logLevel),
+        },
+        log: {
+          level: logLevel,
+        },
+        kibana: {
+          alert: {
+            rule: {
+              execution: {
+                uuid: args.ruleInfo.executionId,
+                status: args.status,
+                status_order: ruleExecutionStatusToNumber(args.status),
+              },
+              revision: args.ruleInfo.ruleRevision,
+            },
+          },
+          space_ids: [args.ruleInfo.spaceId],
+          saved_objects: [
+            {
+              rel: SAVED_OBJECT_REL_PRIMARY,
+              type: RULE_SAVED_OBJECT_TYPE,
+              id: args.ruleInfo.ruleId,
+              namespace: spaceIdToNamespace(args.ruleInfo.spaceId),
+            },
+          ],
+        },
+      });
+    },
+
+    logExecutionMetrics: (args: ExecutionMetricsArgs): void => {
+      const logLevel = LogLevelEnum.info;
+      eventLogger.logEvent({
+        '@timestamp': nowISO(),
+        rule: {
+          id: args.ruleInfo.ruleId,
+          uuid: args.ruleInfo.ruleUuid,
+          name: args.ruleInfo.ruleName,
+          category: args.ruleInfo.ruleType,
+        },
+        event: {
+          kind: 'metric',
+          action: RuleExecutionEventTypeEnum['execution-metrics'],
+          sequence: sequence++,
+          severity: logLevelToNumber(logLevel),
+        },
+        log: {
+          level: logLevel,
+        },
+        kibana: {
+          alert: {
+            rule: {
+              execution: {
+                uuid: args.ruleInfo.executionId,
+                metrics: args.metrics,
               },
               revision: args.ruleInfo.ruleRevision,
             },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_writer.ts
@@ -10,10 +10,6 @@ import type { IEventLogService } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import type { LogLevel } from '../../../../../../../common/api/detection_engine/rule_monitoring';
 import { logLevelToNumber } from '../../../../../../../common/api/detection_engine/rule_monitoring';
-import type {
-  RuleExecutionMetrics,
-  RuleExecutionStatus,
-} from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import { RuleExecutionEventTypeEnum } from '../../../../../../../common/api/detection_engine/rule_monitoring/model';
 import {
   RULE_SAVED_OBJECT_TYPE,
@@ -43,15 +39,6 @@ export interface MessageArgs {
 export interface ExecutionResultLogEntry {
   timestamp: string;
   message: string;
-}
-
-export interface ExecutionResultArgs {
-  ruleInfo: RuleInfo;
-  outcome: RuleExecutionStatus;
-  message?: string;
-  metrics: RuleExecutionMetrics;
-  errors: ExecutionResultLogEntry[];
-  warnings: ExecutionResultLogEntry[];
 }
 
 export const createEventLogWriter = (eventLogService: IEventLogService): IEventLogWriter => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/preview_rule_execution_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/preview_rule_execution_logger.ts
@@ -5,19 +5,16 @@
  * 2.0.
  */
 
-import type {
-  IRuleMonitoringService,
-  RuleExecutionContext,
-  StatusChangeArgs,
-} from '../../../rule_monitoring';
+import type { ExecutionResult, IRuleMonitoringService } from '../../../rule_monitoring';
 
 export interface IPreviewRuleExecutionLogger {
   factory: IRuleMonitoringService['createRuleExecutionLogClientForExecutors'];
+  getExecutionResult: () => ExecutionResult | undefined;
 }
 
-export const createPreviewRuleExecutionLogger = (
-  loggedStatusChanges: Array<RuleExecutionContext & StatusChangeArgs>
-): IPreviewRuleExecutionLogger => {
+export const createPreviewRuleExecutionLogger = (): IPreviewRuleExecutionLogger => {
+  let executionResult: ExecutionResult | undefined;
+
   return {
     factory: ({ context }) => {
       const spyLogger = {
@@ -28,14 +25,20 @@ export const createPreviewRuleExecutionLogger = (
         info: () => {},
         warn: () => {},
         error: () => {},
-
-        logStatusChange: (args: StatusChangeArgs): Promise<void> => {
-          loggedStatusChanges.push({ ...context, ...args });
-          return Promise.resolve();
+        logMetric: () => {},
+        logMetrics: () => {},
+        logExecutionResult: (result: ExecutionResult): void => {
+          executionResult = result;
         },
+
+        closed: () => false,
+        close: () => Promise.resolve(),
       };
 
       return Promise.resolve(spyLogger);
+    },
+    getExecutionResult: () => {
+      return executionResult;
     },
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/preview_rule_execution_logger.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/preview_rule_execution_logger.ts
@@ -10,9 +10,13 @@ import type { ExecutionResult, IRuleMonitoringService } from '../../../rule_moni
 export interface IPreviewRuleExecutionLogger {
   factory: IRuleMonitoringService['createRuleExecutionLogClientForExecutors'];
   getExecutionResult: () => ExecutionResult | undefined;
+  getErrors: () => string[];
+  getWarnings: () => string[];
 }
 
 export const createPreviewRuleExecutionLogger = (): IPreviewRuleExecutionLogger => {
+  const errors: string[] = [];
+  const warnings: string[] = [];
   let executionResult: ExecutionResult | undefined;
 
   return {
@@ -23,8 +27,12 @@ export const createPreviewRuleExecutionLogger = (): IPreviewRuleExecutionLogger 
         trace: () => {},
         debug: () => {},
         info: () => {},
-        warn: () => {},
-        error: () => {},
+        warn: (message: string) => {
+          warnings.push(message);
+        },
+        error: (message: string) => {
+          errors.push(message);
+        },
         logMetric: () => {},
         logMetrics: () => {},
         logExecutionResult: (result: ExecutionResult): void => {
@@ -40,5 +48,7 @@ export const createPreviewRuleExecutionLogger = (): IPreviewRuleExecutionLogger 
     getExecutionResult: () => {
       return executionResult;
     },
+    getErrors: () => errors,
+    getWarnings: () => warnings,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
@@ -47,8 +47,6 @@ import { throwAuthzError } from '../../../../machine_learning/validation';
 import { routeLimitedConcurrencyTag } from '../../../../../utils/route_limited_concurrency_tag';
 import type { SecuritySolutionPluginRouter } from '../../../../../types';
 
-import type { RuleExecutionContext, StatusChangeArgs } from '../../../rule_monitoring';
-
 import type { ConfigType } from '../../../../../config';
 import { alertInstanceFactoryStub } from './alert_instance_factory_stub';
 import type {
@@ -155,8 +153,7 @@ export const previewRulesRoute = (
           const spaceId = siemClient.getSpaceId();
           const previewId = uuidv4();
           const username = security?.authc.getCurrentUser(request)?.username;
-          const loggedStatusChanges: Array<RuleExecutionContext & StatusChangeArgs> = [];
-          const previewRuleExecutionLogger = createPreviewRuleExecutionLogger(loggedStatusChanges);
+          const previewRuleExecutionLogger = createPreviewRuleExecutionLogger();
           const runState: Record<string, unknown> = {
             isLoggedRequestsEnabled: request.query.enable_logged_requests,
           };
@@ -319,25 +316,23 @@ export const previewRulesRoute = (
                 ruleExecutionTimeout: `${PREVIEW_TIMEOUT_SECONDS}s`,
               })) as { state: TState; loggedRequests: RulePreviewLoggedRequest[] });
 
-              const errors = loggedStatusChanges
-                .filter((item) => item.newStatus === RuleExecutionStatusEnum.failed)
-                .map((item) => item.message ?? 'Unknown Error');
-
-              const warnings = loggedStatusChanges
-                .filter((item) => item.newStatus === RuleExecutionStatusEnum['partial failure'])
-                .map((item) => item.message ?? 'Unknown Warning');
+              const executionResult = previewRuleExecutionLogger.getExecutionResult();
 
               logs.push({
-                errors,
-                warnings,
+                errors:
+                  executionResult?.status === RuleExecutionStatusEnum.failed
+                    ? [executionResult?.message]
+                    : [],
+                warnings:
+                  executionResult?.status === RuleExecutionStatusEnum['partial failure']
+                    ? [executionResult?.message]
+                    : [],
                 startedAt: startedAt.toDate().toISOString(),
                 duration: moment().diff(invocationStartTime, 'milliseconds'),
                 ...(loggedRequests ? { requests: loggedRequests } : {}),
               });
 
-              loggedStatusChanges.length = 0;
-
-              if (errors.length) {
+              if (executionResult?.status === RuleExecutionStatusEnum.failed) {
                 break;
               }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
@@ -321,12 +321,12 @@ export const previewRulesRoute = (
               logs.push({
                 errors:
                   executionResult?.status === RuleExecutionStatusEnum.failed
-                    ? [executionResult?.message]
-                    : [],
+                    ? [executionResult?.message, ...previewRuleExecutionLogger.getErrors()]
+                    : previewRuleExecutionLogger.getErrors(),
                 warnings:
                   executionResult?.status === RuleExecutionStatusEnum['partial failure']
-                    ? [executionResult?.message]
-                    : [],
+                    ? [executionResult?.message, ...previewRuleExecutionLogger.getWarnings()]
+                    : previewRuleExecutionLogger.getWarnings(),
                 startedAt: startedAt.toDate().toISOString(),
                 duration: moment().diff(invocationStartTime, 'milliseconds'),
                 ...(loggedRequests ? { requests: loggedRequests } : {}),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -302,7 +302,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             tuples,
             remainingGap,
             warningStatusMessage: rangeTuplesWarningMessage,
-            gap,
             originalFrom,
             originalTo,
           } = await getRuleRangeTuples({
@@ -465,19 +464,10 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
               total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
               frozen_indices_queried_count: frozenIndicesQueriedCount,
-              events_found_count: result.totalEventsFound,
               suppressed_alerts: suppressedAlertsCount,
             });
 
             const createdSignalsCount = result.createdSignals.length;
-
-            if (result.totalEventsFound != null && result.totalEventsFound > 0) {
-              const unaccountedEvents =
-                result.totalEventsFound - createdSignalsCount - suppressedAlertsCount;
-              if (unaccountedEvents > 0) {
-                ruleExecutionLogger.logMetric('unaccounted_events', unaccountedEvents);
-              }
-            }
 
             agent.setCustomContext({ [SECURITY_NUM_ALERTS_CREATED]: createdSignalsCount });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -302,6 +302,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             tuples,
             remainingGap,
             warningStatusMessage: rangeTuplesWarningMessage,
+            gap,
             originalFrom,
             originalTo,
           } = await getRuleRangeTuples({
@@ -461,10 +462,11 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
             ruleExecutionLogger.logMetrics({
-              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
               total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
               frozen_indices_queried_count: frozenIndicesQueriedCount,
               suppressed_alerts: suppressedAlertsCount,
+              gap_duration_s: remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,
+              gap_range: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
             });
 
             const createdSignalsCount = result.createdSignals.length;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -466,7 +466,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               frozen_indices_queried_count: frozenIndicesQueriedCount,
               suppressed_alerts: suppressedAlertsCount,
               gap_duration_s: remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,
-              gap_range: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
+              gap_range: gap,
             });
 
             const createdSignalsCount = result.createdSignals.length;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -460,12 +460,22 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
             ruleExecutionLogger.logMetrics({
-              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
-              total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
-              total_enrichment_duration_ms: Math.round(sum(result.enrichmentTimes.map(Number))),
+              total_search_duration_ms:
+                result.searchAfterTimes.length > 0
+                  ? Math.round(sum(result.searchAfterTimes.map(Number)))
+                  : undefined,
+              total_indexing_duration_ms:
+                result.bulkCreateTimes.length > 0
+                  ? Math.round(sum(result.bulkCreateTimes.map(Number)))
+                  : undefined,
+              total_enrichment_duration_ms:
+                result.enrichmentTimes.length > 0
+                  ? Math.round(sum(result.enrichmentTimes.map(Number)))
+                  : undefined,
               frozen_indices_queried_count: frozenIndicesQueriedCount,
               alerts_suppressed_count: suppressedAlertsCount,
-              gap_duration_s: remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,
+              gap_duration_s:
+                gap && remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,
               gap_range: gap,
             });
 
@@ -487,20 +497,22 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             const hasWarnings = result.warningMessages.length > 0;
             const hasErrors = result.errors.length > 0;
 
-            if (hasWarnings || wrapperWarnings.length > 0) {
+            if (hasErrors || wrapperErrors.length > 0) {
+              status = RuleExecutionStatusEnum.failed;
+              statusMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
+            } else if (hasWarnings || wrapperWarnings.length > 0) {
               status = RuleExecutionStatusEnum['partial failure'];
               statusMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
                 '\n\n'
               );
-            } else if (hasErrors || wrapperErrors.length > 0) {
-              status = RuleExecutionStatusEnum.failed;
-              statusMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
             }
 
             ruleExecutionLogger.logExecutionResult({
               status,
               message: statusMessage,
-              userError: result.userError,
+              userError:
+                result.userError ||
+                result.errors.every((err) => checkErrorDetails(err).isUserError),
             });
           } catch (error) {
             const errorMessage = error.message ?? '(no error message given)';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -464,7 +464,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
               total_enrichment_duration_ms: Math.round(sum(result.enrichmentTimes.map(Number))),
               frozen_indices_queried_count: frozenIndicesQueriedCount,
-              suppressed_alerts: suppressedAlertsCount,
+              alerts_suppressed_count: suppressedAlertsCount,
               gap_duration_s: remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,
               gap_range: gap,
             });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -264,13 +264,13 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             } catch (exc) {
               if (SavedObjectsErrorHelpers.isNotFoundError(exc)) {
                 await ruleExecutionLogger.logExecutionResult({
-                  outcome: RuleExecutionStatusEnum.failed,
+                  status: RuleExecutionStatusEnum.failed,
                   message: `Data view is not found.\nError: ${exc}`,
                   userError: true,
                 });
               } else {
                 await ruleExecutionLogger.logExecutionResult({
-                  outcome: RuleExecutionStatusEnum.failed,
+                  status: RuleExecutionStatusEnum.failed,
                   message: `Check for indices to search failed.\nError: ${exc}`,
                 });
               }
@@ -479,32 +479,32 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               wrapperWarnings.push(disabledActionsWarning);
             }
 
-            let outcome: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;
-            let outcomeMessage = 'Rule execution completed successfully';
+            let status: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;
+            let statusMessage = 'Rule execution completed successfully';
 
             const hasWarnings = result.warningMessages.length > 0;
             const hasErrors = result.errors.length > 0;
 
             if (hasErrors || hasWarnings) {
-              outcome = RuleExecutionStatusEnum['partial failure'];
-              outcomeMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
+              status = RuleExecutionStatusEnum['partial failure'];
+              statusMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
                 '\n\n'
               );
             } else if (wrapperErrors.length > 0 || result.errors.length > 0) {
-              outcome = RuleExecutionStatusEnum.failed;
-              outcomeMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
+              status = RuleExecutionStatusEnum.failed;
+              statusMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
             }
 
             ruleExecutionLogger.logExecutionResult({
-              outcome,
-              message: outcomeMessage,
+              status,
+              message: statusMessage,
               userError: result.userError,
             });
           } catch (error) {
             const errorMessage = error.message ?? '(no error message given)';
 
             ruleExecutionLogger.logExecutionResult({
-              outcome: RuleExecutionStatusEnum.failed,
+              status: RuleExecutionStatusEnum.failed,
               message: `An error occurred during rule execution. ${errorMessage}`,
               userError: checkErrorDetails(errorMessage).isUserError,
             });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -34,10 +34,8 @@ import { getNotificationResultsLink } from '../rule_actions_legacy';
 // eslint-disable-next-line no-restricted-imports
 import { formatAlertForNotificationActions } from '../rule_actions_legacy/logic/notifications/schedule_notification_actions';
 import { createResultObject } from './utils';
-import {
-  RuleExecutionStatus,
-  RuleExecutionStatusEnum,
-} from '../../../../common/api/detection_engine/rule_monitoring';
+import type { RuleExecutionStatus } from '../../../../common/api/detection_engine/rule_monitoring';
+import { RuleExecutionStatusEnum } from '../../../../common/api/detection_engine/rule_monitoring';
 import { truncateList } from '../rule_monitoring';
 import aadFieldConversion from '../routes/index/signal_aad_mapping.json';
 import { extractReferences, injectReferences } from './saved_object_references';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -456,19 +456,18 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               };
             }
 
-            ruleExecutionLogger.logMetrics({
-              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
-              total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
-              frozen_indices_queried_count: frozenIndicesQueriedCount,
-            });
-
             const disabledActions = rule.actions.filter(
               (action) => !actions.isActionTypeEnabled(action.actionTypeId)
             );
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
-            ruleExecutionLogger.logMetric('events_found_count', result.totalEventsFound ?? 0);
-            ruleExecutionLogger.logMetric('suppressed_alerts', suppressedAlertsCount);
+            ruleExecutionLogger.logMetrics({
+              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
+              total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
+              frozen_indices_queried_count: frozenIndicesQueriedCount,
+              events_found_count: result.totalEventsFound,
+              suppressed_alerts: suppressedAlertsCount,
+            });
 
             const createdSignalsCount = result.createdSignals.length;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -34,9 +34,6 @@ import { getNotificationResultsLink } from '../rule_actions_legacy';
 // eslint-disable-next-line no-restricted-imports
 import { formatAlertForNotificationActions } from '../rule_actions_legacy/logic/notifications/schedule_notification_actions';
 import { createResultObject } from './utils';
-import type { RuleExecutionStatus } from '../../../../common/api/detection_engine/rule_monitoring';
-import { RuleExecutionStatusEnum } from '../../../../common/api/detection_engine/rule_monitoring';
-import { truncateList } from '../rule_monitoring';
 import aadFieldConversion from '../routes/index/signal_aad_mapping.json';
 import { extractReferences, injectReferences } from './saved_object_references';
 import { withSecuritySpan } from '../../../utils/with_security_span';
@@ -61,7 +58,6 @@ import {
   SECURITY_RULE_ID,
   SECURITY_TO,
 } from './utils/apm_field_names';
-import { checkErrorDetails } from './utils/check_error_details';
 
 const aliasesFieldMap: FieldMap = {};
 Object.entries(aadFieldConversion).forEach(([key, value]) => {
@@ -210,9 +206,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
 
           let result = createResultObject(state);
 
-          const wrapperWarnings = [];
-          const wrapperErrors = [];
-
           const primaryTimestamp = timestampOverride ?? TIMESTAMP;
           const secondaryTimestamp =
             primaryTimestamp !== TIMESTAMP && !timestampOverrideFallbackDisabled
@@ -261,16 +254,11 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               runtimeMappings = dataViewRuntimeMappings;
             } catch (exc) {
               if (SavedObjectsErrorHelpers.isNotFoundError(exc)) {
-                await ruleExecutionLogger.logExecutionResult({
-                  status: RuleExecutionStatusEnum.failed,
-                  message: `Data view is not found.\nError: ${exc}`,
+                ruleExecutionLogger.error(`Data view is not found.\nError: ${exc}`, {
                   userError: true,
                 });
               } else {
-                await ruleExecutionLogger.logExecutionResult({
-                  status: RuleExecutionStatusEnum.failed,
-                  message: `Check for indices to search failed.\nError: ${exc}`,
-                });
+                ruleExecutionLogger.error(`Check for indices to search failed.\nError: ${exc}`);
               }
 
               return { state: result.state };
@@ -294,7 +282,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               isServerless: isServerless ?? false,
             });
 
-          wrapperWarnings.push(...warnings);
           warnings.forEach((warningMessage) => ruleExecutionLogger.warn(warningMessage));
 
           const {
@@ -315,7 +302,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             alerting,
           });
           if (rangeTuplesWarningMessage != null) {
-            wrapperWarnings.push(rangeTuplesWarningMessage);
             ruleExecutionLogger.warn(rangeTuplesWarningMessage);
           }
 
@@ -334,7 +320,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 ruleParams: params,
               });
             }
-            wrapperErrors.push(gapErrorMessage);
             ruleExecutionLogger.error(gapErrorMessage);
           }
 
@@ -420,6 +405,14 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   },
                 });
 
+                // Log rule run result errors and warnings explicitly here.
+                // This may lead to the same errors or warnings logged twice.
+                // Duplicates issue will be address in https://github.com/elastic/kibana/issues/259389.
+                runResult.errors.forEach((message) =>
+                  ruleExecutionLogger.error(message, { userError: runResult.userError })
+                );
+                runResult.warningMessages.forEach((message) => ruleExecutionLogger.warn(message));
+
                 const createdSignals = result.createdSignals.concat(runResult.createdSignals);
                 const warningMessages = result.warningMessages.concat(runResult.warningMessages);
                 result = {
@@ -491,41 +484,10 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 alertsCreated: createdSignalsCount > 0,
                 disabledActions,
               });
-              wrapperWarnings.push(disabledActionsWarning);
               ruleExecutionLogger.warn(disabledActionsWarning);
             }
-
-            let status: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;
-            let statusMessage = 'Rule execution completed successfully';
-
-            const hasWarnings = result.warningMessages.length > 0;
-            const hasErrors = result.errors.length > 0;
-
-            if (hasErrors || wrapperErrors.length > 0) {
-              status = RuleExecutionStatusEnum.failed;
-              statusMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
-            } else if (hasWarnings || wrapperWarnings.length > 0) {
-              status = RuleExecutionStatusEnum['partial failure'];
-              statusMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
-                '\n\n'
-              );
-            }
-
-            ruleExecutionLogger.logExecutionResult({
-              status,
-              message: statusMessage,
-              userError:
-                result.userError ||
-                result.errors.every((err) => checkErrorDetails(err).isUserError),
-            });
           } catch (error) {
-            const errorMessage = error.message ?? '(no error message given)';
-
-            ruleExecutionLogger.logExecutionResult({
-              status: RuleExecutionStatusEnum.failed,
-              message: `An error occurred during rule execution. ${errorMessage}`,
-              userError: checkErrorDetails(errorMessage).isUserError,
-            });
+            ruleExecutionLogger.error(error.message ?? '(no error message given)');
           } finally {
             await ruleExecutionLogger.close();
           }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isEmpty, partition } from 'lodash';
+import { partition, sum } from 'lodash';
 import agent from 'elastic-apm-node';
 
 import type { estypes } from '@elastic/elasticsearch';
@@ -34,7 +34,10 @@ import { getNotificationResultsLink } from '../rule_actions_legacy';
 // eslint-disable-next-line no-restricted-imports
 import { formatAlertForNotificationActions } from '../rule_actions_legacy/logic/notifications/schedule_notification_actions';
 import { createResultObject } from './utils';
-import { RuleExecutionStatusEnum } from '../../../../common/api/detection_engine/rule_monitoring';
+import {
+  RuleExecutionStatus,
+  RuleExecutionStatusEnum,
+} from '../../../../common/api/detection_engine/rule_monitoring';
 import { truncateList } from '../rule_monitoring';
 import aadFieldConversion from '../routes/index/signal_aad_mapping.json';
 import { extractReferences, injectReferences } from './saved_object_references';
@@ -207,10 +210,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
 
           ruleExecutionLogger.debug(`Starting execution with interval: ${interval}`);
 
-          await ruleExecutionLogger.logStatusChange({
-            newStatus: RuleExecutionStatusEnum.running,
-          });
-
           let result = createResultObject(state);
 
           const wrapperWarnings = [];
@@ -264,14 +263,14 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               runtimeMappings = dataViewRuntimeMappings;
             } catch (exc) {
               if (SavedObjectsErrorHelpers.isNotFoundError(exc)) {
-                await ruleExecutionLogger.logStatusChange({
-                  newStatus: RuleExecutionStatusEnum.failed,
+                await ruleExecutionLogger.logExecutionResult({
+                  outcome: RuleExecutionStatusEnum.failed,
                   message: `Data view is not found.\nError: ${exc}`,
                   userError: true,
                 });
               } else {
-                await ruleExecutionLogger.logStatusChange({
-                  newStatus: RuleExecutionStatusEnum.failed,
+                await ruleExecutionLogger.logExecutionResult({
+                  outcome: RuleExecutionStatusEnum.failed,
                   message: `Check for indices to search failed.\nError: ${exc}`,
                 });
               }
@@ -336,14 +335,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               });
             }
             wrapperErrors.push(gapErrorMessage);
-            await ruleExecutionLogger.logStatusChange({
-              newStatus: RuleExecutionStatusEnum.failed,
-              message: gapErrorMessage,
-              metrics: {
-                executionGap: remainingGap,
-                gapRange: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
-              },
-            });
           }
 
           try {
@@ -465,17 +456,19 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               };
             }
 
+            ruleExecutionLogger.logMetrics({
+              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
+              total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
+              frozen_indices_queried_count: frozenIndicesQueriedCount,
+            });
+
             const disabledActions = rule.actions.filter(
               (action) => !actions.isActionTypeEnabled(action.actionTypeId)
             );
-
-            if (result.totalEventsFound != null) {
-              ruleExecutionLogger.info(`Found matching events: ${result.totalEventsFound}`);
-            }
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
-            if (suppressedAlertsCount > 0) {
-              ruleExecutionLogger.info(`Alerts suppressed: ${suppressedAlertsCount}`);
-            }
+
+            ruleExecutionLogger.logMetric('events_found_count', result.totalEventsFound ?? 0);
+            ruleExecutionLogger.logMetric('suppressed_alerts', suppressedAlertsCount);
 
             const createdSignalsCount = result.createdSignals.length;
 
@@ -483,13 +476,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               const unaccountedEvents =
                 result.totalEventsFound - createdSignalsCount - suppressedAlertsCount;
               if (unaccountedEvents > 0) {
-                ruleExecutionLogger.info(
-                  `Events that did not result in alerts: ${unaccountedEvents}\nThis is typically because alerts for these events already exist from a previous rule execution, or events were excluded by value list exceptions. This number doesn't include suppressed alerts.`
-                );
+                ruleExecutionLogger.logMetric('unaccounted_events', unaccountedEvents);
               }
             }
-
-            ruleExecutionLogger.info(`Alerts created: ${createdSignalsCount}`);
 
             agent.setCustomContext({ [SECURITY_NUM_ALERTS_CREATED]: createdSignalsCount });
 
@@ -501,73 +490,37 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               wrapperWarnings.push(disabledActionsWarning);
             }
 
-            if (result.warningMessages.length > 0 || wrapperWarnings.length > 0) {
-              // write warning messages first because if we have still have an error to write
-              // we want to write the error messages last, so that the errors are set
-              // as the current status of the rule.
-              await ruleExecutionLogger.logStatusChange({
-                newStatus: RuleExecutionStatusEnum['partial failure'],
-                message: truncateList(result.warningMessages.concat(wrapperWarnings)).join('\n\n'),
-                metrics: {
-                  searchDurations: result.searchAfterTimes,
-                  indexingDurations: result.bulkCreateTimes,
-                  enrichmentDurations: result.enrichmentTimes,
-                  frozenIndicesQueriedCount,
-                },
-              });
-            }
-            if (wrapperErrors.length > 0 || result.errors.length > 0) {
-              await ruleExecutionLogger.logStatusChange({
-                newStatus: RuleExecutionStatusEnum.failed,
-                message: truncateList(result.errors.concat(wrapperErrors)).join(', '),
-                metrics: {
-                  searchDurations: result.searchAfterTimes,
-                  indexingDurations: result.bulkCreateTimes,
-                  enrichmentDurations: result.enrichmentTimes,
-                  executionGap: remainingGap,
-                  gapRange: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
-                  frozenIndicesQueriedCount,
-                },
-                userError:
-                  result.userError ||
-                  result.errors.every((err) => checkErrorDetails(err).isUserError),
-              });
-            } else if (!(result.warningMessages.length > 0) && !(wrapperWarnings.length > 0)) {
-              ruleExecutionLogger.debug('Security Rule execution completed');
-              ruleExecutionLogger.debug(
-                `Indexed ${createdSignalsCount} alerts into "${ruleDataClient.indexNameWithNamespace(
-                  spaceId
-                )}".${
-                  !isEmpty(tuples)
-                    ? ` Searched between date ranges: ${JSON.stringify(tuples, null, 2)}.`
-                    : ''
-                }`
+            let outcome: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;
+            let outcomeMessage = 'Rule execution completed successfully';
+
+            const hasWarnings = result.warningMessages.length > 0;
+            const hasErrors = result.errors.length > 0;
+
+            if (hasErrors || hasWarnings) {
+              outcome = RuleExecutionStatusEnum['partial failure'];
+              outcomeMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
+                '\n\n'
               );
-              await ruleExecutionLogger.logStatusChange({
-                newStatus: RuleExecutionStatusEnum.succeeded,
-                message: 'Rule execution completed successfully',
-                metrics: {
-                  searchDurations: result.searchAfterTimes,
-                  indexingDurations: result.bulkCreateTimes,
-                  enrichmentDurations: result.enrichmentTimes,
-                  frozenIndicesQueriedCount,
-                },
-              });
+            } else if (wrapperErrors.length > 0 || result.errors.length > 0) {
+              outcome = RuleExecutionStatusEnum.failed;
+              outcomeMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
             }
+
+            ruleExecutionLogger.logExecutionResult({
+              outcome,
+              message: outcomeMessage,
+              userError: result.userError,
+            });
           } catch (error) {
             const errorMessage = error.message ?? '(no error message given)';
 
-            await ruleExecutionLogger.logStatusChange({
-              newStatus: RuleExecutionStatusEnum.failed,
+            ruleExecutionLogger.logExecutionResult({
+              outcome: RuleExecutionStatusEnum.failed,
               message: `An error occurred during rule execution. ${errorMessage}`,
               userError: checkErrorDetails(errorMessage).isUserError,
-              metrics: {
-                searchDurations: result.searchAfterTimes,
-                indexingDurations: result.bulkCreateTimes,
-                enrichmentDurations: result.enrichmentTimes,
-                frozenIndicesQueriedCount,
-              },
             });
+          } finally {
+            await ruleExecutionLogger.close();
           }
 
           if (!isPreview && analytics) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -295,6 +295,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             });
 
           wrapperWarnings.push(...warnings);
+          warnings.forEach((warningMessage) => ruleExecutionLogger.warn(warningMessage));
 
           const {
             tuples,
@@ -315,6 +316,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
           });
           if (rangeTuplesWarningMessage != null) {
             wrapperWarnings.push(rangeTuplesWarningMessage);
+            ruleExecutionLogger.warn(rangeTuplesWarningMessage);
           }
 
           agent.setCustomContext({ [SECURITY_NUM_RANGE_TUPLES]: tuples.length });
@@ -333,6 +335,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               });
             }
             wrapperErrors.push(gapErrorMessage);
+            ruleExecutionLogger.error(gapErrorMessage);
           }
 
           try {
@@ -489,6 +492,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 disabledActions,
               });
               wrapperWarnings.push(disabledActionsWarning);
+              ruleExecutionLogger.warn(disabledActionsWarning);
             }
 
             let status: RuleExecutionStatus = RuleExecutionStatusEnum.succeeded;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -462,7 +462,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             const suppressedAlertsCount = result.suppressedAlertsCount ?? 0;
 
             ruleExecutionLogger.logMetrics({
+              total_search_duration_ms: Math.round(sum(result.searchAfterTimes.map(Number))),
               total_indexing_duration_ms: Math.round(sum(result.bulkCreateTimes.map(Number))),
+              total_enrichment_duration_ms: Math.round(sum(result.enrichmentTimes.map(Number))),
               frozen_indices_queried_count: frozenIndicesQueriedCount,
               suppressed_alerts: suppressedAlertsCount,
               gap_duration_s: remainingGap ? Math.round(remainingGap.asSeconds()) : undefined,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -485,12 +485,12 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
             const hasWarnings = result.warningMessages.length > 0;
             const hasErrors = result.errors.length > 0;
 
-            if (hasErrors || hasWarnings) {
+            if (hasWarnings || wrapperWarnings.length > 0) {
               status = RuleExecutionStatusEnum['partial failure'];
               statusMessage = truncateList(result.warningMessages.concat(wrapperWarnings)).join(
                 '\n\n'
               );
-            } else if (wrapperErrors.length > 0 || result.errors.length > 0) {
+            } else if (hasErrors || wrapperErrors.length > 0) {
               status = RuleExecutionStatusEnum.failed;
               statusMessage = truncateList(result.errors.concat(wrapperErrors)).join(', ');
             }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -161,9 +161,9 @@ describe('Custom Query Alerts', () => {
 
     expect((await ruleDataClient.getWriter()).bulk).not.toHaveBeenCalled();
     expect(eventsTelemetry.sendAsync).not.toHaveBeenCalled();
-    expect(mockedStatusLogger.logStatusChange).toHaveBeenCalledWith(
+    expect(mockedStatusLogger.logExecutionResult).toHaveBeenCalledWith(
       expect.objectContaining({
-        newStatus: RuleExecutionStatusEnum['partial failure'],
+        status: RuleExecutionStatusEnum['partial failure'],
         message: expect.stringContaining(
           'Unable to find matching indices for rule ALERT_RULE_NAME. This warning will persist until one of the following occurs: a matching index is created or the rule is disabled.'
         ),
@@ -254,9 +254,9 @@ describe('Custom Query Alerts', () => {
     expect(eventsTelemetry.sendAsync).toHaveBeenCalled();
     // ensures that the last status written is a warning status
     // and that status contains the error message
-    expect(mockedStatusLogger.logStatusChange).lastCalledWith(
+    expect(mockedStatusLogger.logExecutionResult).lastCalledWith(
       expect.objectContaining({
-        newStatus: RuleExecutionStatusEnum['partial failure'],
+        status: RuleExecutionStatusEnum['partial failure'],
         message:
           'Timestamp fields check failed to execute Error: hastTimestampFields test error\n' +
           '\n' +

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -19,7 +19,6 @@ import { QUERY_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
 import { docLinksServiceMock } from '@kbn/core/server/mocks';
 import { IndexPatternsFetcher } from '@kbn/data-views-plugin/server';
 import { hasTimestampFields } from '../utils/utils';
-import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine';
 
 jest.mock('@kbn/data-views-plugin/server', () => ({
   ...jest.requireActual('@kbn/data-views-plugin/server'),
@@ -161,13 +160,10 @@ describe('Custom Query Alerts', () => {
 
     expect((await ruleDataClient.getWriter()).bulk).not.toHaveBeenCalled();
     expect(eventsTelemetry.sendAsync).not.toHaveBeenCalled();
-    expect(mockedStatusLogger.logExecutionResult).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: RuleExecutionStatusEnum['partial failure'],
-        message: expect.stringContaining(
-          'Unable to find matching indices for rule ALERT_RULE_NAME. This warning will persist until one of the following occurs: a matching index is created or the rule is disabled.'
-        ),
-      })
+    expect(mockedStatusLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Unable to find matching indices for rule ALERT_RULE_NAME. This warning will persist until one of the following occurs: a matching index is created or the rule is disabled.'
+      )
     );
   });
 
@@ -252,16 +248,11 @@ describe('Custom Query Alerts', () => {
 
     expect((await ruleDataClient.getWriter()).bulk).toHaveBeenCalled();
     expect(eventsTelemetry.sendAsync).toHaveBeenCalled();
-    // ensures that the last status written is a warning status
-    // and that status contains the error message
-    expect(mockedStatusLogger.logExecutionResult).lastCalledWith(
-      expect.objectContaining({
-        status: RuleExecutionStatusEnum['partial failure'],
-        message:
-          'Timestamp fields check failed to execute Error: hastTimestampFields test error\n' +
-          '\n' +
-          "The rule's max alerts per run setting (10000) is greater than the Kibana alerting limit (1000). The rule will only write a maximum of 1000 alerts per rule run.",
-      })
+    expect(mockedStatusLogger.warn).toHaveBeenCalledWith(
+      'Timestamp fields check failed to execute Error: hastTimestampFields test error'
+    );
+    expect(mockedStatusLogger.warn).toHaveBeenCalledWith(
+      "The rule's max alerts per run setting (10000) is greater than the Kibana alerting limit (1000). The rule will only write a maximum of 1000 alerts per rule run."
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -503,7 +503,7 @@ describe('utils', () => {
         },
       };
 
-      const { foundNoIndices } = await hasTimestampFields({
+      const { foundNoIndices, warningMessage } = await hasTimestampFields({
         timestampField,
         timestampFieldCapsResponse: timestampFieldCapsResponse as TransportResult<
           FieldCapsResponse,
@@ -513,11 +513,9 @@ describe('utils', () => {
       });
 
       expect(foundNoIndices).toBeFalsy();
-      expect(ruleExecutionLogger.logExecutionResult).toHaveBeenCalledWith({
-        status: RuleExecutionStatusEnum['partial failure'],
-        message:
-          'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1","myfakeindex-2"]',
-      });
+      expect(warningMessage).toBe(
+        'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1","myfakeindex-2"]'
+      );
     });
 
     test('returns true when missing timestamp field', async () => {
@@ -544,7 +542,7 @@ describe('utils', () => {
         },
       };
 
-      const { foundNoIndices } = await hasTimestampFields({
+      const { foundNoIndices, warningMessage } = await hasTimestampFields({
         timestampField,
         timestampFieldCapsResponse: timestampFieldCapsResponse as TransportResult<
           FieldCapsResponse,
@@ -554,11 +552,9 @@ describe('utils', () => {
       });
 
       expect(foundNoIndices).toBeFalsy();
-      expect(ruleExecutionLogger.logExecutionResult).toHaveBeenCalledWith({
-        sampleDocSearchResultsNoSortIdNoHitstatus: RuleExecutionStatusEnum['partial failure'],
-        message:
-          'The following indices are missing the timestamp field "@timestamp": ["myfakeindex-1","myfakeindex-2"]',
-      });
+      expect(warningMessage).toBe(
+        'The following indices are missing the timestamp field "@timestamp": ["myfakeindex-1","myfakeindex-2"]'
+      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -16,7 +16,6 @@ import type { SanitizedRuleAction } from '@kbn/alerting-plugin/common';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
 import { listMock } from '@kbn/lists-plugin/server/mocks';
 import type { ExceptionListClient } from '@kbn/lists-plugin/server';
-import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
 import { getListArrayMock } from '../../../../../common/detection_engine/schemas/types/lists.mock';
 import { getExceptionListItemSchemaMock } from '@kbn/lists-plugin/common/schemas/response/exception_list_item_schema.mock';
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -513,8 +513,8 @@ describe('utils', () => {
       });
 
       expect(foundNoIndices).toBeFalsy();
-      expect(ruleExecutionLogger.logStatusChange).toHaveBeenCalledWith({
-        newStatus: RuleExecutionStatusEnum['partial failure'],
+      expect(ruleExecutionLogger.logExecutionResult).toHaveBeenCalledWith({
+        status: RuleExecutionStatusEnum['partial failure'],
         message:
           'The following indices are missing the timestamp override field "event.ingested": ["myfakeindex-1","myfakeindex-2"]',
       });
@@ -554,8 +554,8 @@ describe('utils', () => {
       });
 
       expect(foundNoIndices).toBeFalsy();
-      expect(ruleExecutionLogger.logStatusChange).toHaveBeenCalledWith({
-        newStatus: RuleExecutionStatusEnum['partial failure'],
+      expect(ruleExecutionLogger.logExecutionResult).toHaveBeenCalledWith({
+        sampleDocSearchResultsNoSortIdNoHitstatus: RuleExecutionStatusEnum['partial failure'],
         message:
           'The following indices are missing the timestamp field "@timestamp": ["myfakeindex-1","myfakeindex-2"]',
       });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -110,10 +110,7 @@ export const hasTimestampFields = async (args: {
         : timestampFieldCapsResponse.body.fields[timestampField]?.unmapped?.indices
     )}`;
 
-    await ruleExecutionLogger.logStatusChange({
-      newStatus: RuleExecutionStatusEnum['partial failure'],
-      message: errorString,
-    });
+    ruleExecutionLogger.warn(errorString);
 
     return { foundNoIndices: false, warningMessage: errorString };
   }
@@ -347,10 +344,7 @@ export const getRuleRangeTuples = async ({
   if (maxSignals > maxAlertsAllowed) {
     maxSignalsToUse = maxAlertsAllowed;
     warningStatusMessage = `The rule's max alerts per run setting (${maxSignals}) is greater than the Kibana alerting limit (${maxAlertsAllowed}). The rule will only write a maximum of ${maxAlertsAllowed} alerts per rule run.`;
-    await ruleExecutionLogger.logStatusChange({
-      newStatus: RuleExecutionStatusEnum['partial failure'],
-      message: warningStatusMessage,
-    });
+    ruleExecutionLogger.warn(warningStatusMessage);
   }
 
   const tuples = [

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -39,7 +39,6 @@ import type { SanitizedRuleAction } from '@kbn/alerting-plugin/common';
 import type { SuppressionFieldsLatest } from '@kbn/rule-registry-plugin/common/schemas';
 import type { TimestampOverride } from '../../../../../common/api/detection_engine/model/rule_schema';
 import type { Privilege } from '../../../../../common/api/detection_engine';
-import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
 import type {
   SearchAfterAndBulkCreateReturnType,
   SignalSearchResponse,


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/255513**
**Resolves: https://github.com/elastic/kibana/issues/135209**
**[Design document](https://docs.google.com/document/d/1njxu_2MDwR2NGEHJWmI_iFg34OidO8nF0QFOS13x8ck)** (internal)

## Summary

This PR adds functionality to log the rule execution metrics and context data into the Alerting Framework's `execute` event log event.

## Details

Detection Engine Observability initiative requires collecting various metrics related to the security rule execution. We already collect a number of metrics and write them to the **Event Log** and would like to add more later on. On top of that we'd like to log dynamic customer defined metrics. This PR focuses on implementing extensible functionality where we could add more metrics later on. The desired list of metrics is under discussion. Above that make sure we log a single rule result event per execution. 

Historically there is functionality on the Security Solution's side that logs multiple events per each rule execution like `status-change`, `execution-metrics` and `message`. Weirdly it may log multiple `status-change` events per single rule execution where rule status flips between error and success. Additionally Alerting Framework logs rule execution related events to the Event Log as well. In particular it logs `execute-start` and `execute` event where the latter has almost all the metrics Security Solution logs to the Event Log already.

**This PR adds functionality** to log security rule metrics and the rule context data like correlation ids to the Alerting Framework's `execute` event.

Existing events produced on Security Solution's side `status-change` and `execution-metrics` will be written as is. This decision allow to reduce this PR's scope. Getting rid of `status-change` and `execution-metrics` requires a follow up PR tackling rule execution UI, snapshot based telemetry and functional tests relying on the Event Log. 

### Changes

At the high level changes could be described as follows

- Refactor [RuleMonitoring](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts) service to replace individual metrics setters with common `setMetric()` and `setMetrics()`
- Extend [AlertingEventLogger](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts) to write consumer metrics to the `execute` event
- Extend [AlertingEventLogger](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting/server/lib/alerting_event_logger/alerting_event_logger.ts) to write `rule_id` aka `uuid` to the `execute` event
- Refactor [RuleExecutionLogClientForExecutors](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts) to expose `setMetric()` and `setMetrics()` methods and pass the metrics to the [RuleMonitoring](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/alerting/server/monitoring/rule_monitoring_service.ts) service. Additionally make sure we wire a single result per execution.

### The Logged Event

<details>
  <summary>"execute" event example</summary>

```
{
  "_index": ".ds-.kibana-event-log-ds-2026.03.17-000001",
  "_id": "2cc392bd-94c7-4c05-868a-bea57bba2188",
  "_version": 1,
  "_source": {
    "@timestamp": "2026-03-20T11:03:11.235Z",
    "event": {
      "provider": "alerting",
      "action": "execute",
      "kind": "alert",
      "category": [
        "siem"
      ],
      "start": "2026-03-20T11:03:10.467Z",
      "outcome": "failure",
      "end": "2026-03-20T11:03:11.235Z",
      "duration": "768000000",
      "reason": "unknown"
    },
    "kibana": {
      "alert": {
        "rule": {
          "rule_type_id": "siem.queryRule",
          "consumer": "siem",
          "execution": {
            "uuid": "5d5a25b3-52da-4fc2-9945-06f6e4c0d9c8",
            "metrics": {
              "number_of_triggered_actions": 0,
              "number_of_generated_actions": 0,
              "alert_counts": {
                "active": 32,
                "new": 32,
                "recovered": 0
              },
              "number_of_delayed_alerts": 0,
              "number_of_searches": 10,
              "es_search_duration_ms": 77,
              "total_search_duration_ms": 105,
              "alerts_suppressed_count": 0,
              "frozen_indices_queried_count": 0,
              "total_indexing_duration_ms": 345,
              "total_enrichment_duration_ms": 8,
              "execution_gap_duration_s": 451,
              "gap_range": {
                "gte": "2026-03-20T10:29:39.844Z",
                "lte": "2026-03-20T10:37:10.427Z"
              },
              "claim_to_start_duration_ms": 41,
              "total_run_duration_ms": 808,
              "prepare_rule_duration_ms": 14,
              "rule_type_run_duration_ms": 719,
              "process_alerts_duration_ms": 1,
              "persist_alerts_duration_ms": 0,
              "trigger_actions_duration_ms": 1,
              "process_rule_duration_ms": 23,
              "update_alerts_duration_ms": 0
            }
          },
          "revision": 1
        }
      },
      "saved_objects": [
        {
          "rel": "primary",
          "type": "alert",
          "id": "baca894d-1925-447e-a60d-bff768097a78",
          "type_id": "siem.queryRule"
        }
      ],
      "space_ids": [
        "default"
      ],
      "task": {
        "scheduled": "2026-03-20T11:03:08.054Z",
        "schedule_delay": 2413000000
      },
      "alerting": {
        "outcome": "failure",
        "status": "error"
      },
      "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
      "version": "9.4.0"
    },
    "rule": {
      "id": "baca894d-1925-447e-a60d-bff768097a78",
      "license": "basic",
      "category": "siem.queryRule",
      "ruleset": "siem",
      "name": "Test rule 2",
      "uuid": "e3e0eb5e-ecdc-4f7c-9896-5ff923375575"
    },
    "message": "siem.queryRule:baca894d-1925-447e-a60d-bff768097a78: execution failed",
    "error": {
      "message": "8 minutes (450583ms) were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances"
    },
    "ecs": {
      "version": "1.8.0"
    }
  },
  "fields": {
    "rule.id": [
      "baca894d-1925-447e-a60d-bff768097a78"
    ],
    "event.category": [
      "siem"
    ],
    "kibana.alerting.outcome": [
      "failure"
    ],
    "kibana.task.schedule_delay": [
      2413000000
    ],
    "kibana.task.scheduled": [
      "2026-03-20T11:03:08.054Z"
    ],
    "kibana.alert.rule.execution.metrics.alert_counts.active": [
      32
    ],
    "kibana.alert.rule.execution.metrics.claim_to_start_duration_ms": [
      41
    ],
    "kibana.alert.rule.execution.metrics.total_search_duration_ms": [
      105
    ],
    "kibana.alert.rule.execution.metrics.alerts_suppressed_count": [
      0
    ],
    "rule.ruleset": [
      "siem"
    ],
    "event.reason": [
      "unknown"
    ],
    "event.kind": [
      "alert"
    ],
    "kibana.server_uuid": [
      "5b2de169-2785-441b-ae8c-186a1936b17d"
    ],
    "event.outcome": [
      "failure"
    ],
    "rule.name": [
      "Test rule 2"
    ],
    "kibana.alerting.status": [
      "error"
    ],
    "kibana.saved_objects": [
      {
        "type_id": [
          "siem.queryRule"
        ],
        "rel": [
          "primary"
        ],
        "id": [
          "baca894d-1925-447e-a60d-bff768097a78"
        ],
        "type": [
          "alert"
        ]
      }
    ],
    "kibana.alert.rule.execution.metrics.rule_type_run_duration_ms": [
      719
    ],
    "event.provider": [
      "alerting"
    ],
    "kibana.alert.rule.execution.metrics.alert_counts.recovered": [
      0
    ],
    "kibana.alert.rule.execution.metrics.number_of_searches": [
      10
    ],
    "ecs.version": [
      "1.8.0"
    ],
    "kibana.alert.rule.execution.metrics.frozen_indices_queried_count": [
      0
    ],
    "event.start": [
      "2026-03-20T11:03:10.467Z"
    ],
    "kibana.alert.rule.revision": [
      1
    ],
    "kibana.alert.rule.execution.metrics.number_of_triggered_actions": [
      0
    ],
    "kibana.alert.rule.execution.metrics.process_rule_duration_ms": [
      23
    ],
    "kibana.alert.rule.execution.metrics.number_of_delayed_alerts": [
      0
    ],
    "event.end": [
      "2026-03-20T11:03:11.235Z"
    ],
    "kibana.alert.rule.execution.metrics.prepare_rule_duration_ms": [
      14
    ],
    "rule.license": [
      "basic"
    ],
    "kibana.alert.rule.execution.metrics.gap_range": [
      {
        "gte": "2026-03-20T10:29:39.844Z",
        "lte": "2026-03-20T10:37:10.427Z"
      }
    ],
    "kibana.alert.rule.rule_type_id": [
      "siem.queryRule"
    ],
    "kibana.alert.rule.execution.metrics.number_of_generated_actions": [
      0
    ],
    "kibana.alert.rule.execution.metrics.process_alerts_duration_ms": [
      1
    ],
    "kibana.alert.rule.execution.metrics.trigger_actions_duration_ms": [
      1
    ],
    "kibana.alert.rule.execution.metrics.total_indexing_duration_ms": [
      345
    ],
    "kibana.alert.rule.execution.metrics.alert_counts.new": [
      32
    ],
    "kibana.alert.rule.execution.metrics.persist_alerts_duration_ms": [
      0
    ],
    "kibana.alert.rule.execution.metrics.total_enrichment_duration_ms": [
      8
    ],
    "message": [
      "siem.queryRule:baca894d-1925-447e-a60d-bff768097a78: execution failed"
    ],
    "kibana.alert.rule.consumer": [
      "siem"
    ],
    "kibana.alert.rule.execution.metrics.update_alerts_duration_ms": [
      0
    ],
    "event.duration": [
      768000000
    ],
    "rule.uuid": [
      "e3e0eb5e-ecdc-4f7c-9896-5ff923375575"
    ],
    "event.action": [
      "execute"
    ],
    "@timestamp": [
      "2026-03-20T11:03:11.235Z"
    ],
    "error.message": [
      "8 minutes (450583ms) were not queried between this rule execution and the last execution, so signals may have been missed. Consider increasing your look behind time or adding more Kibana instances"
    ],
    "kibana.alert.rule.execution.metrics.total_run_duration_ms": [
      808
    ],
    "kibana.alert.rule.execution.metrics.execution_gap_duration_s": [
      451
    ],
    "kibana.alert.rule.execution.uuid": [
      "5d5a25b3-52da-4fc2-9945-06f6e4c0d9c8"
    ],
    "kibana.space_ids": [
      "default"
    ],
    "kibana.version": [
      "9.4.0"
    ],
    "kibana.alert.rule.execution.metrics.es_search_duration_ms": [
      77
    ],
    "rule.category": [
      "siem.queryRule"
    ]
  }
}
```
</details>

<details>
  <summary>"execute-backfill" event example</summary>

```
{
  "_index": ".ds-.kibana-event-log-ds-2026.03.17-000001",
  "_id": "82159944-e0c8-4e70-a3fa-8604749f6282",
  "_version": 1,
  "_source": {
    "@timestamp": "2026-03-20T11:56:32.166Z",
    "event": {
      "provider": "alerting",
      "action": "execute-backfill",
      "kind": "alert",
      "start": "2026-03-20T11:56:32.160Z",
      "end": "2026-03-20T11:56:32.166Z",
      "duration": "6000000",
      "outcome": "failure",
      "reason": "decrypt"
    },
    "kibana": {
      "alert": {
        "rule": {
          "execution": {
            "uuid": "f21ccc43-1dbb-4795-910b-f2ddf34f37ed",
            "metrics": {
              "claim_to_start_duration_ms": 0,
              "total_run_duration_ms": 19,
              "prepare_rule_duration_ms": 0,
              "rule_type_run_duration_ms": 0,
              "process_alerts_duration_ms": 0,
              "persist_alerts_duration_ms": 0,
              "trigger_actions_duration_ms": 0,
              "process_rule_duration_ms": 5,
              "update_alerts_duration_ms": 0
            },
            "backfill": {
              "id": "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410"
            }
          }
        }
      },
      "saved_objects": [
        {
          "rel": "primary",
          "type": "ad_hoc_run_params",
          "id": "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410"
        }
      ],
      "space_ids": [
        "default"
      ],
      "task": {
        "scheduled": "2026-03-20T11:56:29.305Z",
        "schedule_delay": 2855000000
      },
      "alerting": {
        "status": "error",
        "outcome": "failure"
      },
      "server_uuid": "5b2de169-2785-441b-ae8c-186a1936b17d",
      "version": "9.4.0"
    },
    "rule": {},
    "message": "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410: execution failed",
    "error": {
      "message": "Saved object [ad_hoc_run_params/92981a1d-8dfb-4dfd-ab4a-cfa9f4150410] not found"
    },
    "ecs": {
      "version": "1.8.0"
    }
  },
  "fields": {
    "kibana.alert.rule.execution.metrics.process_rule_duration_ms": [
      5
    ],
    "kibana.alerting.outcome": [
      "failure"
    ],
    "kibana.task.schedule_delay": [
      2855000000
    ],
    "kibana.task.scheduled": [
      "2026-03-20T11:56:29.305Z"
    ],
    "event.end": [
      "2026-03-20T11:56:32.166Z"
    ],
    "kibana.alert.rule.execution.metrics.claim_to_start_duration_ms": [
      0
    ],
    "kibana.alert.rule.execution.metrics.prepare_rule_duration_ms": [
      0
    ],
    "kibana.alert.rule.execution.metrics.process_alerts_duration_ms": [
      0
    ],
    "event.reason": [
      "decrypt"
    ],
    "kibana.alert.rule.execution.metrics.trigger_actions_duration_ms": [
      0
    ],
    "event.kind": [
      "alert"
    ],
    "kibana.server_uuid": [
      "5b2de169-2785-441b-ae8c-186a1936b17d"
    ],
    "event.outcome": [
      "failure"
    ],
    "kibana.alert.rule.execution.metrics.persist_alerts_duration_ms": [
      0
    ],
    "kibana.alerting.status": [
      "error"
    ],
    "kibana.saved_objects": [
      {
        "rel": [
          "primary"
        ],
        "id": [
          "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410"
        ],
        "type": [
          "ad_hoc_run_params"
        ]
      }
    ],
    "message": [
      "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410: execution failed"
    ],
    "kibana.alert.rule.execution.metrics.rule_type_run_duration_ms": [
      0
    ],
    "kibana.alert.rule.execution.metrics.update_alerts_duration_ms": [
      0
    ],
    "event.duration": [
      6000000
    ],
    "kibana.alert.rule.execution.backfill.id": [
      "92981a1d-8dfb-4dfd-ab4a-cfa9f4150410"
    ],
    "event.action": [
      "execute-backfill"
    ],
    "event.provider": [
      "alerting"
    ],
    "@timestamp": [
      "2026-03-20T11:56:32.166Z"
    ],
    "ecs.version": [
      "1.8.0"
    ],
    "error.message": [
      "Saved object [ad_hoc_run_params/92981a1d-8dfb-4dfd-ab4a-cfa9f4150410] not found"
    ],
    "kibana.alert.rule.execution.metrics.total_run_duration_ms": [
      19
    ],
    "kibana.alert.rule.execution.uuid": [
      "f21ccc43-1dbb-4795-910b-f2ddf34f37ed"
    ],
    "kibana.space_ids": [
      "default"
    ],
    "kibana.version": [
      "9.4.0"
    ],
    "event.start": [
      "2026-03-20T11:56:32.160Z"
    ]
  }
}
```
</details>