### PR TITLE
[9.3] Fix SSE streaming for Kibana (#257866)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "resolutions": {
     "**/@babel/parser": "7.24.7",
+    "**/@hapi/mimos/mime-db": "1.53.0",
     "**/@hello-pangea/dnd": "18.0.1",
     "**/@langchain/core": "0.3.80",
     "**/@langchain/google-common": "0.2.18",

--- a/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/onechat/server/routes/chat.ts
@@ -449,6 +449,8 @@ export function registerChatRoutes({
             'Content-Type': cloud?.isCloudEnabled
               ? 'application/octet-stream'
               : 'text/event-stream',
+            // another attempt at disabling compression
+            'Content-Encoding': 'identity',
             'Cache-Control': 'no-cache',
             Connection: 'keep-alive',
             'Transfer-Encoding': 'chunked',

--- a/yarn.lock
+++ b/yarn.lock
@@ -26054,7 +26054,12 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-"mime-db@>= 1.40.0 < 2", mime-db@^1.52.0, mime-db@^1.54.0:
+mime-db@1.53.0, mime-db@^1.52.0:
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.53.0.tgz#3cb63cd820fc29896d9d4e8c32ab4fcd74ccb447"
+  integrity sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==
+
+"mime-db@>= 1.40.0 < 2", mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix SSE streaming for Kibana (#257866)](https://github.com/elastic/kibana/pull/257866)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2026-03-16T12:48:00Z","message":"Fix SSE streaming for Kibana (#257866)\n\n## Summary\n\n(Tentatively) fix SSE streaming response being compressed by HAPI (which\ncauses the cloud proxy to buffer them, causing SSE responses to not be\n\"streaming\")","sha":"81737900313e74061f28d1ff77f9f743ef108925","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:cloud-deploy","ci:project-deploy-elasticsearch","backport:version","v9.4.0","v8.19.13","v9.3.3","v9.2.8"],"title":"Fix SSE streaming for Kibana","number":257866,"url":"https://github.com/elastic/kibana/pull/257866","mergeCommit":{"message":"Fix SSE streaming for Kibana (#257866)\n\n## Summary\n\n(Tentatively) fix SSE streaming response being compressed by HAPI (which\ncauses the cloud proxy to buffer them, causing SSE responses to not be\n\"streaming\")","sha":"81737900313e74061f28d1ff77f9f743ef108925"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257866","number":257866,"mergeCommit":{"message":"Fix SSE streaming for Kibana (#257866)\n\n## Summary\n\n(Tentatively) fix SSE streaming response being compressed by HAPI (which\ncauses the cloud proxy to buffer them, causing SSE responses to not be\n\"streaming\")","sha":"81737900313e74061f28d1ff77f9f743ef108925"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->