### PR TITLE
[Streams] Enable column sorting on features discovery table

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/features_table/features_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/features_table/features_table.tsx
@@ -63,6 +63,7 @@ export function FeaturesTable() {
       name: i18n.translate('xpack.streams.significantEventsDiscovery.featuresTable.featureColumn', {
         defaultMessage: 'Feature',
       }),
+      sortable: (feature: Feature) => (feature.title ?? feature.id).toLowerCase(),
       truncateText: true,
       render: (_name: string, feature: Feature) => {
         const displayTitle = feature.title ?? feature.id;
@@ -91,6 +92,7 @@ export function FeaturesTable() {
       name: i18n.translate('xpack.streams.significantEventsDiscovery.featuresTable.typeColumn', {
         defaultMessage: 'Type',
       }),
+      sortable: true,
       width: '15%',
       render: (type: string) => <EuiBadge color="hollow">{upperFirst(type ?? '–')}</EuiBadge>,
     },
@@ -102,6 +104,7 @@ export function FeaturesTable() {
           defaultMessage: 'Confidence',
         }
       ),
+      sortable: true,
       width: '12%',
       render: (confidence: number) => (
         <EuiHealth color={getConfidenceColor(confidence ?? 0)}>{confidence ?? '–'}</EuiHealth>
@@ -112,6 +115,7 @@ export function FeaturesTable() {
       name: i18n.translate('xpack.streams.significantEventsDiscovery.featuresTable.streamColumn', {
         defaultMessage: 'Stream',
       }),
+      sortable: true,
       width: '15%',
       render: (_streamName: string, feature: Feature) => (
         <EuiBadge color="hollow">{feature.stream_name || '--'}</EuiBadge>
@@ -139,6 +143,12 @@ export function FeaturesTable() {
           itemId="id"
           items={data?.features ?? []}
           loading={loading}
+          sorting={{
+            sort: {
+              field: 'name',
+              direction: 'asc',
+            },
+          }}
           search={{
             box: {
               incremental: true,


### PR DESCRIPTION
## Summary

- Enables sorting on all data columns (Feature, Type, Confidence, Stream) in the Significant Events Discovery features table
- The Feature column uses a custom sort function based on the displayed title (falling back to ID), case-insensitive
- Default sort is ascending by Feature name

<img width="1612" height="410" alt="Screenshot 2026-03-16 at 12 32 45" src="https://github.com/user-attachments/assets/1ae1d75b-0dd5-49b4-9732-c8e66f834844" />


## Test plan

- [ ] Navigate to Streams > Discovery > Features tab
- [ ] Verify each column header is clickable and toggles ascending/descending sort
- [ ] Verify the Feature column sorts alphabetically by displayed title
- [ ] Verify the Confidence column sorts numerically
- [ ] Verify sorting works correctly in combination with the search filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added column sorting to the features table. Users can now sort by Feature, Type, Confidence, and Stream columns. The table defaults to sorting by feature name in ascending order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->