### PR TITLE
[8.19] Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183)

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -1,4 +1,21 @@
 steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_ai_assistant.sh
+    label: 'Serverless AI Assistant - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
     agents:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -10,7 +10,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 14
+    parallelism: 16
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -1,4 +1,38 @@
 steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine.sh
+    label: 'Serverless Detection Engine - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_detection_engine_exceptions.sh
+    label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 3
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
@@ -8,7 +42,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 5
+    parallelism: 7
     retry:
       automatic:
         - exit_status: '-1'
@@ -25,7 +59,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 3
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -1,4 +1,21 @@
 steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
+    label: 'Serverless Entity Analytics - Security Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
     agents:

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -8,7 +8,24 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 3
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
+    label: 'Serverless Explore - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 4
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -8,7 +8,24 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 12
+    parallelism: 9
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
+    label: 'Serverless Investigations - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 14
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -8,7 +8,24 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 8
+    parallelism: 7
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
+    label: 'Osquery Cypress Tests on Serverless'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 5
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -1,4 +1,89 @@
 steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management.sh
+    label: 'Serverless Rule Management - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 8
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_customization.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_installation.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_management.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_rule_management_prebuilt_rules_upgrade.sh
+    label: 'Serverless Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+        - exit_status: '*'
+          limit: 1
+
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
     agents:
@@ -8,7 +93,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 4
+    parallelism: 6
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scripts/steps/functional/security_solution_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_explore.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/steps/functional/common.sh
 
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+export CYPRESS_SHARE_STACKS=true
 
 echo "--- Explore Cypress Tests on Security Solution"
 

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/steps/functional/common.sh
 
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+export CYPRESS_SHARE_STACKS=true
 
 echo "--- Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests"
 

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/steps/functional/common.sh
 
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+export CYPRESS_SHARE_STACKS=true
 
 echo "--- Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests"
 

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/steps/functional/common.sh
 
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+export CYPRESS_SHARE_STACKS=true
 
 echo "--- Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests"
 

--- a/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/steps/functional/common.sh
 
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+export CYPRESS_SHARE_STACKS=true
 
 echo "--- Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests"
 

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/saved_queries.cy.ts
@@ -43,7 +43,8 @@ import {
 import { ServerlessRoleName } from '../../support/roles';
 import { getAdvancedButton } from '../../screens/integrations';
 
-describe('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
+// FLAKY: https://github.com/elastic/kibana/issues/249946
+describe.skip('ALL - Saved queries', { tags: ['@ess', '@serverless'] }, () => {
   let caseId: string;
 
   before(() => {

--- a/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/lib.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/junit_transformer/lib.ts
@@ -215,7 +215,7 @@ ${boilerplate}
     if ('error' in maybeValidationResult) {
       logError(maybeValidationResult.error);
       // Sending broken XML to Failed Test Reporter will cause a job to fail
-      await del(path);
+      await del(path, { force: true });
       log.warning(`${path} file was deleted.`);
       // If there is an error, continue trying to process other files.
       continue;
@@ -228,7 +228,7 @@ ${boilerplate}
       log.warning(`${path} had no test cases.
 ${boilerplate}
 `);
-      await del(path);
+      await del(path, { force: true });
       log.warning(`${path} file was deleted.`);
       // If there is an error, continue trying to process other files.
       continue;
@@ -247,7 +247,7 @@ ${boilerplate}
     if ('error' in maybeSpecFilePath) {
       logError(maybeSpecFilePath.error);
       // Sending broken XML to Failed Test Reporter will cause a job to fail
-      await del(path);
+      await del(path, { force: true });
       log.warning(`${path} file was deleted.`);
       // If there is an error, continue trying to process other files.
       continue;

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/buildkite_checkpoint.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/buildkite_checkpoint.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { execFile as _execFile } from 'child_process';
+import { createHash } from 'crypto';
+import path from 'path';
+
+function execBuildkiteAgent(args: string[]): Promise<{ stdout: string }> {
+  return new Promise((resolve, reject) => {
+    _execFile('buildkite-agent', args, (error, stdout) => {
+      if (error) reject(error);
+      else resolve({ stdout });
+    });
+  });
+}
+
+export function isInBuildkite(): boolean {
+  return Boolean(process.env.BUILDKITE);
+}
+
+const KIBANA_DIR_MARKER = `${path.sep}kibana${path.sep}`;
+
+/**
+ * Strips the agent-specific workspace prefix from absolute spec paths so that
+ * the same spec file produces the same checkpoint key regardless of which
+ * Buildkite agent runs the job. On retry the job may land on a different agent
+ * whose workspace path differs (e.g. bk-agent-prod-gcp-<ID>).
+ */
+export const normalizeSpecPath = (specPath: string): string => {
+  const idx = specPath.indexOf(KIBANA_DIR_MARKER);
+  if (idx !== -1) {
+    return specPath.substring(idx + KIBANA_DIR_MARKER.length);
+  }
+  return specPath;
+};
+
+/**
+ * Builds a deterministic checkpoint key for a given spec file path.
+ * Scoped to the Buildkite step and parallel job so checkpoints don't collide
+ * across different CI workers or pipeline steps.
+ */
+export const getCheckpointKey = (specPath: string): string => {
+  const stepId = process.env.BUILDKITE_STEP_ID || '';
+  const job = process.env.BUILDKITE_PARALLEL_JOB || '0';
+  const normalized = normalizeSpecPath(specPath);
+  const hash = createHash('sha256').update(normalized).digest('hex').substring(0, 12);
+  return `cy_ckpt_${stepId}_${job}_${hash}`;
+};
+
+export async function markSpecCompleted(specPath: string): Promise<void> {
+  try {
+    await execBuildkiteAgent(['meta-data', 'set', getCheckpointKey(specPath), 'done']);
+  } catch {
+    // Best-effort: ignore errors writing checkpoint
+  }
+}
+
+export async function isSpecCompleted(specPath: string): Promise<boolean> {
+  try {
+    const { stdout } = await execBuildkiteAgent([
+      'meta-data',
+      'get',
+      getCheckpointKey(specPath),
+      '--default',
+      '',
+    ]);
+    return stdout.trim() === 'done';
+  } catch {
+    return false;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/lb_config_registry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/lb_config_registry.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LoadBalancerConfig } from './utils';
+import { SECURITY_SOLUTION_LOAD_BALANCER_CONFIG } from './security_solution_config';
+
+/**
+ * Registry that maps Buildkite JOB names to their LoadBalancerConfig.
+ * Each Cypress suite shell script sets `export JOB=<name>`, which this
+ * registry uses to select the right config at runtime.
+ *
+ * Suites without a registered config fall back to the generic weight-based
+ * sort (counting `it()` calls) with no dynamic runner detection.
+ */
+const CONFIG_REGISTRY: Record<string, LoadBalancerConfig> = {
+  'kibana-security-solution-chrome': SECURITY_SOLUTION_LOAD_BALANCER_CONFIG,
+};
+
+/**
+ * Resolve the LoadBalancerConfig for the current CI job.
+ * Returns undefined when no suite-specific config is registered,
+ * causing the runner to fall back to generic weight-based ordering.
+ */
+export const resolveLoadBalancerConfig = (): LoadBalancerConfig | undefined => {
+  const job = process.env.JOB;
+  if (!job) return undefined;
+
+  return CONFIG_REGISTRY[job];
+};

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -32,8 +32,47 @@ import { createKbnClient } from '../endpoint/common/stack_services';
 import type { StartedFleetServer } from '../endpoint/common/fleet_server/fleet_server_services';
 import { startFleetServer } from '../endpoint/common/fleet_server/fleet_server_services';
 import { renderSummaryTable } from './print_run';
-import { parseTestFileConfig, retrieveIntegrations, setDefaultToolingLoggingLevel } from './utils';
+import {
+  groupSpecsByFtrConfig,
+  orderSpecFilesForLoadBalance,
+  parseTestFileConfig,
+  retrieveIntegrations,
+  retrieveIntegrationsConfigAware,
+  setDefaultToolingLoggingLevel,
+} from './utils';
+import type { LoadBalancerConfig, SpecGroup } from './utils';
 import { getFTRConfig } from './get_ftr_config';
+import { resolveLoadBalancerConfig } from './lb_config_registry';
+import { isInBuildkite, isSpecCompleted, markSpecCompleted } from './buildkite_checkpoint';
+
+const filterCompletedSpecs = async (
+  specFiles: string[],
+  logger: { info: (...args: unknown[]) => void }
+): Promise<{ remaining: string[]; skippedCount: number }> => {
+  const completionStatus = await Promise.all(
+    specFiles.map(async (filePath) => {
+      const completed = await isSpecCompleted(filePath);
+      logger.info(`[cypress-checkpoint]   ${completed ? 'SKIP' : 'RUN '} ${filePath}`);
+      return { filePath, completed };
+    })
+  );
+
+  const skipped = completionStatus.filter((s) => s.completed);
+  const remaining = completionStatus.filter((s) => !s.completed).map((s) => s.filePath);
+
+  if (skipped.length > 0) {
+    logger.info(
+      `[cypress-checkpoint] Resumed: skipped ${skipped.length} already-completed, ` +
+        `${remaining.length} remaining`
+    );
+  } else {
+    logger.info(
+      `[cypress-checkpoint] No prior checkpoints found, running all ${remaining.length} specs`
+    );
+  }
+
+  return { remaining, skippedCount: skipped.length };
+};
 
 export const cli = () => {
   run(
@@ -54,6 +93,8 @@ export const cli = () => {
         )
         .boolean('inspect');
 
+      const USE_CHROME_BETA = process.env.USE_CHROME_BETA?.match(/(1|true)/i);
+
       _cliLogger.info(`
 ----------------------------------------------
 Script arguments:
@@ -68,8 +109,6 @@ ${JSON.stringify(argv, null, 2)}
       const cypressConfigFilePath = require.resolve(`../../../../${argv.configFile}`) as string;
       const cypressConfigFile = await import(cypressConfigFilePath);
 
-      // Adjust tooling log level based on the `TOOLING_LOG_LEVEL` property, which can be
-      // defined in the cypress config file or set in the `env`
       setDefaultToolingLoggingLevel(cypressConfigFile?.env?.TOOLING_LOG_LEVEL);
 
       const log = prefixedOutputLogger('cy.parallel()', createToolingLogger());
@@ -94,8 +133,6 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
       log.info('Arguments spec pattern:', specArg);
       log.info('Resulting spec pattern:', specPattern);
 
-      // The grep function will filter Cypress specs by tags: it will include and exclude
-      // spec files according to the tags configuration.
       const grepSpecPattern = grep({
         ...cypressConfigFile,
         specPattern,
@@ -108,13 +145,6 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
       const isGrepReturnedSpecPattern = !isGrepReturnedFilePaths && grepSpecPattern === specPattern;
       const grepFilterSpecs = cypressConfigFile.env?.grepFilterSpecs;
 
-      // IMPORTANT!
-      // When grep returns the same spec pattern as it gets in its arguments, we treat it as
-      // it couldn't find any concrete specs to execute (maybe because all of them are skipped).
-      // In this case, we do an early return - it's important to do that.
-      // If we don't return early, these specs will start executing, and Cypress will be skipping
-      // tests at runtime: those that should be excluded according to the tags passed in the config.
-      // This can take so much time that the job can fail by timeout in CI.
       if (grepFilterSpecs && isGrepReturnedSpecPattern) {
         log.info('No tests found - all tests could have been skipped via Cypress tags');
         // eslint-disable-next-line no-process-exit
@@ -122,7 +152,7 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
       }
 
       const concreteFilePaths = isGrepReturnedFilePaths
-        ? grepSpecPattern // use the returned concrete file paths
+        ? grepSpecPattern
         : globby.sync(
             specPattern,
             excludeSpecPattern
@@ -130,9 +160,18 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
                   ignore: excludeSpecPattern,
                 }
               : undefined
-          ); // convert the glob pattern to concrete file paths
+          );
 
-      let files = retrieveIntegrations(concreteFilePaths);
+      const shareStacks = process.env.CYPRESS_SHARE_STACKS === 'true';
+      const lbConfig: LoadBalancerConfig | undefined = resolveLoadBalancerConfig();
+
+      let files: string[];
+      if (shareStacks && lbConfig) {
+        files = retrieveIntegrationsConfigAware(concreteFilePaths, lbConfig);
+      } else {
+        const orderedFilePaths = orderSpecFilesForLoadBalance(concreteFilePaths, lbConfig);
+        files = retrieveIntegrations(orderedFilePaths, lbConfig);
+      }
 
       log.info('Resolved spec files after retrieveIntegrations:', files);
 
@@ -145,9 +184,23 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
           return acc;
         }, [] as string[]);
 
-        // to avoid running too many tests, we limit the number of files to 3
-        // we may extend this in the future
         files = files.slice(0, 3);
+      }
+
+      let checkpointSkippedCount = 0;
+
+      if (!isOpen && isInBuildkite()) {
+        log.info(
+          `[cypress-checkpoint] Checking ${files.length} specs for prior completion ` +
+            `(step=${process.env.BUILDKITE_STEP_ID || ''}, ` +
+            `job=${process.env.BUILDKITE_PARALLEL_JOB || '0'}, ` +
+            `retry=${process.env.BUILDKITE_RETRY_COUNT || '0'})`
+        );
+
+        await filterCompletedSpecs(files, log).then((checkpoint) => {
+          files = checkpoint.remaining;
+          checkpointSkippedCount = checkpoint.skippedCount;
+        });
       }
 
       if (!files?.length) {
@@ -214,84 +267,121 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
       };
 
       const failedSpecFilePaths: string[] = [];
+      const infraFailedSpecFilePaths: string[] = [];
 
-      const runSpecs = async (filePaths: string[]) =>
-        pMap<
-          string,
+      const isTestAssertionFailure = (
+        runResult:
           | CypressCommandLine.CypressRunResult
           | CypressCommandLine.CypressFailedRunResult
           | undefined
-        >(
-          filePaths,
-          async (filePath) => {
-            let result:
-              | CypressCommandLine.CypressRunResult
-              | CypressCommandLine.CypressFailedRunResult
-              | undefined;
-            failedSpecFilePaths.push(filePath);
+      ): boolean => {
+        if (!runResult) return false;
+        const asRunResult = runResult as CypressCommandLine.CypressRunResult;
+        return Boolean(asRunResult.totalFailed && asRunResult.totalFailed > 0 && asRunResult.runs);
+      };
 
-            await withProcRunner<
-              | CypressCommandLine.CypressRunResult
-              | CypressCommandLine.CypressFailedRunResult
-              | undefined
-            >(log, async (procs) => {
-              const abortCtrl = new AbortController();
+      const runSpecGroups = async (
+        specGroups: SpecGroup[],
+        isRetryRun: boolean = false
+      ): Promise<
+        Array<
+          | CypressCommandLine.CypressRunResult
+          | CypressCommandLine.CypressFailedRunResult
+          | undefined
+        >
+      > => {
+        const allResults: Array<
+          | CypressCommandLine.CypressRunResult
+          | CypressCommandLine.CypressFailedRunResult
+          | undefined
+        > = [];
 
-              const onEarlyExit = (msg: string) => {
-                log.error(msg);
-                abortCtrl.abort();
-              };
+        for (const group of specGroups) {
+          const groupResults = await runSpecGroup(group, isRetryRun);
+          allResults.push(...groupResults);
+        }
 
-              const esPort: number = getEsPort();
-              const kibanaPort: number = getKibanaPort();
-              const fleetServerPort: number = getFleetServerPort();
-              const specFileFTRConfig = parseTestFileConfig(filePath);
-              const ftrConfigFilePath = path.resolve(
-                _.isArray(argv.ftrConfigFile) ? _.last(argv.ftrConfigFile) : argv.ftrConfigFile
-              );
+        return allResults;
+      };
 
-              const config = await getFTRConfig({
-                log,
-                esPort,
-                kibanaPort,
-                fleetServerPort,
-                ftrConfigFilePath,
-                specFilePath: filePath,
-                specFileFTRConfig,
-                isOpen,
-              });
+      const runSpecGroup = async (
+        group: SpecGroup,
+        isRetryRun: boolean
+      ): Promise<
+        Array<
+          | CypressCommandLine.CypressRunResult
+          | CypressCommandLine.CypressFailedRunResult
+          | undefined
+        >
+      > => {
+        const results: Array<
+          | CypressCommandLine.CypressRunResult
+          | CypressCommandLine.CypressFailedRunResult
+          | undefined
+        > = [];
 
-              const createUrlFromFtrConfig = (
-                type: 'elasticsearch' | 'kibana' | 'fleetserver',
-                withAuth: boolean = false
-              ): string => {
-                const getKeyPath = (keyPath: string = ''): string => {
-                  return `servers.${type}${keyPath ? `.${keyPath}` : ''}`;
-                };
+        const esPort: number = getEsPort();
+        const kibanaPort: number = getKibanaPort();
+        const fleetServerPort: number = getFleetServerPort();
 
-                if (!config.get(getKeyPath())) {
-                  throw new Error(`Unable to create URL for ${type}. Not found in FTR config at `);
-                }
+        const firstFilePath = group.specFilePaths[0];
+        const specFileFTRConfig = group.ftrConfig;
+        const ftrConfigFilePath = path.resolve(
+          _.isArray(argv.ftrConfigFile) ? _.last(argv.ftrConfigFile) : argv.ftrConfigFile
+        );
 
-                const url = new URL('http://localhost');
+        await withProcRunner(log, async (procs) => {
+          const abortCtrl = new AbortController();
 
-                url.port = config.get(getKeyPath('port'));
-                url.protocol = config.get(getKeyPath('protocol'));
-                url.hostname = config.get(getKeyPath('hostname'));
+          const onEarlyExit = (msg: string) => {
+            log.error(msg);
+            abortCtrl.abort();
+          };
 
-                if (withAuth) {
-                  url.username = config.get(getKeyPath('username'));
-                  url.password = config.get(getKeyPath('password'));
-                }
+          const config = await getFTRConfig({
+            log,
+            esPort,
+            kibanaPort,
+            fleetServerPort,
+            ftrConfigFilePath,
+            specFilePath: firstFilePath,
+            specFileFTRConfig,
+            isOpen,
+          });
 
-                return url.toString().replace(/\/$/, '');
-              };
+          const createUrlFromFtrConfig = (
+            type: 'elasticsearch' | 'kibana' | 'fleetserver',
+            withAuth: boolean = false
+          ): string => {
+            const getKeyPath = (keyPath: string = ''): string => {
+              return `servers.${type}${keyPath ? `.${keyPath}` : ''}`;
+            };
 
-              const baseUrl = createUrlFromFtrConfig('kibana');
+            if (!config.get(getKeyPath())) {
+              throw new Error(`Unable to create URL for ${type}. Not found in FTR config at `);
+            }
 
-              log.info(`
+            const url = new URL('http://localhost');
+
+            url.port = config.get(getKeyPath('port'));
+            url.protocol = config.get(getKeyPath('protocol'));
+            url.hostname = config.get(getKeyPath('hostname'));
+
+            if (withAuth) {
+              url.username = config.get(getKeyPath('username'));
+              url.password = config.get(getKeyPath('password'));
+            }
+
+            return url.toString().replace(/\/$/, '');
+          };
+
+          const baseUrl = createUrlFromFtrConfig('kibana');
+
+          log.info(`
 ----------------------------------------------
-Cypress FTR setup for file: ${filePath}:
+Cypress FTR setup for config group (${group.specFilePaths.length} spec(s)):
+  Config key: ${group.configKey}
+  Specs: ${group.specFilePaths.map((f) => path.basename(f)).join(', ')}
 ----------------------------------------------
 
 ${JSON.stringify(
@@ -309,123 +399,123 @@ ${JSON.stringify(
 ----------------------------------------------
 `);
 
-              const lifecycle = new Lifecycle(log);
+          const lifecycle = new Lifecycle(log);
 
-              const providers = new ProviderCollection(log, [
-                ...readProviderSpec('Service', {
-                  lifecycle: () => lifecycle,
-                  log: () => log,
-                  config: () => config,
-                }),
-                ...readProviderSpec('Service', config.get('services')),
-              ]);
+          const providers = new ProviderCollection(log, [
+            ...readProviderSpec('Service', {
+              lifecycle: () => lifecycle,
+              log: () => log,
+              config: () => config,
+            }),
+            ...readProviderSpec('Service', config.get('services')),
+          ]);
 
-              const options = {
-                installDir: process.env.KIBANA_INSTALL_DIR,
-                ci: process.env.CI,
-              };
+          const options = {
+            installDir: process.env.KIBANA_INSTALL_DIR,
+            ci: process.env.CI,
+          };
 
-              // Setup fleet if Cypress config requires it
-              let fleetServer: StartedFleetServer | undefined;
-              let shutdownEs;
+          let fleetServer: StartedFleetServer | undefined;
+          let shutdownEs;
 
-              try {
-                shutdownEs = await pRetry(
-                  async () =>
-                    runElasticsearch({
-                      config,
-                      log,
-                      name: `ftr-${esPort}`,
-                      esFrom: config.get('esTestCluster')?.from || 'snapshot',
-                      onEarlyExit,
-                    }),
-                  { retries: 2, forever: false }
-                );
+          const esFromEnv = process.env.CYPRESS_ES_FROM;
+          const configEsFrom = config.get('esTestCluster.from');
+          const esFrom = esFromEnv || (configEsFrom === 'serverless' ? 'serverless' : 'snapshot');
 
-                await runKibanaServer({
-                  procs,
+          try {
+            shutdownEs = await pRetry(
+              async () =>
+                runElasticsearch({
                   config,
-                  installDir: options?.installDir,
-                  extraKbnOpts:
-                    options?.installDir || options?.ci || !isOpen
-                      ? []
-                      : ['--dev', '--no-dev-config', '--no-dev-credentials'],
-                  onEarlyExit,
-                  inspect: argv.inspect,
-                });
-
-                if (cypressConfigFile.env?.WITH_FLEET_SERVER) {
-                  log.info(`Setting up fleet-server for this Cypress config`);
-
-                  const kbnClient = createKbnClient({
-                    url: baseUrl,
-                    username: config.get('servers.kibana.username'),
-                    password: config.get('servers.kibana.password'),
-                    log,
-                  });
-
-                  fleetServer = await pRetry(
-                    async () =>
-                      startFleetServer({
-                        kbnClient,
-                        logger: log,
-                        port:
-                          fleetServerPort ?? config.has('servers.fleetserver.port')
-                            ? (config.get('servers.fleetserver.port') as number)
-                            : undefined,
-                        // `force` is needed to ensure that any currently running fleet server (perhaps left
-                        // over from an interrupted run) is killed and a new one restarted
-                        force: true,
-                      }),
-                    { retries: 2, forever: false }
-                  );
-                }
-
-                await providers.loadAll();
-
-                const functionalTestRunner = new FunctionalTestRunner(
                   log,
-                  config,
-                  EsVersion.getDefault()
-                );
+                  name: `ftr-${esPort}`,
+                  esFrom,
+                  onEarlyExit,
+                }),
+              { retries: 2, forever: false }
+            );
 
-                const ftrEnv = await pRetry(() => functionalTestRunner.run(abortCtrl.signal), {
-                  retries: 1,
-                });
+            await runKibanaServer({
+              procs,
+              config,
+              installDir: options?.installDir,
+              extraKbnOpts:
+                options?.installDir || options?.ci || !isOpen
+                  ? []
+                  : ['--dev', '--no-dev-config', '--no-dev-credentials'],
+              onEarlyExit,
+              inspect: argv.inspect,
+            });
 
-                log.debug(
-                  `Env. variables returned by [functionalTestRunner.run()]:\n`,
-                  JSON.stringify(ftrEnv, null, 2)
-                );
+            if (cypressConfigFile.env?.WITH_FLEET_SERVER) {
+              log.info(`Setting up fleet-server for this Cypress config`);
 
-                // Normalized the set of available env vars in cypress
-                const cyCustomEnv = {
-                  ...ftrEnv,
+              const kbnClient = createKbnClient({
+                url: baseUrl,
+                username: config.get('servers.kibana.username'),
+                password: config.get('servers.kibana.password'),
+                log,
+              });
 
-                  // NOTE:
-                  // ELASTICSEARCH_URL needs to be created here with auth because SIEM cypress setup depends on it. At some
-                  // points we should probably try to refactor that code to use `ELASTICSEARCH_URL_WITH_AUTH` instead
-                  ELASTICSEARCH_URL:
-                    ftrEnv.ELASTICSEARCH_URL ?? createUrlFromFtrConfig('elasticsearch', true),
-                  ELASTICSEARCH_URL_WITH_AUTH: createUrlFromFtrConfig('elasticsearch', true),
-                  ELASTICSEARCH_USERNAME:
-                    ftrEnv.ELASTICSEARCH_USERNAME ?? config.get('servers.elasticsearch.username'),
-                  ELASTICSEARCH_PASSWORD:
-                    ftrEnv.ELASTICSEARCH_PASSWORD ?? config.get('servers.elasticsearch.password'),
+              fleetServer = await pRetry(
+                async () =>
+                  startFleetServer({
+                    kbnClient,
+                    logger: log,
+                    port:
+                      fleetServerPort ?? config.has('servers.fleetserver.port')
+                        ? (config.get('servers.fleetserver.port') as number)
+                        : undefined,
+                    force: true,
+                  }),
+                { retries: 2, forever: false }
+              );
+            }
 
-                  FLEET_SERVER_URL: createUrlFromFtrConfig('fleetserver'),
+            await providers.loadAll();
 
-                  KIBANA_URL: baseUrl,
-                  KIBANA_URL_WITH_AUTH: createUrlFromFtrConfig('kibana', true),
-                  KIBANA_USERNAME: config.get('servers.kibana.username'),
-                  KIBANA_PASSWORD: config.get('servers.kibana.password'),
+            const functionalTestRunner = new FunctionalTestRunner(
+              log,
+              config,
+              EsVersion.getDefault()
+            );
 
-                  IS_SERVERLESS: config.get('serverless'),
+            const ftrEnv = await pRetry(() => functionalTestRunner.run(abortCtrl.signal), {
+              retries: 1,
+            });
 
-                  ...argv.env,
-                };
+            log.debug(
+              `Env. variables returned by [functionalTestRunner.run()]:\n`,
+              JSON.stringify(ftrEnv, null, 2)
+            );
 
-                log.info(`
+            const cyCustomEnv = {
+              ...ftrEnv,
+
+              ELASTICSEARCH_URL:
+                ftrEnv.ELASTICSEARCH_URL ?? createUrlFromFtrConfig('elasticsearch', true),
+              ELASTICSEARCH_URL_WITH_AUTH: createUrlFromFtrConfig('elasticsearch', true),
+              ELASTICSEARCH_USERNAME:
+                ftrEnv.ELASTICSEARCH_USERNAME ?? config.get('servers.elasticsearch.username'),
+              ELASTICSEARCH_PASSWORD:
+                ftrEnv.ELASTICSEARCH_PASSWORD ?? config.get('servers.elasticsearch.password'),
+
+              FLEET_SERVER_URL: createUrlFromFtrConfig('fleetserver'),
+
+              KIBANA_URL: baseUrl,
+              KIBANA_URL_WITH_AUTH: createUrlFromFtrConfig('kibana', true),
+              KIBANA_USERNAME: config.get('servers.kibana.username'),
+              KIBANA_PASSWORD: config.get('servers.kibana.password'),
+
+              IS_SERVERLESS: config.get('serverless'),
+
+              ...argv.env,
+            };
+
+            for (const filePath of group.specFilePaths) {
+              failedSpecFilePaths.push(filePath);
+
+              log.info(`
 ----------------------------------------------
 Cypress run ENV for file: ${filePath}:
 ----------------------------------------------
@@ -435,107 +525,240 @@ ${JSON.stringify(cyCustomEnv, null, 2)}
 ----------------------------------------------
 `);
 
-                if (isOpen) {
-                  await cypress.open({
-                    configFile: cypressConfigFilePath,
-                    config: {
-                      e2e: {
-                        baseUrl,
-                      },
-                      env: cyCustomEnv,
+              const executeCypressRun = async (retryAttempt: boolean) => {
+                if (retryAttempt) {
+                  process.env.CYPRESS_RETRY_RUN = 'true';
+                }
+
+                return cypress.run({
+                  browser: USE_CHROME_BETA ? 'chrome:beta' : 'chrome',
+                  spec: filePath,
+                  configFile: cypressConfigFilePath,
+                  reporter: argv.reporter as string,
+                  reporterOptions: argv.reporterOptions,
+                  headed: argv.headed as boolean,
+                  config: {
+                    e2e: {
+                      baseUrl,
                     },
-                  });
-                } else {
-                  result = await cypress.run({
-                    browser: 'chrome',
-                    spec: filePath,
-                    configFile: cypressConfigFilePath,
-                    reporter: argv.reporter as string,
-                    reporterOptions: argv.reporterOptions,
-                    headed: argv.headed as boolean,
-                    config: {
-                      e2e: {
-                        baseUrl,
-                      },
-                      numTestsKeptInMemory: 0,
-                      env: cyCustomEnv,
+                    numTestsKeptInMemory: 0,
+                    video: retryAttempt,
+                    env: cyCustomEnv,
+                  },
+                  runnerUi: !process.env.CI,
+                });
+              };
+
+              if (isOpen) {
+                await cypress.open({
+                  configFile: cypressConfigFilePath,
+                  config: {
+                    e2e: {
+                      baseUrl,
                     },
-                    runnerUi: !process.env.CI,
-                  });
-                  if (!(result as CypressCommandLine.CypressRunResult)?.totalFailed) {
-                    _.pull(failedSpecFilePaths, filePath);
+                    env: cyCustomEnv,
+                  },
+                });
+              } else {
+                let runResult = await executeCypressRun(isRetryRun);
+
+                if (isTestAssertionFailure(runResult) && !isRetryRun) {
+                  log.info(
+                    `Test assertion failure detected for ${filePath}, retrying in-place against the same stack (with video enabled)...`
+                  );
+                  runResult = await executeCypressRun(true);
+                }
+
+                results.push(runResult);
+
+                if (!(runResult as CypressCommandLine.CypressRunResult)?.totalFailed) {
+                  _.pull(failedSpecFilePaths, filePath);
+                  if (!isOpen && isInBuildkite()) {
+                    markSpecCompleted(filePath).catch(() => {});
                   }
                 }
-              } catch (error) {
-                log.error(error);
               }
+            }
+          } catch (error) {
+            log.error(error);
 
-              if (fleetServer) {
-                await fleetServer.stop();
+            for (const filePath of group.specFilePaths) {
+              if (failedSpecFilePaths.includes(filePath)) {
+                infraFailedSpecFilePaths.push(filePath);
               }
+            }
 
-              await procs.stop('kibana');
-              await shutdownEs?.();
-              cleanupServerPorts({ esPort, kibanaPort, fleetServerPort });
-
-              return result;
+            results.push({
+              status: 'failed',
+              failures: 1,
+              message: error.message,
             });
-            return result;
-          },
-          {
-            concurrency: 1,
           }
-        );
 
-      const initialResults = await runSpecs(files);
-      // If there are failed tests, retry them
-      const retryResults = await runSpecs([...failedSpecFilePaths]);
+          if (fleetServer) {
+            await fleetServer.stop();
+          }
 
-      const finalResults = [
-        // Don't include failed specs from initial run in results
-        ..._.filter(
-          initialResults,
-          (initialResult: CypressCommandLine.CypressRunResult) =>
-            initialResult?.runs &&
-            _.some(
-              initialResult?.runs,
-              (runResult) => !failedSpecFilePaths.includes(runResult.spec.absolute)
-            )
-        ),
-        ..._.filter(retryResults, (retryResult) => !!retryResult),
-      ] as CypressCommandLine.CypressRunResult[];
+          await procs.stop('kibana');
+          await shutdownEs?.();
+          cleanupServerPorts({ esPort, kibanaPort, fleetServerPort });
+        });
 
-      try {
-        renderSummaryTable(finalResults);
-      } catch (e) {
-        log.error('Failed to render summary table');
-        log.error(e);
-      }
+        return results;
+      };
 
-      const hasFailedTests = (
-        runResults: Array<
-          | CypressCommandLine.CypressFailedRunResult
-          | CypressCommandLine.CypressRunResult
-          | undefined
-        >
-      ) =>
-        _.some(
-          // only fail the job if retry failed as well
-          runResults,
-          (runResult) =>
-            (runResult as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
-            (runResult as CypressCommandLine.CypressRunResult)?.totalFailed
-        );
+      if (shareStacks) {
+        const specGroups = groupSpecsByFtrConfig(files);
 
-      const hasFailedInitialTests = hasFailedTests(initialResults);
-      const hasFailedRetryTests = hasFailedTests(retryResults);
+        log.info(`
+----------------------------------------------
+Spec groups by FTR config (${specGroups.length} group(s), ${files.length} spec(s) total):
+----------------------------------------------
+${specGroups
+  .map(
+    (g, i) =>
+      `  Group ${i + 1} [${
+        g.configKey === '{"license":"","kbnServerArgs":[],"productTypes":[]}'
+          ? 'default'
+          : g.configKey
+      }]: ${g.specFilePaths.length} spec(s)\n${g.specFilePaths
+        .map((f) => `    - ${path.basename(f)}`)
+        .join('\n')}`
+  )
+  .join('\n')}
+----------------------------------------------
+`);
 
-      // If the initialResults had failures and failedSpecFilePaths was not populated properly return errors
-      if (
-        (hasFailedRetryTests && failedSpecFilePaths.length) ||
-        (hasFailedInitialTests && !retryResults.length)
-      ) {
-        throw createFailError('Not all tests passed');
+        const initialResults = await runSpecGroups(specGroups);
+
+        const specsNeedingInfraRetry = [...infraFailedSpecFilePaths];
+        const retryGroups = groupSpecsByFtrConfig(specsNeedingInfraRetry);
+        const retryResults = await runSpecGroups(retryGroups, true);
+
+        const finalResults = [
+          ..._.filter(
+            initialResults,
+            (initialResult: CypressCommandLine.CypressRunResult) =>
+              initialResult?.runs &&
+              _.some(
+                initialResult?.runs,
+                (runResult) => !failedSpecFilePaths.includes(runResult.spec.absolute)
+              )
+          ),
+          ..._.filter(retryResults, (retryResult) => !!retryResult),
+        ] as CypressCommandLine.CypressRunResult[];
+
+        try {
+          if (checkpointSkippedCount > 0) {
+            log.info(
+              `[cypress-checkpoint] ${checkpointSkippedCount} spec(s) were skipped ` +
+                `(completed on a previous attempt)`
+            );
+          }
+          renderSummaryTable(finalResults);
+        } catch (e) {
+          log.error('Failed to render summary table');
+          log.error(e);
+        }
+
+        const hasFailedTests = (
+          runResults: Array<
+            | CypressCommandLine.CypressFailedRunResult
+            | CypressCommandLine.CypressRunResult
+            | undefined
+          >
+        ) =>
+          _.some(
+            runResults,
+            (runResult) =>
+              (runResult as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+              (runResult as CypressCommandLine.CypressRunResult)?.totalFailed
+          );
+
+        const hasFailedInitialTests = hasFailedTests(initialResults);
+        const hasFailedRetryTests = hasFailedTests(retryResults);
+
+        if (
+          (hasFailedRetryTests && failedSpecFilePaths.length) ||
+          (hasFailedInitialTests && !retryResults.length)
+        ) {
+          throw createFailError('Not all tests passed');
+        }
+      } else {
+        const runSpecs = async (filePaths: string[], isRetryRun: boolean = false) =>
+          pMap<
+            string,
+            | CypressCommandLine.CypressRunResult
+            | CypressCommandLine.CypressFailedRunResult
+            | undefined
+          >(
+            filePaths,
+            async (filePath) => {
+              const group: SpecGroup = {
+                configKey: '',
+                ftrConfig: parseTestFileConfig(filePath),
+                specFilePaths: [filePath],
+              };
+              const groupResults = await runSpecGroup(group, isRetryRun);
+              return groupResults[0];
+            },
+            { concurrency: 1 }
+          );
+
+        const initialResults = await runSpecs(files);
+
+        const specsNeedingInfraRetry = [...infraFailedSpecFilePaths];
+        const retryResults = await runSpecs(specsNeedingInfraRetry, true);
+
+        const finalResults = [
+          ..._.filter(
+            initialResults,
+            (initialResult: CypressCommandLine.CypressRunResult) =>
+              initialResult?.runs &&
+              _.some(
+                initialResult?.runs,
+                (runResult) => !failedSpecFilePaths.includes(runResult.spec.absolute)
+              )
+          ),
+          ..._.filter(retryResults, (retryResult) => !!retryResult),
+        ] as CypressCommandLine.CypressRunResult[];
+
+        try {
+          if (checkpointSkippedCount > 0) {
+            log.info(
+              `[cypress-checkpoint] ${checkpointSkippedCount} spec(s) were skipped ` +
+                `(completed on a previous attempt)`
+            );
+          }
+          renderSummaryTable(finalResults);
+        } catch (e) {
+          log.error('Failed to render summary table');
+          log.error(e);
+        }
+
+        const hasFailedTests = (
+          runResults: Array<
+            | CypressCommandLine.CypressFailedRunResult
+            | CypressCommandLine.CypressRunResult
+            | undefined
+          >
+        ) =>
+          _.some(
+            runResults,
+            (runResult) =>
+              (runResult as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+              (runResult as CypressCommandLine.CypressRunResult)?.totalFailed
+          );
+
+        const hasFailedInitialTests = hasFailedTests(initialResults);
+        const hasFailedRetryTests = hasFailedTests(retryResults);
+
+        if (
+          (hasFailedRetryTests && failedSpecFilePaths.length) ||
+          (hasFailedInitialTests && !retryResults.length)
+        ) {
+          throw createFailError('Not all tests passed');
+        }
       }
     },
     {

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -30,10 +30,14 @@ import { createToolingLogger } from '../../common/endpoint/data_loaders/utils';
 import { renderSummaryTable } from './print_run';
 import {
   getOnBeforeHook,
+  orderSpecFilesForLoadBalance,
   parseTestFileConfig,
   retrieveIntegrations,
+  retrieveIntegrationsConfigAware,
   setDefaultToolingLoggingLevel,
 } from './utils';
+import type { LoadBalancerConfig } from './utils';
+import { resolveLoadBalancerConfig } from './lb_config_registry';
 import { prefixedOutputLogger } from '../endpoint/common/utils';
 
 import type { ProductType, Credentials, ProjectHandler } from './project_handler/project_handler';
@@ -420,7 +424,16 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
         ? grepSpecPattern // use the returned concrete file paths
         : globby.sync(specPattern); // convert the glob pattern to concrete file paths
 
-      const files = retrieveIntegrations(concreteFilePaths);
+      const shareStacks = process.env.CYPRESS_SHARE_STACKS === 'true';
+      const lbConfig: LoadBalancerConfig | undefined = resolveLoadBalancerConfig();
+
+      let files: string[];
+      if (shareStacks && lbConfig) {
+        files = retrieveIntegrationsConfigAware(concreteFilePaths, lbConfig);
+      } else {
+        const orderedFilePaths = orderSpecFilesForLoadBalance(concreteFilePaths, lbConfig);
+        files = retrieveIntegrations(orderedFilePaths, lbConfig);
+      }
 
       log.info('Resolved spec files after retrieveIntegrations:', files);
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/security_solution_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/security_solution_config.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LoadBalancerConfig } from './utils';
+
+/**
+ * Per-spec weight overrides for Security Solution (non-DW) Cypress specs where
+ * `it()` count doesn't reflect actual runtime. Patterns are matched against
+ * the full file path; the first match wins.
+ *
+ * Heavy specs that involve prebuilt rule installation, complex indicator match
+ * creation, or large navigation suites need runtime-calibrated weights.
+ */
+const SPEC_WEIGHT_OVERRIDES: LoadBalancerConfig['specWeightOverrides'] = [
+  // Navigation suite: 47 it() calls but mostly lightweight assertions (~8 min)
+  { pattern: 'navigation/navigation.cy.ts', weight: 25 },
+
+  // Prebuilt rules upgrade with preview: 29 tests, each with mock package install (~12 min)
+  { pattern: 'upgrade_with_preview.cy.ts', weight: 35 },
+  { pattern: 'upgrade_without_preview.cy.ts', weight: 20 },
+  { pattern: 'upgrade_notifications.cy.ts', weight: 20 },
+
+  // Indicator match: 29 it() but many are skipped via nested describe.skip (~5 min active)
+  { pattern: 'indicator_match_rule.cy.ts', weight: 15 },
+
+  // Large alert tables and bulk actions
+  { pattern: 'bulk_edit_rules.cy.ts', weight: 18 },
+  { pattern: 'rule_customization.cy.ts', weight: 18 },
+  { pattern: 'unsaved_timeline.cy.ts', weight: 12 },
+
+  // Overview tab has many assertions but shares a single alert setup (~6 min)
+  { pattern: 'alert_details_right_panel_overview_tab.cy.ts', weight: 10 },
+
+  // Detection response dashboard: 13 tests with complex data setup (~8 min)
+  { pattern: 'detection_response.cy.ts', weight: 14 },
+
+  // Privileges specs: role switching takes extra time
+  { pattern: 'detection_alerts/privileges.cy.ts', weight: 10 },
+  { pattern: 'rule_details/privileges.cy.ts', weight: 10 },
+
+  // Value lists: 13 tests with file upload operations (~7 min)
+  { pattern: 'value_lists/value_lists.cy.ts', weight: 12 },
+
+  // URL state: 14 tests, many page navigations (~7 min)
+  { pattern: 'urls/state.cy.ts', weight: 12 },
+
+  // Install error handling / table: many mock operations
+  { pattern: 'install_error_handling.cy.ts', weight: 10 },
+  { pattern: 'install_with_preview.cy.ts', weight: 10 },
+  { pattern: 'install_table.cy.ts', weight: 10 },
+];
+
+const SETUP_COST_WEIGHT = 20;
+const PER_SPEC_OVERHEAD = 3;
+const MIN_SPEC_WEIGHT = 3;
+
+export const SECURITY_SOLUTION_LOAD_BALANCER_CONFIG: LoadBalancerConfig = {
+  dynamicRunnerWeights: {},
+  filteredRunnerWeights: {},
+  setupCostWeight: SETUP_COST_WEIGHT,
+  perSpecOverhead: PER_SPEC_OVERHEAD,
+  minSpecWeight: MIN_SPEC_WEIGHT,
+  specWeightOverrides: SPEC_WEIGHT_OVERRIDES,
+};

--- a/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/run_cypress/utils.ts
@@ -16,20 +16,108 @@ import type { ToolingLogTextWriterConfig } from '@kbn/tooling-log';
 import { createToolingLogger } from '../../common/endpoint/data_loaders/utils';
 
 /**
+ * Configuration for the config-aware load balancer.
+ * Suite-specific values (e.g. Defend Workflows) live in separate config files
+ * so that utils.ts stays generic and reusable by other Cypress suites.
+ */
+export interface LoadBalancerConfig {
+  /** Maps dynamic runner function names to their approximate test counts. */
+  dynamicRunnerWeights: Record<string, number>;
+  /** Reduced weights when a spec filters by a single SIEM version. */
+  filteredRunnerWeights: Record<string, number>;
+  /** Weight penalty for each distinct ftrConfig on an agent (~stack setup cost). */
+  setupCostWeight: number;
+  /** Per-spec overhead in weight units (Cypress boot, browser init). */
+  perSpecOverhead: number;
+  /** Minimum weight floor for any spec file. */
+  minSpecWeight: number;
+  /**
+   * Override weights for specs where test count doesn't reflect actual runtime.
+   * Keys are path fragments matched against the full file path (e.g. `tamper_protection/`
+   * or `endpoint_operations.cy.ts`). The first matching entry wins.
+   */
+  specWeightOverrides?: Array<{ pattern: string; weight: number }>;
+}
+
+const DEFAULT_MIN_SPEC_WEIGHT = 1;
+
+/**
+ * Estimate spec file weight for load-balanced ordering across parallel CI agents.
+ * When a LoadBalancerConfig is provided, dynamic runner weights and minimum floor
+ * are applied. Without config, falls back to counting inline `it()` calls only.
+ */
+const getSpecFileWeight = (filePath: string, lbConfig?: LoadBalancerConfig): number => {
+  const minWeight = lbConfig?.minSpecWeight ?? DEFAULT_MIN_SPEC_WEIGHT;
+
+  if (lbConfig?.specWeightOverrides) {
+    const override = lbConfig.specWeightOverrides.find(({ pattern }) => filePath.includes(pattern));
+    if (override) {
+      return Math.max(override.weight, minWeight);
+    }
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, { encoding: 'utf8' });
+    const itMatches = content.match(/\bit\s*\(/g);
+    const itSkipMatches = content.match(/\bit\.skip\s*\(/g);
+    let testCount = (itMatches?.length ?? 0) + (itSkipMatches?.length ?? 0);
+
+    if (lbConfig) {
+      const hasSiemVersionFilter = content.includes('siemVersionFilter');
+
+      for (const [runner, weight] of Object.entries(lbConfig.dynamicRunnerWeights)) {
+        const callPattern = `${runner}(`;
+        const occurrences = content.split(callPattern).length - 1;
+        if (occurrences > 0) {
+          const effectiveWeight =
+            hasSiemVersionFilter && runner in lbConfig.filteredRunnerWeights
+              ? lbConfig.filteredRunnerWeights[runner]
+              : weight;
+          testCount += occurrences * effectiveWeight;
+        }
+      }
+    }
+
+    return Math.max(testCount, minWeight);
+  } catch {
+    return minWeight;
+  }
+};
+
+/**
+ * Order spec file paths for load-balanced distribution across parallel CI jobs.
+ * Sorts by estimated weight (test count) descending, with path as tiebreaker, so that
+ * round-robin in retrieveIntegrations() assigns each agent a similar mix of heavy and light specs.
+ */
+export const orderSpecFilesForLoadBalance = (
+  filePaths: string[],
+  lbConfig?: LoadBalancerConfig
+): string[] => {
+  if (filePaths.length <= 1) return filePaths;
+  const withWeight = filePaths.map((p) => ({ path: p, weight: getSpecFileWeight(p, lbConfig) }));
+  withWeight.sort((a, b) => {
+    if (b.weight !== a.weight) return b.weight - a.weight;
+    return a.path.localeCompare(b.path);
+  });
+  return withWeight.map(({ path }) => path);
+};
+
+/**
  * Retrieve test files using a glob pattern.
  * If process.env.RUN_ALL_TESTS is true, returns all matching files, otherwise, return files that should be run by this job based on process.env.BUILDKITE_PARALLEL_JOB_COUNT and process.env.BUILDKITE_PARALLEL_JOB
  */
-export const retrieveIntegrations = (integrationsPaths: string[]) => {
-  const nonSkippedSpecs = integrationsPaths.filter((filePath) => !isSkipped(filePath));
+export const retrieveIntegrations = (
+  integrationsPaths: string[],
+  lbConfig?: LoadBalancerConfig
+) => {
+  const nonSkippedSpecs = integrationsPaths.filter((filePath) => !isSkipped(filePath, lbConfig));
 
   if (process.env.RUN_ALL_TESTS === 'true') {
     return nonSkippedSpecs;
   } else {
-    // The number of instances of this job were created
     const chunksTotal: number = process.env.BUILDKITE_PARALLEL_JOB_COUNT
       ? parseInt(process.env.BUILDKITE_PARALLEL_JOB_COUNT, 10)
       : 1;
-    // An index which uniquely identifies this instance of the job
     const chunkIndex: number = process.env.BUILDKITE_PARALLEL_JOB
       ? parseInt(process.env.BUILDKITE_PARALLEL_JOB, 10)
       : 0;
@@ -44,7 +132,84 @@ export const retrieveIntegrations = (integrationsPaths: string[]) => {
   }
 };
 
-export const isSkipped = (filePath: string): boolean => {
+/**
+ * Config-aware spec distribution for parallel CI agents.
+ * Instead of naive round-robin, this uses greedy bin-packing that accounts for
+ * ftrConfig setup cost: assigning a spec to an agent that already has its config
+ * avoids an extra ~4 min stack setup. This keeps specs with the same ftrConfig
+ * together on the same agents whenever possible, dramatically reducing total
+ * setup time when CYPRESS_SHARE_STACKS is enabled.
+ */
+export const retrieveIntegrationsConfigAware = (
+  integrationsPaths: string[],
+  lbConfig: LoadBalancerConfig
+): string[] => {
+  const nonSkippedSpecs = integrationsPaths.filter((filePath) => !isSkipped(filePath, lbConfig));
+
+  if (process.env.RUN_ALL_TESTS === 'true') {
+    return nonSkippedSpecs;
+  }
+
+  const chunksTotal: number = process.env.BUILDKITE_PARALLEL_JOB_COUNT
+    ? parseInt(process.env.BUILDKITE_PARALLEL_JOB_COUNT, 10)
+    : 1;
+  const chunkIndex: number = process.env.BUILDKITE_PARALLEL_JOB
+    ? parseInt(process.env.BUILDKITE_PARALLEL_JOB, 10)
+    : 0;
+
+  if (chunksTotal <= 1) {
+    return nonSkippedSpecs;
+  }
+
+  const specs = nonSkippedSpecs.map((filePath) => ({
+    path: filePath,
+    weight: getSpecFileWeight(filePath, lbConfig),
+    configKey: ftrConfigToKey(parseTestFileConfig(filePath)),
+  }));
+
+  specs.sort((a, b) => b.weight - a.weight || a.path.localeCompare(b.path));
+
+  const agents: Array<{
+    paths: string[];
+    totalWeight: number;
+    configs: Set<string>;
+  }> = Array.from({ length: chunksTotal }, () => ({
+    paths: [],
+    totalWeight: 0,
+    configs: new Set<string>(),
+  }));
+
+  const getAgentCost = (agent: (typeof agents)[number], specConfigKey: string): number => {
+    const newConfigPenalty = agent.configs.has(specConfigKey) ? 0 : lbConfig.setupCostWeight;
+    return (
+      agent.totalWeight +
+      agent.paths.length * lbConfig.perSpecOverhead +
+      agent.configs.size * lbConfig.setupCostWeight +
+      newConfigPenalty
+    );
+  };
+
+  for (const spec of specs) {
+    let bestIdx = 0;
+    let bestCost = Infinity;
+
+    for (let i = 0; i < agents.length; i++) {
+      const cost = getAgentCost(agents[i], spec.configKey);
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestIdx = i;
+      }
+    }
+
+    agents[bestIdx].paths.push(spec.path);
+    agents[bestIdx].totalWeight += spec.weight;
+    agents[bestIdx].configs.add(spec.configKey);
+  }
+
+  return agents[chunkIndex].paths;
+};
+
+export const isSkipped = (filePath: string, lbConfig?: LoadBalancerConfig): boolean => {
   const testFile = fs.readFileSync(filePath, { encoding: 'utf8' });
 
   const ast = parser.parse(testFile, {
@@ -59,7 +224,78 @@ export const isSkipped = (filePath: string): boolean => {
   const callExpression = expressionStatement?.expression;
 
   // @ts-expect-error
-  return callExpression?.callee?.property?.name === 'skip';
+  if (callExpression?.callee?.property?.name === 'skip') {
+    return true;
+  }
+
+  const dynamicRunnerNames = lbConfig
+    ? new Set(Object.keys(lbConfig.dynamicRunnerWeights))
+    : undefined;
+
+  return hasAllTestsSkipped(ast, dynamicRunnerNames);
+};
+
+/**
+ * Walk the AST to check if every test source is either:
+ * - an `it.skip(...)` call,
+ * - an `it()` / dynamic runner call inside a `describe.skip(...)` block, or
+ * - absent entirely (no `it()` or dynamic runner calls at all).
+ * Returns true when the file would produce zero running tests.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const hasAllTestsSkipped = (ast: any, dynamicRunnerNames?: Set<string>): boolean => {
+  let totalRunnable = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const walk = (node: any, insideSkip: boolean): void => {
+    if (!node || typeof node !== 'object') return;
+
+    if (node.type === 'CallExpression') {
+      const callee = node.callee;
+
+      const isDescribeSkip =
+        callee?.type === 'MemberExpression' &&
+        callee?.object?.name === 'describe' &&
+        callee?.property?.name === 'skip';
+
+      const isItCall = callee?.name === 'it';
+      const isItSkip =
+        callee?.type === 'MemberExpression' &&
+        callee?.object?.name === 'it' &&
+        callee?.property?.name === 'skip';
+      const isDynamicRunner =
+        dynamicRunnerNames && callee?.name && dynamicRunnerNames.has(callee.name);
+
+      if ((isItCall || isDynamicRunner) && !insideSkip) {
+        totalRunnable++;
+      }
+
+      if (isItSkip) {
+        // it.skip is always skipped regardless of parent context
+      } else if (isDescribeSkip) {
+        for (const arg of node.arguments ?? []) {
+          walk(arg, true);
+        }
+        return;
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') {
+        // Skip metadata keys that don't contain child AST nodes
+      } else {
+        const child = node[key];
+        if (Array.isArray(child)) {
+          for (const item of child) walk(item, insideSkip);
+        } else if (child && typeof child === 'object' && child.type) {
+          walk(child, insideSkip);
+        }
+      }
+    }
+  };
+
+  walk(ast, false);
+  return totalRunnable === 0;
 };
 
 export const parseTestFileConfig = (filePath: string): SecuritySolutionDescribeBlockFtrConfig => {
@@ -138,6 +374,59 @@ const TestFileFtrConfigSchema = schema.object(
 );
 
 export type SecuritySolutionDescribeBlockFtrConfig = TypeOf<typeof TestFileFtrConfigSchema>;
+
+/**
+ * Serialize an ftrConfig to a stable string key for grouping specs that can share a stack.
+ * Specs with identical keys need the same ES license, Kibana args, and product types,
+ * so they can run sequentially against a single ES/Kibana/Fleet instance.
+ */
+const ftrConfigToKey = (config: SecuritySolutionDescribeBlockFtrConfig): string => {
+  const normalized = {
+    license: config.license ?? '',
+    kbnServerArgs: [...(config.kbnServerArgs ?? [])].sort(),
+    productTypes: [...(config.productTypes ?? [])].sort((a, b) =>
+      `${a.product_line}:${a.product_tier}`.localeCompare(`${b.product_line}:${b.product_tier}`)
+    ),
+  };
+  return JSON.stringify(normalized);
+};
+
+export interface SpecGroup {
+  configKey: string;
+  ftrConfig: SecuritySolutionDescribeBlockFtrConfig;
+  specFilePaths: string[];
+}
+
+/**
+ * Group spec file paths by their parsed ftrConfig so that specs sharing the
+ * same stack configuration can be run against a single ES/Kibana instance.
+ * Order within each group is preserved from the input array.
+ */
+export const groupSpecsByFtrConfig = (filePaths: string[]): SpecGroup[] => {
+  const groupMap = new Map<string, SpecGroup>();
+  const groupOrder: string[] = [];
+
+  for (const filePath of filePaths) {
+    const config = parseTestFileConfig(filePath);
+    const key = ftrConfigToKey(config);
+
+    const existing = groupMap.get(key);
+    if (existing) {
+      existing.specFilePaths.push(filePath);
+    } else {
+      groupMap.set(key, { configKey: key, ftrConfig: config, specFilePaths: [filePath] });
+      groupOrder.push(key);
+    }
+  }
+
+  return groupOrder.reduce<SpecGroup[]>((acc, key) => {
+    const group = groupMap.get(key);
+    if (group) {
+      acc.push(group);
+    }
+    return acc;
+  }, []);
+};
 
 export const getOnBeforeHook = (module: unknown, beforeSpecFilePath: string): Function => {
   if (typeof module !== 'object' || module === null) {

--- a/x-pack/solutions/security/test/osquery_cypress/config.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/config.ts
@@ -53,7 +53,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
           'servers.elasticsearch.port'
         )}`,
         `--xpack.fleet.packages.0.name=osquery_manager`,
-        `--xpack.fleet.packages.0.version=latest`,
+        `--xpack.fleet.packages.0.version=1.18.0`,
       ],
     },
   };

--- a/x-pack/solutions/security/test/osquery_cypress/serverless_cli_config.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/serverless_cli_config.ts
@@ -35,7 +35,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
           SERVERLESS_NODES[0].name
         }:${securitySolutionCypressConfig.get('servers.elasticsearch.port')}`,
         `--xpack.fleet.packages.0.name=osquery_manager`,
-        `--xpack.fleet.packages.0.version=latest`,
+        `--xpack.fleet.packages.0.version=1.18.0`,
       ],
     },
 

--- a/x-pack/solutions/security/test/osquery_cypress/serverless_config.base.ts
+++ b/x-pack/solutions/security/test/osquery_cypress/serverless_config.base.ts
@@ -29,6 +29,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--csp.strict=false',
         '--csp.warnLegacyBrowsers=false',
         '--serverless=security',
+        `--xpack.fleet.developer.bundledPackageLocation=./inexistentDir`,
+        `--xpack.fleet.internal.registry.kibanaVersionCheckEnabled=true`,
       ],
     },
   };

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless.config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/cypress_ci_serverless.config.ts
@@ -24,6 +24,7 @@ export default defineCypressConfig({
   },
   execTimeout: 150000,
   pageLoadTimeout: 150000,
+  responseTimeout: 150000,
   numTestsKeptInMemory: 0,
   retries: {
     runMode: 1,

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/esql_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/esql_rule.cy.ts
@@ -182,7 +182,8 @@ describe(
       });
 
       it('shows confirmation modal about existing non-blocking validation errors', function () {
-        const nonExistingDataSourceQuery = 'from fake* metadata _id, _version, _index | limit 5';
+        const nonExistingDataSourceQuery =
+          'from nonexistent_index_name metadata _id, _version, _index | limit 5';
         selectEsqlRuleType();
         fillEsqlQueryBar(nonExistingDataSourceQuery);
         getDefineContinueButton().click();

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
@@ -39,10 +39,11 @@ import { visit } from '../../../../tasks/navigation';
 import { assertDetailsNotExist, getDetails } from '../../../../tasks/rule_details';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 
+// Flaky on serverless: https://github.com/elastic/kibana/issues/241848
 describe(
   'Machine Learning Detection Rules - Editing',
   {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
+    tags: ['@ess', '@serverless', '@skipInServerless', '@skipInServerlessMKI'],
   },
   () => {
     let mlRule: ReturnType<typeof getMachineLearningRule>;

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/support/machine_learning.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/support/machine_learning.ts
@@ -24,6 +24,7 @@ export const executeSetupModuleRequest = ({ moduleName }: { moduleName: string }
     method: 'POST',
     url: `/internal/ml/modules/setup/${moduleName}`,
     failOnStatusCode: true,
+    timeout: 120000,
     body: {
       prefix: '',
       groups: [ML_GROUP_ID],

--- a/x-pack/solutions/security/test/security_solution_cypress/serverless_config.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/serverless_config.ts
@@ -39,6 +39,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ])}`,
         '--csp.strict=false',
         '--csp.warnLegacyBrowsers=false',
+        `--xpack.fleet.developer.bundledPackageLocation=./inexistentDir`,
+        `--xpack.fleet.internal.registry.kibanaVersionCheckEnabled=true`,
       ],
       runOptions: {
         wait: FLEET_PLUGIN_READY_LOG_MESSAGE_REGEXP,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183)](https://github.com/elastic/kibana/pull/255183)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patryk Kopyciński","email":"contact@patrykkopycinski.com"},"sourceCommit":{"committedDate":"2026-03-09T09:01:37Z","message":"Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183)\n\n## Summary\n\nOptimize Buildkite CI for Security Solution Cypress test suites\n(excluding Defend Workflows, handled in #255030) to improve reliability,\nreduce wall-clock time, and control costs.\n\n### Key changes\n\n1. **Right-sized parallelism** to keep all suites under the **27-minute\nthreshold** while minimizing agent count — based on empirical timing\nfrom builds 404750, 404888, 404927, 405077, 405500, 405540\n2. **Removed dependency chain** — Cypress suites now depend only on\n`build`, not on `quick_checks`, `checks`, `linting`,\n`linting_with_types`, `check_types`, `check_oas_snapshot` (saves ~5-10\nmin wall-clock per CI run)\n3. **Added spot zone pinning** (`spotZones:\nus-central1-f,us-central1-c,us-central1-a`) for better preemptible\ninstance availability and cost control\n4. **Split Rule Management Prebuilt Rules** from 1 combined suite into 4\nfocused sub-suites (Customization, Installation, Management, Upgrade) on\nESS for better isolation and faster feedback\n5. **Stack sharing** (`CYPRESS_SHARE_STACKS=true`) enabled for Explore\nESS and all 4 Prebuilt Rules ESS suites to reduce ES/Kibana startup\noverhead\n6. **Config-aware load balancing** — new `LoadBalancerConfig` system\nwith greedy bin-packing algorithm distributes specs by weight and\nftrConfig grouping for balanced agent workloads\n7. **Smart retry logic** — in-place retry for assertion failures (reuses\nstack), full rebuild retry for infra failures, with video recording only\non retries\n8. **AST-based skip detection** — `hasAllTestsSkipped()` does full AST\nwalk to identify fully-skipped spec files at distribution time\n9. **Buildkite checkpoint integration** — specs completed before\npreemption are not re-run on retry\n\n### Changed files\n\n**Pipeline YAMLs** (7 files) — dependency chain removal, spot zone\npinning, parallelism tuning:\n- `ai_assistant.yml`, `detection_engine.yml`, `entity_analytics.yml`,\n`explore.yml`, `investigations.yml`, `osquery_cypress.yml`,\n`rule_management.yml`\n\n**Shell scripts** (5 files) — `CYPRESS_SHARE_STACKS=true` for\nstack-sharing-compatible suites:\n- `security_solution_explore.sh`\n-\n`security_solution_rule_management_prebuilt_rules_{customization,installation,management,upgrade}.sh`\n\n**Runner infrastructure** (6 files):\n\n| File | Change |\n|------|--------|\n| `utils.ts` | `LoadBalancerConfig` interface,\n`retrieveIntegrationsConfigAware()` (greedy bin-packing),\n`hasAllTestsSkipped()` (AST walk), `groupSpecsByFtrConfig()`,\n`SpecGroup` interface |\n| `parallel.ts` | Stack-sharing orchestration\n(`runSpecGroups`/`runSpecGroup`), smart retry, video disabled on first\npass, generic config via `resolveLoadBalancerConfig()`, Buildkite\ncheckpoint support |\n| `parallel_serverless.ts` | Config-aware distribution when\n`CYPRESS_SHARE_STACKS` is set |\n| `junit_transformer/lib.ts` | Added `{ force: true }` to all 3 `del()`\ncalls |\n| `lb_config_registry.ts` | **New** — config registry mapping Buildkite\n`JOB` names to `LoadBalancerConfig` objects |\n| `security_solution_config.ts` | **New** — Security Solution LB config\nwith runtime-calibrated weight overrides |\n\n### Parallelism changes vs main\n\n| Suite | Env | Main | Branch | Delta |\n|-------|-----|------|--------|-------|\n| Serverless Investigations | SL | 11 | 14 | +3 |\n| Serverless Rule Management | SL | 6 | 8 | +2 |\n| Serverless Explore | SL | 3 | 4 | +1 |\n| Serverless Detection Engine | SL | 7 | 8 | +1 |\n| Investigations | ESS | 8 | 9 | +1 |\n| Detection Engine | ESS | 6 | 7 | +1 |\n| Serverless Entity Analytics | SL | 3 | 2 | -1 |\n| AI Assistant | SL | 2 | 1 | -1 |\n| Det.Eng Exceptions | ESS | 3 | 2 | -1 |\n| Det.Eng Exceptions | SL | 4 | 3 | -1 |\n| Detection Engine | SL | 7 | 8 | +1 |\n| Osquery | ESS | 8 | 7 | -1 |\n| Osquery | SL | 8 | 5 | -3 |\n\n**Total agents (excl. DW): 92 (main) → 91 (branch), net -1**\n\n### Build 405540 timing results — ALL PASS ✅\n\nTiming = net Cypress test execution time (Buildkite log section\nduration, excludes agent bootstrap/checkout/distribution overhead). Max\nacross parallel agents.\n\n| Suite | Env | Agents | Max | Avg | Status |\n|-------|-----|--------|-----|-----|--------|\n| SL Detection Engine | SL | 8 | 26m 05s | 20m 25s | ✅ |\n| SL Osquery | SL | 5 | 25m 53s | 17m 12s | ✅ |\n| Osquery | ESS | 7 | 24m 12s | 17m 39s | ✅ |\n| Investigations | ESS | 9 | 23m 11s | 20m 25s | ✅ |\n| SL Entity Analytics | SL | 2 | 23m 11s | 22m 09s | ✅ |\n| SL Det.Eng Exceptions | SL | 3 | 22m 35s | 16m 55s | ✅ |\n| SL Investigations | SL | 14 | 22m 12s | 18m 19s | ✅ |\n| SL Rule Management | SL | 8 | 22m 08s | 16m 21s | ✅ |\n| Detection Engine | ESS | 7 | 22m 06s | 19m 32s | ✅ |\n| Rule Management | ESS | 6 | 21m 25s | 16m 28s | ✅ |\n| Det.Eng Exceptions | ESS | 2 | 20m 43s | 20m 42s | ✅ |\n| Entity Analytics | ESS | 2 | 20m 03s | 19m 20s | ✅ |\n| SL Explore | SL | 4 | 18m 27s | 13m 46s | ✅ |\n| SL AI Assistant | SL | 1 | 18m 12s | — | ✅ |\n| SL RM Prebuilt Rules Upgrade | SL | 2 | 16m 18s | 13m 28s | ✅ |\n| SL RM Prebuilt Rules Management | SL | 1 | 15m 46s | — | ✅ |\n| SL RM Prebuilt Rules Installation | SL | 2 | 15m 41s | 14m 17s | ✅ |\n| AI Assistant | ESS | 1 | 14m 16s | — | ✅ |\n| SL AI4DSOC | SL | 1 | 13m 19s | — | ✅ |\n| Explore | ESS | 2 | 12m 55s | 12m 15s | ✅ |\n| RM Prebuilt Rules Installation | ESS | 1 | 11m 49s | — | ✅ |\n| SL RM Prebuilt Rules Customization | SL | 1 | 11m 39s | — | ✅ |\n| Cloud Security Posture | ESS | 1 | 10m 29s | — | ✅ |\n| SL Cloud Security Posture | SL | 1 | 9m 27s | — | ✅ |\n| RM Prebuilt Rules Customization | ESS | 1 | 8m 39s | — | ✅ |\n| RM Prebuilt Rules Management | ESS | 1 | 7m 01s | — | ✅ |\n| RM Prebuilt Rules Upgrade | ESS | 1 | 6m 14s | — | ✅ |\n| SL Automatic Import | SL | 1 | 3m 08s | — | ✅ |\n\n**28/28 suites under 27-minute threshold.** Max across all suites: 26m\n05s (SL Detection Engine).\n\n### Stack sharing status\n\n| Suite | Status |\n|-------|--------|\n| Explore ESS | ✅ Enabled |\n| RM Prebuilt Rules Customization ESS | ✅ Enabled |\n| RM Prebuilt Rules Installation ESS | ✅ Enabled |\n| RM Prebuilt Rules Management ESS | ✅ Enabled |\n| RM Prebuilt Rules Upgrade ESS | ✅ Enabled |\n| All other ESS suites | Not enabled (needs per-suite cleanup hardening)\n|\n| Serverless suites | N/A (each test gets its own cloud project) |\n\n### CI Build History\n\n| Build | Commit | Result | Notes |\n|-------|--------|--------|-------|\n|\n[#405540](https://buildkite.com/elastic/kibana-pull-request/builds/405540)\n| 020f64b | ✅ Passed | **All 28 suites under 27min.** Final timing data\nabove. |\n|\n[#405500](https://buildkite.com/elastic/kibana-pull-request/builds/405500)\n| 3861445 | ✅ Passed | 2 suites over (Osquery ESS 31m, Rule Mgmt ESS\n28m) — reverted reductions. |\n|\n[#405077](https://buildkite.com/elastic/kibana-pull-request/builds/405077)\n| 9264ab8 | ✅ Passed | 3 SL suites over threshold — increased agents. |\n|\n[#404927](https://buildkite.com/elastic/kibana-pull-request/builds/404927)\n| 90747c5 | ✅ Passed | Reduced 5 suites with headroom. |\n|\n[#404888](https://buildkite.com/elastic/kibana-pull-request/builds/404888)\n| 10e32a5 | ✅ Passed | All 426 jobs passed. Used for reduction baseline.\n|\n|\n[#404750](https://buildkite.com/elastic/kibana-pull-request/builds/404750)\n| c3c73f6 | ✅ Passed | After reverting shared stacks for failing suites.\n|\n\n### Risk Assessment\n\n**Low risk.** All changes are pipeline YAML, shell script, and runner\nTypeScript modifications — no test code or application logic changes.\nParallelism values are backed by empirical CI data across 6 green\nbuilds. Stack sharing is only enabled for suites with proven cleanup\npatterns. Easily reversible by adjusting YAML values.\n\n### Related\n\n- #255030 — Defend Workflows Cypress optimization (handled separately —\nDW parallelism, load balancer config, spec splitting)\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"77e7b998e67c785cb88bffa957afe372c927fb76","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.4.0","v8.19.13"],"title":"Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones","number":255183,"url":"https://github.com/elastic/kibana/pull/255183","mergeCommit":{"message":"Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183)\n\n## Summary\n\nOptimize Buildkite CI for Security Solution Cypress test suites\n(excluding Defend Workflows, handled in #255030) to improve reliability,\nreduce wall-clock time, and control costs.\n\n### Key changes\n\n1. **Right-sized parallelism** to keep all suites under the **27-minute\nthreshold** while minimizing agent count — based on empirical timing\nfrom builds 404750, 404888, 404927, 405077, 405500, 405540\n2. **Removed dependency chain** — Cypress suites now depend only on\n`build`, not on `quick_checks`, `checks`, `linting`,\n`linting_with_types`, `check_types`, `check_oas_snapshot` (saves ~5-10\nmin wall-clock per CI run)\n3. **Added spot zone pinning** (`spotZones:\nus-central1-f,us-central1-c,us-central1-a`) for better preemptible\ninstance availability and cost control\n4. **Split Rule Management Prebuilt Rules** from 1 combined suite into 4\nfocused sub-suites (Customization, Installation, Management, Upgrade) on\nESS for better isolation and faster feedback\n5. **Stack sharing** (`CYPRESS_SHARE_STACKS=true`) enabled for Explore\nESS and all 4 Prebuilt Rules ESS suites to reduce ES/Kibana startup\noverhead\n6. **Config-aware load balancing** — new `LoadBalancerConfig` system\nwith greedy bin-packing algorithm distributes specs by weight and\nftrConfig grouping for balanced agent workloads\n7. **Smart retry logic** — in-place retry for assertion failures (reuses\nstack), full rebuild retry for infra failures, with video recording only\non retries\n8. **AST-based skip detection** — `hasAllTestsSkipped()` does full AST\nwalk to identify fully-skipped spec files at distribution time\n9. **Buildkite checkpoint integration** — specs completed before\npreemption are not re-run on retry\n\n### Changed files\n\n**Pipeline YAMLs** (7 files) — dependency chain removal, spot zone\npinning, parallelism tuning:\n- `ai_assistant.yml`, `detection_engine.yml`, `entity_analytics.yml`,\n`explore.yml`, `investigations.yml`, `osquery_cypress.yml`,\n`rule_management.yml`\n\n**Shell scripts** (5 files) — `CYPRESS_SHARE_STACKS=true` for\nstack-sharing-compatible suites:\n- `security_solution_explore.sh`\n-\n`security_solution_rule_management_prebuilt_rules_{customization,installation,management,upgrade}.sh`\n\n**Runner infrastructure** (6 files):\n\n| File | Change |\n|------|--------|\n| `utils.ts` | `LoadBalancerConfig` interface,\n`retrieveIntegrationsConfigAware()` (greedy bin-packing),\n`hasAllTestsSkipped()` (AST walk), `groupSpecsByFtrConfig()`,\n`SpecGroup` interface |\n| `parallel.ts` | Stack-sharing orchestration\n(`runSpecGroups`/`runSpecGroup`), smart retry, video disabled on first\npass, generic config via `resolveLoadBalancerConfig()`, Buildkite\ncheckpoint support |\n| `parallel_serverless.ts` | Config-aware distribution when\n`CYPRESS_SHARE_STACKS` is set |\n| `junit_transformer/lib.ts` | Added `{ force: true }` to all 3 `del()`\ncalls |\n| `lb_config_registry.ts` | **New** — config registry mapping Buildkite\n`JOB` names to `LoadBalancerConfig` objects |\n| `security_solution_config.ts` | **New** — Security Solution LB config\nwith runtime-calibrated weight overrides |\n\n### Parallelism changes vs main\n\n| Suite | Env | Main | Branch | Delta |\n|-------|-----|------|--------|-------|\n| Serverless Investigations | SL | 11 | 14 | +3 |\n| Serverless Rule Management | SL | 6 | 8 | +2 |\n| Serverless Explore | SL | 3 | 4 | +1 |\n| Serverless Detection Engine | SL | 7 | 8 | +1 |\n| Investigations | ESS | 8 | 9 | +1 |\n| Detection Engine | ESS | 6 | 7 | +1 |\n| Serverless Entity Analytics | SL | 3 | 2 | -1 |\n| AI Assistant | SL | 2 | 1 | -1 |\n| Det.Eng Exceptions | ESS | 3 | 2 | -1 |\n| Det.Eng Exceptions | SL | 4 | 3 | -1 |\n| Detection Engine | SL | 7 | 8 | +1 |\n| Osquery | ESS | 8 | 7 | -1 |\n| Osquery | SL | 8 | 5 | -3 |\n\n**Total agents (excl. DW): 92 (main) → 91 (branch), net -1**\n\n### Build 405540 timing results — ALL PASS ✅\n\nTiming = net Cypress test execution time (Buildkite log section\nduration, excludes agent bootstrap/checkout/distribution overhead). Max\nacross parallel agents.\n\n| Suite | Env | Agents | Max | Avg | Status |\n|-------|-----|--------|-----|-----|--------|\n| SL Detection Engine | SL | 8 | 26m 05s | 20m 25s | ✅ |\n| SL Osquery | SL | 5 | 25m 53s | 17m 12s | ✅ |\n| Osquery | ESS | 7 | 24m 12s | 17m 39s | ✅ |\n| Investigations | ESS | 9 | 23m 11s | 20m 25s | ✅ |\n| SL Entity Analytics | SL | 2 | 23m 11s | 22m 09s | ✅ |\n| SL Det.Eng Exceptions | SL | 3 | 22m 35s | 16m 55s | ✅ |\n| SL Investigations | SL | 14 | 22m 12s | 18m 19s | ✅ |\n| SL Rule Management | SL | 8 | 22m 08s | 16m 21s | ✅ |\n| Detection Engine | ESS | 7 | 22m 06s | 19m 32s | ✅ |\n| Rule Management | ESS | 6 | 21m 25s | 16m 28s | ✅ |\n| Det.Eng Exceptions | ESS | 2 | 20m 43s | 20m 42s | ✅ |\n| Entity Analytics | ESS | 2 | 20m 03s | 19m 20s | ✅ |\n| SL Explore | SL | 4 | 18m 27s | 13m 46s | ✅ |\n| SL AI Assistant | SL | 1 | 18m 12s | — | ✅ |\n| SL RM Prebuilt Rules Upgrade | SL | 2 | 16m 18s | 13m 28s | ✅ |\n| SL RM Prebuilt Rules Management | SL | 1 | 15m 46s | — | ✅ |\n| SL RM Prebuilt Rules Installation | SL | 2 | 15m 41s | 14m 17s | ✅ |\n| AI Assistant | ESS | 1 | 14m 16s | — | ✅ |\n| SL AI4DSOC | SL | 1 | 13m 19s | — | ✅ |\n| Explore | ESS | 2 | 12m 55s | 12m 15s | ✅ |\n| RM Prebuilt Rules Installation | ESS | 1 | 11m 49s | — | ✅ |\n| SL RM Prebuilt Rules Customization | SL | 1 | 11m 39s | — | ✅ |\n| Cloud Security Posture | ESS | 1 | 10m 29s | — | ✅ |\n| SL Cloud Security Posture | SL | 1 | 9m 27s | — | ✅ |\n| RM Prebuilt Rules Customization | ESS | 1 | 8m 39s | — | ✅ |\n| RM Prebuilt Rules Management | ESS | 1 | 7m 01s | — | ✅ |\n| RM Prebuilt Rules Upgrade | ESS | 1 | 6m 14s | — | ✅ |\n| SL Automatic Import | SL | 1 | 3m 08s | — | ✅ |\n\n**28/28 suites under 27-minute threshold.** Max across all suites: 26m\n05s (SL Detection Engine).\n\n### Stack sharing status\n\n| Suite | Status |\n|-------|--------|\n| Explore ESS | ✅ Enabled |\n| RM Prebuilt Rules Customization ESS | ✅ Enabled |\n| RM Prebuilt Rules Installation ESS | ✅ Enabled |\n| RM Prebuilt Rules Management ESS | ✅ Enabled |\n| RM Prebuilt Rules Upgrade ESS | ✅ Enabled |\n| All other ESS suites | Not enabled (needs per-suite cleanup hardening)\n|\n| Serverless suites | N/A (each test gets its own cloud project) |\n\n### CI Build History\n\n| Build | Commit | Result | Notes |\n|-------|--------|--------|-------|\n|\n[#405540](https://buildkite.com/elastic/kibana-pull-request/builds/405540)\n| 020f64b | ✅ Passed | **All 28 suites under 27min.** Final timing data\nabove. |\n|\n[#405500](https://buildkite.com/elastic/kibana-pull-request/builds/405500)\n| 3861445 | ✅ Passed | 2 suites over (Osquery ESS 31m, Rule Mgmt ESS\n28m) — reverted reductions. |\n|\n[#405077](https://buildkite.com/elastic/kibana-pull-request/builds/405077)\n| 9264ab8 | ✅ Passed | 3 SL suites over threshold — increased agents. |\n|\n[#404927](https://buildkite.com/elastic/kibana-pull-request/builds/404927)\n| 90747c5 | ✅ Passed | Reduced 5 suites with headroom. |\n|\n[#404888](https://buildkite.com/elastic/kibana-pull-request/builds/404888)\n| 10e32a5 | ✅ Passed | All 426 jobs passed. Used for reduction baseline.\n|\n|\n[#404750](https://buildkite.com/elastic/kibana-pull-request/builds/404750)\n| c3c73f6 | ✅ Passed | After reverting shared stacks for failing suites.\n|\n\n### Risk Assessment\n\n**Low risk.** All changes are pipeline YAML, shell script, and runner\nTypeScript modifications — no test code or application logic changes.\nParallelism values are backed by empirical CI data across 6 green\nbuilds. Stack sharing is only enabled for suites with proven cleanup\npatterns. Easily reversible by adjusting YAML values.\n\n### Related\n\n- #255030 — Defend Workflows Cypress optimization (handled separately —\nDW parallelism, load balancer config, spec splitting)\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"77e7b998e67c785cb88bffa957afe372c927fb76"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255183","number":255183,"mergeCommit":{"message":"Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183)\n\n## Summary\n\nOptimize Buildkite CI for Security Solution Cypress test suites\n(excluding Defend Workflows, handled in #255030) to improve reliability,\nreduce wall-clock time, and control costs.\n\n### Key changes\n\n1. **Right-sized parallelism** to keep all suites under the **27-minute\nthreshold** while minimizing agent count — based on empirical timing\nfrom builds 404750, 404888, 404927, 405077, 405500, 405540\n2. **Removed dependency chain** — Cypress suites now depend only on\n`build`, not on `quick_checks`, `checks`, `linting`,\n`linting_with_types`, `check_types`, `check_oas_snapshot` (saves ~5-10\nmin wall-clock per CI run)\n3. **Added spot zone pinning** (`spotZones:\nus-central1-f,us-central1-c,us-central1-a`) for better preemptible\ninstance availability and cost control\n4. **Split Rule Management Prebuilt Rules** from 1 combined suite into 4\nfocused sub-suites (Customization, Installation, Management, Upgrade) on\nESS for better isolation and faster feedback\n5. **Stack sharing** (`CYPRESS_SHARE_STACKS=true`) enabled for Explore\nESS and all 4 Prebuilt Rules ESS suites to reduce ES/Kibana startup\noverhead\n6. **Config-aware load balancing** — new `LoadBalancerConfig` system\nwith greedy bin-packing algorithm distributes specs by weight and\nftrConfig grouping for balanced agent workloads\n7. **Smart retry logic** — in-place retry for assertion failures (reuses\nstack), full rebuild retry for infra failures, with video recording only\non retries\n8. **AST-based skip detection** — `hasAllTestsSkipped()` does full AST\nwalk to identify fully-skipped spec files at distribution time\n9. **Buildkite checkpoint integration** — specs completed before\npreemption are not re-run on retry\n\n### Changed files\n\n**Pipeline YAMLs** (7 files) — dependency chain removal, spot zone\npinning, parallelism tuning:\n- `ai_assistant.yml`, `detection_engine.yml`, `entity_analytics.yml`,\n`explore.yml`, `investigations.yml`, `osquery_cypress.yml`,\n`rule_management.yml`\n\n**Shell scripts** (5 files) — `CYPRESS_SHARE_STACKS=true` for\nstack-sharing-compatible suites:\n- `security_solution_explore.sh`\n-\n`security_solution_rule_management_prebuilt_rules_{customization,installation,management,upgrade}.sh`\n\n**Runner infrastructure** (6 files):\n\n| File | Change |\n|------|--------|\n| `utils.ts` | `LoadBalancerConfig` interface,\n`retrieveIntegrationsConfigAware()` (greedy bin-packing),\n`hasAllTestsSkipped()` (AST walk), `groupSpecsByFtrConfig()`,\n`SpecGroup` interface |\n| `parallel.ts` | Stack-sharing orchestration\n(`runSpecGroups`/`runSpecGroup`), smart retry, video disabled on first\npass, generic config via `resolveLoadBalancerConfig()`, Buildkite\ncheckpoint support |\n| `parallel_serverless.ts` | Config-aware distribution when\n`CYPRESS_SHARE_STACKS` is set |\n| `junit_transformer/lib.ts` | Added `{ force: true }` to all 3 `del()`\ncalls |\n| `lb_config_registry.ts` | **New** — config registry mapping Buildkite\n`JOB` names to `LoadBalancerConfig` objects |\n| `security_solution_config.ts` | **New** — Security Solution LB config\nwith runtime-calibrated weight overrides |\n\n### Parallelism changes vs main\n\n| Suite | Env | Main | Branch | Delta |\n|-------|-----|------|--------|-------|\n| Serverless Investigations | SL | 11 | 14 | +3 |\n| Serverless Rule Management | SL | 6 | 8 | +2 |\n| Serverless Explore | SL | 3 | 4 | +1 |\n| Serverless Detection Engine | SL | 7 | 8 | +1 |\n| Investigations | ESS | 8 | 9 | +1 |\n| Detection Engine | ESS | 6 | 7 | +1 |\n| Serverless Entity Analytics | SL | 3 | 2 | -1 |\n| AI Assistant | SL | 2 | 1 | -1 |\n| Det.Eng Exceptions | ESS | 3 | 2 | -1 |\n| Det.Eng Exceptions | SL | 4 | 3 | -1 |\n| Detection Engine | SL | 7 | 8 | +1 |\n| Osquery | ESS | 8 | 7 | -1 |\n| Osquery | SL | 8 | 5 | -3 |\n\n**Total agents (excl. DW): 92 (main) → 91 (branch), net -1**\n\n### Build 405540 timing results — ALL PASS ✅\n\nTiming = net Cypress test execution time (Buildkite log section\nduration, excludes agent bootstrap/checkout/distribution overhead). Max\nacross parallel agents.\n\n| Suite | Env | Agents | Max | Avg | Status |\n|-------|-----|--------|-----|-----|--------|\n| SL Detection Engine | SL | 8 | 26m 05s | 20m 25s | ✅ |\n| SL Osquery | SL | 5 | 25m 53s | 17m 12s | ✅ |\n| Osquery | ESS | 7 | 24m 12s | 17m 39s | ✅ |\n| Investigations | ESS | 9 | 23m 11s | 20m 25s | ✅ |\n| SL Entity Analytics | SL | 2 | 23m 11s | 22m 09s | ✅ |\n| SL Det.Eng Exceptions | SL | 3 | 22m 35s | 16m 55s | ✅ |\n| SL Investigations | SL | 14 | 22m 12s | 18m 19s | ✅ |\n| SL Rule Management | SL | 8 | 22m 08s | 16m 21s | ✅ |\n| Detection Engine | ESS | 7 | 22m 06s | 19m 32s | ✅ |\n| Rule Management | ESS | 6 | 21m 25s | 16m 28s | ✅ |\n| Det.Eng Exceptions | ESS | 2 | 20m 43s | 20m 42s | ✅ |\n| Entity Analytics | ESS | 2 | 20m 03s | 19m 20s | ✅ |\n| SL Explore | SL | 4 | 18m 27s | 13m 46s | ✅ |\n| SL AI Assistant | SL | 1 | 18m 12s | — | ✅ |\n| SL RM Prebuilt Rules Upgrade | SL | 2 | 16m 18s | 13m 28s | ✅ |\n| SL RM Prebuilt Rules Management | SL | 1 | 15m 46s | — | ✅ |\n| SL RM Prebuilt Rules Installation | SL | 2 | 15m 41s | 14m 17s | ✅ |\n| AI Assistant | ESS | 1 | 14m 16s | — | ✅ |\n| SL AI4DSOC | SL | 1 | 13m 19s | — | ✅ |\n| Explore | ESS | 2 | 12m 55s | 12m 15s | ✅ |\n| RM Prebuilt Rules Installation | ESS | 1 | 11m 49s | — | ✅ |\n| SL RM Prebuilt Rules Customization | SL | 1 | 11m 39s | — | ✅ |\n| Cloud Security Posture | ESS | 1 | 10m 29s | — | ✅ |\n| SL Cloud Security Posture | SL | 1 | 9m 27s | — | ✅ |\n| RM Prebuilt Rules Customization | ESS | 1 | 8m 39s | — | ✅ |\n| RM Prebuilt Rules Management | ESS | 1 | 7m 01s | — | ✅ |\n| RM Prebuilt Rules Upgrade | ESS | 1 | 6m 14s | — | ✅ |\n| SL Automatic Import | SL | 1 | 3m 08s | — | ✅ |\n\n**28/28 suites under 27-minute threshold.** Max across all suites: 26m\n05s (SL Detection Engine).\n\n### Stack sharing status\n\n| Suite | Status |\n|-------|--------|\n| Explore ESS | ✅ Enabled |\n| RM Prebuilt Rules Customization ESS | ✅ Enabled |\n| RM Prebuilt Rules Installation ESS | ✅ Enabled |\n| RM Prebuilt Rules Management ESS | ✅ Enabled |\n| RM Prebuilt Rules Upgrade ESS | ✅ Enabled |\n| All other ESS suites | Not enabled (needs per-suite cleanup hardening)\n|\n| Serverless suites | N/A (each test gets its own cloud project) |\n\n### CI Build History\n\n| Build | Commit | Result | Notes |\n|-------|--------|--------|-------|\n|\n[#405540](https://buildkite.com/elastic/kibana-pull-request/builds/405540)\n| 020f64b | ✅ Passed | **All 28 suites under 27min.** Final timing data\nabove. |\n|\n[#405500](https://buildkite.com/elastic/kibana-pull-request/builds/405500)\n| 3861445 | ✅ Passed | 2 suites over (Osquery ESS 31m, Rule Mgmt ESS\n28m) — reverted reductions. |\n|\n[#405077](https://buildkite.com/elastic/kibana-pull-request/builds/405077)\n| 9264ab8 | ✅ Passed | 3 SL suites over threshold — increased agents. |\n|\n[#404927](https://buildkite.com/elastic/kibana-pull-request/builds/404927)\n| 90747c5 | ✅ Passed | Reduced 5 suites with headroom. |\n|\n[#404888](https://buildkite.com/elastic/kibana-pull-request/builds/404888)\n| 10e32a5 | ✅ Passed | All 426 jobs passed. Used for reduction baseline.\n|\n|\n[#404750](https://buildkite.com/elastic/kibana-pull-request/builds/404750)\n| c3c73f6 | ✅ Passed | After reverting shared stacks for failing suites.\n|\n\n### Risk Assessment\n\n**Low risk.** All changes are pipeline YAML, shell script, and runner\nTypeScript modifications — no test code or application logic changes.\nParallelism values are backed by empirical CI data across 6 green\nbuilds. Stack sharing is only enabled for suites with proven cleanup\npatterns. Easily reversible by adjusting YAML values.\n\n### Related\n\n- #255030 — Defend Workflows Cypress optimization (handled separately —\nDW parallelism, load balancer config, spec splitting)\n\n---------\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"77e7b998e67c785cb88bffa957afe372c927fb76"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/257002","number":257002,"state":"MERGED","mergeCommit":{"sha":"153890da2262897acb5423a94e3ebd27fd5f9454","message":"[8.19] Optimize Security Solution Cypress CI: right-size parallelism, remove dependency chain, add spot zones (#255183) (#257002)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Optimize Security Solution Cypress CI: right-size parallelism, remove\ndependency chain, add spot zones\n(#255183)](https://github.com/elastic/kibana/pull/255183)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"url":"https://github.com/elastic/kibana/pull/256998","number":256998,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->