### PR TITLE
[8.19] Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy (#255845)

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.test.ts
@@ -1616,13 +1616,13 @@ describe('config schema', () => {
 describe('createConfig()', () => {
   it('should log a warning and set xpack.security.encryptionKey if not set', async () => {
     const mockRandomBytes = jest.requireMock('crypto').randomBytes;
-    mockRandomBytes.mockReturnValue('ab'.repeat(16));
+    mockRandomBytes.mockReturnValue('ab'.repeat(32));
 
     const logger = loggingSystemMock.create().get();
     const config = createConfig(ConfigSchema.validate({}, { dist: true }), logger, {
       isTLSEnabled: true,
     });
-    expect(config.encryptionKey).toEqual('ab'.repeat(16));
+    expect(config.encryptionKey).toEqual('ab'.repeat(32));
 
     expect(loggingSystemMock.collect(logger).warn).toMatchInlineSnapshot(`
       Array [

--- a/x-pack/platform/plugins/shared/security/server/config.ts
+++ b/x-pack/platform/plugins/shared/security/server/config.ts
@@ -332,7 +332,7 @@ export function createConfig(
         'restart, please set xpack.security.encryptionKey in the kibana.yml or use the bin/kibana-encryption-keys command.'
     );
 
-    encryptionKey = crypto.randomBytes(16).toString('hex');
+    encryptionKey = crypto.randomBytes(32).toString('hex');
   }
 
   const hashedEncryptionKey = crypto.createHash('sha3-256').update(encryptionKey).digest('base64');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy (#255845)](https://github.com/elastic/kibana/pull/255845)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-13T13:24:01Z","message":"Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy (#255845)\n\nThe auto-generated `xpack.security.encryptionKey` used\n`crypto.randomBytes(16).toString('hex')`, producing a 32-character hex\nstring with only **128 bits of entropy** — despite the schema enforcing\n`minLength: 32`. The key length satisfied validation but fell short of\n256-bit cryptographic strength.\n\n## Changes\n\n- **`config.ts`**: Changed `crypto.randomBytes(16)` →\n`crypto.randomBytes(32)`, generating a 64-char hex key with 256-bit\nentropy\n- **`config.test.ts`**: Updated mock return value and expectation to\nreflect the 32-byte key\n\n```ts\n// Before: 16 bytes → 32 hex chars → 128-bit entropy\nencryptionKey = crypto.randomBytes(16).toString('hex');\n\n// After: 32 bytes → 64 hex chars → 256-bit entropy\nencryptionKey = crypto.randomBytes(32).toString('hex');\n```\n\nThe schema's `minLength: 32` validation for user-provided keys is\nunchanged.\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>Require 256-bit (32 char) encryption key in security\nserver config.ts</issue_title>\n> <issue_description>Strengthen the encryption key requirement to 256\nbits (32 characters) in security server config for improved protection.\n> \n> **Context:**\n> In `x-pack/platform/plugins/shared/security/server/config.ts` (see\n[source](https://github.com/elastic/kibana/blob/89acfef87079edda2780454863c20756f07e2b7d/x-pack/platform/plugins/shared/security/server/config.ts#L393)),\nthe encryption key definition and/or validation logic should be updated\nto require a length of 32 characters (256 bits).\n> \n> - Amend the config schema and validation logic to require 32-character\nkeys.\n> - Ensure all references and documentation are updated to reflect this\nstronger requirement.\n> - Update test cases or configuration examples as needed.\n> \n> **Acceptance criteria:**\n> - Encryption keys must be at least 256 bits (32 characters).\n> - Schema and validation logic enforce this minimum length everywhere\nrelevant.\n> - Related documentation and examples are updated.</issue_description>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/kibana-security (Team:Security)</body></comment_new>\n> </comments>\n> \n\n\n</details>\n\n\n\n\n\n- Fixes elastic/kibana#255843\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"e006d1e8ddfb0bda2136bcce92c45974960e6ccf","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","Feature:FIPS","v9.4.0"],"title":"Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy","number":255845,"url":"https://github.com/elastic/kibana/pull/255845","mergeCommit":{"message":"Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy (#255845)\n\nThe auto-generated `xpack.security.encryptionKey` used\n`crypto.randomBytes(16).toString('hex')`, producing a 32-character hex\nstring with only **128 bits of entropy** — despite the schema enforcing\n`minLength: 32`. The key length satisfied validation but fell short of\n256-bit cryptographic strength.\n\n## Changes\n\n- **`config.ts`**: Changed `crypto.randomBytes(16)` →\n`crypto.randomBytes(32)`, generating a 64-char hex key with 256-bit\nentropy\n- **`config.test.ts`**: Updated mock return value and expectation to\nreflect the 32-byte key\n\n```ts\n// Before: 16 bytes → 32 hex chars → 128-bit entropy\nencryptionKey = crypto.randomBytes(16).toString('hex');\n\n// After: 32 bytes → 64 hex chars → 256-bit entropy\nencryptionKey = crypto.randomBytes(32).toString('hex');\n```\n\nThe schema's `minLength: 32` validation for user-provided keys is\nunchanged.\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>Require 256-bit (32 char) encryption key in security\nserver config.ts</issue_title>\n> <issue_description>Strengthen the encryption key requirement to 256\nbits (32 characters) in security server config for improved protection.\n> \n> **Context:**\n> In `x-pack/platform/plugins/shared/security/server/config.ts` (see\n[source](https://github.com/elastic/kibana/blob/89acfef87079edda2780454863c20756f07e2b7d/x-pack/platform/plugins/shared/security/server/config.ts#L393)),\nthe encryption key definition and/or validation logic should be updated\nto require a length of 32 characters (256 bits).\n> \n> - Amend the config schema and validation logic to require 32-character\nkeys.\n> - Ensure all references and documentation are updated to reflect this\nstronger requirement.\n> - Update test cases or configuration examples as needed.\n> \n> **Acceptance criteria:**\n> - Encryption keys must be at least 256 bits (32 characters).\n> - Schema and validation logic enforce this minimum length everywhere\nrelevant.\n> - Related documentation and examples are updated.</issue_description>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/kibana-security (Team:Security)</body></comment_new>\n> </comments>\n> \n\n\n</details>\n\n\n\n\n\n- Fixes elastic/kibana#255843\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"e006d1e8ddfb0bda2136bcce92c45974960e6ccf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255845","number":255845,"mergeCommit":{"message":"Strengthen auto-generated security encryption key from 128-bit to 256-bit entropy (#255845)\n\nThe auto-generated `xpack.security.encryptionKey` used\n`crypto.randomBytes(16).toString('hex')`, producing a 32-character hex\nstring with only **128 bits of entropy** — despite the schema enforcing\n`minLength: 32`. The key length satisfied validation but fell short of\n256-bit cryptographic strength.\n\n## Changes\n\n- **`config.ts`**: Changed `crypto.randomBytes(16)` →\n`crypto.randomBytes(32)`, generating a 64-char hex key with 256-bit\nentropy\n- **`config.test.ts`**: Updated mock return value and expectation to\nreflect the 32-byte key\n\n```ts\n// Before: 16 bytes → 32 hex chars → 128-bit entropy\nencryptionKey = crypto.randomBytes(16).toString('hex');\n\n// After: 32 bytes → 64 hex chars → 256-bit entropy\nencryptionKey = crypto.randomBytes(32).toString('hex');\n```\n\nThe schema's `minLength: 32` validation for user-provided keys is\nunchanged.\n\n\n\n\n\n<details>\n\n<summary>Original prompt</summary>\n\n> \n> ----\n> \n> *This section details on the original issue you should resolve*\n> \n> <issue_title>Require 256-bit (32 char) encryption key in security\nserver config.ts</issue_title>\n> <issue_description>Strengthen the encryption key requirement to 256\nbits (32 characters) in security server config for improved protection.\n> \n> **Context:**\n> In `x-pack/platform/plugins/shared/security/server/config.ts` (see\n[source](https://github.com/elastic/kibana/blob/89acfef87079edda2780454863c20756f07e2b7d/x-pack/platform/plugins/shared/security/server/config.ts#L393)),\nthe encryption key definition and/or validation logic should be updated\nto require a length of 32 characters (256 bits).\n> \n> - Amend the config schema and validation logic to require 32-character\nkeys.\n> - Ensure all references and documentation are updated to reflect this\nstronger requirement.\n> - Update test cases or configuration examples as needed.\n> \n> **Acceptance criteria:**\n> - Encryption keys must be at least 256 bits (32 characters).\n> - Schema and validation logic enforce this minimum length everywhere\nrelevant.\n> - Related documentation and examples are updated.</issue_description>\n> \n> ## Comments on the Issue (you are @copilot in this section)\n> \n> <comments>\n> <comment_new><author>@elasticmachine</author><body>\n> Pinging @elastic/kibana-security (Team:Security)</body></comment_new>\n> </comments>\n> \n\n\n</details>\n\n\n\n\n\n- Fixes elastic/kibana#255843\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: legrego <3493255+legrego@users.noreply.github.com>\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>","sha":"e006d1e8ddfb0bda2136bcce92c45974960e6ccf"}},{"url":"https://github.com/elastic/kibana/pull/257652","number":257652,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/257653","number":257653,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->