### PR TITLE
[ES|QL Control] Focus panel on edit

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -111,7 +111,9 @@ export const getESQLControlFactory = (): EmbeddableFactory<
               controlType: nextState.control_type,
               esqlVariables: variablesInParent,
               onSaveControl,
+              parentApi,
               initialState: nextState,
+              controlId: uuid,
             });
           } catch (e) {
             // eslint-disable-next-line no-console

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -48,6 +48,7 @@ interface Context {
   initialState?: OptionsListESQLControlState;
   parentApi?: unknown;
   triggerSource?: ControlTriggerSource;
+  controlId?: string;
 }
 
 export class CreateESQLControlAction implements Action<Context> {
@@ -85,6 +86,7 @@ export class CreateESQLControlAction implements Action<Context> {
     initialState,
     parentApi,
     triggerSource,
+    controlId,
   }: Context) {
     if (!isActionCompatible(this.core, variableType)) {
       throw new IncompatibleActionError();
@@ -135,6 +137,7 @@ export class CreateESQLControlAction implements Action<Context> {
       },
       flyoutProps: {
         'data-test-subj': 'create_esql_control_flyout',
+        focusedPanelId: controlId,
         isResizable: true,
         maxWidth: 800,
         triggerId: 'dashboard-controls-menu-button',


### PR DESCRIPTION
## Summary

Closes #256387

<img width="1098" height="1141" alt="Screenshot 2026-03-11 at 1 02 45 PM" src="https://github.com/user-attachments/assets/3131e733-5afc-4d8e-83b0-6073dbb97f0a" />

Fixes a bug where ES|QL controls as panels did not set a `focusedPanelId` on the dashboard while they were being edited.  Not only did this prevent the green focus border from appearing on ES|QL controls, but also created a bug where dashboards could get into a broken state if you edited an ES|QL visualization that depended on a control, and then began to edit that control without closing the original visualization's flyout.

### Testing

1. Create an ES|QL control panel on a dashboard from the Add Panel menu, OR create it from the Controls menu and then unpin it so it becomes a moveable panel
2. Edit this control. Ensure the green focus border appears.
3. Create an ES|QL visualization panel which refers to this control, and save it.
4. Edit the ES|QL visualization. Without closing the edit flyout, hover over the ES|QL control and edit it.
5. Close the edit flyout. Ensure that no more panels are focused, and the dashboard is usable again.


### Release Note
This fixes a bug that only affects serverless.