### PR TITLE
[Agent Builder][Dashboard Attachment] Unify attachment preview state and fix version-specific canvas/inline preview behavior

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -20,7 +20,7 @@ export enum ActionButtonType {
   OVERFLOW = 'overflow',
 }
 
-export type AttachmentPreviewState = 'none' | 'preview_only' | 'currently_previewing';
+export type AttachmentPreviewState = 'none' | 'preview_available' | 'previewing';
 /**
  * Props passed to custom attachment content renderers.
  */
@@ -68,7 +68,7 @@ export interface GetActionButtonsParams<TAttachment extends UnknownAttachment = 
    * Optional callback for externally-controlled inline preview state.
    * Use to mark an attachment as currently previewed outside canvas.
    */
-  setPreviewState?: (previewState: AttachmentPreviewState) => void;
+  setPreviewBadgeState?: (previewBadgeState: AttachmentPreviewState) => void;
 }
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -19,6 +19,8 @@ export enum ActionButtonType {
   SECONDARY = 'secondary',
   OVERFLOW = 'overflow',
 }
+
+export type AttachmentPreviewState = 'none' | 'preview_only' | 'currently_previewing';
 /**
  * Props passed to custom attachment content renderers.
  */
@@ -41,6 +43,11 @@ export interface CanvasRenderCallbacks {
   updateOrigin: (origin: unknown) => Promise<UpdateOriginResponse | undefined>;
   /** Close the canvas (expanded flyout view) */
   closeCanvas: () => void;
+  /**
+   * Optional callback for externally-controlled inline preview state.
+   * Use to mark an attachment as currently previewed outside canvas.
+   */
+  setPreviewState?: (previewState: AttachmentPreviewState) => void;
 }
 
 /**
@@ -57,6 +64,11 @@ export interface GetActionButtonsParams<TAttachment extends UnknownAttachment = 
   updateOrigin: (origin: unknown) => Promise<UpdateOriginResponse | undefined>;
   /** Callback to open the attachment in canvas mode (expanded flyout view). Undefined when already in canvas mode. */
   openCanvas?: () => void;
+  /**
+   * Optional callback for externally-controlled inline preview state.
+   * Use to mark an attachment as currently previewed outside canvas.
+   */
+  setPreviewState?: (previewState: AttachmentPreviewState) => void;
 }
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/index.ts
@@ -12,5 +12,6 @@ export type {
   CanvasRenderCallbacks,
   GetActionButtonsParams,
   ActionButton,
+  AttachmentPreviewState,
 } from './contract';
 export { ActionButtonType } from './contract';

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -411,7 +411,7 @@ export const myAttachmentDefinition: AttachmentUIDefinition<MyAttachment> = {
   ),
 
   // Customize buttons based on viewport context
-  getActionButtons: ({ attachment, isCanvas, isSidebar, openCanvas }) => {
+  getActionButtons: ({ attachment, isCanvas, isSidebar, openCanvas, setPreviewBadgeState }) => {
     const buttons = [];
 
     if (isSidebar) {
@@ -439,6 +439,16 @@ export const myAttachmentDefinition: AttachmentUIDefinition<MyAttachment> = {
       });
     }
 
+    // Optional: if preview happens outside canvas, keep inline badge state in sync
+    buttons.push({
+      label: 'Preview',
+      icon: 'eye',
+      type: ActionButtonType.SECONDARY,
+      handler: () => {
+        setPreviewBadgeState?.('previewing');
+      },
+    });
+
     return buttons;
   },
 };
@@ -451,6 +461,13 @@ The `getActionButtons` params include flags to customize behavior per viewport:
 - **`isSidebar`** - `true` when rendered in the sidebar (constrained width)
 - **`isCanvas`** - `true` when rendered in the canvas flyout (expanded view)
 - **`openCanvas`** - Callback to open canvas mode; `undefined` when already in canvas
+- **`setPreviewBadgeState`** - Optional callback to control inline preview badge state when preview is driven outside the canvas
+
+`setPreviewBadgeState` accepts:
+
+- **`none`** - regular inline state
+- **`preview_available`** - show "Preview Only" badge
+- **`previewing`** - show "You're previewing this" badge and hide inline action buttons
 
 #### Dynamic canvas buttons with registerActionButtons
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_header.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_header.tsx
@@ -44,22 +44,17 @@ interface AttachmentHeaderProps {
   /**
    * Controls preview UI state from the parent.
    * - none: show regular action buttons
-   * - preview_only: show "Preview Only" badge
-   * - currently_previewing: show "You're previewing this" and hide action buttons
+   * - preview_available: show "Preview Only" badge
+   * - previewing: show "You're previewing this" and hide action buttons
    */
-  previewState?: 'none' | 'preview_only' | 'currently_previewing';
-  // Backward-compatible props. Prefer `previewState`.
-  showPreviewBadge?: boolean;
-  showCurrentlyPreviewingBadge?: boolean;
+  previewBadgeState?: 'none' | 'preview_available' | 'previewing';
 }
 
 export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
   title,
   actionButtons,
   onClose,
-  previewState,
-  showPreviewBadge = false,
-  showCurrentlyPreviewingBadge = false,
+  previewBadgeState = 'none',
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -89,17 +84,9 @@ export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
     return null;
   }
 
-  const resolvedPreviewState =
-    previewState ??
-    (showCurrentlyPreviewingBadge
-      ? 'currently_previewing'
-      : showPreviewBadge
-      ? 'preview_only'
-      : 'none');
-
   return (
     <EuiSplitPanel.Inner color="subdued" css={headerStyles} paddingSize="m">
-      {resolvedPreviewState === 'preview_only' && (
+      {previewBadgeState === 'preview_available' && (
         <EuiBadge iconType="lock" color="primary" css={badgeStyles}>
           {PREVIEW_ONLY_LABEL}
         </EuiBadge>
@@ -110,10 +97,8 @@ export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
             {title}
           </EuiText>
         </EuiFlexItem>
-        {resolvedPreviewState !== 'currently_previewing' && (
-          <AttachmentActions buttons={actionButtons} />
-        )}
-        {resolvedPreviewState === 'currently_previewing' && (
+        {previewBadgeState !== 'previewing' && <AttachmentActions buttons={actionButtons} />}
+        {previewBadgeState === 'previewing' && (
           <EuiBadge iconType="eye" color="success">
             {CURRENTLY_PREVIEWING_LABEL}
           </EuiBadge>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_header.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/attachment_header.tsx
@@ -41,6 +41,14 @@ interface AttachmentHeaderProps {
   title: string;
   actionButtons?: ActionButton[];
   onClose?: () => void;
+  /**
+   * Controls preview UI state from the parent.
+   * - none: show regular action buttons
+   * - preview_only: show "Preview Only" badge
+   * - currently_previewing: show "You're previewing this" and hide action buttons
+   */
+  previewState?: 'none' | 'preview_only' | 'currently_previewing';
+  // Backward-compatible props. Prefer `previewState`.
   showPreviewBadge?: boolean;
   showCurrentlyPreviewingBadge?: boolean;
 }
@@ -49,6 +57,7 @@ export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
   title,
   actionButtons,
   onClose,
+  previewState,
   showPreviewBadge = false,
   showCurrentlyPreviewingBadge = false,
 }) => {
@@ -80,9 +89,17 @@ export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
     return null;
   }
 
+  const resolvedPreviewState =
+    previewState ??
+    (showCurrentlyPreviewingBadge
+      ? 'currently_previewing'
+      : showPreviewBadge
+      ? 'preview_only'
+      : 'none');
+
   return (
     <EuiSplitPanel.Inner color="subdued" css={headerStyles} paddingSize="m">
-      {showPreviewBadge && (
+      {resolvedPreviewState === 'preview_only' && (
         <EuiBadge iconType="lock" color="primary" css={badgeStyles}>
           {PREVIEW_ONLY_LABEL}
         </EuiBadge>
@@ -93,8 +110,10 @@ export const AttachmentHeader: React.FC<AttachmentHeaderProps> = ({
             {title}
           </EuiText>
         </EuiFlexItem>
-        {showCurrentlyPreviewingBadge === false && <AttachmentActions buttons={actionButtons} />}
-        {showCurrentlyPreviewingBadge === true && (
+        {resolvedPreviewState !== 'currently_previewing' && (
+          <AttachmentActions buttons={actionButtons} />
+        )}
+        {resolvedPreviewState === 'currently_previewing' && (
           <EuiBadge iconType="eye" color="success">
             {CURRENTLY_PREVIEWING_LABEL}
           </EuiBadge>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
@@ -76,13 +76,7 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
       previewedAttachmentKey,
       setPreviewedAttachmentKey,
     }),
-    [
-      canvasState,
-      previewedAttachmentKey,
-      openCanvas,
-      closeCanvas,
-      setCanvasAttachmentOrigin,
-    ]
+    [canvasState, previewedAttachmentKey, openCanvas, closeCanvas, setCanvasAttachmentOrigin]
   );
 
   return <CanvasContext.Provider value={value}>{children}</CanvasContext.Provider>;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
@@ -11,13 +11,19 @@ import type { UnknownAttachment } from '@kbn/agent-builder-common/attachments';
 interface CanvasState {
   attachment: UnknownAttachment;
   isSidebar: boolean;
+  version?: number;
 }
+
+const getAttachmentPreviewKey = (attachmentId: string, version?: number) =>
+  `${attachmentId}:${version ?? 'latest'}`;
 
 interface CanvasContextValue {
   canvasState: CanvasState | null;
-  openCanvas: (attachment: UnknownAttachment, isSidebar: boolean) => void;
+  previewedAttachmentKey: string | null;
+  openCanvas: (attachment: UnknownAttachment, isSidebar: boolean, version?: number) => void;
   closeCanvas: () => void;
   setCanvasAttachmentOrigin: (origin: unknown) => void;
+  setPreviewedAttachmentKey: (attachmentKey: string | null) => void;
 }
 
 const CanvasContext = createContext<CanvasContextValue | null>(null);
@@ -28,14 +34,28 @@ interface CanvasProviderProps {
 
 export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
   const [canvasState, setCanvasState] = useState<CanvasState | null>(null);
+  const [previewedAttachmentKey, setPreviewedAttachmentKey] = useState<string | null>(null);
 
-  const openCanvas = useCallback((attachment: UnknownAttachment, isSidebar: boolean) => {
-    setCanvasState({ attachment, isSidebar });
-  }, []);
+  const openCanvas = useCallback(
+    (attachment: UnknownAttachment, isSidebar: boolean, version?: number) => {
+      setCanvasState({ attachment, isSidebar, version });
+      setPreviewedAttachmentKey(getAttachmentPreviewKey(attachment.id, version));
+    },
+    []
+  );
 
   const closeCanvas = useCallback(() => {
+    if (canvasState) {
+      const canvasPreviewKey = getAttachmentPreviewKey(
+        canvasState.attachment.id,
+        canvasState.version
+      );
+      if (previewedAttachmentKey === canvasPreviewKey) {
+        setPreviewedAttachmentKey(null);
+      }
+    }
     setCanvasState(null);
-  }, []);
+  }, [canvasState, previewedAttachmentKey]);
 
   const setCanvasAttachmentOrigin = useCallback((origin: unknown) => {
     setCanvasState((prev) => {
@@ -48,8 +68,21 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
   }, []);
 
   const value = useMemo(
-    () => ({ canvasState, openCanvas, closeCanvas, setCanvasAttachmentOrigin }),
-    [canvasState, openCanvas, closeCanvas, setCanvasAttachmentOrigin]
+    () => ({
+      canvasState,
+      openCanvas,
+      closeCanvas,
+      setCanvasAttachmentOrigin,
+      previewedAttachmentKey,
+      setPreviewedAttachmentKey,
+    }),
+    [
+      canvasState,
+      previewedAttachmentKey,
+      openCanvas,
+      closeCanvas,
+      setCanvasAttachmentOrigin,
+    ]
   );
 
   return <CanvasContext.Provider value={value}>{children}</CanvasContext.Provider>;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
@@ -14,7 +14,7 @@ interface CanvasState {
   version?: number;
 }
 
-const getAttachmentPreviewKey = (attachmentId: string, version?: number) =>
+export const getAttachmentPreviewKey = (attachmentId: string, version?: number) =>
   `${attachmentId}:${version ?? 'latest'}`;
 
 interface CanvasContextValue {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -138,7 +138,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         title={title}
         actionButtons={canvasHeaderActionButtons}
         onClose={closeCanvas}
-        showPreviewBadge
+        previewState="preview_only"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
         {uiDefinition.renderCanvasContent(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -138,7 +138,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         title={title}
         actionButtons={canvasHeaderActionButtons}
         onClose={closeCanvas}
-        previewState="preview_only"
+        previewBadgeState="preview_available"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
         <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -78,7 +78,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   // Clear dynamic buttons when the canvas attachment changes
   useEffect(() => {
     setDynamicButtons([]);
-  }, [canvasState?.attachment.id]);
+  }, [canvasState?.attachment.id, canvasState?.version]);
 
   const registerActionButtons = useCallback((buttons: ActionButton[]) => {
     setDynamicButtons(buttons);
@@ -141,10 +141,12 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         previewState="preview_only"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        {uiDefinition.renderCanvasContent(
-          { attachment, isSidebar },
-          { registerActionButtons, updateOrigin, closeCanvas }
-        )}
+        <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
+          {uiDefinition.renderCanvasContent(
+            { attachment, isSidebar },
+            { registerActionButtons, updateOrigin, closeCanvas }
+          )}
+        </React.Fragment>
       </EuiFlyoutBody>
     </EuiFlyout>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -10,15 +10,12 @@ import type {
   UnknownAttachment,
   ScreenContextAttachmentData,
 } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentPreviewState } from '@kbn/agent-builder-browser/attachments';
 import { EuiSplitPanel } from '@elastic/eui';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { AttachmentHeader } from './attachment_header';
-import { useCanvasContext } from './canvas_context';
-
-type PreviewState = 'none' | 'preview_available' | 'previewing';
-const getAttachmentPreviewKey = (attachmentId: string, attachmentVersion?: number) =>
-  `${attachmentId}:${attachmentVersion ?? 'latest'}`;
+import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
 
 interface InlineAttachmentWithActionsProps {
   attachment: UnknownAttachment;
@@ -31,7 +28,7 @@ interface InlineAttachmentWithActionsProps {
   /**
    * Shared preview state for header actions/badges.
    */
-  previewBadgeState?: PreviewState;
+  previewBadgeState?: AttachmentPreviewState;
 }
 
 /**
@@ -96,7 +93,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
 
   const isPreviewingAttachment = previewedAttachmentKey === attachmentPreviewKey;
 
-  const resolvedPreviewBadgeState: PreviewState =
+  const resolvedPreviewBadgeState: AttachmentPreviewState =
     previewBadgeState ?? (isPreviewingAttachment ? 'previewing' : 'none');
 
   if (!uiDefinition) {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -16,12 +16,22 @@ import { useConversationContext } from '../../../../../context/conversation/conv
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
 
+type PreviewState = 'none' | 'preview_only' | 'currently_previewing';
+const getAttachmentPreviewKey = (attachmentId: string, attachmentVersion?: number) =>
+  `${attachmentId}:${attachmentVersion ?? 'latest'}`;
+
 interface InlineAttachmentWithActionsProps {
   attachment: UnknownAttachment;
   attachmentsService: AttachmentsService;
   isSidebar: boolean;
   conversationId: string;
   screenContext?: ScreenContextAttachmentData;
+  /** Version number of the attachment being rendered, used for canvas preview comparison */
+  version?: number;
+  /**
+   * Shared preview state for header actions/badges.
+   */
+  previewState?: PreviewState;
 }
 
 /**
@@ -33,13 +43,19 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   isSidebar,
   conversationId,
   screenContext,
+  version,
+  previewState,
 }) => {
-  const { openCanvas: openCanvasContext, canvasState } = useCanvasContext();
+  const {
+    openCanvas: openCanvasContext,
+    previewedAttachmentKey,
+    setPreviewedAttachmentKey,
+  } = useCanvasContext();
   const { conversationActions } = useConversationContext();
 
   const openCanvas = useCallback(() => {
-    openCanvasContext(attachment, isSidebar);
-  }, [openCanvasContext, attachment, isSidebar]);
+    openCanvasContext(attachment, isSidebar, version);
+  }, [openCanvasContext, attachment, isSidebar, version]);
 
   const updateOrigin = useCallback(
     async (origin: unknown) => {
@@ -51,6 +67,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   );
 
   const uiDefinition = attachmentsService.getAttachmentUiDefinition(attachment.type);
+  const attachmentPreviewKey = getAttachmentPreviewKey(attachment.id, version);
 
   const inlineActionButtons = useMemo(
     () =>
@@ -60,13 +77,27 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
         updateOrigin,
         openCanvas,
         isCanvas: false,
+        setPreviewState: (nextPreviewState) => {
+          setPreviewedAttachmentKey(
+            nextPreviewState === 'currently_previewing' ? attachmentPreviewKey : null
+          );
+        },
       }),
-    [uiDefinition, attachment, isSidebar, updateOrigin, openCanvas]
+    [
+      uiDefinition,
+      attachment,
+      isSidebar,
+      updateOrigin,
+      openCanvas,
+      setPreviewedAttachmentKey,
+      attachmentPreviewKey,
+    ]
   );
 
-  const isViewingAttachmentInCanvas = useMemo(() => {
-    return canvasState?.attachment.id === attachment.id;
-  }, [canvasState, attachment]);
+  const isPreviewingAttachment = previewedAttachmentKey === attachmentPreviewKey;
+
+  const resolvedPreviewState: PreviewState =
+    previewState ?? (isPreviewingAttachment ? 'currently_previewing' : 'none');
 
   if (!uiDefinition) {
     return null;
@@ -79,10 +110,14 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
       <AttachmentHeader
         title={title}
         actionButtons={inlineActionButtons}
-        showCurrentlyPreviewingBadge={isViewingAttachmentInCanvas}
+        previewState={resolvedPreviewState}
       />
       <EuiSplitPanel.Inner grow={false} paddingSize="none">
-        {uiDefinition?.renderInlineContent?.({ attachment, isSidebar, screenContext })}
+        {uiDefinition?.renderInlineContent?.({
+          attachment,
+          isSidebar,
+          screenContext,
+        })}
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -16,7 +16,7 @@ import { useConversationContext } from '../../../../../context/conversation/conv
 import { AttachmentHeader } from './attachment_header';
 import { useCanvasContext } from './canvas_context';
 
-type PreviewState = 'none' | 'preview_only' | 'currently_previewing';
+type PreviewState = 'none' | 'preview_available' | 'previewing';
 const getAttachmentPreviewKey = (attachmentId: string, attachmentVersion?: number) =>
   `${attachmentId}:${attachmentVersion ?? 'latest'}`;
 
@@ -31,7 +31,7 @@ interface InlineAttachmentWithActionsProps {
   /**
    * Shared preview state for header actions/badges.
    */
-  previewState?: PreviewState;
+  previewBadgeState?: PreviewState;
 }
 
 /**
@@ -44,7 +44,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   conversationId,
   screenContext,
   version,
-  previewState,
+  previewBadgeState,
 }) => {
   const {
     openCanvas: openCanvasContext,
@@ -77,9 +77,9 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
         updateOrigin,
         openCanvas,
         isCanvas: false,
-        setPreviewState: (nextPreviewState) => {
+        setPreviewBadgeState: (nextPreviewState) => {
           setPreviewedAttachmentKey(
-            nextPreviewState === 'currently_previewing' ? attachmentPreviewKey : null
+            nextPreviewState === 'previewing' ? attachmentPreviewKey : null
           );
         },
       }),
@@ -96,8 +96,8 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
 
   const isPreviewingAttachment = previewedAttachmentKey === attachmentPreviewKey;
 
-  const resolvedPreviewState: PreviewState =
-    previewState ?? (isPreviewingAttachment ? 'currently_previewing' : 'none');
+  const resolvedPreviewBadgeState: PreviewState =
+    previewBadgeState ?? (isPreviewingAttachment ? 'previewing' : 'none');
 
   if (!uiDefinition) {
     return null;
@@ -110,7 +110,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
       <AttachmentHeader
         title={title}
         actionButtons={inlineActionButtons}
-        previewState={resolvedPreviewState}
+        previewBadgeState={resolvedPreviewBadgeState}
       />
       <EuiSplitPanel.Inner grow={false} paddingSize="none">
         {uiDefinition?.renderInlineContent?.({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
@@ -146,6 +146,7 @@ export const createRenderAttachmentRenderer = ({
         attachmentsService={attachmentsService}
         isSidebar={isSidebar}
         screenContext={screenContext}
+        version={versionToUse}
       />
     );
   };

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -62,7 +62,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         checkSavedDashboardExist={checkSavedDashboardExist}
       />
     ),
-    getActionButtons: ({ attachment, openCanvas, isCanvas, setPreviewState }) => {
+    getActionButtons: ({ attachment, openCanvas, isCanvas, setPreviewBadgeState }) => {
       if (isCanvas) {
         return [];
       }
@@ -73,13 +73,13 @@ export const registerDashboardAttachmentUiDefinition = ({
           }),
           icon: 'eye',
           type: ActionButtonType.SECONDARY,
-          handler: async () => {
+          handler: () => {
             if (!dashboardApi) {
               openCanvas?.();
               return;
             }
 
-            setPreviewState?.('currently_previewing');
+            setPreviewBadgeState?.('previewing');
             dashboardApi.setViewMode('edit');
             dashboardApi.setState(getStateFromAttachment(attachment));
           },

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -62,7 +62,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         checkSavedDashboardExist={checkSavedDashboardExist}
       />
     ),
-    getActionButtons: ({ attachment, openCanvas, isCanvas, setPreviewBadgeState }) => {
+    getActionButtons: ({ attachment, openCanvas, isCanvas }) => {
       if (isCanvas) {
         return [];
       }
@@ -79,7 +79,6 @@ export const registerDashboardAttachmentUiDefinition = ({
               return;
             }
 
-            setPreviewBadgeState?.('previewing');
             dashboardApi.setViewMode('edit');
             dashboardApi.setState(getStateFromAttachment(attachment));
           },

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/index.tsx
@@ -62,7 +62,7 @@ export const registerDashboardAttachmentUiDefinition = ({
         checkSavedDashboardExist={checkSavedDashboardExist}
       />
     ),
-    getActionButtons: ({ attachment, openCanvas, isCanvas }) => {
+    getActionButtons: ({ attachment, openCanvas, isCanvas, setPreviewState }) => {
       if (isCanvas) {
         return [];
       }
@@ -73,12 +73,13 @@ export const registerDashboardAttachmentUiDefinition = ({
           }),
           icon: 'eye',
           type: ActionButtonType.SECONDARY,
-          handler: () => {
+          handler: async () => {
             if (!dashboardApi) {
               openCanvas?.();
               return;
             }
 
+            setPreviewState?.('currently_previewing');
             dashboardApi.setViewMode('edit');
             dashboardApi.setState(getStateFromAttachment(attachment));
           },


### PR DESCRIPTION
## Summary

This PR unifies how attachment preview state is handled across inline attachments and canvas, and fixes regressions around versioned attachments.

### Why

1. Dashboard attachments support a Preview action that applies attachment state to the live dashboard. But when I click on the 'Preview' button, there's no way of changing its state to signal to the user this is what they preview ("You're previewing this"). To support this, preview state is now unified and version-aware across attachment consumers (dashboard and canvas), instead of being canvas-specific.

2. I also fixed the bug where after clicking one preview from the attachment, all of them were displying 'You're previewing this' badge instead of only previewed version

3. When clicking on another attachment version, the canvas is refreshed.

### Before
1:
<img width="1042" height="532" alt="Screenshot 2026-03-16 at 11 27 37" src="https://github.com/user-attachments/assets/e80b5141-59c8-4e46-91e2-6685c31ea546" />

### After
[<!-- Insert screenshots -->](https://github.com/user-attachments/assets/b43eb0e8-6d8c-4e90-bc81-f0de3425765e)


2 and 3: witching in canvas mode after:

https://github.com/user-attachments/assets/fa8bd900-de59-4e18-bde7-96d0b7693717

### What changed

- Introduced a unified preview-state model for attachment headers: `none`, `preview_available`, `preview_active`
- Updated `AttachmentHeader` to render from `previewState`.
- Wired dashboard attachment `Preview` action to set preview state via attachment action callbacks.
- Added shared preview key tracking (attachment id + version) to avoid applying "You're previewing this" to all versions.
- Ensured version is passed through render pipeline so preview state remains version-specific.
- Fixed canvas refresh/remount when switching attachment versions in canvas.

## Test Plan

- [ ] Click **Preview** on a dashboard attachment and verify only that attachment/version shows `You're previewing this`.
- [ ] Click **Preview** on a different version of the same attachment and verify badge moves correctly.
- [ ] Open the same attachment version in canvas and verify inline preview state stays consistent.
- [ ] Switch versions while canvas is open and verify canvas content refreshes.
- [ ] Close canvas and verify preview state clears appropriately.
- [ ] Verify no regressions for non-dashboard attachments.