### PR TITLE
[Console] Fix indented body highlighting regression

### DIFF
--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/console_editor.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/console_editor.ts
@@ -34,6 +34,14 @@ export const lexerRules: monaco.languages.IMonarchLanguage = {
       // text
       matchToken('text', '.+?'),
     ],
+    json_root: [
+      // Recognize HTTP methods so the next request is highlighted even if the
+      // previous JSON body didn't correctly transition back to root.
+      matchTokensWithEOL('method', /get|post|put|patch|delete|head/, 'root', 'method_sep'),
+      // Also recognize warning comments that start a new context
+      matchToken('warning', '#!.*$'),
+      ...consoleSharedLexerRules.tokenizer.json_root,
+    ],
     comments: [
       // line comment indicated by #
       matchTokens(['comment.punctuation', 'comment.line'], /(#)(.*$)/),

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.test.ts
@@ -98,7 +98,7 @@ describe('Console highlighting', () => {
     expect(eventNameTokenType).not.toContain('text');
   });
 
-  it('returns to root after the top-level closing brace at end-of-line in the editor', () => {
+  it('highlights the next request method after the top-level closing brace in the editor', () => {
     const text = `GET _all
 {
   "a": {
@@ -114,6 +114,49 @@ GET _search`;
     const methodTokenType = getTokenTypeAtOffset(requestLineAfterJson, 0);
     expect(methodTokenType).toContain('method');
     expect(methodTokenType).not.toContain('text');
+  });
+
+  it('highlights the next request method after an indented top-level closing brace', () => {
+    const text = `POST kibana_sample_data_logs/_search
+  {
+    "query": {
+      "match_all": {}
+    }
+  }
+PUT _transform/my-managed-transform
+{
+  "source": {}
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    const putLine = getLine('PUT _transform/my-managed-transform');
+    const methodTokenType = getTokenTypeAtOffset(putLine, 0);
+    expect(methodTokenType).toContain('method');
+    expect(methodTokenType).not.toContain('text');
+  });
+
+  it('tokenizes intermediate closing braces as paren.rparen, not text', () => {
+    const text = `GET _all
+{
+  "a": {
+    "b": {
+      "c": 1
+    }
+  }
+}`;
+
+    const tokenizedLines = monaco.editor.tokenize(text, CONSOLE_TEST_LANG_ID);
+    const getLine = getLineTokens(tokenizedLines, text);
+
+    for (const line of ['  }', '}']) {
+      const tokens = getLine(line);
+      const braceType = getTokenTypeAtOffset(tokens, line.indexOf('}'));
+      expect(braceType).toContain('paren.rparen');
+      expect(braceType).not.toContain('text');
+      expect(braceType).not.toContain('invalid');
+    }
   });
 
   it('keeps nested braces and following JSON keys highlighted in output', () => {
@@ -209,14 +252,14 @@ describe('Lexer rule composition', () => {
     expect(stringifiedActions).not.toContain('@pop');
   });
 
-  it('json_root includes the Console-specific closing brace EOL rule', () => {
+  it('json_root includes the Console-specific closing brace rule', () => {
     const jsonRoot = (
       consoleSharedLexerRules.tokenizer as Record<string, monaco.languages.IMonarchLanguageRule[]>
     ).json_root;
 
     const hasRule = jsonRoot.some((rule) => {
       const regex = Array.isArray(rule) ? rule[0] : rule?.regex;
-      return regex instanceof RegExp && regex.source === '^}\\s*';
+      return regex instanceof RegExp && regex.source === '}';
     });
 
     expect(hasRule).toBe(true);

--- a/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/console/lexer_rules/shared.ts
@@ -106,13 +106,10 @@ const xjsonRules = { ...buildXjsonRules('json_root') };
 // We replace those rules with Console-specific rules that don't use @push
 const originalJsonRoot = xjsonRules.json_root;
 xjsonRules.json_root = [
-  // Return to root only when an unindented closing brace ends the line.
-  // This targets the top-level request body terminator and avoids breaking
-  // highlighting for nested objects where closing braces are indented.
-  // @ts-expect-error custom rule
-  matchTokensWithEOL('paren.rparen', /^}\s*/, 'root'),
-  // Keep closing braces highlighted inside nested objects without changing state.
-  [/\}/, { token: 'paren.rparen' }],
+  // Keep closing braces highlighted without changing state.
+  // We no longer transition to root here; instead, console_editor.ts
+  // injects method matching into json_root so the next request is recognized.
+  [/}/, { token: 'paren.rparen' }],
   // Don't push for opening braces to prevent stack overflow
   [/{/, { token: 'paren.lparen' }],
   // @ts-expect-error include comments into json


### PR DESCRIPTION
Closes #256864

## Summary

- Fixes a regression introduced in #255426 where subsequent HTTP requests lose their syntax highlighting if the preceding request's JSON body is indented.

## Root Cause

- Because of a previous stack overflow bug (#238531), Console's JSON lexer cannot use Monarch's `@push` and `@pop` states to track brace nesting depth. The state machine is flat.
- In #255426, we tried to fix a bug with deeply nested JSON by restricting the end-of-body detection to only match closing braces at column 0 (`/^}\s*/`).
- This heuristic fails when a user indents their entire request body. Because the final `}` is indented, the lexer never exits the `json_root` state.
- Consequently, the next HTTP request is parsed as if it were still inside the JSON body, causing it to lose its highlighting.

## Fix

- Instead of trying to guess when the JSON body ends using fragile regex heuristics, we use a more robust "resynchronization" pattern.
- Removed the `}` -> `root` transition entirely from `shared.ts`. The lexer now stays safely inside `json_root` regardless of indentation or nesting.
- Injected the HTTP method recognition rules (`GET`, `POST`, `PUT`, etc.) directly into the `json_root` state in `console_editor.ts`.
- The lexer now stays in `json_root` (preserving all rich JSON highlighting for deeply nested objects) until it sees undeniable proof of a new request (an HTTP method or a `#!` warning comment) at the start of a line, at which point it breaks out and starts parsing the new request.

## Before/After Screenshots (or Video)

### Before
<img width="895" alt="bug" src="https://github.com/user-attachments/assets/651a2912-edc3-42fc-b53b-d0b46bd4c723" />

### After
<img width="812" height="1041" alt="image" src="https://github.com/user-attachments/assets/ad5869c7-76ff-403e-bd79-e535f622c854" />

## Test Plan

- Added unit tests to `shared.test.ts` to verify that intermediate closing braces do not break highlighting.
- Added unit tests to verify that indented top-level closing braces correctly transition to the next request.
- Verified manually using Playwright that deeply nested JSON (like `aggregations` and `_meta`) retains its highlighting.
- Verified that all previous fixes (#255426, #255649, #256286) remain intact.
- Verified that `console_output.ts` correctly handles status codes because it relies on `#` comments which are still included in `json_root`.

## Release Note

- Fixes a bug where subsequent requests in the Dev Tools Console would lose syntax highlighting if the preceding request's body was indented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced console editor syntax highlighting for improved recognition of HTTP requests and warning comments across different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->