### PR TITLE
[Dashboard Agent] Extract attachment-to-dashboard state mapping and unify renderer/action types

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/attachment_to_dashboard_state.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/attachment_to_dashboard_state.ts
@@ -14,28 +14,28 @@ import type { DashboardState } from '@kbn/dashboard-plugin/common';
 import type { DashboardPanel, DashboardSection } from '@kbn/dashboard-plugin/server';
 import { i18n } from '@kbn/i18n';
 import {
+  type LensAttributes,
   LensConfigBuilder,
   type LensApiSchemaType,
-  type LensAttributes,
 } from '@kbn/lens-embeddable-utils/config_builder';
 import { isLensLegacyAttributes } from '@kbn/lens-embeddable-utils/config_builder/utils';
 import type { LensSerializedAPIConfig } from '@kbn/lens-common-2';
 import { LENS_EMBEDDABLE_TYPE } from '@kbn/lens-plugin/public';
+import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
 
-export const buildLensPanelFromApi = (
+const lensConfigBuilder = new LensConfigBuilder();
+
+const buildLensPanelFromApi = (
   config: LensApiSchemaType,
   uid?: string
 ): Omit<DashboardPanel, 'grid'> => {
-  const lensAttributes: LensAttributes = new LensConfigBuilder().fromAPIFormat(config);
-
   const lensConfig: LensSerializedAPIConfig = {
     title:
-      lensAttributes.title ??
       config.title ??
       i18n.translate('xpack.dashboardAgent.attachments.dashboard.generatedPanelTitle', {
         defaultMessage: 'Generated panel',
       }),
-    attributes: lensAttributes,
+    attributes: config,
   };
 
   return {
@@ -45,21 +45,21 @@ export const buildLensPanelFromApi = (
   };
 };
 
-export const isLensEmbeddableType = (
+const isLensEmbeddableType = (
   embeddableType: string,
   rawConfig: unknown
 ): rawConfig is LensAttributes => {
   return embeddableType === LENS_EMBEDDABLE_TYPE && isLensLegacyAttributes(rawConfig);
 };
 
-export interface BuildPanelFromRawConfigOptions {
+interface BuildPanelFromRawConfigOptions {
   embeddableType: string;
   rawConfig: Record<string, unknown>;
   title: string | undefined;
   uid?: string;
 }
 
-export const buildPanelFromRawConfig = ({
+const buildPanelFromRawConfig = ({
   embeddableType,
   rawConfig,
   title,
@@ -70,14 +70,14 @@ export const buildPanelFromRawConfig = ({
     config: isLensEmbeddableType(embeddableType, rawConfig)
       ? {
           title: title ?? rawConfig.title ?? 'Panel',
-          attributes: rawConfig,
+          attributes: lensConfigBuilder.toAPIFormat(rawConfig),
         }
       : rawConfig,
     uid,
   };
 };
 
-export const normalizePanels = (panels: AttachmentPanel[]): DashboardPanel[] => {
+const normalizePanels = (panels: AttachmentPanel[]): DashboardPanel[] => {
   const panelList = panels ?? [];
 
   return panelList.reduce<DashboardPanel[]>((acc, panel) => {
@@ -113,7 +113,7 @@ const normalizeSections = (sections: AgentDashboardSection[]): DashboardSection[
   }));
 };
 
-export const normalizeDashboardWidgets = ({
+const normalizeDashboardWidgets = ({
   panels,
   sections,
 }: {
@@ -121,4 +121,22 @@ export const normalizeDashboardWidgets = ({
   sections?: AgentDashboardSection[];
 }): DashboardState['panels'] => {
   return [...normalizePanels(panels), ...normalizeSections(sections ?? [])];
+};
+
+export const DEFAULT_TIME_RANGE = { from: 'now-24h', to: 'now' };
+
+export const getStateFromAttachment = (
+  attachment: DashboardAttachment
+): Pick<DashboardState, 'title' | 'description' | 'panels' | 'time_range'> => {
+  const { title, description, panels = [], sections = [] } = attachment.data;
+
+  return {
+    title: title ?? '',
+    description: description ?? '',
+    panels: normalizeDashboardWidgets({
+      panels,
+      sections,
+    }),
+    time_range: DEFAULT_TIME_RANGE,
+  };
 };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -8,75 +8,15 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
 import type { ActionButton, AttachmentRenderProps } from '@kbn/agent-builder-browser/attachments';
-import type {
-  DashboardAttachmentData,
-  DashboardAttachmentOrigin,
-} from '@kbn/dashboard-agent-common';
-import type { DashboardState } from '@kbn/dashboard-plugin/common';
-import type {
-  DashboardApi,
-  DashboardCreationOptions,
-  DashboardRendererProps,
-} from '@kbn/dashboard-plugin/public';
+import type { DashboardAttachmentOrigin } from '@kbn/dashboard-agent-common';
+import type { DashboardApi, DashboardRendererProps } from '@kbn/dashboard-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type { UseEuiTheme } from '@elastic/eui';
 import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import type { DashboardAttachment } from '@kbn/dashboard-agent-common/types';
-import { normalizeDashboardWidgets } from './panel_grid_layout';
+import { DEFAULT_TIME_RANGE, getStateFromAttachment } from './attachment_to_dashboard_state';
 import { useRegisterActionButtons } from './use_register_action_buttons';
-
-export interface DashboardCanvasInitialInput {
-  timeRange: {
-    from: string;
-    to: string;
-  };
-  viewMode: 'view';
-  panels: DashboardState['panels'];
-  title?: string;
-  description?: string;
-}
-
-const DEFAULT_TIME_RANGE = { from: 'now-24h', to: 'now' };
-
-const createDashboardRendererInitialInput = (
-  data: DashboardAttachmentData
-): DashboardCanvasInitialInput => ({
-  timeRange: DEFAULT_TIME_RANGE,
-  viewMode: 'view',
-  panels: normalizeDashboardWidgets({
-    panels: data.panels ?? [],
-    sections: data.sections,
-  }),
-  title: data.title,
-  description: data.description,
-});
-
-const getDashboardRendererCreationOptions = async ({
-  savedObjectId,
-  initialDashboardInput,
-}: {
-  savedObjectId?: string;
-  initialDashboardInput: DashboardCanvasInitialInput;
-}): Promise<DashboardCreationOptions> => {
-  if (savedObjectId) {
-    return {
-      getInitialInput: () => ({
-        viewMode: 'view',
-      }),
-    };
-  }
-
-  return {
-    getInitialInput: () => {
-      const { timeRange, ...restInitialDashboardInput } = initialDashboardInput;
-      return {
-        ...restInitialDashboardInput,
-        time_range: timeRange,
-      };
-    },
-  };
-};
 
 const dashboardCanvasContentStyles = {
   root: css({
@@ -126,7 +66,6 @@ export const DashboardCanvasContent = ({
   searchBarComponent: UnifiedSearchPublicPluginStart['ui']['SearchBar'];
   doesSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
 }) => {
-  const data = attachment.data;
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();
   const styles = useMemoCss(dashboardCanvasContentStyles);
   const linkedSavedObjectId = attachment.origin?.savedObjectId;
@@ -159,19 +98,18 @@ export const DashboardCanvasContent = ({
   //   },
   //   [linkedSavedObjectId, doesSavedDashboardExist]
   // );
-  const initialDashboardInput = useMemo(() => createDashboardRendererInitialInput(data), [data]);
+  const dashboardState = useMemo(() => getStateFromAttachment(attachment), [attachment]);
 
   const [timeRange, setTimeRange] = useState<{ from: string; to: string }>(
-    initialDashboardInput.timeRange
+    dashboardState.time_range ?? DEFAULT_TIME_RANGE
   );
 
   const getCreationOptions = useCallback(
     () =>
-      getDashboardRendererCreationOptions({
-        savedObjectId: data.savedObjectId,
-        initialDashboardInput,
+      Promise.resolve({
+        getInitialInput: () => ({ ...dashboardState, viewMode: 'view' as const }),
       }),
-    [data.savedObjectId, initialDashboardInput]
+    [dashboardState]
   );
 
   useRegisterActionButtons({
@@ -179,7 +117,7 @@ export const DashboardCanvasContent = ({
     registerActionButtons,
     updateOrigin,
     timeRange,
-    initialDashboardInput,
+    dashboardState,
     linkedSavedObjectId,
     doesSavedDashboardExist,
   });

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/use_register_action_buttons.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/use_register_action_buttons.ts
@@ -9,17 +9,17 @@ import { useEffect } from 'react';
 import { ActionButtonType } from '@kbn/agent-builder-browser/attachments';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { DashboardAttachmentOrigin } from '@kbn/dashboard-agent-common';
+import type { DashboardState } from '@kbn/dashboard-plugin/common';
 import type { DashboardApi } from '@kbn/dashboard-plugin/public';
 import { i18n } from '@kbn/i18n';
 import useLatest from 'react-use/lib/useLatest';
-import type { DashboardCanvasInitialInput } from './dashboard_canvas_content';
 
 interface UseRegisterActionButtonsParams {
   dashboardApi: DashboardApi | undefined;
   registerActionButtons: (buttons: ActionButton[]) => void;
   updateOrigin: (origin: DashboardAttachmentOrigin) => Promise<unknown>;
   timeRange: { from: string; to: string };
-  initialDashboardInput: DashboardCanvasInitialInput;
+  dashboardState: Pick<DashboardState, 'title' | 'description' | 'panels' | 'time_range'>;
   linkedSavedObjectId: string | undefined;
   doesSavedDashboardExist: (dashboardId: string) => Promise<boolean>;
 }
@@ -29,13 +29,13 @@ export const useRegisterActionButtons = ({
   registerActionButtons,
   updateOrigin,
   timeRange,
-  initialDashboardInput,
+  dashboardState,
   linkedSavedObjectId,
   doesSavedDashboardExist,
 }: UseRegisterActionButtonsParams) => {
   const timeRangeRef = useLatest(timeRange);
   const linkedSavedObjectIdRef = useLatest(linkedSavedObjectId);
-  const initialDashboardInputRef = useLatest(initialDashboardInput);
+  const dashboardStateRef = useLatest(dashboardState);
 
   useEffect(() => {
     if (!dashboardApi) {
@@ -53,12 +53,9 @@ export const useRegisterActionButtons = ({
         handler: async () => {
           const linkedId = linkedSavedObjectIdRef.current;
           const soExists = linkedId ? await doesSavedDashboardExist(linkedId) : false;
-          const { title, description, panels } = initialDashboardInputRef.current;
           await locator.navigate({
+            ...dashboardStateRef.current,
             dashboardId: soExists ? linkedSavedObjectIdRef.current : undefined,
-            title,
-            description,
-            panels,
             time_range: timeRangeRef.current,
             viewMode: 'edit',
           });
@@ -87,6 +84,6 @@ export const useRegisterActionButtons = ({
     doesSavedDashboardExist,
     timeRangeRef,
     linkedSavedObjectIdRef,
-    initialDashboardInputRef,
+    dashboardStateRef,
   ]);
 };


### PR DESCRIPTION
## Summary

A small refactoring in preparation to handling Dashboard sidebar integration.

This PR refactors Dashboard Agent attachment handling by moving attachment-to-dashboard-state normalization into a dedicated utility and reusing that typed state across rendering and action button navigation.

### What changed
- Added `attachment_to_dashboard_state.ts` to centralize conversion from `DashboardAttachment` data to dashboard state (`title`, `description`, `panels`, `time_range`) - better and more direct typing
- Replaced inline state/input construction in `dashboard_canvas_content.tsx` with `getStateFromAttachment(...)`.
- Simplified renderer creation options to always derive initial input from the normalized dashboard state.
- Updated `use_register_action_buttons.ts` to consume `dashboardState` (typed from `DashboardState`) instead of the previous local initial-input type.
### Why
- Keeps dashboard state normalization in one place.
- Improves type consistency between dashboard rendering and locator navigation flows.
- Makes attachment rendering code easier to follow and maintain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal dashboard attachment handling by streamlining state conversion logic and reducing unnecessary type conversion layers.
  * Consolidated dashboard state initialization to improve code maintainability and reduce complexity in attachment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->