### PR TITLE
[Side Nav] Fix: content visible above header when scrolled

### DIFF
--- a/src/core/packages/chrome/navigation/src/hooks/use_menu_header_style.test.ts
+++ b/src/core/packages/chrome/navigation/src/hooks/use_menu_header_style.test.ts
@@ -38,7 +38,7 @@ describe('useMenuHeaderStyle', () => {
     expect(typeof result.current).toBe('object');
   });
 
-  it('adjusts padding in dark mode', () => {
+  it('returns sticky header styles in dark mode', () => {
     useEuiTheme.mockReturnValue({ euiTheme: baseTheme, colorMode: 'DARK' });
 
     const { result } = renderHook(() => useMenuHeaderStyle());

--- a/src/core/packages/chrome/navigation/src/hooks/use_menu_header_style.ts
+++ b/src/core/packages/chrome/navigation/src/hooks/use_menu_header_style.ts
@@ -12,16 +12,10 @@ import { css } from '@emotion/react';
 
 /**
  * There is a requirement for the menu header to have a sticky position.
- * `z-index: 1` causes the `1px` border in dark mode to be underneath the header.
  * We cannot apply border to the header because we need to account for the scrollbar.
- *
- * TODO: this needs to be revisited in the future within EUI components to ensure consistency.
  */
 export function useMenuHeaderStyle() {
-  const { euiTheme, colorMode } = useEuiTheme();
-
-  const paddingTop =
-    colorMode === 'DARK' ? `calc(${euiTheme.size.base} - var(--border-width))` : euiTheme.size.base;
+  const { euiTheme } = useEuiTheme();
 
   return css`
     --border-width: ${euiTheme.border.width.thin};
@@ -29,9 +23,10 @@ export function useMenuHeaderStyle() {
     --horizontal-padding: calc(20px - var(--border-width));
 
     position: sticky;
-    top: ${colorMode === 'DARK' ? 'var(--border-width)' : '0'};
+    top: 0;
     z-index: 1;
-    padding: ${paddingTop} var(--horizontal-padding) ${euiTheme.size.xs} var(--horizontal-padding);
+    padding: ${euiTheme.size.base} var(--horizontal-padding) ${euiTheme.size.xs}
+      var(--horizontal-padding);
     margin: 0 1px;
     height: var(--secondary-menu-header-height);
   `;


### PR DESCRIPTION



## Summary

Closes https://github.com/elastic/kibana/issues/249132

**Root cause**: `use_menu_header_style.ts` had a workaround for dark mode where the sticky header was positioned at `top: 1px` instead of `top: 0`.

The original intent of this workaround was to expose the EUI SplitPanel's 1px border in dark mode (which would otherwise be covered by the sticky header's `z-index: 1`). But that 1px gap allowed scrolled content to bleed through from behind the header. The original workaround's rationale is no longer applicable to the current rendering. In the current code, the border is an `outline` on the outer wrapper, and not inside the scrollable container.

<img width="2230" height="1273" alt="image" src="https://github.com/user-attachments/assets/3faf4498-e124-43e8-8ab7-7b642e9f4ea7" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- ~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
