### PR TITLE
[8.19] just increase parallelism for some cypress pipelines that block PRs

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -10,6 +10,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
+    parallelism: 14
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -8,6 +8,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
+    parallelism: 12
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
## Summary
Since the timeouts were introduced, PRs are blocked on these steps.