### PR TITLE
[8.19] [@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills (#255930)

### DIFF
--- a/.agents/skills/scout-ui-testing/SKILL.md
+++ b/.agents/skills/scout-ui-testing/SKILL.md
@@ -95,6 +95,7 @@ test('creates and verifies a dashboard', async ({ pageObjects, page }) => {
 
 - Don’t use `page.waitForTimeout`. Wait on a page-ready signal (loading indicator hidden, container visible, `expect.poll` on element counts).
 - If selectors aren’t stable, add `data-test-subj` (Scout uses it as the `testIdAttribute`).
+- Some locators are restricted by `@kbn/eslint/scout_no_locators` (e.g. `globalLoadingIndicator`). Don’t use them in tests or page objects for app loading state management; rely on Playwright auto-waiting and page-ready signals instead.
 
 ## A11y checks (optional, high value)
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2365,6 +2365,7 @@ module.exports = {
         '@kbn/eslint/scout_no_es_archiver_in_parallel_tests': 'error',
         '@kbn/eslint/scout_no_cross_boundary_imports': 'error',
         '@kbn/eslint/scout_expect_import': 'error',
+        '@kbn/eslint/scout_no_locators': ['error', { restricted: ['globalLoadingIndicator'] }],
         '@kbn/eslint/require_include_in_check_a11y': 'warn',
       },
     },

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -27,6 +27,7 @@ module.exports = {
     scout_no_es_archiver_in_parallel_tests: require('./rules/scout_no_es_archiver_in_parallel_tests'),
     scout_expect_import: require('./rules/scout_expect_import'),
     scout_no_cross_boundary_imports: require('./rules/scout_no_cross_boundary_imports'),
+    scout_no_locators: require('./rules/scout_no_locators'),
     require_kbn_fs: require('./rules/require_kbn_fs'),
     require_include_in_check_a11y: require('./rules/require_include_in_check_a11y'),
   },

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/** @typedef {import("eslint").Rule.RuleModule} Rule */
+
+const WATCHED_METHODS = new Set(['locator', 'waitForSelector']);
+
+/** @type {Rule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Restrict specific testSubj locators in Scout tests',
+      category: 'Best Practices',
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          restricted: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const restricted = new Set(options.restricted || []);
+    if (restricted.size === 0) return {};
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        // Match *.testSubj.<locator|waitForSelector>('...')
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.property.type !== 'Identifier' ||
+          !WATCHED_METHODS.has(callee.property.name) ||
+          callee.object.type !== 'MemberExpression' ||
+          callee.object.property.type !== 'Identifier' ||
+          callee.object.property.name !== 'testSubj'
+        ) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+        if (!firstArg || firstArg.type !== 'Literal' || typeof firstArg.value !== 'string') return;
+
+        if (restricted.has(firstArg.value)) {
+          const method = callee.property.name;
+          context.report({
+            node,
+            message: `The locator \`testSubj.{{method}}('{{name}}')\` is restricted. Tests should not use this element for app loading state management.`,
+            data: { method, name: firstArg.value },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const { RuleTester } = require('eslint');
+const rule = require('./scout_no_locators');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2020,
+  },
+});
+
+const options = [{ restricted: ['globalLoadingIndicator'] }];
+
+ruleTester.run('@kbn/eslint/scout_no_locators', rule, {
+  valid: [
+    {
+      code: `page.testSubj.locator('allowedLocator');`,
+      options,
+    },
+    {
+      code: `page.testSubj.click('globalLoadingIndicator');`,
+      options,
+    },
+    {
+      code: `page.testSubj.waitForSelector('allowedLocator', { state: 'visible' });`,
+      options,
+    },
+    {
+      code: `page.testSubj.locator('globalLoadingIndicator');`,
+      options: [{ restricted: [] }],
+    },
+  ],
+
+  invalid: [
+    {
+      code: `page.testSubj.locator('globalLoadingIndicator');`,
+      options,
+      errors: [
+        {
+          message: `The locator \`testSubj.locator('globalLoadingIndicator')\` is restricted. Tests should not use this element for app loading state management.`,
+        },
+      ],
+    },
+    {
+      code: `this.page.testSubj.locator('globalLoadingIndicator');`,
+      options,
+      errors: [
+        {
+          message: `The locator \`testSubj.locator('globalLoadingIndicator')\` is restricted. Tests should not use this element for app loading state management.`,
+        },
+      ],
+    },
+    {
+      code: `await expect(page.testSubj.locator('globalLoadingIndicator')).toBeHidden();`,
+      options,
+      errors: [
+        {
+          message: `The locator \`testSubj.locator('globalLoadingIndicator')\` is restricted. Tests should not use this element for app loading state management.`,
+        },
+      ],
+    },
+    {
+      code: `await page.testSubj.waitForSelector('globalLoadingIndicator', { state: 'hidden' });`,
+      options,
+      errors: [
+        {
+          message: `The locator \`testSubj.waitForSelector('globalLoadingIndicator')\` is restricted. Tests should not use this element for app loading state management.`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills (#255930)](https://github.com/elastic/kibana/pull/255930)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-11T14:11:02Z","message":"[@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills (#255930)\n\n## Summary\n\nCreate new ESLint rule called `scout_no_locators`, that accepts a list\nof locators to forbid, starting with just one: `globalLoadingIndicator`.\nShould throw warning. Also update skills accordingly.\n\n## Changes\n\n- **New rule**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.js`: catches\n`testSubj.locator(...)` and `testSubj.waitForSelector(...)` calls with\nforbidden selectors. Accepts a `forbidden` array option.\n- **Tests**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.test.js`: 8\ntest cases covering valid usage, action methods that should not be\nflagged, and invalid usage for both `locator` and `waitForSelector`.\n- **Rule registration**: added `scout_no_locators` to\n`packages/kbn-eslint-plugin-eslint/index.js`.\n- **ESLint config**: applied as `warn` in `.eslintrc.js` alongside other\nScout rules, with `{ forbidden: ['globalLoadingIndicator'] }`.\n- **Skills**: updated `scout-ui-testing` and\n`scout-best-practices-reviewer` skills to mention forbidden locators.","sha":"bc62946e255e84b357cf941f80f22ae265f826d8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","test:scout","v9.4.0"],"title":"[@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills","number":255930,"url":"https://github.com/elastic/kibana/pull/255930","mergeCommit":{"message":"[@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills (#255930)\n\n## Summary\n\nCreate new ESLint rule called `scout_no_locators`, that accepts a list\nof locators to forbid, starting with just one: `globalLoadingIndicator`.\nShould throw warning. Also update skills accordingly.\n\n## Changes\n\n- **New rule**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.js`: catches\n`testSubj.locator(...)` and `testSubj.waitForSelector(...)` calls with\nforbidden selectors. Accepts a `forbidden` array option.\n- **Tests**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.test.js`: 8\ntest cases covering valid usage, action methods that should not be\nflagged, and invalid usage for both `locator` and `waitForSelector`.\n- **Rule registration**: added `scout_no_locators` to\n`packages/kbn-eslint-plugin-eslint/index.js`.\n- **ESLint config**: applied as `warn` in `.eslintrc.js` alongside other\nScout rules, with `{ forbidden: ['globalLoadingIndicator'] }`.\n- **Skills**: updated `scout-ui-testing` and\n`scout-best-practices-reviewer` skills to mention forbidden locators.","sha":"bc62946e255e84b357cf941f80f22ae265f826d8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255930","number":255930,"mergeCommit":{"message":"[@kbn/eslint-plugin-eslint] Create `scout_no_locators` rule + update skills (#255930)\n\n## Summary\n\nCreate new ESLint rule called `scout_no_locators`, that accepts a list\nof locators to forbid, starting with just one: `globalLoadingIndicator`.\nShould throw warning. Also update skills accordingly.\n\n## Changes\n\n- **New rule**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.js`: catches\n`testSubj.locator(...)` and `testSubj.waitForSelector(...)` calls with\nforbidden selectors. Accepts a `forbidden` array option.\n- **Tests**:\n`packages/kbn-eslint-plugin-eslint/rules/scout_no_locators.test.js`: 8\ntest cases covering valid usage, action methods that should not be\nflagged, and invalid usage for both `locator` and `waitForSelector`.\n- **Rule registration**: added `scout_no_locators` to\n`packages/kbn-eslint-plugin-eslint/index.js`.\n- **ESLint config**: applied as `warn` in `.eslintrc.js` alongside other\nScout rules, with `{ forbidden: ['globalLoadingIndicator'] }`.\n- **Skills**: updated `scout-ui-testing` and\n`scout-best-practices-reviewer` skills to mention forbidden locators.","sha":"bc62946e255e84b357cf941f80f22ae265f826d8"}}]}] BACKPORT-->