### PR TITLE
add 'preview' flag to new connectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2378,7 +2378,7 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/**
 src/platform/packages/shared/kbn-connector-specs/src/specs/abuseipdb/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/alienvault_otx/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/amazon_s3/** @elastic/workchat-eng
-src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/** @elastic/workflows-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/github/** @elastic/workflows-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/** @elastic/workchat-eng
@@ -2399,9 +2399,10 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/** @elasti
 src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_online/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/slack/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/** @elastic/workchat-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/figma/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/** @elastic/workchat-eng
 src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/** @elastic/workchat-eng
-src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/** @elastic/workflows-eng
+src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/** @elastic/workchat-eng
 
 # Gap fill feature has shared responsibility between response-ops and security-detection-engine
 /x-pack/platform/plugins/shared/alerting/common/routes/gaps @elastic/response-ops @elastic/security-detection-engine

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -56,6 +56,7 @@ export interface ConnectorMetadata {
   description: string;
   docsUrl?: string;
   minimumLicense: LicenseType;
+  isTechnicalPreview?: boolean;
   supportedFeatureIds: Array<
     | 'alerting'
     | 'cases'

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -22,6 +22,7 @@ export const JiraConnector: ConnectorSpec = {
       defaultMessage: 'Connect to Jira to pull data from your project.',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
   auth: {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/brave_search.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/brave_search/brave_search.ts
@@ -31,6 +31,7 @@ export const BraveSearchConnector: ConnectorSpec = {
       defaultMessage: 'Search the web using Brave Search API for privacy-focused results',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/figma/figma.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/figma/figma.ts
@@ -27,6 +27,7 @@ export const FigmaConnector: ConnectorSpec = {
         'Browse Figma design files, inspect structure, render images, and explore team projects',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/firecrawl.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/firecrawl/firecrawl.ts
@@ -86,6 +86,7 @@ export const FirecrawlConnector: ConnectorSpec = {
       defaultMessage: 'Scrape, search, map, and crawl the web via the Firecrawl API.',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_calendar/google_calendar.ts
@@ -46,6 +46,7 @@ export const GoogleCalendar: ConnectorSpec = {
       defaultMessage: 'Search and access events and calendars in Google Calendar',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
   auth: {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/google_drive/google_drive.ts
@@ -52,6 +52,7 @@ export const GoogleDriveConnector: ConnectorSpec = {
       defaultMessage: 'Search and access files and folders in Google Drive',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
   auth: {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/notion/notion.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/notion/notion.ts
@@ -19,6 +19,7 @@ export const NotionConnector: ConnectorSpec = {
       defaultMessage: 'Explore content and databases in Notion',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
@@ -50,6 +50,7 @@ export const SalesforceConnector: ConnectorSpec = {
       defaultMessage: 'Connect to Salesforce to query and explore your org data',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/servicenow_search/servicenow_search.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/servicenow_search/servicenow_search.ts
@@ -52,6 +52,7 @@ export const ServicenowSearch: ConnectorSpec = {
       defaultMessage: 'Search and retrieve records from ServiceNow',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_online/sharepoint_online.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_online/sharepoint_online.ts
@@ -40,6 +40,7 @@ export const SharepointOnline: ConnectorSpec = {
       defaultMessage: 'Kibana Stack Connector for SharePoint Online.',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -474,6 +474,7 @@ export const Slack: ConnectorSpec = {
       defaultMessage: 'List public channels and send messages to Slack channels',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/zendesk.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/zendesk/zendesk.ts
@@ -23,6 +23,7 @@ export const ZendeskConnector: ConnectorSpec = {
         'Connect to Zendesk to search and retrieve tickets, users, and Help Center content.',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/zoom.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/zoom/zoom.ts
@@ -97,6 +97,7 @@ export const Zoom: ConnectorSpec = {
         'Kibana Stack Connector for Zoom — access meetings, recordings, transcripts, and participants.',
     }),
     minimumLicense: 'enterprise',
+    isTechnicalPreview: true,
     supportedFeatureIds: ['workflows'],
   },
 

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types_from_spec/register_from_spec.ts
@@ -70,6 +70,7 @@ const createConnectorTypeFromSpec = (
     id: spec.metadata.id,
     actionTypeTitle: spec.metadata.displayName,
     source: ACTION_TYPE_SOURCES.spec,
+    isExperimental: spec.metadata.isTechnicalPreview,
     selectMessage: spec.metadata.description,
     iconClass: getIcon(spec),
     // Temporary workaround to hide workflows connector when workflows UI setting is disabled.


### PR DESCRIPTION
## Summary

As we approach releasing our new connectors, we want to make sure they display as "preview". This PR:
* adds new metadata to the "v2" specs to signal that a connector is in preview
* consumes that metadata when rendering in the type picker
* updates all the connectors from E&T to use this flag (@elastic/workflows-eng, y'all may be in a similar boat, but I didn't want to touch your connectors for you)

<img width="499" height="461" alt="Screenshot 2026-03-12 at 4 05 33 PM" src="https://github.com/user-attachments/assets/88513f47-d3f8-424a-a53e-005a5c989427" />




