### PR TITLE
[Agent Builder] skip non-indexed fields in flattenMapping

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
@@ -14,6 +14,7 @@ interface MappingProperties {
     properties?: MappingProperties; // Nested object fields
     fields?: MappingProperties; // Multi-fields (alternative analyzers/types)
     meta?: Record<string, string>; // meta
+    index?: boolean;
   };
 }
 
@@ -27,6 +28,10 @@ export const flattenMapping = (mapping: MappingTypeMapping): MappingField[] => {
     let fields: MappingField[] = [];
 
     for (const [key, value] of Object.entries(obj)) {
+      if (value.index === false) {
+        continue;
+      }
+
       const fieldPath = prefix ? `${prefix}.${key}` : key;
 
       if (value.type) {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/types.ts
@@ -15,4 +15,6 @@ export interface MappingField {
   type: string;
   /** meta attached to the field */
   meta: Record<string, string>;
+  /** whether the field is indexed or not */
+  index?: boolean;
 }


### PR DESCRIPTION
[#257930](https://github.com/elastic/kibana/issues/257930)