### PR TITLE
[Discover] PoC: Remove dashboard overrides for Discover session embeddable

### DIFF
--- a/src/platform/plugins/shared/discover/common/embeddable/get_transform_out.ts
+++ b/src/platform/plugins/shared/discover/common/embeddable/get_transform_out.ts
@@ -20,6 +20,7 @@ import type {
   StoredSearchEmbeddableState,
 } from './types';
 import { SAVED_SEARCH_SAVED_OBJECT_REF_NAME } from './get_transform_in';
+import { EDITABLE_SAVED_SEARCH_KEYS } from './constants';
 
 function isByValue(
   state: StoredSearchEmbeddableState
@@ -78,7 +79,7 @@ export function getTransformOut(transformDrilldownsOut: DrilldownTransforms['tra
       (ref) => SavedSearchType === ref.type && ref.name === SAVED_SEARCH_SAVED_OBJECT_REF_NAME
     );
     return {
-      ...state,
+      ...omit(state, EDITABLE_SAVED_SEARCH_KEYS),
       ...(savedObjectRef?.id ? { savedObjectId: savedObjectRef.id } : {}),
     } as SearchEmbeddableByReferenceState;
   }

--- a/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -37,7 +37,6 @@ import type { PublishesWritableTimeRange } from '@kbn/presentation-publishing/in
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
 import type { DiscoverServices } from '../build_services';
 import { EDITABLE_SAVED_SEARCH_KEYS } from '../../common/embeddable/constants';
-import { getSearchEmbeddableDefaults } from './get_search_embeddable_defaults';
 import type {
   PublishesWritableSavedSearch,
   SearchEmbeddableSerializedAttributes,
@@ -129,8 +128,6 @@ export const initializeSearchEmbeddableApi = async ({
   );
   const searchSource$ = new BehaviorSubject<ISearchSource>(searchSource);
   const dataViews$ = new BehaviorSubject<DataView[] | undefined>(dataView ? [dataView] : undefined);
-
-  const defaults = getSearchEmbeddableDefaults(discoverServices.uiSettings);
 
   /** This is the state that can be initialized from the saved initial state */
   const columns$ = new BehaviorSubject<string[] | undefined>(initialState.columns);
@@ -296,17 +293,16 @@ export const initializeSearchEmbeddableApi = async ({
     stateManager,
     anyStateChange$: onAnyStateChange.pipe(map(() => undefined)),
     comparators: {
-      sort: (a, b) => deepEqual(a ?? [], b ?? []),
-      columns: 'deepEquality',
-      grid: (a, b) => deepEqual(a ?? {}, b ?? {}),
-      sampleSize: (a, b) => (a ?? defaults.sampleSize) === (b ?? defaults.sampleSize),
-      rowsPerPage: (a, b) => (a ?? defaults.rowsPerPage) === (b ?? defaults.rowsPerPage),
-      rowHeight: (a, b) => (a ?? defaults.rowHeight) === (b ?? defaults.rowHeight),
-      headerRowHeight: (a, b) =>
-        (a ?? defaults.headerRowHeight) === (b ?? defaults.headerRowHeight),
+      sort: 'skip',
+      columns: 'skip',
+      grid: 'skip',
+      sampleSize: 'skip',
+      rowsPerPage: 'skip',
+      rowHeight: 'skip',
+      headerRowHeight: 'skip',
       serializedSearchSource: 'referenceEquality',
       viewMode: 'referenceEquality',
-      density: 'referenceEquality',
+      density: 'skip',
     },
     reinitializeState,
   };

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
@@ -125,7 +125,7 @@ describe('Serialization utils', () => {
 
       const serializedState: SearchEmbeddableState = {
         title: 'test panel title',
-        sort: [['order_date', 'asc']], // overwrite the saved object sort
+        sort: [['order_date', 'asc']], // dashboard override — should be ignored
         savedObjectId: 'savedSearch',
       };
 
@@ -136,8 +136,8 @@ describe('Serialization utils', () => {
       expect(Object.keys(deserializedState)).toContain('serializedSearchSource');
       expect(Object.keys(deserializedState)).toContain('savedObjectId');
       expect(deserializedState.title).toEqual('test panel title');
-      // For a valid/default tab, dashboard overrides win on top of resolved tab attributes
-      expect(deserializedState.sort).toEqual([['order_date', 'asc']]);
+      // Dashboard overrides are dropped; sort comes from tab-1
+      expect(deserializedState.sort).toEqual([['order_date', 'desc']]);
       expect(deserializedState.columns).toEqual(['_source']); // from tab-1
       expect(deserializedState.selectedTabId).toEqual('tab-1');
       expect(deserializedState.tabs).toEqual(sessionTabs);
@@ -204,7 +204,7 @@ describe('Serialization utils', () => {
       expect(deserializedState.sort).toBeUndefined();
     });
 
-    test('by reference - valid selectedTabId with dashboard overrides', async () => {
+    test('by reference - valid selectedTabId with dashboard overrides dropped', async () => {
       const sessionTabs = [
         mockTab('tab-1', 'Tab 1'),
         mockTab('tab-2', 'Tab 2', {
@@ -220,7 +220,7 @@ describe('Serialization utils', () => {
         title: 'test panel title',
         savedObjectId: 'savedSearch',
         selectedTabId: 'tab-2',
-        // Dashboard override for columns on top of tab-2
+        // Dashboard overrides — should be ignored
         columns: ['custom-col'],
       };
 
@@ -228,8 +228,8 @@ describe('Serialization utils', () => {
         serializedState,
         discoverServices: discoverServiceMock,
       });
-      // For a valid tab, dashboard overrides should win on top of tab-2 attributes
-      expect(deserializedState.columns).toEqual(['custom-col']);
+      // Dashboard overrides are dropped; attributes come from tab-2
+      expect(deserializedState.columns).toEqual(['col-a', 'col-b']);
       expect(deserializedState.sort).toEqual([['timestamp', 'asc']]);
     });
   });
@@ -303,7 +303,7 @@ describe('Serialization utils', () => {
         });
       });
 
-      test('overwrite state', () => {
+      test('overwrite state is no longer persisted', () => {
         const serializedState = serializeState({
           uuid,
           initialState: {
@@ -318,8 +318,6 @@ describe('Serialization utils', () => {
         });
 
         expect(serializedState).toEqual({
-          sampleSize: 500,
-          sort: [['order_date', 'asc']],
           savedObjectId: 'test-id',
           selectedTabId: 'tab-1',
         });

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
@@ -8,13 +8,10 @@
  */
 
 import { omit, pick } from 'lodash';
-import deepEqual from 'react-fast-compare';
 import { type SerializedTimeRange, type SerializedTitles } from '@kbn/presentation-publishing';
 import { toSavedSearchAttributes, type SavedSearch } from '@kbn/saved-search-plugin/common';
 import type { SerializedDrilldowns } from '@kbn/embeddable-plugin/server';
-import { EDITABLE_SAVED_SEARCH_KEYS } from '../../../common/embeddable/constants';
 import type {
-  EditableSavedSearchAttributes,
   SearchEmbeddableByReferenceState,
   SearchEmbeddableByValueState,
   SearchEmbeddableState,
@@ -22,7 +19,6 @@ import type {
 import type { DiscoverServices } from '../../build_services';
 import { EDITABLE_PANEL_KEYS } from '../constants';
 import type { SearchEmbeddableRuntimeState } from '../types';
-import { isTabDeleted } from './is_tab_deleted';
 
 export const deserializeState = async ({
   serializedState,
@@ -49,13 +45,9 @@ export const deserializeState = async ({
 
     const resolvedSelectedTabId = isSelectedTabDeleted ? selectedTabId : resolvedTab?.id;
 
-    const savedObjectOverride = pick(serializedState, EDITABLE_SAVED_SEARCH_KEYS);
-
     // Build runtime state from the resolved tab's attributes
     // ignore the time range from the tab - only global time range + panel time range matter
-    const runtimeSavedSearchState = isSelectedTabDeleted
-      ? {}
-      : { ...omit(resolvedTab, 'timeRange'), ...savedObjectOverride };
+    const runtimeSavedSearchState = isSelectedTabDeleted ? {} : omit(resolvedTab, 'timeRange');
 
     return {
       ...runtimeSavedSearchState,
@@ -88,8 +80,8 @@ export const deserializeState = async ({
 };
 
 export const serializeState = ({
-  uuid,
-  initialState,
+  uuid: _uuid,
+  initialState: _initialState,
   savedSearch,
   serializeTitles,
   serializeTimeRange,
@@ -106,44 +98,19 @@ export const serializeState = ({
   savedObjectId?: string;
   selectedTabId?: string;
 }): SearchEmbeddableState => {
-  const searchSource = savedSearch.searchSource;
-  const searchSourceJSON = JSON.stringify(searchSource.getSerializedFields());
-  const savedSearchAttributes = toSavedSearchAttributes(savedSearch, searchSourceJSON);
-
   if (savedObjectId) {
-    const isSelectedTabDeleted = isTabDeleted(selectedTabId, initialState.tabs ?? []);
-
-    const selectedTab = selectedTabId
-      ? initialState.tabs?.find((tab) => tab.id === selectedTabId)
-      : undefined;
-
-    let overwriteState: EditableSavedSearchAttributes;
-
-    if (isSelectedTabDeleted || !selectedTab) {
-      overwriteState = pick(initialState, EDITABLE_SAVED_SEARCH_KEYS);
-    } else {
-      const editableAttributesBackup = pick(selectedTab, EDITABLE_SAVED_SEARCH_KEYS);
-      const [{ attributes }] = savedSearchAttributes.tabs;
-
-      // only save the current state that is **different** than the saved object state
-      overwriteState = EDITABLE_SAVED_SEARCH_KEYS.reduce((prev, key) => {
-        if (deepEqual(attributes[key], editableAttributesBackup[key])) {
-          return prev;
-        }
-        return { ...prev, [key]: attributes[key] };
-      }, {});
-    }
-
     return {
-      // Serialize the current dashboard state into the panel state **without** updating the saved object
       ...serializeTitles(),
       ...serializeTimeRange(),
       ...serializeDynamicActions?.(),
-      ...overwriteState,
       savedObjectId,
       ...(selectedTabId ? { selectedTabId } : {}),
     };
   }
+
+  const searchSource = savedSearch.searchSource;
+  const searchSourceJSON = JSON.stringify(searchSource.getSerializedFields());
+  const savedSearchAttributes = toSavedSearchAttributes(savedSearch, searchSourceJSON);
 
   return {
     ...serializeTitles(),


### PR DESCRIPTION
## Summary

**PoC / Demo only — not for merge**

This is a proof-of-concept implementing **Option 1** from the "As Code" Discover Sessions Embeddable Overrides design document. The saved object becomes the **single source of truth** — dashboard-level overrides for editable saved search keys (`sort`, `columns`, `rowHeight`, `sampleSize`, `rowsPerPage`, `headerRowHeight`, `density`, `grid`) are no longer persisted or applied.

### Changes

- **`serializeState`**: By-reference panels no longer compute or persist override diffs of `EDITABLE_SAVED_SEARCH_KEYS`. The serialized state for by-reference panels now only contains panel-specific properties (title, description, time range, drilldowns) plus `savedObjectId` and `selectedTabId`.
- **`deserializeState`**: By-reference panels no longer apply stored overrides on top of the resolved tab attributes. The tab from the saved object is used as-is.
- **`transformOut`**: Strips any existing `EDITABLE_SAVED_SEARCH_KEYS` from by-reference stored state, so legacy/existing overrides are dropped when opening a dashboard.
- **Comparators**: All `EDITABLE_SAVED_SEARCH_KEYS` marked as `'skip'` so local edits do not trigger the unsaved changes badge for either by-reference or by-value panels.

### Behavioral impact

- Existing dashboards with by-reference Discover panels that have overrides (e.g., custom column order, density, sort) will revert to the saved object's state on next load.
- Users can no longer make persistent layout tweaks to Discover panels directly from the dashboard — all changes must be made in the Discover app.
- The "Modified" / unsaved changes badge will no longer appear for editable saved search property changes.

## Test plan

- [ ] Open a dashboard with an existing by-reference Discover panel that has overrides → verify overrides are dropped and saved object state is used
- [ ] Edit a Discover panel on a dashboard (change sort, columns, etc.) → verify the unsaved changes badge does **not** appear
- [ ] Save a dashboard after editing a Discover panel → verify no overrides are persisted in the dashboard state
- [ ] Open a dashboard with a by-value Discover panel → verify it still works correctly
- [ ] Verify no regressions in the Discover app itself


Made with [Cursor](https://cursor.com)