### PR TITLE
[canvas] fix markdown library items show up in 'from library' flyout

### DIFF
--- a/src/platform/plugins/shared/saved_search/public/index.ts
+++ b/src/platform/plugins/shared/saved_search/public/index.ts
@@ -18,7 +18,7 @@ export type { SaveSavedSearchOptions } from './service/save_saved_searches';
 export type { SavedSearchUnwrapMetaInfo, SavedSearchUnwrapResult } from './service/to_saved_search';
 export type { SavedSearch } from './service/types';
 export { getSavedSearchFullPathUrl, getSavedSearchUrl } from '../common/saved_searches_url';
-export { VIEW_MODE } from '../common';
+export { VIEW_MODE, SavedSearchType } from '../common';
 export type { SavedSearchPublicPluginStart } from './plugin';
 
 export function plugin() {

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -67,7 +67,11 @@ import type {
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
 
 import { css, injectGlobal } from '@emotion/css';
-import { VisualizeConstants, VISUALIZE_EMBEDDABLE_TYPE, VISUALIZE_SAVED_OBJECT_TYPE } from '@kbn/visualizations-common';
+import {
+  VisualizeConstants,
+  VISUALIZE_EMBEDDABLE_TYPE,
+  VISUALIZE_SAVED_OBJECT_TYPE,
+} from '@kbn/visualizations-common';
 import type { KqlPluginStart } from '@kbn/kql/public';
 import type { DrilldownTransforms } from '@kbn/embeddable-plugin/common';
 import { ProjectRoutingAccess } from '@kbn/cps-utils';

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -67,7 +67,7 @@ import type {
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
 
 import { css, injectGlobal } from '@emotion/css';
-import { VisualizeConstants, VISUALIZE_EMBEDDABLE_TYPE } from '@kbn/visualizations-common';
+import { VisualizeConstants, VISUALIZE_EMBEDDABLE_TYPE, VISUALIZE_SAVED_OBJECT_TYPE } from '@kbn/visualizations-common';
 import type { KqlPluginStart } from '@kbn/kql/public';
 import type { DrilldownTransforms } from '@kbn/embeddable-plugin/common';
 import { ProjectRoutingAccess } from '@kbn/cps-utils';
@@ -497,7 +497,7 @@ export class VisualizationsPlugin
           }
         );
       },
-      savedObjectType: VISUALIZE_EMBEDDABLE_TYPE,
+      savedObjectType: VISUALIZE_SAVED_OBJECT_TYPE,
       savedObjectName: i18n.translate('visualizations.visualizeSavedObjectName', {
         defaultMessage: 'Visualization',
       }),

--- a/x-pack/platform/plugins/private/canvas/kibana.jsonc
+++ b/x-pack/platform/plugins/private/canvas/kibana.jsonc
@@ -40,7 +40,8 @@
       "kibanaUtils",
       "lens",
       "maps",
-      "fieldFormats"
+      "fieldFormats",
+      "savedSearch"
     ]
   }
 }

--- a/x-pack/platform/plugins/private/canvas/moon.yml
+++ b/x-pack/platform/plugins/private/canvas/moon.yml
@@ -72,6 +72,8 @@ dependsOn:
   - '@kbn/core-saved-objects-api-server'
   - '@kbn/visualizations-common'
   - '@kbn/shared-ux-utility'
+  - '@kbn/saved-search-plugin'
+  - '@kbn/lens-common'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -21,12 +21,12 @@ import type { SavedObjectFinderProps } from '@kbn/saved-objects-finder-plugin/pu
 import { SavedObjectFinder } from '@kbn/saved-objects-finder-plugin/public';
 import type { CanAddNewPanel } from '@kbn/presentation-publishing';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
-import { contentManagementService, coreServices } from '../../services/kibana_services';
-import { getCanvasNotifyService } from '../../services/canvas_notify_service';
 import { SavedSearchType } from '@kbn/saved-search-plugin/public';
 import { VISUALIZE_SAVED_OBJECT_TYPE } from '@kbn/visualizations-common';
 import { LENS_CONTENT_TYPE } from '@kbn/lens-common/content_management/constants';
 import { MAP_SAVED_OBJECT_TYPE } from '@kbn/maps-plugin/public';
+import { getCanvasNotifyService } from '../../services/canvas_notify_service';
+import { contentManagementService, coreServices } from '../../services/kibana_services';
 
 const strings = {
   getNoItemsText: () =>
@@ -39,7 +39,12 @@ const strings = {
     }),
 };
 
-const CANVAS_LIBRARY_TYPES = [SavedSearchType, VISUALIZE_SAVED_OBJECT_TYPE, LENS_CONTENT_TYPE, MAP_SAVED_OBJECT_TYPE];
+const CANVAS_LIBRARY_TYPES = [
+  SavedSearchType,
+  VISUALIZE_SAVED_OBJECT_TYPE,
+  LENS_CONTENT_TYPE,
+  MAP_SAVED_OBJECT_TYPE,
+];
 
 export interface Props {
   onClose: () => void;

--- a/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -23,6 +23,10 @@ import type { CanAddNewPanel } from '@kbn/presentation-publishing';
 import type { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
 import { contentManagementService, coreServices } from '../../services/kibana_services';
 import { getCanvasNotifyService } from '../../services/canvas_notify_service';
+import { SavedSearchType } from '@kbn/saved-search-plugin/public';
+import { VISUALIZE_SAVED_OBJECT_TYPE } from '@kbn/visualizations-common';
+import { LENS_CONTENT_TYPE } from '@kbn/lens-common/content_management/constants';
+import { MAP_SAVED_OBJECT_TYPE } from '@kbn/maps-plugin/public';
 
 const strings = {
   getNoItemsText: () =>
@@ -35,6 +39,8 @@ const strings = {
     }),
 };
 
+const CANVAS_LIBRARY_TYPES = [SavedSearchType, VISUALIZE_SAVED_OBJECT_TYPE, LENS_CONTENT_TYPE, MAP_SAVED_OBJECT_TYPE];
+
 export interface Props {
   onClose: () => void;
   container: CanAddNewPanel;
@@ -45,9 +51,8 @@ export const AddEmbeddableFlyout: FC<Props> = ({ container, onClose }) => {
 
   const libraryTypes = useAddFromLibraryTypes();
 
-  const canvasOnlyLibraryTypes = useMemo(() => {
-    // Links panels are not supported in Canvas
-    return libraryTypes.filter(({ type }) => type !== 'links');
+  const canvasLibraryTypes = useMemo(() => {
+    return libraryTypes.filter(({ type }) => CANVAS_LIBRARY_TYPES.includes(type));
   }, [libraryTypes]);
 
   const onChoose: SavedObjectFinderProps['onChoose'] = useCallback(
@@ -88,7 +93,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({ container, onClose }) => {
         <SavedObjectFinder
           id="canvasEmbeddableFlyout"
           onChoose={onChoose}
-          savedObjectMetaData={canvasOnlyLibraryTypes}
+          savedObjectMetaData={canvasLibraryTypes}
           showFilter={true}
           noItemsMessage={strings.getNoItemsText()}
           services={{

--- a/x-pack/platform/plugins/private/canvas/tsconfig.json
+++ b/x-pack/platform/plugins/private/canvas/tsconfig.json
@@ -79,7 +79,9 @@
     "@kbn/deeplinks-analytics",
     "@kbn/core-saved-objects-api-server",
     "@kbn/visualizations-common",
-    "@kbn/shared-ux-utility"
+    "@kbn/shared-ux-utility",
+    "@kbn/saved-search-plugin",
+    "@kbn/lens-common"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -428,7 +428,7 @@ export class LensPlugin {
             }
           );
         },
-        savedObjectType: LENS_EMBEDDABLE_TYPE,
+        savedObjectType: LENS_CONTENT_TYPE,
         savedObjectName: i18n.translate('xpack.lens.mapSavedObjectLabel', {
           defaultMessage: 'Lens',
         }),

--- a/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
+++ b/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
@@ -15,6 +15,7 @@ import { getEditPath } from '../common/constants';
 import { getAllMigrations } from './migrations/saved_object_migrations';
 import type { CustomVisualizationMigrations } from './migrations/types';
 import { lensItemAttributesSchemaV0 } from './content_management/v0';
+import { LENS_CONTENT_TYPE } from '@kbn/lens-common/content_management/constants';
 
 /**
  * Extending V0 Lens attributes schema to match existing. Adds loose `version` property.
@@ -35,7 +36,7 @@ export function setupSavedObjects(
   customVisualizationMigrations: CustomVisualizationMigrations
 ) {
   core.savedObjects.registerType({
-    name: 'lens',
+    name: LENS_CONTENT_TYPE,
     indexPattern: ANALYTICS_SAVED_OBJECT_INDEX,
     hidden: false,
     namespaceType: 'multiple-isolated',

--- a/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
+++ b/x-pack/platform/plugins/shared/lens/server/saved_objects.ts
@@ -11,11 +11,11 @@ import { ANALYTICS_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { DataViewPersistableStateService } from '@kbn/data-views-plugin/common';
 import type { MigrateFunctionsObject } from '@kbn/kibana-utils-plugin/common';
 
+import { LENS_CONTENT_TYPE } from '@kbn/lens-common/content_management/constants';
 import { getEditPath } from '../common/constants';
 import { getAllMigrations } from './migrations/saved_object_migrations';
 import type { CustomVisualizationMigrations } from './migrations/types';
 import { lensItemAttributesSchemaV0 } from './content_management/v0';
-import { LENS_CONTENT_TYPE } from '@kbn/lens-common/content_management/constants';
 
 /**
  * Extending V0 Lens attributes schema to match existing. Adds loose `version` property.


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/257643

Changes canvas library types from black list to white list to prevent newly added items to "AddFromLibraryType" registry from showing up in canvas

PR also cleans up some registry items in "AddFromLibraryType". `savedObjectType` should not use `EMBEDDABLE_TYPE` constants as these are two distinct concepts that can have different values.