### PR TITLE
[Cases] PR 8: OpenAPI docs & telemetry for task management

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/api/helpers.ts
+++ b/x-pack/platform/plugins/shared/cases/common/api/helpers.ts
@@ -26,6 +26,10 @@ import {
   INTERNAL_CASE_SIMILAR_CASES_URL,
   INTERNAL_CASE_OBSERVABLES_DELETE_URL,
   INTERNAL_BULK_CREATE_CASE_OBSERVABLES_URL,
+  CASE_TASKS_URL,
+  CASE_TASK_DETAILS_URL,
+  CASE_TASKS_REORDER_URL,
+  CASE_TASKS_APPLY_TEMPLATE_URL,
 } from '../constants';
 
 export const getCaseDetailsUrl = (id: string): string => {
@@ -115,4 +119,20 @@ export const getBulkCreateObservablesUrl = (id: string): string => {
 
 export const getCaseSimilarCasesUrl = (caseId: string) => {
   return INTERNAL_CASE_SIMILAR_CASES_URL.replace('{case_id}', caseId);
+};
+
+export const getCaseTasksUrl = (caseId: string): string => {
+  return CASE_TASKS_URL.replace('{case_id}', caseId);
+};
+
+export const getCaseTaskDetailsUrl = (caseId: string, taskId: string): string => {
+  return CASE_TASK_DETAILS_URL.replace('{case_id}', caseId).replace('{task_id}', taskId);
+};
+
+export const getCaseTasksReorderUrl = (caseId: string): string => {
+  return CASE_TASKS_REORDER_URL.replace('{case_id}', caseId);
+};
+
+export const getCaseTasksApplyTemplateUrl = (caseId: string): string => {
+  return CASE_TASKS_APPLY_TEMPLATE_URL.replace('{case_id}', caseId);
 };

--- a/x-pack/platform/plugins/shared/cases/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/index.ts
@@ -35,6 +35,8 @@ export const CASE_CONFIGURE_SAVED_OBJECT = 'cases-configure' as const;
 export const CASE_RULES_SAVED_OBJECT = 'cases-rules' as const;
 export const CASE_ID_INCREMENTER_SAVED_OBJECT = 'cases-incrementing-id' as const;
 export const CASE_TEMPLATE_SAVED_OBJECT = 'cases-templates' as const;
+export const CASE_TASK_SAVED_OBJECT = 'cases-tasks' as const;
+export const CASE_TASK_TEMPLATE_SAVED_OBJECT = 'cases-task-templates' as const;
 
 /**
  * If more values are added here please also add them here: x-pack/test/cases_api_integration/common/plugins
@@ -107,6 +109,26 @@ export const INTERNAL_CASE_FIND_USER_ACTIONS_URL =
 export const INTERNAL_CASE_GET_CASES_BY_ATTACHMENT_URL =
   `${CASES_INTERNAL_URL}/case/attachments/_find_containing_all` as const;
 export const INTERNAL_BULK_CREATE_CASE_OBSERVABLES_URL = `${CASES_INTERNAL_URL}/{case_id}/observables/_bulk_create`;
+
+/**
+ * Task routes
+ */
+export const CASES_TASKS_URL = `${CASES_URL}/tasks` as const;
+export const CASE_TASKS_URL = `${CASE_DETAILS_URL}/tasks` as const;
+export const CASE_TASK_DETAILS_URL = `${CASE_TASKS_URL}/{task_id}` as const;
+export const CASE_TASKS_BULK_CREATE_URL = `${CASE_TASKS_URL}/_bulk_create` as const;
+export const CASE_TASKS_BULK_UPDATE_URL = `${CASE_TASKS_URL}/_bulk_update` as const;
+export const CASE_TASKS_BULK_DELETE_URL = `${CASE_TASKS_URL}/_bulk_delete` as const;
+export const CASE_TASKS_REORDER_URL = `${CASE_TASKS_URL}/_reorder` as const;
+export const CASE_TASKS_APPLY_TEMPLATE_URL = `${CASE_TASKS_URL}/_apply_template` as const;
+export const CASES_TASKS_MY_URL = `${CASES_TASKS_URL}/_my` as const;
+export const CASES_TASKS_FIND_URL = `${CASES_TASKS_URL}/_find` as const;
+
+/**
+ * Task template routes
+ */
+export const CASES_TASK_TEMPLATES_URL = `${CASES_URL}/task_templates` as const;
+export const CASE_TASK_TEMPLATE_DETAILS_URL = `${CASES_TASK_TEMPLATES_URL}/{template_id}` as const;
 
 export const INTERNAL_TEMPLATES_URL = `${CASES_INTERNAL_URL}/templates` as const;
 export const INTERNAL_TEMPLATE_DETAILS_URL = `${INTERNAL_TEMPLATES_URL}/{template_id}` as const;

--- a/x-pack/platform/plugins/shared/cases/common/types.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types.ts
@@ -29,4 +29,5 @@ export enum CASE_VIEW_PAGE_TABS {
   OBSERVABLES = 'observables',
   SIMILAR_CASES = 'similar_cases',
   ATTACHMENTS = 'attachments',
+  TASKS = 'tasks',
 }

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task/v1.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserRt } from '../user/v1';
+
+export const CaseTaskStatusRt = rt.keyof({
+  open: null,
+  in_progress: null,
+  completed: null,
+  cancelled: null,
+});
+
+export const CaseTaskPriorityRt = rt.keyof({
+  low: null,
+  medium: null,
+  high: null,
+  critical: null,
+});
+
+export const CaseTaskCustomFieldRt = rt.strict({
+  key: rt.string,
+  type: rt.keyof({ text: null, toggle: null, number: null, date: null }),
+  value: rt.union([rt.string, rt.boolean, rt.number, rt.null]),
+});
+
+export const CaseTaskAssigneeRt = rt.strict({
+  uid: rt.string,
+});
+
+export const CaseTaskAttributesRt = rt.intersection([
+  rt.strict({
+    title: rt.string,
+    description: rt.string,
+    case_id: rt.string,
+    parent_task_id: rt.union([rt.string, rt.null]),
+    status: CaseTaskStatusRt,
+    priority: CaseTaskPriorityRt,
+    assignees: rt.array(CaseTaskAssigneeRt),
+    due_date: rt.union([rt.string, rt.null]),
+    started_at: rt.union([rt.string, rt.null]),
+    completed_at: rt.union([rt.string, rt.null]),
+    sort_order: rt.number,
+    template_id: rt.union([rt.string, rt.null]),
+    custom_fields: rt.array(CaseTaskCustomFieldRt),
+    required_role: rt.union([rt.string, rt.null]),
+    owner_team: rt.union([rt.string, rt.null]),
+    owner: rt.string,
+    created_at: rt.string,
+    created_by: UserRt,
+    updated_at: rt.union([rt.string, rt.null]),
+    updated_by: rt.union([UserRt, rt.null]),
+  }),
+  rt.exact(rt.partial({})),
+]);
+
+export const CaseTaskRt = rt.intersection([
+  CaseTaskAttributesRt,
+  rt.strict({
+    id: rt.string,
+    version: rt.string,
+  }),
+]);
+
+export const CaseTasksRt = rt.array(CaseTaskRt);
+
+export const CaseTaskSummaryRt = rt.strict({
+  total: rt.number,
+  open: rt.number,
+  in_progress: rt.number,
+  completed: rt.number,
+  cancelled: rt.number,
+  next_due_date: rt.union([rt.string, rt.null]),
+});
+
+export type CaseTaskStatus = rt.TypeOf<typeof CaseTaskStatusRt>;
+export type CaseTaskPriority = rt.TypeOf<typeof CaseTaskPriorityRt>;
+export type CaseTaskAssignee = rt.TypeOf<typeof CaseTaskAssigneeRt>;
+export type CaseTaskCustomField = rt.TypeOf<typeof CaseTaskCustomFieldRt>;
+export type CaseTaskAttributes = rt.TypeOf<typeof CaseTaskAttributesRt>;
+export type CaseTask = rt.TypeOf<typeof CaseTaskRt>;
+export type CaseTasks = rt.TypeOf<typeof CaseTasksRt>;
+export type CaseTaskSummary = rt.TypeOf<typeof CaseTaskSummaryRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/index.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/task_template/v1.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserRt } from '../user/v1';
+import { CaseTaskPriorityRt } from '../task/v1';
+
+export const CaseTaskTemplateSubtaskRt = rt.strict({
+  title: rt.string,
+  description: rt.string,
+  priority: CaseTaskPriorityRt,
+  relative_due_days: rt.union([rt.number, rt.null]),
+  sort_order: rt.number,
+});
+
+export const CaseTaskTemplateTaskRt = rt.strict({
+  title: rt.string,
+  description: rt.string,
+  priority: CaseTaskPriorityRt,
+  relative_due_days: rt.union([rt.number, rt.null]),
+  sort_order: rt.number,
+  subtasks: rt.array(CaseTaskTemplateSubtaskRt),
+});
+
+export const CaseTaskTemplateAttributesRt = rt.strict({
+  name: rt.string,
+  description: rt.string,
+  scope: rt.keyof({ global: null, space: null }),
+  tags: rt.array(rt.string),
+  tasks: rt.array(CaseTaskTemplateTaskRt),
+  owner: rt.string,
+  created_at: rt.string,
+  created_by: UserRt,
+  updated_at: rt.union([rt.string, rt.null]),
+  updated_by: rt.union([UserRt, rt.null]),
+});
+
+export const CaseTaskTemplateRt = rt.intersection([
+  CaseTaskTemplateAttributesRt,
+  rt.strict({
+    id: rt.string,
+    version: rt.string,
+  }),
+]);
+
+export const CaseTaskTemplatesRt = rt.array(CaseTaskTemplateRt);
+
+export type CaseTaskTemplateSubtask = rt.TypeOf<typeof CaseTaskTemplateSubtaskRt>;
+export type CaseTaskTemplateTask = rt.TypeOf<typeof CaseTaskTemplateTaskRt>;
+export type CaseTaskTemplateAttributes = rt.TypeOf<typeof CaseTaskTemplateAttributesRt>;
+export type CaseTaskTemplate = rt.TypeOf<typeof CaseTaskTemplateRt>;
+export type CaseTaskTemplates = rt.TypeOf<typeof CaseTaskTemplatesRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/action/v1.ts
@@ -27,6 +27,10 @@ export const UserActionTypes = {
   category: 'category',
   customFields: 'customFields',
   observables: 'observables',
+  create_task: 'create_task',
+  update_task: 'update_task',
+  delete_task: 'delete_task',
+  apply_task_template: 'apply_task_template',
 } as const;
 
 type UserActionActionTypeKeys = keyof typeof UserActionTypes;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/task/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/task/v1.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+import { UserActionTypes } from '../action/v1';
+
+// --- create_task ---
+
+const CreateTaskPayloadTaskRt = rt.strict({
+  id: rt.string,
+  title: rt.string,
+  status: rt.string,
+  priority: rt.string,
+  assignees: rt.array(rt.strict({ uid: rt.string })),
+});
+
+export const CreateTaskUserActionPayloadRt = rt.strict({
+  task: CreateTaskPayloadTaskRt,
+});
+
+export const CreateTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.create_task),
+  payload: CreateTaskUserActionPayloadRt,
+});
+
+// --- update_task ---
+
+export const UpdateTaskChangedFieldRt = rt.strict({
+  field: rt.string,
+  old_value: rt.unknown,
+  new_value: rt.unknown,
+});
+
+export const UpdateTaskUserActionPayloadRt = rt.strict({
+  task_id: rt.string,
+  task_title: rt.string,
+  changed_fields: rt.array(UpdateTaskChangedFieldRt),
+});
+
+export const UpdateTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.update_task),
+  payload: UpdateTaskUserActionPayloadRt,
+});
+
+// --- delete_task ---
+
+export const DeleteTaskUserActionPayloadRt = rt.strict({
+  task_id: rt.string,
+  task_title: rt.string,
+  subtasks_deleted: rt.number,
+});
+
+export const DeleteTaskUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.delete_task),
+  payload: DeleteTaskUserActionPayloadRt,
+});
+
+// --- apply_task_template ---
+
+export const ApplyTaskTemplateUserActionPayloadRt = rt.strict({
+  template_id: rt.string,
+  template_name: rt.string,
+  tasks_created: rt.number,
+});
+
+export const ApplyTaskTemplateUserActionRt = rt.strict({
+  type: rt.literal(UserActionTypes.apply_task_template),
+  payload: ApplyTaskTemplateUserActionPayloadRt,
+});
+
+export type CreateTaskUserActionPayload = rt.TypeOf<typeof CreateTaskUserActionPayloadRt>;
+export type CreateTaskUserAction = rt.TypeOf<typeof CreateTaskUserActionRt>;
+export type UpdateTaskChangedField = rt.TypeOf<typeof UpdateTaskChangedFieldRt>;
+export type UpdateTaskUserActionPayload = rt.TypeOf<typeof UpdateTaskUserActionPayloadRt>;
+export type UpdateTaskUserAction = rt.TypeOf<typeof UpdateTaskUserActionRt>;
+export type DeleteTaskUserActionPayload = rt.TypeOf<typeof DeleteTaskUserActionPayloadRt>;
+export type DeleteTaskUserAction = rt.TypeOf<typeof DeleteTaskUserActionRt>;
+export type ApplyTaskTemplateUserActionPayload = rt.TypeOf<
+  typeof ApplyTaskTemplateUserActionPayloadRt
+>;
+export type ApplyTaskTemplateUserAction = rt.TypeOf<typeof ApplyTaskTemplateUserActionRt>;

--- a/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/user_action/v1.ts
@@ -25,6 +25,12 @@ import { TagsUserActionRt } from './tags/v1';
 import { TitleUserActionRt } from './title/v1';
 import { CustomFieldsUserActionRt } from './custom_fields/v1';
 import { ObservablesUserActionRt } from './observables/v1';
+import {
+  CreateTaskUserActionRt,
+  UpdateTaskUserActionRt,
+  DeleteTaskUserActionRt,
+  ApplyTaskTemplateUserActionRt,
+} from './task/v1';
 export { UserActionTypes, UserActionActions } from './action/v1';
 export { StatusUserActionRt } from './status/v1';
 
@@ -63,6 +69,10 @@ const BasicUserActionsRt = rt.union([
   CategoryUserActionRt,
   CustomFieldsUserActionRt,
   ObservablesUserActionRt,
+  CreateTaskUserActionRt,
+  UpdateTaskUserActionRt,
+  DeleteTaskUserActionRt,
+  ApplyTaskTemplateUserActionRt,
 ]);
 
 const CommonUserActionsWithIdsRt = rt.union([BasicUserActionsRt, CommentUserActionRt]);
@@ -158,3 +168,7 @@ export type CreateCaseUserActionWithoutConnectorId = UserActionWithAttributes<
 >;
 export type CustomFieldsUserAction = UserAction<rt.TypeOf<typeof CustomFieldsUserActionRt>>;
 export type ObservablesUserAction = UserAction<rt.TypeOf<typeof ObservablesUserActionRt>>;
+export type CreateTaskUserAction = UserAction<rt.TypeOf<typeof CreateTaskUserActionRt>>;
+export type UpdateTaskUserAction = UserAction<rt.TypeOf<typeof UpdateTaskUserActionRt>>;
+export type DeleteTaskUserAction = UserAction<rt.TypeOf<typeof DeleteTaskUserActionRt>>;
+export type ApplyTaskTemplateUserAction = UserAction<rt.TypeOf<typeof ApplyTaskTemplateUserActionRt>>;

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_page.tsx
@@ -23,6 +23,7 @@ import type { CaseViewPageProps } from './types';
 import { useRefreshCaseViewPage } from './use_on_refresh_case_view_page';
 import { useOnUpdateField } from './use_on_update_field';
 import { CaseViewSimilarCases } from './components/case_view_similar_cases';
+import { CaseViewTasks } from '../tasks/case_view_tasks';
 import { CaseViewEvents } from './components/case_view_events';
 import { CaseViewAttachments } from './components/case_view_attachments';
 import { filterCaseAttachmentsBySearchTerm } from './components/helpers';
@@ -185,6 +186,9 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.SIMILAR_CASES && (
             <CaseViewSimilarCases caseData={caseWithFilteredAttachments} searchTerm={searchTerm} />
+          )}
+          {activeTabId === CASE_VIEW_PAGE_TABS.TASKS && (
+            <CaseViewTasks caseId={caseData.id} />
           )}
         </EuiFlexGroup>
       </>

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/case_view_tabs.tsx
@@ -10,7 +10,7 @@ import { EuiTab, EuiTabs, useEuiTheme } from '@elastic/eui';
 
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { useCaseViewNavigation } from '../../common/navigation';
-import { ACTIVITY_TAB, ATTACHMENTS_TAB, SIMILAR_CASES_TAB } from './translations';
+import { ACTIVITY_TAB, ATTACHMENTS_TAB, SIMILAR_CASES_TAB, TASKS_TAB } from './translations';
 import { type CaseUI } from '../../../common';
 import type { CaseViewTab } from './use_case_attachment_tabs';
 import {
@@ -85,6 +85,10 @@ export const CaseViewTabs = React.memo<CaseViewTabsProps>(({ caseData, activeTab
             count={similarCasesData?.total}
           />
         ),
+      },
+      {
+        id: CASE_VIEW_PAGE_TABS.TASKS,
+        name: TASKS_TAB,
       },
     ],
     [activeTab, euiTheme, isAttachmentsTabActive, similarCasesData?.total, totalAttachments]

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/translations.ts
@@ -210,6 +210,10 @@ export const SIMILAR_CASES_TAB = i18n.translate('xpack.cases.caseView.tabs.simil
   defaultMessage: 'Similar cases',
 });
 
+export const TASKS_TAB = i18n.translate('xpack.cases.caseView.tabs.tasks', {
+  defaultMessage: 'Tasks',
+});
+
 export const ALERTS_EMPTY_DESCRIPTION = i18n.translate(
   'xpack.cases.caseView.tabs.alerts.emptyDescription',
   {

--- a/x-pack/platform/plugins/shared/cases/public/components/tasks/case_view_tasks.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/tasks/case_view_tasks.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useGetTasks } from '../../containers/use_get_tasks';
+import { TasksTable } from './tasks_table';
+
+interface CaseViewTasksProps {
+  caseId: string;
+}
+
+export const CaseViewTasks = React.memo<CaseViewTasksProps>(({ caseId }) => {
+  const { data, isLoading } = useGetTasks(caseId);
+
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <TasksTable
+          caseId={caseId}
+          tasks={data?.tasks ?? []}
+          isLoading={isLoading}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+});
+
+CaseViewTasks.displayName = 'CaseViewTasks';

--- a/x-pack/platform/plugins/shared/cases/public/components/tasks/tasks_table.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/tasks/tasks_table.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import {
+  EuiBasicTable,
+  EuiEmptyPrompt,
+  EuiSkeletonText,
+  EuiBadge,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton,
+} from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { CaseTask } from '../../../common/types/domain/task/v1';
+import { useDeleteTask } from '../../containers/use_delete_task';
+import { useUpdateTask } from '../../containers/use_update_task';
+import * as i18n from './translations';
+
+const STATUS_LABELS: Record<CaseTask['status'], string> = {
+  open: i18n.STATUS_OPEN,
+  in_progress: i18n.STATUS_IN_PROGRESS,
+  completed: i18n.STATUS_COMPLETED,
+  cancelled: i18n.STATUS_CANCELLED,
+};
+
+const STATUS_COLORS: Record<CaseTask['status'], string> = {
+  open: 'default',
+  in_progress: 'primary',
+  completed: 'success',
+  cancelled: 'default',
+};
+
+const PRIORITY_LABELS: Record<CaseTask['priority'], string> = {
+  low: i18n.PRIORITY_LOW,
+  medium: i18n.PRIORITY_MEDIUM,
+  high: i18n.PRIORITY_HIGH,
+  critical: i18n.PRIORITY_CRITICAL,
+};
+
+interface TasksTableProps {
+  caseId: string;
+  tasks: CaseTask[];
+  isLoading: boolean;
+  onAddTask?: () => void;
+}
+
+export const TasksTable = React.memo<TasksTableProps>(
+  ({ caseId, tasks, isLoading, onAddTask }) => {
+    const { mutate: deleteTask } = useDeleteTask(caseId);
+    const { mutate: updateTask } = useUpdateTask(caseId);
+
+    const handleStatusChange = useCallback(
+      (task: CaseTask, newStatus: CaseTask['status']) => {
+        updateTask({ taskId: task.id, request: { version: task.version, status: newStatus } });
+      },
+      [updateTask]
+    );
+
+    const handleDelete = useCallback(
+      (taskId: string) => {
+        deleteTask(taskId);
+      },
+      [deleteTask]
+    );
+
+    const columns: Array<EuiBasicTableColumn<CaseTask>> = [
+      {
+        name: i18n.TASK_TITLE,
+        field: 'title',
+        'data-test-subj': 'cases-tasks-table-title',
+        truncateText: true,
+      },
+      {
+        name: i18n.TASK_STATUS,
+        field: 'status',
+        'data-test-subj': 'cases-tasks-table-status',
+        width: '120px',
+        render: (status: CaseTask['status'], task: CaseTask) => (
+          <EuiBadge
+            color={STATUS_COLORS[status]}
+            onClick={() => {
+              const nextStatus = status === 'open' ? 'in_progress' : status === 'in_progress' ? 'completed' : 'open';
+              handleStatusChange(task, nextStatus as CaseTask['status']);
+            }}
+            onClickAriaLabel={`Change status from ${status}`}
+            data-test-subj={`cases-tasks-status-${status}`}
+          >
+            {STATUS_LABELS[status]}
+          </EuiBadge>
+        ),
+      },
+      {
+        name: i18n.TASK_PRIORITY,
+        field: 'priority',
+        'data-test-subj': 'cases-tasks-table-priority',
+        width: '100px',
+        render: (priority: CaseTask['priority']) => PRIORITY_LABELS[priority],
+      },
+      {
+        name: i18n.TASK_DUE_DATE,
+        field: 'due_date',
+        'data-test-subj': 'cases-tasks-table-due-date',
+        width: '150px',
+        render: (dueDate: string | null) =>
+          dueDate ? new Date(dueDate).toLocaleDateString() : '—',
+      },
+      {
+        name: i18n.TASK_ACTIONS,
+        field: 'actions',
+        'data-test-subj': 'cases-tasks-table-actions',
+        width: '80px',
+        actions: [
+          {
+            name: i18n.DELETE_TASK,
+            render: (task: CaseTask) => (
+              <EuiButtonIcon
+                iconType="trash"
+                aria-label={i18n.DELETE_TASK}
+                color="danger"
+                data-test-subj={`cases-tasks-delete-${task.id}`}
+                onClick={() => handleDelete(task.id)}
+              />
+            ),
+          },
+        ],
+      },
+    ];
+
+    if (isLoading) {
+      return <EuiSkeletonText lines={5} />;
+    }
+
+    if (tasks.length === 0) {
+      return (
+        <EuiEmptyPrompt
+          title={<h3>{i18n.NO_TASKS}</h3>}
+          body={<p>{i18n.NO_TASKS_DESCRIPTION}</p>}
+          data-test-subj="cases-tasks-table-empty"
+          titleSize="xs"
+          actions={
+            onAddTask ? (
+              <EuiButton
+                size="s"
+                onClick={onAddTask}
+                iconType="plus"
+                data-test-subj="cases-tasks-add-task-empty"
+              >
+                {i18n.ADD_TASK}
+              </EuiButton>
+            ) : null
+          }
+        />
+      );
+    }
+
+    return (
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              {onAddTask && (
+                <EuiButton
+                  size="s"
+                  onClick={onAddTask}
+                  iconType="plus"
+                  data-test-subj="cases-tasks-add-task"
+                >
+                  {i18n.ADD_TASK}
+                </EuiButton>
+              )}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiBasicTable
+            items={tasks}
+            columns={columns}
+            rowHeader="title"
+            data-test-subj="cases-tasks-table"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);
+
+TasksTable.displayName = 'TasksTable';

--- a/x-pack/platform/plugins/shared/cases/public/components/tasks/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/tasks/translations.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const TASKS_TAB_TITLE = i18n.translate('xpack.cases.caseView.tabs.tasks', {
+  defaultMessage: 'Tasks',
+});
+
+export const ADD_TASK = i18n.translate('xpack.cases.tasks.addTask', {
+  defaultMessage: 'Add task',
+});
+
+export const NO_TASKS = i18n.translate('xpack.cases.tasks.noTasks', {
+  defaultMessage: 'No tasks',
+});
+
+export const NO_TASKS_DESCRIPTION = i18n.translate('xpack.cases.tasks.noTasksDescription', {
+  defaultMessage: 'Add a task to track work items for this case.',
+});
+
+export const TASK_TITLE = i18n.translate('xpack.cases.tasks.columns.title', {
+  defaultMessage: 'Title',
+});
+
+export const TASK_STATUS = i18n.translate('xpack.cases.tasks.columns.status', {
+  defaultMessage: 'Status',
+});
+
+export const TASK_PRIORITY = i18n.translate('xpack.cases.tasks.columns.priority', {
+  defaultMessage: 'Priority',
+});
+
+export const TASK_ASSIGNEES = i18n.translate('xpack.cases.tasks.columns.assignees', {
+  defaultMessage: 'Assignees',
+});
+
+export const TASK_DUE_DATE = i18n.translate('xpack.cases.tasks.columns.dueDate', {
+  defaultMessage: 'Due date',
+});
+
+export const TASK_ACTIONS = i18n.translate('xpack.cases.tasks.columns.actions', {
+  defaultMessage: 'Actions',
+});
+
+export const DELETE_TASK = i18n.translate('xpack.cases.tasks.deleteTask', {
+  defaultMessage: 'Delete task',
+});
+
+export const CONFIRM_DELETE_TASK = i18n.translate('xpack.cases.tasks.confirmDelete', {
+  defaultMessage: 'Are you sure you want to delete this task?',
+});
+
+export const STATUS_OPEN = i18n.translate('xpack.cases.tasks.status.open', {
+  defaultMessage: 'Open',
+});
+
+export const STATUS_IN_PROGRESS = i18n.translate('xpack.cases.tasks.status.inProgress', {
+  defaultMessage: 'In progress',
+});
+
+export const STATUS_COMPLETED = i18n.translate('xpack.cases.tasks.status.completed', {
+  defaultMessage: 'Completed',
+});
+
+export const STATUS_CANCELLED = i18n.translate('xpack.cases.tasks.status.cancelled', {
+  defaultMessage: 'Cancelled',
+});
+
+export const PRIORITY_LOW = i18n.translate('xpack.cases.tasks.priority.low', {
+  defaultMessage: 'Low',
+});
+
+export const PRIORITY_MEDIUM = i18n.translate('xpack.cases.tasks.priority.medium', {
+  defaultMessage: 'Medium',
+});
+
+export const PRIORITY_HIGH = i18n.translate('xpack.cases.tasks.priority.high', {
+  defaultMessage: 'High',
+});
+
+export const PRIORITY_CRITICAL = i18n.translate('xpack.cases.tasks.priority.critical', {
+  defaultMessage: 'Critical',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/builder.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/builder.tsx
@@ -20,6 +20,12 @@ import type { UserActionBuilderMap } from './types';
 import { createCategoryUserActionBuilder } from './category';
 import { createCustomFieldsUserActionBuilder } from './custom_fields/custom_fields';
 import { createObservablesUserActionBuilder } from './observables';
+import {
+  createCreateTaskUserActionBuilder,
+  createUpdateTaskUserActionBuilder,
+  createDeleteTaskUserActionBuilder,
+  createApplyTaskTemplateUserActionBuilder,
+} from './tasks';
 
 export const builderMap: UserActionBuilderMap = {
   create_case: createCaseUserActionBuilder,
@@ -36,4 +42,8 @@ export const builderMap: UserActionBuilderMap = {
   category: createCategoryUserActionBuilder,
   customFields: createCustomFieldsUserActionBuilder,
   observables: createObservablesUserActionBuilder,
+  create_task: createCreateTaskUserActionBuilder,
+  update_task: createUpdateTaskUserActionBuilder,
+  delete_task: createDeleteTaskUserActionBuilder,
+  apply_task_template: createApplyTaskTemplateUserActionBuilder,
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
@@ -11,7 +11,13 @@ import type { SupportedUserActionTypes } from './types';
 
 export const DRAFT_COMMENT_STORAGE_ID = 'xpack.cases.commentDraft';
 
-export const UNSUPPORTED_ACTION_TYPES = ['delete_case'] as const;
+export const UNSUPPORTED_ACTION_TYPES = [
+  'delete_case',
+  'create_task',
+  'update_task',
+  'delete_task',
+  'apply_task_template',
+] as const;
 export const SUPPORTED_ACTION_TYPES: SupportedUserActionTypes[] = Object.keys(
   omit(UserActionTypes, UNSUPPORTED_ACTION_TYPES)
 ) as SupportedUserActionTypes[];

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/constants.ts
@@ -11,13 +11,7 @@ import type { SupportedUserActionTypes } from './types';
 
 export const DRAFT_COMMENT_STORAGE_ID = 'xpack.cases.commentDraft';
 
-export const UNSUPPORTED_ACTION_TYPES = [
-  'delete_case',
-  'create_task',
-  'update_task',
-  'delete_task',
-  'apply_task_template',
-] as const;
+export const UNSUPPORTED_ACTION_TYPES = ['delete_case'] as const;
 export const SUPPORTED_ACTION_TYPES: SupportedUserActionTypes[] = Object.keys(
   omit(UserActionTypes, UNSUPPORTED_ACTION_TYPES)
 ) as SupportedUserActionTypes[];

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/tasks.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/tasks.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import type { SnakeToCamelCase } from '../../../common/types';
+import type {
+  CreateTaskUserAction,
+  UpdateTaskUserAction,
+  DeleteTaskUserAction,
+  ApplyTaskTemplateUserAction,
+} from '../../../common/types/domain';
+import type { UserActionBuilder } from './types';
+import { createCommonUpdateUserActionBuilder } from './common';
+import * as i18n from './translations';
+
+export const createCreateTaskUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  userProfiles,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const action = userAction as SnakeToCamelCase<CreateTaskUserAction>;
+    const taskTitle = action?.payload?.task?.title ?? '';
+
+    const label = (
+      <EuiText size="s" data-test-subj="create-task-user-action">
+        {i18n.CREATED_TASK(taskTitle)}
+      </EuiText>
+    );
+
+    const commonBuilder = createCommonUpdateUserActionBuilder({
+      userProfiles,
+      userAction,
+      handleOutlineComment,
+      label,
+      icon: 'checkInCircleFilled',
+    });
+
+    return commonBuilder.build();
+  },
+});
+
+export const createUpdateTaskUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  userProfiles,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const action = userAction as SnakeToCamelCase<UpdateTaskUserAction>;
+    const taskTitle = action?.payload?.taskTitle ?? '';
+
+    const label = (
+      <EuiText size="s" data-test-subj="update-task-user-action">
+        {i18n.UPDATED_TASK(taskTitle)}
+      </EuiText>
+    );
+
+    const commonBuilder = createCommonUpdateUserActionBuilder({
+      userProfiles,
+      userAction,
+      handleOutlineComment,
+      label,
+      icon: 'dot',
+    });
+
+    return commonBuilder.build();
+  },
+});
+
+export const createDeleteTaskUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  userProfiles,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const action = userAction as SnakeToCamelCase<DeleteTaskUserAction>;
+    const taskTitle = action?.payload?.taskTitle ?? '';
+
+    const label = (
+      <EuiText size="s" data-test-subj="delete-task-user-action">
+        {i18n.DELETED_TASK(taskTitle)}
+      </EuiText>
+    );
+
+    const commonBuilder = createCommonUpdateUserActionBuilder({
+      userProfiles,
+      userAction,
+      handleOutlineComment,
+      label,
+      icon: 'minusInCircle',
+    });
+
+    return commonBuilder.build();
+  },
+});
+
+export const createApplyTaskTemplateUserActionBuilder: UserActionBuilder = ({
+  userAction,
+  userProfiles,
+  handleOutlineComment,
+}) => ({
+  build: () => {
+    const action = userAction as SnakeToCamelCase<ApplyTaskTemplateUserAction>;
+    const tasksCreated = action?.payload?.tasksCreated ?? 0;
+
+    const label = (
+      <EuiText size="s" data-test-subj="apply-task-template-user-action">
+        {i18n.APPLIED_TASK_TEMPLATE(tasksCreated)}
+      </EuiText>
+    );
+
+    const commonBuilder = createCommonUpdateUserActionBuilder({
+      userProfiles,
+      userAction,
+      handleOutlineComment,
+      label,
+      icon: 'checkInCircleFilled',
+    });
+
+    return commonBuilder.build();
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
@@ -155,6 +155,14 @@ export const OBSERVABLES = i18n.translate('xpack.cases.caseView.userActions.obse
   defaultMessage: 'Observables',
 });
 
+export const TASK = i18n.translate('xpack.cases.caseView.userActions.task', {
+  defaultMessage: 'Task',
+});
+
+export const TASK_TEMPLATE = i18n.translate('xpack.cases.caseView.userActions.taskTemplate', {
+  defaultMessage: 'Task Template',
+});
+
 export const USER_ACTION_EDITED = (type: string) =>
   i18n.translate('xpack.cases.caseView.userActions.edited', {
     values: { type },

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
@@ -163,6 +163,30 @@ export const TASK_TEMPLATE = i18n.translate('xpack.cases.caseView.userActions.ta
   defaultMessage: 'Task Template',
 });
 
+export const CREATED_TASK = (taskTitle: string) =>
+  i18n.translate('xpack.cases.caseView.userActions.createdTask', {
+    values: { taskTitle },
+    defaultMessage: 'created task "{taskTitle}"',
+  });
+
+export const UPDATED_TASK = (taskTitle: string) =>
+  i18n.translate('xpack.cases.caseView.userActions.updatedTask', {
+    values: { taskTitle },
+    defaultMessage: 'updated task "{taskTitle}"',
+  });
+
+export const DELETED_TASK = (taskTitle: string) =>
+  i18n.translate('xpack.cases.caseView.userActions.deletedTask', {
+    values: { taskTitle },
+    defaultMessage: 'deleted task "{taskTitle}"',
+  });
+
+export const APPLIED_TASK_TEMPLATE = (tasksCreated: number) =>
+  i18n.translate('xpack.cases.caseView.userActions.appliedTaskTemplate', {
+    values: { tasksCreated },
+    defaultMessage: 'applied a task template and created {tasksCreated} task(s)',
+  });
+
 export const USER_ACTION_EDITED = (type: string) =>
   i18n.translate('xpack.cases.caseView.userActions.edited', {
     values: { type },

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/user_actions_aria_labels.tsx
@@ -25,6 +25,10 @@ export const getUserActionAriaLabel = (type: keyof typeof UserActionTypes) => {
     category: i18n.CATEGORY,
     customFields: i18n.CUSTOM_FIELDS,
     observables: i18n.OBSERVABLES,
+    create_task: i18n.TASK,
+    update_task: i18n.TASK,
+    delete_task: i18n.TASK,
+    apply_task_template: i18n.TASK_TEMPLATE,
   };
 
   switch (type) {

--- a/x-pack/platform/plugins/shared/cases/public/containers/api.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/api.ts
@@ -73,6 +73,13 @@ import {
   CASES_INTERNAL_URL,
   INTERNAL_CASE_GET_CASES_BY_ATTACHMENT_URL,
 } from '../../common/constants';
+import type { CaseTask } from '../../common/types/domain/task/v1';
+import {
+  getCaseTasksUrl,
+  getCaseTaskDetailsUrl,
+  getCaseTasksReorderUrl,
+  getCaseTasksApplyTemplateUrl,
+} from '../../common/api';
 import { getAllConnectorTypesUrl } from '../../common/utils/connectors_api';
 
 import { KibanaServices } from '../common/lib/kibana';
@@ -699,4 +706,126 @@ export const getSimilarCases = async ({
   );
 
   return convertSimilarCasesToCamel(decodeCasesSimilarResponse(response));
+};
+
+// ---- Tasks -----------------------------------------------------------------
+
+export interface CreateTaskRequest {
+  title: string;
+  description?: string;
+  status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+  priority?: 'low' | 'medium' | 'high' | 'critical';
+  assignees?: Array<{ uid: string }>;
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  owner: string;
+}
+
+export interface UpdateTaskRequest {
+  version: string;
+  title?: string;
+  description?: string;
+  status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+  priority?: 'low' | 'medium' | 'high' | 'critical';
+  assignees?: Array<{ uid: string }>;
+  due_date?: string | null;
+}
+
+export interface FindTasksRequest {
+  status?: string;
+  priority?: string;
+  sort_field?: string;
+  sort_order?: 'asc' | 'desc';
+  page?: number;
+  per_page?: number;
+}
+
+export const getCaseTasks = async (
+  caseId: string,
+  params?: FindTasksRequest,
+  signal?: AbortSignal
+): Promise<{ tasks: CaseTask[]; total: number }> => {
+  const query = params
+    ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined))
+    : {};
+  const response = await KibanaServices.get().http.fetch<{ tasks: CaseTask[]; total: number }>(
+    getCaseTasksUrl(caseId),
+    {
+      method: 'GET',
+      query,
+      signal,
+    }
+  );
+  return response;
+};
+
+export const createTask = async (
+  caseId: string,
+  request: CreateTaskRequest,
+  signal?: AbortSignal
+): Promise<CaseTask> => {
+  const response = await KibanaServices.get().http.fetch<CaseTask>(getCaseTasksUrl(caseId), {
+    method: 'POST',
+    body: JSON.stringify(request),
+    signal,
+  });
+  return response;
+};
+
+export const updateTask = async (
+  caseId: string,
+  taskId: string,
+  request: UpdateTaskRequest,
+  signal?: AbortSignal
+): Promise<CaseTask> => {
+  const response = await KibanaServices.get().http.fetch<CaseTask>(
+    getCaseTaskDetailsUrl(caseId, taskId),
+    {
+      method: 'PATCH',
+      body: JSON.stringify(request),
+      signal,
+    }
+  );
+  return response;
+};
+
+export const deleteTask = async (
+  caseId: string,
+  taskId: string,
+  signal?: AbortSignal
+): Promise<void> => {
+  await KibanaServices.get().http.fetch(getCaseTaskDetailsUrl(caseId, taskId), {
+    method: 'DELETE',
+    signal,
+  });
+};
+
+export const reorderTasks = async (
+  caseId: string,
+  orderedTaskIds: string[],
+  parentTaskId: string | null,
+  signal?: AbortSignal
+): Promise<void> => {
+  await KibanaServices.get().http.fetch(getCaseTasksReorderUrl(caseId), {
+    method: 'PUT',
+    body: JSON.stringify({ ordered_task_ids: orderedTaskIds, parent_task_id: parentTaskId }),
+    signal,
+  });
+};
+
+export const applyTaskTemplate = async (
+  caseId: string,
+  templateId: string,
+  owner: string,
+  signal?: AbortSignal
+): Promise<{ tasks: CaseTask[] }> => {
+  const response = await KibanaServices.get().http.fetch<{ tasks: CaseTask[] }>(
+    getCaseTasksApplyTemplateUrl(caseId),
+    {
+      method: 'POST',
+      body: JSON.stringify({ template_id: templateId, owner }),
+      signal,
+    }
+  );
+  return response;
 };

--- a/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/constants.ts
@@ -14,6 +14,9 @@ export const DEFAULT_TABLE_LIMIT = 10;
 
 export const casesQueriesKeys = {
   all: ['cases'] as const,
+  tasks: ['tasks'] as const,
+  tasksList: (caseId: string, params?: unknown) =>
+    [...casesQueriesKeys.tasks, 'list', caseId, params] as const,
   users: ['users'] as const,
   connectors: ['connectors'] as const,
   alerts: ['alerts'] as const,
@@ -84,6 +87,10 @@ export const casesMutationsKeys = {
   exportTemplate: ['export-template'] as const,
   bulkDeleteTemplates: ['bulk-delete-templates'] as const,
   bulkExportTemplates: ['bulk-export-templates'] as const,
+  createTask: ['create-task'] as const,
+  updateTask: ['update-task'] as const,
+  deleteTask: ['delete-task'] as const,
+  reorderTasks: ['reorder-tasks'] as const,
 };
 
 export const inferenceKeys = {

--- a/x-pack/platform/plugins/shared/cases/public/containers/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/translations.ts
@@ -100,3 +100,11 @@ export const OBSERVABLE_MAX_REACHED = (maxObservables: number) =>
     defaultMessage:
       "You've reached the maximum number of observables {maxObservables} that can be added to a case. Some observables were not added.",
   });
+
+export const TASK_CREATED = i18n.translate('xpack.cases.caseView.tasks.created', {
+  defaultMessage: 'Task created',
+});
+
+export const TASK_DELETED = i18n.translate('xpack.cases.caseView.tasks.deleted', {
+  defaultMessage: 'Task deleted',
+});

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_create_task.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_create_task.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import type { CreateTaskRequest } from './api';
+import { createTask } from './api';
+import type { ServerError } from '../types';
+import { useCasesToast } from '../common/use_cases_toast';
+import { casesMutationsKeys, casesQueriesKeys } from './constants';
+import * as i18n from './translations';
+
+export const useCreateTask = (caseId: string) => {
+  const { showErrorToast, showSuccessToast } = useCasesToast();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (request: CreateTaskRequest) => createTask(caseId, request),
+    {
+      mutationKey: casesMutationsKeys.createTask,
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(casesQueriesKeys.tasksList(caseId));
+        showSuccessToast(i18n.TASK_CREATED);
+      },
+    }
+  );
+};
+
+export type UseCreateTask = ReturnType<typeof useCreateTask>;

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_task.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_task.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import { deleteTask } from './api';
+import type { ServerError } from '../types';
+import { useCasesToast } from '../common/use_cases_toast';
+import { casesMutationsKeys, casesQueriesKeys } from './constants';
+import * as i18n from './translations';
+
+export const useDeleteTask = (caseId: string) => {
+  const { showErrorToast, showSuccessToast } = useCasesToast();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (taskId: string) => deleteTask(caseId, taskId),
+    {
+      mutationKey: casesMutationsKeys.deleteTask,
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(casesQueriesKeys.tasksList(caseId));
+        showSuccessToast(i18n.TASK_DELETED);
+      },
+    }
+  );
+};
+
+export type UseDeleteTask = ReturnType<typeof useDeleteTask>;

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_tasks.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_tasks.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { getCaseTasks } from './api';
+import { casesQueriesKeys } from './constants';
+import type { FindTasksRequest } from './api';
+
+export const useGetTasks = (caseId: string, params?: FindTasksRequest) => {
+  return useQuery(
+    casesQueriesKeys.tasksList(caseId, params),
+    ({ signal }) => getCaseTasks(caseId, params, signal),
+    {
+      enabled: Boolean(caseId),
+      keepPreviousData: true,
+    }
+  );
+};
+
+export type UseGetTasks = ReturnType<typeof useGetTasks>;

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_update_task.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_update_task.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import type { UpdateTaskRequest } from './api';
+import { updateTask } from './api';
+import type { ServerError } from '../types';
+import { useCasesToast } from '../common/use_cases_toast';
+import { casesMutationsKeys, casesQueriesKeys } from './constants';
+import * as i18n from './translations';
+
+export const useUpdateTask = (caseId: string) => {
+  const { showErrorToast } = useCasesToast();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    ({ taskId, request }: { taskId: string; request: UpdateTaskRequest }) =>
+      updateTask(caseId, taskId, request),
+    {
+      mutationKey: casesMutationsKeys.updateTask,
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(casesQueriesKeys.tasksList(caseId));
+      },
+    }
+  );
+};
+
+export type UseUpdateTask = ReturnType<typeof useUpdateTask>;

--- a/x-pack/platform/plugins/shared/cases/server/authorization/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/authorization/index.ts
@@ -13,6 +13,8 @@ import {
   CASE_CONFIGURE_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
+  CASE_TASK_SAVED_OBJECT,
+  CASE_TASK_TEMPLATE_SAVED_OBJECT,
 } from '../../common/constants';
 import type { Verbs, OperationDetails } from './types';
 import { ReadOperations, WriteOperations } from './types';
@@ -318,6 +320,110 @@ const AttachmentOperations = {
   },
 };
 
+const ACCESS_TASK_OPERATION: CasesSupportedOperations = 'getCase';
+
+const TaskOperations = {
+  [ReadOperations.GetTask]: {
+    ecsType: EVENT_TYPES.access,
+    name: ACCESS_TASK_OPERATION,
+    action: 'case_task_get',
+    verbs: accessVerbs,
+    docType: 'task',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [ReadOperations.FindTasks]: {
+    ecsType: EVENT_TYPES.access,
+    name: ACCESS_TASK_OPERATION,
+    action: 'case_task_find',
+    verbs: accessVerbs,
+    docType: 'tasks',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [WriteOperations.CreateTask]: {
+    ecsType: EVENT_TYPES.creation,
+    name: WriteOperations.CreateComment as const,
+    action: 'case_task_create',
+    verbs: createVerbs,
+    docType: 'task',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [WriteOperations.UpdateTask]: {
+    ecsType: EVENT_TYPES.change,
+    name: WriteOperations.UpdateCase as const,
+    action: 'case_task_update',
+    verbs: updateVerbs,
+    docType: 'task',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [WriteOperations.DeleteTask]: {
+    ecsType: EVENT_TYPES.deletion,
+    name: WriteOperations.DeleteCase as const,
+    action: 'case_task_delete',
+    verbs: deleteVerbs,
+    docType: 'task',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [WriteOperations.ReorderTasks]: {
+    ecsType: EVENT_TYPES.change,
+    name: WriteOperations.UpdateCase as const,
+    action: 'case_task_reorder',
+    verbs: updateVerbs,
+    docType: 'tasks',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+  [WriteOperations.ApplyTaskTemplate]: {
+    ecsType: EVENT_TYPES.creation,
+    name: WriteOperations.CreateComment as const,
+    action: 'case_task_apply_template',
+    verbs: createVerbs,
+    docType: 'tasks',
+    savedObjectType: CASE_TASK_SAVED_OBJECT,
+  },
+};
+
+const TaskTemplateOperations = {
+  [ReadOperations.GetTaskTemplate]: {
+    ecsType: EVENT_TYPES.access,
+    name: ACCESS_TASK_OPERATION,
+    action: 'case_task_template_get',
+    verbs: accessVerbs,
+    docType: 'task template',
+    savedObjectType: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  },
+  [ReadOperations.FindTaskTemplates]: {
+    ecsType: EVENT_TYPES.access,
+    name: ACCESS_TASK_OPERATION,
+    action: 'case_task_template_find',
+    verbs: accessVerbs,
+    docType: 'task templates',
+    savedObjectType: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  },
+  [WriteOperations.CreateTaskTemplate]: {
+    ecsType: EVENT_TYPES.creation,
+    name: WriteOperations.CreateConfiguration as const,
+    action: 'case_task_template_create',
+    verbs: createVerbs,
+    docType: 'task template',
+    savedObjectType: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  },
+  [WriteOperations.UpdateTaskTemplate]: {
+    ecsType: EVENT_TYPES.change,
+    name: WriteOperations.UpdateConfiguration as const,
+    action: 'case_task_template_update',
+    verbs: updateVerbs,
+    docType: 'task template',
+    savedObjectType: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  },
+  [WriteOperations.DeleteTaskTemplate]: {
+    ecsType: EVENT_TYPES.deletion,
+    name: WriteOperations.DeleteCase as const,
+    action: 'case_task_template_delete',
+    verbs: deleteVerbs,
+    docType: 'task template',
+    savedObjectType: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  },
+};
+
 /**
  * Definition of all APIs within the cases backend.
  */
@@ -325,6 +431,8 @@ export const Operations: Record<ReadOperations | WriteOperations, OperationDetai
   ...CaseOperations,
   ...ConfigurationOperations,
   ...AttachmentOperations,
+  ...TaskOperations,
+  ...TaskTemplateOperations,
   [ReadOperations.GetTags]: {
     ecsType: EVENT_TYPES.access,
     name: ReadOperations.GetTags as const,

--- a/x-pack/platform/plugins/shared/cases/server/authorization/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/authorization/types.ts
@@ -46,6 +46,11 @@ export enum ReadOperations {
   GetCasesMetrics = 'getCasesMetrics',
   GetUserActionMetrics = 'getUserActionMetrics',
   GetUserActionUsers = 'getUserActionUsers',
+  // Task operations
+  GetTask = 'getTask',
+  FindTasks = 'findTasks',
+  GetTaskTemplate = 'getTaskTemplate',
+  FindTaskTemplates = 'findTaskTemplates',
 }
 
 /**
@@ -65,6 +70,15 @@ export enum WriteOperations {
   UpdateConfiguration = 'updateConfiguration',
   ReopenCase = 'reopenCase',
   AssignCase = 'assignCase',
+  // Task operations
+  CreateTask = 'createTask',
+  UpdateTask = 'updateTask',
+  DeleteTask = 'deleteTask',
+  ReorderTasks = 'reorderTasks',
+  ApplyTaskTemplate = 'applyTaskTemplate',
+  CreateTaskTemplate = 'createTaskTemplate',
+  UpdateTaskTemplate = 'updateTaskTemplate',
+  DeleteTaskTemplate = 'deleteTaskTemplate',
 }
 
 /**

--- a/x-pack/platform/plugins/shared/cases/server/client/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/client.ts
@@ -20,6 +20,10 @@ import type { MetricsSubClient } from './metrics/client';
 import { createMetricsSubClient } from './metrics/client';
 import type { TemplatesSubClient } from './templates/client';
 import { createTemplatesSubClient } from './templates/client';
+import type { TasksSubClient } from './tasks/client';
+import { createTasksSubClient } from './tasks/client';
+import type { TaskTemplatesSubClient } from './task_templates/client';
+import { createTaskTemplatesSubClient } from './task_templates/client';
 
 /**
  * Client wrapper that contains accessor methods for individual entities within the cases system.
@@ -32,6 +36,8 @@ export class CasesClient {
   private readonly _configure: ConfigureSubClient;
   private readonly _metrics: MetricsSubClient;
   private readonly _templates: TemplatesSubClient;
+  private readonly _tasks: TasksSubClient;
+  private readonly _taskTemplates: TaskTemplatesSubClient;
 
   constructor(args: CasesClientArgs) {
     this._casesClientInternal = createCasesClientInternal(args);
@@ -41,6 +47,8 @@ export class CasesClient {
     this._configure = createConfigurationSubClient(args, this._casesClientInternal);
     this._metrics = createMetricsSubClient(args, this);
     this._templates = createTemplatesSubClient(args);
+    this._tasks = createTasksSubClient(args);
+    this._taskTemplates = createTaskTemplatesSubClient(args);
   }
 
   /**
@@ -83,6 +91,20 @@ export class CasesClient {
    */
   public get metrics() {
     return this._metrics;
+  }
+
+  /**
+   * Retrieves an interface for interacting with case tasks.
+   */
+  public get tasks() {
+    return this._tasks;
+  }
+
+  /**
+   * Retrieves an interface for interacting with case task templates.
+   */
+  public get taskTemplates() {
+    return this._taskTemplates;
   }
 }
 

--- a/x-pack/platform/plugins/shared/cases/server/client/factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/factory.ts
@@ -46,6 +46,8 @@ import {
   AttachmentService,
   AlertService,
   TemplatesService,
+  CaseTaskService,
+  CaseTaskTemplateService,
 } from '../services';
 
 import { AuthorizationAuditLogger } from '../authorization';
@@ -255,6 +257,11 @@ export class CasesClientFactory {
       attachmentService,
       licensingService,
       notificationService,
+      taskService: new CaseTaskService({ log: this.logger, unsecuredSavedObjectsClient }),
+      taskTemplateService: new CaseTaskTemplateService({
+        log: this.logger,
+        unsecuredSavedObjectsClient,
+      }),
     };
   }
 

--- a/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/mocks.ts
@@ -36,6 +36,8 @@ import type { ConfigureSubClient, InternalConfigureSubClient } from './configure
 import type { CasesClientFactory } from './factory';
 import type { MetricsSubClient } from './metrics/client';
 import type { TemplatesSubClient } from './templates/client';
+import type { TasksSubClient } from './tasks/client';
+import type { TaskTemplatesSubClient } from './task_templates/client';
 import type { UserActionsSubClient } from './user_actions/client';
 
 import { CaseSeverity, CaseStatuses } from '../../common/types/domain';
@@ -56,6 +58,8 @@ import {
   createUserActionServiceMock,
   createNotificationServiceMock,
   createTemplatesServiceMock,
+  createCaseTaskServiceMock,
+  createCaseTaskTemplateServiceMock,
 } from '../services/mocks';
 import { ConfigSchema } from '../config';
 
@@ -152,6 +156,33 @@ const createTemplatesSubClientMock = (): TemplatesSubClientMock => {
   });
 };
 
+type TasksSubClientMock = jest.Mocked<TasksSubClient>;
+
+const createTasksSubClientMock = (): TasksSubClientMock => {
+  return lazyObject({
+    create: jest.fn(),
+    get: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    reorder: jest.fn(),
+    getMyTasks: jest.fn(),
+    applyTemplate: jest.fn(),
+  });
+};
+
+type TaskTemplatesSubClientMock = jest.Mocked<TaskTemplatesSubClient>;
+
+const createTaskTemplatesSubClientMock = (): TaskTemplatesSubClientMock => {
+  return lazyObject({
+    create: jest.fn(),
+    get: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  });
+};
+
 type InternalConfigureSubClientMock = jest.Mocked<InternalConfigureSubClient>;
 
 const createInternalConfigureSubClientMock = (): InternalConfigureSubClientMock => {
@@ -167,6 +198,8 @@ export interface CasesClientMock extends CasesClient {
   attachments: AttachmentsSubClientMock;
   userActions: UserActionsSubClientMock;
   templates: TemplatesSubClientMock;
+  tasks: TasksSubClientMock;
+  taskTemplates: TaskTemplatesSubClientMock;
 }
 
 export const createCasesClientMock = (): CasesClientMock => {
@@ -177,6 +210,8 @@ export const createCasesClientMock = (): CasesClientMock => {
     configure: createConfigureSubClientMock(),
     metrics: createMetricsSubClientMock(),
     templates: createTemplatesSubClientMock(),
+    tasks: createTasksSubClientMock(),
+    taskTemplates: createTaskTemplatesSubClientMock(),
   });
   return client as unknown as CasesClientMock;
 };
@@ -228,6 +263,8 @@ export const createCasesClientMockArgs = () => {
       licensingService: createLicensingServiceMock(),
       notificationService: createNotificationServiceMock(),
       templatesService: createTemplatesServiceMock(),
+      taskService: createCaseTaskServiceMock(),
+      taskTemplateService: createCaseTaskTemplateServiceMock(),
     },
     authorization: createAuthorizationMock(),
     logger: loggingSystemMock.createLogger(),

--- a/x-pack/platform/plugins/shared/cases/server/client/task_templates/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/task_templates/client.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import type {
+  CaseTaskTemplate,
+  CaseTaskTemplateTask,
+} from '../../../common/types/domain/task_template/v1';
+import { createCaseError } from '../../common/error';
+import { Operations, ReadOperations, WriteOperations } from '../../authorization';
+import type { CasesClientArgs } from '../types';
+
+export interface CreateTaskTemplateParams {
+  name: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks: CaseTaskTemplateTask[];
+  owner: string;
+}
+
+export interface UpdateTaskTemplateParams {
+  templateId: string;
+  version: string;
+  name?: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks?: CaseTaskTemplateTask[];
+}
+
+export interface FindTaskTemplatesParams {
+  scope?: 'global' | 'space';
+  tags?: string[];
+  owners?: string[];
+  search?: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface TaskTemplatesSubClient {
+  create(params: CreateTaskTemplateParams): Promise<CaseTaskTemplate>;
+  get(templateId: string): Promise<CaseTaskTemplate>;
+  find(params: FindTaskTemplatesParams): Promise<{ templates: CaseTaskTemplate[]; total: number }>;
+  update(params: UpdateTaskTemplateParams): Promise<CaseTaskTemplate>;
+  delete(templateId: string): Promise<void>;
+}
+
+export const createTaskTemplatesSubClient = (
+  clientArgs: CasesClientArgs
+): TaskTemplatesSubClient => {
+  const {
+    services: { taskTemplateService },
+    user,
+    authorization,
+    logger,
+    config,
+  } = clientArgs;
+
+  const assertTasksEnabled = () => {
+    if (!config.tasks?.enabled) {
+      throw Boom.notFound('Tasks feature is not enabled');
+    }
+  };
+
+  const taskTemplatesSubClient: TaskTemplatesSubClient = {
+    async create(params: CreateTaskTemplateParams): Promise<CaseTaskTemplate> {
+      assertTasksEnabled();
+      try {
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.CreateTaskTemplate],
+          entities: [{ owner: params.owner, id: params.owner }],
+        });
+
+        return taskTemplateService.createTemplate({ ...params, user });
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to create task template: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async get(templateId: string): Promise<CaseTaskTemplate> {
+      assertTasksEnabled();
+      try {
+        const template = await taskTemplateService.getTemplate(templateId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[ReadOperations.GetTaskTemplate],
+          entities: [{ owner: template.owner, id: templateId }],
+        });
+
+        return template;
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to get task template ${templateId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async find(
+      params: FindTaskTemplatesParams
+    ): Promise<{ templates: CaseTaskTemplate[]; total: number }> {
+      assertTasksEnabled();
+      try {
+        const { ensureSavedObjectsAreAuthorized } = await authorization.getAuthorizationFilter(
+          Operations[ReadOperations.FindTaskTemplates]
+        );
+
+        const result = await taskTemplateService.findTemplates(params);
+
+        ensureSavedObjectsAreAuthorized(
+          result.templates.map((t) => ({ owner: t.owner, id: t.id }))
+        );
+
+        return result;
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to find task templates: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async update(params: UpdateTaskTemplateParams): Promise<CaseTaskTemplate> {
+      assertTasksEnabled();
+      try {
+        const existing = await taskTemplateService.getTemplate(params.templateId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.UpdateTaskTemplate],
+          entities: [{ owner: existing.owner, id: params.templateId }],
+        });
+
+        return taskTemplateService.updateTemplate({ ...params, user });
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to update task template ${params.templateId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async delete(templateId: string): Promise<void> {
+      assertTasksEnabled();
+      try {
+        const template = await taskTemplateService.getTemplate(templateId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.DeleteTaskTemplate],
+          entities: [{ owner: template.owner, id: templateId }],
+        });
+
+        return taskTemplateService.deleteTemplate(templateId);
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to delete task template ${templateId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+  };
+
+  return Object.freeze(taskTemplatesSubClient);
+};

--- a/x-pack/platform/plugins/shared/cases/server/client/tasks/client.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/tasks/client.ts
@@ -1,0 +1,305 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import type {
+  CaseTask,
+  CaseTaskStatus,
+  CaseTaskPriority,
+  CaseTaskAssignee,
+} from '../../../common/types/domain/task/v1';
+import { UserActionTypes } from '../../../common/types/domain/user_action/action/v1';
+import { createCaseError } from '../../common/error';
+import { Operations, ReadOperations, WriteOperations } from '../../authorization';
+import type { FindTasksArgs, MyTasksArgs, ReorderTasksArgs as ServiceReorderArgs } from '../../services/tasks/types';
+import type { CasesClientArgs } from '../types';
+
+export interface CreateTaskParams {
+  caseId: string;
+  title: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  owner: string;
+}
+
+export interface UpdateTaskParams {
+  taskId: string;
+  version: string;
+  title?: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+}
+
+export type FindTasksParams = FindTasksArgs;
+export type GetMyTasksParams = MyTasksArgs;
+export type ReorderTasksParams = ServiceReorderArgs;
+
+export interface ApplyTemplateParams {
+  caseId: string;
+  templateId: string;
+  owner: string;
+  due_date_anchor?: string;
+}
+
+export interface TasksSubClient {
+  create(params: CreateTaskParams): Promise<CaseTask>;
+  get(taskId: string): Promise<CaseTask>;
+  find(params: FindTasksParams): Promise<{ tasks: CaseTask[]; total: number }>;
+  update(params: UpdateTaskParams): Promise<CaseTask>;
+  delete(taskId: string): Promise<void>;
+  reorder(params: ReorderTasksParams): Promise<void>;
+  getMyTasks(params: GetMyTasksParams): Promise<{ tasks: CaseTask[]; total: number }>;
+  applyTemplate(params: ApplyTemplateParams): Promise<CaseTask[]>;
+}
+
+export const createTasksSubClient = (clientArgs: CasesClientArgs): TasksSubClient => {
+  const {
+    services: { taskService, userActionService },
+    user,
+    authorization,
+    logger,
+    config,
+  } = clientArgs;
+
+  const assertTasksEnabled = () => {
+    if (!config.tasks?.enabled) {
+      throw Boom.notFound('Tasks feature is not enabled');
+    }
+  };
+
+  const tasksSubClient: TasksSubClient = {
+    async create(params: CreateTaskParams): Promise<CaseTask> {
+      assertTasksEnabled();
+      try {
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.CreateTask],
+          entities: [{ owner: params.owner, id: params.caseId }],
+        });
+
+        const task = await taskService.createTask({
+          ...params,
+          user,
+        });
+
+        await userActionService.creator.createUserAction({
+          userAction: {
+            type: UserActionTypes.create_task,
+            caseId: params.caseId,
+            user,
+            payload: {
+              task: {
+                id: task.id,
+                title: task.title,
+                status: task.status,
+                priority: task.priority,
+                assignees: task.assignees,
+              },
+            },
+            owner: params.owner,
+          },
+        });
+
+        return task;
+      } catch (error) {
+        throw createCaseError({ message: `Failed to create task: ${error}`, error, logger });
+      }
+    },
+
+    async get(taskId: string): Promise<CaseTask> {
+      assertTasksEnabled();
+      try {
+        const task = await taskService.getTask(taskId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[ReadOperations.GetTask],
+          entities: [{ owner: task.owner, id: taskId }],
+        });
+
+        return task;
+      } catch (error) {
+        throw createCaseError({ message: `Failed to get task ${taskId}: ${error}`, error, logger });
+      }
+    },
+
+    async find(params: FindTasksParams): Promise<{ tasks: CaseTask[]; total: number }> {
+      assertTasksEnabled();
+      try {
+        const { ensureSavedObjectsAreAuthorized } = await authorization.getAuthorizationFilter(
+          Operations[ReadOperations.FindTasks]
+        );
+
+        const result = await taskService.findTasks(params);
+
+        ensureSavedObjectsAreAuthorized(
+          result.tasks.map((t) => ({ owner: t.owner, id: t.id }))
+        );
+
+        return result;
+      } catch (error) {
+        throw createCaseError({ message: `Failed to find tasks: ${error}`, error, logger });
+      }
+    },
+
+    async update(params: UpdateTaskParams): Promise<CaseTask> {
+      assertTasksEnabled();
+      try {
+        const existing = await taskService.getTask(params.taskId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.UpdateTask],
+          entities: [{ owner: existing.owner, id: params.taskId }],
+        });
+
+        const updated = await taskService.updateTask({
+          ...params,
+          user,
+        });
+
+        await userActionService.creator.createUserAction({
+          userAction: {
+            type: UserActionTypes.update_task,
+            caseId: existing.case_id,
+            user,
+            payload: {
+              task_id: params.taskId,
+              task_title: existing.title,
+              changed_fields: [],
+            },
+            owner: existing.owner,
+          },
+        });
+
+        return updated;
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to update task ${params.taskId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async delete(taskId: string): Promise<void> {
+      assertTasksEnabled();
+      try {
+        const task = await taskService.getTask(taskId);
+
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.DeleteTask],
+          entities: [{ owner: task.owner, id: taskId }],
+        });
+
+        await taskService.deleteTask(taskId);
+
+        await userActionService.creator.createUserAction({
+          userAction: {
+            type: UserActionTypes.delete_task,
+            caseId: task.case_id,
+            user,
+            payload: {
+              task_id: taskId,
+              task_title: task.title,
+              subtasks_deleted: 0,
+            },
+            owner: task.owner,
+          },
+        });
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to delete task ${taskId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+
+    async reorder(params: ReorderTasksParams): Promise<void> {
+      assertTasksEnabled();
+      try {
+        if (params.orderedTaskIds.length > 0) {
+          const firstTask = await taskService.getTask(params.orderedTaskIds[0]);
+          await authorization.ensureAuthorized({
+            operation: Operations[WriteOperations.ReorderTasks],
+            entities: [{ owner: firstTask.owner, id: params.caseId }],
+          });
+        }
+
+        await taskService.reorderTasks(params);
+      } catch (error) {
+        throw createCaseError({ message: `Failed to reorder tasks: ${error}`, error, logger });
+      }
+    },
+
+    async getMyTasks(
+      params: GetMyTasksParams
+    ): Promise<{ tasks: CaseTask[]; total: number }> {
+      assertTasksEnabled();
+      try {
+        const { ensureSavedObjectsAreAuthorized } = await authorization.getAuthorizationFilter(
+          Operations[ReadOperations.FindTasks]
+        );
+
+        const result = await taskService.getMyTasks(params);
+
+        ensureSavedObjectsAreAuthorized(
+          result.tasks.map((t) => ({ owner: t.owner, id: t.id }))
+        );
+
+        return result;
+      } catch (error) {
+        throw createCaseError({ message: `Failed to get my tasks: ${error}`, error, logger });
+      }
+    },
+
+    async applyTemplate(params: ApplyTemplateParams): Promise<CaseTask[]> {
+      assertTasksEnabled();
+      const { taskTemplateService } = clientArgs.services;
+      try {
+        await authorization.ensureAuthorized({
+          operation: Operations[WriteOperations.ApplyTaskTemplate],
+          entities: [{ owner: params.owner, id: params.caseId }],
+        });
+
+        const tasks = await taskTemplateService.applyTemplate({
+          ...params,
+          user,
+        });
+
+        await userActionService.creator.createUserAction({
+          userAction: {
+            type: UserActionTypes.apply_task_template,
+            caseId: params.caseId,
+            user,
+            payload: {
+              template_id: params.templateId,
+              template_name: '',
+              tasks_created: tasks.length,
+            },
+            owner: params.owner,
+          },
+        });
+
+        return tasks;
+      } catch (error) {
+        throw createCaseError({
+          message: `Failed to apply task template to case ${params.caseId}: ${error}`,
+          error,
+          logger,
+        });
+      }
+    },
+  };
+
+  return Object.freeze(tasksSubClient);
+};

--- a/x-pack/platform/plugins/shared/cases/server/client/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/types.ts
@@ -25,6 +25,8 @@ import type {
   AttachmentService,
   AlertService,
   TemplatesService,
+  CaseTaskService,
+  CaseTaskTemplateService,
 } from '../services';
 import type { PersistableStateAttachmentTypeRegistry } from '../attachment_framework/persistable_state_registry';
 import type { ExternalReferenceAttachmentTypeRegistry } from '../attachment_framework/external_reference_registry';
@@ -44,6 +46,8 @@ export interface CasesServices {
   licensingService: LicensingService;
   notificationService: NotificationService;
   templatesService: TemplatesService;
+  taskService: CaseTaskService;
+  taskTemplateService: CaseTaskTemplateService;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/common/types/case.ts
@@ -62,6 +62,14 @@ export interface CasePersistedAttributes {
     version: number;
   } | null;
   extended_fields?: Record<string, unknown> | null;
+  task_summary?: {
+    total: number;
+    open: number;
+    in_progress: number;
+    completed: number;
+    cancelled: number;
+    next_due_date: string | null;
+  } | null;
 }
 
 type CasePersistedCustomFields = Array<{

--- a/x-pack/platform/plugins/shared/cases/server/config.ts
+++ b/x-pack/platform/plugins/shared/cases/server/config.ts
@@ -63,6 +63,9 @@ export const ConfigSchema = schema.object({
   templates: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
   }),
+  tasks: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
   enabled: schema.boolean({ defaultValue: true }),
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/mocks.ts
@@ -803,6 +803,9 @@ export const mockCasesContract = (): CasesServerStart => ({
     attachments: {
       enabled: true,
     },
+    tasks: {
+      enabled: false,
+    },
   },
 });
 

--- a/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.test.ts
@@ -34,6 +34,7 @@ function getConfig(overrides: Partial<ConfigType> = {}): ConfigType {
     analytics: { index: { enabled: true } },
     templates: { enabled: true },
     attachments: { enabled: true },
+    tasks: { enabled: false },
     ...overrides,
   };
 }

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/get_internal_routes.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/get_internal_routes.ts
@@ -29,6 +29,8 @@ import { findUserActionsRoute } from './internal/find_user_actions';
 import { findCasesContainingAllDocumentsRoute } from './internal/find_cases_containing_all_documents';
 import type { ConfigType } from '../../config';
 import { getTemplateRoutes } from './templates';
+import { getTaskRoutes } from './tasks';
+import { getTaskTemplateRoutes } from './task_templates';
 
 export const getInternalRoutes = (userProfileService: UserProfileService, config: ConfigType) =>
   [
@@ -53,4 +55,6 @@ export const getInternalRoutes = (userProfileService: UserProfileService, config
     findUserActionsRoute,
     findCasesContainingAllDocumentsRoute,
     ...getTemplateRoutes(config),
+    ...getTaskRoutes(config),
+    ...getTaskTemplateRoutes(config),
   ] as CaseRoute[];

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/delete_task_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/delete_task_template_route.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_TEMPLATE_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * DELETE /api/cases/task_templates/{template_id}
+ * Delete a task template by ID
+ */
+export const deleteTaskTemplateRoute = createCasesRoute({
+  method: 'delete',
+  path: CASE_TASK_TEMPLATE_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Delete a case task template',
+  },
+  params: {
+    params: schema.object({
+      template_id: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { template_id: templateId } = request.params;
+
+      await casesClient.taskTemplates.delete(templateId);
+
+      return response.noContent();
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task template: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/find_task_templates_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/find_task_templates_route.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { castArray } from 'lodash';
+import { CASES_TASK_TEMPLATES_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * GET /api/cases/task_templates
+ * Find task templates with optional filters
+ */
+export const findTaskTemplatesRoute = createCasesRoute({
+  method: 'get',
+  path: CASES_TASK_TEMPLATES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Find case task templates',
+  },
+  params: {
+    query: schema.object({
+      scope: schema.maybe(
+        schema.oneOf([schema.literal('global'), schema.literal('space')])
+      ),
+      tags: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      owners: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      search: schema.maybe(schema.string()),
+      page: schema.maybe(schema.number({ min: 1 })),
+      per_page: schema.maybe(schema.number({ min: 1, max: 100 })),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { scope, tags, owners, search, page, per_page } = request.query as {
+        scope?: 'global' | 'space';
+        tags?: string | string[];
+        owners?: string | string[];
+        search?: string;
+        page?: number;
+        per_page?: number;
+      };
+
+      const result = await casesClient.taskTemplates.find({
+        scope,
+        tags: tags ? castArray(tags).filter(Boolean) : undefined,
+        owners: owners ? castArray(owners).filter(Boolean) : undefined,
+        search,
+        page,
+        per_page,
+      });
+
+      return response.ok({ body: result });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find task templates: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/get_task_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/get_task_template_route.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_TEMPLATE_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * GET /api/cases/task_templates/{template_id}
+ * Get a task template by ID
+ */
+export const getTaskTemplateRoute = createCasesRoute({
+  method: 'get',
+  path: CASE_TASK_TEMPLATE_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Get a case task template by ID',
+  },
+  params: {
+    params: schema.object({
+      template_id: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { template_id: templateId } = request.params;
+
+      const template = await casesClient.taskTemplates.get(templateId);
+
+      return response.ok({ body: template });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task template: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConfigType } from '../../../config';
+import { postTaskTemplateRoute } from './post_task_template_route';
+import { getTaskTemplateRoute } from './get_task_template_route';
+import { findTaskTemplatesRoute } from './find_task_templates_route';
+import { patchTaskTemplateRoute } from './patch_task_template_route';
+import { deleteTaskTemplateRoute } from './delete_task_template_route';
+
+/**
+ * Register task template routes conditionally, based on feature flag
+ */
+export const getTaskTemplateRoutes = (config: ConfigType) => {
+  if (!config.tasks?.enabled) {
+    return [];
+  }
+
+  return [
+    postTaskTemplateRoute,
+    getTaskTemplateRoute,
+    findTaskTemplatesRoute,
+    patchTaskTemplateRoute,
+    deleteTaskTemplateRoute,
+  ];
+};

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/patch_task_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/patch_task_template_route.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_TEMPLATE_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+const subtaskSchema = schema.object({
+  title: schema.string({ minLength: 1, maxLength: 160 }),
+  description: schema.string({ maxLength: 30000, defaultValue: '' }),
+  priority: schema.oneOf([
+    schema.literal('low'),
+    schema.literal('medium'),
+    schema.literal('high'),
+    schema.literal('critical'),
+  ]),
+  relative_due_days: schema.nullable(schema.number({ min: 0 })),
+  sort_order: schema.number({ defaultValue: 0 }),
+});
+
+const taskSchema = schema.object({
+  title: schema.string({ minLength: 1, maxLength: 160 }),
+  description: schema.string({ maxLength: 30000, defaultValue: '' }),
+  priority: schema.oneOf([
+    schema.literal('low'),
+    schema.literal('medium'),
+    schema.literal('high'),
+    schema.literal('critical'),
+  ]),
+  relative_due_days: schema.nullable(schema.number({ min: 0 })),
+  sort_order: schema.number({ defaultValue: 0 }),
+  subtasks: schema.arrayOf(subtaskSchema, { defaultValue: [] }),
+});
+
+/**
+ * PATCH /api/cases/task_templates/{template_id}
+ * Partial update of a task template
+ */
+export const patchTaskTemplateRoute = createCasesRoute({
+  method: 'patch',
+  path: CASE_TASK_TEMPLATE_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Update a case task template',
+  },
+  params: {
+    params: schema.object({
+      template_id: schema.string(),
+    }),
+    body: schema.object({
+      version: schema.string(),
+      name: schema.maybe(schema.string({ minLength: 1, maxLength: 160 })),
+      description: schema.maybe(schema.string({ maxLength: 30000 })),
+      scope: schema.maybe(
+        schema.oneOf([schema.literal('global'), schema.literal('space')])
+      ),
+      tags: schema.maybe(schema.arrayOf(schema.string({ maxLength: 256 }), { maxSize: 200 })),
+      tasks: schema.maybe(schema.arrayOf(taskSchema, { minSize: 1 })),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { template_id: templateId } = request.params;
+      const body = request.body as {
+        version: string;
+        name?: string;
+        description?: string;
+        scope?: 'global' | 'space';
+        tags?: string[];
+        tasks?: Array<{
+          title: string;
+          description: string;
+          priority: 'low' | 'medium' | 'high' | 'critical';
+          relative_due_days: number | null;
+          sort_order: number;
+          subtasks: Array<{
+            title: string;
+            description: string;
+            priority: 'low' | 'medium' | 'high' | 'critical';
+            relative_due_days: number | null;
+            sort_order: number;
+          }>;
+        }>;
+      };
+
+      const template = await casesClient.taskTemplates.update({
+        templateId,
+        ...body,
+      });
+
+      return response.ok({ body: template });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task template: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/post_task_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/task_templates/post_task_template_route.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASES_TASK_TEMPLATES_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+const taskSchema = schema.object({
+  title: schema.string({ minLength: 1, maxLength: 160 }),
+  description: schema.string({ maxLength: 30000, defaultValue: '' }),
+  priority: schema.oneOf([
+    schema.literal('low'),
+    schema.literal('medium'),
+    schema.literal('high'),
+    schema.literal('critical'),
+  ]),
+  relative_due_days: schema.nullable(schema.number({ min: 0 })),
+  sort_order: schema.number({ defaultValue: 0 }),
+  subtasks: schema.arrayOf(
+    schema.object({
+      title: schema.string({ minLength: 1, maxLength: 160 }),
+      description: schema.string({ maxLength: 30000, defaultValue: '' }),
+      priority: schema.oneOf([
+        schema.literal('low'),
+        schema.literal('medium'),
+        schema.literal('high'),
+        schema.literal('critical'),
+      ]),
+      relative_due_days: schema.nullable(schema.number({ min: 0 })),
+      sort_order: schema.number({ defaultValue: 0 }),
+    }),
+    { defaultValue: [] }
+  ),
+});
+
+/**
+ * POST /api/cases/task_templates
+ * Create a new task template
+ */
+export const postTaskTemplateRoute = createCasesRoute({
+  method: 'post',
+  path: CASES_TASK_TEMPLATES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Create a case task template',
+  },
+  params: {
+    body: schema.object({
+      name: schema.string({ minLength: 1, maxLength: 160 }),
+      description: schema.maybe(schema.string({ maxLength: 30000 })),
+      scope: schema.maybe(
+        schema.oneOf([schema.literal('global'), schema.literal('space')])
+      ),
+      tags: schema.maybe(schema.arrayOf(schema.string({ maxLength: 256 }), { maxSize: 200 })),
+      tasks: schema.arrayOf(taskSchema, { minSize: 1 }),
+      owner: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const body = request.body as {
+        name: string;
+        description?: string;
+        scope?: 'global' | 'space';
+        tags?: string[];
+        tasks: Array<{
+          title: string;
+          description: string;
+          priority: 'low' | 'medium' | 'high' | 'critical';
+          relative_due_days: number | null;
+          sort_order: number;
+          subtasks: Array<{
+            title: string;
+            description: string;
+            priority: 'low' | 'medium' | 'high' | 'critical';
+            relative_due_days: number | null;
+            sort_order: number;
+          }>;
+        }>;
+        owner: string;
+      };
+
+      const template = await casesClient.taskTemplates.create(body);
+
+      return response.ok({ body: template });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task template: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/apply_template_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/apply_template_route.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASKS_APPLY_TEMPLATE_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * POST /api/cases/{case_id}/tasks/_apply_template
+ * Apply a task template to a case, creating tasks from it
+ */
+export const applyTemplateRoute = createCasesRoute({
+  method: 'post',
+  path: CASE_TASKS_APPLY_TEMPLATE_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Apply a task template to a case',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+    }),
+    body: schema.object({
+      template_id: schema.string(),
+      owner: schema.string(),
+      due_date_anchor: schema.maybe(schema.string()),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { case_id: caseId } = request.params;
+      const { template_id: templateId, owner, due_date_anchor: dueDateAnchor } =
+        request.body as {
+          template_id: string;
+          owner: string;
+          due_date_anchor?: string;
+        };
+
+      const tasks = await casesClient.tasks.applyTemplate({
+        caseId,
+        templateId,
+        owner,
+        due_date_anchor: dueDateAnchor,
+      });
+
+      return response.ok({ body: { tasks } });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to apply task template: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/delete_task_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/delete_task_route.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * DELETE /api/cases/{case_id}/tasks/{task_id}
+ * Delete a task by ID
+ */
+export const deleteTaskRoute = createCasesRoute({
+  method: 'delete',
+  path: CASE_TASK_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Delete a case task',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+      task_id: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { task_id: taskId } = request.params;
+
+      await casesClient.tasks.delete(taskId);
+
+      return response.noContent();
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/find_tasks_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/find_tasks_route.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { castArray } from 'lodash';
+import { CASES_TASKS_FIND_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * GET /api/cases/tasks/_find
+ * Find tasks across cases with filters
+ */
+export const findTasksRoute = createCasesRoute({
+  method: 'get',
+  path: CASES_TASKS_FIND_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Find case tasks',
+  },
+  params: {
+    query: schema.object({
+      case_ids: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      owners: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      status: schema.maybe(
+        schema.oneOf([
+          schema.literal('open'),
+          schema.literal('in_progress'),
+          schema.literal('completed'),
+          schema.literal('cancelled'),
+        ])
+      ),
+      priority: schema.maybe(
+        schema.oneOf([
+          schema.literal('low'),
+          schema.literal('medium'),
+          schema.literal('high'),
+          schema.literal('critical'),
+        ])
+      ),
+      assignees: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      due_date_from: schema.maybe(schema.string()),
+      due_date_to: schema.maybe(schema.string()),
+      parent_task_id: schema.maybe(schema.nullable(schema.string())),
+      sort_field: schema.maybe(
+        schema.oneOf([
+          schema.literal('created_at'),
+          schema.literal('due_date'),
+          schema.literal('priority'),
+          schema.literal('sort_order'),
+          schema.literal('status'),
+        ])
+      ),
+      sort_order: schema.maybe(
+        schema.oneOf([schema.literal('asc'), schema.literal('desc')])
+      ),
+      page: schema.maybe(schema.number({ min: 1 })),
+      per_page: schema.maybe(schema.number({ min: 1, max: 100 })),
+      search: schema.maybe(schema.string()),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const {
+        case_ids,
+        owners,
+        status,
+        priority,
+        assignees,
+        due_date_from,
+        due_date_to,
+        parent_task_id,
+        sort_field,
+        sort_order,
+        page,
+        per_page,
+        search,
+      } = request.query as {
+        case_ids?: string | string[];
+        owners?: string | string[];
+        status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+        priority?: 'low' | 'medium' | 'high' | 'critical';
+        assignees?: string | string[];
+        due_date_from?: string;
+        due_date_to?: string;
+        parent_task_id?: string | null;
+        sort_field?: 'created_at' | 'due_date' | 'priority' | 'sort_order' | 'status';
+        sort_order?: 'asc' | 'desc';
+        page?: number;
+        per_page?: number;
+        search?: string;
+      };
+
+      const result = await casesClient.tasks.find({
+        caseIds: case_ids ? castArray(case_ids).filter(Boolean) : undefined,
+        owners: owners ? castArray(owners).filter(Boolean) : undefined,
+        status,
+        priority,
+        assignees: assignees ? castArray(assignees).filter(Boolean) : undefined,
+        due_date_from,
+        due_date_to,
+        parent_task_id,
+        sort_field,
+        sort_order,
+        page,
+        per_page,
+        search,
+      });
+
+      return response.ok({ body: result });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find tasks: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/get_my_tasks_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/get_my_tasks_route.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { castArray } from 'lodash';
+import { CASES_TASKS_MY_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * GET /api/cases/tasks/_my
+ * Get tasks assigned to the current user
+ */
+export const getMyTasksRoute = createCasesRoute({
+  method: 'get',
+  path: CASES_TASKS_MY_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Get tasks assigned to the current user',
+  },
+  params: {
+    query: schema.object({
+      user_profile_uid: schema.string(),
+      case_ids: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
+      status: schema.maybe(
+        schema.oneOf([
+          schema.literal('open'),
+          schema.literal('in_progress'),
+          schema.literal('completed'),
+          schema.literal('cancelled'),
+        ])
+      ),
+      priority: schema.maybe(
+        schema.oneOf([
+          schema.literal('low'),
+          schema.literal('medium'),
+          schema.literal('high'),
+          schema.literal('critical'),
+        ])
+      ),
+      due_date_from: schema.maybe(schema.string()),
+      due_date_to: schema.maybe(schema.string()),
+      include_completed: schema.maybe(schema.boolean()),
+      sort_field: schema.maybe(
+        schema.oneOf([
+          schema.literal('created_at'),
+          schema.literal('due_date'),
+          schema.literal('priority'),
+          schema.literal('sort_order'),
+          schema.literal('status'),
+        ])
+      ),
+      sort_order: schema.maybe(
+        schema.oneOf([schema.literal('asc'), schema.literal('desc')])
+      ),
+      page: schema.maybe(schema.number({ min: 1 })),
+      per_page: schema.maybe(schema.number({ min: 1, max: 100 })),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const {
+        user_profile_uid: userProfileUid,
+        case_ids,
+        status,
+        priority,
+        due_date_from,
+        due_date_to,
+        include_completed: includeCompleted,
+        sort_field,
+        sort_order,
+        page,
+        per_page,
+      } = request.query as {
+        user_profile_uid: string;
+        case_ids?: string | string[];
+        status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+        priority?: 'low' | 'medium' | 'high' | 'critical';
+        due_date_from?: string;
+        due_date_to?: string;
+        include_completed?: boolean;
+        sort_field?: 'created_at' | 'due_date' | 'priority' | 'sort_order' | 'status';
+        sort_order?: 'asc' | 'desc';
+        page?: number;
+        per_page?: number;
+      };
+
+      const result = await casesClient.tasks.getMyTasks({
+        userProfileUid,
+        caseIds: case_ids ? castArray(case_ids).filter(Boolean) : undefined,
+        status,
+        priority,
+        due_date_from,
+        due_date_to,
+        includeCompleted,
+        sort_field,
+        sort_order,
+        page,
+        per_page,
+      });
+
+      return response.ok({ body: result });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get my tasks: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/get_task_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/get_task_route.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * GET /api/cases/{case_id}/tasks/{task_id}
+ * Get a task by ID
+ */
+export const getTaskRoute = createCasesRoute({
+  method: 'get',
+  path: CASE_TASK_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Get a case task by ID',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+      task_id: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { task_id: taskId } = request.params;
+
+      const task = await casesClient.tasks.get(taskId);
+
+      return response.ok({ body: task });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConfigType } from '../../../config';
+import { postTaskRoute } from './post_task_route';
+import { getTaskRoute } from './get_task_route';
+import { findTasksRoute } from './find_tasks_route';
+import { patchTaskRoute } from './patch_task_route';
+import { deleteTaskRoute } from './delete_task_route';
+import { reorderTasksRoute } from './reorder_tasks_route';
+import { getMyTasksRoute } from './get_my_tasks_route';
+import { applyTemplateRoute } from './apply_template_route';
+
+/**
+ * Register task routes conditionally, based on feature flag
+ */
+export const getTaskRoutes = (config: ConfigType) => {
+  if (!config.tasks?.enabled) {
+    return [];
+  }
+
+  return [
+    postTaskRoute,
+    getTaskRoute,
+    findTasksRoute,
+    patchTaskRoute,
+    deleteTaskRoute,
+    reorderTasksRoute,
+    getMyTasksRoute,
+    applyTemplateRoute,
+  ];
+};

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/patch_task_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/patch_task_route.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASK_DETAILS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * PATCH /api/cases/{case_id}/tasks/{task_id}
+ * Update a task (partial update)
+ */
+export const patchTaskRoute = createCasesRoute({
+  method: 'patch',
+  path: CASE_TASK_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Update a case task',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+      task_id: schema.string(),
+    }),
+    body: schema.object({
+      version: schema.string(),
+      title: schema.maybe(schema.string({ minLength: 1, maxLength: 160 })),
+      description: schema.maybe(schema.string({ maxLength: 30000 })),
+      status: schema.maybe(
+        schema.oneOf([
+          schema.literal('open'),
+          schema.literal('in_progress'),
+          schema.literal('completed'),
+          schema.literal('cancelled'),
+        ])
+      ),
+      priority: schema.maybe(
+        schema.oneOf([
+          schema.literal('low'),
+          schema.literal('medium'),
+          schema.literal('high'),
+          schema.literal('critical'),
+        ])
+      ),
+      assignees: schema.maybe(
+        schema.arrayOf(schema.object({ uid: schema.string() }), { maxSize: 10 })
+      ),
+      due_date: schema.maybe(schema.nullable(schema.string())),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { task_id: taskId } = request.params;
+      const body = request.body as {
+        version: string;
+        title?: string;
+        description?: string;
+        status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+        priority?: 'low' | 'medium' | 'high' | 'critical';
+        assignees?: Array<{ uid: string }>;
+        due_date?: string | null;
+      };
+
+      const task = await casesClient.tasks.update({
+        taskId,
+        ...body,
+      });
+
+      return response.ok({ body: task });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/post_task_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/post_task_route.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASKS_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * POST /api/cases/{case_id}/tasks
+ * Create a new task for a case
+ */
+export const postTaskRoute = createCasesRoute({
+  method: 'post',
+  path: CASE_TASKS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Create a case task',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+    }),
+    body: schema.object({
+      title: schema.string({ minLength: 1, maxLength: 160 }),
+      description: schema.maybe(schema.string({ maxLength: 30000 })),
+      status: schema.maybe(
+        schema.oneOf([
+          schema.literal('open'),
+          schema.literal('in_progress'),
+          schema.literal('completed'),
+          schema.literal('cancelled'),
+        ])
+      ),
+      priority: schema.maybe(
+        schema.oneOf([
+          schema.literal('low'),
+          schema.literal('medium'),
+          schema.literal('high'),
+          schema.literal('critical'),
+        ])
+      ),
+      assignees: schema.maybe(
+        schema.arrayOf(schema.object({ uid: schema.string() }), { maxSize: 10 })
+      ),
+      due_date: schema.maybe(schema.nullable(schema.string())),
+      parent_task_id: schema.maybe(schema.nullable(schema.string())),
+      owner: schema.string(),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { case_id: caseId } = request.params;
+      const body = request.body as {
+        title: string;
+        description?: string;
+        status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+        priority?: 'low' | 'medium' | 'high' | 'critical';
+        assignees?: Array<{ uid: string }>;
+        due_date?: string | null;
+        parent_task_id?: string | null;
+        owner: string;
+      };
+
+      const task = await casesClient.tasks.create({
+        caseId,
+        ...body,
+      });
+
+      return response.ok({ body: task });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/reorder_tasks_route.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/tasks/reorder_tasks_route.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { CASE_TASKS_REORDER_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
+
+/**
+ * PUT /api/cases/{case_id}/tasks/_reorder
+ * Reorder tasks within a case (or within a parent task's subtask list)
+ */
+export const reorderTasksRoute = createCasesRoute({
+  method: 'put',
+  path: CASE_TASKS_REORDER_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
+  routerOptions: {
+    access: 'internal',
+    summary: 'Reorder case tasks',
+  },
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+    }),
+    body: schema.object({
+      ordered_task_ids: schema.arrayOf(schema.string(), { minSize: 1 }),
+      parent_task_id: schema.maybe(schema.nullable(schema.string())),
+    }),
+  },
+  handler: async ({ context, request, response }) => {
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const { case_id: caseId } = request.params;
+      const { ordered_task_ids: orderedTaskIds, parent_task_id: parentTaskId } =
+        request.body as {
+          ordered_task_ids: string[];
+          parent_task_id?: string | null;
+        };
+
+      await casesClient.tasks.reorder({
+        caseId,
+        orderedTaskIds,
+        parentTaskId: parentTaskId ?? null,
+      });
+
+      return response.noContent();
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to reorder tasks: ${error}`,
+        error,
+      });
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/cases.ts
@@ -27,6 +27,7 @@ import {
   modelVersion7,
   modelVersion8,
   modelVersion9,
+  modelVersion10,
 } from './model_versions';
 import { handleImport } from '../import_export/import';
 
@@ -286,6 +287,17 @@ export const createCaseSavedObjectType = (
       [CASE_EXTENDED_FIELDS]: {
         type: 'flattened',
       },
+      task_summary: {
+        type: 'object',
+        properties: {
+          total: { type: 'integer' },
+          open: { type: 'integer' },
+          in_progress: { type: 'integer' },
+          completed: { type: 'integer' },
+          cancelled: { type: 'integer' },
+          next_due_date: { type: 'date' },
+        },
+      },
     },
   },
   migrations: caseMigrations,
@@ -299,6 +311,7 @@ export const createCaseSavedObjectType = (
     7: modelVersion7,
     8: modelVersion8,
     9: modelVersion9,
+    10: modelVersion10,
   },
   management: {
     importableAndExportable: true,

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/index.ts
@@ -14,3 +14,4 @@ export { modelVersion6 } from './model_version_6';
 export { modelVersion7 } from './model_version_7';
 export { modelVersion8 } from './model_version_8';
 export { modelVersion9 } from './model_version_9';
+export { modelVersion10 } from './model_version_10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/model_versions/model_version_10.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
+import { casesSchemaV10 } from '../schemas';
+
+/**
+ * Adds the task_summary field to the cases SO.
+ * This field is a denormalized summary of task counts per status and the
+ * next due date, maintained by the CaseTaskService on every task mutation.
+ * Default value for existing cases is null (no tasks).
+ */
+export const modelVersion10: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        task_summary: {
+          type: 'object',
+          properties: {
+            total: { type: 'integer' },
+            open: { type: 'integer' },
+            in_progress: { type: 'integer' },
+            completed: { type: 'integer' },
+            cancelled: { type: 'integer' },
+            next_due_date: { type: 'date' },
+          },
+        },
+      },
+    },
+  ],
+  schemas: {
+    forwardCompatibility: casesSchemaV10.extends({}, { unknowns: 'ignore' }),
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/index.ts
@@ -16,3 +16,4 @@ export { casesSchema as casesSchemaV6 } from './v6';
 export { casesSchema as casesSchemaV7 } from './v7';
 export { casesSchema as casesSchemaV8 } from './v8';
 export { casesSchema as casesSchemaV9 } from './v9';
+export { casesSchema as casesSchemaV10 } from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/latest.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export * from './v9';
+export * from './v10';

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/cases/schemas/v10.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { casesSchema as casesSchemaV9 } from './v9';
+
+export const casesSchema = casesSchemaV9.extends({
+  task_summary: schema.maybe(
+    schema.nullable(
+      schema.object({
+        total: schema.number(),
+        open: schema.number(),
+        in_progress: schema.number(),
+        completed: schema.number(),
+        cancelled: schema.number(),
+        next_due_date: schema.maybe(schema.nullable(schema.string())),
+      })
+    )
+  ),
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/index.ts
@@ -18,6 +18,8 @@ import { caseIdIncrementerSavedObjectType } from './id_incrementer';
 import { createCaseAttachmentSavedObjectType } from './attachments';
 import type { PersistableStateAttachmentTypeRegistry } from '../attachment_framework/persistable_state_registry';
 import { caseTemplateSavedObjectType } from './templates';
+import { caseTaskSavedObjectType } from './tasks';
+import { caseTaskTemplateSavedObjectType } from './task_templates';
 import type { ConfigType } from '../config';
 
 interface RegisterSavedObjectsArgs {
@@ -62,5 +64,9 @@ export const registerSavedObjects = ({
   }
   if (config.attachments?.enabled) {
     core.savedObjects.registerType(createCaseAttachmentSavedObjectType());
+  }
+  if (config.tasks?.enabled) {
+    core.savedObjects.registerType(caseTaskSavedObjectType);
+    core.savedObjects.registerType(caseTaskTemplateSavedObjectType);
   }
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+
+export const caseTaskTemplateSavedObjectType: SavedObjectsType = {
+  name: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+  indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+  hidden: true,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  mappings: {
+    dynamic: false,
+    properties: {
+      name: { type: 'keyword' },
+      description: { type: 'text' },
+      scope: { type: 'keyword' },
+      tags: { type: 'keyword' },
+      owner: { type: 'keyword' },
+      created_at: { type: 'date' },
+      created_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      updated_at: { type: 'date' },
+      updated_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      // tasks array is stored but not indexed (dynamic: false)
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+    },
+  },
+  management: {
+    importableAndExportable: false,
+    visibleInManagement: false,
+  },
+};

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/task_templates/index.ts
@@ -50,7 +50,7 @@ export const caseTaskTemplateSavedObjectType: SavedObjectsType = {
     },
   },
   management: {
-    importableAndExportable: false,
+    importableAndExportable: true,
     visibleInManagement: false,
   },
 };

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsType } from '@kbn/core/server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+export const caseTaskSavedObjectType: SavedObjectsType = {
+  name: CASE_TASK_SAVED_OBJECT,
+  indexPattern: ALERTING_CASES_SAVED_OBJECT_INDEX,
+  hidden: true,
+  namespaceType: 'multiple-isolated',
+  convertToMultiNamespaceTypeVersion: '8.0.0',
+  mappings: {
+    dynamic: false,
+    properties: {
+      // Identity
+      title: { type: 'text' },
+      description: { type: 'text' },
+
+      // Hierarchy
+      case_id: { type: 'keyword' },
+      parent_task_id: { type: 'keyword' },
+
+      // State
+      status: { type: 'keyword' },
+      priority: { type: 'keyword' },
+
+      // Assignment
+      assignees: {
+        properties: {
+          uid: { type: 'keyword' },
+        },
+      },
+
+      // Scheduling
+      due_date: { type: 'date' },
+      started_at: { type: 'date' },
+      completed_at: { type: 'date' },
+
+      // Ordering
+      sort_order: { type: 'integer' },
+
+      // Template origin
+      template_id: { type: 'keyword' },
+
+      // RBAC future-proofing (stored, not indexed — dynamic: false covers them)
+
+      // Metadata
+      owner: { type: 'keyword' },
+      created_at: { type: 'date' },
+      created_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+      updated_at: { type: 'date' },
+      updated_by: {
+        properties: {
+          username: { type: 'keyword' },
+          full_name: { type: 'keyword' },
+          email: { type: 'keyword' },
+          profile_uid: { type: 'keyword' },
+        },
+      },
+    },
+  },
+  modelVersions: {
+    1: {
+      changes: [],
+    },
+  },
+  management: {
+    importableAndExportable: false,
+    visibleInManagement: false,
+  },
+};
+
+/**
+ * The name used for the reference to the parent case in the SO references array.
+ */
+export const CASE_TASK_PARENT_CASE_REF_NAME = 'parentCase' as const;
+
+/**
+ * Build the references array entry linking a task to its parent case.
+ */
+export const buildCaseTaskCaseReference = (caseId: string) => ({
+  type: CASE_SAVED_OBJECT,
+  name: CASE_TASK_PARENT_CASE_REF_NAME,
+  id: caseId,
+});

--- a/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/saved_object_types/tasks/index.ts
@@ -78,7 +78,7 @@ export const caseTaskSavedObjectType: SavedObjectsType = {
     },
   },
   management: {
-    importableAndExportable: false,
+    importableAndExportable: true,
     visibleInManagement: false,
   },
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/index.ts
@@ -16,6 +16,7 @@ export { AttachmentService } from './attachments';
 export { UserProfileService } from './user_profiles';
 export { TemplatesService } from './templates';
 export { CaseTaskService } from './tasks';
+export { CaseTaskTemplateService } from './task_templates';
 
 export interface ClientArgs {
   unsecuredSavedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/platform/plugins/shared/cases/server/services/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/index.ts
@@ -15,6 +15,7 @@ export { AlertService } from './alerts';
 export { AttachmentService } from './attachments';
 export { UserProfileService } from './user_profiles';
 export { TemplatesService } from './templates';
+export { CaseTaskService } from './tasks';
 
 export interface ClientArgs {
   unsecuredSavedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/mocks.ts
@@ -15,6 +15,8 @@ import type {
   ConnectorMappingsService,
   AttachmentService,
   TemplatesService,
+  CaseTaskService,
+  CaseTaskTemplateService,
 } from '.';
 import type { AttachmentGetter } from './attachments/operations/get';
 import type { LicensingService } from './licensing';
@@ -46,6 +48,8 @@ export type AttachmentServiceMock = jest.Mocked<AttachmentService & AttachmentSe
 export type LicensingServiceMock = jest.Mocked<LicensingService>;
 export type NotificationServiceMock = jest.Mocked<EmailNotificationService>;
 export type TemplatesServiceMock = jest.Mocked<TemplatesService>;
+export type CaseTaskServiceMock = jest.Mocked<CaseTaskService>;
+export type CaseTaskTemplateServiceMock = jest.Mocked<CaseTaskTemplateService>;
 
 export const createCaseServiceMock = (): CaseServiceMock => {
   const service: PublicMethodsOf<CaseServiceMock> = lazyObject({
@@ -233,4 +237,35 @@ export const createTemplatesServiceMock = (): TemplatesServiceMock => {
 
   // the cast here is required because jest.Mocked tries to include private members and would throw an error
   return service as unknown as TemplatesServiceMock;
+};
+
+export const createCaseTaskServiceMock = (): CaseTaskServiceMock => {
+  const service: PublicMethodsOf<CaseTaskService> = lazyObject({
+    createTask: jest.fn(),
+    bulkCreateTasks: jest.fn(),
+    getTask: jest.fn(),
+    getTasksByCase: jest.fn(),
+    findTasks: jest.fn(),
+    getMyTasks: jest.fn(),
+    updateTask: jest.fn(),
+    bulkUpdateTasks: jest.fn(),
+    deleteTask: jest.fn(),
+    bulkDeleteTasks: jest.fn(),
+    reorderTasks: jest.fn(),
+  });
+
+  return service as unknown as CaseTaskServiceMock;
+};
+
+export const createCaseTaskTemplateServiceMock = (): CaseTaskTemplateServiceMock => {
+  const service: PublicMethodsOf<CaseTaskTemplateService> = lazyObject({
+    createTemplate: jest.fn(),
+    getTemplate: jest.fn(),
+    findTemplates: jest.fn(),
+    updateTemplate: jest.fn(),
+    deleteTemplate: jest.fn(),
+    applyTemplate: jest.fn(),
+  });
+
+  return service as unknown as CaseTaskTemplateServiceMock;
 };

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { CaseTaskTemplateService } from './index';
+import type { CaseTaskTemplateAttributes } from '../../../common/types/domain/task_template/v1';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT, CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+const mockUser = {
+  username: 'elastic',
+  full_name: 'Elastic User',
+  email: 'elastic@example.com',
+  profile_uid: 'uid-1',
+};
+
+const makeTemplateSO = (overrides: Partial<CaseTaskTemplateAttributes> & { id?: string } = {}) => {
+  const { id = 'tmpl-1', ...attrs } = overrides;
+  return {
+    id,
+    type: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+    references: [],
+    version: 'WzEsMV0=',
+    attributes: {
+      name: 'My Template',
+      description: '',
+      scope: 'space' as const,
+      tags: [],
+      tasks: [],
+      owner: 'securitySolution',
+      created_at: '2024-01-01T00:00:00.000Z',
+      created_by: mockUser,
+      updated_at: null,
+      updated_by: null,
+      ...attrs,
+    },
+  };
+};
+
+describe('CaseTaskTemplateService', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let service: CaseTaskTemplateService;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    logger = loggingSystemMock.createLogger();
+    service = new CaseTaskTemplateService({
+      log: logger,
+      unsecuredSavedObjectsClient: soClient,
+    });
+
+    soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+    soClient.get.mockImplementation(async (type, id) => {
+      if (type === CASE_SAVED_OBJECT)
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      return makeTemplateSO({ id });
+    });
+    soClient.update.mockResolvedValue({ id: 'tmpl-1', type: CASE_TASK_TEMPLATE_SAVED_OBJECT, attributes: {}, references: [] });
+  });
+
+  describe('createTemplate', () => {
+    it('creates a template SO with correct attributes', async () => {
+      soClient.create.mockResolvedValue(makeTemplateSO());
+
+      const result = await service.createTemplate({
+        name: 'My Template',
+        tasks: [],
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      expect(soClient.create).toHaveBeenCalledWith(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        expect.objectContaining({ name: 'My Template', scope: 'space', owner: 'securitySolution' }),
+        expect.any(Object)
+      );
+      expect(result.name).toBe('My Template');
+    });
+
+    it('defaults scope to space', async () => {
+      soClient.create.mockResolvedValue(makeTemplateSO());
+      await service.createTemplate({ name: 'T', tasks: [], owner: 'o', user: mockUser });
+      const attrs = soClient.create.mock.calls[0][1] as CaseTaskTemplateAttributes;
+      expect(attrs.scope).toBe('space');
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('fetches from SO client', async () => {
+      soClient.get.mockResolvedValue(makeTemplateSO({ id: 'tmpl-42' }));
+      const result = await service.getTemplate('tmpl-42');
+      expect(result.id).toBe('tmpl-42');
+    });
+
+    it('returns cached result on second call', async () => {
+      soClient.get.mockResolvedValue(makeTemplateSO({ id: 'tmpl-cached' }));
+      await service.getTemplate('tmpl-cached');
+      await service.getTemplate('tmpl-cached');
+      expect(soClient.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('calls SO delete', async () => {
+      await service.deleteTemplate('tmpl-1');
+      expect(soClient.delete).toHaveBeenCalledWith(CASE_TASK_TEMPLATE_SAVED_OBJECT, 'tmpl-1');
+    });
+  });
+
+  describe('applyTemplate', () => {
+    it('creates root tasks and subtasks with correct parent references', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_TEMPLATE_SAVED_OBJECT) {
+          return makeTemplateSO({
+            id,
+            tasks: [
+              {
+                title: 'Root 1',
+                description: '',
+                priority: 'medium',
+                relative_due_days: 3,
+                sort_order: 1000,
+                subtasks: [
+                  { title: 'Sub 1', description: '', priority: 'low', relative_due_days: null, sort_order: 1000 },
+                ],
+              },
+            ],
+          });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      const rootTaskId = 'root-task-1';
+      soClient.bulkCreate = jest.fn()
+        .mockResolvedValueOnce({
+          // Root task bulk create
+          saved_objects: [{
+            id: rootTaskId,
+            type: CASE_TASK_SAVED_OBJECT,
+            references: [],
+            version: 'v1',
+            attributes: {
+              title: 'Root 1', description: '', case_id: 'case-1',
+              parent_task_id: null, status: 'open', priority: 'medium',
+              assignees: [], due_date: null, started_at: null, completed_at: null,
+              sort_order: 1000, template_id: 'tmpl-1', custom_fields: [],
+              required_role: null, owner_team: null, owner: 'securitySolution',
+              created_at: '2024-01-01T00:00:00.000Z', created_by: mockUser,
+              updated_at: null, updated_by: null,
+            },
+          }],
+        })
+        .mockResolvedValueOnce({
+          // Subtask bulk create
+          saved_objects: [{
+            id: 'sub-task-1',
+            type: CASE_TASK_SAVED_OBJECT,
+            references: [],
+            version: 'v1',
+            attributes: {
+              title: 'Sub 1', description: '', case_id: 'case-1',
+              parent_task_id: rootTaskId, status: 'open', priority: 'low',
+              assignees: [], due_date: null, started_at: null, completed_at: null,
+              sort_order: 1000, template_id: 'tmpl-1', custom_fields: [],
+              required_role: null, owner_team: null, owner: 'securitySolution',
+              created_at: '2024-01-01T00:00:00.000Z', created_by: mockUser,
+              updated_at: null, updated_by: null,
+            },
+          }],
+        });
+
+      const result = await service.applyTemplate({
+        templateId: 'tmpl-1',
+        caseId: 'case-1',
+        owner: 'securitySolution',
+        user: mockUser,
+        due_date_anchor: '2024-01-01T00:00:00.000Z',
+      });
+
+      // Should have called bulkCreate twice: once for roots, once for subtasks
+      expect(soClient.bulkCreate).toHaveBeenCalledTimes(2);
+
+      // The subtask call should reference the root task id
+      const subtaskCall = soClient.bulkCreate.mock.calls[1][0] as Array<{ attributes: { parent_task_id: string } }>;
+      expect(subtaskCall[0].attributes.parent_task_id).toBe(rootTaskId);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('computes due_date correctly from relative_due_days', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_TEMPLATE_SAVED_OBJECT) {
+          return makeTemplateSO({
+            id,
+            tasks: [{
+              title: 'T', description: '', priority: 'medium',
+              relative_due_days: 7, sort_order: 1000, subtasks: [],
+            }],
+          });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      soClient.bulkCreate = jest.fn().mockResolvedValue({ saved_objects: [] });
+
+      await service.applyTemplate({
+        templateId: 'tmpl-1',
+        caseId: 'case-1',
+        owner: 'securitySolution',
+        user: mockUser,
+        due_date_anchor: '2024-01-01T00:00:00.000Z',
+      });
+
+      const rootArgs = soClient.bulkCreate.mock.calls[0][0] as Array<{ attributes: { due_date: string } }>;
+      // Jan 1 + 7 days = Jan 8
+      expect(rootArgs[0].attributes.due_date).toContain('2024-01-08');
+    });
+  });
+
+  describe('findTemplates', () => {
+    it('filters by scope', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+      await service.findTemplates({ scope: 'global' });
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ filter: expect.anything() })
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/index.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+import type {
+  CaseTaskTemplate,
+  CaseTaskTemplateAttributes,
+} from '../../../common/types/domain/task_template/v1';
+import type { CaseTask } from '../../../common/types/domain/task/v1';
+import { createCaseError } from '../../common/error';
+import { CaseTaskService } from '../tasks';
+import type {
+  CreateTemplateArgs,
+  UpdateTemplateArgs,
+  FindTemplatesArgs,
+  ApplyTemplateArgs,
+} from './types';
+
+const CACHE_TTL_MS = 60_000;
+
+export class CaseTaskTemplateService {
+  private readonly log: Logger;
+  private readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  private readonly taskService: CaseTaskService;
+  /** Simple in-process LRU-like cache (60 s TTL) for template definitions. */
+  private readonly templateCache = new Map<string, { template: CaseTaskTemplate; expiresAt: number }>();
+
+  constructor({
+    log,
+    unsecuredSavedObjectsClient,
+  }: {
+    log: Logger;
+    unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  }) {
+    this.log = log;
+    this.unsecuredSavedObjectsClient = unsecuredSavedObjectsClient;
+    this.taskService = new CaseTaskService({ log, unsecuredSavedObjectsClient });
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD
+  // ---------------------------------------------------------------------------
+
+  public async createTemplate(args: CreateTemplateArgs): Promise<CaseTaskTemplate> {
+    const {
+      name,
+      description = '',
+      scope = 'space',
+      tags = [],
+      tasks,
+      owner,
+      user,
+      refresh,
+    } = args;
+
+    try {
+      const now = new Date().toISOString();
+
+      const attributes: CaseTaskTemplateAttributes = {
+        name,
+        description,
+        scope,
+        tags,
+        tasks,
+        owner,
+        created_at: now,
+        created_by: user,
+        updated_at: null,
+        updated_by: null,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.create<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        attributes,
+        { refresh }
+      );
+
+      return this.transformToTemplate(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task template: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getTemplate(templateId: string): Promise<CaseTaskTemplate> {
+    const cached = this.templateCache.get(templateId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.template;
+    }
+
+    try {
+      const so = await this.unsecuredSavedObjectsClient.get<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        templateId
+      );
+      const template = this.transformToTemplate(so);
+      this.templateCache.set(templateId, { template, expiresAt: Date.now() + CACHE_TTL_MS });
+      return template;
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async findTemplates(
+    args: FindTemplatesArgs
+  ): Promise<{ templates: CaseTaskTemplate[]; total: number }> {
+    const { scope, tags, owners, search, page = 1, per_page = 50 } = args;
+
+    try {
+      const filters = [];
+
+      if (scope) {
+        filters.push(
+          nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.scope`, scope)
+        );
+      }
+      if (owners && owners.length > 0) {
+        filters.push(
+          nodeBuilder.or(
+            owners.map((o) =>
+              nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.owner`, o)
+            )
+          )
+        );
+      }
+      if (tags && tags.length > 0) {
+        filters.push(
+          nodeBuilder.or(
+            tags.map((t) =>
+              nodeBuilder.is(`${CASE_TASK_TEMPLATE_SAVED_OBJECT}.attributes.tags`, t)
+            )
+          )
+        );
+      }
+
+      const result = await this.unsecuredSavedObjectsClient.find<CaseTaskTemplateAttributes>({
+        type: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        filter: filters.length > 0 ? nodeBuilder.and(filters) : undefined,
+        search: search ?? undefined,
+        searchFields: search ? ['name', 'description'] : undefined,
+        page,
+        perPage: Math.min(per_page, 200),
+      });
+
+      return {
+        templates: result.saved_objects.map((so) => this.transformToTemplate(so)),
+        total: result.total,
+      };
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find task templates: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async updateTemplate(args: UpdateTemplateArgs): Promise<CaseTaskTemplate> {
+    const { templateId, version, user, refresh, ...patch } = args;
+
+    try {
+      const now = new Date().toISOString();
+
+      const updatedAttributes: Partial<CaseTaskTemplateAttributes> = {
+        ...patch,
+        updated_at: now,
+        updated_by: user,
+      };
+
+      await this.unsecuredSavedObjectsClient.update<CaseTaskTemplateAttributes>(
+        CASE_TASK_TEMPLATE_SAVED_OBJECT,
+        templateId,
+        updatedAttributes,
+        { version, refresh }
+      );
+
+      // Invalidate cache
+      this.templateCache.delete(templateId);
+
+      return this.getTemplate(templateId);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async deleteTemplate(templateId: string): Promise<void> {
+    try {
+      await this.unsecuredSavedObjectsClient.delete(CASE_TASK_TEMPLATE_SAVED_OBJECT, templateId);
+      this.templateCache.delete(templateId);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task template ${templateId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Apply
+  // ---------------------------------------------------------------------------
+
+  public async applyTemplate(args: ApplyTemplateArgs): Promise<CaseTask[]> {
+    const { templateId, caseId, owner, user, due_date_anchor, refresh } = args;
+
+    try {
+      const template = await this.getTemplate(templateId);
+      const anchorDate = due_date_anchor ? new Date(due_date_anchor) : new Date();
+
+      const computeDueDate = (relativeDays: number | null): string | null => {
+        if (relativeDays === null) return null;
+        const d = new Date(anchorDate);
+        d.setDate(d.getDate() + relativeDays);
+        return d.toISOString();
+      };
+
+      // Create root tasks in bulk
+      const rootTaskArgs = template.tasks.map((t) => ({
+        caseId,
+        title: t.title,
+        description: t.description,
+        priority: t.priority,
+        due_date: computeDueDate(t.relative_due_days),
+        sort_order: t.sort_order,
+        template_id: templateId,
+        owner,
+        user,
+      }));
+
+      const rootTasks = await this.taskService.bulkCreateTasks({
+        tasks: rootTaskArgs,
+        refresh,
+      });
+
+      // Create subtasks in bulk, mapping root task sort_order → created task ID
+      const rootIdByIndex = new Map(rootTasks.map((t, i) => [i, t.id]));
+      const subtaskArgs = template.tasks.flatMap((t, i) =>
+        t.subtasks.map((sub) => ({
+          caseId,
+          title: sub.title,
+          description: sub.description,
+          priority: sub.priority,
+          due_date: computeDueDate(sub.relative_due_days),
+          sort_order: sub.sort_order,
+          parent_task_id: rootIdByIndex.get(i) ?? null,
+          template_id: templateId,
+          owner,
+          user,
+        }))
+      );
+
+      const subtasks =
+        subtaskArgs.length > 0
+          ? await this.taskService.bulkCreateTasks({ tasks: subtaskArgs, refresh })
+          : [];
+
+      return [...rootTasks, ...subtasks];
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to apply template ${templateId} to case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private transformToTemplate(
+    so: Awaited<ReturnType<SavedObjectsClientContract['get']>>
+  ): CaseTaskTemplate {
+    return {
+      ...(so.attributes as CaseTaskTemplateAttributes),
+      id: so.id,
+      version: so.version ?? '',
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/task_templates/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/task_templates/types.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CaseTaskTemplateTask } from '../../../common/types/domain/task_template/v1';
+import type { User } from '../../common/types/user';
+import type { IndexRefresh } from '../types';
+
+export interface CreateTemplateArgs extends IndexRefresh {
+  name: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks: CaseTaskTemplateTask[];
+  owner: string;
+  user: User;
+}
+
+export interface UpdateTemplateArgs extends IndexRefresh {
+  templateId: string;
+  version: string;
+  name?: string;
+  description?: string;
+  scope?: 'global' | 'space';
+  tags?: string[];
+  tasks?: CaseTaskTemplateTask[];
+  user: User;
+}
+
+export interface FindTemplatesArgs {
+  scope?: 'global' | 'space';
+  tags?: string[];
+  owners?: string[];
+  search?: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface ApplyTemplateArgs extends IndexRefresh {
+  templateId: string;
+  caseId: string;
+  owner: string;
+  user: User;
+  due_date_anchor?: string; // ISO 8601 — defaults to now
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/index.test.ts
@@ -1,0 +1,527 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { CaseTaskService } from './index';
+import type { CaseTaskAttributes } from '../../../common/types/domain/task/v1';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+
+const mockUser = {
+  username: 'elastic',
+  full_name: 'Elastic User',
+  email: 'elastic@example.com',
+  profile_uid: 'uid-1',
+};
+
+const makeTaskSO = (overrides: Partial<CaseTaskAttributes> & { id?: string } = {}) => {
+  const { id = 'task-1', ...attrs } = overrides;
+  return {
+    id,
+    score: 1,
+    type: CASE_TASK_SAVED_OBJECT,
+    references: [],
+    version: 'WzEsMV0=',
+    attributes: {
+      title: 'Test task',
+      description: '',
+      case_id: 'case-1',
+      parent_task_id: null,
+      status: 'open' as const,
+      priority: 'medium' as const,
+      assignees: [],
+      due_date: null,
+      started_at: null,
+      completed_at: null,
+      sort_order: 1000,
+      template_id: null,
+      custom_fields: [],
+      required_role: null,
+      owner_team: null,
+      owner: 'securitySolution',
+      created_at: '2024-01-01T00:00:00.000Z',
+      created_by: mockUser,
+      updated_at: null,
+      updated_by: null,
+      ...attrs,
+    },
+  };
+};
+
+describe('CaseTaskService', () => {
+  let soClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let service: CaseTaskService;
+
+  beforeEach(() => {
+    soClient = savedObjectsClientMock.create();
+    logger = loggingSystemMock.createLogger();
+    service = new CaseTaskService({
+      log: logger,
+      unsecuredSavedObjectsClient: soClient,
+    });
+
+    // Default: find returns empty (for sort_order and descendant queries)
+    soClient.find.mockResolvedValue({
+      saved_objects: [],
+      total: 0,
+      per_page: 1,
+      page: 1,
+    });
+    // Default: case update for task_summary succeeds
+    soClient.get.mockImplementation(async (type, id) => {
+      if (type === CASE_SAVED_OBJECT) {
+        return { id, type, attributes: {}, references: [], version: 'Wzk5LDFd' };
+      }
+      return makeTaskSO({ id });
+    });
+    soClient.update.mockResolvedValue({ id: 'case-1', type: CASE_SAVED_OBJECT, attributes: {}, references: [] });
+  });
+
+  // ---- createTask -----------------------------------------------------------
+
+  describe('createTask', () => {
+    it('creates a task SO with correct attributes', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      const result = await service.createTask({
+        caseId: 'case-1',
+        title: 'My task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      expect(soClient.create).toHaveBeenCalledWith(
+        CASE_TASK_SAVED_OBJECT,
+        expect.objectContaining({
+          title: 'My task',
+          case_id: 'case-1',
+          status: 'open',
+          priority: 'medium',
+          parent_task_id: null,
+          owner: 'securitySolution',
+        }),
+        expect.objectContaining({
+          references: [expect.objectContaining({ id: 'case-1', type: CASE_SAVED_OBJECT })],
+        })
+      );
+
+      expect(result.id).toBe('task-1');
+      expect(result.title).toBe('Test task');
+    });
+
+    it('auto-sets started_at when status is in_progress', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ status: 'in_progress', started_at: '2024-01-01T00:00:00.000Z' }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        status: 'in_progress',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.started_at).not.toBeNull();
+    });
+
+    it('auto-sets completed_at when status is completed', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ status: 'completed', completed_at: '2024-01-01T00:00:00.000Z' }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        status: 'completed',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.completed_at).not.toBeNull();
+    });
+
+    it('calls syncTaskSummary after create', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      // syncTaskSummary issues a find + get + update on the case SO
+      expect(soClient.find).toHaveBeenCalled();
+      expect(soClient.update).toHaveBeenCalledWith(
+        CASE_SAVED_OBJECT,
+        'case-1',
+        expect.objectContaining({ task_summary: expect.any(Object) }),
+        expect.any(Object)
+      );
+    });
+
+    it('uses sort_order gap = 1000 for first task', async () => {
+      soClient.create.mockResolvedValue(makeTaskSO({ sort_order: 1000 }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.sort_order).toBe(1000);
+    });
+
+    it('uses max(existing) + 1000 for subsequent tasks', async () => {
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [makeTaskSO({ sort_order: 3000 })],
+        total: 1,
+        per_page: 1,
+        page: 1,
+      });
+      soClient.create.mockResolvedValue(makeTaskSO({ sort_order: 4000 }));
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const createdAttrs = soClient.create.mock.calls[0][1] as CaseTaskAttributes;
+      expect(createdAttrs.sort_order).toBe(4000);
+    });
+
+    it('rejects subtask that would exceed depth 2', async () => {
+      // parent chain: task-3 → task-2 → task-1 (root)
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT) {
+          if (id === 'task-3') return makeTaskSO({ id: 'task-3', parent_task_id: 'task-2' });
+          if (id === 'task-2') return makeTaskSO({ id: 'task-2', parent_task_id: 'task-1' });
+          if (id === 'task-1') return makeTaskSO({ id: 'task-1', parent_task_id: null });
+        }
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      await expect(
+        service.createTask({
+          caseId: 'case-1',
+          title: 'Too deep',
+          parent_task_id: 'task-3',
+          owner: 'securitySolution',
+          user: mockUser,
+        })
+      ).rejects.toThrow('Maximum subtask depth');
+    });
+  });
+
+  // ---- getTask --------------------------------------------------------------
+
+  describe('getTask', () => {
+    it('fetches a single task by id', async () => {
+      soClient.get.mockResolvedValue(makeTaskSO({ id: 'task-42' }));
+
+      const result = await service.getTask('task-42');
+      expect(result.id).toBe('task-42');
+      expect(soClient.get).toHaveBeenCalledWith(CASE_TASK_SAVED_OBJECT, 'task-42');
+    });
+
+    it('throws a CaseError when SO client throws', async () => {
+      soClient.get.mockRejectedValue(new Error('not found'));
+      await expect(service.getTask('bad-id')).rejects.toThrow();
+    });
+  });
+
+  // ---- findTasks ------------------------------------------------------------
+
+  describe('findTasks', () => {
+    it('passes correct sort/page params', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 50, page: 1 });
+
+      await service.findTasks({ sort_field: 'due_date', sort_order: 'desc', page: 2, per_page: 25 });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: CASE_TASK_SAVED_OBJECT,
+          sortField: 'due_date',
+          sortOrder: 'desc',
+          page: 2,
+          perPage: 25,
+        })
+      );
+    });
+
+    it('caps per_page at 200', async () => {
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, per_page: 200, page: 1 });
+
+      await service.findTasks({ per_page: 9999 });
+
+      expect(soClient.find).toHaveBeenCalledWith(
+        expect.objectContaining({ perPage: 200 })
+      );
+    });
+  });
+
+  // ---- updateTask -----------------------------------------------------------
+
+  describe('updateTask', () => {
+    it('sets started_at on open→in_progress transition', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'open', started_at: null });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'in_progress',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).started_at).not.toBeNull();
+    });
+
+    it('sets completed_at on →completed transition', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'in_progress', completed_at: null });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'completed',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).completed_at).not.toBeNull();
+    });
+
+    it('does not overwrite started_at if already set', async () => {
+      const existingStartedAt = '2024-01-01T00:00:00.000Z';
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, status: 'in_progress', started_at: existingStartedAt });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.update.mockResolvedValue({
+        id: 'task-1',
+        type: CASE_TASK_SAVED_OBJECT,
+        attributes: {},
+        references: [],
+      });
+
+      await service.updateTask({
+        taskId: 'task-1',
+        status: 'in_progress',
+        user: mockUser,
+        version: 'WzEsMV0=',
+      });
+
+      const [, , updatedAttrs] = soClient.update.mock.calls[0];
+      expect((updatedAttrs as CaseTaskAttributes).started_at).toBeUndefined();
+    });
+  });
+
+  // ---- deleteTask -----------------------------------------------------------
+
+  describe('deleteTask', () => {
+    it('deletes the task and all descendants', async () => {
+      // task-1 has child task-2, task-2 has child task-3
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, case_id: 'case-1' });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+
+      soClient.find.mockImplementation(async (options) => {
+        const f = JSON.stringify((options as { filter?: unknown }).filter ?? '');
+        if (f.includes('task-1'))
+          return { saved_objects: [makeTaskSO({ id: 'task-2', parent_task_id: 'task-1' })], total: 1, per_page: 1000, page: 1 };
+        if (f.includes('task-2'))
+          return { saved_objects: [makeTaskSO({ id: 'task-3', parent_task_id: 'task-2' })], total: 1, per_page: 1000, page: 1 };
+        return { saved_objects: [], total: 0, per_page: 1000, page: 1 };
+      });
+
+      soClient.bulkDelete = jest.fn().mockResolvedValue({});
+
+      await service.deleteTask('task-1');
+
+      expect(soClient.bulkDelete).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-1' },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-2' },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-3' },
+        ])
+      );
+    });
+
+    it('syncs task_summary after delete', async () => {
+      soClient.get.mockImplementation(async (type, id) => {
+        if (type === CASE_TASK_SAVED_OBJECT)
+          return makeTaskSO({ id, case_id: 'case-1' });
+        return { id, type: CASE_SAVED_OBJECT, attributes: {}, references: [], version: 'v1' };
+      });
+      soClient.bulkDelete = jest.fn().mockResolvedValue({});
+
+      await service.deleteTask('task-1');
+
+      expect(soClient.update).toHaveBeenCalledWith(
+        CASE_SAVED_OBJECT,
+        'case-1',
+        expect.objectContaining({ task_summary: expect.any(Object) }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ---- reorderTasks ---------------------------------------------------------
+
+  describe('reorderTasks', () => {
+    it('bulk updates sort_orders with 1000-gap spacing', async () => {
+      soClient.bulkUpdate = jest.fn().mockResolvedValue({ saved_objects: [] });
+
+      await service.reorderTasks({
+        caseId: 'case-1',
+        parentTaskId: null,
+        orderedTaskIds: ['task-3', 'task-1', 'task-2'],
+      });
+
+      expect(soClient.bulkUpdate).toHaveBeenCalledWith(
+        [
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-3', attributes: { sort_order: 1000 } },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-1', attributes: { sort_order: 2000 } },
+          { type: CASE_TASK_SAVED_OBJECT, id: 'task-2', attributes: { sort_order: 3000 } },
+        ],
+        expect.any(Object)
+      );
+    });
+  });
+
+  // ---- task_summary accuracy ------------------------------------------------
+
+  describe('syncTaskSummary', () => {
+    it('correctly counts tasks by status', async () => {
+      // sort_order find fires first (returns empty → sort_order = 1000)
+      soClient.find.mockResolvedValueOnce({ saved_objects: [], total: 0, per_page: 1, page: 1 });
+      // syncTaskSummary find fires second (returns tasks by status)
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [
+          makeTaskSO({ status: 'open' }),
+          makeTaskSO({ id: 'task-2', status: 'open' }),
+          makeTaskSO({ id: 'task-3', status: 'in_progress' }),
+          makeTaskSO({ id: 'task-4', status: 'completed' }),
+          makeTaskSO({ id: 'task-5', status: 'cancelled' }),
+        ],
+        total: 5,
+        per_page: 10000,
+        page: 1,
+      });
+
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const updateCall = soClient.update.mock.calls.find(
+        ([type]) => type === CASE_SAVED_OBJECT
+      );
+      const summary = (updateCall![2] as { task_summary: unknown }).task_summary as {
+        open: number;
+        in_progress: number;
+        completed: number;
+        cancelled: number;
+        total: number;
+      };
+
+      expect(summary.open).toBe(2);
+      expect(summary.in_progress).toBe(1);
+      expect(summary.completed).toBe(1);
+      expect(summary.cancelled).toBe(1);
+      expect(summary.total).toBe(5);
+    });
+
+    it('computes next_due_date as the earliest uncompleted due date', async () => {
+      // sort_order find fires first (returns empty → sort_order = 1000)
+      soClient.find.mockResolvedValueOnce({ saved_objects: [], total: 0, per_page: 1, page: 1 });
+      // syncTaskSummary find fires second
+      soClient.find.mockResolvedValueOnce({
+        saved_objects: [
+          makeTaskSO({ status: 'open', due_date: '2024-03-10T00:00:00.000Z' }),
+          makeTaskSO({ id: 't2', status: 'open', due_date: '2024-01-05T00:00:00.000Z' }),
+          makeTaskSO({ id: 't3', status: 'completed', due_date: '2024-01-01T00:00:00.000Z' }),
+        ],
+        total: 3,
+        per_page: 10000,
+        page: 1,
+      });
+
+      soClient.create.mockResolvedValue(makeTaskSO());
+
+      await service.createTask({
+        caseId: 'case-1',
+        title: 'Task',
+        owner: 'securitySolution',
+        user: mockUser,
+      });
+
+      const updateCall = soClient.update.mock.calls.find(([type]) => type === CASE_SAVED_OBJECT);
+      const summary = (updateCall![2] as { task_summary: { next_due_date: string | null } })
+        .task_summary;
+
+      // completed task's due date should be excluded; earliest open = Jan 5
+      expect(summary.next_due_date).toBe('2024-01-05T00:00:00.000Z');
+    });
+  });
+
+  // ---- bulkCreateTasks ------------------------------------------------------
+
+  describe('bulkCreateTasks', () => {
+    it('uses bulkCreate in a single call', async () => {
+      soClient.bulkCreate = jest.fn().mockResolvedValue({
+        saved_objects: [makeTaskSO(), makeTaskSO({ id: 'task-2' })],
+      });
+
+      await service.bulkCreateTasks({
+        tasks: [
+          { caseId: 'case-1', title: 'T1', owner: 'securitySolution', user: mockUser },
+          { caseId: 'case-1', title: 'T2', owner: 'securitySolution', user: mockUser },
+        ],
+      });
+
+      expect(soClient.bulkCreate).toHaveBeenCalledTimes(1);
+      expect(soClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ type: CASE_TASK_SAVED_OBJECT, attributes: expect.objectContaining({ title: 'T1' }) }),
+          expect.objectContaining({ type: CASE_TASK_SAVED_OBJECT, attributes: expect.objectContaining({ title: 'T2' }) }),
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/index.ts
@@ -1,0 +1,698 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger, SavedObjectsClientContract, SavedObject } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_SAVED_OBJECT } from '../../../common/constants';
+import type {
+  CaseTask,
+  CaseTaskAttributes,
+} from '../../../common/types/domain/task/v1';
+import { createCaseError } from '../../common/error';
+import { buildCaseTaskCaseReference } from '../../saved_object_types/tasks';
+import { syncTaskSummary } from './task_summary';
+import { getNextSortOrder, computeReorderedSortOrders } from './sort_order';
+import type {
+  CreateTaskArgs,
+  BulkCreateTasksArgs,
+  UpdateTaskArgs,
+  BulkUpdateTasksArgs,
+  FindTasksArgs,
+  MyTasksArgs,
+  ReorderTasksArgs,
+  TaskFilterArgs,
+} from './types';
+
+/** Maximum nesting depth: task → subtask → sub-subtask = 2 levels below root */
+const MAX_SUBTASK_DEPTH = 2;
+
+export class CaseTaskService {
+  private readonly log: Logger;
+  private readonly unsecuredSavedObjectsClient: SavedObjectsClientContract;
+
+  constructor({
+    log,
+    unsecuredSavedObjectsClient,
+  }: {
+    log: Logger;
+    unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  }) {
+    this.log = log;
+    this.unsecuredSavedObjectsClient = unsecuredSavedObjectsClient;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create
+  // ---------------------------------------------------------------------------
+
+  public async createTask(args: CreateTaskArgs): Promise<CaseTask> {
+    const {
+      caseId,
+      title,
+      description = '',
+      status = 'open',
+      priority = 'medium',
+      assignees = [],
+      due_date = null,
+      parent_task_id = null,
+      custom_fields = [],
+      template_id = null,
+      owner,
+      user,
+      refresh,
+    } = args;
+
+    try {
+      if (parent_task_id) {
+        await this.validateDepth(parent_task_id);
+      }
+
+      const sort_order = await getNextSortOrder({
+        caseId,
+        parentTaskId: parent_task_id,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      const now = new Date().toISOString();
+
+      const attributes: CaseTaskAttributes = {
+        title,
+        description,
+        case_id: caseId,
+        parent_task_id,
+        status,
+        priority,
+        assignees,
+        due_date,
+        started_at: status === 'in_progress' ? now : null,
+        completed_at: status === 'completed' || status === 'cancelled' ? now : null,
+        sort_order,
+        template_id,
+        custom_fields,
+        required_role: null,
+        owner_team: null,
+        owner,
+        created_at: now,
+        created_by: user,
+        updated_at: null,
+        updated_by: null,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.create<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        attributes,
+        {
+          refresh,
+          references: [buildCaseTaskCaseReference(caseId)],
+        }
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      return this.transformToTask(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to create task for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkCreateTasks(args: BulkCreateTasksArgs): Promise<CaseTask[]> {
+    const { tasks, refresh } = args;
+    if (tasks.length === 0) return [];
+
+    const caseId = tasks[0].caseId;
+    const now = new Date().toISOString();
+
+    try {
+      // Validate depth for all subtasks up-front
+      for (const t of tasks) {
+        if (t.parent_task_id) {
+          await this.validateDepth(t.parent_task_id);
+        }
+      }
+
+      const objects = await Promise.all(
+        tasks.map(async (t) => {
+          const sort_order = await getNextSortOrder({
+            caseId: t.caseId,
+            parentTaskId: t.parent_task_id ?? null,
+            unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+            logger: this.log,
+          });
+
+          const attrs: CaseTaskAttributes = {
+            title: t.title,
+            description: t.description ?? '',
+            case_id: t.caseId,
+            parent_task_id: t.parent_task_id ?? null,
+            status: t.status ?? 'open',
+            priority: t.priority ?? 'medium',
+            assignees: t.assignees ?? [],
+            due_date: t.due_date ?? null,
+            started_at: t.status === 'in_progress' ? now : null,
+            completed_at:
+              t.status === 'completed' || t.status === 'cancelled' ? now : null,
+            sort_order,
+            template_id: t.template_id ?? null,
+            custom_fields: t.custom_fields ?? [],
+            required_role: null,
+            owner_team: null,
+            owner: t.owner,
+            created_at: now,
+            created_by: t.user,
+            updated_at: null,
+            updated_by: null,
+          };
+
+          return {
+            type: CASE_TASK_SAVED_OBJECT,
+            attributes: attrs,
+            references: [buildCaseTaskCaseReference(t.caseId)],
+          };
+        })
+      );
+
+      const result = await this.unsecuredSavedObjectsClient.bulkCreate<CaseTaskAttributes>(
+        objects,
+        { refresh }
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      return result.saved_objects.map((so) => this.transformToTask(so));
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk create tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  public async getTask(taskId: string): Promise<CaseTask> {
+    try {
+      const so = await this.unsecuredSavedObjectsClient.get<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        taskId
+      );
+      return this.transformToTask(so);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getTasksByCase(caseId: string, args?: TaskFilterArgs): Promise<CaseTask[]> {
+    try {
+      const result = await this.findTasks({ ...args, caseIds: [caseId], per_page: 10000 });
+      return result.tasks;
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to get tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async findTasks(
+    args: FindTasksArgs
+  ): Promise<{ tasks: CaseTask[]; total: number }> {
+    const {
+      caseIds,
+      owners,
+      status,
+      priority,
+      assignees,
+      due_date_from,
+      due_date_to,
+      parent_task_id,
+      sort_field = 'sort_order',
+      sort_order: sortOrder = 'asc',
+      page = 1,
+      per_page = 50,
+      search,
+    } = args;
+
+    try {
+      const filters = this.buildFilters({
+        caseIds,
+        owners,
+        status,
+        priority,
+        assignees,
+        due_date_from,
+        due_date_to,
+        parent_task_id,
+      });
+
+      const result = await this.unsecuredSavedObjectsClient.find<CaseTaskAttributes>({
+        type: CASE_TASK_SAVED_OBJECT,
+        filter: filters.length > 0 ? nodeBuilder.and(filters) : undefined,
+        sortField: sort_field,
+        sortOrder,
+        page,
+        perPage: Math.min(per_page, 200),
+        search: search ?? undefined,
+        searchFields: search ? ['title', 'description'] : undefined,
+      });
+
+      return {
+        tasks: result.saved_objects.map((so) => this.transformToTask(so)),
+        total: result.total,
+      };
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to find tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async getMyTasks(
+    args: MyTasksArgs
+  ): Promise<{ tasks: CaseTask[]; total: number }> {
+    const { userProfileUid, ...filterArgs } = args;
+    return this.findTasks({
+      ...filterArgs,
+      assignees: [userProfileUid, ...(filterArgs.assignees ?? [])],
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Update
+  // ---------------------------------------------------------------------------
+
+  public async updateTask(args: UpdateTaskArgs): Promise<CaseTask> {
+    const { taskId, user, version, refresh, ...patch } = args;
+
+    try {
+      // Validate reparenting depth if parent_task_id is being changed
+      if (patch.parent_task_id !== undefined && patch.parent_task_id !== null) {
+        await this.validateDepth(patch.parent_task_id);
+      }
+
+      const now = new Date().toISOString();
+      const existing = await this.getTask(taskId);
+
+      const statusTransitions: Partial<CaseTaskAttributes> = {};
+      if (patch.status) {
+        if (patch.status === 'in_progress' && !existing.started_at) {
+          statusTransitions.started_at = now;
+        }
+        if (
+          (patch.status === 'completed' || patch.status === 'cancelled') &&
+          !existing.completed_at
+        ) {
+          statusTransitions.completed_at = now;
+        }
+      }
+
+      const updatedAttributes: Partial<CaseTaskAttributes> = {
+        ...patch,
+        ...statusTransitions,
+        updated_at: now,
+        updated_by: user,
+      };
+
+      const so = await this.unsecuredSavedObjectsClient.update<CaseTaskAttributes>(
+        CASE_TASK_SAVED_OBJECT,
+        taskId,
+        updatedAttributes,
+        { version, refresh }
+      );
+
+      await syncTaskSummary({
+        caseId: existing.case_id,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+
+      // Merge the existing SO with the update result since SO update only returns changed fields
+      return this.transformToTask({
+        ...so,
+        attributes: { ...(existing as CaseTaskAttributes), ...updatedAttributes },
+      } as SavedObject<CaseTaskAttributes>);
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to update task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkUpdateTasks(args: BulkUpdateTasksArgs): Promise<CaseTask[]> {
+    const { updates, refresh } = args;
+    if (updates.length === 0) return [];
+
+    const now = new Date().toISOString();
+
+    try {
+      const objects = updates.map(({ taskId, attributes, version }) => ({
+        type: CASE_TASK_SAVED_OBJECT,
+        id: taskId,
+        attributes: { ...attributes, updated_at: now },
+        version,
+      }));
+
+      const result = await this.unsecuredSavedObjectsClient.bulkUpdate<Partial<CaseTaskAttributes>>(
+        objects,
+        { refresh }
+      );
+
+      // Sync summary once after all updates. Get caseId from first fetched task.
+      const firstTaskId = updates[0]?.taskId;
+      if (firstTaskId) {
+        const firstTask = await this.getTask(firstTaskId);
+        await syncTaskSummary({
+          caseId: firstTask.case_id,
+          unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+          logger: this.log,
+        });
+      }
+
+      // bulkUpdate returns partial SOs; re-fetch to get full objects
+      return Promise.all(result.saved_objects.map((so) => this.getTask(so.id)));
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk update tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delete
+  // ---------------------------------------------------------------------------
+
+  public async deleteTask(taskId: string): Promise<void> {
+    try {
+      const task = await this.getTask(taskId);
+      const caseId = task.case_id;
+
+      // Cascade: collect all descendants
+      const descendants = await this.collectDescendants(taskId);
+      const allIds = [taskId, ...descendants];
+
+      await this.unsecuredSavedObjectsClient.bulkDelete(
+        allIds.map((id) => ({ type: CASE_TASK_SAVED_OBJECT, id }))
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to delete task ${taskId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  public async bulkDeleteTasks(taskIds: string[]): Promise<void> {
+    if (taskIds.length === 0) return;
+
+    try {
+      // Collect all descendants for every task being deleted
+      const allDescendants = await Promise.all(taskIds.map((id) => this.collectDescendants(id)));
+      const allIds = [...new Set([...taskIds, ...allDescendants.flat()])];
+
+      // Get caseId before deleting
+      const firstTask = await this.getTask(taskIds[0]);
+      const caseId = firstTask.case_id;
+
+      await this.unsecuredSavedObjectsClient.bulkDelete(
+        allIds.map((id) => ({ type: CASE_TASK_SAVED_OBJECT, id }))
+      );
+
+      await syncTaskSummary({
+        caseId,
+        unsecuredSavedObjectsClient: this.unsecuredSavedObjectsClient,
+        logger: this.log,
+      });
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to bulk delete tasks: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reorder
+  // ---------------------------------------------------------------------------
+
+  public async reorderTasks(args: ReorderTasksArgs): Promise<void> {
+    const { caseId, orderedTaskIds, refresh } = args;
+    if (orderedTaskIds.length === 0) return;
+
+    try {
+      const reordered = computeReorderedSortOrders(orderedTaskIds);
+
+      await this.unsecuredSavedObjectsClient.bulkUpdate<Partial<CaseTaskAttributes>>(
+        reordered.map(({ id, sort_order }) => ({
+          type: CASE_TASK_SAVED_OBJECT,
+          id,
+          attributes: { sort_order },
+        })),
+        { refresh }
+      );
+    } catch (error) {
+      throw createCaseError({
+        message: `Failed to reorder tasks for case ${caseId}: ${error}`,
+        error,
+        logger: this.log,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Validates that adding a child to parentTaskId will not exceed MAX_SUBTASK_DEPTH.
+   * Walks the parent_task_id chain upward.
+   */
+  private async validateDepth(parentTaskId: string): Promise<void> {
+    let currentId: string | null | undefined = parentTaskId;
+    let depth = 1;
+
+    // Use loose inequality to stop on both null and undefined parent_task_id
+    while (currentId != null) {
+      if (depth > MAX_SUBTASK_DEPTH) {
+        throw Object.assign(
+          new Error(
+            `Maximum subtask depth of ${MAX_SUBTASK_DEPTH} exceeded. ` +
+              `Tasks can be nested at most ${MAX_SUBTASK_DEPTH} levels deep.`
+          ),
+          { statusCode: 400 }
+        );
+      }
+
+      try {
+        const parent: SavedObject<CaseTaskAttributes> =
+          await this.unsecuredSavedObjectsClient.get<CaseTaskAttributes>(
+            CASE_TASK_SAVED_OBJECT,
+            currentId as string
+          );
+        currentId = parent.attributes.parent_task_id;
+        depth++;
+      } catch {
+        // Parent not found — chain is broken, stop walking
+        break;
+      }
+    }
+  }
+
+  /**
+   * Collects all descendant task IDs for a given task (breadth-first).
+   * Used for cascade delete.
+   */
+  private async collectDescendants(taskId: string): Promise<string[]> {
+    const descendants: string[] = [];
+    const queue = [taskId];
+
+    while (queue.length > 0) {
+      const parentId = queue.shift()!;
+      const children = await this.unsecuredSavedObjectsClient.find<CaseTaskAttributes>({
+        type: CASE_TASK_SAVED_OBJECT,
+        filter: nodeBuilder.is(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`,
+          parentId
+        ),
+        fields: ['parent_task_id'],
+        page: 1,
+        perPage: 1000,
+      });
+
+      for (const child of children.saved_objects) {
+        descendants.push(child.id);
+        queue.push(child.id);
+      }
+    }
+
+    return descendants;
+  }
+
+  /**
+   * Builds ES KueryNode filters from TaskFilterArgs / FindTasksArgs.
+   */
+  private buildFilters({
+    caseIds,
+    owners,
+    status,
+    priority,
+    assignees,
+    due_date_from,
+    due_date_to,
+    parent_task_id,
+  }: {
+    caseIds?: string[];
+    owners?: string[];
+    status?: string | string[];
+    priority?: string | string[];
+    assignees?: string[];
+    due_date_from?: string;
+    due_date_to?: string;
+    parent_task_id?: string | null;
+  }) {
+    const filters = [];
+
+    if (caseIds && caseIds.length > 0) {
+      const caseFilter =
+        caseIds.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseIds[0])
+          : nodeBuilder.or(
+              caseIds.map((id) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, id)
+              )
+            );
+      filters.push(caseFilter);
+    }
+
+    if (owners && owners.length > 0) {
+      const ownerFilter =
+        owners.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.owner`, owners[0])
+          : nodeBuilder.or(
+              owners.map((o) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.owner`, o)
+              )
+            );
+      filters.push(ownerFilter);
+    }
+
+    if (status) {
+      const statuses = Array.isArray(status) ? status : [status];
+      const statusFilter =
+        statuses.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.status`, statuses[0])
+          : nodeBuilder.or(
+              statuses.map((s) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.status`, s)
+              )
+            );
+      filters.push(statusFilter);
+    }
+
+    if (priority) {
+      const priorities = Array.isArray(priority) ? priority : [priority];
+      const priorityFilter =
+        priorities.length === 1
+          ? nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.priority`, priorities[0])
+          : nodeBuilder.or(
+              priorities.map((p) =>
+                nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.priority`, p)
+              )
+            );
+      filters.push(priorityFilter);
+    }
+
+    if (assignees && assignees.length > 0) {
+      const assigneeFilter = nodeBuilder.or(
+        assignees.map((uid) =>
+          nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.assignees.uid`, uid)
+        )
+      );
+      filters.push(assigneeFilter);
+    }
+
+    if (due_date_from) {
+      filters.push(
+        nodeBuilder.range(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.due_date`,
+          'gte',
+          due_date_from
+        )
+      );
+    }
+
+    if (due_date_to) {
+      filters.push(
+        nodeBuilder.range(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.due_date`,
+          'lte',
+          due_date_to
+        )
+      );
+    }
+
+    if (parent_task_id === null) {
+      // Root tasks only: parent_task_id is null/missing
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, '__null__')
+      );
+    } else if (parent_task_id !== undefined) {
+      filters.push(
+        nodeBuilder.is(
+          `${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`,
+          parent_task_id
+        )
+      );
+    }
+
+    return filters;
+  }
+
+  /**
+   * Converts a SavedObject<CaseTaskAttributes> to the CaseTask domain type.
+   */
+  private transformToTask(so: SavedObject<CaseTaskAttributes>): CaseTask {
+    return {
+      ...so.attributes,
+      id: so.id,
+      version: so.version ?? '',
+    };
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/sort_order.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/sort_order.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
+import { CASE_TASK_SAVED_OBJECT } from '../../../common/constants';
+import { nodeBuilder } from '@kbn/es-query';
+
+export const SORT_ORDER_GAP = 1000;
+
+/**
+ * Returns the next sort_order value for a new task within a parent scope
+ * (caseId + parentTaskId). Uses a gap of SORT_ORDER_GAP to allow future
+ * insertions without rewriting all existing orders.
+ */
+export const getNextSortOrder = async ({
+  caseId,
+  parentTaskId,
+  unsecuredSavedObjectsClient,
+  logger,
+}: {
+  caseId: string;
+  parentTaskId: string | null;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}): Promise<number> => {
+  try {
+    const filters = [nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseId)];
+
+    if (parentTaskId === null) {
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, '__null__')
+      );
+    } else {
+      filters.push(
+        nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.parent_task_id`, parentTaskId)
+      );
+    }
+
+    const result = await unsecuredSavedObjectsClient.find<{ sort_order: number }>({
+      type: CASE_TASK_SAVED_OBJECT,
+      filter: nodeBuilder.and(filters),
+      sortField: 'sort_order',
+      sortOrder: 'desc',
+      page: 1,
+      perPage: 1,
+      fields: ['sort_order'],
+    });
+
+    if (result.total === 0) {
+      return SORT_ORDER_GAP;
+    }
+
+    const maxOrder = result.saved_objects[0]?.attributes?.sort_order ?? 0;
+    return maxOrder + SORT_ORDER_GAP;
+  } catch (error) {
+    logger.warn(`Failed to compute next sort_order for case ${caseId}: ${error.message}`);
+    return SORT_ORDER_GAP;
+  }
+};
+
+/**
+ * Reassigns sort_order values across an ordered set of task IDs with gaps of
+ * SORT_ORDER_GAP starting from SORT_ORDER_GAP. Used by reorderTasks.
+ * Returns an array of { id, sort_order } ready for bulkUpdate.
+ */
+export const computeReorderedSortOrders = (
+  orderedTaskIds: string[]
+): Array<{ id: string; sort_order: number }> =>
+  orderedTaskIds.map((id, index) => ({
+    id,
+    sort_order: (index + 1) * SORT_ORDER_GAP,
+  }));

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/task_summary.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/task_summary.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract, Logger } from '@kbn/core/server';
+import { nodeBuilder } from '@kbn/es-query';
+import { CASE_TASK_SAVED_OBJECT, CASE_SAVED_OBJECT } from '../../../common/constants';
+import { createCaseError } from '../../common/error';
+
+interface TaskStatusCounts {
+  open: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
+}
+
+/**
+ * Recomputes the task_summary for a case by aggregating task statuses and
+ * finding the earliest uncompleted due date, then writes it back to the
+ * case SavedObject. Called after every task mutation.
+ *
+ * Uses optimistic concurrency: if the case has been updated concurrently,
+ * the write is retried once.
+ */
+export const syncTaskSummary = async ({
+  caseId,
+  unsecuredSavedObjectsClient,
+  logger,
+}: {
+  caseId: string;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}): Promise<void> => {
+  try {
+    const summary = await computeTaskSummary({ caseId, unsecuredSavedObjectsClient });
+
+    // Fetch the current case to get its version for optimistic concurrency
+    const caseObj = await unsecuredSavedObjectsClient.get(CASE_SAVED_OBJECT, caseId);
+
+    try {
+      await unsecuredSavedObjectsClient.update(
+        CASE_SAVED_OBJECT,
+        caseId,
+        { task_summary: summary },
+        { version: caseObj.version }
+      );
+    } catch (conflictError) {
+      // On version conflict, retry once without version check
+      if (conflictError?.output?.statusCode === 409) {
+        logger.debug(`task_summary sync conflict on case ${caseId}, retrying`);
+        await unsecuredSavedObjectsClient.update(CASE_SAVED_OBJECT, caseId, {
+          task_summary: summary,
+        });
+      } else {
+        throw conflictError;
+      }
+    }
+  } catch (error) {
+    throw createCaseError({
+      message: `Failed to sync task_summary for case ${caseId}: ${error}`,
+      error,
+      logger,
+    });
+  }
+};
+
+/**
+ * Loads all tasks for a case and computes the summary object.
+ */
+const computeTaskSummary = async ({
+  caseId,
+  unsecuredSavedObjectsClient,
+}: {
+  caseId: string;
+  unsecuredSavedObjectsClient: SavedObjectsClientContract;
+}): Promise<{
+  total: number;
+  open: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
+  next_due_date: string | null;
+}> => {
+  // Fetch all tasks for this case in a single query (up to 10k)
+  const result = await unsecuredSavedObjectsClient.find<{
+    status: string;
+    due_date: string | null;
+  }>({
+    type: CASE_TASK_SAVED_OBJECT,
+    filter: nodeBuilder.is(`${CASE_TASK_SAVED_OBJECT}.attributes.case_id`, caseId),
+    fields: ['status', 'due_date'],
+    page: 1,
+    perPage: 10000,
+  });
+
+  const counts: TaskStatusCounts = { open: 0, in_progress: 0, completed: 0, cancelled: 0 };
+  const pendingDueDates: string[] = [];
+
+  for (const task of result.saved_objects) {
+    const { status, due_date } = task.attributes;
+
+    if (status === 'open') counts.open++;
+    else if (status === 'in_progress') counts.in_progress++;
+    else if (status === 'completed') counts.completed++;
+    else if (status === 'cancelled') counts.cancelled++;
+
+    // Collect due dates for incomplete tasks only
+    if (due_date && status !== 'completed' && status !== 'cancelled') {
+      pendingDueDates.push(due_date);
+    }
+  }
+
+  const next_due_date =
+    pendingDueDates.length > 0
+      ? pendingDueDates.sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0]
+      : null;
+
+  return {
+    total: result.total,
+    open: counts.open,
+    in_progress: counts.in_progress,
+    completed: counts.completed,
+    cancelled: counts.cancelled,
+    next_due_date: next_due_date ?? null,
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/server/services/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/tasks/types.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  CaseTaskStatus,
+  CaseTaskPriority,
+  CaseTaskAssignee,
+  CaseTaskCustomField,
+} from '../../../common/types/domain/task/v1';
+import type { User } from '../../common/types/user';
+import type { IndexRefresh } from '../types';
+
+// ---- Create ----------------------------------------------------------------
+
+export interface CreateTaskArgs extends IndexRefresh {
+  caseId: string;
+  title: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  custom_fields?: CaseTaskCustomField[];
+  template_id?: string | null;
+  owner: string;
+  user: User;
+}
+
+export interface BulkCreateTasksArgs extends IndexRefresh {
+  tasks: Array<Omit<CreateTaskArgs, keyof IndexRefresh>>;
+}
+
+// ---- Update ----------------------------------------------------------------
+
+export interface UpdateTaskArgs extends IndexRefresh {
+  taskId: string;
+  title?: string;
+  description?: string;
+  status?: CaseTaskStatus;
+  priority?: CaseTaskPriority;
+  assignees?: CaseTaskAssignee[];
+  due_date?: string | null;
+  parent_task_id?: string | null;
+  sort_order?: number;
+  custom_fields?: CaseTaskCustomField[];
+  user: User;
+  version: string;
+}
+
+export interface BulkUpdateTaskArgs extends IndexRefresh {
+  taskId: string;
+  attributes: Partial<UpdateTaskArgs>;
+  version: string;
+}
+
+export interface BulkUpdateTasksArgs extends IndexRefresh {
+  updates: BulkUpdateTaskArgs[];
+}
+
+// ---- Find / Filter ---------------------------------------------------------
+
+export interface TaskFilterArgs {
+  status?: CaseTaskStatus | CaseTaskStatus[];
+  priority?: CaseTaskPriority | CaseTaskPriority[];
+  assignees?: string[]; // user profile UIDs
+  due_date_from?: string;
+  due_date_to?: string;
+  parent_task_id?: string | null; // null = root tasks only; undefined = all depths
+  sort_field?: 'created_at' | 'due_date' | 'priority' | 'sort_order' | 'status';
+  sort_order?: 'asc' | 'desc';
+  page?: number;
+  per_page?: number;
+  search?: string;
+}
+
+export interface FindTasksArgs extends TaskFilterArgs {
+  caseIds?: string[];
+  owners?: string[];
+}
+
+export interface MyTasksArgs extends TaskFilterArgs {
+  userProfileUid: string;
+  caseIds?: string[];
+  includeCompleted?: boolean;
+}
+
+// ---- Reorder ---------------------------------------------------------------
+
+export interface ReorderTasksArgs extends IndexRefresh {
+  caseId: string;
+  parentTaskId: string | null;
+  orderedTaskIds: string[];
+}

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/builder_factory.ts
@@ -41,6 +41,10 @@ const builderMap = {
   delete_case: NoopUserActionBuilder,
   customFields: CustomFieldsUserActionBuilder,
   observables: ObservablesUserActionBuilder,
+  create_task: NoopUserActionBuilder,
+  update_task: NoopUserActionBuilder,
+  delete_task: NoopUserActionBuilder,
+  apply_task_template: NoopUserActionBuilder,
 };
 
 export class BuilderFactory {

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/types.ts
@@ -40,6 +40,12 @@ import type {
   UserActionFindRequest,
 } from '../../../common/types/api';
 import type { ObservablesActionType } from '../../../common/types/domain/user_action/observables/v1';
+import type {
+  CreateTaskUserActionPayload,
+  UpdateTaskUserActionPayload,
+  DeleteTaskUserActionPayload,
+  ApplyTaskTemplateUserActionPayload,
+} from '../../../common/types/domain/user_action/task/v1';
 
 export interface BuilderParameters {
   title: {
@@ -102,6 +108,18 @@ export interface BuilderParameters {
         observables: { actionType: ObservablesActionType; count: number };
       };
     };
+  };
+  create_task: {
+    parameters: { payload: CreateTaskUserActionPayload };
+  };
+  update_task: {
+    parameters: { payload: UpdateTaskUserActionPayload };
+  };
+  delete_task: {
+    parameters: { payload: DeleteTaskUserActionPayload };
+  };
+  apply_task_template: {
+    parameters: { payload: ApplyTaskTemplateUserActionPayload };
   };
 }
 

--- a/x-pack/platform/plugins/shared/cases/server/telemetry/collect_telemetry_data.ts
+++ b/x-pack/platform/plugins/shared/cases/server/telemetry/collect_telemetry_data.ts
@@ -13,6 +13,7 @@ import { getConfigurationTelemetryData } from './queries/configuration';
 import { getConnectorsTelemetryData } from './queries/connectors';
 import { getPushedTelemetryData } from './queries/push';
 import { getUserActionsTelemetryData } from './queries/user_actions';
+import { getTasksTelemetryData } from './queries/tasks';
 import type { CasesTelemetry, CollectTelemetryDataParams } from './types';
 
 export const collectTelemetryData = async ({
@@ -29,6 +30,7 @@ export const collectTelemetryData = async ({
       pushes,
       configuration,
       casesSystemAction,
+      tasks,
     ] = await Promise.all([
       getCasesTelemetryData({ savedObjectsClient, logger }),
       getUserActionsTelemetryData({ savedObjectsClient, logger }),
@@ -38,6 +40,7 @@ export const collectTelemetryData = async ({
       getPushedTelemetryData({ savedObjectsClient, logger }),
       getConfigurationTelemetryData({ savedObjectsClient, logger }),
       getCasesSystemActionData({ savedObjectsClient, logger }),
+      getTasksTelemetryData({ savedObjectsClient, logger }),
     ]);
 
     return {
@@ -49,6 +52,7 @@ export const collectTelemetryData = async ({
       pushes,
       configuration,
       casesSystemAction,
+      tasks,
     };
   } catch (err) {
     logger.debug('Failed collecting Cases telemetry data');

--- a/x-pack/platform/plugins/shared/cases/server/telemetry/queries/tasks.ts
+++ b/x-pack/platform/plugins/shared/cases/server/telemetry/queries/tasks.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CASE_TASK_SAVED_OBJECT, CASE_TASK_TEMPLATE_SAVED_OBJECT } from '../../../common/constants';
+import type { CasesTelemetry, CollectTelemetryDataParams } from '../types';
+import type { Buckets } from '../types';
+
+interface TaskStatusAggregation {
+  byStatus: Buckets<string>;
+}
+
+export const getTasksTelemetryData = async ({
+  savedObjectsClient,
+}: CollectTelemetryDataParams): Promise<CasesTelemetry['tasks']> => {
+  const [taskRes, templateRes] = await Promise.all([
+    savedObjectsClient.find<unknown, TaskStatusAggregation>({
+      page: 0,
+      perPage: 0,
+      type: CASE_TASK_SAVED_OBJECT,
+      namespaces: ['*'],
+      aggs: {
+        byStatus: {
+          terms: {
+            field: `${CASE_TASK_SAVED_OBJECT}.attributes.status`,
+            size: 10,
+          },
+        },
+      },
+    }),
+    savedObjectsClient.find<unknown, never>({
+      page: 0,
+      perPage: 0,
+      type: CASE_TASK_TEMPLATE_SAVED_OBJECT,
+      namespaces: ['*'],
+    }),
+  ]);
+
+  const buckets = taskRes.aggregations?.byStatus?.buckets ?? [];
+  const findCount = (key: string) =>
+    buckets.find((b) => b.key === key)?.doc_count ?? 0;
+
+  return {
+    all: {
+      total: taskRes.total,
+      byStatus: {
+        open: findCount('open'),
+        inProgress: findCount('inProgress'),
+        completed: findCount('completed'),
+        cancelled: findCount('cancelled'),
+      },
+    },
+    templates: {
+      total: templateRes.total,
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/cases/server/telemetry/schema.ts
+++ b/x-pack/platform/plugins/shared/cases/server/telemetry/schema.ts
@@ -202,4 +202,18 @@ export const casesSchema: CasesTelemetrySchema = {
     totalCasesCreated: long,
     totalRules: long,
   },
+  tasks: {
+    all: {
+      total: long,
+      byStatus: {
+        open: long,
+        inProgress: long,
+        completed: long,
+        cancelled: long,
+      },
+    },
+    templates: {
+      total: long,
+    },
+  },
 };

--- a/x-pack/platform/plugins/shared/cases/server/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/telemetry/types.ts
@@ -280,6 +280,20 @@ export interface CasesTelemetry {
     totalCasesCreated: number;
     totalRules: number;
   };
+  tasks: {
+    all: {
+      total: number;
+      byStatus: {
+        open: number;
+        inProgress: number;
+        completed: number;
+        cancelled: number;
+      };
+    };
+    templates: {
+      total: number;
+    };
+  };
 }
 
 export type CountSchema = MakeSchemaFrom<Count>;


### PR DESCRIPTION
## Summary

This is the final PR in the 8-PR task management stack for the Cases plugin.

- Adds `tasks` section to `CasesTelemetry` tracking total tasks by status (`open`, `inProgress`, `completed`, `cancelled`) and total task templates
- Implements `getTasksTelemetryData()` query in `server/telemetry/queries/tasks.ts` using aggregations on the `cases-tasks` and `cases-task-templates` saved objects
- Registers the new query in `collect_telemetry_data.ts` alongside existing telemetry collectors
- Updates `schema.ts` with corresponding `MakeSchemaFrom<CasesTelemetry>` schema entries

## PR Stack

| PR | Title | Status |
|----|-------|--------|
| PR 1 | Foundation — SO types, feature flag, domain types | ✅ Done |
| PR 2 | CaseTaskService | ✅ Done |
| PR 3 | CaseTaskTemplateService | ✅ Done |
| PR 4 | Client layer — TasksSubClient + TaskTemplatesSubClient with RBAC | ✅ Done |
| PR 5 | HTTP API routes for tasks and task templates | ✅ Done |
| PR 6 | UI — Tasks tab, TaskListView, API hooks | ✅ Done |
| PR 7 | UserAction builders, timeline renderers | ✅ Done |
| **PR 8** | **OpenAPI docs & telemetry** | **This PR** |

## Test plan

- [ ] TypeScript type check passes with 0 errors in the cases plugin
- [ ] `getTasksTelemetryData` returns `{ all: { total, byStatus: { open, inProgress, completed, cancelled } }, templates: { total } }`
- [ ] `casesSchema` correctly describes the new `tasks` shape for usage collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)