### PR TITLE
[8.19] [Search] fix a11y in query rules edit metafield flyout (#252240)

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_flyout.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 
 import {
   EuiButton,
@@ -81,7 +82,6 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
     setCriteriaCalloutActive,
     shouldShowCriteriaCallout,
     shouldShowMetadataEditor,
-    update,
   } = useQueryRuleFlyoutState({
     createMode,
     rulesetId,
@@ -203,7 +203,10 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
               {isIdRule && (
                 <>
                   <EuiCallOut
-                    title="Document action using 'ids' are unsupported"
+                    title={i18n.translate(
+                      'xpack.search.queryRuleset.queryRuleFlyout.documentActionUsingidsLabel',
+                      { defaultMessage: "Document action using 'ids' are unsupported" }
+                    )}
                     color="warning"
                     size="s"
                   >
@@ -317,16 +320,24 @@ export const QueryRuleFlyout: React.FC<QueryRuleFlyoutProps> = ({
                       const error = formState.errors?.criteria?.[index];
                       return (
                         <React.Fragment key={field.id}>
-                          <QueryRuleMetadataEditor
-                            criteria={field}
-                            key={field.id}
-                            onChange={(newCriteria) => {
-                              update(index, newCriteria);
+                          <Controller
+                            control={control}
+                            name={`criteria.${index}`}
+                            render={({ field: { onChange, value } }) => {
+                              return (
+                                <QueryRuleMetadataEditor
+                                  criteria={value}
+                                  key={field.id}
+                                  onRemove={() => {
+                                    remove(index);
+                                  }}
+                                  error={isQueryRuleFieldError(error) ? error : undefined}
+                                  onChange={(newCriteria) => {
+                                    onChange(newCriteria);
+                                  }}
+                                />
+                              );
                             }}
-                            onRemove={() => {
-                              remove(index);
-                            }}
-                            error={isQueryRuleFieldError(error) ? error : undefined}
                           />
                           <EuiSpacer size="m" />
                         </React.Fragment>

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { QueryRulesQueryRuleCriteria } from '@elastic/elasticsearch/lib/api/types';
 import {
@@ -42,6 +42,9 @@ export const QueryRuleMetadataEditor: React.FC<QueryRuleMetadataEditorProps> = (
   error,
 }) => {
   const [metadataField, setMetadataField] = useState<string>(criteria.metadata || '');
+  useEffect(() => {
+    setMetadataField(criteria?.metadata ?? '');
+  }, [criteria]);
 
   return (
     <EuiPanel data-test-subj="searchQueryRulesQueryRuleMetadataEditor" hasBorder>
@@ -116,6 +119,12 @@ export const QueryRuleMetadataEditor: React.FC<QueryRuleMetadataEditorProps> = (
                     'xpack.search.queryRulesetDetail.queryRuleFlyout.metadataEditorOperatorLabel',
                     {
                       defaultMessage: 'Match type',
+                    }
+                  )}
+                  aria-label={i18n.translate(
+                    'xpack.search.queryRulesetDetail.queryRuleFlyout.metadataEditorOperatorLabel',
+                    {
+                      defaultMessage: 'Select matching type',
                     }
                   )}
                 >

--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/use_query_rule_flyout_state.ts
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/use_query_rule_flyout_state.ts
@@ -48,7 +48,6 @@ export const useQueryRuleFlyoutState = ({
     fields: criteria,
     remove,
     replace,
-    update,
     append,
   } = useFieldArray({
     control,
@@ -78,6 +77,10 @@ export const useQueryRuleFlyoutState = ({
     name: 'actions.ids',
   });
 
+  const criteriaFields = useWatch({
+    control,
+    name: 'criteria',
+  });
   useEffect(() => {
     trigger('actions.ids');
   }, [actionIdsFields, trigger]);
@@ -86,7 +89,7 @@ export const useQueryRuleFlyoutState = ({
   }, [actionFields, trigger]);
   useEffect(() => {
     trigger('criteria');
-  }, [criteria, trigger]);
+  }, [trigger, criteriaFields, criteria]);
 
   const { data: indexNames } = useFetchIndexNames('');
 
@@ -183,7 +186,7 @@ export const useQueryRuleFlyoutState = ({
         rule_id: ruleId,
         criteria: isAlways
           ? [{ type: 'always' } as QueryRuleEditorForm['criteria'][0]]
-          : criteria.map((c) => {
+          : criteriaFields.map((c) => {
               const normalizedCriteria = {
                 values: c.values,
                 metadata: c.metadata,
@@ -200,7 +203,7 @@ export const useQueryRuleFlyoutState = ({
         rule_id: ruleId,
         criteria: isAlways
           ? [{ type: 'always' }]
-          : criteria.map((c) => {
+          : criteriaFields.map((c) => {
               const normalizedCriteria = {
                 values: c.values,
                 metadata: c.metadata,
@@ -291,7 +294,7 @@ export const useQueryRuleFlyoutState = ({
 
   const documentCount = actionFields.length || actionIdsFields?.length || 0;
   const shouldShowMetadataEditor = (createMode || !!ruleFromRuleset) && !isAlways;
-  const criteriaCount = criteria.length;
+  const criteriaCount = criteriaFields.length;
 
   return {
     actionFields,
@@ -319,6 +322,6 @@ export const useQueryRuleFlyoutState = ({
     setCriteriaCalloutActive,
     shouldShowCriteriaCallout,
     shouldShowMetadataEditor,
-    update,
+    criteriaFields,
   };
 };

--- a/x-pack/solutions/search/plugins/search_query_rules/public/providers/query_ruleset_details_form.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/providers/query_ruleset_details_form.tsx
@@ -24,7 +24,7 @@ export const QueryRulesetDetailsForm: React.FC<
       mode: 'create',
       rulesetId: '',
       ruleId: '',
-      criteria: [],
+      criteria: [{ type: 'exact', metadata: '', values: [] }],
       type: 'pinned',
       actions: { docs: [], ids: [] },
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search] fix a11y in query rules edit metafield flyout (#252240)](https://github.com/elastic/kibana/pull/252240)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-02-10T16:39:03Z","message":"[Search] fix a11y in query rules edit metafield flyout (#252240)\n\n## Summary\n\nFixes a11y issue in Query rules edit & add rules flyout. \n\nPreviously the form values were using [update from\nuseFieldArray](https://react-hook-form.com/docs/usefieldarray). The\n`update` unmounts & remounted the component after the update, thus the\nwindow was losing its focus. Changed to use\n[Controller](https://react-hook-form.com/docs/usecontroller/controller),\nthis way the focus is maintained by the controller.\n\n\n\nhttps://github.com/user-attachments/assets/96c30af0-94fd-4882-b6ab-d7f8f7530f73\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"172340aa2be7232687fb73da72d590382d3c912c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:version","v9.1.0","v9.2.0","v9.3.0","v9.4.0","v9.2.6"],"title":"[Search] fix a11y in query rules edit metafield flyout","number":252240,"url":"https://github.com/elastic/kibana/pull/252240","mergeCommit":{"message":"[Search] fix a11y in query rules edit metafield flyout (#252240)\n\n## Summary\n\nFixes a11y issue in Query rules edit & add rules flyout. \n\nPreviously the form values were using [update from\nuseFieldArray](https://react-hook-form.com/docs/usefieldarray). The\n`update` unmounts & remounted the component after the update, thus the\nwindow was losing its focus. Changed to use\n[Controller](https://react-hook-form.com/docs/usecontroller/controller),\nthis way the focus is maintained by the controller.\n\n\n\nhttps://github.com/user-attachments/assets/96c30af0-94fd-4882-b6ab-d7f8f7530f73\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"172340aa2be7232687fb73da72d590382d3c912c"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252580","number":252580,"state":"MERGED","mergeCommit":{"sha":"634ee189d3c2ce732887e87d62c4c26a8087685e","message":"[9.2] [Search] fix a11y in query rules edit metafield flyout (#252240) (#252580)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[Search] fix a11y in query rules edit metafield flyout\n(#252240)](https://github.com/elastic/kibana/pull/252240)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Saarika Bhasi <55930906+saarikabhasi@users.noreply.github.com>"}},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/252581","number":252581,"state":"MERGED","mergeCommit":{"sha":"8198fbdf27e360e5902be74ff32c205a56528966","message":"[9.3] [Search] fix a11y in query rules edit metafield flyout (#252240) (#252581)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Search] fix a11y in query rules edit metafield flyout\n(#252240)](https://github.com/elastic/kibana/pull/252240)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Saarika Bhasi <55930906+saarikabhasi@users.noreply.github.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252240","number":252240,"mergeCommit":{"message":"[Search] fix a11y in query rules edit metafield flyout (#252240)\n\n## Summary\n\nFixes a11y issue in Query rules edit & add rules flyout. \n\nPreviously the form values were using [update from\nuseFieldArray](https://react-hook-form.com/docs/usefieldarray). The\n`update` unmounts & remounted the component after the update, thus the\nwindow was losing its focus. Changed to use\n[Controller](https://react-hook-form.com/docs/usecontroller/controller),\nthis way the focus is maintained by the controller.\n\n\n\nhttps://github.com/user-attachments/assets/96c30af0-94fd-4882-b6ab-d7f8f7530f73\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"172340aa2be7232687fb73da72d590382d3c912c"}}]}] BACKPORT-->