### PR TITLE
[Agent Builder] add metadata field to executions

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/types.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/types.ts
@@ -25,6 +25,7 @@ type StorageMappingPropertyType = AllMappingPropertyType &
     | 'long'
     | 'object'
     | 'semantic_text'
+    | 'flattened'
   );
 
 type StorageMappingPropertyObjectType = Required<MappingObjectProperty, 'type'>;
@@ -75,6 +76,7 @@ const types = {
   float: createFactory('float'),
   object: createFactory('object'),
   semantic_text: createFactory('semantic_text'),
+  flattened: createFactory('flattened'),
 } satisfies {
   [TKey in StorageMappingPropertyType]: MappingPropertyFactory<TKey, any>;
 };
@@ -99,6 +101,7 @@ type PrimitiveOf<TProperty extends StorageMappingProperty> = {
       }
     : object;
   semantic_text: string;
+  flattened: Record<string, unknown>;
 }[TProperty['type']];
 
 export type StorageFieldTypeOf<TProperty extends StorageMappingProperty> = PrimitiveOf<TProperty>;

--- a/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
@@ -55,6 +55,7 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
     execution: {
       executeAgent: jest.fn(),
       getExecution: jest.fn(),
+      findExecutions: jest.fn(),
     },
     runtime: {
       createModelProvider: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -220,6 +220,7 @@ export class AgentBuilderPlugin
       execution: {
         executeAgent: execution.executeAgent.bind(execution),
         getExecution: execution.getExecution.bind(execution),
+        findExecutions: execution.findExecutions.bind(execution),
       },
       runtime: {
         createModelProvider: modelProviderFactory,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_follower.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_follower.test.ts
@@ -26,6 +26,7 @@ const createMockExecutionClient = () =>
     appendEvents: jest.fn(),
     peek: jest.fn(),
     readEvents: jest.fn(),
+    find: jest.fn().mockResolvedValue([]),
   } as jest.Mocked<AgentExecutionClient>);
 
 const messageChunkEvent = (text: string): ChatEvent =>

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.test.ts
@@ -22,6 +22,7 @@ const mockExecutionClient: jest.Mocked<AgentExecutionClient> = {
   appendEvents: jest.fn(),
   peek: jest.fn(),
   readEvents: jest.fn(),
+  find: jest.fn().mockResolvedValue([]),
 };
 
 jest.mock('./persistence', () => ({
@@ -431,6 +432,117 @@ describe('AgentExecutionService', () => {
         },
         complete: () => done.fail('Expected an error, not completion'),
       });
+    });
+  });
+
+  describe('executeAgent with metadata', () => {
+    it('should pass metadata to executionClient.create', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      const metadata = { source: 'test', username: 'user1' };
+
+      mockHandleAgentExecution.mockResolvedValue(of());
+      mockCollectAndWriteEvents.mockResolvedValue(undefined);
+
+      await service.executeAgent({
+        request,
+        params: { agentId: 'agent-1', nextInput: { message: 'hello' } },
+        useTaskManager: false,
+        metadata,
+      });
+
+      expect(mockExecutionClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata })
+      );
+    });
+
+    it('should pass undefined metadata when not provided (backward compat)', async () => {
+      const request = httpServerMock.createKibanaRequest();
+
+      mockHandleAgentExecution.mockResolvedValue(of());
+      mockCollectAndWriteEvents.mockResolvedValue(undefined);
+
+      await service.executeAgent({
+        request,
+        params: { agentId: 'agent-1', nextInput: { message: 'hello' } },
+        useTaskManager: false,
+      });
+
+      expect(mockExecutionClient.create).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: undefined })
+      );
+    });
+  });
+
+  describe('findExecutions', () => {
+    it('should delegate to executionClient.find with auto-injected spaceId', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      mockExecutionClient.find.mockResolvedValue([]);
+
+      await service.findExecutions(request, {
+        filter: { metadata: { source: 'test' } },
+      });
+
+      expect(mockExecutionClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spaceId: 'default',
+          filter: { metadata: { source: 'test' } },
+        })
+      );
+    });
+
+    it('should use explicit spaceId when provided, overriding the default', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      mockExecutionClient.find.mockResolvedValue([]);
+
+      await service.findExecutions(request, {
+        spaceId: 'my-space',
+        filter: { status: [ExecutionStatus.running] },
+      });
+
+      expect(mockExecutionClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'my-space' })
+      );
+    });
+
+    it('should use default spaceId when spaceId is undefined in options', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      mockExecutionClient.find.mockResolvedValue([]);
+
+      await service.findExecutions(request, { spaceId: undefined });
+
+      expect(mockExecutionClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'default' })
+      );
+    });
+
+    it('should use defaults when no options provided', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      mockExecutionClient.find.mockResolvedValue([]);
+
+      await service.findExecutions(request);
+
+      expect(mockExecutionClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'default' })
+      );
+    });
+
+    it('should return results from executionClient.find', async () => {
+      const request = httpServerMock.createKibanaRequest();
+      const fakeExecution = {
+        executionId: 'exec-1',
+        '@timestamp': new Date().toISOString(),
+        status: ExecutionStatus.running,
+        agentId: 'agent-1',
+        spaceId: 'default',
+        agentParams: { nextInput: { message: 'hello' } },
+        eventCount: 0,
+        events: [],
+        metadata: { source: 'test' },
+      };
+      mockExecutionClient.find.mockResolvedValue([fakeExecution]);
+
+      const results = await service.findExecutions(request);
+      expect(results).toEqual([fakeExecution]);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -25,6 +25,7 @@ import type {
   ExecuteAgentParams,
   ExecuteAgentResult,
   FollowExecutionOptions,
+  FindExecutionsOptions,
 } from './types';
 import { ExecutionStatus } from './types';
 import { taskTypes } from './task';
@@ -87,6 +88,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     executionId: providedExecutionId,
     useTaskManager,
     abortSignal,
+    metadata,
   }: ExecuteAgentParams): Promise<ExecuteAgentResult> {
     const executionId = providedExecutionId ?? uuidv4();
     const agentId = params.agentId ?? agentBuilderDefaultAgentId;
@@ -113,6 +115,7 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
       agentId,
       spaceId,
       agentParams: validatedParams,
+      metadata,
     });
 
     // Wire up external abort signal to execution abort
@@ -326,6 +329,22 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     const soClient = this.deps.savedObjects.getScopedClient(request);
     const uiSettingsClient = this.deps.uiSettings.asScopedToClient(soClient);
     return uiSettingsClient.get<boolean>(AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID);
+  }
+
+  /**
+   * Find executions matching the given filters. Defaults to the current space derived from request.
+   * Callers that override spaceId are responsible for their own authorization when querying cross-space.
+   */
+  async findExecutions(
+    request: KibanaRequest,
+    options?: FindExecutionsOptions
+  ): Promise<AgentExecution[]> {
+    const defaultSpaceId = getCurrentSpaceId({ request, spaces: this.deps.spaces });
+    const executionClient = this.createExecutionClient();
+    return executionClient.find({
+      ...options,
+      spaceId: options?.spaceId || defaultSpaceId,
+    });
   }
 
   private createExecutionClient(): AgentExecutionClient {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/index.ts
@@ -13,6 +13,8 @@ export type {
   FollowExecutionOptions,
   AgentExecution,
   SerializedExecutionError,
+  FindExecutionsOptions,
+  FindExecutionsFilter,
 } from './types';
 export { ExecutionStatus } from './types';
 export { createAgentExecutionService, type AgentExecutionServiceDeps } from './execution_service';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_client.ts
@@ -5,16 +5,17 @@
  * 2.0.
  */
 
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
 import type { ChatEvent } from '@kbn/agent-builder-common';
-import type { AgentExecution, SerializedExecutionError } from '../types';
+import type { AgentExecution, SerializedExecutionError, FindExecutionsOptions } from '../types';
 import { ExecutionStatus } from '../types';
 import type { AgentExecutionProperties, AgentExecutionStorage } from './agent_execution_storage';
 import { agentExecutionIndexName, createStorage } from './agent_execution_storage';
 
 type CreateExecutionParams = Pick<
   AgentExecution,
-  'executionId' | 'agentId' | 'spaceId' | 'agentParams'
+  'executionId' | 'agentId' | 'spaceId' | 'agentParams' | 'metadata'
 >;
 
 /**
@@ -38,6 +39,7 @@ const fromEs = (source: AgentExecutionProperties): AgentExecution => {
     eventCount: source.event_count ?? 0,
     events: source.events ?? [],
     ...(source.error ? { error: source.error } : {}),
+    ...(source.metadata ? { metadata: source.metadata } : {}),
   };
 };
 
@@ -77,6 +79,9 @@ export interface AgentExecutionClient {
     executionId: string,
     since?: number
   ): Promise<{ events: ChatEvent[]; status: ExecutionStatus; error?: SerializedExecutionError }>;
+
+  /** Search executions by metadata and/or status filters. */
+  find(options: FindExecutionsOptions): Promise<AgentExecution[]>;
 }
 
 export const createAgentExecutionClient = ({
@@ -110,7 +115,16 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
     agentId,
     spaceId,
     agentParams,
+    metadata,
   }: CreateExecutionParams): Promise<AgentExecution> {
+    if (metadata) {
+      for (const key of Object.keys(metadata)) {
+        if (!key) {
+          throw new Error(`Invalid metadata key "${key}": keys must be non-empty`);
+        }
+      }
+    }
+
     const now = new Date().toISOString();
     const document: AgentExecutionProperties = {
       execution_id: executionId,
@@ -121,6 +135,7 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
       agent_params: agentParams,
       event_count: 0,
       events: [],
+      ...(metadata ? { metadata } : {}),
     };
 
     await this.storage.getClient().index({
@@ -137,6 +152,7 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
       agentParams,
       eventCount: 0,
       events: [],
+      ...(metadata ? { metadata } : {}),
     };
   }
 
@@ -222,6 +238,48 @@ class AgentExecutionClientImpl implements AgentExecutionClient {
       status: source.status,
       ...(source.error ? { error: source.error } : {}),
     };
+  }
+
+  async find(options: FindExecutionsOptions): Promise<AgentExecution[]> {
+    const {
+      spaceId,
+      filter = {},
+      size = 10,
+      sort = { field: '@timestamp', order: 'desc' },
+    } = options;
+
+    if (!spaceId) {
+      throw new Error('findExecutions requires a spaceId');
+    }
+
+    const must: QueryDslQueryContainer[] = [{ term: { space_id: spaceId } }];
+
+    if (filter.metadata) {
+      for (const [key, value] of Object.entries(filter.metadata)) {
+        must.push({ term: { [`metadata.${key}`]: value } });
+      }
+    }
+
+    if (filter.status?.length) {
+      must.push({ terms: { status: filter.status } });
+    }
+
+    try {
+      const response = await this.esClient.search<AgentExecutionProperties>({
+        index: agentExecutionIndexName,
+        size,
+        sort: [{ [sort.field]: { order: sort.order } }],
+        _source_excludes: ['events'],
+        query: { bool: { must } },
+      });
+
+      return response.hits.hits.flatMap((hit) => (hit._source ? [fromEs(hit._source)] : []));
+    } catch (err) {
+      if (err?.meta?.statusCode === 404) {
+        return [];
+      }
+      throw err;
+    }
   }
 
   /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_storage.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/persistence/agent_execution_storage.ts
@@ -33,6 +33,7 @@ const storageSettings = {
       }),
       event_count: types.long({}),
       events: types.object({ dynamic: false, properties: {} }),
+      metadata: types.flattened(),
     },
   },
 } satisfies IndexStorageSettings;
@@ -47,6 +48,7 @@ export interface AgentExecutionProperties {
   error?: SerializedExecutionError;
   event_count?: number;
   events?: ChatEvent[];
+  metadata?: Record<string, string>;
 }
 
 export type AgentExecutionStorageSettings = typeof storageSettings;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/types.ts
@@ -95,6 +95,8 @@ export interface AgentExecution {
   eventCount: number;
   /** Inline events emitted during the execution. The array index is the event number. */
   events: ChatEvent[];
+  /** Caller-provided metadata. */
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -116,6 +118,8 @@ export interface ExecuteAgentParams {
    * - `undefined` (default): auto-decide based on context (already on TM -> local; otherwise check the experimental features UI setting).
    */
   useTaskManager?: boolean;
+  /** Arbitrary key-value metadata stored with the execution, searchable via findExecutions. */
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -138,6 +142,35 @@ export interface ExecuteAgentResult {
 export interface FollowExecutionOptions {
   /** Only return events with event_number greater than this value. */
   since?: number;
+}
+
+/**
+ * Filter criteria for {@link AgentExecutionService.findExecutions}.
+ * All specified fields are ANDed together.
+ */
+export interface FindExecutionsFilter {
+  /** Match executions whose metadata contains all specified key-value pairs. */
+  metadata?: Record<string, string>;
+  /** Match executions with one of these statuses. */
+  status?: ExecutionStatus[];
+}
+
+/**
+ * Options for {@link AgentExecutionService.findExecutions}.
+ */
+export interface FindExecutionsOptions {
+  /** Space to scope results to. Defaults to current space from request if omitted. */
+  spaceId?: string;
+  /** Filter criteria. All specified fields are ANDed together. */
+  filter?: FindExecutionsFilter;
+  /** Maximum number of results to return. Defaults to 10. */
+  size?: number;
+  /**
+   * Sort field and order. Defaults to `{ field: '@timestamp', order: 'desc' }`.
+   * Note: field is an explicit union rather than derived from AgentExecutionProperties to avoid
+   * circular dependencies and to prevent exposing snake_case ES field names to consumers.
+   */
+  sort?: { field: '@timestamp' | 'status'; order: 'asc' | 'desc' };
 }
 
 /**
@@ -168,4 +201,14 @@ export interface AgentExecutionService {
    * The observable completes when the execution reaches a terminal status.
    */
   followExecution(executionId: string, options?: FollowExecutionOptions): Observable<ChatEvent>;
+
+  /**
+   * Find executions matching the given filters. Defaults to current space unless spaceId is explicitly provided.
+   * Callers that override spaceId are responsible for their own authorization.
+   * Note: returned executions have `events: []` (events are excluded for performance). Use `getExecution` or `readEvents` for full events.
+   */
+  findExecutions(
+    request: KibanaRequest,
+    options?: FindExecutionsOptions
+  ): Promise<AgentExecution[]>;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -151,6 +151,10 @@ export interface ExecutionStart {
    * Retrieve an agent execution by its ID.
    */
   getExecution: AgentExecutionService['getExecution'];
+  /**
+   * Find executions matching the given filters.
+   */
+  findExecutions: AgentExecutionService['findExecutions'];
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a `metadata` field (generic KV) to agent executions to enhance searching capabilities.

  - adds `flattened` type support to `@kbn/storage-adapter`
  - adds optional `metadata` to agent execution (optional param on `executeAgent`)
	  - stored in ES as `flattened`
  - adds `findExecutions(request, options?)` and exposes it in plugin start contract that allows for finding executions by `metadata` and `status`
	  - default scoped to the request `spaceId` but overridable via `options.spaceId`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios