### PR TITLE
[9.3] [One Workflow] fix: Steps disappearing from workflow overview after completion (#257465)

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/step_execution_repository.mock.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/step_execution_repository.mock.ts
@@ -20,6 +20,14 @@ export class StepExecutionRepositoryMock implements Required<StepExecutionReposi
     );
   }
 
+  public getStepExecutionsByIds(stepExecutionIds: string[]): Promise<EsWorkflowStepExecution[]> {
+    return Promise.resolve(
+      stepExecutionIds
+        .map((id) => this.stepExecutions.get(id) || null)
+        .filter((step) => step !== null) as EsWorkflowStepExecution[]
+    );
+  }
+
   public bulkUpsert(stepExecutions: Partial<EsWorkflowStepExecution>[]): Promise<void> {
     for (const stepExecution of stepExecutions) {
       if (!stepExecution.id) {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.test.ts
@@ -15,6 +15,7 @@ describe('StepExecutionRepository', () => {
     index: jest.Mock;
     update: jest.Mock;
     bulk: jest.Mock;
+    mget: jest.Mock;
     indices: { exists: jest.Mock; create: jest.Mock };
   };
 
@@ -23,6 +24,7 @@ describe('StepExecutionRepository', () => {
       index: jest.fn(),
       update: jest.fn(),
       bulk: jest.fn(),
+      mget: jest.fn(),
       indices: {
         exists: jest.fn().mockResolvedValue(false),
         create: jest.fn().mockResolvedValue({}),
@@ -271,6 +273,95 @@ describe('StepExecutionRepository', () => {
           refresh: false,
         })
       );
+    });
+  });
+
+  describe('getStepExecutionsByIds', () => {
+    it('should retrieve step executions by their IDs', async () => {
+      esClient.mget.mockResolvedValue({
+        docs: [
+          {
+            _id: 'step-1',
+            found: true,
+            _source: { id: 'step-1', stepId: 'test-step-1', status: 'completed' },
+          },
+          {
+            _id: 'step-2',
+            found: true,
+            _source: { id: 'step-2', stepId: 'test-step-2', status: 'running' },
+          },
+        ],
+      });
+
+      const result = await underTest.getStepExecutionsByIds(['step-1', 'step-2']);
+
+      expect(esClient.mget).toHaveBeenCalledWith({
+        index: expect.any(String),
+        ids: ['step-1', 'step-2'],
+      });
+      expect(result).toEqual([
+        { id: 'step-1', stepId: 'test-step-1', status: 'completed' },
+        { id: 'step-2', stepId: 'test-step-2', status: 'running' },
+      ]);
+    });
+
+    it('should skip documents that were not found', async () => {
+      esClient.mget.mockResolvedValue({
+        docs: [
+          { _id: 'step-1', found: true, _source: { id: 'step-1', stepId: 'test-step-1' } },
+          { _id: 'step-2', found: false },
+          { _id: 'step-3', found: true, _source: { id: 'step-3', stepId: 'test-step-3' } },
+        ],
+      });
+
+      const result = await underTest.getStepExecutionsByIds(['step-1', 'step-2', 'step-3']);
+
+      expect(result).toEqual([
+        { id: 'step-1', stepId: 'test-step-1' },
+        { id: 'step-3', stepId: 'test-step-3' },
+      ]);
+    });
+
+    it('should return empty array when no documents are found', async () => {
+      esClient.mget.mockResolvedValue({
+        docs: [
+          { _id: 'step-1', found: false },
+          { _id: 'step-2', found: false },
+        ],
+      });
+
+      const result = await underTest.getStepExecutionsByIds(['step-1', 'step-2']);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle a single ID', async () => {
+      esClient.mget.mockResolvedValue({
+        docs: [
+          {
+            _id: 'step-1',
+            found: true,
+            _source: { id: 'step-1', stepId: 'test-step-1', status: 'pending' },
+          },
+        ],
+      });
+
+      const result = await underTest.getStepExecutionsByIds(['step-1']);
+
+      expect(result).toEqual([{ id: 'step-1', stepId: 'test-step-1', status: 'pending' }]);
+    });
+
+    it('should skip documents where _source is missing', async () => {
+      esClient.mget.mockResolvedValue({
+        docs: [
+          { _id: 'step-1', found: true, _source: null },
+          { _id: 'step-2', found: true, _source: { id: 'step-2', stepId: 'test-step-2' } },
+        ],
+      });
+
+      const result = await underTest.getStepExecutionsByIds(['step-1', 'step-2']);
+
+      expect(result).toEqual([{ id: 'step-2', stepId: 'test-step-2' }]);
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/step_execution_repository.ts
@@ -37,6 +37,30 @@ export class StepExecutionRepository {
     return response.hits.hits.map((hit) => hit._source as EsWorkflowStepExecution);
   }
 
+  /*
+   * Retrieves step executions by their IDs using mget (O(1) operation).
+   * This is real-time (reads from translog) and doesn't require index refresh.
+   *
+   * @param stepExecutionIds - The IDs of the step executions to retrieve.
+   * @returns A promise that resolves to an array of step executions.
+   */
+  public async getStepExecutionsByIds(
+    stepExecutionIds: string[]
+  ): Promise<EsWorkflowStepExecution[]> {
+    const response = await this.esClient.mget<EsWorkflowStepExecution>({
+      index: this.indexName,
+      ids: stepExecutionIds,
+    });
+
+    const stepExecutions: EsWorkflowStepExecution[] = [];
+    for (const doc of response.docs) {
+      if ('found' in doc && doc.found && doc._source) {
+        stepExecutions.push(doc._source as EsWorkflowStepExecution);
+      }
+    }
+    return stepExecutions;
+  }
+
   public async bulkUpsert(stepExecutions: Array<Partial<EsWorkflowStepExecution>>): Promise<void> {
     if (stepExecutions.length === 0) {
       return;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_execution_state.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_execution_state.test.ts
@@ -25,7 +25,7 @@ describe('WorkflowExecutionState', () => {
 
     stepExecutionRepository = {} as unknown as StepExecutionRepository;
     stepExecutionRepository.bulkUpsert = jest.fn();
-    stepExecutionRepository.searchStepExecutionsByExecutionId = jest.fn();
+    stepExecutionRepository.getStepExecutionsByIds = jest.fn();
 
     const fakeWorkflowExecution = {
       id: 'test-workflow-execution-id',
@@ -197,10 +197,9 @@ describe('WorkflowExecutionState', () => {
 
       await underTest.flush();
 
-      expect(workflowExecutionRepository.updateWorkflowExecution).toHaveBeenCalledWith({
-        ...updatedWorkflowExecution,
-        stepExecutionIds: [], // Always includes step execution IDs (empty when no steps)
-      });
+      expect(workflowExecutionRepository.updateWorkflowExecution).toHaveBeenCalledWith(
+        updatedWorkflowExecution
+      );
     });
 
     it('should flush workflow execution changes with execution id even if execution id is not in change', async () => {
@@ -344,8 +343,8 @@ describe('WorkflowExecutionState', () => {
       await underTest.flush(); // second flush with no changes
       await underTest.flush(); // third flush with no changes
 
-      expect(workflowExecutionRepository.updateWorkflowExecution).toHaveBeenCalledTimes(1);
-      expect(stepExecutionRepository.bulkUpsert).toHaveBeenCalledTimes(2); // create the first step execution and then update
+      expect(workflowExecutionRepository.updateWorkflowExecution).toHaveBeenCalledTimes(2);
+      expect(stepExecutionRepository.bulkUpsert).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -396,8 +395,15 @@ describe('WorkflowExecutionState', () => {
   });
 
   describe('load', () => {
+    it('should throw if stepExecutionIds is not set on the workflow execution', async () => {
+      await expect(underTest.load()).rejects.toThrow(
+        'WorkflowExecutionState: Workflow execution must have step execution IDs to be loaded'
+      );
+    });
+
     it('should load existing step executions', async () => {
-      (stepExecutionRepository.searchStepExecutionsByExecutionId as jest.Mock).mockResolvedValue([
+      underTest.updateWorkflowExecution({ stepExecutionIds: ['11', '22'] });
+      (stepExecutionRepository.getStepExecutionsByIds as jest.Mock).mockResolvedValue([
         {
           id: '11',
           stepId: 'testStep',
@@ -411,6 +417,7 @@ describe('WorkflowExecutionState', () => {
       ]);
       await underTest.load();
 
+      expect(stepExecutionRepository.getStepExecutionsByIds).toHaveBeenCalledWith(['11', '22']);
       expect(underTest.getLatestStepExecution('testStep')).toEqual({
         id: '11',
         stepId: 'testStep',
@@ -424,7 +431,8 @@ describe('WorkflowExecutionState', () => {
     });
 
     it('should sort step executions by executionIndex when loaded from repository', async () => {
-      (stepExecutionRepository.searchStepExecutionsByExecutionId as jest.Mock).mockResolvedValue([
+      underTest.updateWorkflowExecution({ stepExecutionIds: ['11', '44', '33', '22'] });
+      (stepExecutionRepository.getStepExecutionsByIds as jest.Mock).mockResolvedValue([
         {
           id: '11',
           stepId: 'testStep',

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -37,8 +37,14 @@ export class WorkflowExecutionState {
   }
 
   public async load(): Promise<void> {
-    const foundSteps = await this.workflowStepExecutionRepository.searchStepExecutionsByExecutionId(
-      this.workflowExecution.id
+    if (!this.workflowExecution.stepExecutionIds) {
+      throw new Error(
+        'WorkflowExecutionState: Workflow execution must have step execution IDs to be loaded'
+      );
+    }
+
+    const foundSteps = await this.workflowStepExecutionRepository.getStepExecutionsByIds(
+      this.workflowExecution.stepExecutionIds
     );
     foundSteps.forEach((stepExecution) => this.stepExecutions.set(stepExecution.id, stepExecution));
     this.buildStepIdExecutionIdIndex();
@@ -136,10 +142,6 @@ export class WorkflowExecutionState {
     await this.workflowExecutionRepository.updateWorkflowExecution({
       ...changes,
       id: this.workflowExecution.id,
-      // Include all step execution IDs sorted by execution order for O(1) mget lookup on read side
-      stepExecutionIds: Array.from(this.stepExecutions.values())
-        .sort((a, b) => a.globalExecutionIndex - b.globalExecutionIndex)
-        .map((step) => step.id),
     });
   }
 
@@ -160,6 +162,13 @@ export class WorkflowExecutionState {
     } as EsWorkflowStepExecution;
     this.stepExecutions.set(step.id as string, newStep);
     this.stepDocumentsChanges.set(step.id as string, newStep);
+    // As we are creating a new step execution, we need to update the workflow execution with the new step execution ID
+    // Due to the fact that execution and flushes are synchronous, it's safe to use incremental approach to update the step execution IDs
+    // while still keeping the order of the step execution IDs according to the global execution index
+    // At the same time it's safer because we don't rely on how many step executions are loaded in resume task.
+    this.updateWorkflowExecution({
+      stepExecutionIds: [...(this.workflowExecution.stepExecutionIds || []), step.id as string],
+    });
   }
 
   private updateStep(step: Partial<EsWorkflowStepExecution>) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[One Workflow] fix: Steps disappearing from workflow overview after completion (#257465)](https://github.com/elastic/kibana/pull/257465)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ihor Panasiuk","email":"igorskynet13@gmail.com"},"sourceCommit":{"committedDate":"2026-03-15T10:03:27Z","message":"[One Workflow] fix: Steps disappearing from workflow overview after completion (#257465)\n\ncloses: https://github.com/elastic/security-team/issues/16302\n\n**Issue:** Users reported that after a workflow completes, the overview\nonly shows the first and last step, while intermediate steps disappear.\nThis occurred in workflows with long wait steps (over 5s) when there\nwere more than 10 prior steps.\n\n**Root cause:** The `stepExecutionIds` manifest on the workflow\nexecution document was being recomputed from the in-memory step\nexecution map at flush time. When a workflow resumed after a wait step,\nthe `load()` method fetched step executions via `mget` using the\npersisted `stepExecutionIds`, but the flush-time recomputation relied on\nall step executions being present in memory. If the loaded set was\nincomplete (e.g., due to the default Elasticsearch search `size: 10`\nlimit on the fallback path), the recomputed `stepExecutionIds` would\nsilently drop steps that weren't in memory — overwriting the correct\nmanifest with a truncated one.\n\n**What changed:** Moved `stepExecutionIds` maintenance from flush-time\nrecomputation to incremental append at step-creation time. When a new\nstep execution is created, its ID is immediately appended to the\nworkflow execution's `stepExecutionIds` array. This is safe because\nexecution and flushes are synchronous, so creation order matches\n`globalExecutionIndex` order.\n\n**Why this is better:**\n- **Correctness:** The `stepExecutionIds` manifest is never overwritten\nwith a subset. Each new step ID is appended exactly once, and existing\nIDs are preserved from the persisted state on resume.\n- **Efficiency:** Eliminates the O(n log n) sort of all step executions\non every workflow flush. The field is only updated when it actually\nchanges (a new step is created).\n- **Resilience:** No longer depends on how many step executions are\nloaded into memory during the resume task — the manifest is built\nincrementally from the source of truth.","sha":"a7717d997c243bded707ff7d0583185f43af5b87","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:One Workflow","v9.4.0","v9.3.2"],"title":"[One Workflow] fix: Steps disappearing from workflow overview after completion","number":257465,"url":"https://github.com/elastic/kibana/pull/257465","mergeCommit":{"message":"[One Workflow] fix: Steps disappearing from workflow overview after completion (#257465)\n\ncloses: https://github.com/elastic/security-team/issues/16302\n\n**Issue:** Users reported that after a workflow completes, the overview\nonly shows the first and last step, while intermediate steps disappear.\nThis occurred in workflows with long wait steps (over 5s) when there\nwere more than 10 prior steps.\n\n**Root cause:** The `stepExecutionIds` manifest on the workflow\nexecution document was being recomputed from the in-memory step\nexecution map at flush time. When a workflow resumed after a wait step,\nthe `load()` method fetched step executions via `mget` using the\npersisted `stepExecutionIds`, but the flush-time recomputation relied on\nall step executions being present in memory. If the loaded set was\nincomplete (e.g., due to the default Elasticsearch search `size: 10`\nlimit on the fallback path), the recomputed `stepExecutionIds` would\nsilently drop steps that weren't in memory — overwriting the correct\nmanifest with a truncated one.\n\n**What changed:** Moved `stepExecutionIds` maintenance from flush-time\nrecomputation to incremental append at step-creation time. When a new\nstep execution is created, its ID is immediately appended to the\nworkflow execution's `stepExecutionIds` array. This is safe because\nexecution and flushes are synchronous, so creation order matches\n`globalExecutionIndex` order.\n\n**Why this is better:**\n- **Correctness:** The `stepExecutionIds` manifest is never overwritten\nwith a subset. Each new step ID is appended exactly once, and existing\nIDs are preserved from the persisted state on resume.\n- **Efficiency:** Eliminates the O(n log n) sort of all step executions\non every workflow flush. The field is only updated when it actually\nchanges (a new step is created).\n- **Resilience:** No longer depends on how many step executions are\nloaded into memory during the resume task — the manifest is built\nincrementally from the source of truth.","sha":"a7717d997c243bded707ff7d0583185f43af5b87"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257465","number":257465,"mergeCommit":{"message":"[One Workflow] fix: Steps disappearing from workflow overview after completion (#257465)\n\ncloses: https://github.com/elastic/security-team/issues/16302\n\n**Issue:** Users reported that after a workflow completes, the overview\nonly shows the first and last step, while intermediate steps disappear.\nThis occurred in workflows with long wait steps (over 5s) when there\nwere more than 10 prior steps.\n\n**Root cause:** The `stepExecutionIds` manifest on the workflow\nexecution document was being recomputed from the in-memory step\nexecution map at flush time. When a workflow resumed after a wait step,\nthe `load()` method fetched step executions via `mget` using the\npersisted `stepExecutionIds`, but the flush-time recomputation relied on\nall step executions being present in memory. If the loaded set was\nincomplete (e.g., due to the default Elasticsearch search `size: 10`\nlimit on the fallback path), the recomputed `stepExecutionIds` would\nsilently drop steps that weren't in memory — overwriting the correct\nmanifest with a truncated one.\n\n**What changed:** Moved `stepExecutionIds` maintenance from flush-time\nrecomputation to incremental append at step-creation time. When a new\nstep execution is created, its ID is immediately appended to the\nworkflow execution's `stepExecutionIds` array. This is safe because\nexecution and flushes are synchronous, so creation order matches\n`globalExecutionIndex` order.\n\n**Why this is better:**\n- **Correctness:** The `stepExecutionIds` manifest is never overwritten\nwith a subset. Each new step ID is appended exactly once, and existing\nIDs are preserved from the persisted state on resume.\n- **Efficiency:** Eliminates the O(n log n) sort of all step executions\non every workflow flush. The field is only updated when it actually\nchanges (a new step is created).\n- **Resilience:** No longer depends on how many step executions are\nloaded into memory during the resume task — the manifest is built\nincrementally from the source of truth.","sha":"a7717d997c243bded707ff7d0583185f43af5b87"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->