### PR TITLE
[Ingest Pipelines] Space not supported as separator in join processor

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/join.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/processors/join.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { getProcessorValue, renderProcessorEditor, setupEnvironment } from './processor.helpers';
+
+const JOIN_TYPE = 'join';
+
+describe('Processor: Join', () => {
+  let onUpdate: jest.Mock;
+  let httpSetup: ReturnType<typeof setupEnvironment>['httpSetup'];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    ({ httpSetup } = setupEnvironment());
+    onUpdate = jest.fn();
+
+    renderProcessorEditor(httpSetup, {
+      value: {
+        processors: [],
+      },
+      onFlyoutOpen: jest.fn(),
+      onUpdate,
+    });
+
+    fireEvent.click(screen.getByTestId('addProcessorButton'));
+    fireEvent.change(within(screen.getByTestId('processorTypeSelector')).getByTestId('input'), {
+      target: { value: JOIN_TYPE },
+    });
+
+    await screen.findByTestId('addProcessorForm');
+    await screen.findByTestId('fieldNameField');
+  });
+
+  test('allows a whitespace separator', async () => {
+    fireEvent.change(within(screen.getByTestId('fieldNameField')).getByTestId('input'), {
+      target: { value: 'field_1' },
+    });
+    fireEvent.change(within(screen.getByTestId('separatorValueField')).getByTestId('input'), {
+      target: { value: ' ' },
+    });
+
+    fireEvent.click(within(screen.getByTestId('addProcessorForm')).getByTestId('submitButton'));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+
+    const processors = getProcessorValue(onUpdate);
+    expect(processors[0][JOIN_TYPE]).toMatchObject({
+      field: 'field_1',
+      separator: ' ',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/join.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/processors/join.tsx
@@ -36,7 +36,9 @@ const fieldsConfig: FieldsConfig = {
         validator: emptyField(
           i18n.translate('xpack.ingestPipelines.pipelineEditor.joinForm.separatorRequiredError', {
             defaultMessage: 'A value is required.',
-          })
+          }),
+          // Do not trim the separator value to avoid whitespace characters being removed
+          false
         ),
       },
     ],
@@ -53,7 +55,12 @@ export const Join: FunctionComponent = () => {
         )}
       />
 
-      <UseField config={fieldsConfig.separator} component={Field} path="fields.separator" />
+      <UseField
+        config={fieldsConfig.separator}
+        component={Field}
+        path="fields.separator"
+        data-test-subj="separatorValueField"
+      />
 
       <TargetField />
     </>


### PR DESCRIPTION
Closes #251849 

## Summary

This PR:

- Fixes Join separator validation: allows a whitespace separator (e.g. " ") by disabling string trimming in the Join processor’s required-field validator.

### How to test

1. Go to Stack Management -> Ingest pipeline
2. Create new pipeline, add join processor. Set field to `items` and separator to " "
3. Test the pipeline with the document below
```
[
  {
    "_index": "test-index",
    "_id": "1",
    "_source": {
      "items": ["foo", "bar", "baz"]
    }
  }
]
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Join processor in the pipeline editor.

* **Bug Fixes**
  * Fixed separator field handling in the Join processor to preserve whitespace values as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->