### PR TITLE
[8.19] Fix SLO Error: Cannot read properties of undefined (reading 'name')  (#257463)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { getSyncLabel } from './sync_badge';
+import { getSyncLabel, SyncBadge } from './sync_badge';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
 
 describe('Sync badge', () => {
   describe('Nodejs', () => {
@@ -77,6 +79,84 @@ describe('Sync badge', () => {
     });
     it('does not show async badge', () => {
       expect(getSyncLabel('rum-js', false)).toBeUndefined();
+    });
+  });
+
+  describe('Go', () => {
+    it('does not show blocking badge', () => {
+      expect(getSyncLabel('go', true)).toBeUndefined();
+    });
+    it('shows async badge', () => {
+      expect(getSyncLabel('go', false)).toBe('async');
+    });
+  });
+  describe('undefined agentName', () => {
+    it('returns undefined when agentName is undefined and sync is true', () => {
+      expect(getSyncLabel(undefined, true)).toBeUndefined();
+    });
+    it('returns undefined when agentName is undefined and sync is false', () => {
+      expect(getSyncLabel(undefined, false)).toBeUndefined();
+    });
+  });
+});
+
+describe('SyncBadge Component', () => {
+  describe('Tooltip functionality', () => {
+    it('does not render badge when sync is undefined', () => {
+      render(<SyncBadge sync={undefined} agentName="nodejs" />);
+
+      expect(screen.queryByText('blocking')).not.toBeInTheDocument();
+      expect(screen.queryByText('async')).not.toBeInTheDocument();
+    });
+
+    it('does not render badge when label conditions are not met', () => {
+      render(<SyncBadge sync={false} agentName="nodejs" />);
+      expect(screen.queryByText('blocking')).not.toBeInTheDocument();
+      expect(screen.queryByText('async')).not.toBeInTheDocument();
+
+      render(<SyncBadge sync={true} agentName="python" />);
+      expect(screen.queryByText('blocking')).not.toBeInTheDocument();
+      expect(screen.queryByText('async')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Badge content', () => {
+    it('shows correct blocking badge for js-base agent', () => {
+      render(<SyncBadge sync={true} agentName="js-base" />);
+      expect(screen.getByText('blocking')).toBeInTheDocument();
+    });
+
+    it('shows correct async badge for php agent', () => {
+      render(<SyncBadge sync={false} agentName="php" />);
+      expect(screen.getByText('async')).toBeInTheDocument();
+    });
+
+    it('shows correct async badge for dotnet agent', () => {
+      render(<SyncBadge sync={false} agentName="dotnet" />);
+      expect(screen.getByText('async')).toBeInTheDocument();
+    });
+
+    it('shows correct async badge for ruby agent', () => {
+      render(<SyncBadge sync={false} agentName="ruby" />);
+      expect(screen.getByText('async')).toBeInTheDocument();
+    });
+
+    it('shows correct async badge for java agent', () => {
+      render(<SyncBadge sync={false} agentName="java" />);
+      expect(screen.getByText('async')).toBeInTheDocument();
+    });
+
+    it('shows correct async badge for iOS/swift agent', () => {
+      render(<SyncBadge sync={false} agentName="iOS/swift" />);
+      expect(screen.getByText('async')).toBeInTheDocument();
+    });
+  });
+
+  describe('undefined agentName', () => {
+    it('does not render badge when agentName is undefined', () => {
+      render(<SyncBadge sync={true} agentName={undefined} />);
+      expect(screen.queryByText('blocking')).not.toBeInTheDocument();
+      expect(screen.queryByText('async')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.tsx
@@ -15,7 +15,7 @@ export interface SyncBadgeProps {
    * Is the request synchronous? True will show blocking, false will show async.
    */
   sync?: boolean;
-  agentName: AgentName;
+  agentName?: AgentName;
 }
 
 const BLOCKING_LABEL = i18n.translate('xpack.apm.transactionDetails.syncBadgeBlocking', {
@@ -41,8 +41,8 @@ const agentsSyncMap: Record<string, boolean> = {
   go: false,
 };
 
-export function getSyncLabel(agentName: AgentName, sync?: boolean) {
-  if (sync === undefined) {
+export function getSyncLabel(agentName?: AgentName, sync?: boolean) {
+  if (sync === undefined || agentName === undefined) {
     return;
   }
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.tsx
@@ -14,6 +14,7 @@ import {
   ENVIRONMENT_NOT_DEFINED,
   getNextEnvironmentUrlParam,
 } from '../../../../../../../common/environment_filter_values';
+import { NOT_AVAILABLE_LABEL } from '../../../../../../../common/i18n';
 import { LatencyAggregationType } from '../../../../../../../common/latency_aggregation_types';
 import type { Transaction } from '../../../../../../../typings/es_schemas/ui/transaction';
 import { useAnyOfApmParams } from '../../../../../../hooks/use_apm_params';
@@ -48,15 +49,20 @@ export function FlyoutTopLevelProperties({ transaction }: Props) {
     currentEnvironmentUrlParam: query?.environment ?? ENVIRONMENT_ALL.value,
   });
 
+  const serviceName = transaction.service?.name;
+  const agentName = transaction.agent?.name;
+  const transactionName = transaction.transaction?.name;
+  const transactionType = transaction.transaction?.type;
+
   const stickyProperties = [
     {
       label: i18n.translate('xpack.apm.transactionDetails.serviceLabel', {
         defaultMessage: 'Service',
       }),
       fieldName: SERVICE_NAME,
-      val: (
+      val: serviceName ? (
         <ServiceLink
-          agentName={transaction.agent.name}
+          agentName={agentName}
           query={{
             kuery: query.kuery,
             latencyAggregationType,
@@ -64,12 +70,14 @@ export function FlyoutTopLevelProperties({ transaction }: Props) {
             rangeFrom: query.rangeFrom,
             rangeTo: query.rangeTo,
             comparisonEnabled: query.comparisonEnabled,
-            transactionType: transaction.transaction.type,
+            transactionType,
             serviceGroup,
             environment: nextEnvironment,
           }}
-          serviceName={transaction.service.name}
+          serviceName={serviceName}
         />
+      ) : (
+        NOT_AVAILABLE_LABEL
       ),
       width: '25%',
     },
@@ -78,22 +86,25 @@ export function FlyoutTopLevelProperties({ transaction }: Props) {
         defaultMessage: 'Transaction',
       }),
       fieldName: TRANSACTION_NAME,
-      val: (
-        <TransactionDetailLink
-          transactionName={transaction.transaction.name}
-          href={link('/services/{serviceName}/transactions/view', {
-            path: { serviceName: transaction.service.name },
-            query: {
-              ...query,
-              serviceGroup,
-              latencyAggregationType,
-              transactionName: transaction.transaction.name,
-            },
-          })}
-        >
-          {transaction.transaction.name}
-        </TransactionDetailLink>
-      ),
+      val:
+        transactionName && serviceName ? (
+          <TransactionDetailLink
+            transactionName={transactionName}
+            href={link('/services/{serviceName}/transactions/view', {
+              path: { serviceName },
+              query: {
+                ...query,
+                serviceGroup,
+                latencyAggregationType,
+                transactionName,
+              },
+            })}
+          >
+            {transactionName}
+          </TransactionDetailLink>
+        ) : (
+          transactionName ?? NOT_AVAILABLE_LABEL
+        ),
       width: '25%',
     },
   ];

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
@@ -207,7 +207,7 @@ function SpanFlyoutBody({
 }) {
   const stackframes = span.span.stacktrace;
   const plaintextStacktrace = span.code?.stacktrace;
-  const codeLanguage = parentTransaction?.service.language?.name;
+  const codeLanguage = parentTransaction?.service?.language?.name;
   const spanDb = span.span.db;
   const spanTypes = getSpanTypes(span);
   const spanHttpStatusCode =
@@ -319,7 +319,7 @@ function SpanFlyoutBody({
 
             <FailureBadge outcome={span.event?.outcome} />
 
-            <SyncBadge sync={span.span.sync} agentName={span.agent.name} />
+            <SyncBadge sync={span.span.sync} agentName={span.agent?.name} />
           </ContainerWithMarginRight>,
         ]}
       />

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.tsx
@@ -58,8 +58,12 @@ export function StickySpanProperties({ span, transaction }: Props) {
     currentEnvironmentUrlParam: environment,
   });
 
-  const spanName = span.span.name;
-  const dependencyName = span.span.destination?.service.resource;
+  const spanName = span.span?.name;
+  const dependencyName = span.span?.destination?.service.resource;
+
+  const transactionServiceName = transaction?.service?.name;
+  const transactionAgentName = transaction?.agent?.name;
+  const transactionName = transaction?.transaction?.name;
 
   const transactionStickyProperties = transaction
     ? [
@@ -68,16 +72,18 @@ export function StickySpanProperties({ span, transaction }: Props) {
             defaultMessage: 'Service',
           }),
           fieldName: SERVICE_NAME,
-          val: (
+          val: transactionServiceName ? (
             <ServiceLink
-              agentName={transaction.agent.name}
+              agentName={transactionAgentName}
               query={{
                 ...query,
                 serviceGroup,
                 environment: nextEnvironment,
               }}
-              serviceName={transaction.service.name}
+              serviceName={transactionServiceName}
             />
+          ) : (
+            NOT_AVAILABLE_LABEL
           ),
           width: '25%',
         },
@@ -86,23 +92,26 @@ export function StickySpanProperties({ span, transaction }: Props) {
             defaultMessage: 'Transaction',
           }),
           fieldName: TRANSACTION_NAME,
-          val: (
-            <TransactionDetailLink
-              transactionName={transaction.transaction.name}
-              href={router.link('/services/{serviceName}/transactions/view', {
-                path: { serviceName: transaction.service.name },
-                query: {
-                  ...query,
-                  environment: nextEnvironment,
-                  serviceGroup,
-                  latencyAggregationType,
-                  transactionName: transaction.transaction.name,
-                },
-              })}
-            >
-              {transaction.transaction.name}
-            </TransactionDetailLink>
-          ),
+          val:
+            transactionName && transactionServiceName ? (
+              <TransactionDetailLink
+                transactionName={transactionName}
+                href={router.link('/services/{serviceName}/transactions/view', {
+                  path: { serviceName: transactionServiceName },
+                  query: {
+                    ...query,
+                    environment: nextEnvironment,
+                    serviceGroup,
+                    latencyAggregationType,
+                    transactionName,
+                  },
+                })}
+              >
+                {transactionName}
+              </TransactionDetailLink>
+            ) : (
+              transactionName ?? NOT_AVAILABLE_LABEL
+            ),
           width: '25%',
         },
       ]
@@ -121,8 +130,8 @@ export function StickySpanProperties({ span, transaction }: Props) {
                 ...query,
                 dependencyName,
               }}
-              subtype={span.span.subtype}
-              type={span.span.type}
+              subtype={span.span?.subtype}
+              type={span.span?.type}
               onClick={() => {
                 trackEvent({
                   app: 'apm',

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/span_metadata/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/span_metadata/index.tsx
@@ -17,13 +17,19 @@ interface Props {
 }
 
 export function SpanMetadata({ span }: Props) {
+  const spanId = span.span?.id;
+
   const { data: spanEvent, status } = useFetcher(
     (callApmApi) => {
+      if (!spanId) {
+        return;
+      }
+
       return callApmApi('GET /internal/apm/event_metadata/{processorEvent}/{id}', {
         params: {
           path: {
             processorEvent: ProcessorEvent.span,
-            id: span.span.id,
+            id: spanId,
           },
           query: {
             start: span['@timestamp'],
@@ -32,7 +38,7 @@ export function SpanMetadata({ span }: Props) {
         },
       });
     },
-    [span]
+    [span, spanId]
   );
 
   const sections = useMemo(

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/transaction_metadata/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/transaction_metadata/index.tsx
@@ -17,13 +17,19 @@ interface Props {
 }
 
 export function TransactionMetadata({ transaction }: Props) {
+  const transactionId = transaction.transaction?.id;
+
   const { data: transactionEvent, status } = useFetcher(
     (callApmApi) => {
+      if (!transactionId) {
+        return;
+      }
+
       return callApmApi('GET /internal/apm/event_metadata/{processorEvent}/{id}', {
         params: {
           path: {
             processorEvent: ProcessorEvent.transaction,
-            id: transaction.transaction.id,
+            id: transactionId,
           },
           query: {
             start: transaction['@timestamp'],
@@ -32,7 +38,7 @@ export function TransactionMetadata({ transaction }: Props) {
         },
       });
     },
-    [transaction]
+    [transaction, transactionId]
   );
 
   const sections = useMemo(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix SLO Error: Cannot read properties of undefined (reading 'name')  (#257463)](https://github.com/elastic/kibana/pull/257463)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Samuel Brito","email":"samuel.brito@elastic.co"},"sourceCommit":{"committedDate":"2026-03-16T12:22:13Z","message":"Fix SLO Error: Cannot read properties of undefined (reading 'name')  (#257463)\n\nCloses https://github.com/elastic/kibana/issues/256172\n\n## Summary\n\n- Added null checks for affected parts of the pages\n- Added unit tests to prevent same issue in the future\n\n\n### How to run tests \n\nHere are the commands to run them:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\nOr run all three at once:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"58c3a6975e282e61ef5e12e6537461ffe9d3e02a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation"],"title":"Fix SLO Error: Cannot read properties of undefined (reading 'name') ","number":257463,"url":"https://github.com/elastic/kibana/pull/257463","mergeCommit":{"message":"Fix SLO Error: Cannot read properties of undefined (reading 'name')  (#257463)\n\nCloses https://github.com/elastic/kibana/issues/256172\n\n## Summary\n\n- Added null checks for affected parts of the pages\n- Added unit tests to prevent same issue in the future\n\n\n### How to run tests \n\nHere are the commands to run them:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\nOr run all three at once:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"58c3a6975e282e61ef5e12e6537461ffe9d3e02a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257463","number":257463,"mergeCommit":{"message":"Fix SLO Error: Cannot read properties of undefined (reading 'name')  (#257463)\n\nCloses https://github.com/elastic/kibana/issues/256172\n\n## Summary\n\n- Added null checks for affected parts of the pages\n- Added unit tests to prevent same issue in the future\n\n\n### How to run tests \n\nHere are the commands to run them:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx`\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\nOr run all three at once:\n\n- `yarn test:jest\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/badge/sync_badge.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/flyout_top_level_properties.test.tsx\nx-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/sticky_span_properties.test.tsx`\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"58c3a6975e282e61ef5e12e6537461ffe9d3e02a"}},{"url":"https://github.com/elastic/kibana/pull/257901","number":257901,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/257902","number":257902,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->