### PR TITLE
[One Workflow] Upgrade liquidjs from 10.24.0 to 10.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1385,7 +1385,7 @@
     "langchain": "0.3.35",
     "langsmith": "0.4.6",
     "launchdarkly-js-client-sdk": "3.9.0",
-    "liquidjs": "10.24.0",
+    "liquidjs": "10.25.0",
     "load-json-file": "6.2.0",
     "lodash": "4.17.23",
     "lru-cache": "11.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25610,10 +25610,10 @@ linkify-it@^5.0.0:
   dependencies:
     uc.micro "^2.0.0"
 
-liquidjs@10.24.0:
-  version "10.24.0"
-  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.24.0.tgz#1aa832189b48b4102049dfa7a8eea40281fa9389"
-  integrity sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==
+liquidjs@10.25.0:
+  version "10.25.0"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.25.0.tgz#a5ec7063c3202348dc5988343502ad27072f4997"
+  integrity sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==
   dependencies:
     commander "^10.0.0"
 


### PR DESCRIPTION
## Summary

Upgrades `liquidjs` from `10.24.0` to `10.25.0` to resolve the Snyk finding.

Kibana's Workflows feature was already fully mitigated by three independent defense layers introduced in #252846:
1. **Tag allowlist** — `include`, `render`, and `layout` are removed from the engine's tag registry
2. **Regex pre-validation** — server-side rejection of templates containing those tags before parsing
3. **No-op filesystem** — custom `FS` implementation that blocks all file I/O

This upgrade eliminates the Snyk finding and keeps the dependency current with upstream security patches.

## References

Closes elastic/security#8972

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->