### PR TITLE
[9.2] Improve input validation in config schemas (#257322)

### DIFF
--- a/src/core/packages/deprecations/server-internal/src/deprecation_config.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecation_config.ts
@@ -13,7 +13,7 @@ import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 
 const configSchema = schema.object({
   // `deprecation.skip_deprecated_settings` is consistent with the equivalent ES feature and config property
-  skip_deprecated_settings: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  skip_deprecated_settings: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 100 }),
   enable_http_debug_logs: schema.boolean({ defaultValue: false }),
 });
 

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
@@ -40,6 +40,7 @@ const requestHeadersWhitelistSchemas = [
     },
   }),
   schema.arrayOf(schema.string(), {
+    maxSize: 100,
     // can't use `validate` option on union types, forced to validate each individual subtypes
     // see https://github.com/elastic/kibana/issues/64906
     validate: (headersWhitelist) => {
@@ -62,9 +63,12 @@ export const configSchema = schema.object({
     defaultValue: false,
   }),
   sniffOnConnectionFault: schema.boolean({ defaultValue: false }),
-  hosts: schema.oneOf([hostURISchema, schema.arrayOf(hostURISchema, { minSize: 1 })], {
-    defaultValue: 'http://localhost:9200',
-  }),
+  hosts: schema.oneOf(
+    [hostURISchema, schema.arrayOf(hostURISchema, { minSize: 1, maxSize: 100 })],
+    {
+      defaultValue: 'http://localhost:9200',
+    }
+  ),
   maxSockets: schema.number({ defaultValue: 800, min: 1 }),
   maxIdleSockets: schema.number({ defaultValue: 256, min: 1 }),
   maxResponseSize: schema.oneOf([schema.literal(false), schema.byteSize()], {
@@ -126,7 +130,10 @@ export const configSchema = schema.object({
         { defaultValue: 'full' }
       ),
       certificateAuthorities: schema.maybe(
-        schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { minSize: 1 })])
+        schema.oneOf([
+          schema.string(),
+          schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 }),
+        ])
       ),
       certificate: schema.maybe(schema.string()),
       key: schema.maybe(schema.string()),
@@ -193,7 +200,7 @@ export const configSchema = schema.object({
       path: schema.string(),
       method: schema.maybe(schema.string()),
     }),
-    { defaultValue: [] }
+    { defaultValue: [], maxSize: 100 }
   ),
   dnsCacheTtl: schema.duration({ defaultValue: 0, min: 0 }),
   publicBaseUrl: schema.maybe(hostURISchema),

--- a/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
+++ b/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
@@ -24,18 +24,18 @@ const privilegeSetSchema = schema.object(
       schema.arrayOf(
         schema.oneOf([
           schema.string(),
-          schema.object({ allOf: schema.arrayOf(schema.string(), { minSize: 2 }) }),
+          schema.object({ allOf: schema.arrayOf(schema.string(), { minSize: 2, maxSize: 100 }) }),
         ]),
-        { minSize: 2 }
+        { minSize: 2, maxSize: 100 }
       )
     ),
     allRequired: schema.maybe(
       schema.arrayOf(
         schema.oneOf([
           schema.string(),
-          schema.object({ anyOf: schema.arrayOf(schema.string(), { minSize: 2 }) }),
+          schema.object({ anyOf: schema.arrayOf(schema.string(), { minSize: 2, maxSize: 100 }) }),
         ]),
-        { minSize: 1 }
+        { minSize: 1, maxSize: 100 }
       )
     ),
   },
@@ -51,6 +51,7 @@ const privilegeSetSchema = schema.object(
 const requiredPrivilegesSchema = schema.arrayOf(
   schema.oneOf([privilegeSetSchema, schema.string()]),
   {
+    maxSize: 100,
     validate: (value) => {
       const anyRequired: string[] = [];
       const allRequired: string[] = [];

--- a/src/core/packages/http/server-internal/src/http_config.ts
+++ b/src/core/packages/http/server-internal/src/http_config.ts
@@ -98,7 +98,7 @@ const configSchema = schema.object(
         allowCredentials: schema.boolean({ defaultValue: false }),
         allowOrigin: schema.oneOf(
           [
-            schema.arrayOf(hostURISchema, { minSize: 1 }),
+            schema.arrayOf(hostURISchema, { minSize: 1, maxSize: 100 }),
             schema.arrayOf(schema.literal('*'), { minSize: 1, maxSize: 1 }),
           ],
           {
@@ -174,7 +174,7 @@ const configSchema = schema.object(
           schema.string({
             hostname: true,
           }),
-          { minSize: 1 }
+          { minSize: 1, maxSize: 100 }
         )
       ),
     }),
@@ -187,7 +187,7 @@ const configSchema = schema.object(
       disableProtection: schema.boolean({ defaultValue: false }),
       allowlist: schema.arrayOf(
         schema.string({ validate: match(/^\//, 'must start with a slash') }),
-        { defaultValue: [] }
+        { defaultValue: [], maxSize: 100 }
       ),
     }),
     eluMonitor: schema.object({
@@ -209,7 +209,7 @@ const configSchema = schema.object(
     requestId: schema.object(
       {
         allowFromAnyIp: schema.boolean({ defaultValue: false }),
-        ipAllowlist: schema.arrayOf(schema.ip(), { defaultValue: [] }),
+        ipAllowlist: schema.arrayOf(schema.ip(), { defaultValue: [], maxSize: 100 }),
       },
       {
         validate(value) {
@@ -252,7 +252,7 @@ const configSchema = schema.object(
 
       /** This should not be configurable in serverless */
       useVersionResolutionStrategyForInternalPaths: offeringBasedSchema({
-        traditional: schema.arrayOf(schema.string(), { defaultValue: [] }),
+        traditional: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 100 }),
         serverless: schema.never(),
       }),
     }),

--- a/src/core/packages/http/server-internal/src/http_service.ts
+++ b/src/core/packages/http/server-internal/src/http_service.ts
@@ -271,7 +271,7 @@ export class HttpService
 
     const stringOrStringArraySchema = schema.oneOf([
       schema.string(),
-      schema.arrayOf(schema.string()),
+      schema.arrayOf(schema.string(), { maxSize: 100 }),
     ]);
     const querySchema = schema.object({
       access: schema.oneOf([schema.literal('public'), schema.literal('internal')], {

--- a/src/core/packages/logging/server-internal/src/appenders/rewrite/policies/meta/meta_policy.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/rewrite/policies/meta/meta_policy.ts
@@ -26,7 +26,8 @@ export const metaRewritePolicyConfigSchema = schema.object({
       value: schema.maybe(
         schema.nullable(schema.oneOf([schema.string(), schema.number(), schema.boolean()]))
       ),
-    })
+    }),
+    { maxSize: 100 }
   ),
 });
 

--- a/src/core/packages/logging/server-internal/src/appenders/rewrite/rewrite_appender.ts
+++ b/src/core/packages/logging/server-internal/src/appenders/rewrite/rewrite_appender.ts
@@ -21,7 +21,7 @@ import { createRewritePolicy, rewritePolicyConfigSchema } from './policies';
 export class RewriteAppender implements DisposableAppender {
   public static configSchema = schema.object({
     type: schema.literal('rewrite'),
-    appenders: schema.arrayOf(schema.string(), { defaultValue: [] }),
+    appenders: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 25 }),
     policy: rewritePolicyConfigSchema,
   });
 

--- a/src/core/packages/logging/server-internal/src/logging_config.ts
+++ b/src/core/packages/logging/server-internal/src/logging_config.ts
@@ -50,6 +50,7 @@ const browserConfig = schema.object({
   }),
   loggers: schema.arrayOf(browserLoggerSchema, {
     defaultValue: [],
+    maxSize: 100,
   }),
 });
 
@@ -59,7 +60,7 @@ const browserConfig = schema.object({
  * @public
  */
 export const loggerSchema = schema.object({
-  appenders: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  appenders: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 25 }),
   name: schema.string(),
   level: levelSchema,
 });
@@ -72,11 +73,13 @@ export const config = {
     }),
     loggers: schema.arrayOf(loggerSchema, {
       defaultValue: [],
+      maxSize: 100,
     }),
     root: schema.object({
       appenders: schema.arrayOf(schema.string(), {
         defaultValue: [DEFAULT_APPENDER_NAME],
         minSize: 1,
+        maxSize: 25,
       }),
       level: levelSchema,
     }),
@@ -104,7 +107,7 @@ export const loggerContextConfigSchema = schema.object({
     defaultValue: new Map<string, AppenderConfigType>(),
   }),
 
-  loggers: schema.arrayOf(loggerSchema, { defaultValue: [] }),
+  loggers: schema.arrayOf(loggerSchema, { defaultValue: [], maxSize: 100 }),
 });
 
 /** @public */

--- a/src/core/packages/node/server-internal/src/node_config.ts
+++ b/src/core/packages/node/server-internal/src/node_config.ts
@@ -44,6 +44,7 @@ export const rolesConfig = schema.arrayOf(
   {
     defaultValue: [NODE_WILDCARD_CHAR],
     minSize: 1,
+    maxSize: 10,
     validate: (value) => {
       if (value.length > 1) {
         if (value.includes(NODE_WILDCARD_CHAR)) {

--- a/src/core/packages/plugins/server-internal/src/plugins_config.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_config.ts
@@ -22,7 +22,7 @@ const configSchema = schema.object({
   /**
    * Defines an array of directories where another plugin should be loaded from.
    */
-  paths: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  paths: schema.arrayOf(schema.string(), { defaultValue: [], maxSize: 100 }),
   /**
    * Defines an array of groups to include when loading plugins.
    * Plugins from all groups will be taken into account if the parameter is not provided.
@@ -33,7 +33,8 @@ const configSchema = schema.object({
         KIBANA_GROUPS.map((groupName) => schema.literal(groupName)) as [
           Type<KibanaGroup> // This cast is needed because it's different to Type<T>[] :sight:
         ]
-      )
+      ),
+      { maxSize: 50 }
     )
   ),
   /**

--- a/src/core/packages/pricing/common/src/pricing_tiers_config.ts
+++ b/src/core/packages/pricing/common/src/pricing_tiers_config.ts
@@ -73,6 +73,7 @@ export const tiersConfigSchema = schema.object({
   }),
   products: schema.maybe(
     schema.arrayOf(pricingProductsSchema, {
+      maxSize: 25,
       validate: (products) => {
         if (products && products.length > 1) {
           const firstTier = products[0].tier;

--- a/src/platform/packages/private/kbn-health-gateway-server/src/kibana/kibana_config.ts
+++ b/src/platform/packages/private/kbn-health-gateway-server/src/kibana/kibana_config.ts
@@ -20,6 +20,7 @@ const hostURISchema = schema.uri({ scheme: ['http', 'https'] });
 const configSchema = schema.object({
   hosts: schema.arrayOf(hostURISchema, {
     minSize: 1,
+    maxSize: 100,
   }),
   requestTimeout: schema.duration({ defaultValue: '30s' }),
   ssl: schema.object({
@@ -28,7 +29,7 @@ const configSchema = schema.object({
       { defaultValue: 'full' }
     ),
     certificateAuthorities: schema.maybe(
-      schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { minSize: 1 })])
+      schema.oneOf([schema.string(), schema.arrayOf(schema.string(), { minSize: 1, maxSize: 100 })])
     ),
     certificate: schema.maybe(schema.string()),
   }),

--- a/src/platform/packages/private/kbn-screenshotting-server/src/config/schema.ts
+++ b/src/platform/packages/private/kbn-screenshotting-server/src/config/schema.ts
@@ -33,6 +33,7 @@ export const ConfigSchema = schema.object({
   networkPolicy: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
     rules: schema.arrayOf(RulesSchema, {
+      maxSize: 100,
       defaultValue: [
         { host: undefined, allow: true, protocol: 'http:' },
         { host: undefined, allow: true, protocol: 'https:' },
@@ -63,7 +64,7 @@ export const ConfigSchema = schema.object({
         bypass: schema.conditional(
           schema.siblingRef('enabled'),
           true,
-          schema.arrayOf(schema.string()),
+          schema.arrayOf(schema.string(), { maxSize: 100 }),
           schema.maybe(schema.never())
         ),
       }),

--- a/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/metrics_schema.ts
+++ b/src/platform/packages/private/opentelemetry/kbn-metrics-config/src/metrics_schema.ts
@@ -44,7 +44,7 @@ export const metricsConfigSchema: Type<MetricsConfig> = schema.object({
   interval: schema.duration({ defaultValue: '10s' }),
   timeout: schema.maybe(schema.duration()),
   exporters: schema.oneOf(
-    [metricsExporterConfigSchema, schema.arrayOf(metricsExporterConfigSchema)],
+    [metricsExporterConfigSchema, schema.arrayOf(metricsExporterConfigSchema, { maxSize: 25 })],
     { defaultValue: [] }
   ),
 });

--- a/src/platform/packages/shared/kbn-server-http-tools/src/ssl/ssl_config.ts
+++ b/src/platform/packages/shared/kbn-server-http-tools/src/ssl/ssl_config.ts
@@ -26,10 +26,11 @@ export const sslSchema = schema.object(
   {
     certificate: schema.maybe(schema.string()),
     certificateAuthorities: schema.maybe(
-      schema.oneOf([schema.arrayOf(schema.string()), schema.string()])
+      schema.oneOf([schema.arrayOf(schema.string(), { maxSize: 100 }), schema.string()])
     ),
     cipherSuites: schema.arrayOf(schema.string(), {
       defaultValue: cryptoConstants.defaultCoreCipherList.split(':'),
+      maxSize: 100,
     }),
     enabled: schema.boolean({
       defaultValue: false,
@@ -52,7 +53,7 @@ export const sslSchema = schema.object(
         schema.literal(TLS_V1_2),
         schema.literal(TLS_V1_3),
       ]),
-      { defaultValue: [TLS_V1_2, TLS_V1_3], minSize: 1 }
+      { defaultValue: [TLS_V1_2, TLS_V1_3], minSize: 1, maxSize: 10 }
     ),
     clientAuthentication: schema.oneOf(
       [schema.literal('none'), schema.literal('optional'), schema.literal('required')],

--- a/src/platform/packages/shared/kbn-tracing-config/src/schema.ts
+++ b/src/platform/packages/shared/kbn-tracing-config/src/schema.ts
@@ -18,7 +18,10 @@ export const tracingConfigSchema: Type<TracingConfig> = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
   sample_rate: schema.number({ defaultValue: 1, min: 0, max: 1 }),
   exporters: schema.oneOf(
-    [inferenceTracingExportConfigSchema, schema.arrayOf(inferenceTracingExportConfigSchema, { maxSize: 25 })],
+    [
+      inferenceTracingExportConfigSchema,
+      schema.arrayOf(inferenceTracingExportConfigSchema, { maxSize: 25 }),
+    ],
     { defaultValue: [] }
   ),
 });

--- a/src/platform/packages/shared/kbn-tracing-config/src/schema.ts
+++ b/src/platform/packages/shared/kbn-tracing-config/src/schema.ts
@@ -18,7 +18,7 @@ export const tracingConfigSchema: Type<TracingConfig> = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
   sample_rate: schema.number({ defaultValue: 1, min: 0, max: 1 }),
   exporters: schema.oneOf(
-    [inferenceTracingExportConfigSchema, schema.arrayOf(inferenceTracingExportConfigSchema)],
+    [inferenceTracingExportConfigSchema, schema.arrayOf(inferenceTracingExportConfigSchema, { maxSize: 25 })],
     { defaultValue: [] }
   ),
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Improve input validation in config schemas (#257322)](https://github.com/elastic/kibana/pull/257322)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christiane (Tina) Heiligers","email":"christiane.heiligers@elastic.co"},"sourceCommit":{"committedDate":"2026-03-13T12:55:03Z","message":"Improve input validation in config schemas (#257322)\n\n## Summary\n\nAdds input validation constraints to schema definitions in config\npackages.\n\n**Platform packages:** tracing, SSL, metrics, screenshotting,\nhealth-gateway\n\n**Core packages:** pricing, plugins, node, logging, http, elasticsearch,\ndeprecations\n\nResolves elastic/kibana-team#2428 (partial)\n\n## Test plan\n\n- [ ] CI passes\n- [x] Existing tests continue to pass\n- [x] No functional changes to API behavior for normal usage\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5123c6a9fec44fbc8452388875a8066937d58750","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","kbn/config-schema","v9.4.0","v9.3.2"],"title":"Improve input validation in config schemas","number":257322,"url":"https://github.com/elastic/kibana/pull/257322","mergeCommit":{"message":"Improve input validation in config schemas (#257322)\n\n## Summary\n\nAdds input validation constraints to schema definitions in config\npackages.\n\n**Platform packages:** tracing, SSL, metrics, screenshotting,\nhealth-gateway\n\n**Core packages:** pricing, plugins, node, logging, http, elasticsearch,\ndeprecations\n\nResolves elastic/kibana-team#2428 (partial)\n\n## Test plan\n\n- [ ] CI passes\n- [x] Existing tests continue to pass\n- [x] No functional changes to API behavior for normal usage\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5123c6a9fec44fbc8452388875a8066937d58750"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257322","number":257322,"mergeCommit":{"message":"Improve input validation in config schemas (#257322)\n\n## Summary\n\nAdds input validation constraints to schema definitions in config\npackages.\n\n**Platform packages:** tracing, SSL, metrics, screenshotting,\nhealth-gateway\n\n**Core packages:** pricing, plugins, node, logging, http, elasticsearch,\ndeprecations\n\nResolves elastic/kibana-team#2428 (partial)\n\n## Test plan\n\n- [ ] CI passes\n- [x] Existing tests continue to pass\n- [x] No functional changes to API behavior for normal usage\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5123c6a9fec44fbc8452388875a8066937d58750"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/257642","number":257642,"state":"MERGED","mergeCommit":{"sha":"e0455f30ef88a01b48de8081ec4fd03e87b3d4ce","message":"[9.3] Improve input validation in config schemas (#257322) (#257642)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Improve input validation in config schemas\n(#257322)](https://github.com/elastic/kibana/pull/257322)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Christiane (Tina) Heiligers <christiane.heiligers@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/257783","number":257783,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->