### PR TITLE
fix(NA): jest checkpoint key missing shard annotation in run.ts

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/jest/run.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.test.ts
@@ -52,6 +52,12 @@ jest.mock('@kbn/repo-info', () => ({
 
 jest.mock('getopts', () => jest.fn());
 
+jest.mock('./buildkite_checkpoint', () => ({
+  isInBuildkite: jest.fn().mockReturnValue(false),
+  isConfigCompleted: jest.fn().mockResolvedValue(false),
+  markConfigCompletedSync: jest.fn(),
+}));
+
 import { relative } from 'path';
 import {
   commonBasePath,
@@ -61,6 +67,7 @@ import {
   resolveJestConfig,
   prepareJestExecution,
   removeFlagFromArgv,
+  runJest,
 } from './run';
 
 describe('run.ts', () => {
@@ -835,6 +842,125 @@ describe('run.ts', () => {
           expect(process.env.JEST_CONFIG_PATH).toBeUndefined();
         });
       });
+    });
+  });
+
+  describe('Buildkite checkpoint with shard annotation', () => {
+    let mockGetopts: jest.Mock;
+    let mockIsInBuildkite: jest.Mock;
+    let mockIsConfigCompleted: jest.Mock;
+    let mockProcessExit: jest.SpyInstance;
+
+    beforeEach(() => {
+      mockGetopts = jest.mocked(jest.requireMock('getopts'));
+      mockIsInBuildkite = jest.mocked(
+        jest.requireMock('./buildkite_checkpoint').isInBuildkite
+      );
+      mockIsConfigCompleted = jest.mocked(
+        jest.requireMock('./buildkite_checkpoint').isConfigCompleted
+      );
+
+      process.env.BUILDKITE = 'true';
+      process.env.BUILDKITE_STEP_ID = 'step-1';
+      process.env.BUILDKITE_PARALLEL_JOB = '0';
+      process.env.BUILDKITE_RETRY_COUNT = '1';
+
+      mockIsInBuildkite.mockReturnValue(true);
+      mockIsConfigCompleted.mockResolvedValue(true);
+
+      mockProcessExit = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called');
+        }) as () => never);
+    });
+
+    afterEach(() => {
+      mockProcessExit.mockRestore();
+      delete process.env.BUILDKITE;
+      delete process.env.BUILDKITE_STEP_ID;
+      delete process.env.BUILDKITE_PARALLEL_JOB;
+      delete process.env.BUILDKITE_RETRY_COUNT;
+    });
+
+    it('should include shard annotation in checkpoint key when --shard is present', async () => {
+      process.argv = [
+        'node',
+        'script',
+        '--config',
+        '/mock/repo/root/x-pack/plugins/alerting/jest.config.js',
+        '--shard=2/6',
+      ];
+
+      mockGetopts.mockReturnValue({
+        _: [],
+        config: '/mock/repo/root/x-pack/plugins/alerting/jest.config.js',
+        shard: '2/6',
+        verbose: false,
+        help: false,
+      });
+
+      try {
+        await runJest();
+      } catch {
+        // Expected: process.exit mock throws
+      }
+
+      expect(mockIsConfigCompleted).toHaveBeenCalledWith(
+        'x-pack/plugins/alerting/jest.config.js||shard=2/6'
+      );
+    });
+
+    it('should include shard annotation when shard comes from config annotation', async () => {
+      process.argv = [
+        'node',
+        'script',
+        '--config',
+        '/mock/repo/root/x-pack/plugins/alerting/jest.config.js||shard=3/6',
+      ];
+
+      mockGetopts.mockReturnValue({
+        _: [],
+        config: '/mock/repo/root/x-pack/plugins/alerting/jest.config.js||shard=3/6',
+        verbose: false,
+        help: false,
+      });
+
+      try {
+        await runJest();
+      } catch {
+        // Expected: process.exit mock throws
+      }
+
+      expect(mockIsConfigCompleted).toHaveBeenCalledWith(
+        'x-pack/plugins/alerting/jest.config.js||shard=3/6'
+      );
+    });
+
+    it('should NOT include shard annotation when no shard is present', async () => {
+      process.argv = [
+        'node',
+        'script',
+        '--config',
+        '/mock/repo/root/x-pack/plugins/alerting/jest.config.js',
+      ];
+
+      mockGetopts.mockReturnValue({
+        _: [],
+        config: '/mock/repo/root/x-pack/plugins/alerting/jest.config.js',
+        verbose: false,
+        help: false,
+      });
+
+      try {
+        await runJest();
+      } catch {
+        // Expected: process.exit mock throws
+      }
+
+      expect(mockIsConfigCompleted).toHaveBeenCalledWith(
+        'x-pack/plugins/alerting/jest.config.js'
+      );
     });
   });
 });

--- a/src/platform/packages/shared/kbn-test/src/jest/run.test.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.test.ts
@@ -853,9 +853,7 @@ describe('run.ts', () => {
 
     beforeEach(() => {
       mockGetopts = jest.mocked(jest.requireMock('getopts'));
-      mockIsInBuildkite = jest.mocked(
-        jest.requireMock('./buildkite_checkpoint').isInBuildkite
-      );
+      mockIsInBuildkite = jest.mocked(jest.requireMock('./buildkite_checkpoint').isInBuildkite);
       mockIsConfigCompleted = jest.mocked(
         jest.requireMock('./buildkite_checkpoint').isConfigCompleted
       );
@@ -868,11 +866,9 @@ describe('run.ts', () => {
       mockIsInBuildkite.mockReturnValue(true);
       mockIsConfigCompleted.mockResolvedValue(true);
 
-      mockProcessExit = jest
-        .spyOn(process, 'exit')
-        .mockImplementation((() => {
-          throw new Error('process.exit called');
-        }) as () => never);
+      mockProcessExit = jest.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit called');
+      }) as () => never);
     });
 
     afterEach(() => {
@@ -958,9 +954,7 @@ describe('run.ts', () => {
         // Expected: process.exit mock throws
       }
 
-      expect(mockIsConfigCompleted).toHaveBeenCalledWith(
-        'x-pack/plugins/alerting/jest.config.js'
-      );
+      expect(mockIsConfigCompleted).toHaveBeenCalledWith('x-pack/plugins/alerting/jest.config.js');
     });
   });
 });

--- a/src/platform/packages/shared/kbn-test/src/jest/run.ts
+++ b/src/platform/packages/shared/kbn-test/src/jest/run.ts
@@ -32,7 +32,7 @@ import type { Config } from '@jest/types';
 
 import jestFlags from './jest_flags.json';
 import { isInBuildkite, isConfigCompleted, markConfigCompletedSync } from './buildkite_checkpoint';
-import { parseShardAnnotation } from './shard_config';
+import { parseShardAnnotation, annotateConfigWithShard } from './shard_config';
 
 const JEST_CACHE_DIR = 'data/jest-cache';
 
@@ -97,8 +97,12 @@ export async function runJest(configName = 'jest.config.js'): Promise<void> {
 
   // Buildkite checkpoint resume: skip this config if it already passed on a previous attempt.
   // Use relative path for checkpoint key so it's stable across different CI agents.
+  // Include shard annotation when sharding is active so each shard has its own checkpoint.
   if (isInBuildkite() && resolvedConfigPath) {
-    const relConfigForCheckpoint = relative(REPO_ROOT, resolvedConfigPath);
+    const relConfig = relative(REPO_ROOT, resolvedConfigPath);
+    const relConfigForCheckpoint = parsedArguments.shard
+      ? annotateConfigWithShard(relConfig, parsedArguments.shard)
+      : relConfig;
     log.info(
       `[jest-checkpoint] Checking prior completion for ${relConfigForCheckpoint} (step=${
         process.env.BUILDKITE_STEP_ID || ''
@@ -181,13 +185,16 @@ export async function runJest(configName = 'jest.config.js'): Promise<void> {
     //
     // Uses synchronous markConfigCompletedSync because async is not supported in 'exit' handlers.
     if (isInBuildkite() && resolvedConfigPath) {
-      const relConfig = relative(REPO_ROOT, resolvedConfigPath);
+      const relCfg = relative(REPO_ROOT, resolvedConfigPath);
+      const checkpointKey = parsedArguments.shard
+        ? annotateConfigWithShard(relCfg, parsedArguments.shard)
+        : relCfg;
       process.on('exit', () => {
         // process.exitCode is 0 or undefined for success (Jest only sets it for failures).
         // Both are falsy, while failure codes (1, etc.) are truthy.
         if (!process.exitCode) {
-          log.info(`[jest-checkpoint] Marking ${relConfig} as completed`);
-          markConfigCompletedSync(relConfig);
+          log.info(`[jest-checkpoint] Marking ${checkpointKey} as completed`);
+          markConfigCompletedSync(checkpointKey);
         }
       });
     }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-operations/issues/472

This PR fixes a bug where failed jest shards were skipped on retry. run.ts was using the bare config path (e.g. alerting/jest.config.js) as the checkpoint key instead of the shard-annotated path (alerting/jest.config.js||shard=2/6), so a successful shard would mark the entire config as "completed" and prevent failed shards from re-running. The fix includes the shard annotation in the checkpoint key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test suite for Buildkite checkpoint integration to verify proper shard annotation handling and configuration tracking across test environments.
  * Enhanced test coverage to ensure consistent behavior when shards are present or absent.

* **Chores**
  * Improved configuration checkpoint handling for sharded test execution to enable better tracking and resumption of distributed test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->