### PR TITLE
[Security Solution][Fix] Fix rule automated response actions dropdown selector

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -42,11 +42,11 @@ export type ResponseActionsApiCommandNames = (typeof RESPONSE_ACTION_API_COMMAND
 
 export type EnabledAutomatedResponseActionsCommands = Extract<
   ResponseActionsApiCommandNames,
-  'isolate'
+  'isolate' | 'suspend-process' | 'kill-process'
 >;
 
 export const ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS: EnabledAutomatedResponseActionsCommands[] =
-  ['isolate'];
+  ['isolate', 'kill-process', 'suspend-process'];
 
 /**
  * The list of possible capabilities, reported by the endpoint in the metadata document

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/action_type_field.tsx
@@ -50,11 +50,14 @@ const ActionTypeFieldComponent = ({
   );
 
   const enabledActions = useMemo(
-    () =>
-      [
-        ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
-        ...(automatedProcessActionsEnabled ? ['kill-process', 'suspend-process'] : []),
-      ] as ['isolate'],
+    () => [
+      ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS.filter((command) => {
+        return !(
+          !automatedProcessActionsEnabled &&
+          (command === 'kill-process' || command === 'suspend-process')
+        );
+      }),
+    ],
     [automatedProcessActionsEnabled]
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/utils.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_response_actions/endpoint/utils.tsx
@@ -47,6 +47,18 @@ const useGetCommandText = (
         description: CONSOLE_COMMANDS.isolate.about,
         tooltip: CONSOLE_COMMANDS.isolate.privileges,
       };
+    case 'kill-process':
+      return {
+        title: CONSOLE_COMMANDS.killProcess.title,
+        description: CONSOLE_COMMANDS.killProcess.about,
+        tooltip: CONSOLE_COMMANDS.killProcess.privileges,
+      };
+    case 'suspend-process':
+      return {
+        title: CONSOLE_COMMANDS.suspendProcess.title,
+        description: CONSOLE_COMMANDS.suspendProcess.about,
+        tooltip: CONSOLE_COMMANDS.suspendProcess.privileges,
+      };
     default:
       return {
         title: '',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
@@ -35,8 +35,12 @@ export const validateAvailableCommands = () => {
     config.env.ftrConfig.kbnServerArgs[0].match(automatedActionsPAttern);
 
   const enabledActions = [
-    ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS,
-    ...(automatedProcessActionsEnabled ? ['kill-process', 'suspend-process'] : []),
+    ...ENABLED_AUTOMATED_RESPONSE_ACTION_COMMANDS.filter((command) => {
+      return !(
+        !automatedProcessActionsEnabled &&
+        (command === 'kill-process' || command === 'suspend-process')
+      );
+    }),
   ];
 
   cy.get('[data-test-subj^="command-type"]').should('have.length', enabledActions.length);


### PR DESCRIPTION
## Summary

- Fixes the response action selection options for `kill-process` and
  `suspend-process` on the SIEM rules automated response action section
    - This fix applies only to `v9.2.x`







