### PR TITLE
[Stack Monitoring] Fix bottom bar message layout

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/public/components/renderers/__snapshots__/setup_mode.test.js.snap
+++ b/x-pack/platform/plugins/private/monitoring/public/components/renderers/__snapshots__/setup_mode.test.js.snap
@@ -52,9 +52,11 @@ exports[`SetupModeRenderer should render the flyout open 1`] = `
             <MemoizedFormattedMessage
               defaultMessage="You are in setup mode. The ({flagIcon}) icon indicates configuration options."
               id="xpack.monitoring.setupMode.description"
+              tagName="span"
               values={
                 Object {
                   "flagIcon": <EuiIcon
+                    aria-label="Flag icon"
                     type="flag"
                   />,
                 }
@@ -141,9 +143,11 @@ exports[`SetupModeRenderer should render with setup mode enabled 1`] = `
             <MemoizedFormattedMessage
               defaultMessage="You are in setup mode. The ({flagIcon}) icon indicates configuration options."
               id="xpack.monitoring.setupMode.description"
+              tagName="span"
               values={
                 Object {
                   "flagIcon": <EuiIcon
+                    aria-label="Flag icon"
                     type="flag"
                   />,
                 }

--- a/x-pack/platform/plugins/private/monitoring/public/components/renderers/setup_mode.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/renderers/setup_mode.js
@@ -6,6 +6,7 @@
  */
 
 import { EuiBottomBar, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { Fragment } from 'react';
 import { withKibana } from '@kbn/kibana-react-plugin/public';
@@ -139,9 +140,17 @@ export class WrappedSetupModeRenderer extends React.Component {
                 <EuiFlexItem grow={false}>
                   <FormattedMessage
                     id="xpack.monitoring.setupMode.description"
+                    tagName="span"
                     defaultMessage="You are in setup mode. The ({flagIcon}) icon indicates configuration options."
                     values={{
-                      flagIcon: <EuiIcon type="flag" />,
+                      flagIcon: (
+                        <EuiIcon
+                          type="flag"
+                          aria-label={i18n.translate('xpack.monitoring.setupMode.flagIcon', {
+                            defaultMessage: 'Flag icon',
+                          })}
+                        />
+                      ),
                     }}
                   />
                 </EuiFlexItem>


### PR DESCRIPTION
Closes #249035 

## Summary

This PR:
- Fixes the Monitoring setup mode bottom bar layout by rendering the description FormattedMessage as a span, keeping the flag icon inline (prevents it from wrapping to the next line).
- Improves accessibility by adding an i18n’d aria-label to the flag icon.

| Before | After |
|--------|--------|
| <img width="505" height="105" alt="Screenshot 2026-03-13 at 14 57 10" src="https://github.com/user-attachments/assets/d09f4d27-d6c6-44c6-a45d-289b5f654969" /> | <img width="637" height="80" alt="Screenshot 2026-03-13 at 14 56 42" src="https://github.com/user-attachments/assets/ab3d23fd-781c-44f9-9814-ab5fce27da94" /> | 

### How to test

1. Go to Stack Monitoring
2. Press the blue button to start monitoring
3. After it's done, it will show a message saying: `You are in setup mode. The ({flagIcon}) icon indicates configuration options.`

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved accessibility of the flag icon in monitoring setup mode with ARIA labels for enhanced screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->