### PR TITLE
[Dashboard Agent] Add closeCanvas callback to canvas attachment contract

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -39,6 +39,8 @@ export interface CanvasRenderCallbacks {
   registerActionButtons: (buttons: ActionButton[]) => void;
   /** Update the attachment's origin reference (e.g., after saving to library) */
   updateOrigin: (origin: unknown) => Promise<UpdateOriginResponse | undefined>;
+  /** Close the canvas (expanded flyout view) */
+  closeCanvas: () => void;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
+++ b/x-pack/platform/plugins/shared/agent_builder/CONTRIBUTOR_GUIDE.md
@@ -458,6 +458,8 @@ For canvas content that needs to register buttons dynamically (e.g., a "Save" bu
 
 The `getActionButtons` function provides **static** buttons. The `registerActionButtons` callback allows canvas content to add **dynamic** buttons that are merged with the static ones.
 
+The callbacks object also exposes `closeCanvas`, which allows canvas content to close the flyout from within attachment UI actions (for example after an "Edit in app" navigation).
+
 ```tsx
 import React, { useEffect, useState } from 'react';
 import {
@@ -473,7 +475,7 @@ interface MyCanvasContentProps extends AttachmentRenderProps<MyAttachment> {
 
 const MyCanvasContent: React.FC<MyCanvasContentProps> = ({
   attachment,
-  callbacks: { registerActionButtons, updateOrigin },
+  callbacks: { registerActionButtons, updateOrigin, closeCanvas },
 }) => {
   const [api, setApi] = useState<MyApi | undefined>();
 
@@ -509,6 +511,23 @@ export const myAttachmentDefinition: AttachmentUIDefinition<MyAttachment> = {
     <MyCanvasContent {...props} callbacks={callbacks} />
   ),
 };
+```
+
+#### Closing the canvas from canvas content
+
+Use `closeCanvas` when an action inside `renderCanvasContent` should dismiss the flyout.
+
+```tsx
+renderCanvasContent: (props, { closeCanvas }) => (
+  <EuiButton
+    onClick={async () => {
+      await locator.navigate({ /* ... */ });
+      closeCanvas();
+    }}
+  >
+    Edit in app
+  </EuiButton>
+);
 ```
 
 #### Linking by-value attachments to persistent storage with updateOrigin

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -132,7 +132,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
       <EuiFlyoutBody css={flyoutBodyStyles}>
         {uiDefinition.renderCanvasContent(
           { attachment, isSidebar },
-          { registerActionButtons, updateOrigin }
+          { registerActionButtons, updateOrigin, closeCanvas }
         )}
       </EuiFlyoutBody>
     </EuiFlyout>


### PR DESCRIPTION
## Summary

- Adds a `closeCanvas` callback to `CanvasRenderCallbacks` in the shared attachment contract.
- This enables canvas content to explicitly close the expanded canvas flyout from the canvas content.
- Our use case: when a user is on a non-Dashboard page (with sidebar agent + canvas open) and clicks `Edit in dashboard`, we need to navigate to Dashboard and close the canvas - the dashboard is shown in app so there is no reason to have canvas open