### PR TITLE
[9.2] chore: Remove empty codeowner entries (#256164)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -442,9 +442,9 @@ src/platform/packages/shared/kbn-ambient-storybook-types @elastic/kibana-operati
 src/platform/packages/shared/kbn-ambient-ui-types @elastic/kibana-operations
 src/platform/packages/shared/kbn-analytics @elastic/kibana-core
 src/platform/packages/shared/kbn-apm-data-view @elastic/obs-presentation-team
-src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-apm-synthtrace @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
 src/platform/packages/shared/kbn-apm-synthtrace-client @elastic/obs-presentation-team @elastic/obs-onboarding-team @elastic/obs-exploration-team
+src/platform/packages/shared/kbn-apm-types-shared @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-apm-ui-shared @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-apm-utils @elastic/obs-presentation-team
 src/platform/packages/shared/kbn-avc-banner @elastic/security-defend-workflows
@@ -1221,7 +1221,6 @@ x-pack/solutions/security/test/security_solution_endpoint @elastic/security-defe
 x-pack/platform/test/serverless/api_integration/test_suites/platform_security @elastic/kibana-security
 
 # Observability Entities Team (@elastic/obs-entities)
-/x-pack/plugins/observability_solution/entities_data_access @elastic/obs-entities
 /x-pack/platform/test/api_integration/apis/entity_manager/fixture_plugin @elastic/obs-entities
 /x-pack/platform/test/api_integration/apis/entity_manager @elastic/obs-entities
 
@@ -1321,9 +1320,6 @@ x-pack/platform/test/serverless/api_integration/test_suites/platform_security @e
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/patterns @elastic/ml-ui
 src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
 # TODO: this deprecation_logs folder should be owned by kibana management team after 9.0
-/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/metrics_data_source_profile @elastic/obs-presentation-team
-/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs_data_source_profile @elastic/kibana-data-discovery @elastic/kibana-core
-/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/patterns_data_source_profile @elastic/ml-ui
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability @elastic/kibana-data-discovery @elastic/obs-exploration-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_document_profile @elastic/obs-presentation-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/observability_root_profile @elastic/obs-exploration-team @elastic/obs-presentation-team
@@ -1397,19 +1393,14 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 # Global Experience
 
 ### Reporting
-/x-pack/platform/test/functional/apps/dashboard/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/apps/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/apps/reporting_management/ @elastic/response-ops
 /x-pack/platform/test/examples/screenshotting/ @elastic/response-ops
-/x-pack/platform/test/fixtures/es_archives/lens/reporting/ @elastic/response-ops
 /x-pack/platform/test/fixtures/es_archives/reporting/ @elastic/response-ops
 /x-pack/platform/test/functional/fixtures/kbn_archives/reporting/ @elastic/response-ops
 /x-pack/platform/test/reporting_api_integration/ @elastic/response-ops
 /x-pack/platform/test/reporting_functional/ @elastic/response-ops
 /x-pack/platform/test/stack_functional_integration/apps/reporting/ @elastic/response-ops
-/docs/user/reporting @elastic/response-ops
-/docs/settings/reporting-settings.asciidoc @elastic/response-ops
-/docs/setup/configuring-reporting.asciidoc @elastic/response-ops
 /x-pack/platform/test/serverless/**/test_suites/reporting/ @elastic/response-ops
 /x-pack/platform/test/accessibility/apps/group3/reporting.ts @elastic/response-ops
 /x-pack/platform/test/functional/page_objects/reporting_page.ts @elastic/response-ops
@@ -1420,12 +1411,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/saved_object_tagging/ @elastic/appex-sharedux
 
 ### Kibana React (to be deprecated)
-/src/plugins/kibana_react/public/ @elastic/appex-sharedux @elastic/kibana-presentation
 
 ### Home Plugin and Packages
-/src/plugins/home/public @elastic/appex-sharedux
 /src/plugins/home/server/*.ts @elastic/appex-sharedux
-/src/plugins/home/server/services/ @elastic/appex-sharedux
 
 ### Code Coverage
 #CC# /src/plugins/home/public @elastic/appex-sharedux
@@ -1448,7 +1436,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/serverless/functional/services/ @elastic/observability-ui
 /x-pack/solutions/observability/test/serverless/functional/page_objects/ @elastic/observability-ui
 /x-pack/solutions/observability/test/serverless/functional/ftr_provider_context.d.ts @elastic/observability-ui
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.logs_essentials.index.ts @elastic/observability-ui
 /x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.logs_essentials.serverless.config.ts @elastic/observability-ui
 /x-pack/solutions/observability/test/kibana.jsonc @elastic/observability-ui
 /x-pack/solutions/observability/test/tsconfig.json @elastic/observability-ui
@@ -1471,7 +1458,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/serverless/functional/test_suites/data_usage @elastic/kibana-management
 /x-pack/platform/test/serverless/functional/page_objects/svl_data_usage.ts @elastic/kibana-management
 /x-pack/solutions/observability/test/observability_ai_assistant_functional @elastic/obs-ai-assistant
-/x-pack/solutions/observability/test/fixtures/es_archives/observability/ai_assistant @elastic/obs-ai-assistant
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/ai_assistant @elastic/obs-ai-assistant
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts @elastic/obs-ai-assistant
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts @elastic/obs-ai-assistant
@@ -1515,7 +1501,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/public/containers @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/hooks @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/images @elastic/obs-presentation-team
-/x-pack/solutions/observability/plugins/infra/public/lib @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/pages @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/services @elastic/obs-presentation-team
 /x-pack/solutions/observability/plugins/infra/public/test_utils @elastic/obs-presentation-team
@@ -1538,7 +1523,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/functional/services/logs_ui @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/api_integration/apis/logs_ui @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/observability_logs_explorer @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/serverless/functional/test_suites/discover @elastic/obs-exploration-team @elastic/kibana-data-discovery
 /src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/api_integration/apis/logs_shared @elastic/obs-exploration-team
@@ -1548,29 +1532,20 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/common/http_api/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/http_api/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/log_analysis @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_search_result @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_search_summary @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/common/log_text_scale @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/performance_tracing.ts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/common/search_strategies/log_entries @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/docs/state_machines @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/apps/logs_app.tsx @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/public/components/log_stream @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/components/logging @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/containers/logs @elastic/obs-exploration-team
-/x-pack/solutions/observability/plugins/infra/public/observability_logs @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/public/pages/logs @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/lib/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_alerts @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/routes/log_analysis @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
-/x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-presentation-team @elastic/obs-exploration-team
 /x-pack/platform/test/common/utils/server_route_repository @elastic/obs-knowledge-team
-/src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-presentation-team @elastic/obs-exploration-team
 
 ## Streams parts owned by Logs UX
-/x-pack/platform/plugins/shared/streams/server/routes/streams/processing @elastic/obs-onboarding-team
-/x-pack/platform/plugins/shared/streams/server/routes/streams/schema @elastic/obs-onboarding-team
 /x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-onboarding-team
 
 # Infra Monitoring tests
@@ -1582,32 +1557,20 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 # Observability UX management team
 /src/platform/test/api_integration/apis/suggestions  @elastic/obs-ux-management-team # Assigned per https://github.com/elastic/kibana/pull/200950#discussion_r1853705079
 /x-pack/solutions/observability/test/api_integration/services/slo.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/services/slo @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/functional/apps/slo @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/observability_api_integration @elastic/obs-ux-management-team # Assigned per https://github.com/elastic/kibana/pull/182243
 /x-pack/solutions/observability/test/functional/services/observability @elastic/obs-ux-management-team
-/x-pack/platform/test/accessibility/apps/group1/uptime.ts @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/accessibility/apps/observability.ts @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/functional/services/slo/ @elastic/obs-ux-management-team
-/x-pack/packages/observability/alert_details @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/observability_functional @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration/apis/security/ @elastic/obs-ux-management-team
 /x-pack/solutions/observability/plugins/infra/public/alerting @elastic/obs-ux-management-team
 /x-pack/solutions/observability/plugins/infra/server/lib/alerting @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/serverless/api_integration/test_suites/es_query_rule @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/alerting/ @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/ @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/alerting_api @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/slo_api @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/ @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.index.ts @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.index.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/serverless/oblt.synthetics.serverless.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.index.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/feature_flag_configs/stateful/oblt.synthetics.stateful.config.ts @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_monitors @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/incident_management/ @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/functional/page_objects/alert_controls.ts @elastic/obs-ux-management-team
@@ -1636,7 +1599,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/fleet_cypress @elastic/fleet
 /x-pack/platform/test/fleet_functional @elastic/fleet
 /x-pack/platform/test/fleet_multi_cluster @elastic/fleet
-/src/dev/build/tasks/bundle_fleet_packages.ts @elastic/fleet @elastic/kibana-operations
 /x-pack/platform/plugins/shared/fleet/server/services/elastic_agent_manifest.ts @elastic/fleet @elastic/obs-cloudnative-monitoring
 /x-pack/solutions/**/test/serverless/**/test_suites/fleet/ @elastic/fleet
 /x-pack/platform/test/serverless/**/test_suites/fleet/ @elastic/fleet
@@ -1646,9 +1608,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/stack_functional_integration/apps/apm @elastic/obs-presentation-team
 /src/platform/test/api_integration/apis/ui_metric/*.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/functional/apps/apm/ @elastic/obs-presentation-team
-/x-pack/solutions/observability/test/api_integration/apm/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/apm_cypress/ @elastic/obs-presentation-team
-/src/apm.js @elastic/kibana-core @vigneshshanmugam
 /x-pack/solutions/observability/test/serverless/api_integration/test_suites/apm_api_integration/ @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/apm_api_integration/ @elastic/obs-presentation-team
 #CC# /src/plugins/apm_oss/ @elastic/apm-ui
@@ -1665,7 +1625,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/functional/services/uptime @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration/apis/uptime @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/api_integration/apis/synthetics @elastic/obs-ux-management-team
-/x-pack/solutions/observability/test/alerting_api_integration/observability/synthetics_rule.ts @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/alerting_api_integration/observability/index.ts @elastic/obs-ux-management-team
 /x-pack/solutions/observability/test/serverless/api_integration/test_suites/synthetics @elastic/obs-ux-management-team
 
@@ -1677,7 +1636,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/dataset_quality_api_integration @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/api_integration/test_suites/dataset_quality_api_integration @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/configs/config.* @elastic/obs-onboarding-team
-/x-pack/solutions/observability/test/serverless/functional/test_suites/landing_page.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/test_suites/navigation.ts @elastic/obs-presentation-team
 /x-pack/solutions/observability/test/functional/page_objects/dataset_quality.ts @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/serverless/functional/configs/index* @elastic/obs-onboarding-team
@@ -1699,11 +1657,8 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/functional/page_objects/observability_page.ts @elastic/observability-ui
 
 # Observability onboarding tour
-/x-pack/solutions/observability/plugins/observability_shared/public/components/tour @elastic/appex-sharedux
-/x-pack/solutions/observability/test/functional/apps/infra/tour.ts @elastic/appex-sharedux
 
 # Observability settings
-/x-pack/plugins/observability_solution/observability/server/ui_settings.ts @elastic/obs-docs
 
 # Streams
 /x-pack/platform/test/api_integration_deployment_agnostic/apis/streams @elastic/streams-program-team @elastic/obs-onboarding-team
@@ -1718,7 +1673,6 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 # Presentation
 /src/platform/test/functional/page_objects/markdown_vis.ts @elastic/kibana-presentation
 /src/platform/test/functional/page_objects/unified_search_page.ts @elastic/kibana-presentation
-/src/platform/test/functional/fixtures/kbn_archiver/dashboard_error_cases.json @elastic/kibana-presentation # Assigned per https://github.com/elastic/kibana/pull/201648#discussion_r1859020986
 /x-pack/platform/test/fixtures/es_archives/getting_started/shakespeare @elastic/kibana-presentation # Assigned per https://github.com/elastic/kibana/pull/201648#discussion_r1860319853
 /x-pack/platform/test/upgrade/screenshots @elastic/kibana-presentation
 /x-pack/platform/test/functional/screenshots @elastic/kibana-presentation
@@ -1784,9 +1738,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/functional_basic/apps/ml/ @elastic/ml-ui
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/config.ts @elastic/ml-ui
 /x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/ml/ @elastic/ml-ui
-/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/ml_rule_types/ @elastic/ml-ui
 /x-pack/platform/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
-/x-pack/platform/test/screenshot_creation/services/ml_screenshots.ts @elastic/ml-ui
 /x-pack/solutions/**/test/serverless/**/test_suites/ml/ @elastic/ml-ui
 
 # Security Machine Learning
@@ -1801,7 +1753,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/functional/services/aiops @elastic/ml-ui
 
 # Transforms maintained by the Kibana Management team.
-/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/transform_rule_types/ @elastic/kibana-management
 /x-pack/platform/test/serverless/**/test_suites/management/transforms/ @elastic/kibana-management
 /x-pack/platform/test/accessibility/apps/group2/transform.ts @elastic/kibana-management
 /x-pack/platform/test/functional/apps/transform/ @elastic/kibana-management
@@ -1812,15 +1763,12 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/package @elastic/kibana-operations
 /src/platform/test/package/roles @elastic/kibana-operations
 /src/platform/test/common/fixtures/plugins/coverage/kibana.json @elastic/kibana-operations
-/x-pack/platform/test/plugin_functional/screenshots @elastic/kibana-operations # Assigned per https://github.com/elastic/kibana/pull/94370/files
 /src/dev/license_checker/config.ts @elastic/kibana-operations
 /src/dev/ @elastic/kibana-operations
 /src/setup_node_env/ @elastic/kibana-operations
 /src/cli/ @elastic/kibana-operations
 /src/cli_keystore/ @elastic/kibana-operations
 /.github/workflows/ @elastic/kibana-operations
-/.github/copilot-instructions.md @elastic/kibana-operations
-/vars/ @elastic/kibana-operations
 /.buildkite/ @elastic/kibana-operations
 /.buildkite/scripts/steps/esql_grammar_sync.sh @elastic/kibana-esql
 /.buildkite/scripts/steps/esql_generate_function_metadata.sh @elastic/kibana-esql
@@ -1834,7 +1782,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /.devcontainer/ @elastic/kibana-operations
 /.eslintrc.js @elastic/kibana-operations
 /.eslintignore @elastic/kibana-operations
-/.ci/.storybook @elastic/kibana-operations
 /src/platform/packages/shared/kbn-lazy-object @elastic/kibana-operations @elastic/observability-ui
 
 # QA - Appex QA
@@ -1911,7 +1858,6 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/functional/services/filter_bar.ts @elastic/appex-qa
 /src/platform/test/functional/services/field_editor.ts @elastic/appex-qa
 /src/platform/test/functional/services/embedding.ts @elastic/appex-qa
-/src/platform/test/functional/services/doc_table.ts @elastic/appex-qa
 /src/platform/test/functional/services/data_grid.ts @elastic/appex-qa
 /src/platform/test/functional/services/combo_box.ts @elastic/appex-qa
 /src/platform/test/functional/page_objects/time_picker.ts @elastic/appex-qa
@@ -1950,19 +1896,15 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/serverless/functional/page_objects/svl_common_page.ts @elastic/appex-qa
 /x-pack/platform/test/README.md @elastic/appex-qa
 /x-pack/platform/test/serverless/README.md @elastic/appex-qa
-/x-pack/platform/test/serverless/api_integration/test_suites/README.md @elastic/appex-qa
 /src/dev/code_coverage @elastic/appex-qa
 /src/platform/test/functional/services/common @elastic/appex-qa
 /src/platform/test/functional/services/lib @elastic/appex-qa
-/src/platform/test/functional/services/remote @elastic/appex-qa
-/src/platform/test/visual_regression @elastic/appex-qa
 /src/platform/packages/shared/kbn-test/src/functional_test_runner @elastic/appex-qa
 /packages/kbn-performance-testing-dataset-extractor @elastic/appex-qa
 /x-pack/platform/test/serverless/api_integration/test_suites/elasticsearch_api @elastic/appex-qa
 /x-pack/platform/test/serverless/functional/test_suites/home_page/  @elastic/appex-qa
 /src/platform/packages/shared/kbn-es/src/stateful_resources/roles.yml @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/ftr_provider_context.d.ts @elastic/appex-qa
-/x-pack/solutions/observability/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/*configs/ @elastic/appex-qa
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/ @elastic/appex-qa
 /x-pack/platform/test/api_integration_deployment_agnostic/README.md @elastic/appex-qa
@@ -2033,7 +1975,6 @@ x-pack/platform/test/plugin_api_integration/test_suites/platform/ @elastic/kiban
 /x-pack/platform/test/functional_cors @elastic/kibana-core
 /x-pack/platform/test/stack_functional_integration/apps/telemetry @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/core* @elastic/kibana-core
-/src/platform/test/plugin_functional/platform/plugins/shared/telemetry @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/session_notifications @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/kbn_top_nav/ @elastic/kibana-core
 /src/platform/test/plugin_functional/plugins/app_link_test @elastic/kibana-core
@@ -2062,7 +2003,6 @@ x-pack/platform/test/plugin_api_integration/test_suites/platform/ @elastic/kiban
 /src/platform/test/functional/apps/bundles @elastic/kibana-core # Assigned per https://github.com/elastic/kibana/pull/64367
 /src/platform/test/examples/hello_world @elastic/kibana-core
 /src/platform/test/examples/routing/index.ts @elastic/kibana-core # Assigned per https://github.com/elastic/kibana/pull/69581
-/src/platform/test/common/platform/plugins/shared/newsfeed @elastic/kibana-core
 /src/platform/test/common/configure_http2.ts @elastic/kibana-core
 /src/platform/test/api_integration/apis/ui_counters @elastic/kibana-core
 /src/platform/test/api_integration/apis/telemetry @elastic/kibana-core
@@ -2125,7 +2065,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 
 # Kibana Localization
 /src/dev/i18n_tools/  @elastic/kibana-localization @elastic/kibana-core
-/src/core/public/i18n/  @elastic/kibana-localization @elastic/kibana-core
 #CC# /x-pack/platform/plugins/private/translations/ @elastic/kibana-localization @elastic/kibana-core
 
 # AppEx AI Infra
@@ -2133,7 +2072,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /x-pack/platform/test/functional_gen_ai/inference @elastic/appex-ai-infra
 
 # AppEx Platform Services Security
-/x-pack/platform/test/serverless/api_integration/test_suites/security_response_headers.ts  @elastic/kibana-security
 /x-pack/platform/test/api_integration/apis/es  @elastic/kibana-security
 /x-pack/platform/test/api_integration/apis/features  @elastic/kibana-security
 
@@ -2204,7 +2142,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /x-pack/platform/test/serverless/**/test_suites/platform_security/ @elastic/kibana-security
 /src/core/packages/http/server-internal/src/cdn_config/ @elastic/kibana-security @elastic/kibana-core
 /x-pack/solutions/observability/test/serverless/api_integration/configs/config.feature_flags.ts @elastic/kibana-security
-/x-pack/platform/test/serverless/functional/test_suites/spaces/multiple_spaces_enabled.ts @elastic/kibana-security
 /x-pack/platform/test/serverless/functional/page_objects/svl_management_page.ts @elastic/kibana-security
 
 /x-pack/solutions/security/test/serverless/functional/configs/index.feature_flags.ts @elastic/kibana-security
@@ -2249,8 +2186,6 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /x-pack/platform/test/functional_with_es_ssl/apps/embeddable_alerts_table/ @elastic/response-ops
 /x-pack/platform/test/functional_with_es_ssl/apps/triggers_actions_ui/ @elastic/response-ops
 /x-pack/platform/test/task_manager_claimer_update_by_query/ @elastic/response-ops
-/docs/user/alerting/ @elastic/response-ops
-/docs/management/connectors/ @elastic/response-ops
 /x-pack/solutions/search/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
 /x-pack/solutions/security/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
 /x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/response_ops_docs @elastic/response-ops
@@ -2273,19 +2208,15 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /src/platform/test/functional/fixtures/kbn_archiver/ccs @elastic/search-kibana
 /src/platform/test/functional/fixtures/kbn_archiver/annotation_listing_page_search.json @elastic/search-kibana
 /src/platform/test/functional/fixtures/es_archiver/search/downsampled @elastic/search-kibana
-/x-pack/solutions/search/functional_solution_sidenav/ @elastic/search-kibana
 /x-pack/platform/test/functional/services/search_sessions.ts @elastic/search-kibana
 /x-pack/platform/test/functional/page_objects/search_sessions_management_page.ts @elastic/search-kibana
 x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/search-kibana
-/x-pack/solutions/search/test/functional/apps/search_playground @elastic/search-kibana
 /x-pack/platform/test/serverless/functional/page_objects/svl_ingest_pipelines.ts @elastic/search-kibana
 /x-pack/platform/test/functional/apps/dev_tools/embedded_console.ts @elastic/search-kibana
 /x-pack/platform/test/functional/apps/ingest_pipelines/feature_controls/ingest_pipelines_security.ts @elastic/search-kibana
 /x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/doc_links @elastic/platform-docs
-/x-pack/solutions/search/test/serverless/api_integration/serverless_search @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/functional/test_suites/ @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/functional/configs/config.ts @elastic/search-kibana  @elastic/appex-qa
-/x-pack/platform/test/api_integration/apis/management/index_management/inference_endpoints.ts @elastic/search-kibana
 /x-pack/solutions/search/test/serverless/api_integration @elastic/search-kibana
 /x-pack/platform/test/serverless/functional/page_objects/svl_api_keys.ts @elastic/search-kibana
 /x-pack/solutions/search/test/functional_search/ @elastic/search-kibana
@@ -2341,7 +2272,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /src/platform/test/functional/apps/saved_objects_management @elastic/kibana-management
 /src/platform/test/functional/apps/console/*.ts @elastic/kibana-management
 /src/platform/test/api_integration/apis/console/*.ts @elastic/kibana-management
-/x-pack/platform/test/api_integration_deployment_agnostic/apis/console/ @elastic/kibana-management
 /src/platform/test/accessibility/apps/management.ts @elastic/kibana-management
 /src/platform/test/accessibility/apps/console.ts @elastic/kibana-management
 /x-pack/platform/test/api_integration/services/index_management.ts @elastic/kibana-management
@@ -2402,7 +2332,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/api_integration/services @elastic/security-solution
 /x-pack/solutions/security/test/accessibility/ @elastic/security-solution
 /x-pack/solutions/security/test/fixtures/es_archives/endpoint/ @elastic/security-solution
-/x-pack/platform/test/plugin_functional/test_suites/resolver/ @elastic/security-solution
 /x-pack/solutions/security/test/security_solution_api_integration @elastic/security-solution
 /x-pack/platform/test/fixtures/es_archives/auditbeat/default @elastic/security-solution
 /x-pack/solutions/security/test/serverless/functional/test_suites/constants.ts @elastic/security-solution
@@ -2442,7 +2371,6 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/plugins/security_solution_ess/public/upselling/pages/attack_discovery @elastic/security-generative-ai
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/automatic_import @elastic/integration-experience
 /x-pack/solutions/security/plugins/security_solution/public/configurations @elastic/security-generative-ai
-/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc @elastic/security-solution @elastic/security-threat-hunting-investigations
 
 # AI4DSOC in Security Solution
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/ai4dsoc @elastic/security-engineering-productivity
@@ -2453,12 +2381,10 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/security_solution_cypress/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/helpers @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/objects @elastic/security-detections-response @elastic/security-threat-hunting
-/x-pack/solutions/security/test/security_solution_cypress/cypress/plugins @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/screens/common @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/support @elastic/security-detections-response @elastic/security-threat-hunting
 /x-pack/solutions/security/test/security_solution_cypress/cypress/urls @elastic/security-threat-hunting-investigations @elastic/security-detection-engine
 
-/x-pack/solutions/security/plugins/security_solution/common/ecs @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/common/test @elastic/security-detections-response @elastic/security-threat-hunting
 
 /x-pack/solutions/security/plugins/security_solution/public/common/components/callouts @elastic/security-detections-response
@@ -2484,7 +2410,6 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 ## Security Solution sub teams - security-engineering-productivity
 ## NOTE: It's important to keep this above other teams' sections because test automation doesn't process
 ## the CODEOWNERS file correctly. See https://github.com/elastic/kibana/issues/173307#issuecomment-1855858929
-/x-pack/solutions/security/.cursor/bug_validator.mdc @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/* @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/cypress/* @elastic/security-engineering-productivity
@@ -2537,7 +2462,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/app/links @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/accessibility @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/alerts_viewer @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/draggables @elastic/security-threat-hunting-investigations
@@ -2550,11 +2474,9 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/common/components/first_last_seen/first_last_seen.tsx @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_date/index.tsx @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/formatted_number/index.tsx @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/guided_onboarding_tour @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/common/components/hover_actions @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/last_event_time @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/common/components/links @elastic/security-threat-hunting-investigations
@@ -2590,7 +2512,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/plugins/security_solution/public/flyout/network_details @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/flyout/rule_details @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/public/investigations @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/notes @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/onboarding @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/overview @elastic/security-threat-hunting-investigations
@@ -2606,7 +2527,6 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/cases @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/filters @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/guided_onboarding @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/inspect @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/navigation @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/explore/overview @elastic/security-threat-hunting-investigations
@@ -2616,11 +2536,9 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 /x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/screens/expandable_flyout  @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/sourcerer/sourcerer_timeline.cy.ts @elastic/security-threat-hunting-investigations
 
 /x-pack/platform/test/fixtures/es_archives/auditbeat/overview @elastic/security-threat-hunting-investigations
 
-x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigations @elastic/security-threat-hunting-investigations
 
 /x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting-investigations
 
@@ -2638,10 +2556,8 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/inv
 /x-pack/platform/test/functional/fixtures/kbn_archives/cases @elastic/kibana-cases
 /x-pack/platform/test/functional/services/cases/ @elastic/kibana-cases
 /x-pack/platform/test/functional_with_es_ssl/apps/cases/ @elastic/kibana-cases
-/x-pack/platform/test/functional_with_es_ssl/platform/plugins/shared/cases @elastic/kibana-cases
 /x-pack/platform/test/functional_with_es_ssl/plugins/cases @elastic/kibana-cases
 
-/x-pack/solutions/search/test/serverless/api_integration/cases/ @elastic/kibana-cases
 /x-pack/solutions/search/test/serverless/functional/test_suites/cases/ @elastic/kibana-cases
 
 /x-pack/solutions/security/test/api_integration/apis/cases/ @elastic/kibana-cases
@@ -2753,7 +2669,6 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/common/cti @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/common/field_maps @elastic/security-detection-engine
 /x-pack/solutions/security/test/fixtures/es_archives/entity/risks @elastic/security-detection-engine
-/x-pack/solutions/security/test/fixtures/es_archives/entity/host_risk @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/public/value_list @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/public/common/components/reference_error_modal @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions @elastic/security-detection-engine
@@ -2800,7 +2715,6 @@ x-pack/platform/plugins/shared/actions/server/lib/token_tracking @elastic/securi
 /x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/isolate_host/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/common/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/common/api/endpoint/ @elastic/security-defend-workflows
-x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defend_insights @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/ @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/lib/license/ @elastic/security-defend-workflows
@@ -2813,9 +2727,6 @@ x-pack/solutions/security/plugins/security_solution/server/assistant/tools/defen
 /x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution_serverless/server/ai4soc @elastic/security-defend-workflows
 x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/defend_insights @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/__mocks__/defend_insights_schema.mock.ts @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/defend_insights @elastic/security-defend-workflows
-x-pack/plugins/elastic_assistant/server/routes/defend_insights @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/content_loaders/defend_insights_loader.* @elastic/security-defend-workflows
 x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/defend_insight_prompts.ts @elastic/security-defend-workflows
@@ -2836,7 +2747,6 @@ x-pack/solutions/security/plugins/security_solution/common/entity_analytics @ela
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/hosts @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/network @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/risk_score @elastic/security-entity-analytics
-x-pack/solutions/security/plugins/security_solution/common/search_strategy/security_solution/user @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/common/components/matrix_histogram @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/entity_analytics @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/public/explore @elastic/security-entity-analytics
@@ -2845,7 +2755,6 @@ x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details
 x-pack/solutions/security/packages/navigation/src/navigation_tree/entity_analytics_navigation_tree.ts @elastic/security-entity-analytics
 
 x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics @elastic/security-entity-analytics
-x-pack/solutions/security/plugins/security_solution/server/lib/risk_score @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/network @elastic/security-entity-analytics
 x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users @elastic/security-entity-analytics
@@ -2887,14 +2796,10 @@ x-pack/platform/test/automatic_import_api_integration @elastic/integration-exper
 # Cloud Security Posture team
 
 ## Packages
-x-pack/packages/kbn-cloud-security-posture @elastic/kibana-cloud-security-posture
 ## Plugins
-x-pack/plugins/cloud_security_posture @elastic/kibana-cloud-security-posture
-x-pack/plugins/kubernetes_security @elastic/kibana-cloud-security-posture
 ## Security Solution sub teams
 x-pack/solutions/security/plugins/security_solution/public/common/components/sessions_viewer @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture @elastic/kibana-cloud-security-posture
-x-pack/solutions/security/plugins/security_solution/public/kubernetes @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/security_solution/server/lib/asset_inventory @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness @elastic/kibana-cloud-security-posture
 x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/generic_right @elastic/kibana-cloud-security-posture
@@ -2954,7 +2859,6 @@ x-pack/solutions/security/plugins/security_solution/server/lib/security_integrat
 #CC# /x-pack/platform/plugins/private/logstash/ @elastic/logstash
 
 # EUI team
-/src/plugins/kibana_react/public/page_template/ @elastic/eui-team @elastic/appex-sharedux
 
 # Changes to translation files should not ping code reviewers
 x-pack/platform/plugins/private/translations/translations
@@ -2998,7 +2902,6 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /src/platform/test/plugin_functional/plugins/eui_provider_dev_warning @elastic/appex-sharedux
 /src/platform/test/functional/page_objects/settings_page.ts @elastic/appex-sharedux
 /src/platform/test/functional/apps/sharing/*.ts @elastic/appex-sharedux
-/src/platform/test/functional/apps/kibana_overviews @elastic/appex-sharedux
 /x-pack/platform/test/product_intercepts_functional @elastic/appex-sharedux
 /src/platform/test/examples/ui_actions/*.ts @elastic/appex-sharedux
 /src/platform/test/examples/state_sync/*.ts @elastic/appex-sharedux
@@ -3012,8 +2915,6 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /x-pack/platform/test/accessibility/apps/group3/snapshot_and_restore.ts @elastic/appex-sharedux
 /x-pack/platform/test/serverless/functional/test_suites/spaces/spaces_selection.ts @elastic/appex-sharedux
 /x-pack/platform/test/serverless/functional/test_suites/spaces/index.ts @elastic/appex-sharedux
-packages/react @elastic/appex-sharedux
-src/platform/testfunctional/page_objects/solution_navigation.ts @elastic/appex-sharedux
 /x-pack/platform/test/serverless/functional/page_objects/svl_common_navigation.ts @elastic/appex-sharedux
 /x-pack/solutions/security/test/serverless/functional/page_objects/svl_sec_landing_page.ts @elastic/appex-sharedux
 /x-pack/solutions/security/test/serverless/functional/test_suites/ftr/navigation.ts @elastic/appex-sharedux
@@ -3043,9 +2944,6 @@ docs/reference                                @elastic/experience-docs
 x-pack/platform/plugins/shared/actions/server/saved_objects/index.ts @elastic/response-ops @elastic/kibana-security
 x-pack/platform/plugins/shared/alerting/server/saved_objects/index.ts @elastic/response-ops @elastic/kibana-security
 x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts @elastic/fleet @elastic/kibana-security
-x-pack/plugins/observability_solution/synthetics/server/saved_objects/saved_objects.ts @elastic/obs-ux-management-team @elastic/kibana-security
-x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics_monitor.ts @elastic/obs-ux-management-team @elastic/kibana-security
-x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics_param.ts @elastic/obs-ux-management-team @elastic/kibana-security
 
 # OpenTelemetry semantic conventions Buildkite pipeline and scripts
 /.buildkite/pipeline-resource-definitions/kibana-otel-semconv-sync.yml @elastic/obs-onboarding-team
@@ -3055,7 +2953,6 @@ x-pack/plugins/observability_solution/synthetics/server/saved_objects/synthetics
 
 # Specialised GitHub workflows for the Observability robots
 /.github/workflows/deploy-my-kibana.yml   @elastic/observablt-robots @elastic/kibana-operations
-/.github/workflows/oblt-github-commands   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
 # Moon related configs

--- a/packages/kbn-generate/src/commands/codeowners_command.ts
+++ b/packages/kbn-generate/src/commands/codeowners_command.ts
@@ -13,6 +13,7 @@ import Path from 'path';
 import { REPO_ROOT, kibanaPackageJson } from '@kbn/repo-info';
 import { getPackages } from '@kbn/repo-packages';
 
+import { cleanNonGeneratedSection } from '../lib/clean_codeowners';
 import type { GenerateCommand } from '../generate_command';
 
 const REL = '.github/CODEOWNERS';
@@ -54,8 +55,14 @@ const ULTIMATE_PRIORITY_RULES =
 export const CodeownersCommand: GenerateCommand = {
   name: 'codeowners',
   description: 'Update the codeowners file based on the package manifest files',
-  usage: 'node scripts/generate codeowners',
-  async run({ log }) {
+  usage: 'node scripts/generate codeowners [--clean-empty]',
+  flags: {
+    boolean: ['clean-empty'],
+    help: `
+      --clean-empty  Remove entries from the overrides section whose path no longer exists in the repo
+    `,
+  },
+  async run({ log, flags }) {
     const pkgs = getPackages(REPO_ROOT);
     const path = Path.resolve(REPO_ROOT, REL);
     const oldCodeowners = await Fsp.readFile(path, 'utf8');
@@ -71,6 +78,18 @@ export const CodeownersCommand: GenerateCommand = {
     const ultStart = content.indexOf(ULTIMATE_PRIORITY_RULES_COMMENT);
     if (ultStart !== -1) {
       content = content.slice(0, ultStart);
+    }
+
+    if (flags['clean-empty']) {
+      const { cleaned: cleanedContent, removed } = cleanNonGeneratedSection(content, REPO_ROOT);
+      content = cleanedContent;
+      removed.forEach(({ lineNumber, line }) => {
+        log.warning(`  removed line ${lineNumber}: ${line.trim()}`);
+      });
+      if (removed.length > 0) {
+        const word = removed.length === 1 ? 'entry' : 'entries';
+        log.info(`Cleaned ${removed.length} dead CODEOWNERS ${word} from overrides section`);
+      }
     }
 
     // sort genarated entries by directory name

--- a/packages/kbn-generate/src/lib/clean_codeowners.ts
+++ b/packages/kbn-generate/src/lib/clean_codeowners.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import Fs from 'fs';
+import Path from 'path';
+
+/**
+ * Get the path (first token) from a CODEOWNERS line, or null if this line
+ * is not an ownership rule (comment, blank, negation, or invalid).
+ */
+function getPathFromLine(line: string): string | null {
+  const trimmed = line.trim();
+  const isCommentOrBlank = !trimmed || trimmed.startsWith('#') || trimmed.startsWith('!');
+  if (isCommentOrBlank) return null;
+
+  const pathToken = trimmed.split(/\s+/)[0];
+  const looksLikePath = pathToken && (pathToken.startsWith('/') || pathToken.includes('/'));
+  if (!looksLikePath) return null;
+
+  return pathToken;
+}
+
+/**
+ * Convert a CODEOWNERS path (e.g. "/src/cli" or "packages/foo") to an absolute
+ * filesystem path under repo root.
+ */
+function toAbsolutePath(ownerPath: string, repoRoot: string): string {
+  const withoutLeadingSlash = ownerPath.startsWith('/') ? ownerPath.slice(1) : ownerPath;
+  return Path.join(repoRoot, withoutLeadingSlash);
+}
+
+/**
+ * For a path that contains no glob: check that the file or directory exists.
+ */
+function existsLiteral(absolutePath: string): boolean {
+  return Fs.existsSync(absolutePath);
+}
+
+/**
+ * For a path that contains * or **: we only check that the parent directory
+ * of the glob segment exists (we don't expand the glob).
+ * E.g. "packages/kbn-asterisk/" -> check that "packages" exists.
+ */
+function existsGlob(ownerPath: string, repoRoot: string): boolean {
+  const withoutLeadingSlash = ownerPath.startsWith('/') ? ownerPath.slice(1) : ownerPath;
+  const upToFirstStar = withoutLeadingSlash.replace(/\*.*$/, '').replace(/\/+$/, '');
+  const parentDir = upToFirstStar.includes('/')
+    ? upToFirstStar.replace(/\/[^/]*$/, '')
+    : upToFirstStar || '.';
+  const absoluteParent = Path.join(repoRoot, parentDir);
+  return Fs.existsSync(absoluteParent);
+}
+
+/**
+ * Return true if the CODEOWNERS path exists in the repo (file, dir, or parent of glob).
+ */
+function pathExistsInRepo(ownerPath: string, repoRoot: string): boolean {
+  const hasGlob = ownerPath.includes('*');
+  if (hasGlob) {
+    return existsGlob(ownerPath, repoRoot);
+  }
+  return existsLiteral(toAbsolutePath(ownerPath, repoRoot));
+}
+
+/**
+ * Remove CODEOWNERS lines that are ownership rules whose path does not exist in the repo.
+ * Only considers lines that look like path + owners; comments and blank lines are kept.
+ * Used to clean the non-generated overrides section.
+ *
+ * @param sectionContent - Raw section text (e.g. the overrides section)
+ * @param repoRoot - Repo root for resolving paths
+ * @returns Cleaned section and list of removed entries (1-based line number within section + line text)
+ */
+export function cleanNonGeneratedSection(
+  sectionContent: string,
+  repoRoot: string
+): { cleaned: string; removed: Array<{ lineNumber: number; line: string }> } {
+  const lines = sectionContent.split('\n');
+  const kept: string[] = [];
+  const removed: Array<{ lineNumber: number; line: string }> = [];
+
+  lines.forEach((line, index) => {
+    const ownerPath = getPathFromLine(line);
+    if (ownerPath === null) {
+      kept.push(line);
+      return;
+    }
+    if (pathExistsInRepo(ownerPath, repoRoot)) {
+      kept.push(line);
+    } else {
+      removed.push({ lineNumber: index + 1, line });
+    }
+  });
+
+  const joined = kept.join('\n');
+  // Not to add an extra \n if the sectionContent already ends with a \n
+  const cleaned = joined + (sectionContent.endsWith('\n') && !joined.endsWith('\n') ? '\n' : '');
+  return { cleaned, removed };
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [chore: Remove empty codeowner entries (#256164)](https://github.com/elastic/kibana/pull/256164)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-03-06T08:38:52Z","message":"chore: Remove empty codeowner entries (#256164)\n\n## Summary\nOver time, we've accumulated manual CODEOWNERS entries that no longer\npoint to valid files/folders. This PR adds an extension to `node\nscripts/generate codeowners` with `--clean-empty` to remove these lines\n- I also ran it to remove these lines from the CODEOWNERS.\n\nMade with the help of Cursor","sha":"6de6e8cbd0b3fd627a5176a76d0986bcd22e1536","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"chore: Remove empty codeowner entries","number":256164,"url":"https://github.com/elastic/kibana/pull/256164","mergeCommit":{"message":"chore: Remove empty codeowner entries (#256164)\n\n## Summary\nOver time, we've accumulated manual CODEOWNERS entries that no longer\npoint to valid files/folders. This PR adds an extension to `node\nscripts/generate codeowners` with `--clean-empty` to remove these lines\n- I also ran it to remove these lines from the CODEOWNERS.\n\nMade with the help of Cursor","sha":"6de6e8cbd0b3fd627a5176a76d0986bcd22e1536"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256164","number":256164,"mergeCommit":{"message":"chore: Remove empty codeowner entries (#256164)\n\n## Summary\nOver time, we've accumulated manual CODEOWNERS entries that no longer\npoint to valid files/folders. This PR adds an extension to `node\nscripts/generate codeowners` with `--clean-empty` to remove these lines\n- I also ran it to remove these lines from the CODEOWNERS.\n\nMade with the help of Cursor","sha":"6de6e8cbd0b3fd627a5176a76d0986bcd22e1536"}}]}] BACKPORT-->