### PR TITLE
[Infra] POC: Shared hosts table component for Observability Overview

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/overview_hosts_table/index.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/components/overview_hosts_table/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { OverviewHostsTable } from './overview_hosts_table';

--- a/x-pack/solutions/observability/plugins/infra/public/components/overview_hosts_table/overview_hosts_table.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/overview_hosts_table/overview_hosts_table.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiBasicTable, EuiLink, EuiLoadingChart } from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { FETCH_STATUS, useFetcher } from '@kbn/observability-shared-plugin/public';
+import { createInventoryMetricFormatter } from '../../pages/metrics/inventory_view/lib/create_inventory_metric_formatter';
+import type {
+  GetInfraMetricsResponsePayload,
+  InfraEntityMetricsItem,
+  InfraEntityMetricType,
+} from '../../../common/http_api/infra';
+
+interface OverviewHostsTableProps {
+  dateRange: { from: number; to: number };
+  schema?: 'ecs' | 'semconv';
+}
+
+const METRICS: InfraEntityMetricType[] = ['cpuV2', 'normalizedLoad1m', 'memoryFree'];
+
+const formatMetric = (type: InfraEntityMetricType, value: number | null) => {
+  if (value === null) return 'N/A';
+  return createInventoryMetricFormatter({ type })(value);
+};
+
+export const OverviewHostsTable: React.FC<OverviewHostsTableProps> = ({ dateRange, schema }) => {
+  const { http } = useKibana().services;
+
+  const { data, status } = useFetcher(
+    async ({ signal }) => {
+      const response = await http.post<GetInfraMetricsResponsePayload>('/api/metrics/infra/host', {
+        body: JSON.stringify({
+          limit: 5,
+          metrics: METRICS,
+          from: new Date(dateRange.from).toISOString(),
+          to: new Date(dateRange.to).toISOString(),
+          ...(schema ? { schema } : {}),
+        }),
+        signal,
+      });
+      return response;
+    },
+    [dateRange.from, dateRange.to, schema, http]
+  );
+
+  const columns: Array<EuiBasicTableColumn<InfraEntityMetricsItem>> = useMemo(
+    () => [
+      {
+        field: 'name',
+        name: i18n.translate('xpack.infra.overviewHostsTable.hostname', {
+          defaultMessage: 'Hostname',
+        }),
+        sortable: true,
+        truncateText: true,
+        render: (name: string) => (
+          <EuiLink
+            href={http.basePath.prepend(`/app/metrics/hosts?host=${encodeURIComponent(name)}`)}
+            data-test-subj="overviewHostsTableHostLink"
+          >
+            {name}
+          </EuiLink>
+        ),
+      },
+      {
+        field: 'metrics',
+        name: i18n.translate('xpack.infra.overviewHostsTable.cpu', { defaultMessage: 'CPU %' }),
+        render: (metrics: InfraEntityMetricsItem['metrics']) =>
+          formatMetric('cpuV2', metrics.find((m) => m.name === 'cpuV2')?.value ?? null),
+      },
+      {
+        field: 'metrics',
+        name: i18n.translate('xpack.infra.overviewHostsTable.load', {
+          defaultMessage: 'Normalized Load',
+        }),
+        render: (metrics: InfraEntityMetricsItem['metrics']) =>
+          formatMetric('normalizedLoad1m', metrics.find((m) => m.name === 'normalizedLoad1m')?.value ?? null),
+      },
+      {
+        field: 'metrics',
+        name: i18n.translate('xpack.infra.overviewHostsTable.memory', {
+          defaultMessage: 'Memory Free',
+        }),
+        render: (metrics: InfraEntityMetricsItem['metrics']) =>
+          formatMetric('memoryFree', metrics.find((m) => m.name === 'memoryFree')?.value ?? null),
+      },
+    ],
+    [http]
+  );
+
+  if (status === FETCH_STATUS.LOADING && !data) {
+    return (
+      <div
+        style={{
+          height: 200,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <EuiLoadingChart size="l" />
+      </div>
+    );
+  }
+
+  return (
+    <EuiBasicTable
+      items={data?.nodes ?? []}
+      columns={columns}
+      loading={status === FETCH_STATUS.LOADING}
+      tableCaption={i18n.translate('xpack.infra.overviewHostsTable.caption', {
+        defaultMessage: 'Host metrics overview',
+      })}
+    />
+  );
+};

--- a/x-pack/solutions/observability/plugins/infra/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/plugin.ts
@@ -52,6 +52,7 @@ import type {
   InfraClientStartDeps,
   InfraClientStartExports,
 } from './types';
+import { OverviewHostsTable } from './components/overview_hosts_table';
 import { getLogsHasDataFetcher, getLogsOverviewDataFetcher } from './utils/logs_overview_fetchers';
 import {
   hostsTitle,
@@ -317,6 +318,7 @@ export class Plugin implements InfraClientPluginClass {
       inventoryViews,
       metricsExplorerViews,
       telemetry,
+      OverviewHostsTable,
     };
 
     return startContract;

--- a/x-pack/solutions/observability/plugins/infra/public/types.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ComponentType } from 'react';
 import type { EuiDraggable, EuiDragDropContext } from '@elastic/eui';
 import type { CoreSetup, CoreStart, Plugin as PluginClass } from '@kbn/core/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
@@ -61,10 +62,16 @@ import type { TelemetryServiceStart } from './services/telemetry';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface InfraClientSetupExports {}
 
+export interface OverviewHostsTableProps {
+  dateRange: { from: number; to: number };
+  schema?: 'ecs' | 'semconv';
+}
+
 export interface InfraClientStartExports {
   inventoryViews: InventoryViewsServiceStart;
   metricsExplorerViews?: MetricsExplorerViewsServiceStart;
   telemetry: TelemetryServiceStart;
+  OverviewHostsTable: ComponentType<OverviewHostsTableProps>;
 }
 
 export interface InfraClientSetupDeps {

--- a/x-pack/solutions/observability/plugins/observability/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/observability/kibana.jsonc
@@ -51,6 +51,7 @@
       "discover",
       "exploratoryView",
       "home",
+      "infra",
       "usageCollection",
       "cloud",
       "spaces",

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/metrics/metrics_section.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/metrics/metrics_section.tsx
@@ -21,6 +21,7 @@ import { SectionContainer } from '../section_container';
 import { getDataHandler } from '../../../../../context/has_data_context/data_handler';
 import { useHasData } from '../../../../../hooks/use_has_data';
 import { useDatePickerContext } from '../../../../../hooks/use_date_picker_context';
+import { useKibana } from '../../../../../utils/kibana_react';
 import { HostLink } from './host_link';
 import { formatDuration } from './lib/format_duration';
 import { MetricWithSparkline } from './metric_with_sparkline';
@@ -44,6 +45,9 @@ export function MetricsSection({ bucketSize }: Props) {
   const { forceUpdate, hasDataMap } = useHasData();
   const { relativeStart, relativeEnd, absoluteStart, absoluteEnd, lastUpdated } =
     useDatePickerContext();
+  const { services } = useKibana();
+  const OverviewHostsTable = services.infra?.OverviewHostsTable;
+
   const [sortDirection, setSortDirection] = useState<Direction>('asc');
   const [sortField, setSortField] = useState<keyof MetricsFetchDataSeries>('uptime');
   const [sortedData, setSortedData] = useState<MetricsFetchDataResponse | null>(null);
@@ -87,6 +91,27 @@ export function MetricsSection({ bucketSize }: Props) {
 
   if (!hasDataMap.infra_metrics?.hasData) {
     return null;
+  }
+
+  // POC: Use shared OverviewHostsTable from infra when available (uses /api/metrics/infra/host)
+  if (OverviewHostsTable && absoluteStart && absoluteEnd) {
+    return (
+      <SectionContainer
+        title={i18n.translate('xpack.observability.overview.metrics.title', {
+          defaultMessage: 'Hosts',
+        })}
+        appLink={{
+          href: '/app/metrics/hosts',
+          label: i18n.translate('xpack.observability.overview.metrics.appLink', {
+            defaultMessage: 'Show inventory',
+          }),
+        }}
+      >
+        <OverviewHostsTable
+          dateRange={{ from: absoluteStart, to: absoluteEnd }}
+        />
+      </SectionContainer>
+    );
   }
 
   const isLoading = status === FETCH_STATUS.LOADING;

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ComponentType } from 'react';
 import type { CasesPublicStart, CasesPublicSetup } from '@kbn/cases-plugin/public';
 import { CasesDeepLinkId, getCasesDeepLinks } from '@kbn/cases-plugin/public';
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
@@ -185,6 +186,13 @@ export interface ObservabilityPublicPluginsStart {
   inspector: InspectorPluginStart;
   savedObjectsTagging: SavedObjectTaggingPluginStart;
   agentBuilder?: AgentBuilderPluginStart;
+  /** Optional infra plugin - provides OverviewHostsTable when available */
+  infra?: {
+    OverviewHostsTable: ComponentType<{
+      dateRange: { from: number; to: number };
+      schema?: 'ecs' | 'semconv';
+    }>;
+  };
   observabilityAgentBuilder?: ObservabilityAgentBuilderPluginPublicStart;
 }
 export type ObservabilityPublicStart = ReturnType<Plugin['start']>;


### PR DESCRIPTION
## Summary

Proof-of-concept for replacing the Observability Overview page Hosts table with a shared component that uses the same data source (POST /api/metrics/infra/host) as the Infra Hosts view.

### Why
The current overview hosts section uses a separate API (POST /api/metrics/overview/top) with hardcoded Metricbeat queries. This means:
- OTel data is not supported
- Different metrics and field mappings than the Hosts view
- Two codepaths to maintain

### What this POC does
- Adds an OverviewHostsTable component to the infra plugin that calls the existing Hosts API
- Exports it via the infra plugin public API
- Replaces the current MetricsSection table in the overview page with this component
- Shows hostname, CPU, load, and memory columns
- Supports both Metricbeat and OTel data schemas (via the existing API)

### What's missing (future work)
- Sparkline charts (the current table has them)
- Sorting server-side
- RX/TX columns
- Host detail flyout integration
- Proper KQL/filter passthrough from overview context
- Eventually deprecate /api/metrics/overview/top

## Test plan
- [ ] Overview page shows hosts from /api/metrics/infra/host
- [ ] Works with OTel data
- [ ] Works with Metricbeat data
- [ ] Loading and empty states render correctly

Made with [Cursor](https://cursor.com)