### PR TITLE
[Security Solution][Session View] returning index along side alert id for onShowAlertDetails callback

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -6,17 +6,14 @@
  */
 
 import type { FC } from 'react';
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiPanel } from '@elastic/eui';
 import type { Process } from '@kbn/session-view-plugin/common';
 import { i18n } from '@kbn/i18n';
-import { PageScope } from '../../../../data_view_manager/constants';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { CustomProcess } from '../../session_view/context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { SESSION_VIEW_TEST_ID } from './test_ids';
-import { useSourcererDataView } from '../../../../sourcerer/containers';
 import {
   DocumentDetailsPreviewPanelKey,
   DocumentDetailsSessionViewPanelKey,
@@ -28,7 +25,6 @@ import { useLicense } from '../../../../common/hooks/use_license';
 import { useSessionViewConfig } from '../../shared/hooks/use_session_view_config';
 import { SessionViewNoDataMessage } from '../../shared/components/session_view_no_data_message';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 export const SESSION_VIEW_ID = 'session-view';
 
@@ -68,20 +64,9 @@ export const SessionView: FC = memo(() => {
   const isEnterprisePlus = useLicense().isEnterprise();
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.alerts);
-
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.alerts);
-
-  const selectedPatterns = newDataViewPickerEnabled
-    ? experimentalSelectedPatterns
-    : oldSelectedPatterns;
-
-  const alertsIndex = useMemo(() => selectedPatterns.join(','), [selectedPatterns]);
-
   const { openPreviewPanel, closePreviewPanel } = useExpandableFlyoutApi();
   const openAlertDetailsPreview = useCallback(
-    (evtId?: string, onClose?: () => void) => {
+    (alertId: string, alertIndex: string, onClose?: () => void) => {
       // In the SessionView component, when the user clicks on the
       // expand button to open a alert in the preview panel, this actually also selects the row and opens
       // the detailed panel in preview.
@@ -91,8 +76,8 @@ export const SessionView: FC = memo(() => {
         openPreviewPanel({
           id: DocumentDetailsPreviewPanelKey,
           params: {
-            id: evtId,
-            indexName: alertsIndex,
+            id: alertId,
+            indexName: alertIndex,
             scopeId,
             banner: ALERT_PREVIEW_BANNER,
             isPreviewMode: true,
@@ -104,7 +89,7 @@ export const SessionView: FC = memo(() => {
         panel: 'preview',
       });
     },
-    [openPreviewPanel, alertsIndex, scopeId, telemetry]
+    [openPreviewPanel, scopeId, telemetry]
   );
 
   const openDetailsInPreview = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
@@ -11,9 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { DetailPanelAlertTab, useFetchSessionViewAlerts } from '@kbn/session-view-plugin/public';
 import type { ProcessEvent } from '@kbn/session-view-plugin/common';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { PageScope } from '../../../../data_view_manager/constants';
 import { LeftPanelVisualizeTab } from '../../left';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { SESSION_VIEW_ID } from '../../left/components/session_view';
 import {
   DocumentDetailsLeftPanelKey,
@@ -21,8 +19,6 @@ import {
 } from '../../shared/constants/panel_keys';
 import { ALERT_PREVIEW_BANNER } from '../../preview/constants';
 import { useSessionViewPanelContext } from '../context';
-import { useSourcererDataView } from '../../../../sourcerer/containers';
-import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 
 /**
  * Tab displayed in the SessionView preview panel, shows alerts related to the session.
@@ -37,16 +33,6 @@ export const AlertsTab = memo(() => {
     isFetching: isFetchingAlerts,
     hasNextPage: hasNextPageAlerts,
   } = useFetchSessionViewAlerts(sessionEntityId, sessionStartTime, investigatedAlertId);
-
-  const { selectedPatterns: oldSelectedPatterns } = useSourcererDataView(PageScope.alerts);
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const experimentalSelectedPatterns = useSelectedPatterns(PageScope.alerts);
-
-  const selectedPatterns = newDataViewPickerEnabled
-    ? experimentalSelectedPatterns
-    : oldSelectedPatterns;
-
-  const alertsIndex = useMemo(() => selectedPatterns.join(','), [selectedPatterns]);
 
   // this code mimics what is being done in the x-pack/plugins/session_view/public/components/session_view/index.tsx file
   const alerts = useMemo(() => {
@@ -63,19 +49,19 @@ export const AlertsTab = memo(() => {
 
   const { openPreviewPanel, openLeftPanel } = useExpandableFlyoutApi();
   const openAlertDetailsPreview = useCallback(
-    (evtId?: string, onClose?: () => void) => {
+    (alertId: string, alertIndex: string) => {
       openPreviewPanel({
         id: DocumentDetailsPreviewPanelKey,
         params: {
-          id: evtId,
-          indexName: alertsIndex,
+          id: alertId,
+          indexName: alertIndex,
           scopeId,
           banner: ALERT_PREVIEW_BANNER,
           isPreviewMode: true,
         },
       });
     },
-    [openPreviewPanel, scopeId, alertsIndex]
+    [openPreviewPanel, scopeId]
   );
 
   // this code mimics what is being done in the x-pack/plugins/session_view/public/components/session_view/index.tsx file

--- a/x-pack/solutions/security/plugins/session_view/common/types/v1.ts
+++ b/x-pack/solutions/security/plugins/session_view/common/types/v1.ts
@@ -156,6 +156,7 @@ export interface ProcessEventAlertRule {
 
 export interface ProcessEventAlert {
   uuid?: string;
+  index?: string;
   reason?: string;
   workflow_status?: string;
   status?: string;

--- a/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_actions/index.test.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_actions/index.test.tsx
@@ -52,7 +52,16 @@ describe('DetailPanelAlertActions component', () => {
     });
 
     it('calls alert flyout callback when View details clicked', async () => {
-      const mockEvent = mockAlerts[0];
+      const mockEvent = {
+        ...mockAlerts[0],
+        kibana: {
+          ...mockAlerts[0].kibana,
+          alert: {
+            ...mockAlerts[0].kibana?.alert,
+            index: '.alerts-security.alerts-default',
+          },
+        },
+      };
 
       renderResult = mockedContext.render(
         <DetailPanelAlertActions
@@ -66,7 +75,10 @@ describe('DetailPanelAlertActions component', () => {
       await waitForEuiPopoverOpen();
       await userEvent.click(renderResult.getByTestId(SHOW_DETAILS_TEST_ID));
       expect(mockShowAlertDetails.mock.calls.length).toBe(1);
-      expect(mockShowAlertDetails.mock.results[0].value).toBe(mockEvent.kibana?.alert?.uuid);
+      expect(mockShowAlertDetails.mock.calls[0]).toEqual([
+        mockEvent.kibana?.alert?.uuid,
+        mockEvent.kibana?.alert?.index,
+      ]);
       expect(mockOnJumpToEvent.mock.calls.length).toBe(0);
     });
 

--- a/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_actions/index.tsx
@@ -16,7 +16,7 @@ export const JUMP_TO_PROCESS_TEST_ID = 'sessionView:detailPanelAlertActionJumpTo
 
 interface DetailPanelAlertActionsDeps {
   event: ProcessEvent;
-  onShowAlertDetails: (alertId: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
   onJumpToEvent: (event: ProcessEvent) => void;
 }
 
@@ -44,8 +44,11 @@ export const DetailPanelAlertActions = ({
   }, [event, onJumpToEvent]);
 
   const onShowDetails = useCallback(() => {
-    if (event.kibana?.alert?.uuid) {
-      onShowAlertDetails(event.kibana.alert.uuid);
+    const alertUuid = event.kibana?.alert?.uuid;
+    const alertIndex = event.kibana?.alert?.index;
+
+    if (alertUuid && alertIndex) {
+      onShowAlertDetails(alertUuid, alertIndex);
       setPopover(false);
     }
   }, [event, onShowAlertDetails]);

--- a/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_group_item/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_group_item/index.tsx
@@ -18,7 +18,7 @@ export const ALERT_GROUP_ITEM_TITLE_TEST_ID = 'sessionView:detailPanelAlertGroup
 interface DetailPanelAlertsGroupItemDeps {
   alerts: ProcessEvent[];
   onJumpToEvent: (event: ProcessEvent) => void;
-  onShowAlertDetails: (alertId: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_list_item/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_list_item/index.tsx
@@ -32,7 +32,7 @@ export const ALERT_LIST_ITEM_TIMESTAMP_TEST_ID = 'sessionView:detailPanelAlertLi
 
 interface DetailPanelAlertsListItemDeps {
   event: ProcessEvent;
-  onShowAlertDetails: (alertId: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
   onJumpToEvent: (event: ProcessEvent) => void;
   isInvestigated?: boolean;
   minimal?: boolean;

--- a/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/detail_panel_alert_tab/index.tsx
@@ -24,7 +24,7 @@ interface DetailPanelAlertTabDeps {
   hasNextPageAlerts?: boolean;
   fetchNextPageAlerts: () => void;
   onJumpToEvent: (event: ProcessEvent) => void;
-  onShowAlertDetails: (alertId: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
   investigatedAlertId?: string;
 }
 

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree/index.tsx
@@ -57,7 +57,7 @@ export interface ProcessTreeDeps {
 
   // a map for alerts with updated status and process.entity_id
   updatedAlertsStatus: AlertStatusEventEntityIdMap;
-  onShowAlertDetails: (alertUuid: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
   onJumpToOutput: (entityId: string) => void;
   showTimestamp?: boolean;
   verboseMode?: boolean;

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.test.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.test.tsx
@@ -39,6 +39,17 @@ describe('ProcessTreeAlerts component', () => {
     mockedContext = createAppRootMockRenderer();
   });
 
+  const mockAlertWithIndex = {
+    ...mockAlert,
+    kibana: {
+      ...mockAlert.kibana,
+      alert: {
+        ...mockAlert.kibana?.alert,
+        index: '.alerts-security.alerts-default',
+      },
+    },
+  };
+
   describe('When ProcessTreeAlert is mounted', () => {
     it('should render alert row correctly', async () => {
       renderResult = mockedContext.render(<ProcessTreeAlert {...props} />);
@@ -109,13 +120,21 @@ describe('ProcessTreeAlerts component', () => {
     it('should execute onShowAlertDetails callback when clicking on expand button', async () => {
       const onShowAlertDetails = jest.fn();
       renderResult = mockedContext.render(
-        <ProcessTreeAlert {...props} onShowAlertDetails={onShowAlertDetails} />
+        <ProcessTreeAlert
+          {...props}
+          alert={mockAlertWithIndex}
+          onShowAlertDetails={onShowAlertDetails}
+        />
       );
 
       const expandButton = renderResult.queryByTestId(EXPAND_BUTTON_TEST_ID);
       expect(expandButton).toBeTruthy();
       expandButton?.click();
       expect(onShowAlertDetails).toHaveBeenCalledTimes(1);
+      expect(onShowAlertDetails.mock.calls[0]).toEqual([
+        mockAlertWithIndex.kibana?.alert?.uuid,
+        mockAlertWithIndex.kibana?.alert?.index,
+      ]);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.tsx
@@ -4,15 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect, useCallback, useMemo } from 'react';
+
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
+  EuiBadge,
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiBadge,
-  EuiText,
-  EuiButtonIcon,
   EuiIconTip,
   EuiPanel,
+  EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ALERT_ICONS } from '../../../common/constants';
@@ -22,13 +23,14 @@ import { getBadgeColorFromAlertStatus } from './helpers';
 import { useStyles } from './styles';
 import { getAlertCategoryDisplayText } from '../../utils/alert_category_display_text';
 import { getAlertIconTooltipContent } from '../../../common/utils/alert_icon_tooltip_content';
+
 export interface ProcessTreeAlertDeps {
   alert: ProcessEvent;
   isInvestigated: boolean;
   isSelected: boolean;
   onClick: (alert: ProcessEventAlert | null) => void;
   selectAlert: (alertUuid: string) => void;
-  onShowAlertDetails: (alertUuid: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
 }
 
 export const ProcessTreeAlert = ({
@@ -42,7 +44,7 @@ export const ProcessTreeAlert = ({
   const styles = useStyles({ isInvestigated, isSelected });
 
   const { event } = alert;
-  const { uuid, rule, workflow_status: status } = alert.kibana?.alert || {};
+  const { uuid, index, rule, workflow_status: status } = alert.kibana?.alert || {};
   const category = event?.category?.[0] as ProcessEventAlertCategory;
   const alertIconType = useMemo(() => {
     if (category && category in ALERT_ICONS) return ALERT_ICONS[category];
@@ -56,10 +58,10 @@ export const ProcessTreeAlert = ({
   }, [isInvestigated, uuid, selectAlert]);
 
   const handleExpandClick = useCallback(() => {
-    if (uuid) {
-      onShowAlertDetails(uuid);
+    if (uuid && index) {
+      onShowAlertDetails(uuid, index);
     }
-  }, [onShowAlertDetails, uuid]);
+  }, [index, onShowAlertDetails, uuid]);
 
   const handleClick = useCallback(() => {
     if (alert.kibana?.alert) {

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alerts/index.tsx
@@ -6,13 +6,13 @@
  */
 
 import type { MouseEvent } from 'react';
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStyles } from './styles';
 import type {
-  ProcessEventAlertCategory,
+  AlertTypeCount,
   ProcessEvent,
   ProcessEventAlert,
-  AlertTypeCount,
+  ProcessEventAlertCategory,
 } from '../../../common';
 import { ProcessTreeAlert } from '../process_tree_alert';
 import { DEFAULT_ALERT_FILTER_VALUE, MOUSE_EVENT_PLACEHOLDER } from '../../../common/constants';
@@ -24,7 +24,7 @@ export interface ProcessTreeAlertsDeps {
   isProcessSelected?: boolean;
   alertTypeCounts: AlertTypeCount[];
   onAlertSelected: (e: MouseEvent) => void;
-  onShowAlertDetails: (alertUuid: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
 }
 
 export function ProcessTreeAlerts({

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -52,7 +52,7 @@ export interface ProcessDeps {
   searchResults?: Process[];
   scrollerRef: RefObject<HTMLDivElement>;
   onChangeJumpToEventVisibility: (isVisible: boolean, isAbove: boolean) => void;
-  onShowAlertDetails: (alertUuid: string) => void;
+  onShowAlertDetails: (alertId: string, alertIndex: string) => void;
   onJumpToOutput: (entityId: string) => void;
   loadNextButton?: ReactElement | null;
   loadPreviousButton?: ReactElement | null;
@@ -299,7 +299,7 @@ export function ProcessTreeNode({
         >
           {isSessionLeader ? (
             <span css={styles.sessionLeader}>
-              <EuiIcon type={sessionIcon} css={styles.icon} />
+              <EuiIcon type={sessionIcon} css={styles.icon} aria-hidden={true} />
               <Nbsp />
               <b css={styles.darkText}>{dataOrDash(name || args?.[0])}</b>
               <Nbsp />
@@ -307,7 +307,7 @@ export function ProcessTreeNode({
                 <FormattedMessage id="xpack.sessionView.startedBy" defaultMessage="started by" />
               </span>
               <Nbsp />
-              <EuiIcon type="user" />
+              <EuiIcon type="user" aria-hidden={true} />
               <Nbsp />
               <b css={styles.darkText}>{userName}</b>
               <Nbsp />

--- a/x-pack/solutions/security/plugins/session_view/public/components/session_view/hooks.ts
+++ b/x-pack/solutions/security/plugins/session_view/public/components/session_view/hooks.ts
@@ -74,7 +74,16 @@ export const useFetchSessionViewProcessEvents = (
         },
       });
 
-      const events = res.events?.map((event: any) => event._source as ProcessEvent) ?? [];
+      const events =
+        res.events?.map((event: any) => {
+          const source = event._source as ProcessEvent;
+
+          if (source?.kibana?.alert && event._index) {
+            source.kibana.alert.index = event._index;
+          }
+
+          return source;
+        }) ?? [];
 
       return { events, cursor, total: res.total };
     },
@@ -157,7 +166,16 @@ export const useFetchSessionViewAlerts = (
         },
       });
 
-      const events = res.events?.map((event: any) => event._source as ProcessEvent) ?? [];
+      const events =
+        res.events?.map((event: any) => {
+          const source = event._source as ProcessEvent;
+
+          if (source?.kibana?.alert && event._index) {
+            source.kibana.alert.index = event._index;
+          }
+
+          return source;
+        }) ?? [];
 
       return {
         events,

--- a/x-pack/solutions/security/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/session_view/index.tsx
@@ -263,9 +263,9 @@ export const SessionView = ({
   }, [openDetails, selectedProcess]);
 
   const onShowAlertDetails = useCallback(
-    (alertUuid: string) => {
+    (alertId: string, alertIndex: string) => {
       if (loadAlertDetails) {
-        loadAlertDetails(alertUuid, () => handleOnAlertDetailsClosed(alertUuid));
+        loadAlertDetails(alertId, alertIndex, () => handleOnAlertDetailsClosed(alertId));
         trackEvent('alert_details_loaded');
       }
     },

--- a/x-pack/solutions/security/plugins/session_view/public/types.ts
+++ b/x-pack/solutions/security/plugins/session_view/public/types.ts
@@ -80,7 +80,8 @@ export interface SessionViewDeps {
   investigatedAlertId?: string;
   // Callback to open the alerts flyout
   loadAlertDetails?: (
-    alertUuid: string,
+    alertId: string,
+    alertIndex: string,
     // Callback used when alert flyout panel is closed
     handleOnAlertDetailsClosed: () => void
   ) => void;


### PR DESCRIPTION
## Summary

This PR makes a small change to the signature of the `onShowAlertDetails` and `loadAlertDetails` callbacks that we can pass to the Session View component. Until now we were getting the `alertId` of the document to open. This was enough as the preview flyout we were opening was fetching the alert document in a specific way.
With the work being done around the conversion to the new EUI flyout, we will be fetching the alert document a different way. In order to make the call as efficient as possible, we should be using the index of the document.

#### The PR makes a small the following code changes in the SessionView plugin :
- update the `useFetchSessionViewAlerts` and `useFetchSessionViewProcessEvents` hooks to keep the `index` value returned by the server, and save it alongside the rest of the alert information. Then we can pass it back to the aforementioned `onShowAlertDetails` callback for it to use to fetch the entire document.
- update all the `ProcessEventAlert` interface by adding the new `index` property
- update the signature of all the `onShowAlertDetails` and `loadAlertDetails` props

#### And then a small code change in the SecuritySolution plugin:
- update the `AlertsTab` to use the newly returned `indexName`, and remove all the code that was retrieving the indices from the dataView as it's no longer needed

> [!NOTE]
> No visual changes should be introduced with this PR.

https://github.com/user-attachments/assets/21e0d6ea-6a8f-4f49-b85a-0b033922735f

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

_PR developed with Cursor + gpt-5.3-codex_