### PR TITLE
[canvas] fix add from library adding incorrect embeddable state

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
@@ -23,7 +23,7 @@ export interface PanelPackage<SerializedState extends object = object> {
   /**
    * The serialized state of this panel.
    */
-  serializedState: SerializedState;
+  serializedState?: SerializedState;
 }
 
 export interface PresentationContainer<ApiType extends unknown = unknown> extends CanAddNewPanel {

--- a/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/interfaces/containers/presentation_container.ts
@@ -23,7 +23,7 @@ export interface PanelPackage<SerializedState extends object = object> {
   /**
    * The serialized state of this panel.
    */
-  serializedState?: SerializedState;
+  serializedState: SerializedState;
 }
 
 export interface PresentationContainer<ApiType extends unknown = unknown> extends CanAddNewPanel {

--- a/src/platform/plugins/shared/embeddable/public/add_from_library/registry.ts
+++ b/src/platform/plugins/shared/embeddable/public/add_from_library/registry.ts
@@ -74,9 +74,9 @@ export function useAddFromLibraryTypes() {
 
 /**
  * Getter for accessing saved object type from AddFromLibrary registry
- * @param type string
+ * @param libraryType string
  * @returns registry item for saved object type
  */
-export const getAddFromLibraryType = (type: string) => {
-  return registry.get(type);
+export const getAddFromLibraryType = (libraryType: string) => {
+  return registry.get(libraryType);
 };

--- a/src/platform/plugins/shared/embeddable/public/index.ts
+++ b/src/platform/plugins/shared/embeddable/public/index.ts
@@ -12,7 +12,7 @@ import { EmbeddablePublicPlugin } from './plugin';
 
 export type { DrilldownDefinition, DrilldownEditorProps } from './drilldowns/types';
 
-export { useAddFromLibraryTypes } from './add_from_library/registry';
+export { getAddFromLibraryType, useAddFromLibraryTypes } from './add_from_library/registry';
 export { PanelNotFoundError, PanelIncompatibleError } from './react_embeddable_system';
 export { EmbeddableStateTransfer } from './state_transfer';
 export {

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -60,7 +60,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({ container, onClose }) => {
       const libraryType = getAddFromLibraryType(type);
       if (!libraryType) {
         getCanvasNotifyService().warning(
-          i18n.translate('canvas.addPanel.typeNotFound', {
+          i18n.translate('xpack.canvas.addPanel.typeNotFound', {
             defaultMessage: 'Unable to load type: {type}',
             values: { type },
           })

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -17,8 +17,12 @@ import type { FC } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
 import { useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
-import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
+import { SavedObjectFinder, SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
+import { CanAddNewPanel } from '@kbn/presentation-publishing';
+import { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
+import { getAddFromLibraryType } from '@kbn/embeddable-plugin/public/add_from_library/registry';
+import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 
 const strings = {
   getNoItemsText: () =>
@@ -33,16 +37,12 @@ const strings = {
 
 export interface Props {
   onClose: () => void;
-  onSelect: (id: string, embeddableType: string, isByValueEnabled?: boolean) => void;
-  availableEmbeddables: string[];
-  isByValueEnabled?: boolean;
+  container: CanAddNewPanel;
 }
 
 export const AddEmbeddableFlyout: FC<Props> = ({
-  onSelect,
-  availableEmbeddables,
+  container,
   onClose,
-  isByValueEnabled,
 }) => {
   const modalTitleId = useGeneratedHtmlId();
 
@@ -53,11 +53,26 @@ export const AddEmbeddableFlyout: FC<Props> = ({
     return libraryTypes.filter(({ type }) => type !== 'links');
   }, [libraryTypes]);
 
-  const onAddPanel = useCallback(
-    (id: string, savedObjectType: string) => {
-      onSelect(id, savedObjectType, isByValueEnabled);
+  const onChoose: SavedObjectFinderProps['onChoose'] = useCallback(
+    async (
+      id: SavedObjectCommon['id'],
+      type: SavedObjectCommon['type'],
+      name: string,
+      savedObject: SavedObjectCommon
+    ) => {
+      const libraryType = getAddFromLibraryType(type);
+      if (!libraryType) {
+        getCanvasNotifyService().warning(
+          i18n.translate('canvas.addPanel.typeNotFound', {
+            defaultMessage: 'Unable to load type: {type}',
+            values: { type },
+          })
+        );
+        return;
+      }
+      libraryType.onAdd(container, savedObject);
     },
-    [isByValueEnabled, onSelect]
+    [container]
   );
 
   return (
@@ -75,7 +90,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({
       <EuiFlyoutBody>
         <SavedObjectFinder
           id="canvasEmbeddableFlyout"
-          onChoose={onAddPanel}
+          onChoose={onChoose}
           savedObjectMetaData={canvasOnlyLibraryTypes}
           showFilter={true}
           noItemsMessage={strings.getNoItemsText()}

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -17,10 +17,11 @@ import type { FC } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
 import { useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
-import { SavedObjectFinder, SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
+import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
+import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
-import { CanAddNewPanel } from '@kbn/presentation-publishing';
-import { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
+import type { CanAddNewPanel } from '@kbn/presentation-publishing';
+import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import { getAddFromLibraryType } from '@kbn/embeddable-plugin/public/add_from_library/registry';
 import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -16,13 +16,12 @@ import { i18n } from '@kbn/i18n';
 import type { FC } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
-import { useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
+import { getAddFromLibraryType, useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
 import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
 import type { CanAddNewPanel } from '@kbn/presentation-publishing';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
-import { getAddFromLibraryType } from '@kbn/embeddable-plugin/public/add_from_library/registry';
 import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 
 const strings = {

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -19,9 +19,9 @@ import React, { useCallback, useMemo } from 'react';
 import { getAddFromLibraryType, useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
 import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
-import { contentManagementService, coreServices } from '../../services/kibana_services';
 import type { CanAddNewPanel } from '@kbn/presentation-publishing';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
+import { contentManagementService, coreServices } from '../../services/kibana_services';
 import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 
 const strings = {
@@ -40,10 +40,7 @@ export interface Props {
   container: CanAddNewPanel;
 }
 
-export const AddEmbeddableFlyout: FC<Props> = ({
-  container,
-  onClose,
-}) => {
+export const AddEmbeddableFlyout: FC<Props> = ({ container, onClose }) => {
   const modalTitleId = useGeneratedHtmlId();
 
   const libraryTypes = useAddFromLibraryTypes();

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -15,7 +15,7 @@ import { addElement } from '../../state/actions/elements';
 import { getSelectedPage } from '../../state/selectors/workpad';
 import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
 import type { State } from '../../../types';
-import { CanAddNewPanel, PanelPackage } from '@kbn/presentation-publishing';
+import type { CanAddNewPanel, PanelPackage } from '@kbn/presentation-publishing';
 
 type AddEmbeddable = (pageId: string, partialElement: { expression: string }) => void;
 

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -13,30 +13,13 @@ import { AddEmbeddableFlyout as Component } from './flyout.component';
 // @ts-expect-error untyped local
 import { addElement } from '../../state/actions/elements';
 import { getSelectedPage } from '../../state/selectors/workpad';
-import { EmbeddableTypes } from '../../../canvas_plugin_src/expression_types/embeddable';
 import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
 import type { State } from '../../../types';
-import { presentationUtilService } from '../../services/kibana_services';
-
-const allowedEmbeddables = {
-  [EmbeddableTypes.map]: (id: string) => {
-    return `savedMap id="${id}" | render`;
-  },
-  [EmbeddableTypes.lens]: (id: string) => {
-    return `savedLens id="${id}" | render`;
-  },
-  [EmbeddableTypes.visualization]: (id: string) => {
-    return `savedVisualization id="${id}" | render`;
-  },
-  /*
-  [EmbeddableTypes.search]: (id: string) => {
-    return `filters | savedSearch id="${id}" | render`;
-  },*/
-};
+import { CanAddNewPanel, PanelPackage } from '@kbn/presentation-publishing';
 
 type AddEmbeddable = (pageId: string, partialElement: { expression: string }) => void;
 
-type FlyoutProps = Pick<ComponentProps, 'onClose'> & Partial<Omit<ComponentProps, 'onClose'>>;
+type FlyoutProps = Pick<ComponentProps, 'onClose'>;
 
 export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (props) => {
   const el: HTMLElement = useMemo(() => document.createElement('div'), []);
@@ -59,19 +42,14 @@ export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (
   }
 
   return createPortal(
-    <Component {...props} availableEmbeddables={Object.keys(allowedEmbeddables)} />,
+    <Component {...props} />,
     el
   );
 };
 
 export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
-  availableEmbeddables,
-  ...restProps
+  onClose
 }) => {
-  const isByValueEnabled = presentationUtilService.labsService.isProjectEnabled(
-    'labs:canvas:byValueEmbeddable'
-  );
-
   const dispatch = useDispatch();
   const pageId = useSelector<State, string>((state) => getSelectedPage(state));
 
@@ -80,38 +58,23 @@ export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
     [dispatch]
   );
 
-  const onSelect = useCallback(
-    (id: string, type: string): void => {
-      const partialElement = {
-        expression: `markdown "Could not find embeddable for type ${type}" | render`,
-      };
-
-      // If by-value is enabled, we'll handle both by-reference and by-value embeddables
-      // with the new generic `embeddable` function.
-      // Otherwise we fallback to the embeddable type specific expressions.
-      if (isByValueEnabled) {
-        partialElement.expression = embeddableInputToExpression(
-          { savedObjectId: id },
-          type,
-          undefined,
-          true
-        );
-      } else if (allowedEmbeddables[type]) {
-        partialElement.expression = allowedEmbeddables[type](id);
-      }
-
-      addEmbeddable(pageId, partialElement);
-      restProps.onClose();
-    },
-    [addEmbeddable, pageId, restProps, isByValueEnabled]
-  );
+  const container = useMemo(() => ({
+    addNewPanel: (panel: PanelPackage) => {
+      const expression = embeddableInputToExpression(
+        panel.serializedState,
+        panel.panelType,
+        undefined,
+        true
+      );
+      addEmbeddable(pageId, { expression });
+      onClose();
+    }
+  } as CanAddNewPanel), [addEmbeddable, pageId, onClose]);
 
   return (
     <EmbeddableFlyoutPortal
-      {...restProps}
-      availableEmbeddables={availableEmbeddables || []}
-      onSelect={onSelect}
-      isByValueEnabled={isByValueEnabled}
+      onClose={onClose}
+      container={container}
     />
   );
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -9,8 +9,6 @@ import React, { useMemo, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import type { Props as ComponentProps } from './flyout.component';
 import { AddEmbeddableFlyout as Component } from './flyout.component';
-// @ts-expect-error untyped local
-import { addElement } from '../../state/actions/elements';
 import { useCanvasApi } from '../hooks/use_canvas_api';
 
 type FlyoutProps = Pick<ComponentProps, 'onClose'>;
@@ -35,21 +33,11 @@ export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (
     return null;
   }
 
-  return createPortal(
-    <Component {...props} />,
-    el
-  );
+  return createPortal(<Component {...props} />, el);
 };
 
-export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
-  onClose
-}) => {
+export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({ onClose }) => {
   const canvasApi = useCanvasApi();
-  
-  return (
-    <EmbeddableFlyoutPortal
-      onClose={onClose}
-      container={canvasApi}
-    />
-  );
+
+  return <EmbeddableFlyoutPortal onClose={onClose} container={canvasApi} />;
 };

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -5,19 +5,13 @@
  * 2.0.
  */
 
-import React, { useMemo, useEffect, useCallback } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { useSelector, useDispatch } from 'react-redux';
 import type { Props as ComponentProps } from './flyout.component';
 import { AddEmbeddableFlyout as Component } from './flyout.component';
 // @ts-expect-error untyped local
 import { addElement } from '../../state/actions/elements';
-import { getSelectedPage } from '../../state/selectors/workpad';
-import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
-import type { State } from '../../../types';
-import type { CanAddNewPanel, PanelPackage } from '@kbn/presentation-publishing';
-
-type AddEmbeddable = (pageId: string, partialElement: { expression: string }) => void;
+import { useCanvasApi } from '../hooks/use_canvas_api';
 
 type FlyoutProps = Pick<ComponentProps, 'onClose'>;
 
@@ -50,31 +44,12 @@ export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (
 export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
   onClose
 }) => {
-  const dispatch = useDispatch();
-  const pageId = useSelector<State, string>((state) => getSelectedPage(state));
-
-  const addEmbeddable: AddEmbeddable = useCallback(
-    (selectedPageId, partialElement) => dispatch(addElement(selectedPageId, partialElement)),
-    [dispatch]
-  );
-
-  const container = useMemo(() => ({
-    addNewPanel: (panel: PanelPackage) => {
-      const expression = embeddableInputToExpression(
-        panel.serializedState,
-        panel.panelType,
-        undefined,
-        true
-      );
-      addEmbeddable(pageId, { expression });
-      onClose();
-    }
-  } as CanAddNewPanel), [addEmbeddable, pageId, onClose]);
-
+  const canvasApi = useCanvasApi();
+  
   return (
     <EmbeddableFlyoutPortal
       onClose={onClose}
-      container={container}
+      container={canvasApi}
     />
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/257260

PR updates canvas to use registered `onAdd` to create embeddable state instead of hardcoding embeddable state to `{ savedObjectId }`.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->