### PR TITLE
[SavedObjects][CI] Traverse parent chain when resolving Serverless baseline snapshot

### DIFF
--- a/.buildkite/scripts/steps/check_saved_objects.sh
+++ b/.buildkite/scripts/steps/check_saved_objects.sh
@@ -6,6 +6,16 @@ source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
 
+# Get the parent commit SHA for a given SHA.
+# Tries local git first, then falls back to the GitHub API.
+# The fallback is needed for commits from emergency release (deploy-fix) branches
+# that are not present in the local git clone.
+getParentSha() {
+  local sha="${1}"
+  git rev-parse "${sha}^" 2>/dev/null || \
+    gh api "repos/elastic/kibana/commits/${sha}" --jq '.parents[0].sha'
+}
+
 # Function to find a valid commit SHA, aka a SHA for which a snapshot exists
 findExistingSnapshotSha() {
   # The merge base commit, to start looking for existing snapshots.
@@ -29,8 +39,8 @@ findExistingSnapshotSha() {
     else
       if [[ "$http_status" == "404"* ]]; then
         echo "Snapshot '$url' NOT FOUND, fetching parent commit snapshot (attempt $attempts of $max_attempts)..." >&2
-        # Obtain the parent SHA
-        sha=$(git rev-parse "$sha"^)
+        # Obtain the parent SHA, falling back to the GitHub API for commits not in the local clone
+        sha=$(getParentSha "$sha")
       else
         echo "Error fetching snapshot '$url' (attempt $attempts of $max_attempts)..." >&2
       fi
@@ -81,7 +91,11 @@ if is_pr; then
   SERVERLESS_BASELINE_FLAG=()
   if [[ "$GITHUB_PR_TARGET_BRANCH" == "main" ]]; then
     GITHUB_SERVERLESS_RELEASE_SHA="$(resolveCurrentServerlessReleaseSha)"
-    SERVERLESS_BASELINE_FLAG=(--serverless-baseline "$GITHUB_SERVERLESS_RELEASE_SHA")
+    if ! GITHUB_SERVERLESS_BASELINE_SHA="$(findExistingSnapshotSha "$GITHUB_SERVERLESS_RELEASE_SHA")"; then
+      echo "❌ Could not find a GCS snapshot for the current Serverless release or any of its ancestors." >&2
+      exit 1
+    fi
+    SERVERLESS_BASELINE_FLAG=(--serverless-baseline "$GITHUB_SERVERLESS_BASELINE_SHA")
   fi
 
   if ! is_auto_commit_disabled; then
@@ -96,7 +110,11 @@ else
   # and ONLY if we are in the main branch (older versions most likely won't be compatible)
   if [[ "$GITHUB_PR_TARGET_BRANCH" == "main" ]]; then
     GITHUB_SERVERLESS_RELEASE_SHA="$(resolveCurrentServerlessReleaseSha)"
+    if ! GITHUB_SERVERLESS_BASELINE_SHA="$(findExistingSnapshotSha "$GITHUB_SERVERLESS_RELEASE_SHA")"; then
+      echo "❌ Could not find a GCS snapshot for the current Serverless release or any of its ancestors." >&2
+      exit 1
+    fi
     # Perform the check against current serverless release
-    node scripts/check_saved_objects --baseline "$GITHUB_SERVERLESS_RELEASE_SHA"
+    node scripts/check_saved_objects --baseline "$GITHUB_SERVERLESS_BASELINE_SHA"
   fi
 fi

--- a/.buildkite/scripts/steps/check_saved_objects.sh
+++ b/.buildkite/scripts/steps/check_saved_objects.sh
@@ -40,7 +40,12 @@ findExistingSnapshotSha() {
       if [[ "$http_status" == "404"* ]]; then
         echo "Snapshot '$url' NOT FOUND, fetching parent commit snapshot (attempt $attempts of $max_attempts)..." >&2
         # Obtain the parent SHA, falling back to the GitHub API for commits not in the local clone
-        sha=$(getParentSha "$sha")
+        local parent_sha
+        if ! parent_sha="$(getParentSha "$sha")" || [[ -z "$parent_sha" || "$parent_sha" == "null" ]]; then
+          echo "❌ Failed to resolve parent SHA for '$sha' while searching for a baseline snapshot." >&2
+          return 1
+        fi
+        sha="$parent_sha"
       else
         echo "Error fetching snapshot '$url' (attempt $attempts of $max_attempts)..." >&2
       fi


### PR DESCRIPTION
## Summary

When an emergency release is deployed from a `deploy-fix` branch, the **on-merge** pipeline does not run for that branch, so no GCS snapshot is uploaded for the emergency-release commit SHA. This causes the **Check changes in Saved Objects** CI step to fail for all PRs targeting `main`, as it uses the serverless release SHA directly as `--serverless-baseline` (and as `--baseline` in the on-merge path).

Closes https://github.com/elastic/kibana-team/issues/3072

## Changes

**`getParentSha` (new helper):** Resolves the parent of a commit using local git first, falling back to the GitHub API when the commit is not present in the local clone. The fallback handles emergency-release commits on `deploy-fix` branches that CI agents may not have locally.

**`findExistingSnapshotSha` (updated):** Now uses `getParentSha` instead of `git rev-parse "$sha"^` directly, making parent traversal resilient to commits from `deploy-fix` branches.

**PR path:** Instead of using `GITHUB_SERVERLESS_RELEASE_SHA` verbatim as `--serverless-baseline`, it now calls `findExistingSnapshotSha` to walk up to the nearest ancestor that has a GCS snapshot, with a clear error message if none is found within the attempt limit.

**On-merge path:** Same fix — the baseline SHA is resolved through `findExistingSnapshotSha`, so the step is resilient when the serverless release is an emergency release with no snapshot.

## Workaround used during the incident

The snapshot for the parent `main` commit was manually copied in GCS under the emergency-release commit SHA. This PR makes that manual step unnecessary for future emergency releases.

## Testing

This step can only be tested in CI. The logic mirrors the already-tested `findExistingSnapshotSha` path used for `GITHUB_PR_MERGE_BASE`.

## Checklist

- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the guidelines
- [x] Review the backport guidelines and apply applicable `backport:*` labels

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved baseline snapshot resolution with an additional fallback to a parent commit when a direct match isn't found, increasing reliability of baseline detection.
  * Updated workflow to pass the resolved baseline explicitly to subsequent checks.

* **Bug Fixes**
  * Added explicit failure handling and clearer abort behavior when a baseline snapshot cannot be resolved, reducing ambiguous outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->