### PR TITLE
fix(security,tests): remove redundant "check that SAML callback endpoint exists in Serverless" test

### DIFF
--- a/x-pack/platform/test/serverless/api_integration/test_suites/platform_security/authentication.ts
+++ b/x-pack/platform/test/serverless/api_integration/test_suites/platform_security/authentication.ts
@@ -196,23 +196,6 @@ export default function ({ getService }: FtrProviderContext) {
           const { status } = await supertestViewerWithApiKey.get('/api/security/logout');
           expect(status).toBe(302);
         });
-
-        it('SAML callback', async () => {
-          const { body, status } = await supertestViewerWithApiKey
-            .post('/api/security/saml/callback')
-            .set(svlCommonApi.getCommonRequestHeader())
-            .send({
-              SAMLResponse: '',
-            });
-
-          // Should fail with 401 (not 404) because there is no valid SAML response in the request body
-          expect(body).toEqual({
-            error: 'Unauthorized',
-            message: 'Unauthorized',
-            statusCode: 401,
-          });
-          expect(status).not.toBe(404);
-        });
       });
     });
   });


### PR DESCRIPTION
## Summary

While monitoring our SAML login logs in Serverless we've noticed a few strange entries that looked like this:

> * xxxxx - 1 out of 5 login attempts failed:
>    * 2026-03-13T11:59:32.433Z - (xx.xx.xx.xxx, 401, UNKNOWN, git-xxxxx) - Details: [ Kibana: "Failed to log in with SAML response, IDP-initiated, no state, {"error":{"root_cause":[{"type":"security_exception","reason":"Failed to parse SAML message","header":{"WWW-Authenticate":["Bearer realm=\"security\"","ApiKey","Basic realm=\"security\", charset=\"UTF-8\""]}}],"type":"security_exception","reason":"Failed to parse SAML message","caused_by":**{"type":"s_a_x_parse_exception","reason":"Premature end of file."}**,"header":{"WWW-Authenticate":["Bearer realm=\"security\"","ApiKey","Basic realm=\"security\", charset=\"UTF-8\""]}},"status":401}" | ES Stack: "org.elasticsearch.ElasticsearchSecurityException: Failed to parse SAML message
        at org.elasticsearch.security@9.4.0/org.elasticsearch.xpack.security.authc.saml.SamlUtils.samlException(SamlUtils.java:1…" ]

After debugging, it turned out the issue was coming from one of our legacy Serverless tests that was simply checking whether we properly define the SAML callback route in Serverless via sending empty SAML response. At this point, the majority of Kibana Serverless tests rely on this endpoint, making this specific test redundant and a source of unnecessary noise.


