### PR TITLE
[9.3] [canvas] fix add from library adding incorrect embeddable state (#257261)

### DIFF
--- a/src/platform/plugins/shared/embeddable/public/add_from_library/registry.ts
+++ b/src/platform/plugins/shared/embeddable/public/add_from_library/registry.ts
@@ -74,9 +74,9 @@ export function useAddFromLibraryTypes() {
 
 /**
  * Getter for accessing saved object type from AddFromLibrary registry
- * @param type string
+ * @param libraryType string
  * @returns registry item for saved object type
  */
-export const getAddFromLibraryType = (type: string) => {
-  return registry.get(type);
+export const getAddFromLibraryType = (libraryType: string) => {
+  return registry.get(libraryType);
 };

--- a/src/platform/plugins/shared/embeddable/public/index.ts
+++ b/src/platform/plugins/shared/embeddable/public/index.ts
@@ -10,7 +10,7 @@
 import type { PluginInitializerContext } from '@kbn/core/public';
 import { EmbeddablePublicPlugin } from './plugin';
 
-export { useAddFromLibraryTypes } from './add_from_library/registry';
+export { getAddFromLibraryType, useAddFromLibraryTypes } from './add_from_library/registry';
 export { PanelNotFoundError, PanelIncompatibleError } from './react_embeddable_system';
 export { EmbeddableStateTransfer } from './state_transfer';
 export {

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -16,9 +16,13 @@ import { i18n } from '@kbn/i18n';
 import type { FC } from 'react';
 import React, { useCallback, useMemo } from 'react';
 
-import { useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
+import { getAddFromLibraryType, useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
+import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
+import type { CanAddNewPanel } from '@kbn/presentation-publishing';
+import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
+import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 
 const strings = {
   getNoItemsText: () =>
@@ -33,17 +37,10 @@ const strings = {
 
 export interface Props {
   onClose: () => void;
-  onSelect: (id: string, embeddableType: string, isByValueEnabled?: boolean) => void;
-  availableEmbeddables: string[];
-  isByValueEnabled?: boolean;
+  container: CanAddNewPanel;
 }
 
-export const AddEmbeddableFlyout: FC<Props> = ({
-  onSelect,
-  availableEmbeddables,
-  onClose,
-  isByValueEnabled,
-}) => {
+export const AddEmbeddableFlyout: FC<Props> = ({ container, onClose }) => {
   const modalTitleId = useGeneratedHtmlId();
 
   const libraryTypes = useAddFromLibraryTypes();
@@ -53,11 +50,26 @@ export const AddEmbeddableFlyout: FC<Props> = ({
     return libraryTypes.filter(({ type }) => type !== 'links');
   }, [libraryTypes]);
 
-  const onAddPanel = useCallback(
-    (id: string, savedObjectType: string) => {
-      onSelect(id, savedObjectType, isByValueEnabled);
+  const onChoose: SavedObjectFinderProps['onChoose'] = useCallback(
+    async (
+      id: SavedObjectCommon['id'],
+      type: SavedObjectCommon['type'],
+      name: string,
+      savedObject: SavedObjectCommon
+    ) => {
+      const libraryType = getAddFromLibraryType(type);
+      if (!libraryType) {
+        getCanvasNotifyService().warning(
+          i18n.translate('xpack.canvas.addPanel.typeNotFound', {
+            defaultMessage: 'Unable to load type: {type}',
+            values: { type },
+          })
+        );
+        return;
+      }
+      libraryType.onAdd(container, savedObject);
     },
-    [isByValueEnabled, onSelect]
+    [container]
   );
 
   return (
@@ -75,7 +87,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({
       <EuiFlyoutBody>
         <SavedObjectFinder
           id="canvasEmbeddableFlyout"
-          onChoose={onAddPanel}
+          onChoose={onChoose}
           savedObjectMetaData={canvasOnlyLibraryTypes}
           showFilter={true}
           noItemsMessage={strings.getNoItemsText()}

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -19,7 +19,7 @@ import React, { useCallback, useMemo } from 'react';
 import { getAddFromLibraryType, useAddFromLibraryTypes } from '@kbn/embeddable-plugin/public';
 import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/public';
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
-import type { CanAddNewPanel } from '@kbn/presentation-publishing';
+import type { CanAddNewPanel } from '@kbn/presentation-containers';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
 import { getCanvasNotifyService } from '../../services/canvas_notify_service';

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.tsx
@@ -5,38 +5,13 @@
  * 2.0.
  */
 
-import React, { useMemo, useEffect, useCallback } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { useSelector, useDispatch } from 'react-redux';
 import type { Props as ComponentProps } from './flyout.component';
 import { AddEmbeddableFlyout as Component } from './flyout.component';
-// @ts-expect-error untyped local
-import { addElement } from '../../state/actions/elements';
-import { getSelectedPage } from '../../state/selectors/workpad';
-import { EmbeddableTypes } from '../../../canvas_plugin_src/expression_types/embeddable';
-import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
-import type { State } from '../../../types';
-import { presentationUtilService } from '../../services/kibana_services';
+import { useCanvasApi } from '../hooks/use_canvas_api';
 
-const allowedEmbeddables = {
-  [EmbeddableTypes.map]: (id: string) => {
-    return `savedMap id="${id}" | render`;
-  },
-  [EmbeddableTypes.lens]: (id: string) => {
-    return `savedLens id="${id}" | render`;
-  },
-  [EmbeddableTypes.visualization]: (id: string) => {
-    return `savedVisualization id="${id}" | render`;
-  },
-  /*
-  [EmbeddableTypes.search]: (id: string) => {
-    return `filters | savedSearch id="${id}" | render`;
-  },*/
-};
-
-type AddEmbeddable = (pageId: string, partialElement: { expression: string }) => void;
-
-type FlyoutProps = Pick<ComponentProps, 'onClose'> & Partial<Omit<ComponentProps, 'onClose'>>;
+type FlyoutProps = Pick<ComponentProps, 'onClose'>;
 
 export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (props) => {
   const el: HTMLElement = useMemo(() => document.createElement('div'), []);
@@ -58,60 +33,11 @@ export const EmbeddableFlyoutPortal: React.FunctionComponent<ComponentProps> = (
     return null;
   }
 
-  return createPortal(
-    <Component {...props} availableEmbeddables={Object.keys(allowedEmbeddables)} />,
-    el
-  );
+  return createPortal(<Component {...props} />, el);
 };
 
-export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({
-  availableEmbeddables,
-  ...restProps
-}) => {
-  const isByValueEnabled = presentationUtilService.labsService.isProjectEnabled(
-    'labs:canvas:byValueEmbeddable'
-  );
+export const AddEmbeddablePanel: React.FunctionComponent<FlyoutProps> = ({ onClose }) => {
+  const canvasApi = useCanvasApi();
 
-  const dispatch = useDispatch();
-  const pageId = useSelector<State, string>((state) => getSelectedPage(state));
-
-  const addEmbeddable: AddEmbeddable = useCallback(
-    (selectedPageId, partialElement) => dispatch(addElement(selectedPageId, partialElement)),
-    [dispatch]
-  );
-
-  const onSelect = useCallback(
-    (id: string, type: string): void => {
-      const partialElement = {
-        expression: `markdown "Could not find embeddable for type ${type}" | render`,
-      };
-
-      // If by-value is enabled, we'll handle both by-reference and by-value embeddables
-      // with the new generic `embeddable` function.
-      // Otherwise we fallback to the embeddable type specific expressions.
-      if (isByValueEnabled) {
-        partialElement.expression = embeddableInputToExpression(
-          { savedObjectId: id },
-          type,
-          undefined,
-          true
-        );
-      } else if (allowedEmbeddables[type]) {
-        partialElement.expression = allowedEmbeddables[type](id);
-      }
-
-      addEmbeddable(pageId, partialElement);
-      restProps.onClose();
-    },
-    [addEmbeddable, pageId, restProps, isByValueEnabled]
-  );
-
-  return (
-    <EmbeddableFlyoutPortal
-      {...restProps}
-      availableEmbeddables={availableEmbeddables || []}
-      onSelect={onSelect}
-      isByValueEnabled={isByValueEnabled}
-    />
-  );
+  return <EmbeddableFlyoutPortal onClose={onClose} container={canvasApi} />;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[canvas] fix add from library adding incorrect embeddable state (#257261)](https://github.com/elastic/kibana/pull/257261)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2026-03-11T22:24:11Z","message":"[canvas] fix add from library adding incorrect embeddable state (#257261)\n\nCloses https://github.com/elastic/kibana/issues/257260\n\nPR updates canvas to use registered `onAdd` to create embeddable state\ninstead of hardcoding embeddable state to `{ savedObjectId }`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0ed094bdf4f6ad2812b56472bb78c79d413ec810","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Embedding","release_note:fix","Team:Presentation","Feature:Drilldowns","backport:version","Project:Dashboards API","v9.4.0","v9.3.3","v9.2.8"],"title":"[canvas] fix add from library adding incorrect embeddable state","number":257261,"url":"https://github.com/elastic/kibana/pull/257261","mergeCommit":{"message":"[canvas] fix add from library adding incorrect embeddable state (#257261)\n\nCloses https://github.com/elastic/kibana/issues/257260\n\nPR updates canvas to use registered `onAdd` to create embeddable state\ninstead of hardcoding embeddable state to `{ savedObjectId }`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0ed094bdf4f6ad2812b56472bb78c79d413ec810"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257261","number":257261,"mergeCommit":{"message":"[canvas] fix add from library adding incorrect embeddable state (#257261)\n\nCloses https://github.com/elastic/kibana/issues/257260\n\nPR updates canvas to use registered `onAdd` to create embeddable state\ninstead of hardcoding embeddable state to `{ savedObjectId }`.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0ed094bdf4f6ad2812b56472bb78c79d413ec810"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->