### PR TITLE
[ES|QL] Adds a tech preview icon to the visor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/index.tsx
@@ -12,6 +12,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIconTip,
   useEuiTheme,
   type EuiComboBoxOptionOption,
 } from '@elastic/eui';
@@ -55,6 +56,10 @@ const nlPlaceholder = i18n.translate('esqlEditor.visor.nlPlaceholder', {
 
 const closeButtonAriaLabel = i18n.translate('esqlEditor.visor.closeButtonAriaLabel', {
   defaultMessage: 'Close quick search visor',
+});
+
+const techPreviewTooltip = i18n.translate('esqlEditor.visor.techPreviewTooltip', {
+  defaultMessage: 'Technical preview',
 });
 
 export function QuickSearchVisor({
@@ -250,6 +255,9 @@ export function QuickSearchVisor({
         >
           {isNlToEsqlEnabled && (
             <>
+              <EuiFlexItem grow={false} css={styles.techPreviewIcon}>
+                <EuiIconTip type="beaker" size="s" color="subdued" content={techPreviewTooltip} />
+              </EuiFlexItem>
               <EuiFlexItem grow={false} css={styles.modeSelectWrapper}>
                 <ModeSelector onModeChange={onModeChange} />
               </EuiFlexItem>

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_visor/visor.styles.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_visor/visor.styles.ts
@@ -117,8 +117,14 @@ export const visorStyles = (
         }
       }
     `,
+    techPreviewIcon: css`
+      padding-left: ${euiTheme.size.s};
+      flex-shrink: 0;
+      flex-grow: 0;
+      display: flex;
+      align-items: center;
+    `,
     modeSelectWrapper: css`
-      padding-left: ${euiTheme.size.xs};
       flex-shrink: 0;
       flex-grow: 0;
       width: ${modeSelectWidth}px;


### PR DESCRIPTION
## Summary

Adds a tech preview icon to the visor (when NL feature is on)

<img width="1047" height="163" alt="image" src="https://github.com/user-attachments/assets/d4fe001e-5338-4302-9148-616dd214d35f" />


