### PR TITLE
Avoid globalRegistry metadata registration by default in fromJSONSchema

### DIFF
--- a/src/platform/packages/shared/kbn-zod/v4/from_json_schema/index.test.ts
+++ b/src/platform/packages/shared/kbn-zod/v4/from_json_schema/index.test.ts
@@ -845,6 +845,30 @@ describe('JSON Schema to Zod parser - Unit tests', () => {
   });
 
   describe('Meta information extraction', () => {
+    beforeEach(() => {
+      z.globalRegistry.clear();
+    });
+
+    it('does not preserve meta by default', () => {
+      const jsonSchema = {
+        type: 'object',
+        properties: {
+          browseUrl: {
+            type: 'string',
+            label: 'Browse URL',
+          },
+        },
+      };
+
+      const zodSchema = fromJSONSchema(jsonSchema);
+      expect(zodSchema).toBeDefined();
+
+      const schemaWithShape = zodSchema as unknown as { shape?: Record<string, ZodType> };
+      const browseUrl = schemaWithShape.shape!.browseUrl;
+      expect(z.globalRegistry.has(browseUrl)).toBe(false);
+      expect(getMeta(browseUrl)).toEqual({});
+    });
+
     it('preserves meta on single-option discriminated union and its fields', () => {
       const jsonSchema = {
         anyOf: [
@@ -867,7 +891,7 @@ describe('JSON Schema to Zod parser - Unit tests', () => {
         label: 'Authentication',
       };
 
-      const zodSchema = fromJSONSchema(jsonSchema);
+      const zodSchema = fromJSONSchema(jsonSchema, { preserveMeta: true });
       expect(zodSchema).toBeDefined();
       expect(zodSchema).toBeInstanceOf(z.ZodDiscriminatedUnion);
 
@@ -900,7 +924,7 @@ describe('JSON Schema to Zod parser - Unit tests', () => {
 
       const jsonSchema = z.toJSONSchema(originalSchema);
 
-      const restoredSchema = fromJSONSchema(jsonSchema);
+      const restoredSchema = fromJSONSchema(jsonSchema, { preserveMeta: true });
       expect(restoredSchema).toBeDefined();
 
       const schemaWithShape = restoredSchema as unknown as { shape?: Record<string, ZodType> };
@@ -929,7 +953,7 @@ describe('JSON Schema to Zod parser - Unit tests', () => {
         },
       };
 
-      const zodSchema = fromJSONSchema(jsonSchema);
+      const zodSchema = fromJSONSchema(jsonSchema, { preserveMeta: true });
       expect(zodSchema).toBeDefined();
 
       const schemaWithShape = zodSchema as unknown as { shape?: Record<string, ZodType> };

--- a/src/platform/packages/shared/kbn-zod/v4/from_json_schema/index.ts
+++ b/src/platform/packages/shared/kbn-zod/v4/from_json_schema/index.ts
@@ -27,31 +27,52 @@ import { parseUnion } from './parse_union';
 export type { JsonSchema } from './types';
 export { extractMeta as extractUiMeta } from './meta_utils';
 
+export interface FromJSONSchemaOptions {
+  /**
+   * Restore non-standard JSON Schema keys as Zod UI metadata.
+   *
+   * This writes to `z.globalRegistry`, so callers should opt in only when they
+   * actually need metadata-driven UI behavior.
+   */
+  preserveMeta?: boolean;
+}
+
 /**
  * Converts a JSON Schema object to a native Zod v4 schema at runtime.
  *
  * This is a temporary polyfill for Zod v4's native fromJSONSchema function.
  */
-export function fromJSONSchema(jsonSchema: Record<string, unknown>): z.ZodType | undefined {
+export function fromJSONSchema(
+  jsonSchema: Record<string, unknown>,
+  options: FromJSONSchemaOptions = {}
+): z.ZodType | undefined {
+  const { preserveMeta = false } = options;
+
   try {
+    const parseJsonSchema = (schema: JsonSchema): z.ZodType => {
+      const zodSchema = parseSchemaByType(schema, parseJsonSchema, preserveMeta);
+
+      if (preserveMeta) {
+        const meta = extractMeta(schema);
+        if (Object.keys(meta).length > 0) {
+          z.globalRegistry.add(zodSchema, meta as Record<string, unknown>);
+        }
+      }
+
+      return zodSchema;
+    };
+
     return parseJsonSchema(jsonSchema as JsonSchema);
   } catch {
     return undefined;
   }
 }
 
-function parseJsonSchema(schema: JsonSchema): z.ZodType {
-  const zodSchema = parseSchemaByType(schema);
-
-  const meta = extractMeta(schema);
-  if (Object.keys(meta).length > 0) {
-    z.globalRegistry.add(zodSchema, meta as Record<string, unknown>);
-  }
-
-  return zodSchema;
-}
-
-function parseSchemaByType(schema: JsonSchema): z.ZodType {
+function parseSchemaByType(
+  schema: JsonSchema,
+  parseJsonSchema: (schema: JsonSchema) => z.ZodType,
+  preserveMeta: boolean
+): z.ZodType {
   let zodSchema: z.ZodType;
 
   if (schema.anyOf || schema.oneOf) {
@@ -73,7 +94,7 @@ function parseSchemaByType(schema: JsonSchema): z.ZodType {
         zodSchema = parseBoolean();
         break;
       case 'object':
-        zodSchema = parseObject(schema, parseJsonSchema);
+        zodSchema = parseObject(schema, parseJsonSchema, preserveMeta);
         break;
       case 'array':
         zodSchema = parseArray(schema, parseJsonSchema);

--- a/src/platform/packages/shared/kbn-zod/v4/from_json_schema/parse_object.ts
+++ b/src/platform/packages/shared/kbn-zod/v4/from_json_schema/parse_object.ts
@@ -15,7 +15,8 @@ type JsonSchemaParser = (schema: JsonSchema) => z.ZodType;
 
 export function parseObject(
   schema: JsonSchema,
-  parseJsonSchema: JsonSchemaParser
+  parseJsonSchema: JsonSchemaParser,
+  preserveMeta: boolean
 ): z.ZodObject<z.ZodRawShape> {
   const shape: Record<string, z.ZodType> = {};
   const requiredFields = new Set(schema.required || []);
@@ -33,7 +34,7 @@ export function parseObject(
       fieldSchema = fieldSchema.default(propSchema.default);
     }
 
-    if (Object.keys(fieldMeta).length > 0) {
+    if (preserveMeta && Object.keys(fieldMeta).length > 0) {
       z.globalRegistry.add(fieldSchema, fieldMeta as Record<string, unknown>);
     }
 


### PR DESCRIPTION
## Summary

Avoid registering metadata in `z.globalRegistry` during `fromJSONSchema()` conversion unless a caller explicitly opts in. This prevents unbounded memory growth in repeated runtime schema conversion paths like MCP tool schema loading while preserving metadata support for UI-driven callers.

Credit for bug discovery @jbudz 

## Need review from

  • src/platform/packages/shared/kbn-zod @elastic/kibana-core
  • src/platform/plugins/shared/workflows_extensions @elastic/workflows-eng
  • src/platform/plugins/shared/workflows_management @elastic/workflows-eng
  • x-pack/platform/plugins/shared/agent_builder @elastic/workchat-eng
  • x-pack/platform/plugins/shared/inference @elastic/search-kibana
  • x-pack/platform/plugins/shared/observability_ai_assistant @elastic/obs-ai-team

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release note

`release_note:skip`

### Identify risks

- [x] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- Low risk: metadata is no longer restored by default when converting JSON Schema to Zod. Callers that need metadata-driven UI behavior must opt in with `preserveMeta: true`.

Made with [Cursor](https://cursor.com)