### PR TITLE
Split API docs CODEOWNERS across domain-specific docs teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3155,11 +3155,11 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/intercepts/*.ts @elastic/appex-sharedux
 
 # OpenAPI shared infrastructure
-oas_docs/linters                              @elastic/experience-docs
-oas_docs/overlays                             @elastic/experience-docs
-oas_docs/kibana.info.serverless.yaml          @elastic/experience-docs
-oas_docs/kibana.info.yaml                     @elastic/experience-docs
-oas_docs/output                               @elastic/api-docs-reviewer
+oas_docs/linters                              @elastic/developer-docs
+oas_docs/overlays                             @elastic/ski-docs
+oas_docs/kibana.info.serverless.yaml          @elastic/ski-docs
+oas_docs/kibana.info.yaml                     @elastic/ski-docs
+oas_docs/output                               @elastic/ski-docs
 
 # Documentation settings and reference
 docs/settings-gen                             @elastic/experience-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2549,14 +2549,14 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 #CC# /x-pack/solutions/security/plugins/security_solution/ @elastic/security-solution
 
 # Security Solution OpenAPI bundles
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_* @elastic/security-detection-rule-management
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_* @elastic/security-defend-workflows
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_* @elastic/security-entity-analytics
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_* @elastic/security-detection-rule-management
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_* @elastic/security-defend-workflows
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_* @elastic/security-entity-analytics
-/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_* @elastic/security-detection-rule-management @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_* @elastic/security-defend-workflows @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_* @elastic/security-entity-analytics @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_* @elastic/security-detection-rule-management @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_* @elastic/security-defend-workflows @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_* @elastic/security-entity-analytics @elastic/security-docs-reviewers
+/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_* @elastic/security-threat-hunting-investigations @elastic/security-docs-reviewers
 
 # Security Solution Offering plugins
 # TODO: assign sub directories to sub teams
@@ -3154,14 +3154,46 @@ x-pack/solutions/observability/plugins/observability_shared/public/components/pr
 /x-pack/solutions/security/test/serverless/functional/page_objects/svl_sec_landing_page.ts @elastic/appex-sharedux
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/intercepts/*.ts @elastic/appex-sharedux
 
-# OpenAPI spec files
+# OpenAPI shared infrastructure
 oas_docs/linters                              @elastic/experience-docs
 oas_docs/overlays                             @elastic/experience-docs
 oas_docs/kibana.info.serverless.yaml          @elastic/experience-docs
 oas_docs/kibana.info.yaml                     @elastic/experience-docs
-oas_docs/output                               @elastic/experience-docs
+oas_docs/output                               @elastic/api-docs-reviewer
 
-# Documentation settings files
+# OpenAPI input specs -- experience-docs (response ops, general)
+/x-pack/platform/plugins/shared/alerting/docs/openapi/           @elastic/response-ops @elastic/experience-docs
+/x-pack/platform/plugins/shared/cases/docs/openapi/              @elastic/kibana-cases @elastic/experience-docs
+/x-pack/platform/plugins/shared/actions/docs/openapi/            @elastic/response-ops @elastic/experience-docs
+/src/platform/plugins/shared/data_views/docs/openapi/            @elastic/kibana-data-discovery @elastic/experience-docs
+/x-pack/platform/plugins/shared/features/docs/openapi/           @elastic/kibana-core @elastic/experience-docs
+/src/core/packages/saved-objects/docs/openapi/                    @elastic/kibana-core @elastic/experience-docs
+/x-pack/platform/plugins/shared/security/docs/openapi/           @elastic/kibana-security @elastic/experience-docs
+/src/platform/plugins/shared/share/docs/openapi/                  @elastic/appex-sharedux @elastic/experience-docs
+
+# OpenAPI input specs -- developer-docs
+/x-pack/platform/plugins/shared/ml/common/openapi/               @elastic/ml-ui @elastic/developer-docs
+/x-pack/platform/plugins/shared/task_manager/docs/openapi/       @elastic/response-ops @elastic/developer-docs
+/x-pack/platform/plugins/private/upgrade_assistant/docs/openapi/ @elastic/kibana-management @elastic/developer-docs
+
+# OpenAPI input specs -- ingest-docs
+/x-pack/platform/plugins/private/logstash/docs/openapi/          @elastic/logstash @elastic/ingest-docs
+
+# OpenAPI input specs -- security-docs-reviewers
+/x-pack/solutions/security/packages/kbn-securitysolution-lists-common/docs/openapi/  @elastic/security-detection-engine @elastic/security-docs-reviewers
+/x-pack/solutions/security/packages/kbn-securitysolution-exceptions-common/docs/openapi/  @elastic/security-detection-engine @elastic/security-docs-reviewers
+/x-pack/solutions/security/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/  @elastic/security-detection-engine @elastic/security-docs-reviewers
+/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/  @elastic/security-generative-ai @elastic/security-docs-reviewers
+/x-pack/platform/plugins/shared/osquery/docs/openapi/            @elastic/security-defend-workflows @elastic/security-docs-reviewers
+
+# OpenAPI input specs -- obs-docs-reviewers
+/x-pack/solutions/observability/plugins/apm/docs/openapi/        @elastic/obs-presentation-team @elastic/obs-docs-reviewers
+/x-pack/solutions/observability/plugins/slo/docs/openapi/        @elastic/actionable-obs-team @elastic/obs-docs-reviewers
+/x-pack/solutions/observability/plugins/uptime/docs/openapi/     @elastic/actionable-obs-team @elastic/obs-docs-reviewers
+/x-pack/solutions/observability/plugins/synthetics/docs/openapi/ @elastic/actionable-obs-team @elastic/obs-docs-reviewers
+/x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/  @elastic/obs-ai-team @elastic/obs-docs-reviewers
+
+# Documentation settings and reference
 docs/settings-gen                             @elastic/experience-docs
 docs/reference                                @elastic/experience-docs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3161,6 +3161,10 @@ oas_docs/kibana.info.serverless.yaml          @elastic/experience-docs
 oas_docs/kibana.info.yaml                     @elastic/experience-docs
 oas_docs/output                               @elastic/api-docs-reviewer
 
+# Documentation settings and reference
+docs/settings-gen                             @elastic/experience-docs
+docs/reference                                @elastic/experience-docs
+
 # OpenAPI input specs -- experience-docs (response ops, general)
 /x-pack/platform/plugins/shared/alerting/docs/openapi/           @elastic/response-ops @elastic/experience-docs
 /x-pack/platform/plugins/shared/cases/docs/openapi/              @elastic/kibana-cases @elastic/experience-docs
@@ -3192,10 +3196,6 @@ oas_docs/output                               @elastic/api-docs-reviewer
 /x-pack/solutions/observability/plugins/uptime/docs/openapi/     @elastic/actionable-obs-team @elastic/obs-docs-reviewers
 /x-pack/solutions/observability/plugins/synthetics/docs/openapi/ @elastic/actionable-obs-team @elastic/obs-docs-reviewers
 /x-pack/solutions/observability/plugins/observability_ai_assistant_app/docs/openapi/  @elastic/obs-ai-team @elastic/obs-docs-reviewers
-
-# Documentation settings and reference
-docs/settings-gen                             @elastic/experience-docs
-docs/reference                                @elastic/experience-docs
 
 /x-pack/platform/test/serverless/functional/test_suites/strip_unknown_config_workaround @elastic/kibana-core
 


### PR DESCRIPTION
## Summary

This PR updates `.github/CODEOWNERS` to distribute API documentation ownership across domain-specific docs teams, rather than having all API docs owned solely by `experience-docs` via the monolithic `oas_docs/output` entry.

### What changed

1. **Removed `experience-docs` from `oas_docs/output`** -- previously, every API spec change triggered an `experience-docs` review because the built output is a monolith. This caused unnecessary noise.

2. **Added `ski-docs` as owner of `oas_docs/output`** -- ensures a writer must sign off on every change to the built output, regardless of domain.

3. **Added per-domain CODEOWNERS on OpenAPI input spec directories** -- each entry lists both the existing dev team and the new docs team, so dev team review is preserved.

4. **Appended `security-docs-reviewers` to existing security solution OpenAPI entries** (lines 2552-2559) -- these already had file-specific dev-team ownership; we add the docs team alongside rather than overriding with a directory-level entry.

### New ownership

Sub-teams with domain-specific knowledge:

- **`experience-docs`** -- Kibana and general APIs
- **`obs-docs-reviewers`** -- Observability-specific APIs
- **`security-docs-reviewers`** -- Security-specific APIs
- **`dev-docs`** -- ML, task manager, and upgrade APIs
- **`ingest-docs`** -- Logstash APIs

### API ownership mapping

| API | Eng team | Docs team | Input spec path |
|-----|----------|-----------|----------------|
| Alerting | `response-ops` | `experience-docs` | `alerting/docs/openapi/` |
| Cases | `kibana-cases` | `experience-docs` | `cases/docs/openapi/` |
| Connectors (actions) | `response-ops` | `experience-docs` | `actions/docs/openapi/` |
| Data views | `kibana-data-discovery` | `experience-docs` | `data_views/docs/openapi/` |
| Features | `kibana-core` | `experience-docs` | `features/docs/openapi/` |
| Saved objects | `kibana-core` | `experience-docs` | `saved-objects/docs/openapi/` |
| User session (security) | `kibana-security` | `experience-docs` | `security/docs/openapi/` |
| Short URLs (share) | `appex-sharedux` | `experience-docs` | `share/docs/openapi/` |
| Machine learning | `ml-ui` | `developer-docs` | `ml/common/openapi/` |
| Task manager | `response-ops` | `developer-docs` | `task_manager/docs/openapi/` |
| Upgrade assistant | `kibana-management` | `developer-docs` | `upgrade_assistant/docs/openapi/` |
| Logstash | `logstash` | `ingest-docs` | `logstash/docs/openapi/` |
| Security lists | `security-detection-engine` | `security-docs-reviewers` | `kbn-securitysolution-lists-common/docs/openapi/` |
| Security exceptions | `security-detection-engine` | `security-docs-reviewers` | `kbn-securitysolution-exceptions-common/docs/openapi/` |
| Security endpoint exceptions | `security-detection-engine` | `security-docs-reviewers` | `kbn-securitysolution-endpoint-exceptions-common/docs/openapi/` |
| Elastic Assistant | `security-generative-ai` | `security-docs-reviewers` | `kbn-elastic-assistant-common/docs/openapi/` |
| Osquery | `security-defend-workflows` | `security-docs-reviewers` | `osquery/docs/openapi/` |
| Security detections | `security-detection-rule-management` | `security-docs-reviewers` | `security_solution/docs/openapi/*/security_solution_detections_api_*` |
| Security endpoint mgmt | `security-defend-workflows` | `security-docs-reviewers` | `security_solution/docs/openapi/*/security_solution_endpoint_management_api_*` |
| Security entity analytics | `security-entity-analytics` | `security-docs-reviewers` | `security_solution/docs/openapi/*/security_solution_entity_analytics_api_*` |
| Security timeline | `security-threat-hunting-investigations` | `security-docs-reviewers` | `security_solution/docs/openapi/*/security_solution_timeline_api_*` |
| APM | `obs-presentation-team` | `obs-docs-reviewers` | `apm/docs/openapi/` |
| SLO | `actionable-obs-team` | `obs-docs-reviewers` | `slo/docs/openapi/` |
| Uptime | `actionable-obs-team` | `obs-docs-reviewers` | `uptime/docs/openapi/` |
| Synthetics | `actionable-obs-team` | `obs-docs-reviewers` | `synthetics/docs/openapi/` |
| Obs AI Assistant | `obs-ai-team` | `obs-docs-reviewers` | `observability_ai_assistant_app/docs/openapi/` |

### How CODEOWNERS works here

- **Last match wins.** Our new entries (later in the file) override parent-directory dev-team entries for just the `docs/openapi/` subdirectories. Including the dev team on our line ensures they are not silently dropped.
- **Multiple teams on one line = either can approve.** Listing both eng and docs teams means an approval from either satisfies the CODEOWNERS requirement for that file. The separate `api-docs-reviewer` ownership on `oas_docs/output` acts as a backstop requiring a writer to sign off on the final built output.

### Not covered

These APIs enter via the runtime-captured `bundle.json` (gitignored) and have no standalone input spec file to set CODEOWNERS on:

- Fleet APIs (Elastic Agent, Fleet outputs/policies/proxies, EPM)
- Agent Builder APIs
- Data streams APIs
- Message Signing Service
- Streams APIs

For these, only `ski-docs` will be pinged. The first writer to view the PR should ping the correct sub-team to take a look.

