### PR TITLE
[Infra] Support OTel host metrics in Observability Overview hosts table

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/http_api/overview_api.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/http_api/overview_api.ts
@@ -44,7 +44,7 @@ export const TopNodesRequestRT = rt.intersection([
       to: rt.number,
     }),
   }),
-  rt.partial({ sort: rt.string, sortDirection: rt.string }),
+  rt.partial({ sort: rt.string, sortDirection: rt.string, schema: rt.string }),
 ]);
 
 export type TopNodesRequest = rt.TypeOf<typeof TopNodesRequestRT>;

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/index.ts
@@ -8,6 +8,8 @@ import { createRouteValidationFunction } from '@kbn/io-ts-utils';
 import { TopNodesRequestRT } from '../../../common/http_api/overview_api';
 import type { InfraBackendLibs } from '../../lib/infra_types';
 import { createSearchClient } from '../../lib/create_search_client';
+import { getInfraMetricsClient } from '../../lib/helpers/get_infra_metrics_client';
+import { getPreferredSchema } from '../../lib/helpers/get_preferred_schema';
 import { queryTopNodes } from './lib/get_top_nodes';
 
 export const initOverviewRoute = (libs: InfraBackendLibs) => {
@@ -27,7 +29,24 @@ export const initOverviewRoute = (libs: InfraBackendLibs) => {
       const soClient = (await requestContext.core).savedObjects.client;
       const source = await libs.sources.getSourceConfiguration(soClient, options.sourceId);
 
-      const topNResponse = await queryTopNodes(options, client, source);
+      const infraMetricsClient = await getInfraMetricsClient({
+        libs,
+        context: requestContext,
+        request,
+      });
+      const { preferredSchema } = await getPreferredSchema({
+        infraMetricsClient,
+        dataSource: 'host',
+        from: options.timerange.from,
+        to: options.timerange.to,
+      });
+
+      const schema =
+        (options.schema === 'ecs' || options.schema === 'semconv'
+          ? options.schema
+          : undefined) ?? preferredSchema;
+
+      const topNResponse = await queryTopNodes(options, client, source, schema);
 
       return response.ok({
         body: topNResponse,

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/convert_es_response_to_top_nodes_response.ts
@@ -25,18 +25,18 @@ export const convertESResponseToTopNodesResponse = (
           return {
             timestamp: bucket.key,
             cpu: bucket.cpu.value,
-            iowait: bucket.iowait.value,
+            iowait: bucket.iowait?.value ?? null,
             load: bucket.load.value,
-            rx: bucket.rx?.bytes.value || null,
-            tx: bucket.tx?.bytes.value || null,
+            rx: bucket.rx?.bytes?.value ?? null,
+            tx: bucket.tx?.bytes?.value ?? null,
           };
         }),
         cpu: node.cpu.value,
-        iowait: node.iowait.value,
+        iowait: node.iowait?.value ?? null,
         load: node.load.value,
-        uptime: node.uptime.value,
-        rx: node.rx?.bytes.value || null,
-        tx: node.tx?.bytes.value || null,
+        uptime: node.uptime?.value ?? null,
+        rx: node.rx?.bytes?.value ?? null,
+        tx: node.tx?.bytes?.value ?? null,
       };
     }),
   };

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/create_top_nodes_query.ts
@@ -5,13 +5,31 @@
  * 2.0.
  */
 
+import type { estypes } from '@elastic/elasticsearch';
+import type { DataSchemaFormat } from '@kbn/metrics-data-access-plugin/common';
+import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
 import type { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
 import type { TopNodesRequest } from '../../../../common/http_api/overview_api';
 import { TIMESTAMP_FIELD } from '../../../../common/constants';
 
 export const createTopNodesQuery = (
   options: TopNodesRequest,
-  source: MetricsSourceConfiguration
+  source: MetricsSourceConfiguration,
+  schema?: DataSchemaFormat | null
+) => {
+  const effectiveSchema = schema ?? 'ecs';
+  const inventoryModel = findInventoryModel('host');
+  const nodeFilters = inventoryModel.nodeFilter?.({ schema: effectiveSchema }) ?? [];
+
+  if (effectiveSchema === 'semconv') {
+    return createSemconvTopNodesQuery(options, nodeFilters);
+  }
+  return createEcsTopNodesQuery(options, nodeFilters);
+};
+
+const createEcsTopNodesQuery = (
+  options: TopNodesRequest,
+  nodeFilters: estypes.QueryDslQueryContainer[]
 ) => {
   const nestedSearchFields: { [key: string]: string } = {
     rx: 'rx>bytes',
@@ -23,6 +41,7 @@ export const createTopNodesQuery = (
     : 'uptime';
   const sortField = sortByHost ? '_key' : metricsSortField;
   const sortDirection = options.sortDirection ?? 'asc';
+
   return {
     runtime_mappings: {
       rx_bytes_per_period: {
@@ -61,9 +80,7 @@ export const createTopNodesQuery = (
               },
             },
           },
-          {
-            match_phrase: { 'event.module': 'system' },
-          },
+          ...nodeFilters,
         ],
       },
     },
@@ -185,6 +202,134 @@ export const createTopNodesQuery = (
                       field: 'tx_bytes_per_period',
                     },
                   },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+const createSemconvTopNodesQuery = (
+  options: TopNodesRequest,
+  nodeFilters: estypes.QueryDslQueryContainer[]
+) => {
+  const sortByHost = options.sort && options.sort === 'name';
+  const metricsSortField = options.sort || 'cpu';
+  const sortField = sortByHost ? '_key' : metricsSortField;
+  const sortDirection = options.sortDirection ?? 'asc';
+
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              [TIMESTAMP_FIELD]: {
+                gte: options.timerange.from,
+                lte: options.timerange.to,
+                format: 'epoch_millis',
+              },
+            },
+          },
+          ...nodeFilters,
+        ],
+      },
+    },
+    aggs: {
+      nodes: {
+        terms: {
+          field: 'host.name',
+          size: options.size,
+          order: { [sortField]: sortDirection },
+        },
+        aggs: {
+          metadata: {
+            top_metrics: {
+              metrics: [
+                { field: 'host.os.platform' },
+                { field: 'host.name' },
+                { field: 'cloud.provider' },
+              ],
+              sort: { [TIMESTAMP_FIELD]: 'desc' },
+              size: 1,
+            },
+          },
+          cpu_idle: {
+            terms: {
+              field: 'state',
+              include: ['idle', 'wait'],
+            },
+            aggs: {
+              avg: {
+                avg: {
+                  field: 'system.cpu.utilization',
+                },
+              },
+            },
+          },
+          cpu_idle_total: {
+            sum_bucket: {
+              buckets_path: 'cpu_idle>avg',
+            },
+          },
+          cpu: {
+            bucket_script: {
+              buckets_path: {
+                cpuIdleTotal: 'cpu_idle_total',
+              },
+              script: '1 - params.cpuIdleTotal',
+              gap_policy: 'skip',
+            },
+          },
+          load: {
+            avg: {
+              field: 'system.cpu.load_average.15m',
+            },
+          },
+          timeseries: {
+            date_histogram: {
+              field: '@timestamp',
+              fixed_interval: options.bucketSize,
+              extended_bounds: {
+                min: options.timerange.from,
+                max: options.timerange.to,
+              },
+            },
+            aggs: {
+              cpu_idle: {
+                terms: {
+                  field: 'state',
+                  include: ['idle', 'wait'],
+                },
+                aggs: {
+                  avg: {
+                    avg: {
+                      field: 'system.cpu.utilization',
+                    },
+                  },
+                },
+              },
+              cpu_idle_total: {
+                sum_bucket: {
+                  buckets_path: 'cpu_idle>avg',
+                },
+              },
+              cpu: {
+                bucket_script: {
+                  buckets_path: {
+                    cpuIdleTotal: 'cpu_idle_total',
+                  },
+                  script: '1 - params.cpuIdleTotal',
+                  gap_policy: 'skip',
+                },
+              },
+              load: {
+                avg: {
+                  field: 'system.cpu.load_average.15m',
                 },
               },
             },

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/get_top_nodes.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { DataSchemaFormat } from '@kbn/metrics-data-access-plugin/common';
 import type { ESSearchClient } from '@kbn/metrics-data-access-plugin/server';
 import type { TopNodesRequest } from '../../../../common/http_api/overview_api';
 import type { MetricsSourceConfiguration } from '../../../../common/metrics_sources';
@@ -14,11 +15,12 @@ import type { ESResponseForTopNodes } from './types';
 export const queryTopNodes = async (
   options: TopNodesRequest,
   client: ESSearchClient,
-  source: MetricsSourceConfiguration
+  source: MetricsSourceConfiguration,
+  schema?: DataSchemaFormat | null
 ) => {
   const params = {
     index: source.configuration.metricAlias,
-    body: createTopNodesQuery(options, source),
+    body: createTopNodesQuery(options, source, schema),
   };
 
   const response = await client<{}, ESResponseForTopNodes>(params);

--- a/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/types.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/overview/lib/types.ts
@@ -22,12 +22,12 @@ interface NodeMetric {
 
 interface NodeMetrics {
   doc_count: number;
-  uptime: NodeMetric;
+  uptime?: NodeMetric;
   cpu: NodeMetric;
-  iowait: NodeMetric;
+  iowait?: NodeMetric;
   load: NodeMetric;
-  rx: RuntimeField;
-  tx: RuntimeField;
+  rx?: RuntimeField;
+  tx?: RuntimeField;
 }
 
 interface TimeSeriesMetric extends NodeMetrics {


### PR DESCRIPTION
## Summary

Fixes the Observability Overview page's Hosts table to display host metrics from OpenTelemetry data (via `hostmetricsreceiver.otel`) in addition to Metricbeat data.

**Problem:** The `POST /api/metrics/overview/top` endpoint hardcodes `event.module: system` as a filter, which excludes OTel data. The query also uses Metricbeat-specific field names.

**Solution:** Use `getPreferredSchema()` (the same detection logic used by the Infra Hosts view) to determine whether data is ECS or semconv, then generate schema-appropriate queries with the correct field names and filters.

Changes:
- Added schema detection to the overview route handler via `getPreferredSchema`
- Modified `createTopNodesQuery` to generate schema-specific queries (ECS vs semconv)
- For semconv: uses `system.cpu.utilization` for CPU, `system.cpu.load_average.15m` for load
- For semconv: uptime, iowait, rx, tx are not available and return null
- Made response types handle optional metrics gracefully

Closes https://github.com/elastic/kibana/issues/257493

## Test plan
- [ ] With Metricbeat data: hosts table shows same data as before (no regression)
- [ ] With OTel hostmetricsreceiver data: hosts table shows CPU and load metrics
- [ ] With both: prefers semconv (OTel) data per existing convention
- [ ] Sparkline charts work for available metrics

Made with [Cursor](https://cursor.com)