### PR TITLE
Fix shard-aware checkpoint identity in scripts/jest

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/jest/run.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.ts
@@ -31,13 +31,32 @@ import { SCOUT_REPORTER_ENABLED } from '@kbn/scout-info';
 import type { Config } from '@jest/types';
 
 import jestFlags from './jest_flags.json';
-import { isInBuildkite, isConfigCompleted, markConfigCompletedSync } from './buildkite_checkpoint';
-import { parseShardAnnotation } from './shard_config';
+import {
+  isInBuildkite,
+  isConfigCompleted,
+  markConfigCompletedSync,
+  getCheckpointKey,
+} from './buildkite_checkpoint';
+import { annotateConfigWithShard, parseShardAnnotation } from './shard_config';
 
 const JEST_CACHE_DIR = 'data/jest-cache';
 
 // Skip 'node' and script name
 const NODE_ARGV_SLICE_INDEX = 2;
+
+/**
+ * Builds the checkpoint identity and key for a resolved config path and optional shard.
+ * Used so each shard has its own Buildkite checkpoint when running in parallel.
+ */
+function getCheckpointIdentity(
+  relConfigPath: string,
+  shard: string | undefined
+): { identity: string; key: string } {
+  const identity = shard
+    ? annotateConfigWithShard(relConfigPath, shard)
+    : relConfigPath;
+  return { identity, key: getCheckpointKey(identity) };
+}
 
 /**
  * Runs Jest tests with automatic config discovery and argument forwarding.
@@ -95,25 +114,32 @@ export async function runJest(configName = 'jest.config.js'): Promise<void> {
   let testFiles: string[] = [];
   let resolvedConfigPath: string = parsedArguments.config ?? '';
 
+  const getShardValue = (): string | undefined => {
+    const shard = parsedArguments.shard;
+    return typeof shard === 'string' && shard.length > 0 ? shard : undefined;
+  };
+
   // Buildkite checkpoint resume: skip this config if it already passed on a previous attempt.
   // Use relative path for checkpoint key so it's stable across different CI agents.
   if (isInBuildkite() && resolvedConfigPath) {
-    const relConfigForCheckpoint = relative(REPO_ROOT, resolvedConfigPath);
+    const relConfig = relative(REPO_ROOT, resolvedConfigPath);
+    const { identity, key: checkpointKey } = getCheckpointIdentity(relConfig, getShardValue());
+
     log.info(
-      `[jest-checkpoint] Checking prior completion for ${relConfigForCheckpoint} (step=${
+      `[jest-checkpoint] Checking prior completion for ${identity} (step=${
         process.env.BUILDKITE_STEP_ID || ''
       }, job=${process.env.BUILDKITE_PARALLEL_JOB || '0'}, retry=${
         process.env.BUILDKITE_RETRY_COUNT || '0'
-      })`
+      }, key=${checkpointKey})`
     );
-    const alreadyCompleted = await isConfigCompleted(relConfigForCheckpoint);
+    const alreadyCompleted = await isConfigCompleted(identity);
     if (alreadyCompleted) {
       log.info(
-        `[jest-checkpoint] Skipping ${relConfigForCheckpoint} (already completed on previous attempt)`
+        `[jest-checkpoint] Skipping ${identity} (already completed on previous attempt, key=${checkpointKey})`
       );
       process.exit(0);
     }
-    log.info(`[jest-checkpoint] No prior checkpoint found, running config`);
+    log.info(`[jest-checkpoint] No prior checkpoint found, running config (key=${checkpointKey})`);
   }
 
   // Handle config discovery if no config was explicitly provided
@@ -182,12 +208,13 @@ export async function runJest(configName = 'jest.config.js'): Promise<void> {
     // Uses synchronous markConfigCompletedSync because async is not supported in 'exit' handlers.
     if (isInBuildkite() && resolvedConfigPath) {
       const relConfig = relative(REPO_ROOT, resolvedConfigPath);
+      const { identity, key: checkpointKey } = getCheckpointIdentity(relConfig, getShardValue());
       process.on('exit', () => {
         // process.exitCode is 0 or undefined for success (Jest only sets it for failures).
         // Both are falsy, while failure codes (1, etc.) are truthy.
         if (!process.exitCode) {
-          log.info(`[jest-checkpoint] Marking ${relConfig} as completed`);
-          markConfigCompletedSync(relConfig);
+          log.info(`[jest-checkpoint] Marking ${identity} as completed (key=${checkpointKey})`);
+          markConfigCompletedSync(identity);
         }
       });
     }

--- a/src/platform/packages/shared/kbn-test/src/jest/run.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.ts
@@ -52,9 +52,7 @@ function getCheckpointIdentity(
   relConfigPath: string,
   shard: string | undefined
 ): { identity: string; key: string } {
-  const identity = shard
-    ? annotateConfigWithShard(relConfigPath, shard)
-    : relConfigPath;
+  const identity = shard ? annotateConfigWithShard(relConfigPath, shard) : relConfigPath;
   return { identity, key: getCheckpointKey(identity) };
 }
 


### PR DESCRIPTION
## Summary
- make `scripts/jest` use shard-aware checkpoint identities (`config||shard=X/Y`) when checking and writing Buildkite checkpoints
- keep checkpoint key computation/read-write consistent with `scripts/jest_all` resume behavior
- add checkpoint key details to log lines to simplify CI retry debugging

In general, during retries we would skip the configs because it was checking the wrong hash. This might also be the reason why we don't generate any artifacts or send reports during retries. Code was generated by AI but I fully checked everything myself. 

## Problem
When a config is sharded, `scripts/jest_all` pre-checks each shard with shard-specific keys, but `scripts/jest` previously checked/wrote the plain config key. On retry this could cause a shard selected as `RUN` by `jest_all` to be skipped by `scripts/jest` if another shard had already marked the plain config key as done.

## Validation
- `yarn test:jest src/platform/packages/shared/kbn-test/src/jest/run.test.ts src/platform/packages/shared/kbn-test/src/jest/run_all.test.ts`
- `node scripts/check_changes.ts`

## Testing 
I was testing this in a dummy [PR](https://github.com/elastic/kibana/pull/256932) where I was able to reproduce this issue consistently and eventually fixed it. This PR includes just the changes for the fix itself and removed very verbose logging.  

Before ->  https://buildkite.com/elastic/kibana-pull-request/builds/408253
After -> https://buildkite.com/elastic/kibana-pull-request/builds/408296

Fixes: https://github.com/elastic/kibana-operations/issues/472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to test infrastructure checkpoint handling with enhanced shard-aware logic for better test execution tracking and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->