### PR TITLE
Allows all connectors in ES3, rather than explicit allowlist

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -74,32 +74,6 @@ uiSettings.overrides.defaultRoute: /app/elasticsearch
 # Specify in telemetry the project type
 telemetry.labels.serverless: search
 
-# Alerts and LLM config
-xpack.actions.enabledActionTypes:
-  [
-    '.email',
-    '.index',
-    '.slack',
-    '.slack_api',
-    '.jira',
-    '.jira-cloud',
-    '.webhook',
-    '.teams',
-    '.gen-ai',
-    '.bedrock',
-    '.gemini',
-    '.inference',
-    '.mcp',
-    '.notion',
-    '.github',
-    '.google_drive',
-    '.google_calendar',
-    '.sharepoint-online',
-    '.http',
-    '.http-system',
-    '.workflows',
-  ]
-
 # Customize empty page state for analytics apps
 no_data_page.analyticsNoDataPageFlavor: 'serverless_search'
 


### PR DESCRIPTION
## Summary

As Agent Builder will soon be able to work with Kibana Connectors, Product feels that it would be better to have all connectors available in ES3, rather than a limited subset. This takes the total number of connectors from `~20` to `~60`.

![big_catalog](https://github.com/user-attachments/assets/6dbbf6c1-65d9-4be2-8388-3740c476398b)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated serverless configuration by removing explicit action type restrictions, allowing the system to manage integrations and available actions through alternative configuration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->