### PR TITLE
[FTR] Fix flaky clickPanelLink in solution navigation page object

### DIFF
--- a/src/platform/test/functional/page_objects/solution_navigation.ts
+++ b/src/platform/test/functional/page_objects/solution_navigation.ts
@@ -332,7 +332,12 @@ export function SolutionNavigationProvider(ctx: Pick<FtrProviderContext, 'getSer
       async clickPanelLink(navId: string) {
         // TODO: properly distinguish between panel link and main nav link
         // https://github.com/elastic/kibana/issues/236242
-        await testSubjects.click(`~nav-item-id-${navId}`);
+        await retry.try(async () => {
+          const link = await testSubjects.find(`~nav-item-id-${navId}`, 2500);
+          await link.scrollIntoViewIfNecessary();
+          await link.moveMouseTo();
+          await link.click();
+        });
       },
 
       async expectPanelExists(sectionId: NavigationId) {


### PR DESCRIPTION
## Summary

The `clickPanelLink` method in the solution navigation FTR page object was doing a bare `testSubjects.click()` with no retry or stabilization logic. When a side panel is still animating or its content hasn't fully rendered, the click can land on the wrong element or not register at all — causing flaky failures like the "navigates to maintenance windows" test in the MKI observability pipeline, where breadcrumbs showed `['Tags']` instead of `['Maintenance Windows']`.

## Changes

- Wrapped `clickPanelLink` in `retry.try` so transient failures (stale element, panel still loading) are retried
- Added `scrollIntoViewIfNecessary()` and `moveMouseTo()` before clicking to ensure the target element is in the viewport and the cursor is positioned on it before the click fires

Verified against a live MKI observability project — full navigation test suite passes.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->