### PR TITLE
[9.3] [Streams] Add lowercase stream name validation in create classic stream flyout (#256382)

### DIFF
--- a/src/platform/packages/private/kbn-tinymath/src/index.js
+++ b/src/platform/packages/private/kbn-tinymath/src/index.js
@@ -7,10 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-const { get } = require('lodash');
-const memoizeOne = require('memoize-one');
-const { functions: includedFunctions } = require('./functions');
-const { parse: parseFn } = require('./grammar.peggy');
+import { get } from 'lodash';
+import memoizeOne from 'memoize-one';
+import { functions as includedFunctions } from './functions';
+import { parse as parseFn } from './grammar.peggy';
 
 function parse(input, options) {
   if (input == null) {
@@ -81,4 +81,4 @@ function isOperable(args) {
   });
 }
 
-module.exports = { parse: memoizedParse, evaluate, interpret };
+export { memoizedParse as parse, evaluate, interpret };

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/moon.yml
@@ -23,6 +23,7 @@ dependsOn:
   - '@kbn/storybook'
   - '@kbn/index-management-shared-types'
   - '@kbn/index-lifecycle-management-common-shared'
+  - '@kbn/streams-schema'
 tags:
   - shared-common
   - package

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_stream_section.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_stream_section.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render, fireEvent } from '@testing-library/react';
+import { MAX_STREAM_NAME_LENGTH } from '@kbn/streams-schema';
 import { NameStreamSection } from './name_stream_section';
 
 const defaultProps = {
@@ -157,6 +158,24 @@ describe('NameStreamSection', () => {
       expect(getByText(/It cannot start with/i)).toBeInTheDocument();
     });
 
+    it('displays uppercase validation error message', () => {
+      const { getByText } = renderComponent({
+        validationError: 'uppercase',
+      });
+
+      expect(getByText('Stream name cannot contain uppercase characters.')).toBeInTheDocument();
+    });
+
+    it('displays tooLong validation error message', () => {
+      const { getByText } = renderComponent({
+        validationError: 'tooLong',
+      });
+
+      expect(
+        getByText(`Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`)
+      ).toBeInTheDocument();
+    });
+
     it('displays duplicate validation error message', () => {
       const { getByText } = renderComponent({
         validationError: 'duplicate',
@@ -184,6 +203,8 @@ describe('NameStreamSection', () => {
 
       expect(queryByText(/You must specify a valid text string/i)).not.toBeInTheDocument();
       expect(queryByText(/Stream name cannot include/i)).not.toBeInTheDocument();
+      expect(queryByText(/uppercase/i)).not.toBeInTheDocument();
+      expect(queryByText(/cannot be longer than/i)).not.toBeInTheDocument();
       expect(queryByText(/already exists/i)).not.toBeInTheDocument();
       expect(queryByText(/higher priority/i)).not.toBeInTheDocument();
     });

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_stream_section.tsx
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/components/create_classic_stream_flyout/steps/name_and_confirm/name_stream_section.tsx
@@ -17,6 +17,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { MAX_STREAM_NAME_LENGTH } from '@kbn/streams-schema';
 import { css } from '@emotion/react';
 import type { ValidationErrorType } from '../../../../utils';
 import { StreamNameInput } from '../../../stream_name_input';
@@ -64,6 +65,24 @@ const getValidationErrorMessage = (
         />
       </span>
     );
+  }
+
+  if (validationError === 'uppercase') {
+    return i18n.translate(
+      'xpack.createClassicStreamFlyout.nameAndConfirmStep.uppercaseValidationError',
+      {
+        defaultMessage: 'Stream name cannot contain uppercase characters.',
+      }
+    );
+  }
+
+  if (validationError === 'tooLong') {
+    return i18n.translate('xpack.createClassicStreamFlyout.nameAndConfirmStep.tooLongError', {
+      defaultMessage: 'Stream name cannot be longer than {maxLength} characters.',
+      values: {
+        maxLength: MAX_STREAM_NAME_LENGTH,
+      },
+    });
   }
 
   if (validationError === 'duplicate') {

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/validation_utils.test.ts
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/validation_utils.test.ts
@@ -6,10 +6,10 @@
  */
 
 import type { TemplateListItem as IndexTemplate } from '@kbn/index-management-shared-types';
+import { MAX_STREAM_NAME_LENGTH } from '@kbn/streams-schema';
 
 import {
   hasEmptyWildcards,
-  hasInvalidFormat,
   validateStreamName,
   type StreamNameValidator,
 } from './validation_utils';
@@ -49,129 +49,6 @@ describe('validation_utils', () => {
     });
   });
 
-  describe('hasInvalidFormat', () => {
-    describe('reserved names', () => {
-      it('returns true for "." (dot)', () => {
-        expect(hasInvalidFormat('.')).toBe(true);
-      });
-
-      it('returns true for ".." (double dot)', () => {
-        expect(hasInvalidFormat('..')).toBe(true);
-      });
-    });
-
-    describe('invalid prefixes', () => {
-      it('returns true when stream name starts with "-"', () => {
-        expect(hasInvalidFormat('-logs')).toBe(true);
-      });
-
-      it('returns true when stream name starts with "_"', () => {
-        expect(hasInvalidFormat('_logs')).toBe(true);
-      });
-
-      it('returns true when stream name starts with "+"', () => {
-        expect(hasInvalidFormat('+logs')).toBe(true);
-      });
-
-      it('returns true when stream name starts with ".ds-"', () => {
-        expect(hasInvalidFormat('.ds-logs')).toBe(true);
-      });
-
-      it('returns false when stream name contains but does not start with invalid prefix', () => {
-        expect(hasInvalidFormat('logs-_data')).toBe(false);
-        expect(hasInvalidFormat('logs.ds-data')).toBe(false);
-      });
-    });
-
-    describe('invalid characters', () => {
-      it('returns true when stream name contains backslash', () => {
-        expect(hasInvalidFormat('logs\\data')).toBe(true);
-      });
-
-      it('returns true when stream name contains forward slash', () => {
-        expect(hasInvalidFormat('logs/data')).toBe(true);
-      });
-
-      it('returns true when stream name contains asterisk', () => {
-        expect(hasInvalidFormat('logs*data')).toBe(true);
-      });
-
-      it('returns true when stream name contains question mark', () => {
-        expect(hasInvalidFormat('logs?data')).toBe(true);
-      });
-
-      it('returns true when stream name contains double quote', () => {
-        expect(hasInvalidFormat('logs"data')).toBe(true);
-      });
-
-      it('returns true when stream name contains less than', () => {
-        expect(hasInvalidFormat('logs<data')).toBe(true);
-      });
-
-      it('returns true when stream name contains greater than', () => {
-        expect(hasInvalidFormat('logs>data')).toBe(true);
-      });
-
-      it('returns true when stream name contains pipe', () => {
-        expect(hasInvalidFormat('logs|data')).toBe(true);
-      });
-
-      it('returns true when stream name contains comma', () => {
-        expect(hasInvalidFormat('logs,data')).toBe(true);
-      });
-
-      it('returns true when stream name contains hash', () => {
-        expect(hasInvalidFormat('logs#data')).toBe(true);
-      });
-
-      it('returns true when stream name contains colon', () => {
-        expect(hasInvalidFormat('logs:data')).toBe(true);
-      });
-
-      it('returns true when stream name contains space', () => {
-        expect(hasInvalidFormat('logs data')).toBe(true);
-      });
-
-      it('returns true when stream name contains multiple invalid characters', () => {
-        expect(hasInvalidFormat('logs*/data#test')).toBe(true);
-      });
-    });
-
-    describe('valid stream names', () => {
-      it('returns false for simple valid name', () => {
-        expect(hasInvalidFormat('logs')).toBe(false);
-      });
-
-      it('returns false for name with hyphens', () => {
-        expect(hasInvalidFormat('logs-myapp-data')).toBe(false);
-      });
-
-      it('returns false for name with dots (not at start or reserved)', () => {
-        expect(hasInvalidFormat('logs.apache.access')).toBe(false);
-      });
-
-      it('returns false for name with underscores (not at start)', () => {
-        expect(hasInvalidFormat('logs_myapp_v2')).toBe(false);
-      });
-
-      it('returns false for name with numbers', () => {
-        expect(hasInvalidFormat('logs-v2-2024')).toBe(false);
-      });
-
-      it('returns false for name starting with valid dot prefix', () => {
-        expect(hasInvalidFormat('.logs')).toBe(false);
-      });
-
-      it('returns false for complex valid name', () => {
-        expect(hasInvalidFormat('logs-myapp.apache_access-v2-prod')).toBe(false);
-      });
-
-      it('returns false for empty string', () => {
-        expect(hasInvalidFormat('')).toBe(false);
-      });
-    });
-  });
-
   describe('validateStreamName', () => {
     const mockTemplate: IndexTemplate = {
       name: 'test-template',
@@ -196,6 +73,20 @@ describe('validation_utils', () => {
         });
       });
 
+      it('returns invalidFormat error when stream name contains hash', async () => {
+        const result = await validateStreamName('logs#data', mockTemplate);
+        expect(result).toEqual({
+          errorType: 'invalidFormat',
+        });
+      });
+
+      it('returns invalidFormat error when stream name contains colon', async () => {
+        const result = await validateStreamName('logs:data', mockTemplate);
+        expect(result).toEqual({
+          errorType: 'invalidFormat',
+        });
+      });
+
       it('returns invalidFormat error when stream name starts with invalid prefix', async () => {
         const result = await validateStreamName('-logs', mockTemplate);
         expect(result).toEqual({
@@ -208,6 +99,25 @@ describe('validation_utils', () => {
         expect(result).toEqual({
           errorType: 'invalidFormat',
         });
+      });
+
+      it('returns uppercase error when stream name contains uppercase characters', async () => {
+        const result = await validateStreamName('Logs-myapp-data', mockTemplate);
+        expect(result).toEqual({
+          errorType: 'uppercase',
+        });
+      });
+
+      it('returns tooLong error when stream name exceeds max length', async () => {
+        const tooLongName = 'a'.repeat(MAX_STREAM_NAME_LENGTH + 1);
+        const result = await validateStreamName(tooLongName, mockTemplate);
+        expect(result).toEqual({ errorType: 'tooLong' });
+      });
+
+      it('returns no error for stream name at max length', async () => {
+        const maxLengthName = 'a'.repeat(MAX_STREAM_NAME_LENGTH);
+        const result = await validateStreamName(maxLengthName, mockTemplate);
+        expect(result).toEqual({ errorType: null });
       });
 
       it('returns no error for valid stream name', async () => {
@@ -307,6 +217,17 @@ describe('validation_utils', () => {
         expect(mockValidator).not.toHaveBeenCalled();
       });
 
+      it('does not call validator when stream name contains uppercase characters', async () => {
+        const mockValidator: StreamNameValidator = jest.fn();
+
+        const result = await validateStreamName('Logs-myapp', mockTemplate, mockValidator);
+
+        expect(result).toEqual({
+          errorType: 'uppercase',
+        });
+        expect(mockValidator).not.toHaveBeenCalled();
+      });
+
       it('throws error when validator is aborted', async () => {
         const abortController = new AbortController();
         const mockValidator: StreamNameValidator = jest
@@ -333,7 +254,7 @@ describe('validation_utils', () => {
     });
 
     describe('validation order', () => {
-      it('validates in correct order: wildcards -> format -> external validator', async () => {
+      it('validates in correct order: wildcards -> format -> lowercase -> external validator', async () => {
         const validationOrder: string[] = [];
         const mockValidator: StreamNameValidator = jest.fn().mockImplementation(async () => {
           validationOrder.push('external');
@@ -355,6 +276,12 @@ describe('validation_utils', () => {
         // Stream name with invalid format - should not reach external validator
         await validateStreamName('-logs', mockTemplate, mockValidator);
         expect(validationOrder).toEqual([]);
+
+        validationOrder.length = 0;
+
+        // Stream name with uppercase - should not reach external validator
+        await validateStreamName('Logs-myapp', mockTemplate, mockValidator);
+        expect(validationOrder).toEqual([]);
       });
     });
 
@@ -362,12 +289,6 @@ describe('validation_utils', () => {
       it('handles empty string', async () => {
         const result = await validateStreamName('', mockTemplate);
         expect(result).toEqual({ errorType: 'empty' });
-      });
-
-      it('handles very long valid stream name', async () => {
-        const longName = 'logs-' + 'a'.repeat(250);
-        const result = await validateStreamName(longName, mockTemplate);
-        expect(result).toEqual({ errorType: null });
       });
     });
   });

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/validation_utils.ts
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/src/utils/validation_utils.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TemplateListItem as IndexTemplate } from '@kbn/index-management-shared-types';
+import { validateStreamName as validateSchemaStreamName } from '@kbn/streams-schema';
 
 /**
  * Checks if a stream name has unfilled wildcards (contains *)
@@ -15,58 +16,16 @@ export const hasEmptyWildcards = (streamName: string): boolean => {
 };
 
 /**
- * Characters that are not allowed in data stream names
- */
-const INVALID_CHARACTERS = ['\\', '/', '*', '?', '"', '<', '>', '|', ',', '#', ':', ' '];
-
-/**
- * Prefixes that data stream names cannot start with
- */
-const INVALID_PREFIXES = ['-', '_', '+', '.ds-'];
-
-/**
- * Reserved names that cannot be used as data stream names
- */
-const RESERVED_NAMES = ['.', '..'];
-
-/**
- * Checks if a data stream name has an invalid format according to Elasticsearch naming rules.
- *
- * Rules:
- * - Cannot include: \, /, *, ?, ", <, >, |, ,, #, :, or a space character
- * - Cannot start with: -, _, +, or .ds-
- * - Cannot be: . or ..
- *
- * @param streamName The data stream name to validate
- * @returns true if the stream name format is INVALID, false if valid
- */
-export const hasInvalidFormat = (streamName: string): boolean => {
-  // Check for reserved names
-  if (RESERVED_NAMES.includes(streamName)) {
-    return true;
-  }
-
-  // Check for invalid prefixes
-  for (const prefix of INVALID_PREFIXES) {
-    if (streamName.startsWith(prefix)) {
-      return true;
-    }
-  }
-
-  // Check for invalid characters
-  for (const char of INVALID_CHARACTERS) {
-    if (streamName.includes(char)) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-/**
  * Validation error types for stream name validation
  */
-export type ValidationErrorType = 'empty' | 'invalidFormat' | 'duplicate' | 'higherPriority' | null;
+export type ValidationErrorType =
+  | 'empty'
+  | 'invalidFormat'
+  | 'uppercase'
+  | 'tooLong'
+  | 'duplicate'
+  | 'higherPriority'
+  | null;
 
 /**
  * Result from stream name validation
@@ -106,9 +65,23 @@ export const validateStreamName = async (
     return { errorType: 'empty' };
   }
 
-  // Check for invalid format
-  if (hasInvalidFormat(streamName)) {
-    return { errorType: 'invalidFormat' };
+  // Validate stream name against Elasticsearch naming requirements
+  const schemaValidation = validateSchemaStreamName(streamName);
+  if (!schemaValidation.valid) {
+    switch (schemaValidation.error) {
+      case 'tooLong':
+        return { errorType: 'tooLong' };
+      case 'uppercase':
+        return { errorType: 'uppercase' };
+      case 'invalidCharacter':
+      case 'invalidPrefix':
+      case 'reservedName':
+        return { errorType: 'invalidFormat' };
+      case 'empty':
+      default:
+        // Should already be caught above, but keep it defensive
+        return { errorType: 'empty' };
+    }
   }
 
   // Run the external validator if provided

--- a/x-pack/platform/packages/shared/kbn-classic-stream-flyout/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-classic-stream-flyout/tsconfig.json
@@ -11,6 +11,7 @@
     "@kbn/i18n-react",
     "@kbn/storybook",
     "@kbn/index-management-shared-types",
-    "@kbn/index-lifecycle-management-common-shared"
+    "@kbn/index-lifecycle-management-common-shared",
+    "@kbn/streams-schema"
   ]
 }

--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -137,6 +137,8 @@ export type {
 export { emptyAssets } from './src/helpers/empty_assets';
 export {
   validateStreamName,
+  type StreamNameValidationError,
+  type StreamNameValidationResult,
   MAX_STREAM_NAME_LENGTH,
   INVALID_STREAM_NAME_CHARACTERS,
 } from './src/helpers/stream_name_validation';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.test.ts
@@ -8,6 +8,8 @@
 import {
   validateStreamName,
   MAX_STREAM_NAME_LENGTH,
+  INVALID_STREAM_NAME_PREFIXES,
+  RESERVED_STREAM_NAMES,
   INVALID_STREAM_NAME_CHARACTERS,
 } from './stream_name_validation';
 
@@ -22,6 +24,7 @@ describe('validateStreamName', () => {
   it('returns invalid for empty name', () => {
     expect(validateStreamName('')).toEqual({
       valid: false,
+      error: 'empty',
       message: 'Stream name must not be empty.',
     });
   });
@@ -30,7 +33,9 @@ describe('validateStreamName', () => {
     const longName = 'a'.repeat(MAX_STREAM_NAME_LENGTH + 1);
     expect(validateStreamName(longName)).toEqual({
       valid: false,
+      error: 'tooLong',
       message: `Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`,
+      meta: { maxLength: MAX_STREAM_NAME_LENGTH },
     });
   });
 
@@ -42,14 +47,17 @@ describe('validateStreamName', () => {
   it('returns invalid for uppercase characters', () => {
     expect(validateStreamName('Logs')).toEqual({
       valid: false,
+      error: 'uppercase',
       message: 'Stream name cannot contain uppercase characters.',
     });
     expect(validateStreamName('LOGS')).toEqual({
       valid: false,
+      error: 'uppercase',
       message: 'Stream name cannot contain uppercase characters.',
     });
     expect(validateStreamName('loGs')).toEqual({
       valid: false,
+      error: 'uppercase',
       message: 'Stream name cannot contain uppercase characters.',
     });
   });
@@ -57,8 +65,37 @@ describe('validateStreamName', () => {
   it('returns invalid for space character', () => {
     expect(validateStreamName('my stream')).toEqual({
       valid: false,
+      error: 'invalidCharacter',
       message: 'Stream name cannot contain spaces.',
+      meta: { character: ' ' },
     });
+  });
+
+  it('returns invalid for reserved names', () => {
+    for (const reserved of RESERVED_STREAM_NAMES) {
+      expect(validateStreamName(reserved)).toEqual({
+        valid: false,
+        error: 'reservedName',
+        message: `Stream name cannot be "${reserved}".`,
+        meta: { name: reserved },
+      });
+    }
+  });
+
+  it('returns invalid for names with invalid prefixes', () => {
+    for (const prefix of INVALID_STREAM_NAME_PREFIXES) {
+      expect(validateStreamName(`${prefix}logs`)).toEqual({
+        valid: false,
+        error: 'invalidPrefix',
+        message: `Stream name cannot start with "${prefix}".`,
+        meta: { prefix },
+      });
+    }
+  });
+
+  it('does not treat invalid prefix as invalid when it is not at the start', () => {
+    expect(validateStreamName('logs-_data')).toEqual({ valid: true });
+    expect(validateStreamName('logs.ds-data')).toEqual({ valid: true });
   });
 
   describe('invalid characters', () => {
@@ -67,6 +104,8 @@ describe('validateStreamName', () => {
       { char: '\\', display: '"\\\\"' },
       { char: '*', display: '"*"' },
       { char: ',', display: '","' },
+      { char: '#', display: '"#"' },
+      { char: ':', display: '":"' },
       { char: '/', display: '"/"' },
       { char: '<', display: '"<"' },
       { char: '>', display: '">"' },
@@ -80,6 +119,8 @@ describe('validateStreamName', () => {
         expect(result.valid).toBe(false);
         if (!result.valid) {
           expect(result.message).toContain('Stream name cannot contain');
+          expect(result.error).toBe('invalidCharacter');
+          expect(result.meta).toEqual({ character: char });
         }
       });
     });
@@ -92,6 +133,8 @@ describe('validateStreamName', () => {
       '\\',
       '*',
       ',',
+      '#',
+      ':',
       '/',
       '<',
       '>',

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/stream_name_validation.ts
@@ -8,39 +8,123 @@
 export const MAX_STREAM_NAME_LENGTH = 200;
 
 /**
+ * Reserved stream names.
+ * These are the names that are not allowed to be used as data stream names by Elasticsearch.
+ * @see https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create-data-stream#operation-indices-create-data-stream-path
+ */
+export const RESERVED_STREAM_NAMES = ['.', '..'];
+
+/**
+ * Invalid stream name prefixes.
+ * These are the prefixes that Elasticsearch does not allow in data stream names.
+ * @see https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create-data-stream#operation-indices-create-data-stream-path
+ */
+export const INVALID_STREAM_NAME_PREFIXES = ['-', '_', '+', '.ds-'];
+
+/**
  * Characters that are not allowed in stream names.
  * These are the characters that Elasticsearch does not allow in index template/data stream names.
- * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
+ * @see https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-create-data-stream#operation-indices-create-data-stream-path
  */
-export const INVALID_STREAM_NAME_CHARACTERS = [' ', '"', '\\', '*', ',', '/', '<', '>', '?', '|'];
+export const INVALID_STREAM_NAME_CHARACTERS = [
+  ' ',
+  '"',
+  '\\',
+  '*',
+  ',',
+  '#',
+  ':',
+  '/',
+  '<',
+  '>',
+  '?',
+  '|',
+];
+
+export type StreamNameValidationError =
+  | 'empty'
+  | 'tooLong'
+  | 'reservedName'
+  | 'invalidPrefix'
+  | 'uppercase'
+  | 'invalidCharacter';
+
+interface StreamNameValidationMetaByError {
+  empty: never;
+  tooLong: { maxLength: number };
+  reservedName: { name: string };
+  invalidPrefix: { prefix: string };
+  uppercase: never;
+  invalidCharacter: { character: string };
+}
+
+type StreamNameValidationInvalidResult = {
+  [E in StreamNameValidationError]: {
+    valid: false;
+    error: E;
+    message: string;
+    meta?: StreamNameValidationMetaByError[E];
+  };
+}[StreamNameValidationError];
+
+export type StreamNameValidationResult = { valid: true } | StreamNameValidationInvalidResult;
 
 /**
  * Validates a stream name against Elasticsearch naming requirements.
  * Returns an object indicating validity and an error message if invalid.
  */
-export const validateStreamName = (
-  name: string
-): { valid: true } | { valid: false; message: string } => {
+export const validateStreamName = (name: string): StreamNameValidationResult => {
   if (!name || name.length === 0) {
-    return { valid: false, message: 'Stream name must not be empty.' };
+    return { valid: false, error: 'empty', message: 'Stream name must not be empty.' };
   }
 
   if (name.length > MAX_STREAM_NAME_LENGTH) {
     return {
       valid: false,
+      error: 'tooLong',
       message: `Stream name cannot be longer than ${MAX_STREAM_NAME_LENGTH} characters.`,
+      meta: { maxLength: MAX_STREAM_NAME_LENGTH },
     };
   }
 
-  if (name !== name.toLowerCase()) {
-    return { valid: false, message: 'Stream name cannot contain uppercase characters.' };
+  if (RESERVED_STREAM_NAMES.includes(name)) {
+    return {
+      valid: false,
+      error: 'reservedName',
+      message: `Stream name cannot be "${name}".`,
+      meta: { name },
+    };
+  }
+
+  for (const prefix of INVALID_STREAM_NAME_PREFIXES) {
+    if (name.startsWith(prefix)) {
+      return {
+        valid: false,
+        error: 'invalidPrefix',
+        message: `Stream name cannot start with "${prefix}".`,
+        meta: { prefix },
+      };
+    }
   }
 
   for (const char of INVALID_STREAM_NAME_CHARACTERS) {
     if (name.includes(char)) {
       const charDisplay = char === ' ' ? 'spaces' : `"${char}"`;
-      return { valid: false, message: `Stream name cannot contain ${charDisplay}.` };
+      return {
+        valid: false,
+        error: 'invalidCharacter',
+        message: `Stream name cannot contain ${charDisplay}.`,
+        meta: { character: char },
+      };
     }
+  }
+
+  if (name !== name.toLowerCase()) {
+    return {
+      valid: false,
+      error: 'uppercase',
+      message: 'Stream name cannot contain uppercase characters.',
+    };
   }
 
   return { valid: true };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Streams] Add lowercase stream name validation in create classic stream flyout (#256382)](https://github.com/elastic/kibana/pull/256382)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Damian Polewski","email":"125268832+damian-polewski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-12T09:18:39Z","message":"[Streams] Add lowercase stream name validation in create classic stream flyout (#256382)\n\nCloses #255594 \n\n## Summary\n\nThis PR:\n\n- Adds stricter classic stream name validation in the classic stream\nflyout, including a uppercase error and \"name is too long\" error\nhandling,\n- Reuses the shared `@kbn/streams-schema` stream name validator instead\nof maintaining duplicate “invalid format” logic in the flyout, and\nextends the schema validator to cover reserved names (`.`/`..`), invalid\nprefixes (`-`, `_`, `+`, `.ds-`), and additional invalid characters\n(`#`, `:`), with unit tests,\n- Cleans up and strengthens tests around stream name validation and\nflyout error messages.\n- Changes `require()` in `kbn/tinymath` to `import` statements to fix\nStorybook runtime errors: `TypeError: memoizeOne is not a function`","sha":"5f879d36d621b2fa207750632f80542d5c6cd469","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport missing","backport:version","Feature:Streams","v9.4.0","v9.3.2"],"title":"[Streams] Add lowercase stream name validation in create classic stream flyout","number":256382,"url":"https://github.com/elastic/kibana/pull/256382","mergeCommit":{"message":"[Streams] Add lowercase stream name validation in create classic stream flyout (#256382)\n\nCloses #255594 \n\n## Summary\n\nThis PR:\n\n- Adds stricter classic stream name validation in the classic stream\nflyout, including a uppercase error and \"name is too long\" error\nhandling,\n- Reuses the shared `@kbn/streams-schema` stream name validator instead\nof maintaining duplicate “invalid format” logic in the flyout, and\nextends the schema validator to cover reserved names (`.`/`..`), invalid\nprefixes (`-`, `_`, `+`, `.ds-`), and additional invalid characters\n(`#`, `:`), with unit tests,\n- Cleans up and strengthens tests around stream name validation and\nflyout error messages.\n- Changes `require()` in `kbn/tinymath` to `import` statements to fix\nStorybook runtime errors: `TypeError: memoizeOne is not a function`","sha":"5f879d36d621b2fa207750632f80542d5c6cd469"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256382","number":256382,"mergeCommit":{"message":"[Streams] Add lowercase stream name validation in create classic stream flyout (#256382)\n\nCloses #255594 \n\n## Summary\n\nThis PR:\n\n- Adds stricter classic stream name validation in the classic stream\nflyout, including a uppercase error and \"name is too long\" error\nhandling,\n- Reuses the shared `@kbn/streams-schema` stream name validator instead\nof maintaining duplicate “invalid format” logic in the flyout, and\nextends the schema validator to cover reserved names (`.`/`..`), invalid\nprefixes (`-`, `_`, `+`, `.ds-`), and additional invalid characters\n(`#`, `:`), with unit tests,\n- Cleans up and strengthens tests around stream name validation and\nflyout error messages.\n- Changes `require()` in `kbn/tinymath` to `import` statements to fix\nStorybook runtime errors: `TypeError: memoizeOne is not a function`","sha":"5f879d36d621b2fa207750632f80542d5c6cd469"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->