### PR TITLE
[ES|QL] Fixes a small regression at the extensions logic

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/__tests__/helpers.ts
@@ -387,8 +387,7 @@ export function createCustomCallbackMocks(
     getTimeseriesIndices: jest.fn(async () => ({ indices: timeseriesIndices })),
     getViews: jest.fn(async () => ({ views })),
     getEditorExtensions: jest.fn(async (queryString: string) => {
-      // from * is called in the empty state
-      if (queryString.includes('logs*') || queryString === 'from *') {
+      if (queryString.includes('logs*') || queryString.includes('a_index')) {
         return {
           recommendedQueries: editorExtensions.recommendedQueries,
           recommendedFields: editorExtensions.recommendedFields,

--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/autocomplete.ts
@@ -158,7 +158,9 @@ export async function suggest(
         innerText,
         resourceRetriever
       );
-      const editorExtensions = (await resourceRetriever?.getEditorExtensions?.('from *')) ?? {
+      const editorExtensions = (await resourceRetriever?.getEditorExtensions?.(
+        fromCommand + ' '
+      )) ?? {
         recommendedQueries: [],
       };
       const recommendedQueriesSuggestionsFromExtensions = mapRecommendedQueriesFromExtensions(


### PR DESCRIPTION
## Summary

This PR https://github.com/elastic/kibana/pull/256443 created a small regression. Typing a space in an empty editor, we used to get recommended queries in the autocomplete dropdown, but this is no longer happening.

This PR is fixing it:

<img width="622" height="389" alt="image" src="https://github.com/user-attachments/assets/308c229f-b027-44d3-aa19-d3ca2f8c9c49" />



