### PR TITLE
[Alerting v2] [Rule authoring] Block comma key in number input component

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/number_input.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/number_input.test.tsx
@@ -132,7 +132,7 @@ describe('NumberInput', () => {
   });
 
   describe('key filtering', () => {
-    it.each(['-', '+', '.', 'e', 'E'])('prevents typing "%s"', (key) => {
+    it.each(['-', '+', ',', '.', 'e', 'E'])('prevents typing "%s"', (key) => {
       renderInput({ value: 5 });
       const input = screen.getByTestId('testNumberInput');
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils.test.ts
@@ -220,7 +220,7 @@ describe('utils', () => {
 
   describe('numeric input helpers', () => {
     it('exposes invalid number keys for EuiFieldNumber guards', () => {
-      expect(INVALID_NUMBER_KEYS).toEqual(['-', '+', '.', 'e', 'E']);
+      expect(INVALID_NUMBER_KEYS).toEqual(['-', '+', ',', '.', 'e', 'E']);
     });
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/utils.ts
@@ -10,7 +10,7 @@ import type { DataViewFieldMap } from '@kbn/data-views-plugin/common';
 
 type TimeUnit = 's' | 'm' | 'h' | 'd';
 export const POSITIVE_INTEGER_REGEX = /^[1-9][0-9]*$/;
-export const INVALID_NUMBER_KEYS = ['-', '+', '.', 'e', 'E'];
+export const INVALID_NUMBER_KEYS = ['-', '+', ',', '.', 'e', 'E'];
 
 const TIME_UNITS: Record<TimeUnit, string> = {
   s: i18n.translate('xpack.alertingV2.ruleForm.timeUnits.seconds', {


### PR DESCRIPTION
## Summary

- Add `,` (comma) to the list of blocked keys in number input field component, preventing users from typing commas in duration and count inputs where only positive integers are valid.

## Test plan

- [ ] Open a rule form with number inputs (schedule, lookback window, state transition count/timeframe)
- [ ] Verify pressing `,` does nothing in any number field
- [ ] Verify other valid keys (digits, backspace, arrow keys) still work normally