### PR TITLE
[APM] Ensure partial composite objects aren't built in waterfall spans

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_docs_per_page.ts
@@ -163,12 +163,18 @@ export async function getTraceDocsPerPage({
           .requireFields(requiredSpanFields)
           .unflatten();
 
+        const hasCompleteSpanComposite =
+          !!span.composite &&
+          !!span.composite.sum?.us &&
+          !!span.composite.count &&
+          !!span.composite.compression_strategy;
+
         const spanWaterfallEvent: WaterfallSpan = {
           ...spanEvent,
           processor: processor as { event: 'span' },
           span: {
             ...span,
-            composite: span.composite
+            composite: hasCompleteSpanComposite
               ? (span.composite as Required<WaterfallSpan['span']>['composite'])
               : undefined,
             links: spanLinks,


### PR DESCRIPTION
## Summary

Closes #256636

This PR fixes an issue where incomplete data can cause the waterfall view to crash.

The server side code that fetches span documents for waterfall views requests all `span.composite` fields (count, sum and compression strategy) as optional parameters. Because of the way *unflattening* fields from an ES response works this process can potentially build partial objects. For instance, if only `span.composite.count` is present in the ES document the unflattened object will have the following shape

```typescript
{ "composite": { "count": 5 } }
```

While that is correct and expected behaviour, the problem is that the `WaterfallSpan` interface that gets sent to Kibana doesn't expect partial objects. There's even an explicit type cast `Required<WaterfallSpan['span']>['composite']` that forces the type to require all fields. So, while the `composite` fields itself is optional, if present all properties should exist and be defined.

So, this PR introduces a fix meant to ensure that `span.composite` is only defined if all required fields were returned by ES. If any of them is missing, `composite` will be set to `undefined` and UI components that expect a complete composite object will avoid rendering. This will prevent further issues related to this field being incomplete when it isn't typed as such

## Release note

Fixes an issue where waterfall views could crash the APM plugin when ES documents miss some optional fields

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->