### PR TITLE
[Agent Builder] Hide conversation input attachment previews for already-persisted attachments

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -151,6 +151,8 @@ export const getVisibleAttachmentsForInput = ({
       if (!attachment.id) {
         return true;
       }
+      // Hide attachments already in the conversation: input attachments with matching IDs
+      // are treated as updates to existing content, not new pills to display.
       return !persistedAttachmentIds.has(attachment.id);
     })
     .map((attachment, index) => ({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input.tsx
@@ -14,6 +14,11 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import type {
+  Attachment,
+  AttachmentInput,
+  VersionedAttachment,
+} from '@kbn/agent-builder-common/attachments';
 import type { PropsWithChildren } from 'react';
 import React, { useEffect, useMemo } from 'react';
 import { useConversationId } from '../../../context/conversation/use_conversation_id';
@@ -22,6 +27,7 @@ import { useAgentBuilderAgents } from '../../../hooks/agents/use_agents';
 import { useValidateAgentId } from '../../../hooks/agents/use_validate_agent_id';
 import { useIsSendingMessage } from '../../../hooks/use_is_sending_message';
 import {
+  useConversation,
   useAgentId,
   useHasActiveConversation,
   useIsAwaitingPrompt,
@@ -118,6 +124,41 @@ const enabledPlaceholder = i18n.translate(
   }
 );
 
+interface GetVisibleAttachmentsForInputParams {
+  attachments?: AttachmentInput[];
+  shouldHideAttachments: boolean;
+  conversationAttachments?: VersionedAttachment[];
+}
+
+export const getVisibleAttachmentsForInput = ({
+  attachments,
+  shouldHideAttachments,
+  conversationAttachments,
+}: GetVisibleAttachmentsForInputParams): Attachment[] => {
+  if (!attachments || shouldHideAttachments) {
+    return [];
+  }
+
+  const persistedAttachmentIds = new Set(
+    (conversationAttachments ?? []).map((attachment) => attachment.id)
+  );
+
+  return attachments
+    .filter((attachment) => {
+      if (attachment.hidden) {
+        return false;
+      }
+      if (!attachment.id) {
+        return true;
+      }
+      return !persistedAttachmentIds.has(attachment.id);
+    })
+    .map((attachment, index) => ({
+      ...attachment,
+      id: attachment.id ?? `attachment-${index}`,
+    }));
+};
+
 export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }) => {
   const isSendingMessage = useIsSendingMessage();
   const { sendMessage, pendingMessage, error, isResuming } = useSendMessage();
@@ -127,6 +168,7 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }
   const messageEditor = useMessageEditor();
   const hasActiveConversation = useHasActiveConversation();
   const isAwaitingPrompt = useIsAwaitingPrompt();
+  const { conversation } = useConversation();
   const { attachments, initialMessage, autoSendInitialMessage, resetInitialMessage } =
     useConversationContext();
 
@@ -150,15 +192,15 @@ export const ConversationInput: React.FC<ConversationInputProps> = ({ onSubmit }
 
   const shouldCollapseInput = isSendingMessage || hasActiveConversation;
 
-  const visibleAttachments = useMemo(() => {
-    if (!attachments || shouldHideAttachments) return [];
-    return attachments
-      .filter((attachment) => !attachment.hidden)
-      .map((attachment, idx) => ({
-        ...attachment,
-        id: attachment.id ?? `attachment-${idx}`,
-      }));
-  }, [attachments, shouldHideAttachments]);
+  const visibleAttachments = useMemo(
+    () =>
+      getVisibleAttachmentsForInput({
+        attachments,
+        shouldHideAttachments,
+        conversationAttachments: conversation?.attachments,
+      }),
+    [attachments, shouldHideAttachments, conversation?.attachments]
+  );
 
   const isNewConversation = !conversationId;
   // Set initial message in input when {autoSendInitialMessage} is false and {initialMessage} is provided

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input_visibility.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/conversation_input_visibility.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AttachmentInput, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import { getVisibleAttachmentsForInput } from './conversation_input';
+
+const createConversationAttachment = (id: string): VersionedAttachment => ({
+  id,
+  type: 'test',
+  versions: [],
+  current_version: 1,
+});
+
+describe('getVisibleAttachmentsForInput', () => {
+  it('returns empty list when attachments should be hidden', () => {
+    const result = getVisibleAttachmentsForInput({
+      attachments: [{ id: 'new-id', type: 'test', data: {} }],
+      shouldHideAttachments: true,
+      conversationAttachments: [createConversationAttachment('existing-id')],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('hides attachment when id already exists in persisted conversation', () => {
+    const attachments: AttachmentInput[] = [
+      { id: 'existing-id', type: 'test', data: {} },
+      { id: 'new-id', type: 'test', data: {} },
+    ];
+
+    const result = getVisibleAttachmentsForInput({
+      attachments,
+      shouldHideAttachments: false,
+      conversationAttachments: [createConversationAttachment('existing-id')],
+    });
+
+    expect(result).toEqual([{ id: 'new-id', type: 'test', data: {} }]);
+  });
+
+  it('keeps attachments without id and assigns fallback id using visible index', () => {
+    const attachments: AttachmentInput[] = [
+      { id: 'existing-id', type: 'test', data: {} },
+      { type: 'test', data: {} },
+    ];
+
+    const result = getVisibleAttachmentsForInput({
+      attachments,
+      shouldHideAttachments: false,
+      conversationAttachments: [createConversationAttachment('existing-id')],
+    });
+
+    expect(result).toEqual([{ id: 'attachment-0', type: 'test', data: {} }]);
+  });
+
+  it('keeps attachments when conversation data is unavailable', () => {
+    const attachments: AttachmentInput[] = [{ id: 'new-id', type: 'test', data: {} }];
+
+    const result = getVisibleAttachmentsForInput({
+      attachments,
+      shouldHideAttachments: false,
+      conversationAttachments: undefined,
+    });
+
+    expect(result).toEqual([{ id: 'new-id', type: 'test', data: {} }]);
+  });
+});


### PR DESCRIPTION
This change prevents “preview” attachment pills from appearing in ConversationInput when addAttachment() is used to edit an attachment that already exists in the conversation.

In our flow, the caller (Dashboard Agent code) uses addAttachment() when the user manually edits the dashboard, which causes an attachment pill to appear in conversation input, but it's confusing, because the attachment is already there.

Previously, ConversationInput rendered all context attachments (except hidden ones), which caused edited attachments (same id) to still appear as new/pending in the input row.
Now, input attachment visibility checks persisted conversation.attachments and filters out attachments whose id is already present.

<img width="570" height="242" alt="image" src="https://github.com/user-attachments/assets/59168aff-a4cb-404e-a77c-70b850b89283" />

