### PR TITLE
HTTP/2 by default for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serverless-security": "node --no-experimental-require-module scripts/kibana --dev --serverless=security",
     "serverless-workplace-ai": "node --no-experimental-require-module scripts/kibana --dev --serverless=workplaceai",
     "spec_to_console": "node --no-experimental-require-module scripts/spec_to_console",
-    "start": "node --no-experimental-require-module scripts/kibana --dev",
+    "start": "node --no-experimental-require-module scripts/kibana --dev --http2",
     "storybook": "node --no-experimental-require-module scripts/storybook",
     "test:ftr": "node --no-experimental-require-module scripts/functional_tests",
     "test:ftr:runner": "node --no-experimental-require-module scripts/functional_test_runner",


### PR DESCRIPTION
## Summary

Since 9.0, HTTP/2 + TLS is the default configuration for Kibana.

This `package.json` change will update our default development environment to better reflect users' expected experiences and protect us from false signals.