### PR TITLE
[ES|QL] Take remote indices under consideration when there is no local data

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
@@ -9,7 +9,11 @@
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { HttpStart } from '@kbn/core/public';
 import { ESQL_TYPE } from '@kbn/data-view-utils';
-import { TIMEFIELD_ROUTE } from '@kbn/esql-types';
+import {
+  type ESQLSourceResult,
+  SOURCES_AUTOCOMPLETE_ROUTE,
+  TIMEFIELD_ROUTE,
+} from '@kbn/esql-types';
 import { getIndexPatternFromESQLQuery } from './get_index_pattern_from_query';
 
 // uses browser sha256 method with fallback if unavailable
@@ -102,29 +106,31 @@ export async function getESQLAdHocDataview({
 }
 
 /**
- * This can be used to get an initial index for a default ES|QL query.
+ * Gets an initial index for a default ES|QL query by querying both local and remote (CCS) indices.
  * Could be used during onboarding when data views to get a better index are not yet available.
  * Can be used in combination with {@link getESQLAdHocDataview} to create a dataview for the index.
+ *
+ * Prefers a local `logs*` pattern if any local index starts with "logs",
+ * otherwise returns the first available non-hidden index (local or remote).
  */
-export async function getIndexForESQLQuery(deps: {
-  dataViews: { getIndices: DataViewsPublicPluginStart['getIndices'] };
-}): Promise<string | null> {
-  const indices = (
-    await deps.dataViews.getIndices({
-      showAllIndices: false,
-      pattern: '*',
-      isRollupIndex: () => false,
-    })
-  )
-    .filter((index) => !index.name.startsWith('.'))
-    .map((index) => index.name);
+export async function getIndexForESQLQuery(deps: { http: HttpStart }): Promise<string | null> {
+  const fetchIndices = async (scope: 'local' | 'all' | 'remote') => {
+    const response = await deps.http.get(`${SOURCES_AUTOCOMPLETE_ROUTE}${scope}`).catch(() => []);
+    return (response as ESQLSourceResult[]).filter((source) => !source.hidden);
+  };
 
-  let indexName = indices[0];
-  if (indices.length > 0) {
-    if (indices.find((index) => index.startsWith('logs'))) {
-      indexName = 'logs*';
-    }
+  let indices = await fetchIndices('local');
+  // only if no local indices are found, try to fetch remote indices
+  if (indices.length === 0) {
+    indices = await fetchIndices('remote');
   }
 
-  return indexName ?? null;
+  if (indices.length === 0) return null;
+
+  const hasLocalLogs = indices.some(
+    (source) => !source.name.includes(':') && source.name.startsWith('logs')
+  );
+  if (hasLocalLogs) return 'logs*';
+
+  return indices[0].name;
 }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/no_data/dashboard_app_no_data.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/no_data/dashboard_app_no_data.tsx
@@ -68,10 +68,9 @@ export const DashboardAppNoDataPage = ({
     abortController?.abort(AbortReason.REPLACED);
     if (lensHelpersAsync.value) {
       const abc = new AbortController();
-      const { dataViews } = dataService;
-      const indexName = (await getIndexForESQLQuery({ dataViews })) ?? '*';
+      const indexName = (await getIndexForESQLQuery({ http: coreServices.http })) ?? '*';
       const dataView = await getESQLAdHocDataview({
-        dataViewsService: dataViews,
+        dataViewsService: dataService.dataViews,
         query: `FROM ${indexName}`,
         http: coreServices.http,
       });

--- a/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
+++ b/src/platform/plugins/shared/discover/common/esql_locator_get_location.ts
@@ -23,7 +23,7 @@ export const esqlLocatorGetLocation = async ({
   dataViews: DataViewsPublicPluginStart;
   http: HttpStart;
 }): ReturnType<DiscoverESQLLocatorGetLocation> => {
-  const indexName = (await getIndexForESQLQuery({ dataViews })) ?? '*';
+  const indexName = (await getIndexForESQLQuery({ http })) ?? '*';
   const dataView = await getESQLAdHocDataview({
     dataViewsService: dataViews,
     query: `FROM ${indexName}`,

--- a/src/platform/plugins/shared/esql/server/routes/get_all_sources.ts
+++ b/src/platform/plugins/shared/esql/server/routes/get_all_sources.ts
@@ -18,9 +18,12 @@ export const registerGetSourcesRoute = (router: IRouter, { logger }: PluginIniti
       path: `${SOURCES_AUTOCOMPLETE_ROUTE}{scope}`,
       validate: {
         params: schema.object({
-          scope: schema.oneOf([schema.literal('all'), schema.literal('local')], {
-            defaultValue: 'local', // Default to 'local' if no scope is provided
-          }),
+          scope: schema.oneOf(
+            [schema.literal('all'), schema.literal('local'), schema.literal('remote')],
+            {
+              defaultValue: 'local', // Default to 'local' if no scope is provided
+            }
+          ),
         }),
       },
       security: {

--- a/src/platform/plugins/shared/esql/server/services/esql_service.ts
+++ b/src/platform/plugins/shared/esql/server/services/esql_service.ts
@@ -83,11 +83,17 @@ export class EsqlService {
    * @param scope The scope to retrieve indices for (local or all).
    * @returns A promise that resolves to an array of ESQL source results.
    */
-  public async getAllIndices(scope: 'local' | 'all' = 'local'): Promise<ESQLSourceResult[]> {
+  public async getAllIndices(
+    scope: 'local' | 'all' | 'remote' = 'local'
+  ): Promise<ESQLSourceResult[]> {
     const { client } = this.options;
 
-    // All means local + remote indices (queried with <cluster>:*)
-    const namesToQuery = scope === 'local' ? ['*'] : ['*', '*:*'];
+    const scopeToNames: Record<typeof scope, string[]> = {
+      local: ['*'],
+      remote: ['*:*'],
+      all: ['*', '*:*'],
+    };
+    const namesToQuery = scopeToNames[scope];
 
     // hidden and not, important for finding timeseries mode
     // mode is not returned for time_series datastreams, we need to find it from the indices

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/esql.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/esql.ts
@@ -33,7 +33,7 @@ export async function loadESQLAttributes({
   if (!isESQLModeEnabled({ uiSettings })) {
     return;
   }
-  const indexName = await getIndexForESQLQuery({ dataViews });
+  const indexName = await getIndexForESQLQuery({ http: coreStart.http });
   // Early exit if there's no data view to use
   if (!indexName) {
     return;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/256264

When there is no data locally but exist in remote indices we want to suggest an ES|QL query from an available remote index.

I changed the implementation to not rely on dataview but use the route we are using for autocomplete too.


