### PR TITLE
[kbn/storage-adapter] add support for transport options and nested fields

### DIFF
--- a/src/platform/packages/shared/kbn-storage-adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/index.ts
@@ -18,8 +18,18 @@ import type {
   Result,
   SearchRequest,
 } from '@elastic/elasticsearch/lib/api/types';
+import type { TransportRequestOptions } from '@elastic/transport';
 import type { InferSearchResponseOf } from '@kbn/es-types';
 import type { StorageFieldTypeOf, StorageMappingProperty } from './types';
+
+/**
+ * Curated subset of transport-level options that can be forwarded
+ * to the underlying Elasticsearch client on a per-request basis.
+ */
+export type StorageTransportOptions = Pick<
+  TransportRequestOptions,
+  'requestTimeout' | 'maxResponseSize' | 'maxCompressedResponseSize' | 'signal'
+>;
 
 interface StorageSchemaProperties {
   [x: string]: StorageMappingProperty;
@@ -97,7 +107,8 @@ export type StorageClientGetResponse<TDocument extends { _id?: string }> = GetRe
 export type StorageClientSearch<TDocumentType = never> = <
   TSearchRequest extends StorageClientSearchRequest
 >(
-  request: TSearchRequest
+  request: TSearchRequest,
+  transportOptions?: StorageTransportOptions
 ) => Promise<StorageClientSearchResponse<TDocumentType, TSearchRequest>>;
 
 /**
@@ -108,21 +119,25 @@ export type StorageClientSearch<TDocumentType = never> = <
  * to throw a BulkOperationError when any operation fails.
  */
 export type StorageClientBulk<TDocumentType extends { _id?: string } = never> = (
-  request: StorageClientBulkRequest<TDocumentType>
+  request: StorageClientBulkRequest<TDocumentType>,
+  transportOptions?: StorageTransportOptions
 ) => Promise<StorageClientBulkResponse>;
 
 export type StorageClientIndex<TDocumentType = never> = (
-  request: StorageClientIndexRequest<TDocumentType>
+  request: StorageClientIndexRequest<TDocumentType>,
+  transportOptions?: StorageTransportOptions
 ) => Promise<StorageClientIndexResponse>;
 
 export type StorageClientDelete = (
-  request: StorageClientDeleteRequest
+  request: StorageClientDeleteRequest,
+  transportOptions?: StorageTransportOptions
 ) => Promise<StorageClientDeleteResponse>;
 
 export type StorageClientClean = () => Promise<StorageClientCleanResponse>;
 
 export type StorageClientGet<TDocumentType extends { _id?: string } = never> = (
-  request: StorageClientGetRequest
+  request: StorageClientGetRequest,
+  transportOptions?: StorageTransportOptions
 ) => Promise<StorageClientGetResponse<TDocumentType>>;
 
 export type StorageClientExistsIndex = () => Promise<boolean>;

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { StorageTransportOptions } from '../..';
+import { StorageIndexAdapter, type StorageSettings } from '../..';
+
+const createLoggerMock = (): jest.Mocked<Logger> => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    get: jest.fn(),
+  } as unknown as jest.Mocked<Logger>;
+  logger.get.mockReturnValue(logger);
+  return logger;
+};
+
+const storageSettings = {
+  name: 'test_index',
+  schema: {
+    properties: {
+      foo: { type: 'keyword' as const },
+    },
+  },
+} satisfies StorageSettings;
+
+const createMockEsClient = () => {
+  const client = {
+    search: jest.fn().mockResolvedValue({
+      hits: { hits: [{ _id: 'doc1', _index: 'test_index', _source: { foo: 'bar' } }] },
+    }),
+    index: jest.fn().mockResolvedValue({
+      _id: 'doc1',
+      _index: 'test_index-000001',
+      _shards: { successful: 1 },
+      result: 'created',
+    }),
+    bulk: jest.fn().mockResolvedValue({
+      errors: false,
+      items: [{ index: { _id: 'doc1', result: 'created', status: 201 } }],
+      took: 1,
+    }),
+    delete: jest.fn().mockResolvedValue({ result: 'deleted' }),
+    indices: {
+      putIndexTemplate: jest.fn().mockResolvedValue({}),
+      getIndexTemplate: jest.fn().mockResolvedValue({
+        index_templates: [
+          {
+            index_template: {
+              _meta: { version: 'current' },
+            },
+          },
+        ],
+      }),
+      get: jest.fn().mockResolvedValue({
+        'test_index-000001': {
+          mappings: { _meta: { version: 'current' } },
+          aliases: { test_index: { is_write_index: true } },
+        },
+      }),
+      getAlias: jest.fn().mockResolvedValue({
+        'test_index-000001': {
+          aliases: { test_index: { is_write_index: true } },
+        },
+      }),
+      create: jest.fn().mockResolvedValue({}),
+      exists: jest.fn().mockResolvedValue(true),
+      simulateIndexTemplate: jest.fn().mockResolvedValue({
+        template: { mappings: {} },
+      }),
+      putMapping: jest.fn().mockResolvedValue({}),
+    },
+  } as unknown as jest.Mocked<ElasticsearchClient>;
+  return client;
+};
+
+describe('StorageIndexAdapter - transport options forwarding', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let loggerMock: jest.Mocked<Logger>;
+  const transportOptions: StorageTransportOptions = {
+    maxResponseSize: 50 * 1024 * 1024,
+    requestTimeout: 30_000,
+  };
+
+  beforeEach(() => {
+    esClient = createMockEsClient();
+    loggerMock = createLoggerMock();
+  });
+
+  it('forwards transport options to esClient.search', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.search(
+      { track_total_hits: false, size: 10, query: { match_all: {} } },
+      transportOptions
+    );
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 'test_index' }),
+      transportOptions
+    );
+  });
+
+  it('forwards transport options to esClient.index', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.index({ id: 'doc1', document: { foo: 'bar' } }, transportOptions);
+
+    expect(esClient.index).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'doc1', require_alias: true }),
+      transportOptions
+    );
+  });
+
+  it('forwards transport options to esClient.bulk', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.bulk(
+      {
+        operations: [{ index: { _id: 'doc1', document: { foo: 'bar' } } }],
+      },
+      transportOptions
+    );
+
+    expect(esClient.bulk).toHaveBeenCalledWith(
+      expect.objectContaining({ require_alias: true }),
+      transportOptions
+    );
+  });
+
+  it('forwards transport options to esClient.delete', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.delete({ id: 'doc1' }, transportOptions);
+
+    expect(esClient.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'doc1' }),
+      transportOptions
+    );
+  });
+
+  it('forwards transport options through get to esClient.search', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.get({ id: 'doc1' }, transportOptions);
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ terminate_after: 1 }),
+      transportOptions
+    );
+  });
+
+  it('works without transport options (backward compatible)', async () => {
+    const adapter = new StorageIndexAdapter(esClient, loggerMock, storageSettings);
+    const client = adapter.getClient();
+
+    await client.search({ track_total_hits: false, size: 10, query: { match_all: {} } });
+
+    expect(esClient.search).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 'test_index' }),
+      undefined
+    );
+  });
+});

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.test.ts
@@ -168,9 +168,6 @@ describe('StorageIndexAdapter - transport options forwarding', () => {
 
     await client.search({ track_total_hits: false, size: 10, query: { match_all: {} } });
 
-    expect(esClient.search).toHaveBeenCalledWith(
-      expect.objectContaining({ index: 'test_index' }),
-      undefined
-    );
+    expect(esClient.search).toHaveBeenCalledWith(expect.objectContaining({ index: 'test_index' }));
   });
 });

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -22,6 +22,7 @@ import { isResponseError } from '@kbn/es-errors';
 import { last, mapValues, padStart } from 'lodash';
 import type { DiagnosticResult } from '@elastic/elasticsearch';
 import { errors } from '@elastic/elasticsearch';
+import type { TransportRequestOptions } from '@elastic/transport';
 import type {
   IndexStorageSettings,
   StorageClientBulkResponse,
@@ -38,6 +39,7 @@ import type {
   StorageClientClean,
   StorageClientCleanResponse,
   InternalIStorageClient,
+  StorageTransportOptions,
 } from '../..';
 import { getSchemaVersion } from '../get_schema_version';
 import type { StorageMappingProperty } from '../../types';
@@ -94,6 +96,12 @@ function wrapEsCall<T>(p: Promise<T>): Promise<T> {
     caughtError.stack += error.stack;
     throw caughtError;
   });
+}
+
+function optionalTransportArgs(
+  transportOptions?: StorageTransportOptions
+): [] | [TransportRequestOptions] {
+  return transportOptions ? [transportOptions] : [];
 }
 
 export interface StorageIndexAdapterOptions<TApplicationType> {
@@ -285,16 +293,14 @@ export class StorageIndexAdapter<
   }
 
   private search: StorageClientSearch<TApplicationType> = async (request, transportOptions) => {
+    const searchRequest = {
+      ...request,
+      index: this.getSearchIndexPattern(),
+      allow_no_indices: true,
+    };
     return (await wrapEsCall(
       this.esClient
-        .search(
-          {
-            ...request,
-            index: this.getSearchIndexPattern(),
-            allow_no_indices: true,
-          },
-          transportOptions
-        )
+        .search(searchRequest, ...optionalTransportArgs(transportOptions))
         .then((response) => {
           return {
             ...response,
@@ -345,7 +351,7 @@ export class StorageIndexAdapter<
             index: this.getWriteTarget(),
             require_alias: true,
           },
-          transportOptions
+          ...optionalTransportArgs(transportOptions)
         )
       );
 
@@ -400,7 +406,7 @@ export class StorageIndexAdapter<
             index: this.getWriteTarget(),
             require_alias: true,
           },
-          transportOptions
+          ...optionalTransportArgs(transportOptions)
         )
       );
     };
@@ -487,7 +493,7 @@ export class StorageIndexAdapter<
             id,
             index: document._index,
           },
-          transportOptions
+          ...optionalTransportArgs(transportOptions)
         )
       );
 

--- a/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/src/index_adapter/index.ts
@@ -284,14 +284,17 @@ export class StorageIndexAdapter<
     return await cb();
   }
 
-  private search: StorageClientSearch<TApplicationType> = async (request) => {
+  private search: StorageClientSearch<TApplicationType> = async (request, transportOptions) => {
     return (await wrapEsCall(
       this.esClient
-        .search({
-          ...request,
-          index: this.getSearchIndexPattern(),
-          allow_no_indices: true,
-        })
+        .search(
+          {
+            ...request,
+            index: this.getSearchIndexPattern(),
+            allow_no_indices: true,
+          },
+          transportOptions
+        )
         .then((response) => {
           return {
             ...response,
@@ -328,20 +331,22 @@ export class StorageIndexAdapter<
     )) as unknown as ReturnType<StorageClientSearch<TApplicationType>>;
   };
 
-  private index: StorageClientIndex<TApplicationType> = async ({
-    id,
-    refresh = 'wait_for',
-    ...request
-  }): Promise<StorageClientIndexResponse> => {
+  private index: StorageClientIndex<TApplicationType> = async (
+    { id, refresh = 'wait_for', ...request },
+    transportOptions
+  ): Promise<StorageClientIndexResponse> => {
     const attemptIndex = async (): Promise<IndexResponse> => {
       const indexResponse = await wrapEsCall(
-        this.esClient.index({
-          ...request,
-          id,
-          refresh,
-          index: this.getWriteTarget(),
-          require_alias: true,
-        })
+        this.esClient.index(
+          {
+            ...request,
+            id,
+            refresh,
+            index: this.getWriteTarget(),
+            require_alias: true,
+          },
+          transportOptions
+        )
       );
 
       return indexResponse;
@@ -354,12 +359,10 @@ export class StorageIndexAdapter<
     });
   };
 
-  private bulk: StorageClientBulk<TApplicationType> = ({
-    operations,
-    refresh = 'wait_for',
-    throwOnFail = false,
-    ...request
-  }): Promise<StorageClientBulkResponse> => {
+  private bulk: StorageClientBulk<TApplicationType> = (
+    { operations, refresh = 'wait_for', throwOnFail = false, ...request },
+    transportOptions
+  ): Promise<StorageClientBulkResponse> => {
     if (operations.length === 0) {
       this.logger.debug(`Bulk request with 0 operations is a noop`);
       return Promise.resolve({
@@ -389,13 +392,16 @@ export class StorageIndexAdapter<
 
     const attemptBulk = async () => {
       return wrapEsCall(
-        this.esClient.bulk({
-          ...request,
-          refresh,
-          operations: bulkOperations,
-          index: this.getWriteTarget(),
-          require_alias: true,
-        })
+        this.esClient.bulk(
+          {
+            ...request,
+            refresh,
+            operations: bulkOperations,
+            index: this.getWriteTarget(),
+            require_alias: true,
+          },
+          transportOptions
+        )
       );
     };
 
@@ -449,11 +455,10 @@ export class StorageIndexAdapter<
     };
   };
 
-  private delete: StorageClientDelete = async ({
-    id,
-    refresh = 'wait_for',
-    ...request
-  }): Promise<StorageClientDeleteResponse> => {
+  private delete: StorageClientDelete = async (
+    { id, refresh = 'wait_for', ...request },
+    transportOptions
+  ): Promise<StorageClientDeleteResponse> => {
     this.logger.debug(`Deleting document with id ${id}`);
     const searchResponse = await this.search({
       track_total_hits: false,
@@ -475,12 +480,15 @@ export class StorageIndexAdapter<
 
     if (document) {
       await wrapEsCall(
-        this.esClient.delete({
-          ...request,
-          refresh,
-          id,
-          index: document._index,
-        })
+        this.esClient.delete(
+          {
+            ...request,
+            refresh,
+            id,
+            index: document._index,
+          },
+          transportOptions
+        )
       );
 
       return { acknowledged: true, result: 'deleted' };
@@ -489,24 +497,30 @@ export class StorageIndexAdapter<
     return { acknowledged: true, result: 'not_found' };
   };
 
-  private get: StorageClientGet<TApplicationType> = async ({ id, ...request }) => {
-    const response = await this.search({
-      track_total_hits: false,
-      size: 1,
-      terminate_after: 1,
-      query: {
-        bool: {
-          filter: [
-            {
-              term: {
-                _id: id,
+  private get: StorageClientGet<TApplicationType> = async (
+    { id, ...request },
+    transportOptions
+  ) => {
+    const response = await this.search(
+      {
+        track_total_hits: false,
+        size: 1,
+        terminate_after: 1,
+        query: {
+          bool: {
+            filter: [
+              {
+                term: {
+                  _id: id,
+                },
               },
-            },
-          ],
+            ],
+          },
         },
+        ...request,
       },
-      ...request,
-    });
+      transportOptions
+    );
 
     const hit: SearchHit = response.hits.hits[0];
 

--- a/src/platform/packages/shared/kbn-storage-adapter/types.ts
+++ b/src/platform/packages/shared/kbn-storage-adapter/types.ts
@@ -24,6 +24,7 @@ type StorageMappingPropertyType = AllMappingPropertyType &
     | 'double'
     | 'long'
     | 'object'
+    | 'nested'
     | 'semantic_text'
   );
 
@@ -74,6 +75,7 @@ const types = {
   byte: createFactory('byte'),
   float: createFactory('float'),
   object: createFactory('object'),
+  nested: createFactory('nested'),
   semantic_text: createFactory('semantic_text'),
 } satisfies {
   [TKey in StorageMappingPropertyType]: MappingPropertyFactory<TKey, any>;
@@ -98,6 +100,11 @@ type PrimitiveOf<TProperty extends StorageMappingProperty> = {
         [key in keyof TProperty['properties']]?: StorageFieldTypeOf<TProperty['properties'][key]>;
       }
     : object;
+  nested: TProperty extends { properties: Record<string, StorageMappingProperty> }
+    ? Array<{
+        [key in keyof TProperty['properties']]?: StorageFieldTypeOf<TProperty['properties'][key]>;
+      }>
+    : Array<object>;
   semantic_text: string;
 }[TProperty['type']];
 


### PR DESCRIPTION
## Summary

- Allow passing `transportOptions` as a second parameter, similar to how the standard ES client behaves
- Add `nested` field type support