### PR TITLE
[SigEvents] Rename Insights tab to Significant Events

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
@@ -129,7 +129,7 @@ export function Summary({ count }: { count: number }) {
                     data-test-subj="significant_events_regenerate_insights_button"
                   >
                     {i18n.translate('xpack.streams.insights.regenerateButtonLabel', {
-                      defaultMessage: 'Re-discover significant events',
+                      defaultMessage: 'Re-discover Significant Events',
                     })}
                   </EuiButton>
                 </EuiFlexItem>
@@ -185,7 +185,7 @@ export function Summary({ count }: { count: number }) {
                   'xpack.streams.sigEventsDiscovery.insightsTab.significantEventsFoundDescription',
                   {
                     defaultMessage:
-                      'Discover significant events from your logs, and understand what they mean with the power of AI and Elastic Observability.',
+                      'Discover Significant Events from your logs, and understand what they mean with the power of AI and Elastic Observability.',
                   }
                 )}
               </EuiText>
@@ -200,7 +200,7 @@ export function Summary({ count }: { count: number }) {
                     children:
                       task?.status === TaskStatus.InProgress
                         ? i18n.translate('xpack.streams.insights.generatingButtonLabel', {
-                            defaultMessage: 'Discovering significant events',
+                            defaultMessage: 'Discovering Significant Events',
                           })
                         : i18n.translate('xpack.streams.insights.generateButtonLabel', {
                             defaultMessage: 'Discover Significant Events',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/insights/summary.tsx
@@ -129,7 +129,7 @@ export function Summary({ count }: { count: number }) {
                     data-test-subj="significant_events_regenerate_insights_button"
                   >
                     {i18n.translate('xpack.streams.insights.regenerateButtonLabel', {
-                      defaultMessage: 'Re-generate insights',
+                      defaultMessage: 'Re-discover significant events',
                     })}
                   </EuiButton>
                 </EuiFlexItem>
@@ -185,7 +185,7 @@ export function Summary({ count }: { count: number }) {
                   'xpack.streams.sigEventsDiscovery.insightsTab.significantEventsFoundDescription',
                   {
                     defaultMessage:
-                      'Start extracting insights from your logs, and understand what they mean with the power of AI and Elastic Observability.',
+                      'Discover significant events from your logs, and understand what they mean with the power of AI and Elastic Observability.',
                   }
                 )}
               </EuiText>
@@ -200,10 +200,10 @@ export function Summary({ count }: { count: number }) {
                     children:
                       task?.status === TaskStatus.InProgress
                         ? i18n.translate('xpack.streams.insights.generatingButtonLabel', {
-                            defaultMessage: 'Generating insights',
+                            defaultMessage: 'Discovering significant events',
                           })
                         : i18n.translate('xpack.streams.insights.generateButtonLabel', {
-                            defaultMessage: 'Generate insights',
+                            defaultMessage: 'Discover Significant Events',
                           }),
                     onClick: onGenerateInsightsClick,
                     isDisabled: isGenerateButtonPending,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -147,7 +147,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
                   onClick={() => {
                     toasts.remove(toast);
                     router.push('/_discovery/{tab}', {
-                      path: { tab: 'insights' },
+                      path: { tab: 'significant_events' },
                       query: {},
                     });
                   }}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/translations.ts
@@ -110,14 +110,14 @@ export const ONBOARDING_SCHEDULING_FAILURE_TITLE = i18n.translate(
 export const DISCOVER_INSIGHTS_BUTTON_LABEL = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.discoverInsightsButtonLabel',
   {
-    defaultMessage: 'Discover Insights',
+    defaultMessage: 'Discover Significant Events',
   }
 );
 
 export const INSIGHTS_SCHEDULING_FAILURE_TITLE = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.insightsSchedulingErrorTitle',
   {
-    defaultMessage: 'Could not start insight generation',
+    defaultMessage: 'Could not start significant events generation',
   }
 );
 
@@ -125,7 +125,8 @@ export function getInsightsCompleteToastTitle(count: number): string {
   return i18n.translate(
     'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastTitle',
     {
-      defaultMessage: '{count} {count, plural, one {insight} other {insights}} found',
+      defaultMessage:
+        '{count} {count, plural, one {significant event} other {significant events}} found',
       values: { count },
     }
   );
@@ -134,13 +135,13 @@ export function getInsightsCompleteToastTitle(count: number): string {
 export const INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastViewButton',
   {
-    defaultMessage: 'View insights',
+    defaultMessage: 'View significant events',
   }
 );
 
 export const NO_INSIGHTS_TOAST_TITLE = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.noInsightsToastTitle',
   {
-    defaultMessage: 'No insights found',
+    defaultMessage: 'No significant events found',
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/streams_view/translations.ts
@@ -117,7 +117,7 @@ export const DISCOVER_INSIGHTS_BUTTON_LABEL = i18n.translate(
 export const INSIGHTS_SCHEDULING_FAILURE_TITLE = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.insightsSchedulingErrorTitle',
   {
-    defaultMessage: 'Could not start significant events generation',
+    defaultMessage: 'Could not start Significant Events generation',
   }
 );
 
@@ -126,7 +126,7 @@ export function getInsightsCompleteToastTitle(count: number): string {
     'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastTitle',
     {
       defaultMessage:
-        '{count} {count, plural, one {significant event} other {significant events}} found',
+        '{count} {count, plural, one {Significant Event} other {Significant Events}} found',
       values: { count },
     }
   );
@@ -135,13 +135,13 @@ export function getInsightsCompleteToastTitle(count: number): string {
 export const INSIGHTS_COMPLETE_TOAST_VIEW_BUTTON = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.insightsCompleteToastViewButton',
   {
-    defaultMessage: 'View significant events',
+    defaultMessage: 'View Significant Events',
   }
 );
 
 export const NO_INSIGHTS_TOAST_TITLE = i18n.translate(
   'xpack.streams.significantEventsDiscovery.streamsView.noInsightsToastTitle',
   {
-    defaultMessage: 'No significant events found',
+    defaultMessage: 'No Significant Events found',
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
@@ -22,7 +22,7 @@ import { QueriesTable } from './components/queries_table/queries_table';
 import { StreamsView } from './components/streams_view/streams_view';
 import { InsightsTab } from './components/insights/tab';
 
-const discoveryTabs = ['streams', 'features', 'queries', 'insights'] as const;
+const discoveryTabs = ['streams', 'features', 'queries', 'significant_events'] as const;
 type DiscoveryTab = (typeof discoveryTabs)[number];
 
 function isValidDiscoveryTab(value: string): value is DiscoveryTab {
@@ -103,12 +103,12 @@ export function SignificantEventsDiscoveryPage() {
       isSelected: tab === 'queries',
     },
     {
-      id: 'insights',
-      label: i18n.translate('xpack.streams.significantEventsDiscovery.insightsTab', {
-        defaultMessage: 'Insights',
+      id: 'significant_events',
+      label: i18n.translate('xpack.streams.significantEventsDiscovery.significantEventsTab', {
+        defaultMessage: 'Significant Events',
       }),
-      href: router.link('/_discovery/{tab}', { path: { tab: 'insights' } }),
-      isSelected: tab === 'insights',
+      href: router.link('/_discovery/{tab}', { path: { tab: 'significant_events' } }),
+      isSelected: tab === 'significant_events',
     },
   ];
 
@@ -142,7 +142,7 @@ export function SignificantEventsDiscoveryPage() {
         {tab === 'streams' && <StreamsView refreshUnbackedQueriesCount={refetch} />}
         {tab === 'features' && <FeaturesTable />}
         {tab === 'queries' && <QueriesTable />}
-        {tab === 'insights' && <InsightsTab />}
+        {tab === 'significant_events' && <InsightsTab />}
       </StreamsAppPageTemplate.Body>
     </>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
@@ -62,6 +62,10 @@ export function SignificantEventsDiscoveryPage() {
     return <RedirectTo path="/" />;
   }
 
+  if (tab === 'insights') {
+    return <RedirectTo path="/_discovery/{tab}" params={{ path: { tab: 'significant_events' } }} />;
+  }
+
   if (!isValidDiscoveryTab(tab)) {
     return <RedirectTo path="/_discovery/{tab}" params={{ path: { tab: 'streams' } }} />;
   }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
@@ -62,10 +62,6 @@ export function SignificantEventsDiscoveryPage() {
     return <RedirectTo path="/" />;
   }
 
-  if (tab === 'insights') {
-    return <RedirectTo path="/_discovery/{tab}" params={{ path: { tab: 'significant_events' } }} />;
-  }
-
   if (!isValidDiscoveryTab(tab)) {
     return <RedirectTo path="/_discovery/{tab}" params={{ path: { tab: 'streams' } }} />;
   }


### PR DESCRIPTION
## Summary

- Rename the "Insights" tab to "Significant Events" in the Significant Events Discovery page
- Update the URL path from `_discovery/insights` to `_discovery/significant_events`
- Update all related UI text (button labels, toast messages, description) to use "Significant Events" terminology consistently

### Changed files

- `page.tsx` — tab ID, label, href, route path, conditional render
- `streams_view.tsx` — toast navigation path
- `translations.ts` — toast and button label strings
- `summary.tsx` — generate/regenerate button labels and description text

<img width="821" height="651" alt="Screenshot 2026-03-16 at 12 42 21" src="https://github.com/user-attachments/assets/d6d14580-36d1-4426-8080-779218c129ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized terminology across the Significant Events Discovery feature: replaced "Insights" with "Significant Events" in button labels, tab labels, toast messages, and descriptive text for consistency.
  * Updated navigation so toast/view actions now route to the "Significant Events" tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->