### PR TITLE
[9.3] [Streams] Add comprehensive stream name validation (#251938)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -135,6 +135,11 @@ export type {
 } from './src/api/significant_events';
 
 export { emptyAssets } from './src/helpers/empty_assets';
+export {
+  validateStreamName,
+  MAX_STREAM_NAME_LENGTH,
+  INVALID_STREAM_NAME_CHARACTERS,
+} from './src/helpers/stream_name_validation';
 
 export {
   type Feature,

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  validateStreamName,
+  MAX_STREAM_NAME_LENGTH,
+  INVALID_STREAM_NAME_CHARACTERS,
+} from './stream_name_validation';
+
+describe('validateStreamName', () => {
+  it('returns valid for a valid stream name', () => {
+    expect(validateStreamName('logs')).toEqual({ valid: true });
+    expect(validateStreamName('logs.nginx')).toEqual({ valid: true });
+    expect(validateStreamName('my-stream-name')).toEqual({ valid: true });
+    expect(validateStreamName('logs_2024')).toEqual({ valid: true });
+  });
+
+  it('returns invalid for empty name', () => {
+    expect(validateStreamName('')).toEqual({
+      valid: false,
+      message: 'Stream name must not be empty.',
+    });
+  });
+
+  it('returns invalid for name exceeding max length', () => {
+    const longName = 'a'.repeat(MAX_STREAM_NAME_LENGTH + 1);
+    expect(validateStreamName(longName)).toEqual({
+      valid: false,
+      message: `Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`,
+    });
+  });
+
+  it('returns valid for name at max length', () => {
+    const maxLengthName = 'a'.repeat(MAX_STREAM_NAME_LENGTH);
+    expect(validateStreamName(maxLengthName)).toEqual({ valid: true });
+  });
+
+  it('returns invalid for uppercase characters', () => {
+    expect(validateStreamName('Logs')).toEqual({
+      valid: false,
+      message: 'Stream name cannot contain uppercase characters.',
+    });
+    expect(validateStreamName('LOGS')).toEqual({
+      valid: false,
+      message: 'Stream name cannot contain uppercase characters.',
+    });
+    expect(validateStreamName('loGs')).toEqual({
+      valid: false,
+      message: 'Stream name cannot contain uppercase characters.',
+    });
+  });
+
+  it('returns invalid for space character', () => {
+    expect(validateStreamName('my stream')).toEqual({
+      valid: false,
+      message: 'Stream name cannot contain spaces.',
+    });
+  });
+
+  describe('invalid characters', () => {
+    const testCases = [
+      { char: '"', display: '"\\""' },
+      { char: '\\', display: '"\\\\"' },
+      { char: '*', display: '"*"' },
+      { char: ',', display: '","' },
+      { char: '/', display: '"/"' },
+      { char: '<', display: '"<"' },
+      { char: '>', display: '">"' },
+      { char: '?', display: '"?"' },
+      { char: '|', display: '"|"' },
+    ];
+
+    testCases.forEach(({ char, display }) => {
+      it(`returns invalid for "${char}" character`, () => {
+        const result = validateStreamName(`logs${char}nginx`);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.message).toContain('Stream name cannot contain');
+        }
+      });
+    });
+  });
+
+  it('exports the correct invalid characters list', () => {
+    expect(INVALID_STREAM_NAME_CHARACTERS).toEqual([
+      ' ',
+      '"',
+      '\\',
+      '*',
+      ',',
+      '/',
+      '<',
+      '>',
+      '?',
+      '|',
+    ]);
+  });
+
+  it('exports the correct max length', () => {
+    expect(MAX_STREAM_NAME_LENGTH).toBe(200);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const MAX_STREAM_NAME_LENGTH = 200;
+
+/**
+ * Characters that are not allowed in stream names.
+ * These are the characters that Elasticsearch does not allow in index template/data stream names.
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
+ */
+export const INVALID_STREAM_NAME_CHARACTERS = [' ', '"', '\\', '*', ',', '/', '<', '>', '?', '|'];
+
+/**
+ * Validates a stream name against Elasticsearch naming requirements.
+ * Returns an object indicating validity and an error message if invalid.
+ */
+export const validateStreamName = (
+  name: string
+): { valid: true } | { valid: false; message: string } => {
+  if (!name || name.length === 0) {
+    return { valid: false, message: 'Stream name must not be empty.' };
+  }
+
+  if (name.length > MAX_STREAM_NAME_LENGTH) {
+    return {
+      valid: false,
+      message: `Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`,
+    };
+  }
+
+  if (name !== name.toLowerCase()) {
+    return { valid: false, message: 'Stream name cannot contain uppercase characters.' };
+  }
+
+  for (const char of INVALID_STREAM_NAME_CHARACTERS) {
+    if (name.includes(char)) {
+      const charDisplay = char === ' ' ? 'spaces' : `"${char}"`;
+      return { valid: false, message: `Stream name cannot contain ${charDisplay}.` };
+    }
+  }
+
+  return { valid: true };
+};

--- a/x-pack/platform/plugins/shared/streams/common/constants.ts
+++ b/x-pack/platform/plugins/shared/streams/common/constants.ts
@@ -55,5 +55,3 @@ export const STREAMS_TIERED_FEATURES = [
 ];
 
 export const FAILURE_STORE_SELECTOR = '::failures';
-
-export const MAX_STREAM_NAME_LENGTH = 200;

--- a/x-pack/platform/plugins/shared/streams/public/index.ts
+++ b/x-pack/platform/plugins/shared/streams/public/index.ts
@@ -11,11 +11,7 @@ import type { StreamsPluginSetup, StreamsPluginStart } from './types';
 
 export type { StreamsPluginSetup, StreamsPluginStart };
 
-export {
-  STREAMS_API_PRIVILEGES,
-  STREAMS_UI_PRIVILEGES,
-  MAX_STREAM_NAME_LENGTH,
-} from '../common/constants';
+export { STREAMS_API_PRIVILEGES, STREAMS_UI_PRIVILEGES } from '../common/constants';
 
 export {
   excludeFrozenQuery,

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/classic_stream.ts
@@ -15,7 +15,12 @@ import type {
   IngestStreamLifecycle,
   IngestStreamSettings,
 } from '@kbn/streams-schema';
-import { isIlmLifecycle, isInheritLifecycle, Streams } from '@kbn/streams-schema';
+import {
+  isIlmLifecycle,
+  isInheritLifecycle,
+  Streams,
+  validateStreamName,
+} from '@kbn/streams-schema';
 import { isMappingProperties } from '@kbn/streams-schema/src/fields';
 import {
   isDisabledLifecycleFailureStore,
@@ -146,6 +151,15 @@ export class ClassicStream extends StreamActiveRecord<Streams.ClassicStream.Defi
     desiredState: State,
     startingState: State
   ): Promise<ValidationResult> {
+    // Validate the stream's name
+    const nameValidation = validateStreamName(this._definition.name);
+    if (!nameValidation.valid) {
+      return {
+        isValid: false,
+        errors: [new Error(nameValidation.message)],
+      };
+    }
+
     if (this.dependencies.isServerless) {
       if (isIlmLifecycle(this.getLifecycle())) {
         return { isValid: false, errors: [new Error('Using ILM is not supported in Serverless')] };

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -15,6 +15,7 @@ import {
   getSegments,
   isInheritLifecycle,
   getInheritedFieldsFromAncestors,
+  validateStreamName,
 } from '@kbn/streams-schema';
 import {
   getAncestors,
@@ -32,7 +33,6 @@ import {
   isInheritFailureStore,
 } from '@kbn/streams-schema/src/models/ingest/failure_store';
 import { validateStreamlang } from '@kbn/streamlang';
-import { MAX_STREAM_NAME_LENGTH } from '../../../../../common/constants';
 import { generateLayer } from '../../component_templates/generate_layer';
 import { getComponentTemplateName } from '../../component_templates/name';
 import { isDefinitionNotFoundError } from '../../errors/definition_not_found_error';
@@ -331,6 +331,15 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       };
     }
 
+    // Validate the stream's own name
+    const nameValidation = validateStreamName(this._definition.name);
+    if (!nameValidation.valid) {
+      return {
+        isValid: false,
+        errors: [new Error(nameValidation.message)],
+      };
+    }
+
     const nestingLevel = getSegments(this._definition.name).length;
 
     if (nestingLevel > MAX_NESTING_LEVEL) {
@@ -384,25 +393,22 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
     const children: Set<string> = new Set();
     const prefix = this.definition.name + '.';
     for (const routing of this._definition.ingest.wired.routing) {
-      const hasUpperCaseChars = routing.destination !== routing.destination.toLowerCase();
-      if (hasUpperCaseChars) {
-        return {
-          isValid: false,
-          errors: [new Error(`Stream name cannot contain uppercase characters.`)],
-        };
+      // Only validate child stream name if the child doesn't exist in desired state.
+      // If it exists, it will validate its own name in its own doValidateUpsertion call,
+      // avoiding duplicate error messages.
+      if (!desiredState.has(routing.destination)) {
+        const childNameValidation = validateStreamName(routing.destination);
+        if (!childNameValidation.valid) {
+          return {
+            isValid: false,
+            errors: [new Error(childNameValidation.message)],
+          };
+        }
       }
       if (routing.destination.length <= prefix.length) {
         return {
           isValid: false,
           errors: [new Error(`Stream name must not be empty.`)],
-        };
-      }
-      if (routing.destination.length > MAX_STREAM_NAME_LENGTH) {
-        return {
-          isValid: false,
-          errors: [
-            new Error(`Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`),
-          ],
         };
       }
       if (children.has(routing.destination)) {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.test.tsx
@@ -108,46 +108,49 @@ describe('StreamNameFormRow', () => {
 
   describe('getHelpText', () => {
     it('should return empty error help text when stream name is shorter than the prefix', () => {
-      const result = getHelpText(true, false, false);
+      const result = getHelpText(true, false);
       expect(result).toBe('Stream name is required.');
     });
 
-    it('should return name too long error help text when stream name is longer than 200 characters', () => {
-      const result = getHelpText(false, true, false);
-      expect(result).toBe('Stream name cannot be longer than 200 characters.');
-    });
-
     it('should return undefined help text when input is valid', () => {
-      const result = getHelpText(false, false, false);
+      const result = getHelpText(false, false);
       expect(result).toBeUndefined();
     });
   });
 
   describe('getErrorMessage', () => {
-    it('should return uppercase chars error message when stream name contains uppercase characters', () => {
-      const result = getErrorMessage(true, false, false, false, 'logs.', 'linux', mockRouter);
+    it('should return the base validation error message when provided', () => {
+      const result = getErrorMessage(
+        'Stream name cannot contain uppercase characters.',
+        false,
+        false,
+        false,
+        'logs.',
+        'linux',
+        mockRouter
+      );
       expect(result).toBe('Stream name cannot contain uppercase characters.');
     });
 
     it('should return name conflict error message when stream name is duplicated', () => {
-      const result = getErrorMessage(false, true, false, false, 'logs.', 'linux', mockRouter);
+      const result = getErrorMessage(undefined, true, false, false, 'logs.', 'linux', mockRouter);
       expect(result).toBe('A stream with this name already exists');
     });
 
     it('should return root child does not exist error message when root child stream does not exist', () => {
-      const result = getErrorMessage(false, false, false, true, 'logs.', 'linux', mockRouter);
+      const result = getErrorMessage(undefined, false, false, true, 'logs.', 'linux', mockRouter);
       expect(result).toBe('The child stream logs.linux does not exist. Please create it first.');
     });
 
     it('should return name contains dot error message component when stream name contains a dot', () => {
-      const result = getErrorMessage(false, false, true, true, 'logs.', 'linux', mockRouter);
+      const result = getErrorMessage(undefined, false, true, true, 'logs.', 'linux', mockRouter);
       render(<I18nProvider>{result}</I18nProvider>);
       expect(screen.getByText(/Stream name cannot contain the "." character/)).toBeInTheDocument();
       expect(screen.getByTestId('streamsAppChildStreamLink')).toHaveTextContent('logs.linux');
     });
 
     it('should return undefined error message when input is valid', () => {
-      const result = getErrorMessage(false, false, false, false, 'logs.', 'linux', mockRouter);
+      const result = getErrorMessage(undefined, false, false, false, 'logs.', 'linux', mockRouter);
       expect(result).toBeUndefined();
     });
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/stream_name_form_row.tsx
@@ -18,7 +18,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { MAX_STREAM_NAME_LENGTH } from '@kbn/streams-plugin/public';
+import { validateStreamName } from '@kbn/streams-schema';
 import type { ReactNode } from 'react';
 import React, { useMemo, useState } from 'react';
 import type { StatefulStreamsAppRouter } from '../../../hooks/use_streams_app_router';
@@ -42,29 +42,17 @@ interface StreamNameFormRowProps {
 const MIN_NAME_LENGTH = 1;
 const PREFIX_MAX_VISIBLE_CHARACTERS = 25;
 
-export const getHelpText = (
-  isStreamNameEmpty: boolean,
-  isStreamNameTooLong: boolean,
-  readOnly: boolean
-): string | undefined => {
+export const getHelpText = (isStreamNameEmpty: boolean, readOnly: boolean): string | undefined => {
   if (isStreamNameEmpty && !readOnly) {
     return i18n.translate('xpack.streams.streamDetailRouting.minimumNameHelpText', {
       defaultMessage: `Stream name is required.`,
     });
-  } else if (isStreamNameTooLong && !readOnly) {
-    return i18n.translate('xpack.streams.streamDetailRouting.maximumNameHelpText', {
-      defaultMessage: `Stream name cannot be longer than {maxLength} characters.`,
-      values: {
-        maxLength: MAX_STREAM_NAME_LENGTH,
-      },
-    });
-  } else {
-    return undefined;
   }
+  return undefined;
 };
 
 export const getErrorMessage = (
-  containsUpperCaseChars: boolean,
+  baseValidationError: string | undefined,
   isDuplicatedName: boolean,
   rootChildExists: boolean,
   isDotPresent: boolean,
@@ -72,10 +60,9 @@ export const getErrorMessage = (
   rootChild: string,
   router: StatefulStreamsAppRouter
 ): ReactNode | string | undefined => {
-  if (containsUpperCaseChars) {
-    return i18n.translate('xpack.streams.streamDetailRouting.uppercaseCharsError', {
-      defaultMessage: 'Stream name cannot contain uppercase characters.',
-    });
+  // Return base validation errors from the shared validator first
+  if (baseValidationError) {
+    return baseValidationError;
   }
   if (isDuplicatedName) {
     return i18n.translate('xpack.streams.streamDetailRouting.nameConflictError', {
@@ -168,17 +155,20 @@ export const useChildStreamInput = (
     [routing, prefix, rootChild]
   );
 
+  // Use shared validation for basic stream name checks
+  const baseValidation = validateStreamName(localStreamName);
   const isStreamNameEmpty = localStreamName.length <= prefix.length;
-  const isStreamNameTooLong = localStreamName.length > MAX_STREAM_NAME_LENGTH;
-  const isLengthValid = !isStreamNameEmpty && !isStreamNameTooLong;
-  const containsUpperCaseChars = localStreamName !== localStreamName.toLowerCase();
+  // Base validation passes if the name is valid according to shared validator
+  // However, we also need to check if the partition (the part after the prefix) is empty
+  const baseValidationError =
+    !baseValidation.valid && !isStreamNameEmpty ? baseValidation.message : undefined;
 
-  const helpText = getHelpText(isStreamNameEmpty, isStreamNameTooLong, readOnly);
+  const helpText = getHelpText(isStreamNameEmpty, readOnly);
 
   const isDotPresent = !readOnly && partitionName.includes('.');
 
   const errorMessage = getErrorMessage(
-    containsUpperCaseChars,
+    baseValidationError,
     isDuplicatedName,
     rootChildExists,
     isDotPresent,
@@ -191,7 +181,7 @@ export const useChildStreamInput = (
     localStreamName,
     setLocalStreamName,
     isStreamNameValid:
-      isLengthValid && !isDotPresent && !isDuplicatedName && !containsUpperCaseChars,
+      baseValidation.valid && !isStreamNameEmpty && !isDotPresent && !isDuplicatedName,
     prefix,
     partitionName,
     helpText,

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/create_routing_rules.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_routing/create_routing_rules.spec.ts
@@ -119,28 +119,6 @@ test.describe(
       }
     });
 
-    test('should show validation errors for invalid stream names verified on the server', async ({
-      page,
-      pageObjects,
-    }) => {
-      await pageObjects.streams.clickCreateRoutingRule();
-
-      // Try invalid stream names
-      const invalidNames = ['invalid name with spaces', 'special>chars'];
-
-      for (const invalidName of invalidNames) {
-        await pageObjects.streams.fillRoutingRuleName(invalidName);
-        await pageObjects.streams.saveRoutingRule();
-
-        // Wait for the error toast to appear
-        await pageObjects.toasts.waitFor();
-
-        // Should stay in creating state due to validation error
-        await expect(page.getByTestId('streamsAppRoutingStreamEntryNameField')).toBeVisible();
-        await pageObjects.toasts.closeAll();
-      }
-    });
-
     test('should handle insufficient privileges gracefully', async ({
       page,
       browserAuth,

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/basic.ts
@@ -796,6 +796,81 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         await putStream(apiClient, 'logs.super.duper.hyper.deeply.nested.streamname', body, 400);
       });
+
+      describe('stream name validation', () => {
+        const validStreamBody: Streams.WiredStream.UpsertRequest = {
+          ...emptyAssets,
+          stream: {
+            description: '',
+            ingest: {
+              lifecycle: { inherit: {} },
+              processing: { steps: [] },
+              settings: {},
+              wired: { fields: {}, routing: [] },
+              failure_store: { inherit: {} },
+            },
+          },
+        };
+
+        it('fails to create a wired stream with uppercase characters in the name', async () => {
+          const response = await putStream(apiClient, 'logs.UpperCase', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain uppercase characters.'
+          );
+        });
+
+        it('fails to create a wired stream with spaces in the name', async () => {
+          const response = await putStream(apiClient, 'logs.with space', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain spaces.'
+          );
+        });
+
+        it('fails to create a wired stream with asterisk in the name', async () => {
+          const response = await putStream(apiClient, 'logs.with*asterisk', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain "*".'
+          );
+        });
+
+        it('fails to create a wired stream with angle brackets in the name', async () => {
+          const response = await putStream(apiClient, 'logs.with<brackets>', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain "<".'
+          );
+        });
+
+        it('fails to create a wired stream with question mark in the name', async () => {
+          const response = await putStream(apiClient, 'logs.with?question', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain "?".'
+          );
+        });
+
+        it('fails to create a wired stream with pipe in the name', async () => {
+          const response = await putStream(apiClient, 'logs.with|pipe', validStreamBody, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain "|".'
+          );
+        });
+
+        it('fails to fork a wired stream with special characters in the destination name', async () => {
+          const body = {
+            stream: {
+              name: 'logs.with*special',
+            },
+            where: {
+              field: 'log.logger',
+              eq: 'test',
+            },
+            status,
+          };
+          const response = await forkStream(apiClient, 'logs', body, 400);
+          expect((response as unknown as { message: string }).message).to.contain(
+            'Stream name cannot contain "*".'
+          );
+        });
+      });
     });
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/classic.ts
@@ -531,6 +531,94 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
+    describe('Classic stream name validation', () => {
+      const validClassicStreamBody = {
+        ...emptyAssets,
+        stream: {
+          description: '',
+          ingest: {
+            lifecycle: { inherit: {} },
+            processing: { steps: [] },
+            settings: {},
+            classic: {},
+            failure_store: { inherit: {} },
+          },
+        },
+      };
+
+      it('fails to create a classic stream with uppercase characters in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-UpperCase-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain uppercase characters.'
+        );
+      });
+
+      it('fails to create a classic stream with spaces in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-with space-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain spaces.'
+        );
+      });
+
+      it('fails to create a classic stream with asterisk in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-with*asterisk-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain "*".'
+        );
+      });
+
+      it('fails to create a classic stream with angle brackets in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-with<brackets>-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain "<".'
+        );
+      });
+
+      it('fails to create a classic stream with question mark in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-with?question-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain "?".'
+        );
+      });
+
+      it('fails to create a classic stream with pipe in the name', async () => {
+        const response = await putStream(
+          apiClient,
+          'logs-with|pipe-default',
+          validClassicStreamBody,
+          400
+        );
+        expect((response as any).message).to.eql(
+          'Desired stream state is invalid: Stream name cannot contain "|".'
+        );
+      });
+    });
+
     describe('Classic streams sharing template/pipeline', () => {
       const TEMPLATE_NAME = 'my-shared-template';
       const FIRST_STREAM_NAME = 'mytest-first';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Streams] Add comprehensive stream name validation (#251938)](https://github.com/elastic/kibana/pull/251938)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2026-02-20T08:28:55Z","message":"[Streams] Add comprehensive stream name validation (#251938)\n\n## 🍒 Summary\n\nThis change adds comprehensive input validation for stream names to\nprevent Elasticsearch errors when users create streams with invalid\nnames (uppercase characters, spaces, or special characters).\n\nCloses https://github.com/elastic/observability-error-backlog/issues/450\nFollow-up of https://github.com/elastic/kibana/pull/242581 , patching a\ncouple more cases and centralizing the validation\n\n## 🛠️ Changes\n\n- Created a shared `validateStreamName()` function in\n`common/constants.ts` that validates:\n  - Non-empty names\n  - Max length of 200 characters\n  - Lowercase only (no uppercase characters)\n- No special characters: `\"`, `\\`, `*`, `,`, `/`, `<`, `>`, `?`, `|`, or\nspaces\n- Added validation for the stream's own name in\n`WiredStream.doValidateUpsertion()` (was only validating child stream\nnames before)\n- Added validation for the stream's own name in\n`ClassicStream.doValidateUpsertion()` (had no name validation at all\nbefore)\n- Refactored existing child stream routing validation to use the shared\nhelper\n- Added 13 API integration tests covering various invalid stream name\nscenarios\n\n## 🎙️ Prompts\n\n- \"implement stream name validation checking for lowercase, no spaces,\nand no special characters\"\n- \"add API integration tests for stream name validation in wired and\nclassic streams\"\n\n🤖 This pull request was assisted by Cursor\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"119ca9bb9814f504c5665479564014b476edd3b3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-onboarding","backport:version","Feature:Streams","v9.4.0","v9.3.2"],"title":"[Streams] Add comprehensive stream name validation","number":251938,"url":"https://github.com/elastic/kibana/pull/251938","mergeCommit":{"message":"[Streams] Add comprehensive stream name validation (#251938)\n\n## 🍒 Summary\n\nThis change adds comprehensive input validation for stream names to\nprevent Elasticsearch errors when users create streams with invalid\nnames (uppercase characters, spaces, or special characters).\n\nCloses https://github.com/elastic/observability-error-backlog/issues/450\nFollow-up of https://github.com/elastic/kibana/pull/242581 , patching a\ncouple more cases and centralizing the validation\n\n## 🛠️ Changes\n\n- Created a shared `validateStreamName()` function in\n`common/constants.ts` that validates:\n  - Non-empty names\n  - Max length of 200 characters\n  - Lowercase only (no uppercase characters)\n- No special characters: `\"`, `\\`, `*`, `,`, `/`, `<`, `>`, `?`, `|`, or\nspaces\n- Added validation for the stream's own name in\n`WiredStream.doValidateUpsertion()` (was only validating child stream\nnames before)\n- Added validation for the stream's own name in\n`ClassicStream.doValidateUpsertion()` (had no name validation at all\nbefore)\n- Refactored existing child stream routing validation to use the shared\nhelper\n- Added 13 API integration tests covering various invalid stream name\nscenarios\n\n## 🎙️ Prompts\n\n- \"implement stream name validation checking for lowercase, no spaces,\nand no special characters\"\n- \"add API integration tests for stream name validation in wired and\nclassic streams\"\n\n🤖 This pull request was assisted by Cursor\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"119ca9bb9814f504c5665479564014b476edd3b3"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/251938","number":251938,"mergeCommit":{"message":"[Streams] Add comprehensive stream name validation (#251938)\n\n## 🍒 Summary\n\nThis change adds comprehensive input validation for stream names to\nprevent Elasticsearch errors when users create streams with invalid\nnames (uppercase characters, spaces, or special characters).\n\nCloses https://github.com/elastic/observability-error-backlog/issues/450\nFollow-up of https://github.com/elastic/kibana/pull/242581 , patching a\ncouple more cases and centralizing the validation\n\n## 🛠️ Changes\n\n- Created a shared `validateStreamName()` function in\n`common/constants.ts` that validates:\n  - Non-empty names\n  - Max length of 200 characters\n  - Lowercase only (no uppercase characters)\n- No special characters: `\"`, `\\`, `*`, `,`, `/`, `<`, `>`, `?`, `|`, or\nspaces\n- Added validation for the stream's own name in\n`WiredStream.doValidateUpsertion()` (was only validating child stream\nnames before)\n- Added validation for the stream's own name in\n`ClassicStream.doValidateUpsertion()` (had no name validation at all\nbefore)\n- Refactored existing child stream routing validation to use the shared\nhelper\n- Added 13 API integration tests covering various invalid stream name\nscenarios\n\n## 🎙️ Prompts\n\n- \"implement stream name validation checking for lowercase, no spaces,\nand no special characters\"\n- \"add API integration tests for stream name validation in wired and\nclassic streams\"\n\n🤖 This pull request was assisted by Cursor\n\n---------\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"119ca9bb9814f504c5665479564014b476edd3b3"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->