### PR TITLE
[Streams] Enable parallel execution for stream evals

### DIFF
--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pattern_extraction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pattern_extraction.spec.ts
@@ -43,11 +43,11 @@ import {
 evaluate.describe.configure({ timeout: 300_000 });
 
 evaluate.describe('Pattern extraction quality evaluation', () => {
-  evaluate.beforeEach(async ({ apiServices }) => {
+  evaluate.beforeAll(async ({ apiServices }) => {
     await apiServices.streams.enable();
   });
 
-  evaluate.afterEach(async ({ apiServices }) => {
+  evaluate.afterAll(async ({ apiServices }) => {
     await apiServices.streams.disable();
   });
 

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pipeline_suggestion.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pipeline_suggestion.spec.ts
@@ -34,9 +34,19 @@ import { indexSynthtraceScenario } from './synthtrace_helpers';
 
 evaluate.describe.configure({ timeout: 600_000 });
 
+/**
+ * Get worker-specific stream prefix to avoid collisions in parallel execution.
+ * Uses the TEST_PARALLEL_INDEX environment variable set by Playwright.
+ */
+function getWorkerStreamPrefix(): string {
+  const parallelIndex = process.env.TEST_PARALLEL_INDEX ?? '0';
+  return `w${parallelIndex}`;
+}
+
 evaluate.describe('Pipeline suggestion quality evaluation', () => {
   const from = kbnDatemath.parse('now-2m')!;
   const to = kbnDatemath.parse('now')!;
+  const workerStreamPrefix = getWorkerStreamPrefix();
 
   /**
    * Flatten nested objects into dot notation.
@@ -583,7 +593,7 @@ evaluate.describe('Pipeline suggestion quality evaluation', () => {
       evaluate.afterAll(async ({ apiServices, esClient }) => {
         await apiServices.streams.disable();
         await esClient.indices.deleteDataStream({
-          name: 'logs*',
+          name: `logs.otel.${workerStreamPrefix}*`,
         });
       });
 
@@ -607,10 +617,13 @@ evaluate.describe('Pipeline suggestion quality evaluation', () => {
               // No need to fork or index - documents are passed directly
               example.input.stream_name = 'logs.otel';
             } else {
-              // INDEX MODE: Create system-specific stream AND index data
-              // stream_name in dataset must be logs.otel.<system> (child of logs.otel per API)
+              // INDEX MODE: Create worker-specific stream to avoid parallel collisions
+              // Use logs.otel.<workerPrefix>.<system> pattern (e.g., logs.otel.w0.apache)
+              const workerStreamName = `logs.otel.${workerStreamPrefix}.${example.input.system.toLowerCase()}`;
+              example.input.stream_name = workerStreamName;
+
               // Route based on attributes.filepath which is set to "{System}.log" by synthtrace
-              await apiServices.streams.forkStream('logs.otel', example.input.stream_name, {
+              await apiServices.streams.forkStream('logs.otel', workerStreamName, {
                 field: 'attributes.filepath',
                 eq: `${example.input.system}.log`,
               });

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pipeline_suggestion.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/pipeline_suggestion.spec.ts
@@ -618,8 +618,9 @@ evaluate.describe('Pipeline suggestion quality evaluation', () => {
               example.input.stream_name = 'logs.otel';
             } else {
               // INDEX MODE: Create worker-specific stream to avoid parallel collisions
-              // Use logs.otel.<workerPrefix>.<system> pattern (e.g., logs.otel.w0.apache)
-              const workerStreamName = `logs.otel.${workerStreamPrefix}.${example.input.system.toLowerCase()}`;
+              // Use logs.otel.<workerPrefix>_<system> pattern (e.g., logs.otel.w0_apache)
+              // Note: Using underscore, not dot, because the child must be a direct child of logs.otel
+              const workerStreamName = `logs.otel.${workerStreamPrefix}_${example.input.system.toLowerCase()}`;
               example.input.stream_name = workerStreamName;
 
               // Route based on attributes.filepath which is set to "{System}.log" by synthtrace

--- a/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-evals-suite-streams/evals/significant_events/feature_duplication/features_duplication.spec.ts
@@ -23,9 +23,20 @@ import {
   createIdConsistencyEvaluator,
 } from '../../../src/evaluators/feature_duplication_evaluators';
 
+/**
+ * Get worker-specific stream prefix to avoid collisions in parallel execution.
+ * Uses the TEST_PARALLEL_INDEX environment variable set by Playwright.
+ */
+function getWorkerStreamPrefix(): string {
+  const parallelIndex = process.env.TEST_PARALLEL_INDEX ?? '0';
+  return `w${parallelIndex}`;
+}
+
 evaluate.describe('Streams features duplication (harness)', () => {
   const from = kbnDatemath.parse('now-10m')!;
   const to = kbnDatemath.parse('now')!;
+  const workerStreamPrefix = getWorkerStreamPrefix();
+  const workerStreamName = `logs.otel.${workerStreamPrefix}`;
 
   async function runRepeatedFeatureIdentification({
     esClient,
@@ -76,12 +87,14 @@ evaluate.describe('Streams features duplication (harness)', () => {
     evaluate.describe(dataset.name, { tag: tags.stateful.classic }, () => {
       evaluate.beforeAll(async ({ apiServices }) => {
         await apiServices.streams.enable();
+        // Create a worker-specific child stream to isolate data between parallel workers
+        await apiServices.streams.forkStream('logs.otel', workerStreamName, { always: {} });
       });
 
       evaluate.afterAll(async ({ apiServices, esClient }) => {
         await apiServices.streams.disable();
         await esClient.indices.deleteDataStream({
-          name: 'logs*',
+          name: `logs.otel.${workerStreamPrefix}*`,
         });
       });
 
@@ -110,14 +123,15 @@ evaluate.describe('Streams features duplication (harness)', () => {
             to,
           });
 
-          await esClient.indices.refresh({ index: dataset.input.stream_name });
+          // Refresh the worker-specific stream to ensure indexed data is available
+          await esClient.indices.refresh({ index: workerStreamName });
 
           await executorClient.runExperiment(
             {
               dataset: {
                 name: dataset.name,
                 description: dataset.description,
-                examples: [{ input: dataset.input }],
+                examples: [{ input: { ...dataset.input, stream_name: workerStreamName } }],
               },
               task: async ({
                 input,


### PR DESCRIPTION
## Summary

Enable stream evals to run in parallel by using worker-specific stream names. Each Playwright worker now operates on isolated streams to avoid conflicts when running multiple workers concurrently.

**Changes:**
- `pipeline_suggestion.spec.ts`: Use `logs.otel.w<N>.<system>` pattern for INDEX mode tests
- `pattern_extraction.spec.ts`: Change `beforeEach`/`afterEach` to `beforeAll`/`afterAll` to avoid race conditions
- `features_duplication.spec.ts`: Create worker-specific child streams with `always:{}` routing

**How it works:**
- Uses Playwright's `TEST_PARALLEL_INDEX` environment variable to create unique stream prefixes (w0, w1, w2, etc.)
- Each worker creates its own child streams under `logs.otel.w<N>.*`
- Cleanup only removes the worker's streams, not global patterns

## Test plan

- [ ] Run evals with `--workers=4` to verify parallel execution works without conflicts
- [ ] CI validates the changes as part of the eval pipeline

Refs: elastic/streams-program#776

Made with [Cursor](https://cursor.com)