### PR TITLE
[Discover] PoC: Persist by-value panel state and fix unsaved-changes badge

### DIFF
--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo } from 'react';
+import deepEqual from 'react-fast-compare';
 import { BehaviorSubject, firstValueFrom, merge, skip, map } from 'rxjs';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import { generateFilters } from '@kbn/data-plugin/public';
@@ -39,6 +40,7 @@ import { initializeEditApi } from './initialize_edit_api';
 import { initializeFetch, isEsqlMode } from './initialize_fetch';
 import { initializeInlineEditingApi } from './initialize_inline_editing_api';
 import { initializeSearchEmbeddableApi } from './initialize_search_embeddable_api';
+import { EDITABLE_SAVED_SEARCH_KEYS } from '../../common/embeddable/constants';
 import type { SearchEmbeddableState } from '../../common/embeddable/types';
 import type { SearchEmbeddableApi } from './types';
 import { deserializeState, serializeState } from './utils/serialization_utils';
@@ -154,6 +156,7 @@ export const getSearchEmbeddableFactory = ({
           inlineEditingApi.anyStateChange$
         ),
         getComparators: () => {
+          const isByValue = !savedObjectId$.getValue();
           const isDeleted = isSelectedTabDeleted(selectedTabId$.getValue());
           const shouldSkipTabComparators = isDeleted || inlineEditingApi.isEditing();
 
@@ -171,7 +174,19 @@ export const getSearchEmbeddableFactory = ({
                 )
               : {}),
             selectedTabId: shouldSkipTabComparators ? 'skip' : 'referenceEquality',
-            attributes: 'skip',
+            // By-value panels store editable state (EDITABLE_SAVED_SEARCH_KEYS) in attributes;
+            // compare only those keys. Treat missing and undefined the same (e.g. rowsPerPage
+            // absent in saved vs undefined in current) so we don't get false unsaved-changes.
+            attributes: isByValue
+              ? (a: unknown, b: unknown) => {
+                  const aAttr = (a as Record<string, unknown>) ?? {};
+                  const bAttr = (b as Record<string, unknown>) ?? {};
+                  for (const key of EDITABLE_SAVED_SEARCH_KEYS) {
+                    if (!deepEqual(aAttr[key] ?? undefined, bAttr[key] ?? undefined)) return false;
+                  }
+                  return true;
+                }
+              : 'skip',
             breakdownField: 'skip',
             hideAggregatedPreview: 'skip',
             hideChart: 'skip',


### PR DESCRIPTION
**Description:**

## PoC / Demo

Fixes behavior where:
1. **Persistence:** In-panel changes (columns, sort, grid, rowHeight, sampleSize, etc. — `EDITABLE_SAVED_SEARCH_KEYS`) on a Discover session embeddable added **by value** (unlinked) were not persisted when saving the dashboard after the first save.
2. **Unsaved badge:** The dashboard "Unsaved changes" badge did not appear for those in-panel edits.

### Cause
- By-value panels store editable state in `attributes`. The embeddable used `attributes: 'skip'` in `getComparators()`, so the dashboard never detected changes and never refreshed the panel state it uses on save.
- After adding attribute comparison, the badge showed immediately because saved state often omits keys (e.g. `rowsPerPage`, `sampleSize`) while current serialized state includes them as `undefined`, so `deepEqual` saw a difference.

### Changes
- **Compare `attributes` for by-value panels** using only `EDITABLE_SAVED_SEARCH_KEYS`, so in-panel edits are detected and the layout manager stores the latest `serializeState()` on save.
- **Normalize comparison** so missing keys in saved state and explicit `undefined` in current state are treated the same (`aAttr[key] ?? undefined` vs `bAttr[key] ?? undefined`), avoiding false unsaved-changes on load.

### Testing
- Add a Discover session to a dashboard, unlink it (by value), change columns/sort/etc. in the panel → unsaved badge appears; save dashboard → reload → changes are persisted.
- Open a dashboard with an existing by-value Discover panel → no unsaved badge until you actually edit the panel.