### PR TITLE
Fix the HTTP route registration to limit the compressed payloads

### DIFF
--- a/docs/reference/configuration-reference/general-settings.yml
+++ b/docs/reference/configuration-reference/general-settings.yml
@@ -958,6 +958,7 @@ groups:
         id: server-maxpayload
         description: |
           The maximum payload size in bytes for incoming server requests.
+          This option controls the maximum payload size Kibana can handle, rather than the incoming request size, which also limits the inflated size when compression is used.
         datatype: int
         default: 1048576
         applies_to:

--- a/src/core/packages/http/server-internal/src/http_server.test.ts
+++ b/src/core/packages/http/server-internal/src/http_server.test.ts
@@ -28,6 +28,7 @@ import { createServer } from '@kbn/server-http-tools';
 import type { HttpConfig } from './http_config';
 import { HttpServer } from './http_server';
 import { Readable } from 'stream';
+import { gzipSync } from 'zlib';
 import { KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
 import moment from 'moment';
 import type { Observable } from 'rxjs';
@@ -1416,6 +1417,44 @@ describe('body options', () => {
       error: 'Request Entity Too Large',
       message: 'Payload content length greater than maximum allowed: 1',
     });
+  });
+
+  test('should reject a gzip-bomb that inflates beyond `maxBytes`', async () => {
+    const { registerRouter, server: innerServer } = await server.setup({ config$ });
+
+    const router = new Router('', logger, enhanceWithContext, routerOptions);
+    router.post(
+      {
+        path: '/',
+        validate: { body: schema.object({ test: schema.string() }) },
+        options: { body: { maxBytes: 64 } },
+        security: {
+          authz: {
+            requiredPrivileges: ['foo'],
+          },
+        },
+      },
+      (context, req, res) => res.ok({ body: req.route })
+    );
+    registerRouter(router);
+
+    await server.start();
+    await supertest(innerServer.listener)
+      .post('/')
+      .set('Content-Encoding', 'gzip')
+      .set('Content-Type', 'application/json')
+      .send(
+        gzipSync(
+          JSON.stringify({
+            test: '0'.repeat(1024),
+          })
+        )
+      )
+      .expect(413, {
+        statusCode: 413,
+        error: 'Request Entity Too Large',
+        message: 'Payload content length greater than maximum allowed: 64',
+      });
   });
 
   test('should not parse the content in the request', async () => {

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -1074,6 +1074,12 @@ export class HttpServer {
               parse,
               timeout: timeout?.payload,
               multipart: true,
+              compression: maxBytes
+                ? {
+                    gzip: { maxOutputLength: maxBytes },
+                    deflate: { maxOutputLength: maxBytes },
+                  }
+                : undefined,
             }
           : undefined,
         timeout: {

--- a/src/platform/packages/shared/kbn-server-http-tools/src/get_server_options.test.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/get_server_options.test.ts
@@ -107,4 +107,16 @@ describe('getServerOptions', () => {
 
     expect(getServerOptions(httpConfig).routes!.payload!.timeout).toEqual(9007);
   });
+
+  it('configures max payload size', () => {
+    const options = getServerOptions(
+      createConfig({
+        maxPayload: ByteSizeValue.parse('1kb'),
+      })
+    );
+
+    expect(options).toHaveProperty('routes.compression.deflate.maxOutputLength', 1024);
+    expect(options).toHaveProperty('routes.compression.gzip.maxOutputLength', 1024);
+    expect(options).toHaveProperty('routes.payload.maxBytes', 1024);
+  });
 });

--- a/src/platform/packages/shared/kbn-server-http-tools/src/get_server_options.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/get_server_options.ts
@@ -25,6 +25,7 @@ export function getServerOptions(config: IHttpConfig, { configureTLS = true } = 
         headers: corsAllowedHeaders,
       }
     : false;
+  const maxPayload = config.maxPayload.getValueInBytes();
 
   const options: ServerOptions = {
     host: config.host,
@@ -39,9 +40,13 @@ export function getServerOptions(config: IHttpConfig, { configureTLS = true } = 
         privacy: 'private',
         otherwise: 'private, no-cache, no-store, must-revalidate',
       },
+      compression: {
+        deflate: { maxOutputLength: maxPayload },
+        gzip: { maxOutputLength: maxPayload },
+      },
       cors,
       payload: {
-        maxBytes: config.maxPayload.getValueInBytes(),
+        maxBytes: maxPayload,
         timeout: config.payloadTimeout,
       },
       validate: {

--- a/src/platform/plugins/shared/saved_objects_management/server/routes/scroll_count.ts
+++ b/src/platform/plugins/shared/saved_objects_management/server/routes/scroll_count.ts
@@ -26,7 +26,9 @@ export const registerScrollForCountRoute = (router: IRouter) => {
       },
       validate: {
         body: schema.object({
-          typesToInclude: schema.arrayOf(schema.string(), { maxSize: SAVED_OBJECT_TYPES_MAX_SIZE }),
+          typesToInclude: schema.arrayOf(schema.string({ maxLength: 1000 }), {
+            maxSize: SAVED_OBJECT_TYPES_MAX_SIZE,
+          }),
           searchString: schema.maybe(schema.string()),
           references: schema.maybe(
             schema.arrayOf(


### PR DESCRIPTION
Resolves #251549.

- This PR fixes the HTTP server wrapper to also limit the max payload size of the inflated contents. The solution should prevent potential DoS when an attacker sends gzip bombs.
- The second change adds a size limit to the SO management scroll count endpoint to prevent a DoS attack.


<!--ONMERGE {"backportTargets":["8.19","9.3","9.4"]} ONMERGE-->