### PR TITLE
fix: Update CI tests for disabled-by-default alerting_v2 plugin

### DIFF
--- a/.buildkite/ftr_base_serverless_configs.yml
+++ b/.buildkite/ftr_base_serverless_configs.yml
@@ -12,6 +12,7 @@ disabled:
 enabled:
   # Serverless deployment-agnostic configs to run platform api-integration tests
   - x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.serverless.config.ts
+  - x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.alerting_v2.serverless.config.ts
   - x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/search.serverless.config.ts
   - x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/security.serverless.config.ts
   - x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.logs_essentials.serverless.config.ts

--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -434,3 +434,4 @@ enabled:
   - x-pack/platform/test/saved_object_api_integration/user_profiles/config.ts
     # stateful config files that run deployment-agnostic tests
   - x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.stateful.config.ts
+  - x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.alerting_v2.stateful.config.ts

--- a/src/core/server/integration_tests/saved_objects/registration/type_registrations.test.ts
+++ b/src/core/server/integration_tests/saved_objects/registration/type_registrations.test.ts
@@ -16,7 +16,6 @@ const previouslyRegisteredTypes = [
   'action_task_params',
   'ad_hoc_run_params',
   'alert',
-  'alerting_rule',
   'alerting_rule_template',
   'api_key_pending_invalidation',
   'api_key_to_invalidate',
@@ -189,7 +188,6 @@ const previouslyRegisteredTypes = [
   'workplace_search_telemetry',
   'gap_auto_fill_scheduler',
   'trial-companion-nba-milestone',
-  'alerting_notification_policy',
 ].sort();
 
 describe('SO type registrations', () => {

--- a/x-pack/platform/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/platform/test/api_integration/apis/features/features/features.ts
@@ -148,8 +148,6 @@ export default function ({ getService }: FtrProviderContext) {
             'fleet',
             'fleetv2',
             'cloudConnect',
-            'alerting_v2_alerts',
-            'alerting_v2_rules',
           ].sort()
         );
       });

--- a/x-pack/platform/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration/apis/security/privileges.ts
@@ -356,8 +356,6 @@ export default function ({ getService }: FtrProviderContext) {
       dataQuality: ['all', 'read', 'minimal_all', 'minimal_read', 'manage_rules', 'manage_alerts'],
       manageReporting: ['all', 'read', 'minimal_all', 'minimal_read'],
       apm: ['all', 'read', 'minimal_all', 'minimal_read', 'settings_save'],
-      alerting_v2_alerts: ['all', 'read', 'minimal_all', 'minimal_read'],
-      alerting_v2_rules: ['all', 'read', 'minimal_all', 'minimal_read'],
       discover: [
         'all',
         'read',

--- a/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
+++ b/x-pack/platform/test/api_integration_basic/apis/security/privileges.ts
@@ -88,8 +88,6 @@ export default function ({ getService }: FtrProviderContext) {
             streams: ['all', 'read', 'minimal_all', 'minimal_read'],
             dataQuality: ['all', 'read', 'minimal_all', 'minimal_read'],
             manageReporting: ['all', 'read', 'minimal_all', 'minimal_read'],
-            alerting_v2_alerts: ['all', 'read', 'minimal_all', 'minimal_read'],
-            alerting_v2_rules: ['all', 'read', 'minimal_all', 'minimal_read'],
           },
           global: ['all', 'read'],
           space: ['all', 'read'],
@@ -481,8 +479,6 @@ export default function ({ getService }: FtrProviderContext) {
             ],
             manageReporting: ['all', 'read', 'minimal_all', 'minimal_read'],
             apm: ['all', 'read', 'minimal_all', 'minimal_read', 'settings_save'],
-            alerting_v2_alerts: ['all', 'read', 'minimal_all', 'minimal_read'],
-            alerting_v2_rules: ['all', 'read', 'minimal_all', 'minimal_read'],
             discover: [
               'all',
               'read',

--- a/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.alerting_v2.index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.alerting_v2.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic Alerting V2 API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/alerting_v2'));
+  });
+}

--- a/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.alerting_v2.serverless.config.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.alerting_v2.serverless.config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessFeatureFlagTestConfig } from '../../default_configs/feature_flag.serverless.config.base';
+
+export default createServerlessFeatureFlagTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.alerting_v2.index.ts')],
+  kbnServerArgs: ['--xpack.alerting_v2.enabled=true'],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic Alerting V2 API Integration Tests',
+  },
+});

--- a/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/configs/serverless/oblt.index.ts
@@ -12,7 +12,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
 
     // load new oblt and platform deployment-agnostic test here
     // Note: if your tests runtime is over 5 minutes, create a new index and config file
-    loadTestFile(require.resolve('../../apis/alerting_v2'));
     loadTestFile(require.resolve('../../apis/core'));
     loadTestFile(require.resolve('../../apis/management'));
     loadTestFile(require.resolve('../../apis/painless_lab'));

--- a/x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.alerting_v2.index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.alerting_v2.index.ts
@@ -9,12 +9,6 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_co
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
   describe('apis', () => {
-    // load new platform deployment-agnostic test here
-    loadTestFile(require.resolve('../../apis/core'));
-    loadTestFile(require.resolve('../../apis/management'));
-    loadTestFile(require.resolve('../../apis/painless_lab'));
-    loadTestFile(require.resolve('../../apis/saved_objects_management'));
-    loadTestFile(require.resolve('../../apis/intercepts'));
-    loadTestFile(require.resolve('../../apis/streams'));
+    loadTestFile(require.resolve('../../apis/alerting_v2'));
   });
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.alerting_v2.stateful.config.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/configs/stateful/platform.alerting_v2.stateful.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createStatefulFeatureFlagTestConfig } from '../../default_configs/feature_flag.stateful.config.base';
+
+export default createStatefulFeatureFlagTestConfig({
+  testFiles: [require.resolve('./platform.alerting_v2.index.ts')],
+  kbnServerArgs: ['--xpack.alerting_v2.enabled=true'],
+  junit: {
+    reportName: 'Platform Stateful - Deployment-agnostic Alerting V2 API Integration Tests',
+  },
+});

--- a/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/platform/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -162,8 +162,6 @@ export default function ({ getService }: FtrProviderContext) {
         'alerting:xpack.uptime.alerts.tlsCertificate',
         'alerting_health_check',
         'alerting_telemetry',
-        'alerting_v2:dispatcher',
-        'alerting_v2:rule_executor',
         'alerts_invalidate_api_keys',
         'apm-source-map-migration-task',
         'apm-telemetry-task',

--- a/x-pack/platform/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
+++ b/x-pack/platform/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
@@ -124,8 +124,6 @@ export default function ({ getService }: FtrProviderContext) {
         savedObjectsManagement: 1,
         savedQueryManagement: 0,
         dataQuality: 0,
-        alerting_v2_alerts: 0,
-        alerting_v2_rules: 0,
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes CI failures caused by the `alerting_v2` plugin being disabled by default (`enabled: false`).

### Changes

**Alerting V2 FTR tests — moved to feature-flag configs**

The deployment-agnostic alerting_v2 API tests need the plugin explicitly enabled. Since the standard configs don't allow custom `kbnServerArgs`, the tests are moved to dedicated feature-flag configs that pass `--xpack.alerting_v2.enabled=true`:

- New stateful config: `platform.alerting_v2.stateful.config.ts`
- New serverless config: `oblt.alerting_v2.serverless.config.ts`
- Removed `loadTestFile('alerting_v2')` from the default platform/oblt index files
- Registered both new configs in the Buildkite FTR manifests

**Global snapshot tests — removed alerting_v2 entries**

With the plugin disabled by default, its features/privileges/task types/SO types are not registered. Removed alerting_v2 entries from:

- Security privileges tests (trial + basic) — `alerting_v2_alerts`, `alerting_v2_rules`
- Features API test — `alerting_v2_alerts`, `alerting_v2_rules`
- Spaces telemetry test — `alerting_v2_alerts: 0`, `alerting_v2_rules: 0`
- Task manager registered task types — `alerting_v2:dispatcher`, `alerting_v2:rule_executor`
- SO type registrations — `alerting_rule`, `alerting_notification_policy`

Supersedes #257735 (closed due to accidental merge noise).

Made with [Cursor](https://cursor.com)