### PR TITLE
[9.2] [Console] Fix incorrect brace autocomplete insertion (#256286)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -12,7 +12,10 @@
  */
 import type { monaco } from '@kbn/monaco';
 
+import type { MonacoEditorActionsProvider } from '../monaco_editor_actions_provider';
+
 const mockPopulateContext = jest.fn();
+const mockEditor = {} as unknown as MonacoEditorActionsProvider;
 
 jest.mock('../../../../lib/autocomplete/engine', () => {
   return {
@@ -27,6 +30,7 @@ import {
   getUrlPathCompletionItems,
   shouldTriggerSuggestions,
   getInsertText,
+  getBodyCompletionItems,
 } from './autocomplete_utils';
 
 describe('autocomplete_utils', () => {
@@ -216,6 +220,116 @@ describe('autocomplete_utils', () => {
       const items = getUrlPathCompletionItems(mockModel, mockPosition);
       expect(items.length).toBe(5);
     });
+
+    it('filters structural suggestions when cursor is inside an unclosed quote (unmatched endpoint)', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'match_all', insertValue: '{' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'POST not_a_real_endpoint',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "query": "';
+          }
+          if (range.startLineNumber === 3 && range.startColumn === 1) {
+            return '  "query": "';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 12, word: '' }),
+        getLineMaxColumn: () => 12,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 3, column: 12 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['match_all']);
+    });
+
+    it('filters structural suggestions when cursor is inside an unclosed quote (matched endpoint)', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'type' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      const mockEndpoint = {
+        bodyAutocompleteRootComponents: [],
+      };
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.endpoint = mockEndpoint;
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT /test',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "mappings": {\n    "properties": {\n      "integer_field": "';
+          }
+          if (range.startLineNumber === 5 && range.startColumn === 1) {
+            return '      "integer_field": "';
+          }
+          return '';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 24, word: '' }),
+        getLineMaxColumn: () => 24,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 5, column: 24 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['type']);
+    });
+
+    it('filters structural suggestions when cursor is before existing content on the line', async () => {
+      const mockAutocompleteSet = [
+        { name: '{' },
+        { name: 'type' },
+      ] as unknown as AutoCompleteContext['autoCompleteSet'];
+
+      const mockEndpoint = {
+        bodyAutocompleteRootComponents: [],
+      };
+
+      mockPopulateContext.mockImplementation((...args) => {
+        const context = args[0][1];
+        context.endpoint = mockEndpoint;
+        context.autoCompleteSet = mockAutocompleteSet;
+      });
+
+      const mockModel = {
+        getLineContent: () => 'PUT /test_index',
+        getValueInRange: jest.fn((range: any) => {
+          if (range.startLineNumber === 2) {
+            return '{\n  "mappings": {\n    "properties": {\n      "integer_field": ';
+          }
+          if (range.startLineNumber === 5 && range.startColumn === 1) {
+            return '      "integer_field": ';
+          }
+          // content after cursor: existing value
+          return '"keyword"';
+        }),
+        getWordUntilPosition: () => ({ startColumn: 23, word: '' }),
+        getLineMaxColumn: () => 32,
+      } as unknown as monaco.editor.ITextModel;
+
+      const mockPosition = { lineNumber: 5, column: 23 } as monaco.Position;
+
+      const items = await getBodyCompletionItems(mockModel, mockPosition, 1, mockEditor);
+
+      expect(items.map((item) => item.label)).toEqual(['type']);
+    });
   });
 
   describe('getInsertText', () => {
@@ -225,20 +339,44 @@ describe('autocomplete_utils', () => {
       expect(getInsertText({ name: undefined } as ResultTerm, '', mockContext)).toBe('');
     });
 
-    it('handles unclosed quotes correctly', () => {
+    it('does not add quotes around braces and brackets', () => {
       expect(
         getInsertText(
-          { name: 'match_all' } as ResultTerm,
+          { name: '{' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('{$0}');
+      expect(
+        getInsertText(
+          { name: '[' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('[$0]');
+      expect(
+        getInsertText(
+          { name: '{' } as ResultTerm,
           '{\n' + '    "query": {\n' + '      "match_a',
           mockContext
         )
-      ).toBe('match_all"');
+      ).toBe('{$0}');
     });
 
     it('wraps insertValue with quotes when appropriate', () => {
       expect(
         getInsertText(
-          { name: 'match_all' } as ResultTerm,
+          { name: 'query', insertValue: 'match_all' } as ResultTerm,
+          '{\n' + '    "query": {\n' + '      ',
+          mockContext
+        )
+      ).toBe('"match_all"');
+    });
+
+    it('uses name when insertValue is a structural token', () => {
+      expect(
+        getInsertText(
+          { name: 'match_all', insertValue: '{' } as ResultTerm,
           '{\n' + '    "query": {\n' + '      ',
           mockContext
         )

--- a/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -288,6 +288,19 @@ export const getBodyCompletionItems = async (
   );
 };
 
+const getStructuralSnippet = (token: string) => {
+  if (token === '{') {
+    return '{$0}';
+  }
+  if (token === '[') {
+    return '[$0]';
+  }
+  return undefined;
+};
+
+const usesStructuralSnippet = ({ name }: Pick<ResultTerm, 'name'>): boolean =>
+  typeof name === 'string' && getStructuralSnippet(name) !== undefined;
+
 const getSuggestions = (
   model: monaco.editor.ITextModel,
   position: monaco.Position,
@@ -313,6 +326,10 @@ const getSuggestions = (
   if (lineContentAfterPosition.startsWith('"')) {
     endColumn = endColumn + 1;
   }
+  const bodyContentLines = bodyContentBeforePosition.split('\n');
+  const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
+  const isInsideQuotedString = hasUnclosedQuote(currentContentLine);
+
   const range = {
     startLineNumber: position.lineNumber,
     // replace the whole word with the suggestion
@@ -322,6 +339,13 @@ const getSuggestions = (
   };
   return (
     filterTermsWithoutName(autocompleteSet)
+      .filter((item) => {
+        if ((isInsideQuotedString || !context.addTemplate) && usesStructuralSnippet(item)) {
+          return false;
+        }
+
+        return true;
+      })
       // map autocomplete items to completion items
       .map((item) => {
         const suggestion = {
@@ -338,6 +362,7 @@ const getSuggestions = (
       })
   );
 };
+
 export const getInsertText = (
   { name, insertValue, template, value }: ResultTerm,
   bodyContent: string,
@@ -349,19 +374,22 @@ export const getInsertText = (
 
   let insertText = '';
   if (typeof name === 'string') {
-    const bodyContentLines = bodyContent.split('\n');
-    const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
-    if (hasUnclosedQuote(currentContentLine)) {
-      // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
-      insertText = '';
+    const structuralSnippet = getStructuralSnippet(name);
+    if (structuralSnippet) {
+      insertText = structuralSnippet;
     } else {
-      // The cursor is at the beginning of a field so the insert text should start with a quote
-      insertText = '"';
-    }
-    if (insertValue && insertValue !== '{' && insertValue !== '[') {
-      insertText += `${insertValue}"`;
-    } else {
-      insertText += `${name}"`;
+      const bodyContentLines = bodyContent.split('\n');
+      const currentContentLine = bodyContentLines[bodyContentLines.length - 1].trim();
+      if (hasUnclosedQuote(currentContentLine)) {
+        // The cursor is after an unmatched quote (e.g. '..."abc', '..."')
+        insertText = '';
+      } else {
+        // The cursor is at the beginning of a field so the insert text should start with a quote
+        insertText = '"';
+      }
+      // insertValue can override the inserted token, but structural tokens are inserted as snippets above
+      const insertableName = insertValue && !getStructuralSnippet(insertValue) ? insertValue : name;
+      insertText += `${insertableName}"`;
     }
   } else {
     insertText = name + '';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Console] Fix incorrect brace autocomplete insertion (#256286)](https://github.com/elastic/kibana/pull/256286)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2026-03-10T12:42:21Z","message":"[Console] Fix incorrect brace autocomplete insertion (#256286)\n\nCloses #220475\n\n## Summary\n\n- Fixes an issue where autocompleting an opening brace `{` or bracket\n`[` in the Console request body incorrectly wrapped the suggestion in\ndouble quotes.\n- Suppresses `{`/`[` structural suggestions when they would corrupt\nexisting content (inside unclosed quotes or before existing values).\n\n## Root Cause\n\n- The autocomplete `getInsertText` logic always assumed suggestions were\nstrings and wrapped them in quotes when inside objects, without treating\nstructural characters like `{` and `[` as special cases.\n- The autocomplete `getSuggestions` logic did not guard against offering\n`{`/`[` in contexts where inserting them would be destructive —\nspecifically:\n1. When the cursor is inside an unclosed quote (matched or unmatched\nendpoint).\n2. When there is existing content to the right of the cursor (e.g., a\nstring value like `\"keyword\"`).\n\n## Fix\n\n- Modified `getInsertText` to explicitly handle `{` and `[` by inserting\nthem with the Monaco snippet placeholder `{$0}` and `[$0]` respectively,\nwhich bypasses the quote-wrapping logic and properly aligns with\nexisting formatting behavior.\n- Added a filter in `getSuggestions` that suppresses structural `{`/`[`\nsuggestions when:\n  - The cursor is inside an unclosed quote (`hasUnclosedQuote`), OR\n- There is existing content after the cursor that would be corrupted\n(`!context.addTemplate`).\n\n## Scenarios Fixed\n\n### 1. Selecting `{` inserted `\"{\"` instead of `{}`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/095d6930-0ee2-4b84-ae02-e6dd90ed1e4d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e563aa4d-6fe2-42b1-94b4-cb5765c6f592\n\n### 2. `{` suggested inside unclosed quote (unmatched endpoint)\n\n`POST not_a_real_endpoint` → `{ \"query\": \"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n### 3. `{` suggested inside unclosed quote (matched endpoint)\n\n`PUT /test` → `{ \"mappings\": { \"properties\": { \"integer_field\": \"` →\nCtrl+Space showed `{`. Now shows \"No suggestions.\"\n\n### 4. `{` suggested before existing content\n\n`PUT /test_index` → `{ \"mappings\": { \"properties\": { \"integer_field\":\n\"keyword\"` → move cursor before `\"keyword\"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n## Test Plan\n\n- Open Kibana Console\n- **Scenario 1 (insertion):** Type `PUT /test_index` with body `{\n\"mappings\": { \"properties\": { \"field1\": ` → Ctrl+Space → select `{` →\nverify `{}` is inserted (not `\"{}\"`), cursor placed inside.\n- **Scenario 2 (unclosed quote, unmatched):** Type `POST\nnot_a_real_endpoint` with body `{ \"query\": \"` → Ctrl+Space → verify no\n`{` suggestion.\n- **Scenario 3 (unclosed quote, matched):** Type `PUT /test` with body\n`{ \"mappings\": { \"properties\": { \"integer_field\": \"` → Ctrl+Space →\nverify no `{` suggestion.\n- **Scenario 4 (before existing content):** Type `PUT /test_index` with\nbody `{ \"mappings\": { \"properties\": { \"integer_field\": \"keyword\"` → move\ncursor before `\"keyword\"` → Ctrl+Space → verify no `{` suggestion.\n- All existing Jest tests pass (46 tests), ESLint clean, type check\nclean.\n\n## Release Note\n\nFixes Console autocomplete to insert `{}`/`[]` snippets instead of\nquoted braces when selecting `{` or `[` suggestions in request bodies,\nand suppresses these structural suggestions in contexts where they would\ncorrupt existing content.\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Improved autocomplete suggestions for structural tokens (braces and\nbrackets) in complex editing contexts.\n* Fixed quote handling to prevent unnecessary wrapping around structural\ntokens during insertion.\n* Enhanced context detection for unmatched endpoints to provide more\naccurate and relevant suggestions.\n\n* **Tests**\n* Expanded test coverage for structural token handling and quote\nbehavior in autocomplete scenarios.\n","sha":"53824fd35b01bd90c85993743c8bacdab9a46d83","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Console","release_note:fix","Team:Kibana Management","backport missing","backport:all-open","v9.4.0"],"title":"[Console] Fix incorrect brace autocomplete insertion","number":256286,"url":"https://github.com/elastic/kibana/pull/256286","mergeCommit":{"message":"[Console] Fix incorrect brace autocomplete insertion (#256286)\n\nCloses #220475\n\n## Summary\n\n- Fixes an issue where autocompleting an opening brace `{` or bracket\n`[` in the Console request body incorrectly wrapped the suggestion in\ndouble quotes.\n- Suppresses `{`/`[` structural suggestions when they would corrupt\nexisting content (inside unclosed quotes or before existing values).\n\n## Root Cause\n\n- The autocomplete `getInsertText` logic always assumed suggestions were\nstrings and wrapped them in quotes when inside objects, without treating\nstructural characters like `{` and `[` as special cases.\n- The autocomplete `getSuggestions` logic did not guard against offering\n`{`/`[` in contexts where inserting them would be destructive —\nspecifically:\n1. When the cursor is inside an unclosed quote (matched or unmatched\nendpoint).\n2. When there is existing content to the right of the cursor (e.g., a\nstring value like `\"keyword\"`).\n\n## Fix\n\n- Modified `getInsertText` to explicitly handle `{` and `[` by inserting\nthem with the Monaco snippet placeholder `{$0}` and `[$0]` respectively,\nwhich bypasses the quote-wrapping logic and properly aligns with\nexisting formatting behavior.\n- Added a filter in `getSuggestions` that suppresses structural `{`/`[`\nsuggestions when:\n  - The cursor is inside an unclosed quote (`hasUnclosedQuote`), OR\n- There is existing content after the cursor that would be corrupted\n(`!context.addTemplate`).\n\n## Scenarios Fixed\n\n### 1. Selecting `{` inserted `\"{\"` instead of `{}`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/095d6930-0ee2-4b84-ae02-e6dd90ed1e4d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e563aa4d-6fe2-42b1-94b4-cb5765c6f592\n\n### 2. `{` suggested inside unclosed quote (unmatched endpoint)\n\n`POST not_a_real_endpoint` → `{ \"query\": \"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n### 3. `{` suggested inside unclosed quote (matched endpoint)\n\n`PUT /test` → `{ \"mappings\": { \"properties\": { \"integer_field\": \"` →\nCtrl+Space showed `{`. Now shows \"No suggestions.\"\n\n### 4. `{` suggested before existing content\n\n`PUT /test_index` → `{ \"mappings\": { \"properties\": { \"integer_field\":\n\"keyword\"` → move cursor before `\"keyword\"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n## Test Plan\n\n- Open Kibana Console\n- **Scenario 1 (insertion):** Type `PUT /test_index` with body `{\n\"mappings\": { \"properties\": { \"field1\": ` → Ctrl+Space → select `{` →\nverify `{}` is inserted (not `\"{}\"`), cursor placed inside.\n- **Scenario 2 (unclosed quote, unmatched):** Type `POST\nnot_a_real_endpoint` with body `{ \"query\": \"` → Ctrl+Space → verify no\n`{` suggestion.\n- **Scenario 3 (unclosed quote, matched):** Type `PUT /test` with body\n`{ \"mappings\": { \"properties\": { \"integer_field\": \"` → Ctrl+Space →\nverify no `{` suggestion.\n- **Scenario 4 (before existing content):** Type `PUT /test_index` with\nbody `{ \"mappings\": { \"properties\": { \"integer_field\": \"keyword\"` → move\ncursor before `\"keyword\"` → Ctrl+Space → verify no `{` suggestion.\n- All existing Jest tests pass (46 tests), ESLint clean, type check\nclean.\n\n## Release Note\n\nFixes Console autocomplete to insert `{}`/`[]` snippets instead of\nquoted braces when selecting `{` or `[` suggestions in request bodies,\nand suppresses these structural suggestions in contexts where they would\ncorrupt existing content.\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Improved autocomplete suggestions for structural tokens (braces and\nbrackets) in complex editing contexts.\n* Fixed quote handling to prevent unnecessary wrapping around structural\ntokens during insertion.\n* Enhanced context detection for unmatched endpoints to provide more\naccurate and relevant suggestions.\n\n* **Tests**\n* Expanded test coverage for structural token handling and quote\nbehavior in autocomplete scenarios.\n","sha":"53824fd35b01bd90c85993743c8bacdab9a46d83"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256286","number":256286,"mergeCommit":{"message":"[Console] Fix incorrect brace autocomplete insertion (#256286)\n\nCloses #220475\n\n## Summary\n\n- Fixes an issue where autocompleting an opening brace `{` or bracket\n`[` in the Console request body incorrectly wrapped the suggestion in\ndouble quotes.\n- Suppresses `{`/`[` structural suggestions when they would corrupt\nexisting content (inside unclosed quotes or before existing values).\n\n## Root Cause\n\n- The autocomplete `getInsertText` logic always assumed suggestions were\nstrings and wrapped them in quotes when inside objects, without treating\nstructural characters like `{` and `[` as special cases.\n- The autocomplete `getSuggestions` logic did not guard against offering\n`{`/`[` in contexts where inserting them would be destructive —\nspecifically:\n1. When the cursor is inside an unclosed quote (matched or unmatched\nendpoint).\n2. When there is existing content to the right of the cursor (e.g., a\nstring value like `\"keyword\"`).\n\n## Fix\n\n- Modified `getInsertText` to explicitly handle `{` and `[` by inserting\nthem with the Monaco snippet placeholder `{$0}` and `[$0]` respectively,\nwhich bypasses the quote-wrapping logic and properly aligns with\nexisting formatting behavior.\n- Added a filter in `getSuggestions` that suppresses structural `{`/`[`\nsuggestions when:\n  - The cursor is inside an unclosed quote (`hasUnclosedQuote`), OR\n- There is existing content after the cursor that would be corrupted\n(`!context.addTemplate`).\n\n## Scenarios Fixed\n\n### 1. Selecting `{` inserted `\"{\"` instead of `{}`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/095d6930-0ee2-4b84-ae02-e6dd90ed1e4d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/e563aa4d-6fe2-42b1-94b4-cb5765c6f592\n\n### 2. `{` suggested inside unclosed quote (unmatched endpoint)\n\n`POST not_a_real_endpoint` → `{ \"query\": \"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n### 3. `{` suggested inside unclosed quote (matched endpoint)\n\n`PUT /test` → `{ \"mappings\": { \"properties\": { \"integer_field\": \"` →\nCtrl+Space showed `{`. Now shows \"No suggestions.\"\n\n### 4. `{` suggested before existing content\n\n`PUT /test_index` → `{ \"mappings\": { \"properties\": { \"integer_field\":\n\"keyword\"` → move cursor before `\"keyword\"` → Ctrl+Space showed `{`. Now\nshows \"No suggestions.\"\n\n## Test Plan\n\n- Open Kibana Console\n- **Scenario 1 (insertion):** Type `PUT /test_index` with body `{\n\"mappings\": { \"properties\": { \"field1\": ` → Ctrl+Space → select `{` →\nverify `{}` is inserted (not `\"{}\"`), cursor placed inside.\n- **Scenario 2 (unclosed quote, unmatched):** Type `POST\nnot_a_real_endpoint` with body `{ \"query\": \"` → Ctrl+Space → verify no\n`{` suggestion.\n- **Scenario 3 (unclosed quote, matched):** Type `PUT /test` with body\n`{ \"mappings\": { \"properties\": { \"integer_field\": \"` → Ctrl+Space →\nverify no `{` suggestion.\n- **Scenario 4 (before existing content):** Type `PUT /test_index` with\nbody `{ \"mappings\": { \"properties\": { \"integer_field\": \"keyword\"` → move\ncursor before `\"keyword\"` → Ctrl+Space → verify no `{` suggestion.\n- All existing Jest tests pass (46 tests), ESLint clean, type check\nclean.\n\n## Release Note\n\nFixes Console autocomplete to insert `{}`/`[]` snippets instead of\nquoted braces when selecting `{` or `[` suggestions in request bodies,\nand suppresses these structural suggestions in contexts where they would\ncorrupt existing content.\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Improved autocomplete suggestions for structural tokens (braces and\nbrackets) in complex editing contexts.\n* Fixed quote handling to prevent unnecessary wrapping around structural\ntokens during insertion.\n* Enhanced context detection for unmatched endpoints to provide more\naccurate and relevant suggestions.\n\n* **Tests**\n* Expanded test coverage for structural token handling and quote\nbehavior in autocomplete scenarios.\n","sha":"53824fd35b01bd90c85993743c8bacdab9a46d83"}}]}] BACKPORT-->