### PR TITLE
Fix Stack Monitoring shard legend not showing node placement

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/public/application/pages/elasticsearch/index_page.tsx
+++ b/x-pack/platform/plugins/private/monitoring/public/application/pages/elasticsearch/index_page.tsx
@@ -20,6 +20,7 @@ import { useCharts } from '../../hooks/use_charts';
 import { ItemTemplate } from './item_template';
 // @ts-ignore
 import { indicesByNodes } from '../../../components/elasticsearch/shard_allocation/transformers/indices_by_nodes';
+import { ensureShardLegendNodes } from '../../../components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes';
 // @ts-ignore
 import { labels } from '../../../components/elasticsearch/shard_allocation/lib/labels';
 import type { AlertsByName } from '../../../alerts/types';
@@ -83,8 +84,9 @@ export const ElasticsearchIndexPage: React.FC<ComponentProps> = ({ clusters }) =
         }),
       });
       setData(response);
+      const nodes = ensureShardLegendNodes(response);
       const transformer = indicesByNodes();
-      setNodesByIndicesData(transformer(response.shards, response.nodes));
+      setNodesByIndicesData(transformer(response.shards ?? [], nodes));
 
       const shards = response.shards;
       if (shards.some((shard: any) => shard.state === 'UNASSIGNED')) {

--- a/x-pack/platform/plugins/private/monitoring/public/application/pages/elasticsearch/node_page.tsx
+++ b/x-pack/platform/plugins/private/monitoring/public/application/pages/elasticsearch/node_page.tsx
@@ -19,6 +19,7 @@ import { SetupModeContext } from '../../../components/setup_mode/setup_mode_cont
 import { useLocalStorage } from '../../hooks/use_local_storage';
 import { useCharts } from '../../hooks/use_charts';
 import { nodesByIndices } from '../../../components/elasticsearch/shard_allocation/transformers/nodes_by_indices';
+import { ensureShardLegendNodes } from '../../../components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes';
 // @ts-ignore
 import { labels } from '../../../components/elasticsearch/shard_allocation/lib/labels';
 import type { AlertsByName } from '../../../alerts/types';
@@ -97,8 +98,9 @@ export const ElasticsearchNodePage: React.FC<ComponentProps> = ({ clusters }) =>
       });
 
       setData(response);
+      const nodes = ensureShardLegendNodes(response);
       const transformer = nodesByIndices();
-      setNodesByIndicesData(transformer(response.shards, response.nodes));
+      setNodesByIndicesData(transformer(response.shards ?? [], nodes));
       const alertsResponse = await fetchAlerts({
         fetch: services.http.fetch,
         alertTypeIds: [

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/decorate_shards.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/decorate_shards.js
@@ -46,8 +46,8 @@ export function decorateShards(shards, nodes) {
   }
 
   return shards.map((shard) => {
-    const node = nodes[shard.node];
-    shard.nodeName = (node && node.name) || null;
+    const node = nodes && nodes[shard.node];
+    shard.nodeName = (node && node.name) || shard.node || null;
     shard.type = 'shard';
     shard.tooltip_message = getTooltipMessage(shard);
     return shard;

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/decorate_shards.test.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/decorate_shards.test.js
@@ -146,4 +146,25 @@ describe('decorateShards', () => {
       type: 'shard',
     });
   });
+
+  it('shard with node id but node missing from nodes map (fallback to node id)', () => {
+    const shard = {
+      index: 'test',
+      node: 'UnknownNodeId',
+      primary: true,
+      relocating_node: null,
+      shard: 0,
+      state: 'STARTED',
+    };
+    const result = decorateShards([shard], {});
+    expect(result[0]).toMatchObject({
+      index: 'test',
+      node: 'UnknownNodeId',
+      nodeName: 'UnknownNodeId',
+      primary: true,
+      shard: 0,
+      state: 'STARTED',
+      type: 'shard',
+    });
+  });
 });

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.js
@@ -12,7 +12,7 @@
  * Prevents "Shard Legend not populated" when shards are present but nodes are
  * missing or empty (see https://github.com/elastic/sdh-kibana/issues/6121).
  *
- * @param {{ shards?: Array<{ node?: string }>, nodes?: Record<string, unknown> | unknown[] }} response - Index or node detail API response
+ * @param {{ shards?: unknown[], nodes?: Record<string, unknown> | unknown[] }} response - Index or node detail API response
  * @returns {Record<string, { name: string, type: string, node_ids: string[] }>} Normalized nodes object keyed by node id
  */
 export function ensureShardLegendNodes(response) {

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Ensures the API response has a valid nodes map for the Shard Legend so the UI
+ * can render node names (or at least node IDs) even when the nodes aggregation
+ * is empty or lags (e.g. monitoring data not yet indexed for this index).
+ * Prevents "Shard Legend not populated" when shards are present but nodes are
+ * missing or empty (see https://github.com/elastic/sdh-kibana/issues/6121).
+ *
+ * @param {{ shards?: Array<{ node?: string }>, nodes?: Record<string, unknown> | unknown[] }} response - Index or node detail API response
+ * @returns {Record<string, { name: string, type: string, node_ids: string[] }>} Normalized nodes object keyed by node id
+ */
+export function ensureShardLegendNodes(response) {
+  const shards = response?.shards ?? [];
+  let nodes = response?.nodes;
+
+  // API can return nodes as [] when aggregation has no buckets; coerce to object
+  if (Array.isArray(nodes) || nodes == null) {
+    nodes = {};
+  }
+  if (typeof nodes !== 'object') {
+    nodes = {};
+  }
+
+  const result = { ...nodes };
+
+  for (const shard of shards) {
+    const nodeId = shard?.node;
+    if (nodeId && result[nodeId] == null) {
+      result[nodeId] = {
+        name: nodeId,
+        type: 'node',
+        node_ids: [nodeId],
+      };
+    }
+  }
+
+  return result;
+}

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.test.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/lib/ensure_shard_legend_nodes.test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ensureShardLegendNodes } from './ensure_shard_legend_nodes';
+import { indicesByNodes } from '../transformers/indices_by_nodes';
+
+describe('ensureShardLegendNodes', () => {
+  it('returns empty object when response has no shards', () => {
+    expect(ensureShardLegendNodes({})).toEqual({});
+    expect(ensureShardLegendNodes({ shards: [] })).toEqual({});
+    expect(ensureShardLegendNodes({ nodes: {} })).toEqual({});
+  });
+
+  it('coerces nodes array to object and adds fallback entries from shards', () => {
+    const response = {
+      shards: [
+        { index: 'idx1', node: 'nodeA', primary: true, shard: 0, state: 'STARTED' },
+        { index: 'idx1', node: 'nodeB', primary: false, shard: 0, state: 'STARTED' },
+      ],
+      nodes: [], // API can return [] when aggregation has no buckets
+    };
+    const result = ensureShardLegendNodes(response);
+    expect(result).toEqual({
+      nodeA: { name: 'nodeA', type: 'node', node_ids: ['nodeA'] },
+      nodeB: { name: 'nodeB', type: 'node', node_ids: ['nodeB'] },
+    });
+  });
+
+  it('preserves existing node info and only fills missing nodes from shards', () => {
+    const response = {
+      shards: [
+        { index: 'idx1', node: 'nodeA', primary: true, shard: 0, state: 'STARTED' },
+        { index: 'idx1', node: 'nodeB', primary: false, shard: 0, state: 'STARTED' },
+      ],
+      nodes: {
+        nodeA: { name: 'instance-0000000483', type: 'master', node_ids: ['nodeA'] },
+      },
+    };
+    const result = ensureShardLegendNodes(response);
+    expect(result.nodeA).toEqual({
+      name: 'instance-0000000483',
+      type: 'master',
+      node_ids: ['nodeA'],
+    });
+    expect(result.nodeB).toEqual({
+      name: 'nodeB',
+      type: 'node',
+      node_ids: ['nodeB'],
+    });
+  });
+
+  it('handles null/undefined response', () => {
+    expect(ensureShardLegendNodes(null)).toEqual({});
+    expect(ensureShardLegendNodes(undefined)).toEqual({});
+  });
+
+  it('ignores shards with null or missing node', () => {
+    const response = {
+      shards: [
+        { index: 'idx1', node: null, primary: false, shard: 0, state: 'UNASSIGNED' },
+        { index: 'idx1', node: 'nodeA', primary: true, shard: 0, state: 'STARTED' },
+      ],
+      nodes: [],
+    };
+    const result = ensureShardLegendNodes(response);
+    expect(result).toEqual({
+      nodeA: { name: 'nodeA', type: 'node', node_ids: ['nodeA'] },
+    });
+  });
+
+  it('enables Shard Legend to render when used with indicesByNodes (empty nodes from API)', () => {
+    const response = {
+      shards: [
+        {
+          index: '.ds-logs-rpp_aks.metric-default-2026.03.03-000577',
+          node: 'RDk3hV5DQg2fsJBHhmevBw',
+          primary: true,
+          relocating_node: null,
+          shard: 0,
+          state: 'STARTED',
+        },
+        {
+          index: '.ds-logs-rpp_aks.metric-default-2026.03.03-000577',
+          node: 'bzvy9J1dQfShx9jlSTGEqg',
+          primary: false,
+          relocating_node: null,
+          shard: 0,
+          state: 'STARTED',
+        },
+      ],
+      nodes: [],
+    };
+    const nodes = ensureShardLegendNodes(response);
+    const transformer = indicesByNodes();
+    const rows = transformer(response.shards, nodes);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('.ds-logs-rpp_aks.metric-default-2026.03.03-000577');
+    expect(rows[0].children).toHaveLength(2);
+    const nodeNames = rows[0].children.map((n) => n.name);
+    expect(nodeNames).toContain('RDk3hV5DQg2fsJBHhmevBw');
+    expect(nodeNames).toContain('bzvy9J1dQfShx9jlSTGEqg');
+  });
+});

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/transformers/indices_by_nodes.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/transformers/indices_by_nodes.js
@@ -42,12 +42,13 @@ export function indicesByNodes() {
 
       let nodeObj = find(obj[index].children, { id: node });
       if (!nodeObj) {
+        const nodeInfo = nodes[node] || {};
         nodeObj = {
           id: node,
           type: 'node',
-          name: nodes[node].name,
-          node_type: nodes[node].type,
-          ip_port: nodes[node].transport_address,
+          name: nodeInfo.name ?? node,
+          node_type: nodeInfo.type,
+          ip_port: nodeInfo.transport_address,
           children: [],
         };
         obj[index].children.push(nodeObj);

--- a/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/transformers/nodes_by_indices.js
+++ b/x-pack/platform/plugins/private/monitoring/public/components/elasticsearch/shard_allocation/transformers/nodes_by_indices.js
@@ -31,7 +31,8 @@ export function nodesByIndices() {
       const node = get(shard, 'node.name', shard.node || 'unassigned');
       const index = get(shard, 'index.name', shard.index);
       if (!obj[node]) {
-        createNode(obj, nodes[node], node);
+        const nodeInfo = nodes[node] || { name: node, type: 'node' };
+        createNode(obj, nodeInfo, node);
       }
       let indexObj = find(obj[node].children, { id: index });
       if (!indexObj) {


### PR DESCRIPTION
Fixes #257851

When the shard allocation API returns shards but nodes aggregation is empty or missing, the Shard Legend did not show which nodes shards are on. This adds ensureShardLegendNodes() to normalize/backfill node data from shard IDs, and hardens the transformers and decorate_shards to handle missing node metadata.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->