### PR TITLE
[Agent Builder] add missing `usageApi` dependency

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -43,6 +43,7 @@
       "licenseManagement",
       "workflowsManagement",
       "usageCollection",
+      "usageApi",
       "home",
     ],
     "extraPublicDirs": []


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/257926

Metering couldn't be send, because the dependency was never there 🤦 