### PR TITLE
[APM] Fix page crash when reading `span_count` on `undefined`

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/transaction_flyout/dropped_spans_warning.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/transaction_flyout/dropped_spans_warning.tsx
@@ -13,7 +13,7 @@ import { useApmPluginContext } from '../../../../../../../context/apm_plugin/use
 
 export function DroppedSpansWarning({ transactionDoc }: { transactionDoc: Transaction }) {
   const { docLinks } = useApmPluginContext().core;
-  const dropped = transactionDoc.transaction.span_count?.dropped;
+  const dropped = transactionDoc.transaction?.span_count?.dropped;
   if (!dropped) {
     return null;
   }


### PR DESCRIPTION
## Summary

Closes #256626

Adds optional chaining to `transaction?.span_count` to prevent the code from crashing when `transaction` is undefined


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->