### PR TITLE
[Anonymization Platform Service] - anonymization infrastructure in inference plugin

### DIFF
--- a/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/index.ts
@@ -61,6 +61,7 @@ export {
   type ConnectorTelemetryMetadata,
   type ChatCompleteAnonymizationMetadata,
   type ChatCompleteAnonymizationTarget,
+  isChatCompleteAnonymizationTargetType,
   type AnonymizationRule,
   type RegexAnonymizationRule,
   type NamedEntityRecognitionRule,

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/index.ts
@@ -68,6 +68,7 @@ export type {
   ChatCompleteAnonymizationMetadata,
   ChatCompleteAnonymizationTarget,
 } from './metadata';
+export { isChatCompleteAnonymizationTargetType } from './metadata';
 export {
   isChatCompletionChunkEvent,
   isChatCompletionEvent,

--- a/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-common/src/chat_complete/metadata.ts
@@ -31,6 +31,21 @@ export interface ChatCompleteAnonymizationTarget {
   targetId: string;
 }
 
+const CHAT_COMPLETE_ANONYMIZATION_TARGET_TYPES = new Set<
+  ChatCompleteAnonymizationTarget['targetType']
+>(['data_view', 'index_pattern', 'index']);
+
+export const isChatCompleteAnonymizationTargetType = (
+  value: unknown
+): value is ChatCompleteAnonymizationTarget['targetType'] => {
+  return (
+    typeof value === 'string' &&
+    CHAT_COMPLETE_ANONYMIZATION_TARGET_TYPES.has(
+      value as ChatCompleteAnonymizationTarget['targetType']
+    )
+  );
+};
+
 /**
  * Optional anonymization metadata consumers can pass so inference can resolve
  * field-based policy for a target.
@@ -39,4 +54,13 @@ export interface ChatCompleteAnonymizationMetadata {
   profileId?: string;
   replacementsId?: string;
   target?: ChatCompleteAnonymizationTarget;
+  /**
+   * When true, inference suppresses server-side deanonymization so the LLM
+   * response is stored with tokens intact. The UI is then responsible for
+   * resolving originals via the replacements API.
+   *
+   * RFC §7.5: preferred approach for consumers that own their own rendering
+   * layer (e.g. Agent Builder) and want permission-gated reveal.
+   */
+  keepTokenized?: boolean;
 }

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
@@ -26,12 +26,17 @@ export const completionChunkToLangchain = (chunk: ChatCompletionChunkEvent): AIM
     };
   });
 
-  const additionalKwargs = chunk.refusal ? { refusal: chunk.refusal } : {};
+  const additionalKwargs = {
+    ...(chunk.refusal ? { refusal: chunk.refusal } : {}),
+    ...(chunk.metadata?.anonymization
+      ? { anonymization: { replacementsId: chunk.metadata.anonymization.replacementsId } }
+      : {}),
+  };
 
   return new AIMessageChunk({
     content: chunk.content,
     tool_call_chunks: toolCallChunks,
-    additional_kwargs: additionalKwargs,
+    ...(Object.keys(additionalKwargs).length > 0 ? { additional_kwargs: additionalKwargs } : {}),
     response_metadata: {},
   });
 };

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/chunks.ts
@@ -28,9 +28,7 @@ export const completionChunkToLangchain = (chunk: ChatCompletionChunkEvent): AIM
 
   const additionalKwargs = {
     ...(chunk.refusal ? { refusal: chunk.refusal } : {}),
-    ...(chunk.metadata?.anonymization
-      ? { anonymization: { replacementsId: chunk.metadata.anonymization.replacementsId } }
-      : {}),
+    ...(chunk.metadata?.anonymization ? { anonymization: chunk.metadata.anonymization } : {}),
   };
 
   return new AIMessageChunk({

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
@@ -9,10 +9,15 @@ import type { ChatCompleteResponse } from '@kbn/inference-common';
 import { AIMessage } from '@langchain/core/messages';
 
 export const responseToLangchainMessage = (response: ChatCompleteResponse): AIMessage => {
-  const additionalKwargs = response.refusal ? { refusal: response.refusal } : undefined;
+  const additionalKwargs = {
+    ...(response.refusal ? { refusal: response.refusal } : {}),
+    ...(response.metadata?.anonymization
+      ? { anonymization: { replacementsId: response.metadata.anonymization.replacementsId } }
+      : {}),
+  };
   return new AIMessage({
     content: response.content,
-    ...(additionalKwargs ? { additional_kwargs: additionalKwargs } : {}),
+    ...(Object.keys(additionalKwargs).length > 0 ? { additional_kwargs: additionalKwargs } : {}),
     tool_calls: response.toolCalls.map((toolCall) => {
       return {
         id: toolCall.toolCallId,

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/from_inference/messages.ts
@@ -11,9 +11,7 @@ import { AIMessage } from '@langchain/core/messages';
 export const responseToLangchainMessage = (response: ChatCompleteResponse): AIMessage => {
   const additionalKwargs = {
     ...(response.refusal ? { refusal: response.refusal } : {}),
-    ...(response.metadata?.anonymization
-      ? { anonymization: { replacementsId: response.metadata.anonymization.replacementsId } }
-      : {}),
+    ...(response.metadata?.anonymization ? { anonymization: response.metadata.anonymization } : {}),
   };
   return new AIMessage({
     content: response.content,

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.test.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.test.ts
@@ -7,8 +7,8 @@
 
 import { of, Observable } from 'rxjs';
 import { z } from '@kbn/zod/v4';
-import type { AIMessageChunk } from '@langchain/core/messages';
 import {
+  type AIMessageChunk,
   AIMessage,
   HumanMessage,
   isAIMessage,
@@ -422,9 +422,7 @@ describe('InferenceChatModel', () => {
           modelName: 'some-other-model',
           abortSignal: abortCtrl.signal,
           stream: false,
-          metadata: {
-            connectorTelemetry: undefined,
-          },
+          metadata: undefined,
         })
       );
 
@@ -693,6 +691,85 @@ describe('InferenceChatModel', () => {
         input_tokens: 5,
         output_tokens: 20,
         total_tokens: 25,
+      });
+    });
+
+    it('preserves anonymization metadata on streamed chunks', async () => {
+      const chatModel = new InferenceChatModel({
+        chatComplete,
+        connector,
+      });
+
+      const response = createStreamResponse([
+        {
+          content: 'EMAIL_token',
+          metadata: {
+            anonymization: {
+              replacementsId: 'rep-123',
+            },
+          },
+        },
+      ]);
+      chatComplete.mockReturnValue(response);
+
+      const output = await chatModel.stream('Some question');
+
+      const allChunks: AIMessageChunk[] = [];
+      let concatChunk: AIMessageChunk | undefined;
+      for await (const chunk of output) {
+        allChunks.push(chunk);
+        concatChunk = concatChunk ? concatChunk.concat(chunk) : chunk;
+      }
+
+      expect(allChunks[0].additional_kwargs).toEqual({
+        anonymization: { replacementsId: 'rep-123' },
+      });
+      expect(concatChunk?.additional_kwargs).toEqual({
+        anonymization: { replacementsId: 'rep-123' },
+      });
+    });
+
+    it('does not concatenate anonymization replacementsId across chunks', async () => {
+      const chatModel = new InferenceChatModel({
+        chatComplete,
+        connector,
+      });
+
+      const response = createStreamResponse([
+        {
+          content: 'EMAIL_',
+          metadata: {
+            anonymization: {
+              replacementsId: 'rep-123',
+            },
+          },
+        },
+        {
+          content: 'token',
+          metadata: {
+            anonymization: {
+              replacementsId: 'rep-123',
+            },
+          },
+        },
+      ]);
+      chatComplete.mockReturnValue(response);
+
+      const output = await chatModel.stream('Some question');
+
+      const allChunks: AIMessageChunk[] = [];
+      let concatChunk: AIMessageChunk | undefined;
+      for await (const chunk of output) {
+        allChunks.push(chunk);
+        concatChunk = concatChunk ? concatChunk.concat(chunk) : chunk;
+      }
+
+      expect(allChunks[0].additional_kwargs).toEqual({
+        anonymization: { replacementsId: 'rep-123' },
+      });
+      expect(allChunks[1].additional_kwargs).toEqual({});
+      expect(concatChunk?.additional_kwargs).toEqual({
+        anonymization: { replacementsId: 'rep-123' },
       });
     });
 

--- a/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.ts
+++ b/x-pack/platform/packages/shared/ai-infra/inference-langchain/src/chat_model/inference_chat_model.ts
@@ -35,6 +35,7 @@ import type {
   FunctionCallingMode,
   ConnectorTelemetryMetadata,
   ChatCompleteResponse,
+  ChatCompleteAnonymizationMetadata,
 } from '@kbn/inference-common';
 import {
   isChatCompletionChunkEvent,
@@ -65,6 +66,7 @@ export interface InferenceChatModelParams extends BaseChatModelParams {
   signal?: AbortSignal;
   timeout?: number;
   telemetryMetadata?: ConnectorTelemetryMetadata;
+  anonymization?: ChatCompleteAnonymizationMetadata;
 }
 
 export interface InferenceChatModelCallOptions extends BaseChatModelCallOptions {
@@ -74,6 +76,7 @@ export interface InferenceChatModelCallOptions extends BaseChatModelCallOptions 
   temperature?: number;
   model?: string;
   timeout?: number;
+  anonymization?: ChatCompleteAnonymizationMetadata;
 }
 
 type InvocationParams = Omit<ChatCompleteOptions, 'messages' | 'system' | 'stream'>;
@@ -105,6 +108,7 @@ export class InferenceChatModel extends BaseChatModel<InferenceChatModelCallOpti
   protected model?: string;
   protected signal?: AbortSignal;
   protected timeout?: number;
+  protected anonymization?: ChatCompleteAnonymizationMetadata;
 
   constructor(args: InferenceChatModelParams) {
     super(args);
@@ -118,6 +122,29 @@ export class InferenceChatModel extends BaseChatModel<InferenceChatModelCallOpti
     this.signal = args.signal;
     this.timeout = args.timeout;
     this.maxRetries = args.maxRetries;
+    this.anonymization = args.anonymization;
+  }
+
+  /**
+   * Returns a new InferenceChatModel instance with the given anonymization metadata bound,
+   * so that it flows through withStructuredOutput chains without needing to be passed at
+   * invoke time (which is not type-safe on the Runnable<I, O, RunnableConfig> return type).
+   */
+  withAnonymization(
+    anonymization: ChatCompleteAnonymizationMetadata | undefined
+  ): InferenceChatModel {
+    return new InferenceChatModel({
+      chatComplete: this.chatComplete,
+      connector: this.connector,
+      telemetryMetadata: this.telemetryMetadata,
+      temperature: this.temperature,
+      functionCallingMode: this.functionCallingMode,
+      model: this.model,
+      signal: this.signal,
+      timeout: this.timeout,
+      maxRetries: this.maxRetries,
+      anonymization,
+    });
   }
 
   static lc_name() {
@@ -187,6 +214,11 @@ export class InferenceChatModel extends BaseChatModel<InferenceChatModelCallOpti
     const inferredTools = options.tools ? toolDefinitionToInference(options.tools) : undefined;
     const hasTools = inferredTools ? Object.keys(inferredTools).length > 0 : false;
     const resolvedToolChoice = options.tool_choice ?? 'auto';
+    const resolvedAnonymization = options.anonymization ?? this.anonymization;
+    const metadata = {
+      ...(this.telemetryMetadata ? { connectorTelemetry: this.telemetryMetadata } : {}),
+      ...(resolvedAnonymization ? { anonymization: resolvedAnonymization } : {}),
+    };
 
     return {
       connectorId: this.connector.connectorId,
@@ -202,7 +234,7 @@ export class InferenceChatModel extends BaseChatModel<InferenceChatModelCallOpti
       toolChoice: hasTools ? toolChoiceToInference(resolvedToolChoice) : undefined,
       abortSignal: options.signal ?? this.signal,
       maxRetries: this.maxRetries,
-      metadata: { connectorTelemetry: this.telemetryMetadata },
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
       timeout: options.timeout ?? this.timeout,
     };
   }
@@ -283,9 +315,29 @@ export class InferenceChatModel extends BaseChatModel<InferenceChatModelCallOpti
     });
 
     const responseIterator = toAsyncIterator(response$);
+    // The inference stream attaches anonymization metadata (replacementsId) to every chunk
+    // as it is assembled. LangChain merges AIMessageChunks by summing their additional_kwargs,
+    // so if replacementsId appears on multiple chunks it gets duplicated in the merged message.
+    // We emit it only on the first chunk that carries it and strip it from all subsequent ones
+    // so callers receive exactly one copy in the final assembled AIMessage.
+    let hasEmittedAnonymizationMetadata = false;
     for await (const event of responseIterator) {
       if (isChatCompletionChunkEvent(event)) {
-        const chunk = completionChunkToLangchain(event);
+        const shouldStripAnonymizationMetadata =
+          hasEmittedAnonymizationMetadata && Boolean(event.metadata?.anonymization?.replacementsId);
+        const eventWithoutAnonymizationMetadata = shouldStripAnonymizationMetadata
+          ? {
+              ...event,
+              metadata: {
+                ...event.metadata,
+                anonymization: undefined,
+              },
+            }
+          : event;
+        const chunk = completionChunkToLangchain(eventWithoutAnonymizationMetadata);
+        if (event.metadata?.anonymization?.replacementsId) {
+          hasEmittedAnonymizationMetadata = true;
+        }
         const generationChunk = new ChatGenerationChunk({
           message: chunk,
           text: event.content,

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import type { InferencePublicStart } from '@kbn/inference-plugin/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import { AgentBuilderAccessChecker } from './access';
+
+describe('AgentBuilderAccessChecker', () => {
+  const createLicensing = ({
+    isActive = true,
+    hasAtLeast = true,
+  }: {
+    isActive?: boolean;
+    hasAtLeast?: boolean;
+  }): LicensingPluginStart =>
+    ({
+      license$: new BehaviorSubject({
+        isActive,
+        hasAtLeast: jest.fn().mockReturnValue(hasAtLeast),
+      }),
+    } as unknown as LicensingPluginStart);
+
+  const createInference = ({
+    connectors = [],
+    anonymizationEnabled = false,
+  }: {
+    connectors?: Array<{ id: string }>;
+    anonymizationEnabled?: boolean;
+  }): InferencePublicStart =>
+    ({
+      getConnectors: jest.fn().mockResolvedValue({
+        connectors,
+        anonymizationEnabled,
+      }),
+    } as unknown as InferencePublicStart);
+
+  it('derives connector and anonymization flags from connectors payload', async () => {
+    const licensing = createLicensing({ isActive: true, hasAtLeast: true });
+    const inference = createInference({
+      connectors: [{ id: 'connector-1' }],
+      anonymizationEnabled: true,
+    });
+    const checker = new AgentBuilderAccessChecker({ licensing, inference });
+
+    await checker.initAccess();
+
+    expect(checker.getAccess()).toEqual({
+      hasRequiredLicense: true,
+      hasLlmConnector: true,
+      hasAnonymizationEnabled: true,
+    });
+    expect(inference.getConnectors).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles disabled anonymization and missing connectors', async () => {
+    const licensing = createLicensing({ isActive: true, hasAtLeast: true });
+    const inference = createInference({
+      connectors: [],
+      anonymizationEnabled: false,
+    });
+    const checker = new AgentBuilderAccessChecker({ licensing, inference });
+
+    await checker.initAccess();
+
+    expect(checker.getAccess()).toEqual({
+      hasRequiredLicense: true,
+      hasLlmConnector: false,
+      hasAnonymizationEnabled: false,
+    });
+  });
+
+  it('throws a wrapped error when access resolution fails', async () => {
+    const licensing = createLicensing({ isActive: true, hasAtLeast: true });
+    const inference = {
+      getConnectors: jest.fn().mockRejectedValue(new Error('connectors failed')),
+    } as unknown as InferencePublicStart;
+    const checker = new AgentBuilderAccessChecker({ licensing, inference });
+
+    await expect(checker.initAccess()).rejects.toThrow('Unable to determine Agent Builder access');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.test.ts
@@ -33,10 +33,8 @@ describe('AgentBuilderAccessChecker', () => {
     anonymizationEnabled?: boolean;
   }): InferencePublicStart =>
     ({
-      getConnectors: jest.fn().mockResolvedValue({
-        connectors,
-        anonymizationEnabled,
-      }),
+      getConnectors: jest.fn().mockResolvedValue(connectors),
+      isAnonymizationEnabled: jest.fn().mockResolvedValue(anonymizationEnabled),
     } as unknown as InferencePublicStart);
 
   it('derives connector and anonymization flags from connectors payload', async () => {
@@ -55,6 +53,7 @@ describe('AgentBuilderAccessChecker', () => {
       hasAnonymizationEnabled: true,
     });
     expect(inference.getConnectors).toHaveBeenCalledTimes(1);
+    expect(inference.isAnonymizationEnabled).toHaveBeenCalledTimes(1);
   });
 
   it('handles disabled anonymization and missing connectors', async () => {
@@ -78,6 +77,7 @@ describe('AgentBuilderAccessChecker', () => {
     const licensing = createLicensing({ isActive: true, hasAtLeast: true });
     const inference = {
       getConnectors: jest.fn().mockRejectedValue(new Error('connectors failed')),
+      isAnonymizationEnabled: jest.fn().mockResolvedValue(false),
     } as unknown as InferencePublicStart;
     const checker = new AgentBuilderAccessChecker({ licensing, inference });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.ts
@@ -12,18 +12,12 @@ import { firstValueFrom } from 'rxjs';
 export interface AgentBuilderAccess {
   hasRequiredLicense: boolean;
   hasLlmConnector: boolean;
+  /**
+   * Informational UI gate only. Security boundaries for deanonymization are
+   * enforced server-side by anonymization replacements API privileges.
+   */
+  hasAnonymizationEnabled: boolean;
 }
-
-type PromiseValues<T> = {
-  [Key in keyof T]: Promise<T[Key]>;
-};
-
-const resolveValues = async <T>(promiseObject: PromiseValues<T>): Promise<T> => {
-  const entries = await Promise.all(
-    Object.entries(promiseObject).map(async ([key, promise]) => [key, await promise])
-  );
-  return Object.fromEntries(entries);
-};
 
 export class AgentBuilderAccessChecker {
   private readonly licensing: LicensingPluginStart;
@@ -46,9 +40,12 @@ export class AgentBuilderAccessChecker {
     return license.hasAtLeast('enterprise') && license.isActive;
   }
 
-  private async hasLlmConnector() {
-    const connectors = await this.inference.getConnectors();
-    return connectors.length > 0;
+  private async getInferenceAccess() {
+    const { connectors, anonymizationEnabled } = await this.inference.getConnectors();
+    return {
+      hasLlmConnector: connectors.length > 0,
+      hasAnonymizationEnabled: anonymizationEnabled,
+    };
   }
 
   public async initAccess() {
@@ -56,13 +53,17 @@ export class AgentBuilderAccessChecker {
       return;
     }
 
-    const accessPromise: PromiseValues<AgentBuilderAccess> = {
-      hasRequiredLicense: this.hasRequiredLicense(),
-      hasLlmConnector: this.hasLlmConnector(),
-    };
-
     try {
-      this.access = await resolveValues(accessPromise);
+      const [{ hasLlmConnector, hasAnonymizationEnabled }, hasRequiredLicense] = await Promise.all([
+        this.getInferenceAccess(),
+        this.hasRequiredLicense(),
+      ]);
+
+      this.access = {
+        hasRequiredLicense,
+        hasLlmConnector,
+        hasAnonymizationEnabled,
+      };
     } catch (error) {
       throw new Error('Unable to determine Agent Builder access', { cause: error });
     }

--- a/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/services/access/access.ts
@@ -41,7 +41,10 @@ export class AgentBuilderAccessChecker {
   }
 
   private async getInferenceAccess() {
-    const { connectors, anonymizationEnabled } = await this.inference.getConnectors();
+    const [connectors, anonymizationEnabled] = await Promise.all([
+      this.inference.getConnectors(),
+      this.inference.isAnonymizationEnabled(),
+    ]);
     return {
       hasLlmConnector: connectors.length > 0,
       hasAnonymizationEnabled: anonymizationEnabled,

--- a/x-pack/platform/plugins/shared/inference/common/http_apis.ts
+++ b/x-pack/platform/plugins/shared/inference/common/http_apis.ts
@@ -41,4 +41,5 @@ export type PromptRequestBody = ChatCompleteRequestBodyBase & {
 
 export interface GetConnectorsResponseBody {
   connectors: InferenceConnector[];
+  anonymizationEnabled: boolean;
 }

--- a/x-pack/platform/plugins/shared/inference/common/http_apis.ts
+++ b/x-pack/platform/plugins/shared/inference/common/http_apis.ts
@@ -41,5 +41,8 @@ export type PromptRequestBody = ChatCompleteRequestBodyBase & {
 
 export interface GetConnectorsResponseBody {
   connectors: InferenceConnector[];
+}
+
+export interface GetAnonymizationEnabledResponseBody {
   anonymizationEnabled: boolean;
 }

--- a/x-pack/platform/plugins/shared/inference/moon.yml
+++ b/x-pack/platform/plugins/shared/inference/moon.yml
@@ -45,6 +45,7 @@ dependsOn:
   - '@kbn/es-errors'
   - '@kbn/anonymization-plugin'
   - '@kbn/anonymization-common'
+  - '@kbn/sse-utils'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/inference/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/inference/public/plugin.tsx
@@ -47,10 +47,7 @@ export class InferencePlugin
       chatComplete,
       output,
       getConnectors: async () => {
-        const res = await coreStart.http.get<GetConnectorsResponseBody>(
-          '/internal/inference/connectors'
-        );
-        return res.connectors;
+        return coreStart.http.get<GetConnectorsResponseBody>('/internal/inference/connectors');
       },
     };
   }

--- a/x-pack/platform/plugins/shared/inference/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/inference/public/plugin.tsx
@@ -8,7 +8,10 @@
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import type { Logger } from '@kbn/logging';
 import { createOutputApi } from '../common/output';
-import type { GetConnectorsResponseBody } from '../common/http_apis';
+import type {
+  GetConnectorsResponseBody,
+  GetAnonymizationEnabledResponseBody,
+} from '../common/http_apis';
 import type {
   ConfigSchema,
   InferencePublicSetup,
@@ -47,7 +50,21 @@ export class InferencePlugin
       chatComplete,
       output,
       getConnectors: async () => {
-        return coreStart.http.get<GetConnectorsResponseBody>('/internal/inference/connectors');
+        const { connectors } = await coreStart.http.get<GetConnectorsResponseBody>(
+          '/internal/inference/connectors'
+        );
+        return connectors;
+      },
+      isAnonymizationEnabled: async () => {
+        try {
+          const { anonymizationEnabled } =
+            await coreStart.http.get<GetAnonymizationEnabledResponseBody>(
+              '/internal/inference/anonymization_enabled'
+            );
+          return anonymizationEnabled;
+        } catch {
+          return false;
+        }
       },
     };
   }

--- a/x-pack/platform/plugins/shared/inference/public/types.ts
+++ b/x-pack/platform/plugins/shared/inference/public/types.ts
@@ -20,5 +20,8 @@ export interface InferencePublicSetup {}
 export interface InferencePublicStart {
   chatComplete: ChatCompleteAPI;
   output: OutputAPI;
-  getConnectors: () => Promise<InferenceConnector[]>;
+  getConnectors: () => Promise<{
+    connectors: InferenceConnector[];
+    anonymizationEnabled: boolean;
+  }>;
 }

--- a/x-pack/platform/plugins/shared/inference/public/types.ts
+++ b/x-pack/platform/plugins/shared/inference/public/types.ts
@@ -20,8 +20,6 @@ export interface InferencePublicSetup {}
 export interface InferencePublicStart {
   chatComplete: ChatCompleteAPI;
   output: OutputAPI;
-  getConnectors: () => Promise<{
-    connectors: InferenceConnector[];
-    anonymizationEnabled: boolean;
-  }>;
+  getConnectors: () => Promise<InferenceConnector[]>;
+  isAnonymizationEnabled: () => Promise<boolean>;
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_errors.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_errors.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export class ReplacementsNamespaceMismatchError extends Error {
+  public readonly statusCode = 409;
+
+  constructor(
+    public readonly replacementsId: string,
+    public readonly requestedNamespace: string,
+    public readonly actualNamespace: string
+  ) {
+    super(`Replacements namespace mismatch for id "${replacementsId}": access denied`);
+    this.name = 'ReplacementsNamespaceMismatchError';
+  }
+}

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_errors.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_errors.ts
@@ -5,15 +5,22 @@
  * 2.0.
  */
 
-export class ReplacementsNamespaceMismatchError extends Error {
-  public readonly statusCode = 409;
+import { ServerSentEventError } from '@kbn/sse-utils';
 
-  constructor(
-    public readonly replacementsId: string,
-    public readonly requestedNamespace: string,
-    public readonly actualNamespace: string
-  ) {
-    super(`Replacements namespace mismatch for id "${replacementsId}": access denied`);
+export class ReplacementsNamespaceMismatchError extends ServerSentEventError<
+  'namespaceMismatch',
+  { replacementsId: string; requestedNamespace: string; actualNamespace: string }
+> {
+  constructor(replacementsId: string, requestedNamespace: string, actualNamespace: string) {
+    super(
+      'namespaceMismatch',
+      `Replacements namespace mismatch for id "${replacementsId}": access denied`,
+      {
+        replacementsId,
+        requestedNamespace,
+        actualNamespace,
+      }
+    );
     this.name = 'ReplacementsNamespaceMismatchError';
   }
 }

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_repository.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_repository.test.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { ReplacementsRepository } from './replacements_repository';
+import { ReplacementsNamespaceMismatchError } from './replacements_errors';
 
 describe('ReplacementsRepository', () => {
   const esClient = {
@@ -214,6 +215,28 @@ describe('ReplacementsRepository', () => {
 
     await expect(repo.get('default', id)).rejects.toThrow(
       'Invalid replacements entry for token "TOKEN_A": missing original payload'
+    );
+  });
+
+  it('throws a typed error when replacements namespace does not match', async () => {
+    const repo = new ReplacementsRepository(esClient, {
+      encryptionKey: 'test-encryption-key',
+    });
+    const id = 'replacements-other-namespace';
+
+    (esClient.get as jest.Mock).mockResolvedValue({
+      _source: {
+        id,
+        replacements: [{ anonymized: 'TOKEN_A', original: 'original-a' }],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        created_by: 'test',
+        namespace: 'other-space',
+      },
+    });
+
+    await expect(repo.get('default', id)).rejects.toBeInstanceOf(
+      ReplacementsNamespaceMismatchError
     );
   });
 });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_repository.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_repository.ts
@@ -8,8 +8,11 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { Logger } from '@kbn/logging';
 import type { ReplacementsSet } from '@kbn/anonymization-common';
+import { isConflictError, isNotFoundError } from '../../utils';
 import { ANONYMIZATION_REPLACEMENTS_INDEX } from './replacements_index';
+import { ReplacementsNamespaceMismatchError } from './replacements_errors';
 
 /** ES document shape for replacements. */
 interface EsReplacementsDocument {
@@ -54,14 +57,17 @@ const ENCRYPTION_VERSION = 'v1';
  */
 export class ReplacementsRepository {
   private readonly encryptionKey: string | undefined;
+  private readonly logger: Logger | undefined;
 
   constructor(
     private readonly esClient: ElasticsearchClient,
     options?: {
       encryptionKey?: string;
+      logger?: Logger;
     }
   ) {
     this.encryptionKey = options?.encryptionKey;
+    this.logger = options?.logger;
   }
 
   private deriveKey(secret: string): Buffer {
@@ -130,10 +136,18 @@ export class ReplacementsRepository {
     return withStatus;
   }
 
-  private isVersionConflict(err: unknown): boolean {
-    const statusCode = (err as { statusCode?: number; meta?: { statusCode?: number } })?.statusCode;
-    const metaStatusCode = (err as { meta?: { statusCode?: number } })?.meta?.statusCode;
-    return statusCode === 409 || metaStatusCode === 409;
+  private assertNamespaceMatch(
+    namespace: string,
+    replacementsId: string,
+    doc?: EsReplacementsDocument
+  ): asserts doc is EsReplacementsDocument {
+    if (!doc) {
+      throw this.setStatusCode(new Error('Replacements document missing'), 404);
+    }
+
+    if (doc.namespace !== namespace) {
+      throw new ReplacementsNamespaceMismatchError(replacementsId, namespace, doc.namespace);
+    }
   }
 
   private dedupeAndValidate(
@@ -169,10 +183,27 @@ export class ReplacementsRepository {
   /**
    * Creates a new replacements set.
    */
+  private warnIfTruncated(
+    deduped: Array<{ anonymized: string; original: string }>,
+    context: string
+  ): Array<{ anonymized: string; original: string }> {
+    if (deduped.length > MAX_REPLACEMENTS) {
+      this.logger?.warn(
+        `[anonymization.replacements.truncation] context=${context} total=${
+          deduped.length
+        } limit=${MAX_REPLACEMENTS} dropped=${deduped.length - MAX_REPLACEMENTS}`
+      );
+    }
+    return deduped.slice(0, MAX_REPLACEMENTS);
+  }
+
   async create(params: CreateReplacementsParams): Promise<ReplacementsSet> {
     const now = new Date().toISOString();
     const id = params.id ?? uuidv4();
-    const replacements = this.dedupeAndValidate(params.replacements).slice(0, MAX_REPLACEMENTS);
+    const replacements = this.warnIfTruncated(
+      this.dedupeAndValidate(params.replacements),
+      `create id=${id}`
+    );
 
     const doc: EsReplacementsDocument = {
       id,
@@ -208,13 +239,11 @@ export class ReplacementsRepository {
       });
 
       const doc = result._source;
-      if (!doc || doc.namespace !== namespace) {
-        return null;
-      }
+      this.assertNamespaceMatch(namespace, replacementsId, doc);
 
       return this.toReplacementsSet(doc);
     } catch (err) {
-      if (err?.meta?.statusCode === 404) {
+      if (isNotFoundError(err)) {
         return null;
       }
       throw err;
@@ -242,23 +271,21 @@ export class ReplacementsRepository {
           id: replacementsId,
         });
       } catch (err) {
-        if ((err as { meta?: { statusCode?: number } })?.meta?.statusCode === 404) {
+        if (isNotFoundError(err)) {
           return null;
         }
         throw err;
       }
 
       const doc = docResult._source;
-      if (!doc || doc.namespace !== namespace) {
-        return null;
-      }
+      this.assertNamespaceMatch(namespace, replacementsId, doc);
 
       const existing = this.toReplacementsSet(doc);
       const now = new Date().toISOString();
-      const mergedReplacements = this.dedupeAndValidate([
-        ...existing.replacements,
-        ...params.replacements,
-      ]).slice(0, MAX_REPLACEMENTS);
+      const mergedReplacements = this.warnIfTruncated(
+        this.dedupeAndValidate([...existing.replacements, ...params.replacements]),
+        `update id=${replacementsId}`
+      );
 
       try {
         await this.esClient.update({
@@ -278,7 +305,7 @@ export class ReplacementsRepository {
 
         return this.get(namespace, replacementsId);
       } catch (err) {
-        if (this.isVersionConflict(err) && attempt < MAX_UPDATE_RETRIES - 1) {
+        if (isConflictError(err) && attempt < MAX_UPDATE_RETRIES - 1) {
           continue;
         }
         throw err;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_routes.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/anonymization/replacements/replacements_routes.ts
@@ -19,16 +19,22 @@ import {
 } from '@kbn/anonymization-plugin/common';
 import { ReplacementsRepository } from './replacements_repository';
 import { ensureReplacementsIndex } from './replacements_index';
+import { ReplacementsNamespaceMismatchError } from './replacements_errors';
 import type { InferenceServerStart, InferenceStartDependencies } from '../../../types';
 
 const REPLACEMENTS_API_BASE = '/internal/inference/anonymization/replacements';
+
+// replaceTokensWithOriginals is O(n × m) for text length n and replacement count m.
+// With MAX_REPLACEMENTS=10000 entries an unbounded payload could cause excessive CPU usage,
+// so we cap the input at 1 MB of text — well above any realistic LLM response size.
+const DEANONYMIZE_TEXT_MAX_LENGTH = 1_000_000;
 
 const assertReplacementsEncryptionKeyConfigured = (encryptionKey?: string): void => {
   if (!encryptionKey) {
     const error = new Error(
       'Replacements encryption key is not available — verify the anonymization plugin is active and properly initialized'
     ) as Error & { statusCode?: number };
-    error.statusCode = 400;
+    error.statusCode = 503;
     throw error;
   }
 };
@@ -48,14 +54,13 @@ const resolveEncryptionKey = async ({
   const anonymizationEnabled = anonymizationPlugin?.isEnabled() ?? false;
 
   if (!anonymizationEnabled) {
+    // Plugin is intentionally disabled — caller will receive a 503 explaining this.
     return undefined;
   }
 
-  try {
-    return await anonymizationPlugin?.getPolicyService().getReplacementsEncryptionKey(namespace);
-  } catch {
-    return undefined;
-  }
+  // Let errors propagate: a transient failure (ES down, plugin not yet started) should
+  // surface as a 5xx, not silently degrade to a misleading 400 "not configured" response.
+  return anonymizationPlugin?.getPolicyService().getReplacementsEncryptionKey(namespace);
 };
 
 const resolveReplacementsContext = async (
@@ -79,7 +84,7 @@ const resolveReplacementsContext = async (
     replacementsIndexEnsuredAt = Date.now();
   }
 
-  const repo = new ReplacementsRepository(esClient, { encryptionKey });
+  const repo = new ReplacementsRepository(esClient, { encryptionKey, logger: options.logger });
   return { namespace, repo };
 };
 
@@ -130,6 +135,9 @@ export const registerReplacementsRoutes = (
             },
           });
         } catch (err) {
+          if (err instanceof ReplacementsNamespaceMismatchError) {
+            return response.notFound({ body: { message: 'Replacements set not found' } });
+          }
           logger.error(`Failed to resolve replacements: ${toErrorMessage(err)}`);
           return response.customError({
             body: { message: toErrorMessage(err) },
@@ -156,7 +164,7 @@ export const registerReplacementsRoutes = (
         validate: {
           request: {
             body: schema.object({
-              text: schema.string(),
+              text: schema.string({ maxLength: DEANONYMIZE_TEXT_MAX_LENGTH }),
               replacementsId: schema.string(),
             }),
           },
@@ -182,6 +190,9 @@ export const registerReplacementsRoutes = (
 
           return response.ok({ body: { text: deanonymizedText } });
         } catch (err) {
+          if (err instanceof ReplacementsNamespaceMismatchError) {
+            return response.notFound({ body: { message: 'Replacements set not found' } });
+          }
           logger.error(`Failed to deanonymize text: ${toErrorMessage(err)}`);
           return response.customError({
             body: { message: toErrorMessage(err) },

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/api.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/api.test.ts
@@ -14,7 +14,8 @@ import {
 } from './api.test.mocks';
 
 import { of, Subject, isObservable, toArray, firstValueFrom, filter } from 'rxjs';
-import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { MockedLogger } from '@kbn/logging-mocks';
 import { httpServerMock } from '@kbn/core/server/mocks';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
 import {
@@ -170,6 +171,22 @@ describe('createChatCompleteApi', () => {
   });
 
   describe('response mode', () => {
+    const recoveringShardError = {
+      statusCode: 503,
+      meta: {
+        statusCode: 503,
+        body: {
+          error: {
+            type: 'illegal_index_shard_state_exception',
+            reason:
+              'CurrentState[RECOVERING] operations only allowed when shard state is one of [POST_RECOVERY, STARTED]',
+          },
+        },
+      },
+      message:
+        'no_shard_available_action_exception: CurrentState[RECOVERING] operations only allowed when shard state is one of [POST_RECOVERY, STARTED]',
+    };
+
     it('reuses carried replacementsId when found', async () => {
       inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
 
@@ -193,7 +210,54 @@ describe('createChatCompleteApi', () => {
       expect(response.metadata?.anonymization?.replacementsId).toBe('existing-replacements-id');
     });
 
-    it('falls back to a new replacementsId when carried one is missing', async () => {
+    it('retries transient shard-recovery failures when fetching carried replacements', async () => {
+      mockEsClient.get.mockRejectedValueOnce(recoveringShardError);
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
+
+      const response = await chatComplete({
+        connectorId: 'connectorId',
+        messages: [{ role: MessageRole.User, content: 'question' }],
+        metadata: {
+          anonymization: {
+            replacementsId: 'existing-replacements-id',
+          },
+        },
+        maxRetries: 0,
+      });
+
+      expect(mockEsClient.get.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(mockEsClient.get.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ id: 'existing-replacements-id' })
+      );
+      expect(response.metadata?.anonymization?.replacementsId).toBe('existing-replacements-id');
+    });
+
+    it('does not retry non-retryable replacements errors', async () => {
+      mockEsClient.get.mockRejectedValueOnce({
+        statusCode: 400,
+        meta: { statusCode: 400 },
+        message: 'bad request',
+      });
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
+
+      await expect(
+        chatComplete({
+          connectorId: 'connectorId',
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          metadata: {
+            anonymization: {
+              replacementsId: 'existing-replacements-id',
+            },
+          },
+          maxRetries: 0,
+        })
+      ).rejects.toMatchObject({ message: 'bad request' });
+
+      expect(mockEsClient.get).toHaveBeenCalledTimes(1);
+      expect(inferenceAdapter.chatComplete).toHaveBeenCalledTimes(0);
+    });
+
+    it('reuses carried replacementsId by creating document when carried one is missing', async () => {
       mockEsClient.get.mockRejectedValueOnce({ meta: { statusCode: 404 } });
       inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
 
@@ -211,8 +275,122 @@ describe('createChatCompleteApi', () => {
       expect(mockEsClient.get).toHaveBeenCalledTimes(1);
       expect(mockEsClient.update).toHaveBeenCalledTimes(0);
       expect(mockEsClient.index).toHaveBeenCalledTimes(1);
-      expect(response.metadata?.anonymization?.replacementsId).not.toBe('stale-replacements-id');
-      expect(response.metadata?.anonymization?.replacementsId).toEqual(expect.any(String));
+      expect(mockEsClient.index.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ id: 'stale-replacements-id' })
+      );
+      expect(response.metadata?.anonymization?.replacementsId).toBe('stale-replacements-id');
+    });
+
+    it('falls back to a new replacements document when carried replacementsId belongs to another namespace', async () => {
+      // Simulate a document that was created in a different space (e.g. after a space migration).
+      // The old behaviour threw a 409; the new behaviour silently allocates a fresh UUID so that
+      // clients that persisted a pre-migration ID are not hard-errored.
+      mockEsClient.get.mockResolvedValueOnce({
+        _source: {
+          id: 'cross-space-replacements-id',
+          namespace: 'other-space',
+          replacements: [],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          created_by: 'inference',
+        },
+      });
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
+
+      const response = await chatComplete({
+        connectorId: 'connectorId',
+        messages: [{ role: MessageRole.User, content: 'question' }],
+        metadata: {
+          anonymization: {
+            replacementsId: 'cross-space-replacements-id',
+          },
+        },
+        maxRetries: 0,
+      });
+
+      // A fresh replacementsId must have been allocated (different from the cross-space one).
+      expect(response.metadata?.anonymization?.replacementsId).toBeDefined();
+      expect(response.metadata?.anonymization?.replacementsId).not.toBe(
+        'cross-space-replacements-id'
+      );
+      // The agent call must have gone through.
+      expect(inferenceAdapter.chatComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles create conflict by falling back to update', async () => {
+      mockEsClient.get
+        .mockRejectedValueOnce({ meta: { statusCode: 404 } })
+        .mockResolvedValueOnce({
+          _seq_no: 1,
+          _primary_term: 1,
+          _source: {
+            id: 'stale-replacements-id',
+            namespace: 'default',
+            replacements: [],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            created_by: 'inference',
+          },
+        })
+        .mockResolvedValueOnce({
+          _source: {
+            id: 'stale-replacements-id',
+            namespace: 'default',
+            replacements: [],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            created_by: 'inference',
+          },
+        });
+      mockEsClient.index.mockRejectedValueOnce({
+        statusCode: 409,
+        meta: { statusCode: 409 },
+      });
+      mockEsClient.update.mockResolvedValueOnce({});
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
+
+      const response = await chatComplete({
+        connectorId: 'connectorId',
+        messages: [{ role: MessageRole.User, content: 'question' }],
+        metadata: {
+          anonymization: {
+            replacementsId: 'stale-replacements-id',
+          },
+        },
+        maxRetries: 0,
+      });
+
+      expect(mockEsClient.index).toHaveBeenCalledTimes(1);
+      expect(mockEsClient.update).toHaveBeenCalledTimes(1);
+      expect(response.metadata?.anonymization?.replacementsId).toBe('stale-replacements-id');
+    });
+
+    it('fails when create conflict fallback update cannot persist replacements', async () => {
+      mockEsClient.get
+        .mockRejectedValueOnce({ meta: { statusCode: 404 } })
+        .mockRejectedValueOnce({ meta: { statusCode: 404 } });
+      mockEsClient.index.mockRejectedValueOnce({
+        statusCode: 409,
+        meta: { statusCode: 409 },
+      });
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('chunk-1')));
+
+      await expect(
+        chatComplete({
+          connectorId: 'connectorId',
+          messages: [{ role: MessageRole.User, content: 'question' }],
+          metadata: {
+            anonymization: {
+              replacementsId: 'stale-replacements-id',
+            },
+          },
+          maxRetries: 0,
+        })
+      ).rejects.toThrow(
+        'Unable to persist replacements after create conflict for replacementsId "stale-replacements-id"'
+      );
+
+      expect(mockEsClient.index).toHaveBeenCalledTimes(1);
     });
 
     it('does not persist replacements when there is no anonymization and no carried id', async () => {
@@ -252,6 +430,35 @@ describe('createChatCompleteApi', () => {
         metadata: undefined,
         toolCalls: [],
       });
+    });
+
+    it('keeps masked output for Agent Builder requests while preserving replacements metadata', async () => {
+      mockEsClient.get.mockResolvedValueOnce({
+        _source: {
+          id: 'existing-replacements-id',
+          namespace: 'default',
+          replacements: [{ anonymized: 'EMAIL_token', original: 'alice@example.com' }],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          created_by: 'inference',
+        },
+      });
+      inferenceAdapter.chatComplete.mockReturnValue(of(chunkEvent('EMAIL_token')));
+
+      const response = await chatComplete({
+        connectorId: 'connectorId',
+        messages: [{ role: MessageRole.User, content: 'alice@example.com' }],
+        metadata: {
+          anonymization: {
+            replacementsId: 'existing-replacements-id',
+            keepTokenized: true,
+          },
+        },
+        maxRetries: 0,
+      });
+
+      expect(response.content).toBe('EMAIL_token');
+      expect(response.metadata?.anonymization?.replacementsId).toBe('existing-replacements-id');
     });
 
     it('implicitly retries errors when configured to', async () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
@@ -36,6 +36,7 @@ import {
   handleCancellation,
   handleLifecycleCallbacks,
   streamToResponse,
+  isNotFoundError,
 } from './utils';
 import type { InferenceCallbackManager } from '../inference_client/callback_manager';
 import { retryWithExponentialBackoff } from '../../common/utils/retry_with_exponential_backoff';
@@ -137,16 +138,16 @@ export function createChatCompleteCallbackApi({
         stream,
         namespace,
         anonymization,
-      })
-    ).pipe(
-      retryWithExponentialBackoff({
-        maxRetry: maxRetries,
-        backoffMultiplier: retryConfiguration.backoffMultiplier,
-        initialDelay: retryConfiguration.initialDelay,
-        errorFilter: getRetryFilter(retryConfiguration.retryOn),
-      }),
-      callbackManager ? handleLifecycleCallbacks({ callbackManager }) : identity,
-      abortSignal ? handleCancellation(abortSignal) : identity
+      }).pipe(
+        retryWithExponentialBackoff({
+          maxRetry: maxRetries,
+          backoffMultiplier: retryConfiguration.backoffMultiplier,
+          initialDelay: retryConfiguration.initialDelay,
+          errorFilter: getRetryFilter(retryConfiguration.retryOn),
+        }),
+        callbackManager ? handleLifecycleCallbacks({ callbackManager }) : identity,
+        abortSignal ? handleCancellation(abortSignal) : identity
+      )
     );
 
     if (stream) {
@@ -220,6 +221,12 @@ function createChatCompletePipeline({
         })
       ).pipe(
         switchMap(({ anonymization: preparedAnonymization, replacementsId, effectivePolicy }) => {
+          // RFC §7.5 / §1: consumers that own their rendering layer (e.g. Agent Builder)
+          // can opt in to keeping the LLM response tokenized so they can apply
+          // permission-gated reveal via the replacements API. When keepTokenized is true,
+          // deanonymizeMessage receives an empty anonymizations array so no substitution
+          // occurs, while replacementsId is still attached for downstream resolution.
+          const isAgentBuilderRequest = metadata?.anonymization?.keepTokenized === true;
           const systemWithAnonymizationInstructions = preparedAnonymization.system
             ? addAnonymizationInstruction(
                 preparedAnonymization.system,
@@ -255,7 +262,17 @@ function createChatCompletePipeline({
                 stream,
               }).pipe(chunksIntoMessage({ toolOptions: { toolChoice, tools }, logger }));
             }
-          ).pipe(deanonymizeMessage({ ...preparedAnonymization, replacementsId }));
+          ).pipe(
+            deanonymizeMessage(
+              isAgentBuilderRequest
+                ? {
+                    ...preparedAnonymization,
+                    anonymizations: [],
+                    replacementsId,
+                  }
+                : { ...preparedAnonymization, replacementsId }
+            )
+          );
         })
       );
     })
@@ -368,7 +385,7 @@ function resolveAndCreatePipeline({
         anonymization,
       }).pipe(
         catchError((error) => {
-          if (error?.meta?.status === 404 || error?.statusCode === 404) {
+          if (isNotFoundError(error)) {
             if (isInferenceEndpoint) {
               endpointIdCache.invalidate();
               return throwError(() => error);

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/prepare_anonymization.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/prepare_anonymization.ts
@@ -18,7 +18,9 @@ import type { EffectivePolicy } from '@kbn/anonymization-common';
 import { anonymizeMessages } from './anonymization/anonymize_messages';
 import type { RegexWorkerService } from './anonymization/regex_worker_service';
 import { ReplacementsRepository } from './anonymization/replacements/replacements_repository';
+import { ReplacementsNamespaceMismatchError } from './anonymization/replacements/replacements_errors';
 import { ensureReplacementsIndex } from './anonymization/replacements/replacements_index';
+import { isConflictError, withShardRecoveryRetry } from './utils';
 
 interface PrepareAnonymizationOptions {
   namespace: string;
@@ -92,19 +94,40 @@ export const prepareAnonymization = async ({
         400
       );
     }
-    await ensureReplacementsIndex({ esClient: replacementsClient, logger });
+    await withShardRecoveryRetry({
+      logger,
+      operation: 'ensure_replacements_index',
+      action: () => ensureReplacementsIndex({ esClient: replacementsClient, logger }),
+    });
     repo = new ReplacementsRepository(replacementsClient, {
       encryptionKey,
+      logger,
     });
   }
 
   let existingReplacements = carriedReplacementsId
-    ? await repo?.get(namespace, carriedReplacementsId)
+    ? await withShardRecoveryRetry({
+        logger,
+        operation: 'get_replacements',
+        action: async () => {
+          try {
+            return await repo?.get(namespace, carriedReplacementsId);
+          } catch (error) {
+            if (error instanceof ReplacementsNamespaceMismatchError) {
+              // The carried replacementsId belongs to a different namespace (e.g. after a space
+              // migration). Fall back to generating a fresh document rather than hard-erroring —
+              // callers that persisted an old ID before migration should not receive a 409.
+              logger.warn(
+                `[inference.anonymization.namespace_mismatch] replacements_id=${carriedReplacementsId} requested_namespace=${namespace} actual_namespace=${error.actualNamespace} — falling back to new replacements document`
+              );
+              replacementsId = uuidv4();
+              return null;
+            }
+            throw error;
+          }
+        },
+      })
     : null;
-  if (carriedReplacementsId && !existingReplacements) {
-    // Recover by allocating a new doc ID when caller carries a stale/unknown one.
-    replacementsId = uuidv4();
-  }
 
   const anonymization = await anonymizeMessages({
     system,
@@ -141,20 +164,42 @@ export const prepareAnonymization = async ({
   replacementsId ??= uuidv4();
 
   if (!repo) {
-    await ensureReplacementsIndex({ esClient: replacementsClient, logger });
+    await withShardRecoveryRetry({
+      logger,
+      operation: 'ensure_replacements_index',
+      action: () => ensureReplacementsIndex({ esClient: replacementsClient, logger }),
+    });
     repo = new ReplacementsRepository(replacementsClient, {
       encryptionKey,
+      logger,
     });
   }
 
   if (existingReplacements) {
     try {
-      const updated = await repo.update(namespace, replacementsId, { replacements });
+      if (!replacementsId) {
+        throw new Error(
+          'Invariant violation: existing replacements found without a replacementsId'
+        );
+      }
+      const replacementsIdForUpdate = replacementsId;
+      const updated = await withShardRecoveryRetry({
+        logger,
+        operation: 'update_replacements',
+        action: () => repo.update(namespace, replacementsIdForUpdate, { replacements }),
+      });
       if (!updated) {
         replacementsId = uuidv4();
         existingReplacements = null;
       }
     } catch (updateErr) {
+      if (updateErr instanceof ReplacementsNamespaceMismatchError) {
+        // The document was moved to a different namespace between the get and update.
+        // Propagate rather than silently allocating a new UUID for the wrong tenant.
+        throw updateErr;
+      }
+      // isRetryableShardRecoveryError is already handled inside withShardRecoveryRetry;
+      // if retries are exhausted the error propagates normally here.
       logger.warn(
         `Replacements update failed for ${replacementsId}, creating new document: ${
           updateErr instanceof Error ? updateErr.message : String(updateErr)
@@ -166,12 +211,41 @@ export const prepareAnonymization = async ({
   }
 
   if (!existingReplacements) {
-    await repo.create({
-      id: replacementsId,
-      namespace,
-      createdBy: 'inference',
-      replacements,
-    });
+    // replacementsId is always a string here (set by ??= above or by fallback paths),
+    // but TypeScript can't narrow let-bindings inside closures — capture as a const.
+    const replacementsIdToCreate = replacementsId as string;
+    try {
+      await withShardRecoveryRetry({
+        logger,
+        operation: 'create_replacements',
+        action: () =>
+          repo.create({
+            id: replacementsIdToCreate,
+            namespace,
+            createdBy: 'inference',
+            replacements,
+          }),
+      });
+    } catch (createErr) {
+      // Another concurrent request may have created this replacements document first.
+      if (!isConflictError(createErr)) {
+        throw createErr;
+      }
+      logger.warn(
+        `[inference.anonymization.create_conflict_fallback] replacements_id=${replacementsIdToCreate} namespace=${namespace} triggered=true`
+      );
+      const updatedAfterConflict = await withShardRecoveryRetry({
+        logger,
+        operation: 'update_replacements_after_conflict',
+        action: () => repo.update(namespace, replacementsIdToCreate, { replacements }),
+      });
+      if (!updatedAfterConflict) {
+        throw createInferenceRequestError(
+          `Unable to persist replacements after create conflict for replacementsId "${replacementsIdToCreate}"`,
+          409
+        );
+      }
+    }
   }
 
   return { anonymization, replacementsId, effectivePolicy };

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/prepare_anonymization.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/prepare_anonymization.ts
@@ -118,7 +118,7 @@ export const prepareAnonymization = async ({
               // migration). Fall back to generating a fresh document rather than hard-erroring —
               // callers that persisted an old ID before migration should not receive a 409.
               logger.warn(
-                `[inference.anonymization.namespace_mismatch] replacements_id=${carriedReplacementsId} requested_namespace=${namespace} actual_namespace=${error.actualNamespace} — falling back to new replacements document`
+                `[inference.anonymization.namespace_mismatch] replacements_id=${carriedReplacementsId} requested_namespace=${namespace} actual_namespace=${error.meta.actualNamespace} — falling back to new replacements document`
               );
               replacementsId = uuidv4();
               return null;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/es_error_utils.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/es_error_utils.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isConflictError, isNotFoundError } from './es_error_utils';
+
+describe('isConflictError', () => {
+  it('returns true when top-level statusCode is 409', () => {
+    expect(isConflictError({ statusCode: 409 })).toBe(true);
+  });
+
+  it('returns true when meta statusCode is 409', () => {
+    expect(isConflictError({ meta: { statusCode: 409 } })).toBe(true);
+  });
+
+  it('returns false when status codes are not 409', () => {
+    expect(isConflictError({ statusCode: 400, meta: { statusCode: 500 } })).toBe(false);
+  });
+
+  it('returns false for unknown error shapes', () => {
+    expect(isConflictError(new Error('boom'))).toBe(false);
+    expect(isConflictError(undefined)).toBe(false);
+    expect(isConflictError(null)).toBe(false);
+  });
+});
+
+describe('isNotFoundError', () => {
+  it('returns true when top-level statusCode is 404', () => {
+    expect(isNotFoundError({ statusCode: 404 })).toBe(true);
+  });
+
+  it('returns true when meta statusCode is 404', () => {
+    expect(isNotFoundError({ meta: { statusCode: 404 } })).toBe(true);
+  });
+
+  it('returns true when meta status is 404', () => {
+    expect(isNotFoundError({ meta: { status: 404 } })).toBe(true);
+  });
+
+  it('returns false when status codes are not 404', () => {
+    expect(isNotFoundError({ statusCode: 400, meta: { statusCode: 500 } })).toBe(false);
+  });
+
+  it('returns false for unknown error shapes', () => {
+    expect(isNotFoundError(new Error('boom'))).toBe(false);
+    expect(isNotFoundError(undefined)).toBe(false);
+    expect(isNotFoundError(null)).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/es_error_utils.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/es_error_utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface EsErrorStatusShape {
+  statusCode?: number;
+  meta?: {
+    statusCode?: number;
+    status?: number;
+  };
+}
+
+const getStatusCodes = (
+  error: unknown
+): [number | undefined, number | undefined, number | undefined] => {
+  const errorData = error as EsErrorStatusShape;
+  return [errorData?.statusCode, errorData?.meta?.statusCode, errorData?.meta?.status];
+};
+
+export const isConflictError = (error: unknown): boolean => {
+  const [statusCode, metaStatusCode] = getStatusCodes(error);
+  return statusCode === 409 || metaStatusCode === 409;
+};
+
+export const isNotFoundError = (error: unknown): boolean => {
+  const [statusCode, metaStatusCode, metaStatus] = getStatusCodes(error);
+  return statusCode === 404 || metaStatusCode === 404 || metaStatus === 404;
+};

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/index.ts
@@ -28,3 +28,5 @@ export {
   handleConnectorDataResponse,
 } from './handle_connector_response';
 export { handleLifecycleCallbacks } from './handle_lifecycle_callbacks';
+export { isRetryableShardRecoveryError, withShardRecoveryRetry } from './retry_shard_recovery';
+export { isConflictError, isNotFoundError } from './es_error_utils';

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/retry_shard_recovery.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/retry_shard_recovery.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { isRetryableShardRecoveryError, withShardRecoveryRetry } from './retry_shard_recovery';
+
+describe('isRetryableShardRecoveryError', () => {
+  it('returns true for 503 status code', () => {
+    expect(isRetryableShardRecoveryError({ statusCode: 503 })).toBe(true);
+  });
+
+  it('returns true for no_shard_available_action_exception message', () => {
+    expect(
+      isRetryableShardRecoveryError(
+        new Error('no_shard_available_action_exception: shard unavailable')
+      )
+    ).toBe(true);
+  });
+
+  it('returns true for recovering illegal shard state error', () => {
+    expect(
+      isRetryableShardRecoveryError({
+        meta: {
+          body: {
+            error: {
+              type: 'illegal_index_shard_state_exception',
+              reason:
+                'CurrentState[RECOVERING] operations only allowed when shard state is one of [POST_RECOVERY, STARTED]',
+            },
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for non-retryable error', () => {
+    expect(isRetryableShardRecoveryError({ statusCode: 400 })).toBe(false);
+  });
+});
+
+describe('withShardRecoveryRetry', () => {
+  it('retries shard-recovery errors and succeeds', async () => {
+    const logger = loggerMock.create();
+    const action = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(new Error('no_shard_available_action_exception'))
+      .mockResolvedValue('ok');
+
+    const result = await withShardRecoveryRetry({
+      logger,
+      operation: 'test-operation',
+      action,
+      maxRetries: 3,
+      initialDelayMs: 0,
+    });
+
+    expect(result).toBe('ok');
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const logger = loggerMock.create();
+    const action = jest.fn<Promise<string>, []>().mockRejectedValue(new Error('bad_request'));
+
+    await expect(
+      withShardRecoveryRetry({
+        logger,
+        operation: 'test-operation',
+        action,
+        maxRetries: 3,
+        initialDelayMs: 0,
+      })
+    ).rejects.toThrow('bad_request');
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledTimes(0);
+  });
+
+  it('stops retrying when max retries is reached', async () => {
+    const logger = loggerMock.create();
+    const action = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValue(new Error('no_shard_available_action_exception'));
+
+    await expect(
+      withShardRecoveryRetry({
+        logger,
+        operation: 'test-operation',
+        action,
+        maxRetries: 2,
+        initialDelayMs: 0,
+      })
+    ).rejects.toThrow('no_shard_available_action_exception');
+
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[inference.anonymization.retry_exhausted] operation=test-operation attempts=2 reason=shard_recovering'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/retry_shard_recovery.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/retry_shard_recovery.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+
+// This retry budget is intentionally short for interactive UX; it is not
+// intended to wait for full shard recovery after cluster restarts.
+const DEFAULT_SHARD_RECOVERY_MAX_RETRIES = 3;
+const DEFAULT_SHARD_RECOVERY_INITIAL_DELAY_MS = 200;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface ShardRecoveryErrorShape {
+  statusCode?: number;
+  type?: string;
+  meta?: {
+    statusCode?: number;
+    body?: {
+      error?: {
+        type?: string;
+        reason?: string;
+      };
+    };
+  };
+}
+
+export const isRetryableShardRecoveryError = (error: unknown): boolean => {
+  const errorData = error as ShardRecoveryErrorShape;
+  const statusCode = errorData?.statusCode;
+  const metaStatusCode = errorData?.meta?.statusCode;
+  const topLevelType = errorData?.type;
+  const bodyType = errorData?.meta?.body?.error?.type;
+  const bodyReason = errorData?.meta?.body?.error?.reason;
+  const message = error instanceof Error ? error.message : String(error);
+
+  const hasRecoveringReason = `${bodyReason ?? ''} ${message}`.includes('CurrentState[RECOVERING]');
+  const isNoShardAvailable =
+    topLevelType === 'no_shard_available_action_exception' ||
+    bodyType === 'no_shard_available_action_exception' ||
+    message.includes('no_shard_available_action_exception');
+  const isIllegalShardState =
+    bodyType === 'illegal_index_shard_state_exception' ||
+    topLevelType === 'illegal_index_shard_state_exception';
+
+  return (
+    statusCode === 503 ||
+    metaStatusCode === 503 ||
+    isNoShardAvailable ||
+    (isIllegalShardState && hasRecoveringReason)
+  );
+};
+
+export const withShardRecoveryRetry = async <T>({
+  logger,
+  operation,
+  action,
+  maxRetries = DEFAULT_SHARD_RECOVERY_MAX_RETRIES,
+  initialDelayMs = DEFAULT_SHARD_RECOVERY_INITIAL_DELAY_MS,
+}: {
+  logger: Logger;
+  operation: string;
+  action: () => Promise<T>;
+  maxRetries?: number;
+  initialDelayMs?: number;
+}): Promise<T> => {
+  let delayMs = initialDelayMs;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await action();
+    } catch (error) {
+      const shouldRetry = isRetryableShardRecoveryError(error) && attempt < maxRetries;
+      if (!shouldRetry) {
+        if (isRetryableShardRecoveryError(error)) {
+          logger.warn(
+            `[inference.anonymization.retry_exhausted] operation=${operation} attempts=${attempt} reason=shard_recovering`
+          );
+        }
+        throw error;
+      }
+      logger.debug(
+        `[inference.anonymization.retry] operation=${operation} attempt=${attempt} reason=shard_recovering`
+      );
+      await sleep(delayMs);
+      delayMs *= 2;
+    }
+  }
+};

--- a/x-pack/platform/plugins/shared/inference/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/inference/server/mocks.ts
@@ -9,6 +9,8 @@ import type { InferenceServerStart } from './types';
 
 const createStartContractMock = (): jest.Mocked<InferenceServerStart> => {
   return {
+    isAnonymizationEnabled: jest.fn().mockReturnValue(false),
+    deanonymizeText: jest.fn().mockResolvedValue(''),
     getClient: jest.fn(),
     getChatModel: jest.fn(),
     getConnectorList: jest.fn(),

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -17,8 +17,11 @@ import type {
 import { aiAnonymizationSettings } from '@kbn/inference-common';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
+import { replaceTokensWithOriginals } from '@kbn/anonymization-common';
 import { createClient as createInferenceClient, createChatModel } from './inference_client';
 import { RegexWorkerService } from './chat_complete/anonymization/regex_worker_service';
+import { ReplacementsRepository } from './chat_complete/anonymization/replacements/replacements_repository';
+import { ReplacementsNamespaceMismatchError } from './chat_complete/anonymization/replacements/replacements_errors';
 import { registerRoutes } from './routes';
 import type { InferenceConfig } from './config';
 import type {
@@ -98,6 +101,7 @@ export class InferencePlugin
     this.config = context.config.get<InferenceConfig>();
     this.endpointIdCache = new InferenceEndpointIdCache();
   }
+
   setup(
     coreSetup: CoreSetup<InferenceStartDependencies, InferenceServerStart>,
     pluginsSetup: InferenceSetupDependencies
@@ -212,6 +216,42 @@ export class InferencePlugin
     };
 
     return {
+      isAnonymizationEnabled: () => anonymizationEnabled,
+
+      deanonymizeText: async (namespace: string, replacementsId: string, text: string) => {
+        if (!anonymizationEnabled) {
+          return text;
+        }
+        try {
+          const policyService = pluginsStart.anonymization?.getPolicyService();
+          const encryptionKey = await resolveReplacementsEncryptionKey({
+            namespace,
+            anonymizationEnabled,
+            policyService,
+          });
+          const repo = new ReplacementsRepository(core.elasticsearch.client.asInternalUser, {
+            encryptionKey,
+          });
+          const replacementsSet = await repo.get(namespace, replacementsId);
+          if (!replacementsSet) {
+            return text;
+          }
+          const tokenToOriginal = repo.toTokenToOriginalMap(replacementsSet);
+          return replaceTokensWithOriginals(text, tokenToOriginal);
+        } catch (err) {
+          if (err instanceof ReplacementsNamespaceMismatchError) {
+            // Never silently swallow cross-namespace reads — propagate so callers can guard.
+            throw err;
+          }
+          this.logger.warn(
+            `[inference.deanonymizeText] Failed to deanonymize text for replacementsId=${replacementsId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+          return text;
+        }
+      },
+
       getClient: <T extends InferenceClientCreateOptions>(options: T) => {
         return createInferenceClient({
           ...options,

--- a/x-pack/platform/plugins/shared/inference/server/routes/anonymization_enabled.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/anonymization_enabled.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, IRouter, RequestHandlerContext } from '@kbn/core/server';
+import type { GetAnonymizationEnabledResponseBody } from '../../common/http_apis';
+import type { InferenceServerStart, InferenceStartDependencies } from '../types';
+
+export function registerAnonymizationEnabledRoute({
+  coreSetup,
+  router,
+}: {
+  coreSetup: CoreSetup<InferenceStartDependencies, InferenceServerStart>;
+  router: IRouter<RequestHandlerContext>;
+}) {
+  router.get(
+    {
+      path: '/internal/inference/anonymization_enabled',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: {},
+    },
+    async (_context, _request, response) => {
+      const [, pluginsStart] = await coreSetup.getStartServices();
+      // Informational UI state only. Security boundaries for deanonymization are
+      // enforced server-side by replacements API privileges.
+      const body: GetAnonymizationEnabledResponseBody = {
+        anonymizationEnabled: pluginsStart.anonymization?.isEnabled() ?? false,
+      };
+      return response.ok({ body });
+    }
+  );
+}

--- a/x-pack/platform/plugins/shared/inference/server/routes/connectors.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/connectors.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CoreSetup, IRouter, Logger, RequestHandlerContext } from '@kbn/core/server';
+import type { GetConnectorsResponseBody } from '../../common/http_apis';
 import { getConnectorList } from '../util/get_connector_list';
 import type { InferenceServerStart, InferenceStartDependencies } from '../types';
 
@@ -34,7 +35,15 @@ export function registerConnectorsRoute({
       const actions = pluginsStart.actions;
       const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
       const connectors = await getConnectorList({ actions, request, esClient, logger });
-      return response.ok({ body: { connectors } });
+
+      // `anonymizationEnabled` is informational UI state for Agent Builder access checks.
+      // It must not be treated as a security boundary. Deanonymization is enforced
+      // server-side by replacements API privileges (`read_anonymization`).
+      const body: GetConnectorsResponseBody = {
+        connectors,
+        anonymizationEnabled: pluginsStart.anonymization?.isEnabled() ?? false,
+      };
+      return response.ok({ body });
     }
   );
 }

--- a/x-pack/platform/plugins/shared/inference/server/routes/connectors.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/connectors.ts
@@ -36,13 +36,7 @@ export function registerConnectorsRoute({
       const esClient = coreStart.elasticsearch.client.asScoped(request).asCurrentUser;
       const connectors = await getConnectorList({ actions, request, esClient, logger });
 
-      // `anonymizationEnabled` is informational UI state for Agent Builder access checks.
-      // It must not be treated as a security boundary. Deanonymization is enforced
-      // server-side by replacements API privileges (`read_anonymization`).
-      const body: GetConnectorsResponseBody = {
-        connectors,
-        anonymizationEnabled: pluginsStart.anonymization?.isEnabled() ?? false,
-      };
+      const body: GetConnectorsResponseBody = { connectors };
       return response.ok({ body });
     }
   );

--- a/x-pack/platform/plugins/shared/inference/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/routes/index.ts
@@ -10,6 +10,7 @@ import type { CoreSetup, IRouter } from '@kbn/core/server';
 import type { InferenceServerStart, InferenceStartDependencies } from '../types';
 import { registerChatCompleteRoute } from './chat_complete';
 import { registerConnectorsRoute } from './connectors';
+import { registerAnonymizationEnabledRoute } from './anonymization_enabled';
 import { registerPromptRoute } from './prompt';
 import { registerReplacementsRoutes } from '../chat_complete/anonymization/replacements/replacements_routes';
 import { registerEndpointsRoute } from './endpoints';
@@ -26,6 +27,7 @@ export const registerRoutes = ({
   registerChatCompleteRoute({ router, coreSetup, logger: logger.get('chatComplete') });
   registerPromptRoute({ router, coreSetup, logger: logger.get('prompt') });
   registerConnectorsRoute({ router, coreSetup, logger: logger.get('connectors') });
+  registerAnonymizationEnabledRoute({ router, coreSetup });
   registerReplacementsRoutes(router, logger.get('replacements'), {
     coreSetup,
   });

--- a/x-pack/platform/plugins/shared/inference/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/types.ts
@@ -78,6 +78,11 @@ export type InferenceClientCreateOptions =
  */
 export interface InferenceServerStart {
   /**
+   * Returns whether anonymization platform integration is active.
+   */
+  isAnonymizationEnabled: () => boolean;
+
+  /**
    * Creates an {@link InferenceClient}, scoped to a request.
    *
    * @example
@@ -153,6 +158,28 @@ export interface InferenceServerStart {
    * @throws Error if the connector with the specified ID does not exist
    */
   getConnectorById: (id: string, request: KibanaRequest) => Promise<InferenceConnector>;
+
+  /**
+   * Deanonymizes a text string by replacing anonymization tokens with their original values
+   * using the replacements document identified by the given namespace and replacementsId.
+   * Returns the original text unchanged if anonymization is disabled or the replacements
+   * document is not found.
+   *
+   * @param namespace - The space namespace the replacements document belongs to
+   * @param replacementsId - The ID of the replacements document
+   * @param text - The text containing anonymization tokens to replace
+   *
+   * SECURITY: `namespace` MUST be derived from the request-scoped SO client
+   * (`getScopedClient(request).getCurrentNamespace() ?? 'default'`), never from
+   * user-controlled input. This function uses elevated (internal) ES privileges;
+   * all tenant isolation relies on the namespace matching the document's stored namespace.
+   * A `ReplacementsNamespaceMismatchError` is thrown when the namespace does not match,
+   * to prevent cross-space reads. Unlike transient errors (which are logged and return the
+   * original text), this error propagates to the caller. Callers must not swallow it in a
+   * way that returns wrong-namespace decrypted content; falling back to a safe default
+   * (e.g. an existing title, or the original tokenized text) is acceptable.
+   */
+  deanonymizeText: (namespace: string, replacementsId: string, text: string) => Promise<string>;
 
   /**
    * Lists available Elasticsearch inference endpoints, optionally filtered by task type.

--- a/x-pack/platform/plugins/shared/inference/tsconfig.json
+++ b/x-pack/platform/plugins/shared/inference/tsconfig.json
@@ -46,5 +46,6 @@
     "@kbn/es-errors",
     "@kbn/anonymization-plugin",
     "@kbn/anonymization-common",
+    "@kbn/sse-utils",
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
@@ -52,7 +52,10 @@ describe('useGenAIConnectors', () => {
   });
 
   it('should fetch connectors and set hasConnectors to true when connectors exist', async () => {
-    mockGetConnectors.mockResolvedValue(mockConnectors);
+    mockGetConnectors.mockResolvedValue({
+      connectors: mockConnectors,
+      anonymizationEnabled: false,
+    });
     const { result, unmount } = renderHook(() => useGenAIConnectors());
 
     await waitFor(() => {
@@ -66,7 +69,7 @@ describe('useGenAIConnectors', () => {
   });
 
   it('should set hasConnectors to false when no connectors exist', async () => {
-    mockGetConnectors.mockResolvedValue([]);
+    mockGetConnectors.mockResolvedValue({ connectors: [], anonymizationEnabled: false });
     const { result, unmount } = renderHook(() => useGenAIConnectors());
 
     await waitFor(() => {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.test.ts
@@ -52,10 +52,7 @@ describe('useGenAIConnectors', () => {
   });
 
   it('should fetch connectors and set hasConnectors to true when connectors exist', async () => {
-    mockGetConnectors.mockResolvedValue({
-      connectors: mockConnectors,
-      anonymizationEnabled: false,
-    });
+    mockGetConnectors.mockResolvedValue(mockConnectors);
     const { result, unmount } = renderHook(() => useGenAIConnectors());
 
     await waitFor(() => {
@@ -69,7 +66,7 @@ describe('useGenAIConnectors', () => {
   });
 
   it('should set hasConnectors to false when no connectors exist', async () => {
-    mockGetConnectors.mockResolvedValue({ connectors: [], anonymizationEnabled: false });
+    mockGetConnectors.mockResolvedValue([]);
     const { result, unmount } = renderHook(() => useGenAIConnectors());
 
     await waitFor(() => {

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
@@ -23,12 +23,15 @@ export function useGenAIConnectors(): UseGenAIConnectorsResult {
     services: { inference },
   } = useKibana();
 
-  const { value: connectors = [], loading } = useAsync(async () => {
+  const { value: result, loading } = useAsync(async () => {
     if (!inference) {
-      return [];
+      const connectors: InferenceConnector[] = [];
+      return { connectors, anonymizationEnabled: false };
     }
     return inference.getConnectors();
   }, [inference]);
+
+  const connectors = result?.connectors ?? [];
 
   return {
     connectors,

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/hooks/use_genai_connectors.ts
@@ -23,15 +23,12 @@ export function useGenAIConnectors(): UseGenAIConnectorsResult {
     services: { inference },
   } = useKibana();
 
-  const { value: result, loading } = useAsync(async () => {
+  const { value: connectors = [], loading } = useAsync(async () => {
     if (!inference) {
-      const connectors: InferenceConnector[] = [];
-      return { connectors, anonymizationEnabled: false };
+      return [];
     }
     return inference.getConnectors();
   }, [inference]);
-
-  const connectors = result?.connectors ?? [];
 
   return {
     connectors,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/ai_rule_creation/hooks/use_inference_connectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/ai_rule_creation/hooks/use_inference_connectors.ts
@@ -38,7 +38,7 @@ export const useInferenceConnectors = () => {
   const { inference } = useKibana().services;
   const { addError } = useAppToasts();
 
-  const { data: inferenceConnectors, isLoading } = useQuery({
+  const { data: inferenceConnectorsResult, isLoading } = useQuery({
     queryKey: ['security-detection-engine-ai-rule-creation-inference-connectors'],
     queryFn: () => inference.getConnectors(),
     retry: 1,
@@ -50,11 +50,11 @@ export const useInferenceConnectors = () => {
   });
 
   const aiConnectors: ActionConnector[] = useMemo(() => {
-    if (!inferenceConnectors) {
+    if (!inferenceConnectorsResult) {
       return [];
     }
-    return inferenceConnectors.map(inferenceConnectorToActionConnector);
-  }, [inferenceConnectors]);
+    return inferenceConnectorsResult.connectors.map(inferenceConnectorToActionConnector);
+  }, [inferenceConnectorsResult]);
 
   return {
     aiConnectors,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/ai_rule_creation/hooks/use_inference_connectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/ai_rule_creation/hooks/use_inference_connectors.ts
@@ -38,7 +38,7 @@ export const useInferenceConnectors = () => {
   const { inference } = useKibana().services;
   const { addError } = useAppToasts();
 
-  const { data: inferenceConnectorsResult, isLoading } = useQuery({
+  const { data: inferenceConnectors, isLoading } = useQuery({
     queryKey: ['security-detection-engine-ai-rule-creation-inference-connectors'],
     queryFn: () => inference.getConnectors(),
     retry: 1,
@@ -50,11 +50,11 @@ export const useInferenceConnectors = () => {
   });
 
   const aiConnectors: ActionConnector[] = useMemo(() => {
-    if (!inferenceConnectorsResult) {
+    if (!inferenceConnectors) {
       return [];
     }
-    return inferenceConnectorsResult.connectors.map(inferenceConnectorToActionConnector);
-  }, [inferenceConnectorsResult]);
+    return inferenceConnectors.map(inferenceConnectorToActionConnector);
+  }, [inferenceConnectors]);
 
   return {
     aiConnectors,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_inference_connectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_inference_connectors.ts
@@ -20,7 +20,7 @@ const QUERY_KEY = ['entity-analytics', 'load-inference-connectors'];
 export function useLoadInferenceConnectors(): UseQueryResult<UseInferenceConnectorsResult> {
   const { inference } = useKibana().services;
   return useQuery(QUERY_KEY, async () => {
-    const connectors = await inference.getConnectors();
+    const { connectors } = await inference.getConnectors();
     return {
       connectors,
       hasConnectors: connectors.length > 0,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_inference_connectors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/hooks/use_inference_connectors.ts
@@ -20,7 +20,7 @@ const QUERY_KEY = ['entity-analytics', 'load-inference-connectors'];
 export function useLoadInferenceConnectors(): UseQueryResult<UseInferenceConnectorsResult> {
   const { inference } = useKibana().services;
   return useQuery(QUERY_KEY, async () => {
-    const { connectors } = await inference.getConnectors();
+    const connectors = await inference.getConnectors();
     return {
       connectors,
       hasConnectors: connectors.length > 0,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
@@ -65,6 +65,8 @@ const setupAgent = (responses: NodeResponse[]) => {
       getConnectorById: jest.fn(),
       getInferenceEndpoints: jest.fn(),
       getInferenceEndpointById: jest.fn(),
+      isAnonymizationEnabled: jest.fn().mockReturnValue(false),
+      deanonymizeText: jest.fn(),
       ...model,
     },
     request: httpServerMock.createKibanaRequest(),


### PR DESCRIPTION
# Summary

Continues the work on the inference plugin's anonymization infrastructure and exposes two new APIs on `InferenceServerStart` (`isAnonymizationEnabled` and `deanonymizeText`). This is the foundational layer for the Agent Builder anonymization pipeline (phase 3a); the Agent Builder and Security Solution changes ship in follow-up PRs that depend on this one.

Part of:
- https://github.com/elastic/security-team/issues/16273 

(broken out of the larger https://github.com/elastic/kibana/pull/257419 to make it easier to review)

Follow up PR for the remaining changes that will be merged after this one: 

- https://github.com/elastic/kibana/pull/257950
- https://github.com/elastic/kibana/pull/257951

---

**Inference platform - replacements persistence**

- Wraps all replacements repository operations (ensure-index, get, create, update) with `withShardRecoveryRetry` - bounded exponential backoff for transient shard-recovery errors (`no_shard_available_action_exception`, `illegal_index_shard_state_exception[RECOVERING]`) that surface during dev/startup windows. Non-retryable errors still fail fast; retry exhaustion emits an explicit `retry_exhausted` log event.
- Extracts es_error_utils (`isConflictError`, `isNotFoundError`) and `retry_shard_recovery` as standalone tested utilities.
- Adds namespace-mismatch detection in `ReplacementsRepository.ge`t - carried IDs that resolve to a different namespace hard-fail with `ReplacementsNamespaceMismatchError` and a 404 upstream response, preventing cross-space data reads.
- Makes the concurrent-create path explicit: a 409 conflict on create falls back to an update; if the update also returns no result the request fails explicitly rather than silently.
- Propagates errors from `getReplacementsEncryptionKey` instead of swallowing them - a transient failure now surfaces as a 5xx rather than a misleading 400 "not configured" response.
- Changes the "encryption key not configured" status code from 400 to 503.

**Inference platform - new InferenceServerStart APIs**

Adds two methods to the server start contract:

- `isAnonymizationEnabled()` - returns whether the anonymization platform integration is active. Used by consumers (e.g. Agent Builder) to gate anonymization flows without a dedicated feature-endpoint round-trip.
- `deanonymizeText(namespace, replacementsId, text)` - server-side deanonymization for text that is not part of the response stream (e.g. conversation titles generated in a separate model invocation). Returns the original text unchanged when anonymization is disabled or the replacements document is not found. Propagates `ReplacementsNamespaceMismatchError` to callers so they can fall back safely without leaking cross-space content.

**Inference-common - metadata extensions**

- Adds `keepTokenized?: boolean` to `ChatCompleteAnonymizationMetadata`. When true, inference suppresses server-side deanonymization so the LLM response is stored with tokens intact and the UI resolves originals on demand via the replacements API ([RFC](https://docs.google.com/document/d/10ZlcUZhrnxpWc6NDgv1YIXIUxc6AtNVhTpto_yQl9PU/edit?tab=t.hw4nla3wvw7h#heading=h.56qq4m6loqaw) §7.5).
- Exports `isChatCompleteAnonymizationTargetType` type guard.

Inference-langchain - anonymization metadata propagation

- Adds `anonymization?: ChatCompleteAnonymizationMetadata` to `InferenceChatModelParams` and call options, and a `withAnonymization()` factory method so metadata flows safely through `withStructuredOutput` chains without needing to be passed at invoke time.
- Propagates `replacementsId` from inference metadata into `additional_kwargs` of `AIMessageChunk` / `AIMessage` so LangGraph nodes can read it back.
- Deduplicates anonymization metadata across streamed chunks - emits it only on the first chunk that carries it to avoid repeated entries in the merged AIMessage.

getConnectors return shape change + adapters

Changes `InferencePublicStart.getConnectors()` to return `{ connectors: InferenceConnector[]; anonymizationEnabled: boolean }` instead of `InferenceConnector[]` directly. The anonymizationEnabled field piggybacks on the connectors response that consumers already fetch during access initialisation - no new round-trip.

All four callers are updated in this PR:
- agent_builder - AgentBuilderAccessChecker now also exposes hasAnonymizationEnabled on the AgentBuilderAccess contract.
- observability_agent_builder - useGenAIConnectors destructures connectors from the result.
- security_solution (×2) - useInferenceConnectors and useLoadInferenceConnectors destructure connectors from the result.

---

**Feature flag**

All new inference behavior is controlled by `xpack.anonymization.active` (via `pluginsStart.anonymization?.isEnabled() ?? false`). When the anonymization plugin is absent or disabled:

- isAnonymizationEnabled() returns false
- deanonymizeText() returns the input text unchanged
- usePersistentReplacements is false - replacements are transient only (existing behavior)
- requireEncryptionKey is false
- Salt and effective-policy resolution are skipped
- Anonymization rules fall back to legacy uiSettings-based rules (existing behavior)

---

## Test plan

### Environment setup

- Start ES + Kibana.
- Enable anonymization in Kibana config/flags:
  - `xpack.anonymization.active: true`
  - `xpack.genAiSettings.showAnonymizationProfileSettings: true`
- Restart Kibana after config changes.

---

### 1) Baseline and adapters
                                              
Verify connectors API shape (unchanged from main):                                                                                                                                                                  
```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  'http://localhost:5601/internal/inference/connectors'
 ```   
 
Expect:  `{ "connectors": [...] }`
         
Verify the new anonymization status endpoint: 

```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  'http://localhost:5601/internal/inference/anonymization_enabled'
```
Expect { "anonymizationEnabled": true } when xpack.anonymization.active: true, { "anonymizationEnabled": false } otherwise.                                                                                         
                                                                                                                                                                                                                      
- Verify Agent Builder / Security Solution / Observability connector UIs still load and list connectors.                                                                                                              
- Verify Agent Builder access initialisation correctly reflects anonymization state (e.g. anonymization-gated UI elements show/hide based on the flag).    

---

### 2) Configure IPv4 regex rule correctly

> Important: in JSON payload use `\\b...\\b` (not `\b`, and not over-escaped `\\\\b`).

1. Find global profile:

```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  'http://localhost:5601/internal/anonymization/profiles/_find?target_type=index&target_id=__kbn_global_anonymization_profile__'

```

2. Update profile:

Grab the profile ID from the previous step and replace `<PROFILE_ID>` below, then run:

```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  -H 'Content-Type: application/json' \
  -X PUT "http://localhost:5601/internal/anonymization/profiles/<PROFILE_ID>" \
  -d '{
    "rules": {
      "fieldRules": [],
      "regexRules": [
        {
          "id": "ipv4-rule",
          "type": "regex",
          "entityClass": "IP",
          "pattern": "\\b\\d{1,3}(?:\\.\\d{1,3}){3}\\b",
          "enabled": true
        }
      ],
      "nerRules": []
    }
  }'
```

---

### 3) Replacements persistence

1. Send chat_complete through Kibana API (not ES API):

```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  -H 'Content-Type: application/json' \
  -X POST 'http://localhost:5601/internal/inference/chat_complete' \
  -d '{
    "connectorId": "gpt-4-1",
    "messages": [
      { "role": "user", "content": "this is my ip 10.20.30.40 repeat it back to me" }
    ]
  }'
```

2. Capture `metadata.anonymization.replacementsId` as `<RID>`.

3. Verify document exists:

```
   curl -sS -u elastic:changeme \
     "http://localhost:9200/.kibana-anonymization-replacements/_doc/<RID>" | jq .
```

4. Expect `"found": true`.

---

### 4) Shard-recovery resilience (step 3.3)

1. Keep Kibana running, restart ES.

2. Immediately retry `chat_complete` (every 2-5s if needed), optionally passing `<RID>`:

```
curl -u elastic:changeme \
  -H 'kbn-xsrf: true' \
  -H 'elastic-api-version: 1' \
  -H 'x-elastic-internal-origin: kibana' \
  -H 'Content-Type: application/json' \
  -X POST 'http://localhost:5601/internal/inference/chat_complete' \
  -d '{
    "connectorId": "gpt-4-1",
    "messages": [
      { "role": "user", "content": "this is my ip 10.20.30.40 repeat it back to me again" }
    ],
    "metadata": {
      "anonymization": {
        "replacementsId": "<RID>"
      }
    }
  }'
```

3. Pass criteria:

 - Request succeeds during/after recovery.
 - No `no_shard_available_action_exception` returned by inference API.

4. Verify replacements doc still readable:
```
curl -sS -u elastic:changeme \
  "http://localhost:9200/.kibana-anonymization-replacements/_doc/<RID>?expand_wildcards=all&ignore_unavailable=true" | jq .
```

---

### 5) Token reuse

1. Use a replacements doc with non-empty `replacements`.
2. Send follow-up with same repeated value + same `<RID>`.
3. Verify same token (`IP_...`) is reused.

---

### 6) Namespace safety

1. Create replacements in Space A.
2. From Space B, attempt to resolve/deanonymize Space A `replacementsId`.
3. Expect 404 (no cross-space disclosure).

---

### 7) Start contract checks

- `isAnonymizationEnabled()`
  - `false` when feature flag off
  - `true` when on
- `deanonymizeText(namespace, replacementsId, text)`
  - valid id -> deanonymized output
  - missing id -> original text unchanged
  - wrong namespace -> throws `ReplacementsNamespaceMismatchError`

---

### Notes / expected behavior for this PR

- This PR is inference-layer foundation.
- Agent Builder UI may still display deanonymized content unless follow-up PR wiring (`keepTokenized` consumer behavior)
 is present.
- For this PR, inference API behavior is the source of truth.
