### PR TITLE
[Discover] [Dashboard] Update breadcrumb copy for new Discover panel

### DIFF
--- a/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/actions/add_discover_session_panel_action.ts
@@ -54,7 +54,7 @@ export class AddDiscoverSessionPanelAction implements Action<EmbeddableApiContex
     const valueInput: DiscoverSessionTab = {
       id: uuidv4(),
       label: i18n.translate('discover.savedSearchEmbeddable.action.addPanel.byValueTabName', {
-        defaultMessage: 'New by-value Discover session',
+        defaultMessage: 'New Discover session',
       }),
       sort: [],
       columns: [],

--- a/src/platform/test/functional/apps/discover/embeddable/_new_panel_embeddable.ts
+++ b/src/platform/test/functional/apps/discover/embeddable/_new_panel_embeddable.ts
@@ -68,9 +68,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           .then((firstBreadcrumb) => expect(firstBreadcrumb).to.be('Dashboards')),
         discover
           .getSavedSearchTitle()
-          .then((lastBreadcrumb) =>
-            expect(lastBreadcrumb).to.be('Editing New by-value Discover session')
-          ),
+          .then((lastBreadcrumb) => expect(lastBreadcrumb).to.be('Editing New Discover session')),
         testSubjects
           .exists('unifiedTabs_tabsBar', { timeout: 1000 })
           .then((unifiedTabs) => expect(unifiedTabs).not.to.be(true)),


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/256293#discussion_r2908309892.

Synced with @florent-leborgne offline, and we agreed not to use "by-value" in the UI copy. Instead just going with "New Discover session" in the breadcrumb when adding a new Discover panel to a dashboard:
<img src="https://github.com/user-attachments/assets/c051ea00-d721-47d1-a88b-063020e2a092" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.