### PR TITLE
[One Workflow] add default max-iterations for loop steps

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -9,6 +9,7 @@
 
 import { graphlib } from '@dagrejs/dagre';
 import { omit } from 'lodash';
+import { DEFAULT_LOOP_MAX_ITERATIONS } from '../../spec/schema';
 import type {
   BaseStep,
   DataSetStep,
@@ -799,10 +800,11 @@ function insertGraphBetweenNodes(
 }
 
 function normalizeMaxIterations(raw?: MaxIterations): {
-  maxIterations?: number;
-  onLimit?: 'continue' | 'fail';
+  maxIterations: number;
+  onLimit: 'continue' | 'fail';
 } {
-  if (raw == null) return {};
+  if (raw == null)
+    return { maxIterations: DEFAULT_LOOP_MAX_ITERATIONS, onLimit: 'continue' };
   if (typeof raw === 'number') return { maxIterations: raw, onLimit: 'continue' };
   return { maxIterations: raw.limit, onLimit: raw['on-limit'] };
 }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -803,8 +803,7 @@ function normalizeMaxIterations(raw?: MaxIterations): {
   maxIterations: number;
   onLimit: 'continue' | 'fail';
 } {
-  if (raw == null)
-    return { maxIterations: DEFAULT_LOOP_MAX_ITERATIONS, onLimit: 'continue' };
+  if (raw == null) return { maxIterations: DEFAULT_LOOP_MAX_ITERATIONS, onLimit: 'continue' };
   if (typeof raw === 'number') return { maxIterations: raw, onLimit: 'continue' };
   return { maxIterations: raw.limit, onLimit: raw['on-limit'] };
 }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/build_execution_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/build_execution_graph.test.ts
@@ -8,17 +8,18 @@
  */
 
 import { graphlib } from '@dagrejs/dagre';
-import type {
-  ConnectorStep,
-  ElasticsearchStep,
-  ForEachStep,
-  IfStep,
-  KibanaStep,
-  LoopBreakStep,
-  LoopContinueStep,
-  WaitStep,
-  WhileStep,
-  WorkflowYaml,
+import {
+  type ConnectorStep,
+  DEFAULT_LOOP_MAX_ITERATIONS,
+  type ElasticsearchStep,
+  type ForEachStep,
+  type IfStep,
+  type KibanaStep,
+  type LoopBreakStep,
+  type LoopContinueStep,
+  type WaitStep,
+  type WhileStep,
+  type WorkflowYaml,
 } from '../../../spec/schema';
 import type {
   AtomicGraphNode,
@@ -780,6 +781,8 @@ describe('convertToWorkflowGraph', () => {
           stepType: 'foreach',
           stepId: 'testForeachStep',
           startNodeId: 'enterForeach_testForeachStep',
+          maxIterations: DEFAULT_LOOP_MAX_ITERATIONS,
+          onLimit: 'continue',
         } as ExitForeachNode);
       });
 
@@ -945,6 +948,8 @@ describe('convertToWorkflowGraph', () => {
           stepId: 'foreach_testForeachConnectorStep',
           stepType: 'foreach',
           startNodeId: 'enterForeach_foreach_testForeachConnectorStep',
+          maxIterations: DEFAULT_LOOP_MAX_ITERATIONS,
+          onLimit: 'continue',
         } as ExitForeachNode);
       });
     });

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { graphlib } from '@dagrejs/dagre';
-import type { ConnectorStep, ForEachStep, WorkflowYaml } from '../../../spec/schema';
+import {
+  type ConnectorStep,
+  DEFAULT_LOOP_MAX_ITERATIONS,
+  type ForEachStep,
+  type WorkflowYaml,
+} from '../../../spec/schema';
 import type { ExitForeachNode } from '../../types/nodes/loop_nodes';
 import { convertToWorkflowGraph } from '../build_execution_graph';
 
@@ -358,7 +363,7 @@ describe('convertToWorkflowGraph', () => {
       expect(exitNode.onLimit).toBe('fail');
     });
 
-    it('should not set maxIterations on exit node when not configured', () => {
+    it('should apply default maxIterations with continue mode when not configured', () => {
       const workflowDefinition = {
         steps: [
           {
@@ -379,8 +384,8 @@ describe('convertToWorkflowGraph', () => {
 
       const executionGraph = convertToWorkflowGraph(workflowDefinition as WorkflowYaml);
       const exitNode = executionGraph.node('exitForeach_foreachStep') as ExitForeachNode;
-      expect(exitNode.maxIterations).toBeUndefined();
-      expect(exitNode.onLimit).toBeUndefined();
+      expect(exitNode.maxIterations).toBe(DEFAULT_LOOP_MAX_ITERATIONS);
+      expect(exitNode.onLimit).toBe('continue');
     });
 
     it('should support max-iterations combined with iteration-timeout and iteration-on-failure', () => {

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -199,6 +199,8 @@ export const MaxIterationsSchema = z.union([
 ]);
 export type MaxIterations = z.infer<typeof MaxIterationsSchema>;
 
+export const DEFAULT_LOOP_MAX_ITERATIONS = 2000;
+
 export const LoopStepPropsSchema = z.object({
   'max-iterations': MaxIterationsSchema.optional(),
   'iteration-timeout': DurationSchema.optional(),


### PR DESCRIPTION
## Summary

- Loop steps (`foreach`/`while`) without an explicit `max-iterations` now default to **2000 iterations** with `on-limit: continue`, acting as a safety guardrail against unbounded loops.
- Introduced `DEFAULT_LOOP_MAX_ITERATIONS` constant in `spec/schema.ts` for centralized configuration.
- Updated `normalizeMaxIterations` to always return a value, and updated related tests.