### PR TITLE
[Agent Builder] Support opening embeddable chat with explicit conversationId

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-browser/attachments/contract.ts
@@ -29,6 +29,8 @@ export interface AttachmentRenderProps<TAttachment extends UnknownAttachment = U
   isSidebar: boolean;
   /** Data from the screen context attachment, if present in the conversation */
   screenContext?: ScreenContextAttachmentData;
+  /** The current conversation ID */
+  conversationId: string | undefined;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/embeddable_conversations_provider.tsx
@@ -112,6 +112,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
   );
 
   // One-time initialization per provider instance:
+  // - If conversationId is explicitly provided, validates and uses it directly.
   // - If newConversation flag is set, clears the conversation ID to start fresh.
   // - Otherwise, if there's a persisted conversation ID, validates and restores it.
   // - Otherwise, clears the conversation ID.
@@ -119,7 +120,9 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
   useEffect(() => {
     if (hasInitializedConversationIdRef.current) return;
 
-    if (contextProps.newConversation) {
+    if (contextProps.conversationId) {
+      validateAndSetConversationId(contextProps.conversationId);
+    } else if (contextProps.newConversation) {
       setConversationId(undefined);
     } else if (persistedConversationId) {
       validateAndSetConversationId(persistedConversationId);
@@ -128,6 +131,7 @@ export const EmbeddableConversationsProvider: React.FC<EmbeddableConversationsPr
     }
     hasInitializedConversationIdRef.current = true;
   }, [
+    contextProps.conversationId,
     contextProps.newConversation,
     persistedConversationId,
     setConversationId,

--- a/x-pack/platform/plugins/shared/agent_builder/public/embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/embeddable/types.ts
@@ -24,6 +24,12 @@ export interface EmbeddableConversationProps {
   newConversation?: boolean;
 
   /**
+   * Specific conversation ID to open. When provided, opens this conversation directly
+   * instead of looking up the persisted conversation for the sessionTag/agentId combination.
+   */
+  conversationId?: string;
+
+  /**
    * Session tag for conversation context. Used to maintain separate conversation
    * histories for different parts of the application.
    *


### PR DESCRIPTION
## Summary

- Adds `conversationId` to `AttachmentRenderProps` so attachment UIs can preserve conversation context when navigating to other apps.
- Adds `conversationId` to `EmbeddableConversationProps` to allow opening a specific conversation directly in embeddable chat.
- Updates embeddable initialization logic to prioritize explicit `conversationId` over `newConversation` and persisted session state.
- Documents the new public APIs in `CONTRIBUTOR_GUIDE.md`.

## Why

When navigating from full-screen chat/canvas to "Edit in dashboard", we need to preserve context and open Agent chat with the same conversation selected.  
Without explicit conversation targeting, embeddable chat may restore a different/persisted conversation and lose the expected continuity.

## Behavior

- If `conversationId` is provided to the embeddable, that conversation is validated and opened.
- Otherwise existing behavior remains:
  - `newConversation: true` starts fresh.
  - else persisted conversation is restored for the `sessionTag`/`agentId` pair.

This is not wired up yet, but the functionality is there already.