### PR TITLE
[Synthetics] Dynamically resolve synthetics package version in deployment-agnostic tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sample_data/test_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sample_data/test_policy.ts
@@ -7,7 +7,7 @@
 import expect from 'expect';
 import { omit, sortBy } from 'lodash';
 import type { PackagePolicy, PackagePolicyConfigRecord } from '@kbn/fleet-plugin/common';
-import { INSTALLED_VERSION } from '../../../services/synthetics_private_location';
+import { DEFAULT_SYNTHETICS_VERSION } from '../../../services/synthetics_private_location';
 import { commonVars } from './test_project_monitor_policy';
 
 interface PolicyProps {
@@ -32,7 +32,11 @@ export const getTestSyntheticsPolicy = (props: PolicyProps): PackagePolicy => {
     name: 'test-monitor-name-Test private location 0-default',
     namespace: namespace ?? 'testnamespace',
     spaceIds: ['default'],
-    package: { name: 'synthetics', title: 'Elastic Synthetics', version: INSTALLED_VERSION },
+    package: {
+      name: 'synthetics',
+      title: 'Elastic Synthetics',
+      version: DEFAULT_SYNTHETICS_VERSION,
+    },
     enabled: true,
     policy_id: '5347cd10-0368-11ed-8df7-a7424c6f5167',
     policy_ids: ['5347cd10-0368-11ed-8df7-a7424c6f5167'],

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sample_data/test_project_monitor_policy.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/sample_data/test_project_monitor_policy.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
-import { INSTALLED_VERSION } from '../../../services/synthetics_private_location';
+import { DEFAULT_SYNTHETICS_VERSION } from '../../../services/synthetics_private_location';
 import { getDataStream } from './test_policy';
 
 export const commonVars = {
@@ -53,7 +53,7 @@ export const getTestProjectSyntheticsPolicyLightweight = (
   name: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-${locationName}`,
   namespace: namespace || undefined,
   spaceIds: ['default'],
-  package: { name: 'synthetics', title: 'Elastic Synthetics', version: INSTALLED_VERSION },
+  package: { name: 'synthetics', title: 'Elastic Synthetics', version: DEFAULT_SYNTHETICS_VERSION },
   enabled: true,
   policy_id: '46034710-0ba6-11ed-ba04-5f123b9faa8b',
   policy_ids: ['46034710-0ba6-11ed-ba04-5f123b9faa8b'],
@@ -548,7 +548,7 @@ export const getTestProjectSyntheticsPolicy = (
   name: `4b6abc6c-118b-4d93-a489-1135500d09f1-${projectId}-default-Test private location 0`,
   namespace: namespace || undefined,
   spaceIds: ['default'],
-  package: { name: 'synthetics', title: 'Elastic Synthetics', version: INSTALLED_VERSION },
+  package: { name: 'synthetics', title: 'Elastic Synthetics', version: DEFAULT_SYNTHETICS_VERSION },
   enabled: true,
   policy_id: '46034710-0ba6-11ed-ba04-5f123b9faa8b',
   policy_ids: ['46034710-0ba6-11ed-ba04-5f123b9faa8b'],

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -33,19 +33,19 @@ export class PrivateLocationTestService {
     return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
   }
 
-  async installSyntheticsPackage() {
+  async installSyntheticsPackage({ version }: { version?: string } = {}) {
     await this.supertestWithAuth
       .post('/api/fleet/setup')
       .set('kbn-xsrf', 'true')
       .send()
       .expect(200);
-    const version = await this.fetchSyntheticsPackageVersion();
+    const resolvedVersion = version ?? (await this.fetchSyntheticsPackageVersion());
     await this.retry.try(async () => {
       await this.supertestWithAuth
         .delete(`/api/fleet/epm/packages/synthetics`)
         .set('kbn-xsrf', 'true');
       await this.supertestWithAuth
-        .post(`/api/fleet/epm/packages/synthetics/${version}`)
+        .post(`/api/fleet/epm/packages/synthetics/${resolvedVersion}`)
         .set('kbn-xsrf', 'true')
         .send({ force: true })
         .expect(200);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/services/synthetics_private_location.ts
@@ -13,7 +13,7 @@ import type { KibanaSupertestProvider } from '@kbn/ftr-common-functional-service
 import type { PackagePolicy } from '@kbn/fleet-plugin/common';
 import type { DeploymentAgnosticFtrProviderContext } from '../ftr_provider_context';
 
-export const INSTALLED_VERSION = '1.4.2';
+export const DEFAULT_SYNTHETICS_VERSION = '1.5.0';
 
 export class PrivateLocationTestService {
   private supertestWithAuth: ReturnType<typeof KibanaSupertestProvider>;
@@ -26,14 +26,20 @@ export class PrivateLocationTestService {
     this.retry = getService('retry');
   }
 
-  async installSyntheticsPackage(
-    { version }: { version: string } = { version: INSTALLED_VERSION }
-  ) {
+  async fetchSyntheticsPackageVersion(): Promise<string> {
+    const res = await this.supertestWithAuth
+      .get('/api/fleet/epm/packages/synthetics')
+      .set('kbn-xsrf', 'true');
+    return res.body?.item?.version ?? DEFAULT_SYNTHETICS_VERSION;
+  }
+
+  async installSyntheticsPackage() {
     await this.supertestWithAuth
       .post('/api/fleet/setup')
       .set('kbn-xsrf', 'true')
       .send()
       .expect(200);
+    const version = await this.fetchSyntheticsPackageVersion();
     await this.retry.try(async () => {
       await this.supertestWithAuth
         .delete(`/api/fleet/epm/packages/synthetics`)


### PR DESCRIPTION
Replaces hardcoded `INSTALLED_VERSION = '1.4.2'` with a dynamic fetch from the Fleet EPM API in `api_integration_deployment_agnostic` tests, fixing failures when the bundled synthetics package version changes. Similar fix was applied to `api_integration` tests in https://github.com/elastic/kibana/pull/257343.
