### PR TITLE
[One Workflow] Fix false validation errors for item/index in data.map steps

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.test.ts
@@ -260,6 +260,69 @@ describe('getContextSchemaForPath', () => {
     expectZodSchemaEqual((context.shape as any).while, WhileContextSchema);
   });
 
+  it('should return item and index context for data.map step with.fields', () => {
+    const definitionWithDataMap = {
+      version: '1' as const,
+      name: 'test-workflow',
+      enabled: true,
+      triggers: [{ type: 'manual' as const }],
+      steps: [
+        {
+          name: 'map-step',
+          type: 'data.map',
+          items: '${{ consts.items }}',
+          with: {
+            fields: {
+              title: '${{ item.title }}',
+              pos: '${{ index }}',
+            },
+          },
+        },
+      ],
+      consts: { items: [{ title: 'hello' }] },
+    } as unknown as WorkflowYaml;
+
+    const graph = WorkflowGraph.fromWorkflowDefinition(definitionWithDataMap);
+    const context = getContextSchemaForPath(definitionWithDataMap, graph, [
+      'steps',
+      0,
+      'with',
+      'fields',
+      'title',
+    ]);
+
+    expect((context.shape as any).item).toBeDefined();
+    expect((context.shape as any).index).toBeDefined();
+  });
+
+  it('should add item/index context for data.map step outside with block', () => {
+    const definitionWithDataMap = {
+      version: '1' as const,
+      name: 'test-workflow',
+      enabled: true,
+      triggers: [{ type: 'manual' as const }],
+      steps: [
+        {
+          name: 'map-step',
+          type: 'data.map',
+          items: '${{ consts.items }}',
+          with: {
+            fields: {
+              title: '${{ item.title }}',
+            },
+          },
+        },
+      ],
+      consts: { items: [{ title: 'hello' }] },
+    } as unknown as WorkflowYaml;
+
+    const graph = WorkflowGraph.fromWorkflowDefinition(definitionWithDataMap);
+    const context = getContextSchemaForPath(definitionWithDataMap, graph, ['steps', 0, 'items']);
+
+    expect((context.shape as any).item).toBeDefined();
+    expect((context.shape as any).index).toBeDefined();
+  });
+
   it('should return the context for first step in false branch of if-split', () => {
     const context = getContextSchemaForPath(definition, workflowGraph, [
       'steps',

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
@@ -11,9 +11,10 @@ import _ from 'lodash';
 import type { Document } from 'yaml';
 import type { WorkflowYaml } from '@kbn/workflows';
 import { DynamicStepContextSchema, WhileContextSchema } from '@kbn/workflows';
-import { isEnterForeach, isEnterWhile, type WorkflowGraph } from '@kbn/workflows/graph';
+import { isAtomic, isEnterForeach, isEnterWhile, type WorkflowGraph } from '@kbn/workflows/graph';
 import type { z } from '@kbn/zod/v4';
 import { getContextSchemaWithTemplateLocals } from './extend_context_with_template_locals';
+import { getDataMapContextSchema } from './get_data_map_context_schema';
 import { getForeachStateSchema } from './get_foreach_state_schema';
 import { getNearestStepPath } from './get_nearest_step_path';
 import { getStepsCollectionSchema } from './get_steps_collection_schema';
@@ -89,12 +90,14 @@ function maybeExtendWithTemplateLocals(
   return schema;
 }
 
+const DATA_MAP_STEP_TYPE = 'data.map';
+
 function getStepContextSchemaEnrichmentEntries(
   stepContextSchema: typeof DynamicStepContextSchema,
   workflowExecutionGraph: WorkflowGraph,
   stepId: string
 ) {
-  const enrichments: { key: 'foreach' | 'while'; value: z.ZodType }[] = [];
+  const enrichments: { key: string; value: z.ZodType }[] = [];
   const stack = workflowExecutionGraph.getNodeStack(stepId);
 
   for (const nodeId of stack) {
@@ -124,6 +127,15 @@ function getStepContextSchemaEnrichmentEntries(
   if (selfNode) {
     if (isEnterWhile(selfNode) && !enrichments.some((e) => e.key === 'while')) {
       enrichments.push({ key: 'while', value: WhileContextSchema });
+    }
+
+    if (selfNode.stepType === DATA_MAP_STEP_TYPE && isAtomic(selfNode)) {
+      const { item, index } = getDataMapContextSchema(
+        stepContextSchema,
+        selfNode.configuration?.items
+      );
+      enrichments.push({ key: 'item', value: item });
+      enrichments.push({ key: 'index', value: index });
     }
   }
 

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_context_for_path.ts
@@ -12,6 +12,7 @@ import type { Document } from 'yaml';
 import type { WorkflowYaml } from '@kbn/workflows';
 import { DynamicStepContextSchema, WhileContextSchema } from '@kbn/workflows';
 import { isAtomic, isEnterForeach, isEnterWhile, type WorkflowGraph } from '@kbn/workflows/graph';
+import { DataMapStepTypeId } from '@kbn/workflows-extensions/common';
 import type { z } from '@kbn/zod/v4';
 import { getContextSchemaWithTemplateLocals } from './extend_context_with_template_locals';
 import { getDataMapContextSchema } from './get_data_map_context_schema';
@@ -90,14 +91,12 @@ function maybeExtendWithTemplateLocals(
   return schema;
 }
 
-const DATA_MAP_STEP_TYPE = 'data.map';
-
 function getStepContextSchemaEnrichmentEntries(
   stepContextSchema: typeof DynamicStepContextSchema,
   workflowExecutionGraph: WorkflowGraph,
   stepId: string
 ) {
-  const enrichments: { key: string; value: z.ZodType }[] = [];
+  const enrichments: { key: 'foreach' | 'while' | 'item' | 'index'; value: z.ZodType }[] = [];
   const stack = workflowExecutionGraph.getNodeStack(stepId);
 
   for (const nodeId of stack) {
@@ -129,7 +128,7 @@ function getStepContextSchemaEnrichmentEntries(
       enrichments.push({ key: 'while', value: WhileContextSchema });
     }
 
-    if (selfNode.stepType === DATA_MAP_STEP_TYPE && isAtomic(selfNode)) {
+    if (selfNode.stepType === DataMapStepTypeId && isAtomic(selfNode)) {
       const { item, index } = getDataMapContextSchema(
         stepContextSchema,
         selfNode.configuration?.items

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_data_map_context_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_data_map_context_schema.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DynamicStepContextSchema } from '@kbn/workflows';
+import { z } from '@kbn/zod/v4';
+import { inferZodType } from '../../../../common/lib/zod';
+import { VARIABLE_REGEX } from '../../../../common/lib/regex';
+import { InvalidForeachParameterError } from './errors';
+import { getForeachItemSchema } from './get_foreach_state_schema';
+
+interface DataMapContextSchemaEntries {
+  item: z.ZodType;
+  index: z.ZodType;
+}
+
+/**
+ * Derives `item` and `index` schemas for a `data.map` step.
+ *
+ * The `items` config behaves like `foreach` — it can be a literal array or a
+ * variable reference — so we reuse `getForeachItemSchema` for type derivation.
+ */
+export function getDataMapContextSchema(
+  stepContextSchema: typeof DynamicStepContextSchema,
+  items: unknown
+): DataMapContextSchemaEntries {
+  let itemSchema: z.ZodType = z.unknown();
+
+  try {
+    if (Array.isArray(items)) {
+      if (items.length > 0) {
+        itemSchema = inferZodType(items[0]);
+      }
+    } else if (typeof items === 'string') {
+      const cleanedParam = items.match(VARIABLE_REGEX)?.groups?.key ?? items;
+      itemSchema = getForeachItemSchema(stepContextSchema, cleanedParam);
+    }
+  } catch (error) {
+    if (error instanceof InvalidForeachParameterError) {
+      itemSchema = z.unknown().describe(error.message);
+    } else {
+      throw error;
+    }
+  }
+
+  return {
+    item: itemSchema,
+    index: z.number(),
+  };
+}

--- a/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_data_map_context_schema.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/workflow_context/lib/get_data_map_context_schema.ts
@@ -9,10 +9,9 @@
 
 import type { DynamicStepContextSchema } from '@kbn/workflows';
 import { z } from '@kbn/zod/v4';
-import { inferZodType } from '../../../../common/lib/zod';
+import { parseVariablePath } from '../../../../common/lib/parse_variable_path';
 import { VARIABLE_REGEX } from '../../../../common/lib/regex';
-import { InvalidForeachParameterError } from './errors';
-import { getForeachItemSchema } from './get_foreach_state_schema';
+import { getSchemaAtPath, inferZodType } from '../../../../common/lib/zod';
 
 interface DataMapContextSchemaEntries {
   item: z.ZodType;
@@ -22,34 +21,45 @@ interface DataMapContextSchemaEntries {
 /**
  * Derives `item` and `index` schemas for a `data.map` step.
  *
- * The `items` config behaves like `foreach` — it can be a literal array or a
- * variable reference — so we reuse `getForeachItemSchema` for type derivation.
+ * Unlike `foreach`, `data.map` only accepts literal arrays or `${{ }}`
+ * template variable references — no JSON strings or complex expressions.
  */
 export function getDataMapContextSchema(
   stepContextSchema: typeof DynamicStepContextSchema,
   items: unknown
 ): DataMapContextSchemaEntries {
-  let itemSchema: z.ZodType = z.unknown();
-
-  try {
-    if (Array.isArray(items)) {
-      if (items.length > 0) {
-        itemSchema = inferZodType(items[0]);
-      }
-    } else if (typeof items === 'string') {
-      const cleanedParam = items.match(VARIABLE_REGEX)?.groups?.key ?? items;
-      itemSchema = getForeachItemSchema(stepContextSchema, cleanedParam);
-    }
-  } catch (error) {
-    if (error instanceof InvalidForeachParameterError) {
-      itemSchema = z.unknown().describe(error.message);
-    } else {
-      throw error;
-    }
-  }
-
   return {
-    item: itemSchema,
+    item: getDataMapItemSchema(stepContextSchema, items),
     index: z.number(),
   };
+}
+
+function getDataMapItemSchema(
+  stepContextSchema: typeof DynamicStepContextSchema,
+  items: unknown
+): z.ZodType {
+  if (Array.isArray(items) && items.length > 0) {
+    return inferZodType(items[0]);
+  }
+
+  if (typeof items !== 'string') {
+    return z.unknown();
+  }
+
+  const variableKey = items.match(VARIABLE_REGEX)?.groups?.key;
+  if (!variableKey) {
+    return z.unknown();
+  }
+
+  const parsedPath = parseVariablePath(variableKey);
+  if (!parsedPath || parsedPath.errors || !parsedPath.propertyPath) {
+    return z.unknown();
+  }
+
+  const { schema: iterableSchema } = getSchemaAtPath(stepContextSchema, parsedPath.propertyPath);
+  if (iterableSchema instanceof z.ZodArray) {
+    return iterableSchema.element as z.ZodType;
+  }
+
+  return z.unknown();
 }

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/data_map_validation_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/data_map_validation_workflows.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * data.map step using item and index in with.fields — should be valid.
+ */
+export const getDataMapWithItemAndIndex = () => `name: Data Map Validation
+enabled: false
+triggers:
+  - type: manual
+consts:
+  items:
+    - title: hello
+    - title: world
+steps:
+  - name: map-step
+    type: data.map
+    items: "\${{ consts.items }}"
+    with:
+      fields:
+        title: "\${{ item.title }}"
+        pos: "\${{ index }}"`;
+
+/**
+ * data.map step referencing a non-existent variable — should be flagged.
+ */
+export const getDataMapWithInvalidVariable = () => `name: Data Map Validation
+enabled: false
+triggers:
+  - type: manual
+consts:
+  items:
+    - title: hello
+steps:
+  - name: map-step
+    type: data.map
+    items: "\${{ consts.items }}"
+    with:
+      fields:
+        title: "\${{ item.title }}"
+        bad: "\${{ nonexistent.field }}"`;

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/fixtures/workflows/index.ts
@@ -30,6 +30,10 @@ export {
   getTriggerAlertWorkflowYaml,
 } from './alert_workflows';
 export {
+  getDataMapWithItemAndIndex,
+  getDataMapWithInvalidVariable,
+} from './data_map_validation_workflows';
+export {
   getAssignAfterUseSameLine,
   getAssignBeforeUseSameLine,
   getCaptureAfterUseSameLine,

--- a/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor/data_map_variable_validation.spec.ts
+++ b/src/platform/plugins/shared/workflows_management/test/scout_workflows_ui/ui/parallel_tests/workflow_editor/data_map_variable_validation.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import { spaceTest as test } from '../../fixtures';
+import {
+  getDataMapWithInvalidVariable,
+  getDataMapWithItemAndIndex,
+} from '../../fixtures/workflows';
+
+test.describe(
+  'Variable validation: data.map item and index bindings',
+  {
+    tag: [
+      ...tags.stateful.classic,
+      ...tags.serverless.observability.complete,
+      ...tags.serverless.security.complete,
+    ],
+  },
+  () => {
+    test.beforeEach(async ({ browserAuth, pageObjects }) => {
+      await browserAuth.loginAsPrivilegedUser();
+      await pageObjects.workflowEditor.gotoNewWorkflow();
+    });
+
+    test('item and index references inside data.map with.fields are valid', async ({
+      pageObjects,
+    }) => {
+      const accordion = pageObjects.workflowEditor.validationErrorsAccordion;
+
+      await pageObjects.workflowEditor.setYamlEditorValue(getDataMapWithItemAndIndex());
+      await expect(accordion).toContainText('No validation errors');
+    });
+
+    test('invalid variable inside data.map with.fields is still flagged', async ({
+      pageObjects,
+    }) => {
+      const accordion = pageObjects.workflowEditor.validationErrorsAccordion;
+
+      await pageObjects.workflowEditor.setYamlEditorValue(getDataMapWithInvalidVariable());
+
+      await expect(accordion.getByText('Variable nonexistent.field is invalid')).toBeVisible();
+      await expect(accordion).not.toContainText('Variable item.title is invalid');
+    });
+  }
+);


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16284

## Summary

The client-side context schema builder (`getContextSchemaForPath`) didn't add `item` and `index` to the variable context for `data.map` steps — the server-side handler binds them at runtime, but the editor didn't know about them, so valid references like `${{ item.title }}` were flagged as invalid.

### Before
<img width="1920" height="1080" alt="before_fix" src="https://github.com/user-attachments/assets/d98342ec-9ba9-4a7a-af34-5164f390b7e7" />


### After
<img width="1920" height="1080" alt="after_fix" src="https://github.com/user-attachments/assets/7e8ba77a-7700-4083-a979-ba65d52dcf20" />

### What changed

- Added `getDataMapContextSchema` (mirrors `getForeachStateSchema`) that derives the item type from the step's `items` config via the graph node, and returns `item`/`index` bindings
- Detection uses the self-node's `stepType` in `getStepContextSchemaEnrichmentEntries`, consistent with how `while` self-enrichment already works — no new args needed
- Scout UI test covering both the happy path (item/index are valid) and the negative case (truly invalid vars are still flagged)

### Repro

```yaml
steps:
  - name: build_user_list
    type: data.map
    items: "${{ consts.users }}"
    with:
      fields:
        display_name: "${{ item.name }}"   # was flagged, now valid
        position: "${{ index }}"           # was flagged, now valid
```

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->