### PR TITLE
Improve logging when generating processing pipelines

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
@@ -9,7 +9,7 @@ import { z } from '@kbn/zod/v4';
 import { suggestProcessingPipeline, type SuggestProcessingPipelineResult } from '@kbn/streams-ai';
 import { from, map, catchError } from 'rxjs';
 import type { ServerSentEventBase } from '@kbn/sse-utils';
-import { createSSEInternalError } from '@kbn/sse-utils';
+import { createSSEInternalError, createSSERequestError, isSSEError } from '@kbn/sse-utils';
 import type { Observable } from 'rxjs';
 import {
   Streams,
@@ -18,7 +18,7 @@ import {
   getStreamTypeFromDefinition,
 } from '@kbn/streams-schema';
 import { type StreamlangDSL, type GrokProcessor, type DissectProcessor } from '@kbn/streamlang';
-import type { InferenceClient } from '@kbn/inference-common';
+import { type InferenceClient, isInferenceError } from '@kbn/inference-common';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
 import {
@@ -128,11 +128,12 @@ export const suggestProcessingPipelineRoute = createServerRoute({
     logger,
     telemetry,
   }): Promise<SuggestProcessingPipelineResponse> => {
-    logger.debug('[suggest_pipeline] Request received');
     logger.debug(
-      `[suggest_pipeline] extracted_patterns: grok=${Boolean(
-        params.body.extracted_patterns?.grok
-      )} dissect=${Boolean(params.body.extracted_patterns?.dissect)}`
+      `[${params.path.name}][suggest_pipeline] Request received (connectorId=${
+        params.body.connector_id
+      } grok=${Boolean(params.body.extracted_patterns?.grok)} dissect=${Boolean(
+        params.body.extracted_patterns?.dissect
+      )})`
     );
 
     // Wrap entire logic in Observable so errors can be sent as SSE events
@@ -171,7 +172,7 @@ export const suggestProcessingPipelineRoute = createServerRoute({
 
           if (grok) {
             logger.debug(
-              `[suggest_pipeline] (parallel) scheduling grok patternGroups=${grok.patternGroups.length} fieldName=${grok.fieldName}`
+              `[${stream.name}][suggest_pipeline] (parallel) scheduling grok (patternGroups=${grok.patternGroups.length} fieldName=${grok.fieldName} connectorId=${params.body.connector_id})`
             );
             candidatePromises.push(
               processGrokPatterns({
@@ -188,7 +189,9 @@ export const suggestProcessingPipelineRoute = createServerRoute({
                 logger,
               }).catch((error) => {
                 if (isNoLLMSuggestionsError(error)) {
-                  logger.debug('[suggest_pipeline] No LLM suggestions available for grok');
+                  logger.debug(
+                    `[${stream.name}][suggest_pipeline] No LLM suggestions available for grok (connectorId=${params.body.connector_id})`
+                  );
                   return null;
                 }
                 throw error;
@@ -197,7 +200,7 @@ export const suggestProcessingPipelineRoute = createServerRoute({
           }
           if (dissect) {
             logger.debug(
-              `[suggest_pipeline] (parallel) scheduling dissect messages=${dissect.messages.length} fieldName=${dissect.fieldName}`
+              `[${stream.name}][suggest_pipeline] (parallel) scheduling dissect (messages=${dissect.messages.length} fieldName=${dissect.fieldName} connectorId=${params.body.connector_id})`
             );
             candidatePromises.push(
               processDissectPattern({
@@ -214,7 +217,9 @@ export const suggestProcessingPipelineRoute = createServerRoute({
                 logger,
               }).catch((error) => {
                 if (isNoLLMSuggestionsError(error)) {
-                  logger.debug('[suggest_pipeline] No LLM suggestions available for dissect');
+                  logger.debug(
+                    `[${stream.name}][suggest_pipeline] No LLM suggestions available for dissect (connectorId=${params.body.connector_id})`
+                  );
                   return null;
                 }
                 throw error;
@@ -232,13 +237,17 @@ export const suggestProcessingPipelineRoute = createServerRoute({
               parsedRate: number;
             } => r !== null
           );
-          candidates.forEach((c) =>
-            logger.debug(`[suggest_pipeline] Candidate type=${c.type} parsedRate=${c.parsedRate}`)
+          candidates.forEach((c, index) =>
+            logger.debug(
+              `[${stream.name}][suggest_pipeline] Candidate ${index + 1}/${
+                candidates.length
+              } (type=${c.type} parsedRate=${c.parsedRate})`
+            )
           );
           if (candidates.length > 0) {
             candidates.sort((a, b) => b.parsedRate - a.parsedRate);
             logger.debug(
-              `[suggest_pipeline] Selected processor type=${candidates[0].type} parsedRate=${candidates[0].parsedRate}`
+              `[${stream.name}][suggest_pipeline] Selected ${candidates[0].type} processor (parsedRate=${candidates[0].parsedRate})`
             );
             parsingProcessor = candidates[0].processor;
           }
@@ -269,6 +278,13 @@ export const suggestProcessingPipelineRoute = createServerRoute({
         });
 
         const durationMs = Date.now() - startTime;
+        logger.debug(
+          `[${stream.name}][suggest_pipeline] Processing pipeline generated (connectorId=${
+            params.body.connector_id
+          } durationMs=${durationMs} steps=${result.metadata.stepsUsed} hasPipeline=${
+            result.pipeline !== null
+          })`
+        );
 
         // Report telemetry for pipeline suggestion
         telemetry.trackProcessingPipelineSuggested({
@@ -288,7 +304,9 @@ export const suggestProcessingPipelineRoute = createServerRoute({
       })),
       catchError((error) => {
         if (isNoLLMSuggestionsError(error)) {
-          logger.debug('No LLM suggestions available for pipeline generation');
+          logger.debug(
+            `[${params.path.name}][suggest_pipeline] No LLM suggestions available for pipeline generation (connectorId=${params.body.connector_id})`
+          );
           // Return null pipeline instead of error - frontend will handle this gracefully
           return [
             {
@@ -297,13 +315,31 @@ export const suggestProcessingPipelineRoute = createServerRoute({
             },
           ];
         }
-        logger.error('Failed to generate pipeline suggestion:', error);
-        // Convert error to SSE error event so it's sent to client with full message
-        throw createSSEInternalError(error.message || 'Failed to generate pipeline suggestion');
+        logger.error(
+          `[${params.path.name}][suggest_pipeline] Failed to generate pipeline suggestion` +
+            ` (connectorId=${params.body.connector_id}${formatInferenceErrorMeta(error)}): ${
+              error.message
+            }`
+        );
+        const errorMessage = error.message || 'Failed to generate pipeline suggestion';
+        if (isSSEError(error) && error.status) {
+          throw createSSERequestError(errorMessage, error.status);
+        }
+        throw createSSEInternalError(errorMessage);
       })
     );
   },
 });
+
+const formatInferenceErrorMeta = (error: unknown): string => {
+  if (isInferenceError(error)) {
+    const parts: string[] = [];
+    if (error.code) parts.push(`code=${error.code}`);
+    if (error.meta?.status) parts.push(`status=${error.meta.status}`);
+    return parts.length > 0 ? `, ${parts.join(', ')}` : '';
+  }
+  return '';
+};
 
 /**
  * Process grok patterns extracted client-side:
@@ -344,12 +380,15 @@ async function processGrokPatterns({
   // Request grok pattern reviews for each group in parallel
   const grokResults = await Promise.allSettled(
     patternGroups.map(async (group) => {
-      logger.debug(`[suggest_pipeline][grok] Reviewing group messages=${group.messages.length}`);
-      // Call LLM to review patterns directly
+      logger.debug(
+        `[${streamName}][suggest_pipeline][grok] Reviewing group (messages=${group.messages.length} connectorId=${connectorId})`
+      );
       const patterns = group.nodes
         .filter((node): node is { pattern: string } => 'pattern' in node)
         .map((node) => node.pattern);
-      logger.debug(`[suggest_pipeline][grok] Derived patterns=${patterns.length}`);
+      logger.debug(
+        `[${streamName}][suggest_pipeline][grok] Derived patterns (patterns=${patterns.length} connectorId=${connectorId})`
+      );
 
       const grokProcessor = await handleProcessingGrokSuggestions({
         params: {
@@ -368,14 +407,16 @@ async function processGrokPatterns({
         signal,
         logger,
       });
-      logger.debug('[suggest_pipeline][grok] LLM review response received');
+      logger.debug(
+        `[${streamName}][suggest_pipeline][grok] LLM review response received (connectorId=${connectorId})`
+      );
 
       const grokProcessorResult = getGrokProcessor(
         patterns.map((pattern) => ({ pattern })),
         grokProcessor
       );
       logger.debug(
-        `[suggest_pipeline][grok] getGrokProcessor produced patterns=${grokProcessorResult.patterns.length}`
+        `[${streamName}][suggest_pipeline][grok] getGrokProcessor produced (patterns=${grokProcessorResult.patterns.length} connectorId=${connectorId})`
       );
 
       return grokProcessorResult;
@@ -387,8 +428,12 @@ async function processGrokPatterns({
     if (result.status === 'fulfilled') {
       acc.push(result.value);
     } else {
-      logger.error('[suggest_pipeline][grok] LLM review failed:', result.reason);
-      // Don't re-throw - allow partial success
+      logger.error(
+        `[${streamName}][suggest_pipeline][grok] LLM review failed` +
+          ` (connectorId=${connectorId}${formatInferenceErrorMeta(result.reason)}): ${
+            result.reason.message
+          }`
+      );
     }
     return acc;
   }, []);
@@ -408,7 +453,7 @@ async function processGrokPatterns({
   // If all patterns were empty, return null
   if (filteredPatterns.length === 0) {
     logger.debug(
-      '[suggest_pipeline][grok] All patterns were empty after filtering out empty string patterns'
+      `[${streamName}][suggest_pipeline][grok] All patterns were empty after filtering out empty string patterns`
     );
     return null;
   }
@@ -489,48 +534,67 @@ async function processDissectPattern({
   }
 
   // Extract dissect pattern on server-side
-  logger.debug('[suggest_pipeline][dissect] Grouping messages by pattern');
+  logger.debug(`[${streamName}][suggest_pipeline][dissect] Grouping messages by pattern`);
   const grouped = groupMessagesByDissectPattern(messages);
   if (grouped.length === 0) {
-    logger.debug('[suggest_pipeline][dissect] No patterns found in messages');
+    logger.debug(`[${streamName}][suggest_pipeline][dissect] No patterns found in messages`);
     return null;
   }
 
   const largestGroup = grouped[0];
   logger.debug(
-    `[suggest_pipeline][dissect] Extracting pattern from largest group messages=${largestGroup.messages.length}`
+    `[${streamName}][suggest_pipeline][dissect] Extracting pattern from largest group (messages=${largestGroup.messages.length})`
   );
   const dissectPattern = extractDissectPattern(largestGroup.messages);
 
   if (!dissectPattern.ast.nodes.length) {
-    logger.debug('[suggest_pipeline][dissect] No AST nodes in extracted pattern');
+    logger.debug(`[${streamName}][suggest_pipeline][dissect] No AST nodes in extracted pattern`);
     return null;
   }
 
   // Use extracted fields for review & processor generation
   const reviewFields = getDissectReviewFields(dissectPattern, 10);
-  const dissectReview = await handleProcessingDissectSuggestions({
-    params: {
-      path: { name: streamName },
-      body: {
-        connector_id: connectorId,
-        sample_messages: largestGroup.messages.slice(0, 10),
-        review_fields: reviewFields,
+  logger.debug(
+    `[${streamName}][suggest_pipeline][dissect] Reviewing fields (connectorId=${connectorId})`
+  );
+  let dissectReview;
+  try {
+    dissectReview = await handleProcessingDissectSuggestions({
+      params: {
+        path: { name: streamName },
+        body: {
+          connector_id: connectorId,
+          sample_messages: largestGroup.messages.slice(0, 10),
+          review_fields: reviewFields,
+        },
       },
-    },
-    inferenceClient,
-    scopedClusterClient,
-    streamsClient,
-    fieldsMetadataClient,
-    signal,
-    logger,
-  });
+      inferenceClient,
+      scopedClusterClient,
+      streamsClient,
+      fieldsMetadataClient,
+      signal,
+      logger,
+    });
+    logger.debug(
+      `[${streamName}][suggest_pipeline][dissect] LLM review response received (connectorId=${connectorId})`
+    );
+  } catch (error) {
+    logger.error(
+      `[${streamName}][suggest_pipeline][dissect] LLM review failed` +
+        ` (connectorId=${connectorId}${formatInferenceErrorMeta(error)}): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+    );
+    throw error;
+  }
 
   const dissectProcessor = getDissectProcessorWithReview(dissectPattern, dissectReview, fieldName);
   const pattern = dissectProcessor.pattern;
 
   if (!pattern || pattern.trim().length === 0) {
-    logger.debug('[suggest_pipeline][dissect] Empty pattern generated; skipping simulation');
+    logger.debug(
+      `[${streamName}][suggest_pipeline][dissect] Empty pattern generated; skipping simulation`
+    );
     return null;
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
@@ -315,13 +315,13 @@ export const suggestProcessingPipelineRoute = createServerRoute({
             },
           ];
         }
+        const errorMessage = getErrorMessage(error) || 'Failed to generate pipeline suggestion';
         logger.error(
           `[${params.path.name}][suggest_pipeline] Failed to generate pipeline suggestion` +
-            ` (connectorId=${params.body.connector_id}${formatInferenceErrorMeta(error)}): ${
-              error.message
-            }`
+            ` (connectorId=${params.body.connector_id}${formatInferenceErrorMeta(
+              error
+            )}): ${errorMessage}`
         );
-        const errorMessage = error.message || 'Failed to generate pipeline suggestion';
         if (isSSEError(error) && error.status) {
           throw createSSERequestError(errorMessage, error.status);
         }
@@ -330,6 +330,9 @@ export const suggestProcessingPipelineRoute = createServerRoute({
     );
   },
 });
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 const formatInferenceErrorMeta = (error: unknown): string => {
   if (isInferenceError(error)) {
@@ -430,9 +433,9 @@ async function processGrokPatterns({
     } else {
       logger.error(
         `[${streamName}][suggest_pipeline][grok] LLM review failed` +
-          ` (connectorId=${connectorId}${formatInferenceErrorMeta(result.reason)}): ${
-            result.reason.message
-          }`
+          ` (connectorId=${connectorId}${formatInferenceErrorMeta(
+            result.reason
+          )}): ${getErrorMessage(result.reason)}`
       );
     }
     return acc;
@@ -581,9 +584,7 @@ async function processDissectPattern({
   } catch (error) {
     logger.error(
       `[${streamName}][suggest_pipeline][dissect] LLM review failed` +
-        ` (connectorId=${connectorId}${formatInferenceErrorMeta(error)}): ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        ` (connectorId=${connectorId}${formatInferenceErrorMeta(error)}): ${getErrorMessage(error)}`
     );
     throw error;
   }

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/management/suggest_processing_pipeline_route.ts
@@ -339,7 +339,7 @@ const formatInferenceErrorMeta = (error: unknown): string => {
     const parts: string[] = [];
     if (error.code) parts.push(`code=${error.code}`);
     if (error.meta?.status) parts.push(`status=${error.meta.status}`);
-    return parts.length > 0 ? `, ${parts.join(', ')}` : '';
+    return parts.length > 0 ? ` ${parts.join(' ')}` : '';
   }
   return '';
 };


### PR DESCRIPTION
Resolves https://github.com/elastic/observability-error-backlog/issues/543

## Summary

- When AI-powered pipeline suggestions fail (e.g. 403 forbidden, request timeout, missing tool calls), the error message was invisible in production logs because `Logger.error(message, error)` treats the second argument as structured ECS metadata rather than a printable value. Error messages are now interpolated into the log string so they appear in the log line.
- All log lines now include the stream name and connector ID, making it possible to filter and correlate logs for a specific stream or AI model without inspecting surrounding log entries.
- Provider errors with HTTP status codes (e.g. 403) are now forwarded to the client as `requestError` with the original status instead of being flattened to a generic `internalError`, enabling more actionable error toasts.

## Screenshot

<img width="1290" height="783" alt="Screenshot 2026-03-10 at 16 41 45" src="https://github.com/user-attachments/assets/e703599d-0c85-443b-9cd5-9686e6516a15" />

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error signaling to streaming clients for pipeline failures and inference-related errors.
  * Added richer contextual error information (connector ID, stream name, inference metadata) for clearer troubleshooting.
  * Wrapped review steps in safer error handling to log and propagate failures reliably.

* **Diagnostics**
  * Expanded detailed logging across pattern inference and processing paths, including scheduling, candidate evaluation, selected processors, and generation duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->