### PR TITLE
Bump Prebuilt Rules Upgrade ESS parallelism from 1 to 2

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -161,7 +161,7 @@ steps:
     depends_on:
       - build
     timeout_in_minutes: 60
-    parallelism: 1
+    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
## Summary

Increase `parallelism` from `1` to `2` for the **Rule Management - Prebuilt Rules Upgrade** ESS Cypress suite in the pull request pipeline.

### Why

The PR pipeline currently runs all 6 upgrade spec files (68 tests) sequentially on a single agent, resulting in ~38 min wall-clock time including stack setup overhead. The `on_merge` pipeline already uses `parallelism: 2` for this suite — this PR aligns the PR pipeline to match.

### Expected impact

- **Wall-clock reduction**: ~38 min → ~20 min (the load balancer puts the heavy `upgrade_with_preview.cy.ts` on one agent and distributes the remaining 5 lighter specs across the other)
- **Cost**: +1 preemptible n2-standard-4 agent (~$0.03/run)
- **Stack sharing**: Already enabled (`CYPRESS_SHARE_STACKS=true`) in the shell script, so both agents benefit from reduced ES/Kibana restart overhead

### What changed

| File | Change |
|------|--------|
| `.buildkite/pipelines/pull_request/security_solution/rule_management.yml` | ESS Upgrade `parallelism: 1` → `parallelism: 2` |

### Empirical data (Build #410148)

| Spec file | Tests | Serverless time |
|-----------|-------|----------------|
| `upgrade_with_preview.cy.ts` | 29 | 8m 33s |
| `upgrade_without_preview.cy.ts` | 15 | 3m 49s |
| `upgrade_notifications.cy.ts` | 15 | 3m 12s |
| `upgrade_error_handling.cy.ts` | 5 | 1m 21s |
| `upgrade_with_preview_basic_license.cy.ts` | 3 | — |
| `upgrade_without_preview_basic_license.cy.ts` | 1 | — |

### Risk Assessment

**Very low risk.** Single YAML value change — no test code or runner logic changes. Easily reversible. Already proven on the `on_merge` pipeline with `parallelism: 2`.


Made with [Cursor](https://cursor.com)

<!--ONMERGE {"backportTargets":["8.19","9.3"]} ONMERGE-->