### PR TITLE
[Cases] PR 3: CaseTaskTemplateService — CRUD + applyTemplate

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -35,6 +35,8 @@ export const CASE_CONFIGURE_SAVED_OBJECT = 'cases-configure' as const;
 export const CASE_RULES_SAVED_OBJECT = 'cases-rules' as const;
 export const CASE_ID_INCREMENTER_SAVED_OBJECT = 'cases-incrementing-id' as const;
 export const CASE_TEMPLATE_SAVED_OBJECT = 'cases-templates' as const;
+export const CASE_TASK_SAVED_OBJECT = 'cases-tasks' as const;
+export const CASE_TASK_TEMPLATE_SAVED_OBJECT = 'cases-task-templates' as const;
 
 /**
  * If more values are added here please also add them here: x-pack/test/cases_api_integration/common/plugins
@@ -107,6 +109,26 @@ export const INTERNAL_CASE_FIND_USER_ACTIONS_URL =
 export const INTERNAL_CASE_GET_CASES_BY_ATTACHMENT_URL =
   `${CASES_INTERNAL_URL}/case/attachments/_find_containing_all` as const;
 export const INTERNAL_BULK_CREATE_CASE_OBSERVABLES_URL = `${CASES_INTERNAL_URL}/{case_id}/observables/_bulk_create`;
+
+/**
+ * Task routes
+ */
+export const CASES_TASKS_URL = `${CASES_URL}/tasks` as const;
+export const CASE_TASKS_URL = `${CASE_DETAILS_URL}/tasks` as const;
+export const CASE_TASK_DETAILS_URL = `${CASE_TASKS_URL}/{task_id}` as const;
+export const CASE_TASKS_BULK_CREATE_URL = `${CASE_TASKS_URL}/_bulk_create` as const;
+export const CASE_TASKS_BULK_UPDATE_URL = `${CASE_TASKS_URL}/_bulk_update` as const;
+export const CASE_TASKS_BULK_DELETE_URL = `${CASE_TASKS_URL}/_bulk_delete` as const;
+export const CASE_TASKS_REORDER_URL = `${CASE_TASKS_URL}/_reorder` as const;
+export const CASE_TASKS_APPLY_TEMPLATE_URL = `${CASE_TASKS_URL}/_apply_template` as const;
+export const CASES_TASKS_MY_URL = `${CASES_TASKS_URL}/_my` as const;
+export const CASES_TASKS_FIND_URL = `${CASES_TASKS_URL}/_find` as const;
+
+/**
+ * Task template routes
+ */
+export const CASES_TASK_TEMPLATES_URL = `${CASES_URL}/task_templates` as const;
+export const CASE_TASK_TEMPLATE_DETAILS_URL = `${CASES_TASK_TEMPLATES_URL}/{template_id}` as const;
 
 export const INTERNAL_TEMPLATES_URL = `${CASES_INTERNAL_URL}/templates` as const;
 export const INTERNAL_TEMPLATE_DETAILS_URL = `${INTERNAL_TEMPLATES_URL}/{template_id}` as const;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task/v1.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserRt } from '../user/v1';
+
+export const CaseTaskStatusRt = rt.keyof({
+  open: null,
+  in_progress: null,
+  completed: null,
+  cancelled: null,
+});
+
+export const CaseTaskPriorityRt = rt.keyof({
+  low: null,
+  medium: null,
+  high: null,
+  critical: null,
+});
+
+export const CaseTaskCustomFieldRt = rt.strict({
+  key: rt.string,
+  type: rt.keyof({ text: null, toggle: null, number: null, date: null }),
+  value: rt.union([rt.string, rt.boolean, rt.number, rt.null]),
+});
+
+export const CaseTaskAssigneeRt = rt.strict({
+  uid: rt.string,
+});
+
+export const CaseTaskAttributesRt = rt.intersection([
+  rt.strict({
+    title: rt.string,
+    description: rt.string,
+    case_id: rt.string,
+    parent_task_id: rt.union([rt.string, rt.null]),
+    status: CaseTaskStatusRt,
+    priority: CaseTaskPriorityRt,
+    assignees: rt.array(CaseTaskAssigneeRt),
+    due_date: rt.union([rt.string, rt.null]),
+    started_at: rt.union([rt.string, rt.null]),
+    completed_at: rt.union([rt.string, rt.null]),
+    sort_order: rt.number,
+    template_id: rt.union([rt.string, rt.null]),
+    custom_fields: rt.array(CaseTaskCustomFieldRt),
+    required_role: rt.union([rt.string, rt.null]),
+    owner_team: rt.union([rt.string, rt.null]),
+    owner: rt.string,
+    created_at: rt.string,
+    created_by: UserRt,
+    updated_at: rt.union([rt.string, rt.null]),
+    updated_by: rt.union([UserRt, rt.null]),
+  }),
+  rt.exact(rt.partial({})),
+]);
+
+export const CaseTaskRt = rt.intersection([
+  CaseTaskAttributesRt,
+  rt.strict({
+    id: rt.string,
+    version: rt.string,
+  }),
+]);
+
+export const CaseTasksRt = rt.array(CaseTaskRt);
+
+export const CaseTaskSummaryRt = rt.strict({
+  total: rt.number,
+  open: rt.number,
+  in_progress: rt.number,
+  completed: rt.number,
+  cancelled: rt.number,
+  next_due_date: rt.union([rt.string, rt.null]),
+});
+
+export type CaseTaskStatus = rt.TypeOf<typeof CaseTaskStatusRt>;
+export type CaseTaskPriority = rt.TypeOf<typeof CaseTaskPriorityRt>;
+export type CaseTaskAssignee = rt.TypeOf<typeof CaseTaskAssigneeRt>;
+export type CaseTaskCustomField = rt.TypeOf<typeof CaseTaskCustomFieldRt>;
+export type CaseTaskAttributes = rt.TypeOf<typeof CaseTaskAttributesRt>;
+export type CaseTask = rt.TypeOf<typeof CaseTaskRt>;
+export type CaseTasks = rt.TypeOf<typeof CaseTasksRt>;
+export type CaseTaskSummary = rt.TypeOf<typeof CaseTaskSummaryRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/v1.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserRt } from '../user/v1';
+import { CaseTaskPriorityRt } from '../task/v1';
+
+export const CaseTaskTemplateSubtaskRt = rt.strict({
+  title: rt.string,
+  description: rt.string,
+  priority: CaseTaskPriorityRt,
+  relative_due_days: rt.union([rt.number, rt.null]),
+  sort_order: rt.number,
+});
+
+export const CaseTaskTemplateTaskRt = rt.strict({
+  title: rt.string,
+  description: rt.string,
+  priority: CaseTaskPriorityRt,
+  relative_due_days: rt.union([rt.number, rt.null]),
+  sort_order: rt.number,
+  subtasks: rt.array(CaseTaskTemplateSubtaskRt),
+});
+
+export const CaseTaskTemplateAttributesRt = rt.strict({
+  name: rt.string,
+  description: rt.string,
+  scope: rt.keyof({ global: null, space: null }),
+  tags: rt.array(rt.string),
+  tasks: rt.array(CaseTaskTemplateTaskRt),
+  owner: rt.string,
+  created_at: rt.string,
+  created_by: UserRt,
+  updated_at: rt.union([rt.string, rt.null]),
+  updated_by: rt.union([UserRt, rt.null]),
+});
+
+export const CaseTaskTemplateRt = rt.intersection([
+  CaseTaskTemplateAttributesRt,
+  rt.strict({
+    id: rt.string,
+    version: rt.string,
+  }),
+]);
+
+export const CaseTaskTemplatesRt = rt.array(CaseTaskTemplateRt);
+
+export type CaseTaskTemplateSubtask = rt.TypeOf<typeof CaseTaskTemplateSubtaskRt>;
+export type CaseTaskTemplateTask = rt.TypeOf<typeof CaseTaskTemplateTaskRt>;
+export type CaseTaskTemplateAttributes = rt.TypeOf<typeof CaseTaskTemplateAttributesRt>;
+export type CaseTaskTemplate = rt.TypeOf<typeof CaseTaskTemplateRt>;
+export type CaseTaskTemplates = rt.TypeOf<typeof CaseTaskTemplatesRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
@@ -27,6 +27,10 @@ export const UserActionTypes = {
   category: 'category',
   customFields: 'customFields',
   observables: 'observables',
+  create_task: 'create_task',
+  update_task: 'update_task',
+  delete_task: 'delete_task',
+  apply_task_template: 'apply_task_template',
 } as const;
 
 type UserActionActionTypeKeys = keyof typeof UserActionTypes;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/task/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/task/v1.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserActionTypes } from '../action/v1';
+
+// --- create_task ---
+
+const CreateTaskPayloadTaskRt = rt.strict({
+  id: rt.string,
+  title: rt.string,
+  status: rt.string,
+  priority: rt.string,
+  assignees: rt.array(rt.strict({ uid: rt.string })),
+});
+
+export const CreateTaskUserActionPayloadRt = rt.strict({
+  task: CreateTaskPayloadTaskRt,
+});
+
+export const CreateTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.create_task),
+  payload: CreateTaskUserActionPayloadRt,
+});
+
+// --- update_task ---
+
+export const UpdateTaskChangedFieldRt = rt.strict({
+  field: rt.string,
+  old_value: rt.unknown,
+  new_value: rt.unknown,
+});
+
+export const UpdateTaskUserActionPayloadRt = rt.strict({
+  task_id: rt.string,
+  task_title: rt.string,
+  changed_fields: rt.array(UpdateTaskChangedFieldRt),
+});
+
+export const UpdateTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.update_task),
+  payload: UpdateTaskUserActionPayloadRt,
+});
+
+// --- delete_task ---
+
+export const DeleteTaskUserActionPayloadRt = rt.strict({
+  task_id: rt.string,
+  task_title: rt.string,
+  subtasks_deleted: rt.number,
+});
+
+export const DeleteTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.delete_task),
+  payload: DeleteTaskUserActionPayloadRt,
+});
+
+// --- apply_task_template ---
+
+export const ApplyTaskTemplateUserActionPayloadRt = rt.strict({
+  template_id: rt.string,
+  template_name: rt.string,
+  tasks_created: rt.number,
+});
+
+export const ApplyTaskTemplateUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.apply_task_template),
+  payload: ApplyTaskTemplateUserActionPayloadRt,
+});
+
+export type CreateTaskUserActionPayload = rt.TypeOf<typeof CreateTaskUserActionPayloadRt>;
+export type CreateTaskUserAction = rt.TypeOf<typeof CreateTaskUserActionRt>;
+export type UpdateTaskChangedField = rt.TypeOf<typeof UpdateTaskChangedFieldRt>;
+export type UpdateTaskUserActionPayload = rt.TypeOf<typeof UpdateTaskUserActionPayloadRt>;
+export type UpdateTaskUserAction = rt.TypeOf<typeof UpdateTaskUserActionRt>;
+export type DeleteTaskUserActionPayload = rt.TypeOf<typeof DeleteTaskUserActionPayloadRt>;
+export type DeleteTaskUserAction = rt.TypeOf<typeof DeleteTaskUserActionRt>;
+export type ApplyTaskTemplateUserActionPayload = rt.TypeOf<
+  typeof ApplyTaskTemplateUserActionPayloadRt
+>;
+export type ApplyTaskTemplateUserAction = rt.TypeOf<typeof ApplyTaskTemplateUserActionRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
@@ -25,6 +25,12 @@ import { TagsUserActionRt } from './tags/v1';
 import { TitleUserActionRt } from './title/v1';
 import { CustomFieldsUserActionRt } from './custom_fields/v1';
 import { ObservablesUserActionRt } from './observables/v1';
+import {
+  CreateTaskUserActionRt,
+  UpdateTaskUserActionRt,
+  DeleteTaskUserActionRt,
+  ApplyTaskTemplateUserActionRt,
+} from './task/v1';
 export { UserActionTypes, UserActionActions } from './action/v1';
 export { StatusUserActionRt } from './status/v1';
 
@@ -63,6 +69,10 @@ const BasicUserActionsRt = rt.union([
   CategoryUserActionRt,
   CustomFieldsUserActionRt,
   ObservablesUserActionRt,
+  CreateTaskUserActionRt,
+  UpdateTaskUserActionRt,
+  DeleteTaskUserActionRt,
+  ApplyTaskTemplateUserActionRt,
 ]);
 
 const CommonUserActionsWithIdsRt = rt.union([BasicUserActionsRt, CommentUserActionRt]);
@@ -158,3 +168,7 @@ export type CreateCaseUserActionWithoutConnectorId = UserActionWithAttributes<
 >;
 export type CustomFieldsUserAction = UserAction<rt.TypeOf<typeof CustomFieldsUserActionRt>>;
 export type ObservablesUserAction = UserAction<rt.TypeOf<typeof ObservablesUserActionRt>>;
+export type CreateTaskUserAction = UserAction<rt.TypeOf<typeof CreateTaskUserActionRt>>;
+export type UpdateTaskUserAction = UserAction<rt.TypeOf<typeof UpdateTaskUserActionRt>>;
+export type DeleteTaskUserAction = UserAction<rt.TypeOf<typeof DeleteTaskUserActionRt>>;
+export type ApplyTaskTemplateUserAction = UserAction<rt.TypeOf<typeof ApplyTaskTemplateUserActionRt>>;

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
@@ -11,7 +11,13 @@ import type { SupportedUserActionTypes } from './types';
 
 export const DRAFT_COMMENT_STORAGE_ID = 'xpack.cases.commentDraft';
 
-export const UNSUPPORTED_ACTION_TYPES = ['delete_case'] as const;
+export const UNSUPPORTED_ACTION_TYPES = [
+  'delete_case',
+  'create_task',
+  'update_task',
+  'delete_task',
+  'apply_task_template',
+] as const;
 export const SUPPORTED_ACTION_TYPES: SupportedUserActionTypes[] = Object.keys(
   omit(UserActionTypes, UNSUPPORTED_ACTION_TYPES)
 ) as SupportedUserActionTypes[];

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
@@ -155,6 +155,14 @@ export const OBSERVABLES = i18n.translate('xpack.cases.caseView.userActions.obse
   defaultMessage: 'Observables',
 });
 
+export const TASK = i18n.translate('xpack.cases.caseView.userActions.task', {
+  defaultMessage: 'Task',
+});
+
+export const TASK_TEMPLATE = i18n.translate('xpack.cases.caseView.userActions.taskTemplate', {
+  defaultMessage: 'Task Template',
+});
+
 export const USER_ACTION_EDITED = (type: string) =>
   i18n.translate('xpack.cases.caseView.userActions.edited', {
     values: { type },

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
@@ -25,6 +25,10 @@ export const getUserActionAriaLabel = (type: keyof typeof UserActionTypes) => {
     category: i18n.CATEGORY,
     customFields: i18n.CUSTOM_FIELDS,
     observables: i18n.OBSERVABLES,
+    create_task: i18n.TASK,
+    update_task: i18n.TASK,
+    delete_task: i18n.TASK,
+    apply_task_template: i18n.TASK_TEMPLATE,
   };
 
   switch (type) {

--- a/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
@@ -62,6 +62,14 @@ export interface CasePersistedAttributes {
     version: number;
   } | null;
   extended_fields?: Record<string, unknown> | null;
+  task_summary?: {
+    total: number;
+    open: number;
+    in_progress: number;
+    completed: number;
+    cancelled: number;
+    next_due_date: string | null;
+  } | null;
 }
 
 type CasePersistedCustomFields = Array<{

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -63,6 +63,9 @@ export const ConfigSchema = schema.object({
   templates: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
   }),
+  tasks: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
   enabled: schema.boolean({ defaultValue: true }),
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/mocks.ts
@@ -803,6 +803,9 @@ export const mockCasesContract = (): CasesServerStart => ({
     attachments: {
       enabled: true,
     },
+    tasks: {
+      enabled: false,
+    },
   },
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -34,6 +34,7 @@ function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
     analytics: { index: { enabled: true } },
     templates: { enabled: true },
     attachments: { enabled: true },
+    tasks: { enabled: false },
     ...overrides,
   };
 }

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
@@ -27,6 +27,7 @@ import {
   modelVersion7,
   modelVersion8,
   modelVersion9,
+  modelVersion10,
 } from './model_versions';
 import { handleImport } from '../import_export/import';
 
@@ -286,6 +287,17 @@ export const createCaseSavedObjectType = (
       [CASE_EXTENDED_FIELDS]: {
         type: 'flattened',
       },
+      task_summary: {
+        type: 'object',
+        properties: {
+          total: { type: 'integer' },
+          open: { type: 'integer' },
+          in_progress: { type: 'integer' },
+          completed: { type: 'integer' },
+          cancelled: { type: 'integer' },
+          next_due_date: { type: 'date' },
+        },
+      },
     },
   },
   migrations: caseMigrations,
@@ -299,6 +311,7 @@ export const createCaseSavedObjectType = (
     7: modelVersion7,
     8: modelVersion8,
     9: modelVersion9,
+    10: modelVersion10,
   },
   management: {
     importableAndExportable: true,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
@@ -14,3 +14,4 @@ export { modelVersion6 } from './model_version_6';
 export { modelVersion7 } from './model_version_7';
 export { modelVersion8 } from './model_version_8';
 export { modelVersion9 } from './model_version_9';
+export { modelVersion10 } from './model_version_10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
+import { casesSchemaV10 } from '../schemas';
+
+/**
+ * Adds the task_summary field to the cases SO.
+ * This field is a denormalized summary of task counts per status and the
+ * next due date, maintained by the CaseTaskService on every task mutation.
+ * Default value for existing cases is null (no tasks).
+ */
+export const modelVersion10: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        task_summary: {
+          type: 'object',
+          properties: {
+            total: { type: 'integer' },
+            open: { type: 'integer' },
+            in_progress: { type: 'integer' },
+            completed: { type: 'integer' },
+            cancelled: { type: 'integer' },
+            next_due_date: { type: 'date' },
+          },
+        },
+      },
+    },
+  ],
+  schemas: {
+    forwardCompatibility: casesSchemaV10.extends({}, { unknowns: 'ignore' }),
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
@@ -16,3 +16,4 @@ export { casesSchema as casesSchemaV6 } from './v6';
 export { casesSchema as casesSchemaV7 } from './v7';
 export { casesSchema as casesSchemaV8 } from './v8';
 export { casesSchema as casesSchemaV9 } from './v9';
+export { casesSchema as casesSchemaV10 } from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export * from './v9';
+export * from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { casesSchema as casesSchemaV9 } from './v9';
+
+export const casesSchema = casesSchemaV9.extends({
+  task_summary: schema.maybe(
+    schema.nullable(
+      schema.object({
+        total: schema.number(),
+        open: schema.number(),
+        in_progress: schema.number(),
+        completed: schema.number(),
+        cancelled: schema.number(),
+        next_due_date: schema.maybe(schema.nullable(schema.string())),
+      })
+    )
+  ),
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
@@ -18,6 +18,8 @@ import { caseIdIncrementerSavedObjectType } from './id_incrementer';
 import { createCaseAttachmentSavedObjectType } from './attachments';
 import type { PersistableStateAttachmentTypeRegistry } from '../attachment_framework/persistable_state_registry';
 import { caseTemplateSavedObjectType } from './templates';
+import { caseTaskSavedObjectType } from './tasks';
+import { caseTaskTemplateSavedObjectType } from './task_templates';
 import type { ConfigType } from '../config';
 
 interface RegisterSavedObjectsArgs {
@@ -62,5 +64,9 @@ export const registerSavedObjects = ({
   }
   if (config.attachments?.enabled) {
     core.savedObjects.registerType(createCaseAttachmentSavedObjectType());
+  }
+  if (config.tasks?.enabled) {
+    core.savedObjects.registerType(caseTaskSavedObjectType);
+    core.savedObjects.registerType(caseTaskTemplateSavedObjectType);
   }
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+
+export const caseTaskTemplateSavedObjectType: SavedObjectsType = {
+  name: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+  hidden: true,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  mappings: {
+    dynamic: false,
+    properties: {
+      name: { type: 'keyword' },
+      description: { type: 'text' },
+      scope: { type: 'keyword' },
+      tags: { type: 'keyword' },
+      owner: { type: 'keyword' },
+      created_at: { type: 'date' },
+      created_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      updated_at: { type: 'date' },
+      updated_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      // tasks array is stored but not indexed (dynamic: false)
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+    },
+  },
+  management: {
+    importableAndExportable: false,
+    visibleInManagement: false,
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+export const caseTaskSavedObjectType: SavedObjectsType = {
+  name: CASE_TASK_SAVED_OBJECT,
+  indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+  hidden: true,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  mappings: {
+    dynamic: false,
+    properties: {
+      // Identity
+      title: { type: 'text' },
+      description: { type: 'text' },
+
+      // Hierarchy
+      case_id: { type: 'keyword' },
+      parent_task_id: { type: 'keyword' },
+
+      // State
+      status: { type: 'keyword' },
+      priority: { type: 'keyword' },
+
+      // Assignment
+      assignees: {
+        properties: {
+          uid: { type: 'keyword' },
+        },
+      },
+
+      // Scheduling
+      due_date: { type: 'date' },
+      started_at: { type: 'date' },
+      completed_at: { type: 'date' },
+
+      // Ordering
+      sort_order: { type: 'integer' },
+
+      // Template origin
+      template_id: { type: 'keyword' },
+
+      // RBAC future-proofing (stored, not indexed — dynamic: false covers them)
+
+      // Metadata
+      owner: { type: 'keyword' },
+      created_at: { type: 'date' },
+      created_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      updated_at: { type: 'date' },
+      updated_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+    },
+  },
+  management: {
+    importableAndExportable: false,
+    visibleInManagement: false,
+  },
+};
+
+/**
+ * The name used for the reference to the parent case in the SO references array.
+ */
+export const CASE_TASK_PARENT_CASE_REF_NAME = 'parentCase' as const;
+
+/**
+ * Build the references array entry linking a task to its parent case.
+ */
+export const buildCaseTaskCaseReference = (caseId: string) => ({
+  type: CASE_SAVED_OBJECT,
+  name: CASE_TASK_PARENT_CASE_REF_NAME,
+  id: caseId,
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/index.ts
@@ -16,6 +16,7 @@ export { AttachmentService } from './attachments';
 export { UserProfileService } from './user_profiles';
 export { TemplatesService } from './templates';
 export { CaseTaskService } from './tasks';
+export { CaseTaskTemplateService } from './task_templates';
 
 export interface ClientArgs {
   unsecuredSavedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/platform/plugins/shared/cases/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/index.ts
@@ -15,6 +15,7 @@ export { AlertService } from './alerts';
 export { AttachmentService } from './attachments';
 export { UserProfileService } from './user_profiles';
 export { TemplatesService } from './templates';
+export { CaseTaskService } from './tasks';
 
 export interface ClientArgs {
   unsecuredSavedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { CaseTaskTemplateService } from './index';
+import type { CaseTaskTemplateAttributes } from '../../../common/types/domain/task_template/v1';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT, CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+const mockUser = {
+  username: 'elastic',
+  full_name: 'Elastic User',
+  email: 'elastic@example.com',
+  profile_uid: 'uid-1',
+};
+
+const makeTemplateSO = (overrides: Partial<CaseTaskTemplateAttributes> & { id?: string } = {}) => {
+  const { id = 'tmpl-1', ...attrs } = overrides;
+  return {
+    id,
+    type: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+    references: [],
+    version: 'WzEsMV0=',
+    attributes: {
+      name: 'My Template',
+      description: '',
+      scope: 'space' as const,
+      tags: [],
+      tasks: [],
+      owner: 'securitySolution',
+      created_at: '2024-01-01T00:00:00.000Z',
+      created_by: mockUser,
+      updated_at: null,
+      updated_by: null,
+      ...attrs,
+    },
+  };
+};
+
+describe('CaseTaskTemplateService', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let service: CaseTaskTemplateService;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    logger = loggingSystemMock.createLogger();
+    service = new CaseTaskTemplateService({
+      log: logger,
+      unsecuredSavedObjectsClient: soClient,
+    });
+
+    soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+    soClient.get.mockImplementation(async (type, id) => {
+      if (type === CASE_SAVED_OBJECT)
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      return makeTemplateSO({ id });
+    });
+    soClient.update.mockResolvedValue({ id: 'tmpl-1', type: CASE_TASK_TEMPLATE_SAVED_OBJECT, attributes: {}, references: [] });
+  });
+
+  describe('createTemplate', () => {
+    it('creates a template SO with correct attributes', async () => {
+      soClient.create.mockResolvedValue(makeTemplateSO());
+
+      const result = await service.createTemplate({
+        name: 'My Template',
+        tasks: [],
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      expect(soClient.create).toHaveBeenCalledWith(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        expect.objectContaining({ name: 'My Template', scope: 'space', owner: 'securitySolution' }),
+        expect.any(Object)
+      );
+      expect(result.name).toBe('My Template');
+    });
+
+    it('defaults scope to space', async () => {
+      soClient.create.mockResolvedValue(makeTemplateSO());
+      await service.createTemplate({ name: 'T', tasks: [], owner: 'o', user: mockUser });
+      const attrs = soClient.create.mock.calls[0][1] as CaseTaskTemplateAttributes;
+      expect(attrs.scope).toBe('space');
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('fetches from SO client', async () => {
+      soClient.get.mockResolvedValue(makeTemplateSO({ id: 'tmpl-42' }));
+      const result = await service.getTemplate('tmpl-42');
+      expect(result.id).toBe('tmpl-42');
+    });
+
+    it('returns cached result on second call', async () => {
+      soClient.get.mockResolvedValue(makeTemplateSO({ id: 'tmpl-cached' }));
+      await service.getTemplate('tmpl-cached');
+      await service.getTemplate('tmpl-cached');
+      expect(soClient.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('calls SO delete', async () => {
+      await service.deleteTemplate('tmpl-1');
+      expect(soClient.delete).toHaveBeenCalledWith(CASE_TASK_TEMPLATE_SAVED_OBJECT, 'tmpl-1');
+    });
+  });
+
+  describe('applyTemplate', () => {
+    it('creates root tasks and subtasks with correct parent references', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_TEMPLATE_SAVED_OBJECT) {
+          return makeTemplateSO({
+            id,
+            tasks: [
+              {
+                title: 'Root 1',
+                description: '',
+                priority: 'medium',
+                relative_due_days: 3,
+                sort_order: 1000,
+                subtasks: [
+                  { title: 'Sub 1', description: '', priority: 'low', relative_due_days: null, sort_order: 1000 },
+                ],
+              },
+            ],
+          });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      const rootTaskId = 'root-task-1';
+      soClient.bulkCreate = jest.fn()
+        .mockResolvedValueOnce({
+          // Root task bulk create
+          saved_objects: [{
+            id: rootTaskId,
+            type: CASE_TASK_SAVED_OBJECT,
+            references: [],
+            version: 'v1',
+            attributes: {
+              title: 'Root 1', description: '', case_id: 'case-1',
+              parent_task_id: null, status: 'open', priority: 'medium',
+              assignees: [], due_date: null, started_at: null, completed_at: null,
+              sort_order: 1000, template_id: 'tmpl-1', custom_fields: [],
+              required_role: null, owner_team: null, owner: 'securitySolution',
+              created_at: '2024-01-01T00:00:00.000Z', created_by: mockUser,
+              updated_at: null, updated_by: null,
+            },
+          }],
+        })
+        .mockResolvedValueOnce({
+          // Subtask bulk create
+          saved_objects: [{
+            id: 'sub-task-1',
+            type: CASE_TASK_SAVED_OBJECT,
+            references: [],
+            version: 'v1',
+            attributes: {
+              title: 'Sub 1', description: '', case_id: 'case-1',
+              parent_task_id: rootTaskId, status: 'open', priority: 'low',
+              assignees: [], due_date: null, started_at: null, completed_at: null,
+              sort_order: 1000, template_id: 'tmpl-1', custom_fields: [],
+              required_role: null, owner_team: null, owner: 'securitySolution',
+              created_at: '2024-01-01T00:00:00.000Z', created_by: mockUser,
+              updated_at: null, updated_by: null,
+            },
+          }],
+        });
+
+      const result = await service.applyTemplate({
+        templateId: 'tmpl-1',
+        caseId: 'case-1',
+        owner: 'securitySolution',
+        user: mockUser,
+        due_date_anchor: '2024-01-01T00:00:00.000Z',
+      });
+
+      // Should have called bulkCreate twice: once for roots, once for subtasks
+      expect(soClient.bulkCreate).toHaveBeenCalledTimes(2);
+
+      // The subtask call should reference the root task id
+      const subtaskCall = soClient.bulkCreate.mock.calls[1][0] as Array<{ attributes: { parent_task_id: string } }>;
+      expect(subtaskCall[0].attributes.parent_task_id).toBe(rootTaskId);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('computes due_date correctly from relative_due_days', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_TEMPLATE_SAVED_OBJECT) {
+          return makeTemplateSO({
+            id,
+            tasks: [{
+              title: 'T', description: '', priority: 'medium',
+              relative_due_days: 7, sort_order: 1000, subtasks: [],
+            }],
+          });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      soClient.bulkCreate = jest.fn().mockResolvedValue({ saved_objects: [] });
+
+      await service.applyTemplate({
+        templateId: 'tmpl-1',
+        caseId: 'case-1',
+        owner: 'securitySolution',
+        user: mockUser,
+        due_date_anchor: '2024-01-01T00:00:00.000Z',
+      });
+
+      const rootArgs = soClient.bulkCreate.mock.calls[0][0] as Array<{ attributes: { due_date: string } }>;
+      // Jan 1 + 7 days = Jan 8
+      expect(rootArgs[0].attributes.due_date).toContain('2024-01-08');
+    });
+  });
+
+  describe('findTemplates', () => {
+    it('filters by scope', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+      await service.findTemplates({ scope: 'global' });
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: expect.anything() })
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+import type {
+  CaseTaskTemplate,
+  CaseTaskTemplateAttributes,
+} from '../../../common/types/domain/task_template/v1';
+import type { CaseTask } from '../../../common/types/domain/task/v1';
+import { createCaseError } from '../../common/error';
+import { CaseTaskService } from '../tasks';
+import type {
+  CreateTemplateArgs,
+  UpdateTemplateArgs,
+  FindTemplatesArgs,
+  ApplyTemplateArgs,
+} from './types';
+
+const CACHE_TTL_MS = 60_000;
+
+export class CaseTaskTemplateService {
+  private readonly log: Logger;
+  private readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  private readonly taskService: CaseTaskService;
+  /** Simple in-process LRU-like cache (60 s TTL) for template definitions. */
+  private readonly templateCache = new Map<string, { template: CaseTaskTemplate; expiresAt: number }>();
+
+  constructor({
+    log,
+    unsecuredSavedObjectsClient,
+  }: {
+    log: Logger;
+    unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  }) {
+    this.log = log;
+    this.unsecuredSavedObjectsClient = unsecuredSavedObjectsClient;
+    this.taskService = new CaseTaskService({ log, unsecuredSavedObjectsClient });
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  public async createTemplate(args: CreateTemplateArgs): Promise<CaseTaskTemplate> {
+    const {
+      name,
+      description = '',
+      scope = 'space',
+      tags = [],
+      tasks,
+      owner,
+      user,
+      refresh,
+    } = args;
+
+    try {
+      const now = new Date().toISOString();
+
+      const attributes: CaseTaskTemplateAttributes = {
+        name,
+        description,
+        scope,
+        tags,
+        tasks,
+        owner,
+        created_at: now,
+        created_by: user,
+        updated_at: null,
+        updated_by: null,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.create<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        attributes,
+        { refresh }
+      );
+
+      return this.transformToTemplate(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task template: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getTemplate(templateId: string): Promise<CaseTaskTemplate> {
+    const cached = this.templateCache.get(templateId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.template;
+    }
+
+    try {
+      const so = await this.unsecuredSavedObjectsClient.get<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        templateId
+      );
+      const template = this.transformToTemplate(so);
+      this.templateCache.set(templateId, { template, expiresAt: Date.now() + CACHE_TTL_MS });
+      return template;
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async findTemplates(
+    args: FindTemplatesArgs
+  ): Promise<{ templates: CaseTaskTemplate[]; total: number }> {
+    const { scope, tags, owners, search, page = 1, per_page = 50 } = args;
+
+    try {
+      const filters = [];
+
+      if (scope) {
+        filters.push(
+          nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.scope`, scope)
+        );
+      }
+      if (owners && owners.length > 0) {
+        filters.push(
+          nodeBuilder.or(
+            owners.map((o) =>
+              nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.owner`, o)
+            )
+          )
+        );
+      }
+      if (tags && tags.length > 0) {
+        filters.push(
+          nodeBuilder.or(
+            tags.map((t) =>
+              nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.tags`, t)
+            )
+          )
+        );
+      }
+
+      const result = await this.unsecuredSavedObjectsClient.find<CaseTaskTemplateAttributes>({
+        type: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        filter: filters.length > 0 ? nodeBuilder.and(filters) : undefined,
+        search: search ?? undefined,
+        searchFields: search ? ['name', 'description'] : undefined,
+        page,
+        perPage: Math.min(per_page, 200),
+      });
+
+      return {
+        templates: result.saved_objects.map((so) => this.transformToTemplate(so)),
+        total: result.total,
+      };
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find task templates: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async updateTemplate(args: UpdateTemplateArgs): Promise<CaseTaskTemplate> {
+    const { templateId, version, user, refresh, ...patch } = args;
+
+    try {
+      const now = new Date().toISOString();
+
+      const updatedAttributes: Partial<CaseTaskTemplateAttributes> = {
+        ...patch,
+        updated_at: now,
+        updated_by: user,
+      };
+
+      await this.unsecuredSavedObjectsClient.update<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        templateId,
+        updatedAttributes,
+        { version, refresh }
+      );
+
+      // Invalidate cache
+      this.templateCache.delete(templateId);
+
+      return this.getTemplate(templateId);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async deleteTemplate(templateId: string): Promise<void> {
+    try {
+      await this.unsecuredSavedObjectsClient.delete(CASE_TASK_TEMPLATE_SAVED_OBJECT, templateId);
+      this.templateCache.delete(templateId);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Apply
+  // ---------------------------------------------------------------------------
+
+  public async applyTemplate(args: ApplyTemplateArgs): Promise<CaseTask[]> {
+    const { templateId, caseId, owner, user, due_date_anchor, refresh } = args;
+
+    try {
+      const template = await this.getTemplate(templateId);
+      const anchorDate = due_date_anchor ? new Date(due_date_anchor) : new Date();
+
+      const computeDueDate = (relativeDays: number | null): string | null => {
+        if (relativeDays === null) return null;
+        const d = new Date(anchorDate);
+        d.setDate(d.getDate() + relativeDays);
+        return d.toISOString();
+      };
+
+      // Create root tasks in bulk
+      const rootTaskArgs = template.tasks.map((t) => ({
+        caseId,
+        title: t.title,
+        description: t.description,
+        priority: t.priority,
+        due_date: computeDueDate(t.relative_due_days),
+        sort_order: t.sort_order,
+        template_id: templateId,
+        owner,
+        user,
+      }));
+
+      const rootTasks = await this.taskService.bulkCreateTasks({
+        tasks: rootTaskArgs,
+        refresh,
+      });
+
+      // Create subtasks in bulk, mapping root task sort_order → created task ID
+      const rootIdByIndex = new Map(rootTasks.map((t, i) => [i, t.id]));
+      const subtaskArgs = template.tasks.flatMap((t, i) =>
+        t.subtasks.map((sub) => ({
+          caseId,
+          title: sub.title,
+          description: sub.description,
+          priority: sub.priority,
+          due_date: computeDueDate(sub.relative_due_days),
+          sort_order: sub.sort_order,
+          parent_task_id: rootIdByIndex.get(i) ?? null,
+          template_id: templateId,
+          owner,
+          user,
+        }))
+      );
+
+      const subtasks =
+        subtaskArgs.length > 0
+          ? await this.taskService.bulkCreateTasks({ tasks: subtaskArgs, refresh })
+          : [];
+
+      return [...rootTasks, ...subtasks];
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to apply template ${templateId} to case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private transformToTemplate(
+    so: Awaited<ReturnType<SavedObjectsClientContract['get']>>
+  ): CaseTaskTemplate {
+    return {
+      ...(so.attributes as CaseTaskTemplateAttributes),
+      id: so.id,
+      version: so.version ?? '',
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/types.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CaseTaskTemplateTask } from '../../../common/types/domain/task_template/v1';
+import type { User } from '../../common/types/user';
+import type { IndexRefresh } from '../types';
+
+export interface CreateTemplateArgs extends IndexRefresh {
+  name: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks: CaseTaskTemplateTask[];
+  owner: string;
+  user: User;
+}
+
+export interface UpdateTemplateArgs extends IndexRefresh {
+  templateId: string;
+  version: string;
+  name?: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks?: CaseTaskTemplateTask[];
+  user: User;
+}
+
+export interface FindTemplatesArgs {
+  scope?: 'global' | 'space';
+  tags?: string[];
+  owners?: string[];
+  search?: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface ApplyTemplateArgs extends IndexRefresh {
+  templateId: string;
+  caseId: string;
+  owner: string;
+  user: User;
+  due_date_anchor?: string; // ISO 8601 — defaults to now
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/index.test.ts
@@ -1,0 +1,527 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { CaseTaskService } from './index';
+import type { CaseTaskAttributes } from '../../../common/types/domain/task/v1';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+const mockUser = {
+  username: 'elastic',
+  full_name: 'Elastic User',
+  email: 'elastic@example.com',
+  profile_uid: 'uid-1',
+};
+
+const makeTaskSO = (overrides: Partial<CaseTaskAttributes> & { id?: string } = {}) => {
+  const { id = 'task-1', ...attrs } = overrides;
+  return {
+    id,
+    score: 1,
+    type: CASE_TASK_SAVED_OBJECT,
+    references: [],
+    version: 'WzEsMV0=',
+    attributes: {
+      title: 'Test task',
+      description: '',
+      case_id: 'case-1',
+      parent_task_id: null,
+      status: 'open' as const,
+      priority: 'medium' as const,
+      assignees: [],
+      due_date: null,
+      started_at: null,
+      completed_at: null,
+      sort_order: 1000,
+      template_id: null,
+      custom_fields: [],
+      required_role: null,
+      owner_team: null,
+      owner: 'securitySolution',
+      created_at: '2024-01-01T00:00:00.000Z',
+      created_by: mockUser,
+      updated_at: null,
+      updated_by: null,
+      ...attrs,
+    },
+  };
+};
+
+describe('CaseTaskService', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let service: CaseTaskService;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    logger = loggingSystemMock.createLogger();
+    service = new CaseTaskService({
+      log: logger,
+      unsecuredSavedObjectsClient: soClient,
+    });
+
+    // Default: find returns empty (for sort_order and descendant queries)
+    soClient.find.mockResolvedValue({
+      saved_objects: [],
+      total: 0,
+      per_page: 1,
+      page: 1,
+    });
+    // Default: case update for task_summary succeeds
+    soClient.get.mockImplementation(async (type, id) => {
+      if (type === CASE_SAVED_OBJECT) {
+        return { id, type, attributes: {}, references: [], version: 'Wzk5LDFd' };
+      }
+      return makeTaskSO({ id });
+    });
+    soClient.update.mockResolvedValue({ id: 'case-1', type: CASE_SAVED_OBJECT, attributes: {}, references: [] });
+  });
+
+  // ---- createTask -----------------------------------------------------------
+
+  describe('createTask', () => {
+    it('creates a task SO with correct attributes', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      const result = await service.createTask({
+        caseId: 'case-1',
+        title: 'My task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      expect(soClient.create).toHaveBeenCalledWith(
+        CASE_TASK_SAVED_OBJECT,
+        expect.objectContaining({
+          title: 'My task',
+          case_id: 'case-1',
+          status: 'open',
+          priority: 'medium',
+          parent_task_id: null,
+          owner: 'securitySolution',
+        }),
+        expect.objectContaining({
+          references: [expect.objectContaining({ id: 'case-1', type: CASE_SAVED_OBJECT })],
+        })
+      );
+
+      expect(result.id).toBe('task-1');
+      expect(result.title).toBe('Test task');
+    });
+
+    it('auto-sets started_at when status is in_progress', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ status: 'in_progress', started_at: '2024-01-01T00:00:00.000Z' }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        status: 'in_progress',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.started_at).not.toBeNull();
+    });
+
+    it('auto-sets completed_at when status is completed', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ status: 'completed', completed_at: '2024-01-01T00:00:00.000Z' }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        status: 'completed',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.completed_at).not.toBeNull();
+    });
+
+    it('calls syncTaskSummary after create', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      // syncTaskSummary issues a find + get + update on the case SO
+      expect(soClient.find).toHaveBeenCalled();
+      expect(soClient.update).toHaveBeenCalledWith(
+        CASE_SAVED_OBJECT,
+        'case-1',
+        expect.objectContaining({ task_summary: expect.any(Object) }),
+        expect.any(Object)
+      );
+    });
+
+    it('uses sort_order gap = 1000 for first task', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ sort_order: 1000 }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.sort_order).toBe(1000);
+    });
+
+    it('uses max(existing) + 1000 for subsequent tasks', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [makeTaskSO({ sort_order: 3000 })],
+        total: 1,
+        per_page: 1,
+        page: 1,
+      });
+      soClient.create.mockResolvedValue(makeTaskSO({ sort_order: 4000 }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.sort_order).toBe(4000);
+    });
+
+    it('rejects subtask that would exceed depth 2', async () => {
+      // parent chain: task-3 → task-2 → task-1 (root)
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT) {
+          if (id === 'task-3') return makeTaskSO({ id: 'task-3', parent_task_id: 'task-2' });
+          if (id === 'task-2') return makeTaskSO({ id: 'task-2', parent_task_id: 'task-1' });
+          if (id === 'task-1') return makeTaskSO({ id: 'task-1', parent_task_id: null });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      await expect(
+        service.createTask({
+          caseId: 'case-1',
+          title: 'Too deep',
+          parent_task_id: 'task-3',
+          owner: 'securitySolution',
+          user: mockUser,
+        })
+      ).rejects.toThrow('Maximum subtask depth');
+    });
+  });
+
+  // ---- getTask --------------------------------------------------------------
+
+  describe('getTask', () => {
+    it('fetches a single task by id', async () => {
+      soClient.get.mockResolvedValue(makeTaskSO({ id: 'task-42' }));
+
+      const result = await service.getTask('task-42');
+      expect(result.id).toBe('task-42');
+      expect(soClient.get).toHaveBeenCalledWith(CASE_TASK_SAVED_OBJECT, 'task-42');
+    });
+
+    it('throws a CaseError when SO client throws', async () => {
+      soClient.get.mockRejectedValue(new Error('not found'));
+      await expect(service.getTask('bad-id')).rejects.toThrow();
+    });
+  });
+
+  // ---- findTasks ------------------------------------------------------------
+
+  describe('findTasks', () => {
+    it('passes correct sort/page params', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+
+      await service.findTasks({ sort_field: 'due_date', sort_order: 'desc', page: 2, per_page: 25 });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: CASE_TASK_SAVED_OBJECT,
+          sortField: 'due_date',
+          sortOrder: 'desc',
+          page: 2,
+          perPage: 25,
+        })
+      );
+    });
+
+    it('caps per_page at 200', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 200, page: 1 });
+
+      await service.findTasks({ per_page: 9999 });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ perPage: 200 })
+      );
+    });
+  });
+
+  // ---- updateTask -----------------------------------------------------------
+
+  describe('updateTask', () => {
+    it('sets started_at on open→in_progress transition', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'open', started_at: null });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'in_progress',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).started_at).not.toBeNull();
+    });
+
+    it('sets completed_at on →completed transition', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'in_progress', completed_at: null });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'completed',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).completed_at).not.toBeNull();
+    });
+
+    it('does not overwrite started_at if already set', async () => {
+      const existingStartedAt = '2024-01-01T00:00:00.000Z';
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'in_progress', started_at: existingStartedAt });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'in_progress',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).started_at).toBeUndefined();
+    });
+  });
+
+  // ---- deleteTask -----------------------------------------------------------
+
+  describe('deleteTask', () => {
+    it('deletes the task and all descendants', async () => {
+      // task-1 has child task-2, task-2 has child task-3
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, case_id: 'case-1' });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      soClient.find.mockImplementation(async (options) => {
+        const f = JSON.stringify((options as { filter?: unknown }).filter ?? '');
+        if (f.includes('task-1'))
+          return { saved_objects: [makeTaskSO({ id: 'task-2', parent_task_id: 'task-1' })], total: 1, per_page: 1000, page: 1 };
+        if (f.includes('task-2'))
+          return { saved_objects: [makeTaskSO({ id: 'task-3', parent_task_id: 'task-2' })], total: 1, per_page: 1000, page: 1 };
+        return { saved_objects: [], total: 0, per_page: 1000, page: 1 };
+      });
+
+      soClient.bulkDelete = jest.fn().mockResolvedValue({});
+
+      await service.deleteTask('task-1');
+
+      expect(soClient.bulkDelete).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-1' },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-2' },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-3' },
+        ])
+      );
+    });
+
+    it('syncs task_summary after delete', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, case_id: 'case-1' });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.bulkDelete = jest.fn().mockResolvedValue({});
+
+      await service.deleteTask('task-1');
+
+      expect(soClient.update).toHaveBeenCalledWith(
+        CASE_SAVED_OBJECT,
+        'case-1',
+        expect.objectContaining({ task_summary: expect.any(Object) }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ---- reorderTasks ---------------------------------------------------------
+
+  describe('reorderTasks', () => {
+    it('bulk updates sort_orders with 1000-gap spacing', async () => {
+      soClient.bulkUpdate = jest.fn().mockResolvedValue({ saved_objects: [] });
+
+      await service.reorderTasks({
+        caseId: 'case-1',
+        parentTaskId: null,
+        orderedTaskIds: ['task-3', 'task-1', 'task-2'],
+      });
+
+      expect(soClient.bulkUpdate).toHaveBeenCalledWith(
+        [
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-3', attributes: { sort_order: 1000 } },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-1', attributes: { sort_order: 2000 } },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-2', attributes: { sort_order: 3000 } },
+        ],
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ---- task_summary accuracy ------------------------------------------------
+
+  describe('syncTaskSummary', () => {
+    it('correctly counts tasks by status', async () => {
+      // sort_order find fires first (returns empty → sort_order = 1000)
+      soClient.find.mockResolvedValueOnce({ saved_objects: [], total: 0, per_page: 1, page: 1 });
+      // syncTaskSummary find fires second (returns tasks by status)
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [
+          makeTaskSO({ status: 'open' }),
+          makeTaskSO({ id: 'task-2', status: 'open' }),
+          makeTaskSO({ id: 'task-3', status: 'in_progress' }),
+          makeTaskSO({ id: 'task-4', status: 'completed' }),
+          makeTaskSO({ id: 'task-5', status: 'cancelled' }),
+        ],
+        total: 5,
+        per_page: 10000,
+        page: 1,
+      });
+
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const updateCall = soClient.update.mock.calls.find(
+        ([type]) => type === CASE_SAVED_OBJECT
+      );
+      const summary = (updateCall![2] as { task_summary: unknown }).task_summary as {
+        open: number;
+        in_progress: number;
+        completed: number;
+        cancelled: number;
+        total: number;
+      };
+
+      expect(summary.open).toBe(2);
+      expect(summary.in_progress).toBe(1);
+      expect(summary.completed).toBe(1);
+      expect(summary.cancelled).toBe(1);
+      expect(summary.total).toBe(5);
+    });
+
+    it('computes next_due_date as the earliest uncompleted due date', async () => {
+      // sort_order find fires first (returns empty → sort_order = 1000)
+      soClient.find.mockResolvedValueOnce({ saved_objects: [], total: 0, per_page: 1, page: 1 });
+      // syncTaskSummary find fires second
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [
+          makeTaskSO({ status: 'open', due_date: '2024-03-10T00:00:00.000Z' }),
+          makeTaskSO({ id: 't2', status: 'open', due_date: '2024-01-05T00:00:00.000Z' }),
+          makeTaskSO({ id: 't3', status: 'completed', due_date: '2024-01-01T00:00:00.000Z' }),
+        ],
+        total: 3,
+        per_page: 10000,
+        page: 1,
+      });
+
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const updateCall = soClient.update.mock.calls.find(([type]) => type === CASE_SAVED_OBJECT);
+      const summary = (updateCall![2] as { task_summary: { next_due_date: string | null } })
+        .task_summary;
+
+      // completed task's due date should be excluded; earliest open = Jan 5
+      expect(summary.next_due_date).toBe('2024-01-05T00:00:00.000Z');
+    });
+  });
+
+  // ---- bulkCreateTasks ------------------------------------------------------
+
+  describe('bulkCreateTasks', () => {
+    it('uses bulkCreate in a single call', async () => {
+      soClient.bulkCreate = jest.fn().mockResolvedValue({
+        saved_objects: [makeTaskSO(), makeTaskSO({ id: 'task-2' })],
+      });
+
+      await service.bulkCreateTasks({
+        tasks: [
+          { caseId: 'case-1', title: 'T1', owner: 'securitySolution', user: mockUser },
+          { caseId: 'case-1', title: 'T2', owner: 'securitySolution', user: mockUser },
+        ],
+      });
+
+      expect(soClient.bulkCreate).toHaveBeenCalledTimes(1);
+      expect(soClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ type: CASE_TASK_SAVED_OBJECT, attributes: expect.objectContaining({ title: 'T1' }) }),
+          expect.objectContaining({ type: CASE_TASK_SAVED_OBJECT, attributes: expect.objectContaining({ title: 'T2' }) }),
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/index.ts
@@ -1,0 +1,698 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract, SavedObject } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_SAVED_OBJECT } from '../../../common/constants';
+import type {
+  CaseTask,
+  CaseTaskAttributes,
+} from '../../../common/types/domain/task/v1';
+import { createCaseError } from '../../common/error';
+import { buildCaseTaskCaseReference } from '../../saved_object_types/tasks';
+import { syncTaskSummary } from './task_summary';
+import { getNextSortOrder, computeReorderedSortOrders } from './sort_order';
+import type {
+  CreateTaskArgs,
+  BulkCreateTasksArgs,
+  UpdateTaskArgs,
+  BulkUpdateTasksArgs,
+  FindTasksArgs,
+  MyTasksArgs,
+  ReorderTasksArgs,
+  TaskFilterArgs,
+} from './types';
+
+/** Maximum nesting depth: task → subtask → sub-subtask = 2 levels below root */
+const MAX_SUBTASK_DEPTH = 2;
+
+export class CaseTaskService {
+  private readonly log: Logger;
+  private readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
+
+  constructor({
+    log,
+    unsecuredSavedObjectsClient,
+  }: {
+    log: Logger;
+    unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  }) {
+    this.log = log;
+    this.unsecuredSavedObjectsClient = unsecuredSavedObjectsClient;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create
+  // ---------------------------------------------------------------------------
+
+  public async createTask(args: CreateTaskArgs): Promise<CaseTask> {
+    const {
+      caseId,
+      title,
+      description = '',
+      status = 'open',
+      priority = 'medium',
+      assignees = [],
+      due_date = null,
+      parent_task_id = null,
+      custom_fields = [],
+      template_id = null,
+      owner,
+      user,
+      refresh,
+    } = args;
+
+    try {
+      if (parent_task_id) {
+        await this.validateDepth(parent_task_id);
+      }
+
+      const sort_order = await getNextSortOrder({
+        caseId,
+        parentTaskId: parent_task_id,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      const now = new Date().toISOString();
+
+      const attributes: CaseTaskAttributes = {
+        title,
+        description,
+        case_id: caseId,
+        parent_task_id,
+        status,
+        priority,
+        assignees,
+        due_date,
+        started_at: status === 'in_progress' ? now : null,
+        completed_at: status === 'completed' || status === 'cancelled' ? now : null,
+        sort_order,
+        template_id,
+        custom_fields,
+        required_role: null,
+        owner_team: null,
+        owner,
+        created_at: now,
+        created_by: user,
+        updated_at: null,
+        updated_by: null,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.create<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        attributes,
+        {
+          refresh,
+          references: [buildCaseTaskCaseReference(caseId)],
+        }
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      return this.transformToTask(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkCreateTasks(args: BulkCreateTasksArgs): Promise<CaseTask[]> {
+    const { tasks, refresh } = args;
+    if (tasks.length === 0) return [];
+
+    const caseId = tasks[0].caseId;
+    const now = new Date().toISOString();
+
+    try {
+      // Validate depth for all subtasks up-front
+      for (const t of tasks) {
+        if (t.parent_task_id) {
+          await this.validateDepth(t.parent_task_id);
+        }
+      }
+
+      const objects = await Promise.all(
+        tasks.map(async (t) => {
+          const sort_order = await getNextSortOrder({
+            caseId: t.caseId,
+            parentTaskId: t.parent_task_id ?? null,
+            unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+            logger: this.log,
+          });
+
+          const attrs: CaseTaskAttributes = {
+            title: t.title,
+            description: t.description ?? '',
+            case_id: t.caseId,
+            parent_task_id: t.parent_task_id ?? null,
+            status: t.status ?? 'open',
+            priority: t.priority ?? 'medium',
+            assignees: t.assignees ?? [],
+            due_date: t.due_date ?? null,
+            started_at: t.status === 'in_progress' ? now : null,
+            completed_at:
+              t.status === 'completed' || t.status === 'cancelled' ? now : null,
+            sort_order,
+            template_id: t.template_id ?? null,
+            custom_fields: t.custom_fields ?? [],
+            required_role: null,
+            owner_team: null,
+            owner: t.owner,
+            created_at: now,
+            created_by: t.user,
+            updated_at: null,
+            updated_by: null,
+          };
+
+          return {
+            type: CASE_TASK_SAVED_OBJECT,
+            attributes: attrs,
+            references: [buildCaseTaskCaseReference(t.caseId)],
+          };
+        })
+      );
+
+      const result = await this.unsecuredSavedObjectsClient.bulkCreate<CaseTaskAttributes>(
+        objects,
+        { refresh }
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      return result.saved_objects.map((so) => this.transformToTask(so));
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk create tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  public async getTask(taskId: string): Promise<CaseTask> {
+    try {
+      const so = await this.unsecuredSavedObjectsClient.get<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        taskId
+      );
+      return this.transformToTask(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getTasksByCase(caseId: string, args?: TaskFilterArgs): Promise<CaseTask[]> {
+    try {
+      const result = await this.findTasks({ ...args, caseIds: [caseId], per_page: 10000 });
+      return result.tasks;
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async findTasks(
+    args: FindTasksArgs
+  ): Promise<{ tasks: CaseTask[]; total: number }> {
+    const {
+      caseIds,
+      owners,
+      status,
+      priority,
+      assignees,
+      due_date_from,
+      due_date_to,
+      parent_task_id,
+      sort_field = 'sort_order',
+      sort_order: sortOrder = 'asc',
+      page = 1,
+      per_page = 50,
+      search,
+    } = args;
+
+    try {
+      const filters = this.buildFilters({
+        caseIds,
+        owners,
+        status,
+        priority,
+        assignees,
+        due_date_from,
+        due_date_to,
+        parent_task_id,
+      });
+
+      const result = await this.unsecuredSavedObjectsClient.find<CaseTaskAttributes>({
+        type: CASE_TASK_SAVED_OBJECT,
+        filter: filters.length > 0 ? nodeBuilder.and(filters) : undefined,
+        sortField: sort_field,
+        sortOrder,
+        page,
+        perPage: Math.min(per_page, 200),
+        search: search ?? undefined,
+        searchFields: search ? ['title', 'description'] : undefined,
+      });
+
+      return {
+        tasks: result.saved_objects.map((so) => this.transformToTask(so)),
+        total: result.total,
+      };
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getMyTasks(
+    args: MyTasksArgs
+  ): Promise<{ tasks: CaseTask[]; total: number }> {
+    const { userProfileUid, ...filterArgs } = args;
+    return this.findTasks({
+      ...filterArgs,
+      assignees: [userProfileUid, ...(filterArgs.assignees ?? [])],
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Update
+  // ---------------------------------------------------------------------------
+
+  public async updateTask(args: UpdateTaskArgs): Promise<CaseTask> {
+    const { taskId, user, version, refresh, ...patch } = args;
+
+    try {
+      // Validate reparenting depth if parent_task_id is being changed
+      if (patch.parent_task_id !== undefined && patch.parent_task_id !== null) {
+        await this.validateDepth(patch.parent_task_id);
+      }
+
+      const now = new Date().toISOString();
+      const existing = await this.getTask(taskId);
+
+      const statusTransitions: Partial<CaseTaskAttributes> = {};
+      if (patch.status) {
+        if (patch.status === 'in_progress' && !existing.started_at) {
+          statusTransitions.started_at = now;
+        }
+        if (
+          (patch.status === 'completed' || patch.status === 'cancelled') &&
+          !existing.completed_at
+        ) {
+          statusTransitions.completed_at = now;
+        }
+      }
+
+      const updatedAttributes: Partial<CaseTaskAttributes> = {
+        ...patch,
+        ...statusTransitions,
+        updated_at: now,
+        updated_by: user,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.update<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        taskId,
+        updatedAttributes,
+        { version, refresh }
+      );
+
+      await syncTaskSummary({
+        caseId: existing.case_id,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      // Merge the existing SO with the update result since SO update only returns changed fields
+      return this.transformToTask({
+        ...so,
+        attributes: { ...(existing as CaseTaskAttributes), ...updatedAttributes },
+      } as SavedObject<CaseTaskAttributes>);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkUpdateTasks(args: BulkUpdateTasksArgs): Promise<CaseTask[]> {
+    const { updates, refresh } = args;
+    if (updates.length === 0) return [];
+
+    const now = new Date().toISOString();
+
+    try {
+      const objects = updates.map(({ taskId, attributes, version }) => ({
+        type: CASE_TASK_SAVED_OBJECT,
+        id: taskId,
+        attributes: { ...attributes, updated_at: now },
+        version,
+      }));
+
+      const result = await this.unsecuredSavedObjectsClient.bulkUpdate<Partial<CaseTaskAttributes>>(
+        objects,
+        { refresh }
+      );
+
+      // Sync summary once after all updates. Get caseId from first fetched task.
+      const firstTaskId = updates[0]?.taskId;
+      if (firstTaskId) {
+        const firstTask = await this.getTask(firstTaskId);
+        await syncTaskSummary({
+          caseId: firstTask.case_id,
+          unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+          logger: this.log,
+        });
+      }
+
+      // bulkUpdate returns partial SOs; re-fetch to get full objects
+      return Promise.all(result.saved_objects.map((so) => this.getTask(so.id)));
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk update tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delete
+  // ---------------------------------------------------------------------------
+
+  public async deleteTask(taskId: string): Promise<void> {
+    try {
+      const task = await this.getTask(taskId);
+      const caseId = task.case_id;
+
+      // Cascade: collect all descendants
+      const descendants = await this.collectDescendants(taskId);
+      const allIds = [taskId, ...descendants];
+
+      await this.unsecuredSavedObjectsClient.bulkDelete(
+        allIds.map((id) => ({ type: CASE_TASK_SAVED_OBJECT, id }))
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkDeleteTasks(taskIds: string[]): Promise<void> {
+    if (taskIds.length === 0) return;
+
+    try {
+      // Collect all descendants for every task being deleted
+      const allDescendants = await Promise.all(taskIds.map((id) => this.collectDescendants(id)));
+      const allIds = [...new Set([...taskIds, ...allDescendants.flat()])];
+
+      // Get caseId before deleting
+      const firstTask = await this.getTask(taskIds[0]);
+      const caseId = firstTask.case_id;
+
+      await this.unsecuredSavedObjectsClient.bulkDelete(
+        allIds.map((id) => ({ type: CASE_TASK_SAVED_OBJECT, id }))
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk delete tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reorder
+  // ---------------------------------------------------------------------------
+
+  public async reorderTasks(args: ReorderTasksArgs): Promise<void> {
+    const { caseId, orderedTaskIds, refresh } = args;
+    if (orderedTaskIds.length === 0) return;
+
+    try {
+      const reordered = computeReorderedSortOrders(orderedTaskIds);
+
+      await this.unsecuredSavedObjectsClient.bulkUpdate<Partial<CaseTaskAttributes>>(
+        reordered.map(({ id, sort_order }) => ({
+          type: CASE_TASK_SAVED_OBJECT,
+          id,
+          attributes: { sort_order },
+        })),
+        { refresh }
+      );
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to reorder tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Validates that adding a child to parentTaskId will not exceed MAX_SUBTASK_DEPTH.
+   * Walks the parent_task_id chain upward.
+   */
+  private async validateDepth(parentTaskId: string): Promise<void> {
+    let currentId: string | null | undefined = parentTaskId;
+    let depth = 1;
+
+    // Use loose inequality to stop on both null and undefined parent_task_id
+    while (currentId != null) {
+      if (depth > MAX_SUBTASK_DEPTH) {
+        throw Object.assign(
+          new Error(
+            `Maximum subtask depth of ${MAX_SUBTASK_DEPTH} exceeded. ` +
+              `Tasks can be nested at most ${MAX_SUBTASK_DEPTH} levels deep.`
+          ),
+          { statusCode: 400 }
+        );
+      }
+
+      try {
+        const parent: SavedObject<CaseTaskAttributes> =
+          await this.unsecuredSavedObjectsClient.get<CaseTaskAttributes>(
+            CASE_TASK_SAVED_OBJECT,
+            currentId as string
+          );
+        currentId = parent.attributes.parent_task_id;
+        depth++;
+      } catch {
+        // Parent not found — chain is broken, stop walking
+        break;
+      }
+    }
+  }
+
+  /**
+   * Collects all descendant task IDs for a given task (breadth-first).
+   * Used for cascade delete.
+   */
+  private async collectDescendants(taskId: string): Promise<string[]> {
+    const descendants: string[] = [];
+    const queue = [taskId];
+
+    while (queue.length > 0) {
+      const parentId = queue.shift()!;
+      const children = await this.unsecuredSavedObjectsClient.find<CaseTaskAttributes>({
+        type: CASE_TASK_SAVED_OBJECT,
+        filter: nodeBuilder.is(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`,
+          parentId
+        ),
+        fields: ['parent_task_id'],
+        page: 1,
+        perPage: 1000,
+      });
+
+      for (const child of children.saved_objects) {
+        descendants.push(child.id);
+        queue.push(child.id);
+      }
+    }
+
+    return descendants;
+  }
+
+  /**
+   * Builds ES KueryNode filters from TaskFilterArgs / FindTasksArgs.
+   */
+  private buildFilters({
+    caseIds,
+    owners,
+    status,
+    priority,
+    assignees,
+    due_date_from,
+    due_date_to,
+    parent_task_id,
+  }: {
+    caseIds?: string[];
+    owners?: string[];
+    status?: string | string[];
+    priority?: string | string[];
+    assignees?: string[];
+    due_date_from?: string;
+    due_date_to?: string;
+    parent_task_id?: string | null;
+  }) {
+    const filters = [];
+
+    if (caseIds && caseIds.length > 0) {
+      const caseFilter =
+        caseIds.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseIds[0])
+          : nodeBuilder.or(
+              caseIds.map((id) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, id)
+              )
+            );
+      filters.push(caseFilter);
+    }
+
+    if (owners && owners.length > 0) {
+      const ownerFilter =
+        owners.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.owner`, owners[0])
+          : nodeBuilder.or(
+              owners.map((o) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.owner`, o)
+              )
+            );
+      filters.push(ownerFilter);
+    }
+
+    if (status) {
+      const statuses = Array.isArray(status) ? status : [status];
+      const statusFilter =
+        statuses.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.status`, statuses[0])
+          : nodeBuilder.or(
+              statuses.map((s) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.status`, s)
+              )
+            );
+      filters.push(statusFilter);
+    }
+
+    if (priority) {
+      const priorities = Array.isArray(priority) ? priority : [priority];
+      const priorityFilter =
+        priorities.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.priority`, priorities[0])
+          : nodeBuilder.or(
+              priorities.map((p) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.priority`, p)
+              )
+            );
+      filters.push(priorityFilter);
+    }
+
+    if (assignees && assignees.length > 0) {
+      const assigneeFilter = nodeBuilder.or(
+        assignees.map((uid) =>
+          nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.assignees.uid`, uid)
+        )
+      );
+      filters.push(assigneeFilter);
+    }
+
+    if (due_date_from) {
+      filters.push(
+        nodeBuilder.range(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.due_date`,
+          'gte',
+          due_date_from
+        )
+      );
+    }
+
+    if (due_date_to) {
+      filters.push(
+        nodeBuilder.range(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.due_date`,
+          'lte',
+          due_date_to
+        )
+      );
+    }
+
+    if (parent_task_id === null) {
+      // Root tasks only: parent_task_id is null/missing
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, '__null__')
+      );
+    } else if (parent_task_id !== undefined) {
+      filters.push(
+        nodeBuilder.is(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`,
+          parent_task_id
+        )
+      );
+    }
+
+    return filters;
+  }
+
+  /**
+   * Converts a SavedObject<CaseTaskAttributes> to the CaseTask domain type.
+   */
+  private transformToTask(so: SavedObject<CaseTaskAttributes>): CaseTask {
+    return {
+      ...so.attributes,
+      id: so.id,
+      version: so.version ?? '',
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/sort_order.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/sort_order.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
+import { CASE_TASK_SAVED_OBJECT } from '../../../common/constants';
+import { nodeBuilder } from '@kbn/es-query';
+
+export const SORT_ORDER_GAP = 1000;
+
+/**
+ * Returns the next sort_order value for a new task within a parent scope
+ * (caseId + parentTaskId). Uses a gap of SORT_ORDER_GAP to allow future
+ * insertions without rewriting all existing orders.
+ */
+export const getNextSortOrder = async ({
+  caseId,
+  parentTaskId,
+  unsecuredSavedObjectsClient,
+  logger,
+}: {
+  caseId: string;
+  parentTaskId: string | null;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}): Promise<number> => {
+  try {
+    const filters = [nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseId)];
+
+    if (parentTaskId === null) {
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, '__null__')
+      );
+    } else {
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, parentTaskId)
+      );
+    }
+
+    const result = await unsecuredSavedObjectsClient.find<{ sort_order: number }>({
+      type: CASE_TASK_SAVED_OBJECT,
+      filter: nodeBuilder.and(filters),
+      sortField: 'sort_order',
+      sortOrder: 'desc',
+      page: 1,
+      perPage: 1,
+      fields: ['sort_order'],
+    });
+
+    if (result.total === 0) {
+      return SORT_ORDER_GAP;
+    }
+
+    const maxOrder = result.saved_objects[0]?.attributes?.sort_order ?? 0;
+    return maxOrder + SORT_ORDER_GAP;
+  } catch (error) {
+    logger.warn(`Failed to compute next sort_order for case ${caseId}: ${error.message}`);
+    return SORT_ORDER_GAP;
+  }
+};
+
+/**
+ * Reassigns sort_order values across an ordered set of task IDs with gaps of
+ * SORT_ORDER_GAP starting from SORT_ORDER_GAP. Used by reorderTasks.
+ * Returns an array of { id, sort_order } ready for bulkUpdate.
+ */
+export const computeReorderedSortOrders = (
+  orderedTaskIds: string[]
+): Array<{ id: string; sort_order: number }> =>
+  orderedTaskIds.map((id, index) => ({
+    id,
+    sort_order: (index + 1) * SORT_ORDER_GAP,
+  }));

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/task_summary.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/task_summary.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract, Logger } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+import { createCaseError } from '../../common/error';
+
+interface TaskStatusCounts {
+  open: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
+}
+
+/**
+ * Recomputes the task_summary for a case by aggregating task statuses and
+ * finding the earliest uncompleted due date, then writes it back to the
+ * case SavedObject. Called after every task mutation.
+ *
+ * Uses optimistic concurrency: if the case has been updated concurrently,
+ * the write is retried once.
+ */
+export const syncTaskSummary = async ({
+  caseId,
+  unsecuredSavedObjectsClient,
+  logger,
+}: {
+  caseId: string;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}): Promise<void> => {
+  try {
+    const summary = await computeTaskSummary({ caseId, unsecuredSavedObjectsClient });
+
+    // Fetch the current case to get its version for optimistic concurrency
+    const caseObj = await unsecuredSavedObjectsClient.get(CASE_SAVED_OBJECT, caseId);
+
+    try {
+      await unsecuredSavedObjectsClient.update(
+        CASE_SAVED_OBJECT,
+        caseId,
+        { task_summary: summary },
+        { version: caseObj.version }
+      );
+    } catch (conflictError) {
+      // On version conflict, retry once without version check
+      if (conflictError?.output?.statusCode === 409) {
+        logger.debug(`task_summary sync conflict on case ${caseId}, retrying`);
+        await unsecuredSavedObjectsClient.update(CASE_SAVED_OBJECT, caseId, {
+          task_summary: summary,
+        });
+      } else {
+        throw conflictError;
+      }
+    }
+  } catch (error) {
+    throw createCaseError({
+      message: `Failed to sync task_summary for case ${caseId}: ${error}`,
+      error,
+      logger,
+    });
+  }
+};
+
+/**
+ * Loads all tasks for a case and computes the summary object.
+ */
+const computeTaskSummary = async ({
+  caseId,
+  unsecuredSavedObjectsClient,
+}: {
+  caseId: string;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+}): Promise<{
+  total: number;
+  open: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
+  next_due_date: string | null;
+}> => {
+  // Fetch all tasks for this case in a single query (up to 10k)
+  const result = await unsecuredSavedObjectsClient.find<{
+    status: string;
+    due_date: string | null;
+  }>({
+    type: CASE_TASK_SAVED_OBJECT,
+    filter: nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseId),
+    fields: ['status', 'due_date'],
+    page: 1,
+    perPage: 10000,
+  });
+
+  const counts: TaskStatusCounts = { open: 0, in_progress: 0, completed: 0, cancelled: 0 };
+  const pendingDueDates: string[] = [];
+
+  for (const task of result.saved_objects) {
+    const { status, due_date } = task.attributes;
+
+    if (status === 'open') counts.open++;
+    else if (status === 'in_progress') counts.in_progress++;
+    else if (status === 'completed') counts.completed++;
+    else if (status === 'cancelled') counts.cancelled++;
+
+    // Collect due dates for incomplete tasks only
+    if (due_date && status !== 'completed' && status !== 'cancelled') {
+      pendingDueDates.push(due_date);
+    }
+  }
+
+  const next_due_date =
+    pendingDueDates.length > 0
+      ? pendingDueDates.sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0]
+      : null;
+
+  return {
+    total: result.total,
+    open: counts.open,
+    in_progress: counts.in_progress,
+    completed: counts.completed,
+    cancelled: counts.cancelled,
+    next_due_date: next_due_date ?? null,
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/types.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CaseTaskStatus,
+  CaseTaskPriority,
+  CaseTaskAssignee,
+  CaseTaskCustomField,
+} from '../../../common/types/domain/task/v1';
+import type { User } from '../../common/types/user';
+import type { IndexRefresh } from '../types';
+
+// ---- Create ----------------------------------------------------------------
+
+export interface CreateTaskArgs extends IndexRefresh {
+  caseId: string;
+  title: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  custom_fields?: CaseTaskCustomField[];
+  template_id?: string | null;
+  owner: string;
+  user: User;
+}
+
+export interface BulkCreateTasksArgs extends IndexRefresh {
+  tasks: Array<Omit<CreateTaskArgs, keyof IndexRefresh>>;
+}
+
+// ---- Update ----------------------------------------------------------------
+
+export interface UpdateTaskArgs extends IndexRefresh {
+  taskId: string;
+  title?: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  sort_order?: number;
+  custom_fields?: CaseTaskCustomField[];
+  user: User;
+  version: string;
+}
+
+export interface BulkUpdateTaskArgs extends IndexRefresh {
+  taskId: string;
+  attributes: Partial<UpdateTaskArgs>;
+  version: string;
+}
+
+export interface BulkUpdateTasksArgs extends IndexRefresh {
+  updates: BulkUpdateTaskArgs[];
+}
+
+// ---- Find / Filter ---------------------------------------------------------
+
+export interface TaskFilterArgs {
+  status?: CaseTaskStatus | CaseTaskStatus[];
+  priority?: CaseTaskPriority | CaseTaskPriority[];
+  assignees?: string[]; // user profile UIDs
+  due_date_from?: string;
+  due_date_to?: string;
+  parent_task_id?: string | null; // null = root tasks only; undefined = all depths
+  sort_field?: 'created_at' | 'due_date' | 'priority' | 'sort_order' | 'status';
+  sort_order?: 'asc' | 'desc';
+  page?: number;
+  per_page?: number;
+  search?: string;
+}
+
+export interface FindTasksArgs extends TaskFilterArgs {
+  caseIds?: string[];
+  owners?: string[];
+}
+
+export interface MyTasksArgs extends TaskFilterArgs {
+  userProfileUid: string;
+  caseIds?: string[];
+  includeCompleted?: boolean;
+}
+
+// ---- Reorder ---------------------------------------------------------------
+
+export interface ReorderTasksArgs extends IndexRefresh {
+  caseId: string;
+  parentTaskId: string | null;
+  orderedTaskIds: string[];
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
@@ -41,6 +41,10 @@ const builderMap = {
   delete_case: NoopUserActionBuilder,
   customFields: CustomFieldsUserActionBuilder,
   observables: ObservablesUserActionBuilder,
+  create_task: NoopUserActionBuilder,
+  update_task: NoopUserActionBuilder,
+  delete_task: NoopUserActionBuilder,
+  apply_task_template: NoopUserActionBuilder,
 };
 
 export class BuilderFactory {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -40,6 +40,12 @@ import type {
   UserActionFindRequest,
 } from '../../../common/types/api';
 import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
+import type {
+  CreateTaskUserActionPayload,
+  UpdateTaskUserActionPayload,
+  DeleteTaskUserActionPayload,
+  ApplyTaskTemplateUserActionPayload,
+} from '../../../common/types/domain/user_action/task/v1';
 
 export interface BuilderParameters {
   title: {
@@ -102,6 +108,18 @@ export interface BuilderParameters {
         observables: { actionType: ObservablesActionType; count: number };
       };
     };
+  };
+  create_task: {
+    parameters: { payload: CreateTaskUserActionPayload };
+  };
+  update_task: {
+    parameters: { payload: UpdateTaskUserActionPayload };
+  };
+  delete_task: {
+    parameters: { payload: DeleteTaskUserActionPayload };
+  };
+  apply_task_template: {
+    parameters: { payload: ApplyTaskTemplateUserActionPayload };
   };
 }
 


### PR DESCRIPTION
## Summary

Builds on #257816 (PR 1) and #257836 (PR 2).

- `CaseTaskTemplateService` with CRUD: `createTemplate`, `getTemplate`, `findTemplates`, `updateTemplate`, `deleteTemplate`
- Instance-level 60-second TTL cache to avoid repeated SO lookups for template definitions
- `applyTemplate`: resolves template, bulk-creates root tasks, then bulk-creates subtasks with correct `parent_task_id` references
- `relative_due_days` → `due_date` computation using an anchor date (defaults to now)
- Scope-based filtering (`'global' | 'space'`) in `findTemplates`

## Test plan
- [x] 28 unit tests passing (all methods including applyTemplate with parent references and date computation)
- [x] 0 TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)