### PR TITLE
[Agent Builder] Close canvas when switching conversations

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CanvasFlyout } from './canvas_flyout';
+
+const mockCloseCanvas = jest.fn();
+let mockConversationId = 'conversation-1';
+
+jest.mock('./canvas_context', () => ({
+  useCanvasContext: () => ({
+    canvasState: null,
+    closeCanvas: mockCloseCanvas,
+    setCanvasAttachmentOrigin: jest.fn(),
+    updateCanvasAttachment: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../../context/conversation/use_conversation_id', () => ({
+  useConversationId: () => mockConversationId,
+}));
+
+jest.mock('../../../../../context/conversation/conversation_context', () => ({
+  useConversationContext: () => ({
+    conversationActions: { invalidateConversation: jest.fn() },
+  }),
+}));
+
+jest.mock('../../../../../hooks/use_conversation', () => ({
+  useConversation: () => ({
+    conversation: null,
+  }),
+}));
+
+const mockAttachmentsService = {
+  getAttachmentUiDefinition: jest.fn(),
+  updateOrigin: jest.fn(),
+} as any;
+
+describe('CanvasFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConversationId = 'conversation-1';
+  });
+
+  it('closes canvas when conversation ID changes', () => {
+    const { rerender } = render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(mockCloseCanvas).not.toHaveBeenCalled();
+
+    mockConversationId = 'conversation-2';
+    rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(mockCloseCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close canvas when conversation ID stays the same', () => {
+    const { rerender } = render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+    rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(mockCloseCanvas).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiFlyout, EuiFlyoutBody, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -34,6 +34,17 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
   const { canvasState, closeCanvas, setCanvasAttachmentOrigin } = useCanvasContext();
   const conversationId = useConversationId();
   const { conversationActions } = useConversationContext();
+
+  // Track previous conversation ID to detect changes
+  const prevConversationIdRef = useRef(conversationId);
+
+  // Close canvas when conversation ID changes
+  useEffect(() => {
+    if (prevConversationIdRef.current !== conversationId) {
+      closeCanvas();
+      prevConversationIdRef.current = conversationId;
+    }
+  }, [conversationId, closeCanvas]);
 
   const updateOrigin = useCallback(
     async (origin: unknown) => {


### PR DESCRIPTION
- **Before:** Canvas could remain open after moving to another conversation.

https://github.com/user-attachments/assets/3dc88f3c-8ba2-4f22-8b2a-02ea98a89f78

- **After:** Canvas closes automatically on conversation change.

https://github.com/user-attachments/assets/d16e9132-ab48-4445-9b45-1cc938970b9e

## Summary

- Closes the canvas preview when the user navigates to a different conversation.
- Prevents canvas state from leaking across conversations.
- Keeps attachment preview behavior scoped to the conversation where the canvas was opened.

## Why

Canvas content is conversation-specific.  
When users switch conversations, keeping the previous canvas open is confusing and can show stale/incorrect context.

## Test plan

- [ ] Open a conversation and preview an attachment in canvas.
- [ ] Switch to another conversation.
- [ ] Verify the canvas closes immediately.
- [ ] Switch back to the original conversation and confirm canvas is not unexpectedly persisted/open.