### PR TITLE
[Inference UI] Inference endpoints resolver

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
@@ -24,7 +24,7 @@ export interface InferenceEndpointSetting {
   id: string;
 }
 
-interface InferenceFeatureSetting {
+export interface InferenceFeatureSetting {
   feature_id: string;
   endpoints: InferenceEndpointSetting[];
 }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/moon.yml
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/moon.yml
@@ -52,6 +52,7 @@ dependsOn:
   - '@kbn/cloud-connect-plugin'
   - '@kbn/core-logging-server-mocks'
   - '@kbn/core-security-server'
+  - '@kbn/inference-common'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
@@ -18,6 +18,9 @@ export type {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
   InferenceFeatureConfig,
+  RegisterResult,
   InferenceFeatureRegistryContract,
   InferenceFeatureRegistryStartContract,
+  InferenceInferenceEndpointInfo,
+  InferenceEndpointsContract,
 } from './types';

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
@@ -23,6 +23,5 @@ export type {
   InferenceFeatureRegistryStartContract,
   InferenceInferenceEndpointInfo,
   InferenceEndpointsContract,
-  ScopedInferenceEndpointsClient,
   ResolvedInferenceEndpoints,
 } from './types';

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
@@ -23,5 +23,6 @@ export type {
   InferenceFeatureRegistryStartContract,
   InferenceInferenceEndpointInfo,
   InferenceEndpointsContract,
+  ScopedInferenceEndpointsClient,
   ResolvedInferenceEndpoints,
 } from './types';

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
@@ -21,7 +21,6 @@ export type {
   RegisterResult,
   InferenceFeatureRegistryContract,
   InferenceFeatureRegistryStartContract,
-  InferenceInferenceEndpointInfo,
   InferenceEndpointsContract,
   ResolvedInferenceEndpoints,
 } from './types';

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/index.ts
@@ -23,4 +23,5 @@ export type {
   InferenceFeatureRegistryStartContract,
   InferenceInferenceEndpointInfo,
   InferenceEndpointsContract,
+  ResolvedInferenceEndpoints,
 } from './types';

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -8,6 +8,7 @@
 import type { ElasticsearchClient, ISavedObjectsRepository, SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import { type InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { InferenceFeatureConfig } from './types';
 import type { InferenceSettingsAttributes } from '../common/types';
@@ -31,6 +32,23 @@ const createEndpointInfo = (id: string): InferenceInferenceEndpointInfo =>
     task_type: 'text_embedding',
     service: 'elasticsearch',
   } as InferenceInferenceEndpointInfo);
+
+const createExpectedConnector = (id: string): InferenceConnector => ({
+  type: InferenceConnectorType.Inference,
+  name: id,
+  connectorId: id,
+  config: {
+    inferenceId: id,
+    providerConfig: {
+      model_id: undefined,
+    },
+    taskType: 'text_embedding',
+    service: 'elasticsearch',
+    serviceSettings: undefined,
+  },
+  capabilities: {},
+  isInferenceEndpoint: true,
+});
 
 const createSoClient = (
   features: InferenceSettingsAttributes['features'] | 'not_found' = []
@@ -95,7 +113,7 @@ describe('getForFeature', () => {
         createEsClient({ ep1: info }),
         'f1'
       )
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('ep1')], warnings: [] });
   });
 
   it('returns hydrated endpoints from recommendedEndpoints', async () => {
@@ -103,7 +121,7 @@ describe('getForFeature', () => {
     const info = createEndpointInfo('rec1');
     await expect(
       getForFeature(registry, createSoClient(), createEsClient({ rec1: info }), 'f1')
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('rec1')], warnings: [] });
   });
 
   it('walks the fallback chain to parent recommendedEndpoints', async () => {
@@ -112,7 +130,7 @@ describe('getForFeature', () => {
     const info = createEndpointInfo('prec1');
     await expect(
       getForFeature(registry, createSoClient(), createEsClient({ prec1: info }), 'child')
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('prec1')], warnings: [] });
   });
 
   it('walks the full chain: child -> parent -> grandparent', async () => {
@@ -124,7 +142,7 @@ describe('getForFeature', () => {
     const info = createEndpointInfo('gp_ep');
     await expect(
       getForFeature(registry, createSoClient(), createEsClient({ gp_ep: info }), 'child')
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('gp_ep')], warnings: [] });
   });
 
   it('prefers SO override over recommendedEndpoints', async () => {
@@ -137,7 +155,7 @@ describe('getForFeature', () => {
         createEsClient({ so_ep: soInfo, rec1: createEndpointInfo('rec1') }),
         'f1'
       )
-    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('so_ep')], warnings: [] });
   });
 
   it('skips SO entry with empty endpoints and falls through to recommended', async () => {
@@ -150,7 +168,7 @@ describe('getForFeature', () => {
         createEsClient({ rec1: info }),
         'f1'
       )
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('rec1')], warnings: [] });
   });
 
   it('handles SO 404 and falls through to recommended', async () => {
@@ -158,7 +176,7 @@ describe('getForFeature', () => {
     const info = createEndpointInfo('rec1');
     await expect(
       getForFeature(registry, createSoClient('not_found'), createEsClient({ rec1: info }), 'f1')
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('rec1')], warnings: [] });
   });
 
   it('returns warning for ES endpoints that no longer exist (404)', async () => {
@@ -172,7 +190,7 @@ describe('getForFeature', () => {
       createEsClient({ ep1: 'not_found', ep2: info }),
       'f1'
     );
-    expect(result.endpoints).toEqual([info]);
+    expect(result.endpoints).toEqual([createExpectedConnector('ep2')]);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain('ep1');
   });
@@ -230,7 +248,7 @@ describe('getForFeature', () => {
         createEsClient({ child_ep: info, parent_ep: createEndpointInfo('parent_ep') }),
         'child'
       )
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('child_ep')], warnings: [] });
   });
 
   it('uses first recommendedEndpoints found in chain when child has none', async () => {
@@ -253,7 +271,7 @@ describe('getForFeature', () => {
         createEsClient({ parent_ep: info, gp_ep: createEndpointInfo('gp_ep') }),
         'child'
       )
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('parent_ep')], warnings: [] });
   });
 
   it('prefers parent SO override over child recommendedEndpoints', async () => {
@@ -273,7 +291,7 @@ describe('getForFeature', () => {
         createEsClient({ so_ep: soInfo, child_ep: createEndpointInfo('child_ep') }),
         'child'
       )
-    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('so_ep')], warnings: [] });
   });
 
   it('uses grandparent recommendedEndpoints when parent has none', async () => {
@@ -285,7 +303,7 @@ describe('getForFeature', () => {
     const info = createEndpointInfo('gp_ep');
     await expect(
       getForFeature(registry, createSoClient(), createEsClient({ gp_ep: info }), 'child')
-    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('gp_ep')], warnings: [] });
   });
 
   it('prefers grandparent SO override over all recommendedEndpoints', async () => {
@@ -319,6 +337,6 @@ describe('getForFeature', () => {
         }),
         'child'
       )
-    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+    ).resolves.toEqual({ endpoints: [createExpectedConnector('gp_so')], warnings: [] });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -5,13 +5,18 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, ISavedObjectsRepository, SavedObject } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  SavedObjectsClientContract,
+  SavedObject,
+} from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { InferenceFeatureConfig } from './types';
 import type { InferenceSettingsAttributes } from '../common/types';
 import { InferenceFeatureRegistry } from './inference_feature_registry';
-import { InferenceEndpoints } from './inference_endpoints';
+import { getForFeature } from './inference_endpoints';
 
 const createValidFeature = (
   overrides: Partial<InferenceFeatureConfig> = {}
@@ -31,9 +36,9 @@ const createEndpointInfo = (id: string): InferenceInferenceEndpointInfo =>
     service: 'elasticsearch',
   } as InferenceInferenceEndpointInfo);
 
-const createSoRepo = (
+const createSoClient = (
   features: InferenceSettingsAttributes['features'] | 'not_found' = []
-): ISavedObjectsRepository =>
+): SavedObjectsClientContract =>
   ({
     get: jest.fn().mockImplementation(() => {
       if (features === 'not_found') {
@@ -45,7 +50,7 @@ const createSoRepo = (
         attributes: { features },
       } as SavedObject<InferenceSettingsAttributes>;
     }),
-  } as unknown as ISavedObjectsRepository);
+  } as unknown as SavedObjectsClientContract);
 
 const createEsClient = (
   endpointMap: Record<string, InferenceInferenceEndpointInfo | 'not_found'> = {}
@@ -64,52 +69,54 @@ const createEsClient = (
     },
   } as unknown as ElasticsearchClient);
 
-describe('InferenceEndpoints', () => {
+describe('getForFeature', () => {
   let registry: InferenceFeatureRegistry;
 
   beforeEach(() => {
-    registry = new InferenceFeatureRegistry();
+    registry = new InferenceFeatureRegistry(loggingSystemMock.createLogger());
   });
 
-  const makeEndpoints = (
-    soRepo: ISavedObjectsRepository,
-    esClient: ElasticsearchClient
-  ): InferenceEndpoints => new InferenceEndpoints(registry, soRepo, esClient);
-
   it('throws when featureId is not registered', async () => {
-    const ep = makeEndpoints(createSoRepo(), createEsClient());
-    await expect(ep.getForFeature('unknown')).rejects.toThrow('not registered');
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient(), 'unknown')
+    ).rejects.toThrow('not registered');
   });
 
   it('returns empty result when no endpoints resolved', async () => {
     registry.register(createValidFeature({ featureId: 'f1' }));
-    const ep = makeEndpoints(createSoRepo(), createEsClient());
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [], warnings: [] });
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient(), 'f1')
+    ).resolves.toEqual({ endpoints: [], warnings: [] });
   });
 
   it('returns hydrated endpoints from SO override', async () => {
     registry.register(createValidFeature({ featureId: 'f1' }));
     const info = createEndpointInfo('ep1');
-    const ep = makeEndpoints(
-      createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'ep1' }] }]),
-      createEsClient({ ep1: info })
-    );
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient([{ feature_id: 'f1', endpoints: [{ id: 'ep1' }] }]),
+        createEsClient({ ep1: info }),
+        'f1'
+      )
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('returns hydrated endpoints from recommendedEndpoints', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const info = createEndpointInfo('rec1');
-    const ep = makeEndpoints(createSoRepo(), createEsClient({ rec1: info }));
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient({ rec1: info }), 'f1')
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('walks the fallback chain to parent recommendedEndpoints', async () => {
     registry.register(createValidFeature({ featureId: 'parent', recommendedEndpoints: ['prec1'] }));
     registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
     const info = createEndpointInfo('prec1');
-    const ep = makeEndpoints(createSoRepo(), createEsClient({ prec1: info }));
-    await expect(ep.getForFeature('child')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient({ prec1: info }), 'child')
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('walks the full chain: child -> parent -> grandparent', async () => {
@@ -119,35 +126,43 @@ describe('InferenceEndpoints', () => {
     registry.register(createValidFeature({ featureId: 'parent', parentFeatureId: 'grandparent' }));
     registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
     const info = createEndpointInfo('gp_ep');
-    const ep = makeEndpoints(createSoRepo(), createEsClient({ gp_ep: info }));
-    await expect(ep.getForFeature('child')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient({ gp_ep: info }), 'child')
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('prefers SO override over recommendedEndpoints', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const soInfo = createEndpointInfo('so_ep');
-    const ep = makeEndpoints(
-      createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'so_ep' }] }]),
-      createEsClient({ so_ep: soInfo, rec1: createEndpointInfo('rec1') })
-    );
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient([{ feature_id: 'f1', endpoints: [{ id: 'so_ep' }] }]),
+        createEsClient({ so_ep: soInfo, rec1: createEndpointInfo('rec1') }),
+        'f1'
+      )
+    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
   });
 
   it('skips SO entry with empty endpoints and falls through to recommended', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const info = createEndpointInfo('rec1');
-    const ep = makeEndpoints(
-      createSoRepo([{ feature_id: 'f1', endpoints: [] }]),
-      createEsClient({ rec1: info })
-    );
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient([{ feature_id: 'f1', endpoints: [] }]),
+        createEsClient({ rec1: info }),
+        'f1'
+      )
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('handles SO 404 and falls through to recommended', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const info = createEndpointInfo('rec1');
-    const ep = makeEndpoints(createSoRepo('not_found'), createEsClient({ rec1: info }));
-    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
+    await expect(
+      getForFeature(registry, createSoClient('not_found'), createEsClient({ rec1: info }), 'f1')
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('returns warning for ES endpoints that no longer exist (404)', async () => {
@@ -155,8 +170,12 @@ describe('InferenceEndpoints', () => {
       createValidFeature({ featureId: 'f1', recommendedEndpoints: ['ep1', 'ep2'] })
     );
     const info = createEndpointInfo('ep2');
-    const ep = makeEndpoints(createSoRepo(), createEsClient({ ep1: 'not_found', ep2: info }));
-    const result = await ep.getForFeature('f1');
+    const result = await getForFeature(
+      registry,
+      createSoClient(),
+      createEsClient({ ep1: 'not_found', ep2: info }),
+      'f1'
+    );
     expect(result.endpoints).toEqual([info]);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain('ep1');
@@ -171,17 +190,19 @@ describe('InferenceEndpoints', () => {
           .mockRejectedValue(Object.assign(new Error('ES unavailable'), { statusCode: 503 })),
       },
     } as unknown as ElasticsearchClient;
-    const ep = makeEndpoints(createSoRepo(), esClient);
-    await expect(ep.getForFeature('f1')).rejects.toThrow('ES unavailable');
+    await expect(getForFeature(registry, createSoClient(), esClient, 'f1')).rejects.toThrow(
+      'ES unavailable'
+    );
   });
 
   it('propagates non-404 SO errors', async () => {
     registry.register(createValidFeature({ featureId: 'f1' }));
-    const soRepo = {
+    const soClient = {
       get: jest.fn().mockRejectedValue(new Error('Connection refused')),
-    } as unknown as ISavedObjectsRepository;
-    const ep = makeEndpoints(soRepo, createEsClient());
-    await expect(ep.getForFeature('f1')).rejects.toThrow('Connection refused');
+    } as unknown as SavedObjectsClientContract;
+    await expect(getForFeature(registry, soClient, createEsClient(), 'f1')).rejects.toThrow(
+      'Connection refused'
+    );
   });
 
   it('detects cycles and returns empty result', async () => {
@@ -189,7 +210,8 @@ describe('InferenceEndpoints', () => {
     registry.register(createValidFeature({ featureId: 'b', parentFeatureId: 'a' }));
     // Inject cycle
     (registry as any).features.get('a').parentFeatureId = 'b';
-    const ep = makeEndpoints(createSoRepo(), createEsClient());
-    await expect(ep.getForFeature('a')).resolves.toEqual({ endpoints: [], warnings: [] });
+    await expect(getForFeature(registry, createSoClient(), createEsClient(), 'a')).resolves.toEqual(
+      { endpoints: [], warnings: [] }
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -81,10 +81,10 @@ describe('InferenceEndpoints', () => {
     await expect(ep.getForFeature('unknown')).rejects.toThrow('not registered');
   });
 
-  it('returns empty array when no endpoints resolved', async () => {
+  it('returns empty result when no endpoints resolved', async () => {
     registry.register(createValidFeature({ featureId: 'f1' }));
     const ep = makeEndpoints(createSoRepo(), createEsClient());
-    await expect(ep.getForFeature('f1')).resolves.toEqual([]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [], warnings: [] });
   });
 
   it('returns hydrated endpoints from SO override', async () => {
@@ -94,14 +94,14 @@ describe('InferenceEndpoints', () => {
       createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'ep1' }] }]),
       createEsClient({ ep1: info })
     );
-    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('returns hydrated endpoints from recommendedEndpoints', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const info = createEndpointInfo('rec1');
     const ep = makeEndpoints(createSoRepo(), createEsClient({ rec1: info }));
-    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('walks the fallback chain to parent recommendedEndpoints', async () => {
@@ -109,7 +109,7 @@ describe('InferenceEndpoints', () => {
     registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
     const info = createEndpointInfo('prec1');
     const ep = makeEndpoints(createSoRepo(), createEsClient({ prec1: info }));
-    await expect(ep.getForFeature('child')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('child')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('walks the full chain: child -> parent -> grandparent', async () => {
@@ -120,7 +120,7 @@ describe('InferenceEndpoints', () => {
     registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
     const info = createEndpointInfo('gp_ep');
     const ep = makeEndpoints(createSoRepo(), createEsClient({ gp_ep: info }));
-    await expect(ep.getForFeature('child')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('child')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('prefers SO override over recommendedEndpoints', async () => {
@@ -130,7 +130,7 @@ describe('InferenceEndpoints', () => {
       createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'so_ep' }] }]),
       createEsClient({ so_ep: soInfo, rec1: createEndpointInfo('rec1') })
     );
-    await expect(ep.getForFeature('f1')).resolves.toEqual([soInfo]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
   });
 
   it('skips SO entry with empty endpoints and falls through to recommended', async () => {
@@ -140,23 +140,26 @@ describe('InferenceEndpoints', () => {
       createSoRepo([{ feature_id: 'f1', endpoints: [] }]),
       createEsClient({ rec1: info })
     );
-    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
   it('handles SO 404 and falls through to recommended', async () => {
     registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
     const info = createEndpointInfo('rec1');
     const ep = makeEndpoints(createSoRepo('not_found'), createEsClient({ rec1: info }));
-    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+    await expect(ep.getForFeature('f1')).resolves.toEqual({ endpoints: [info], warnings: [] });
   });
 
-  it('skips ES endpoints that no longer exist (404) without failing', async () => {
+  it('returns warning for ES endpoints that no longer exist (404)', async () => {
     registry.register(
       createValidFeature({ featureId: 'f1', recommendedEndpoints: ['ep1', 'ep2'] })
     );
     const info = createEndpointInfo('ep2');
     const ep = makeEndpoints(createSoRepo(), createEsClient({ ep1: 'not_found', ep2: info }));
-    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+    const result = await ep.getForFeature('f1');
+    expect(result.endpoints).toEqual([info]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('ep1');
   });
 
   it('propagates non-404 ES errors', async () => {
@@ -181,12 +184,12 @@ describe('InferenceEndpoints', () => {
     await expect(ep.getForFeature('f1')).rejects.toThrow('Connection refused');
   });
 
-  it('detects cycles and returns empty array', async () => {
+  it('detects cycles and returns empty result', async () => {
     registry.register(createValidFeature({ featureId: 'a' }));
     registry.register(createValidFeature({ featureId: 'b', parentFeatureId: 'a' }));
     // Inject cycle
     (registry as any).features.get('a').parentFeatureId = 'b';
     const ep = makeEndpoints(createSoRepo(), createEsClient());
-    await expect(ep.getForFeature('a')).resolves.toEqual([]);
+    await expect(ep.getForFeature('a')).resolves.toEqual({ endpoints: [], warnings: [] });
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -5,11 +5,7 @@
  * 2.0.
  */
 
-import type {
-  ElasticsearchClient,
-  SavedObjectsClientContract,
-  SavedObject,
-} from '@kbn/core/server';
+import type { ElasticsearchClient, ISavedObjectsRepository, SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
@@ -38,7 +34,7 @@ const createEndpointInfo = (id: string): InferenceInferenceEndpointInfo =>
 
 const createSoClient = (
   features: InferenceSettingsAttributes['features'] | 'not_found' = []
-): SavedObjectsClientContract =>
+): ISavedObjectsRepository =>
   ({
     get: jest.fn().mockImplementation(() => {
       if (features === 'not_found') {
@@ -50,7 +46,7 @@ const createSoClient = (
         attributes: { features },
       } as SavedObject<InferenceSettingsAttributes>;
     }),
-  } as unknown as SavedObjectsClientContract);
+  } as unknown as ISavedObjectsRepository);
 
 const createEsClient = (
   endpointMap: Record<string, InferenceInferenceEndpointInfo | 'not_found'> = {}
@@ -199,7 +195,7 @@ describe('getForFeature', () => {
     registry.register(createValidFeature({ featureId: 'f1' }));
     const soClient = {
       get: jest.fn().mockRejectedValue(new Error('Connection refused')),
-    } as unknown as SavedObjectsClientContract;
+    } as unknown as ISavedObjectsRepository;
     await expect(getForFeature(registry, soClient, createEsClient(), 'f1')).rejects.toThrow(
       'Connection refused'
     );

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -205,13 +205,13 @@ describe('getForFeature', () => {
     );
   });
 
-  it('detects cycles and returns empty result', async () => {
+  it('detects cycles and returns empty result with warning', async () => {
     registry.register(createValidFeature({ featureId: 'a' }));
     registry.register(createValidFeature({ featureId: 'b', parentFeatureId: 'a' }));
-    // Inject cycle
     (registry as any).features.get('a').parentFeatureId = 'b';
-    await expect(getForFeature(registry, createSoClient(), createEsClient(), 'a')).resolves.toEqual(
-      { endpoints: [], warnings: [] }
-    );
+    const result = await getForFeature(registry, createSoClient(), createEsClient(), 'a');
+    expect(result.endpoints).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('Cyclic dependency');
   });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, ISavedObjectsRepository, SavedObject } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import type { InferenceFeatureConfig } from './types';
+import type { InferenceSettingsAttributes } from '../common/types';
+import { InferenceFeatureRegistry } from './inference_feature_registry';
+import { InferenceEndpoints } from './inference_endpoints';
+
+const createValidFeature = (
+  overrides: Partial<InferenceFeatureConfig> = {}
+): InferenceFeatureConfig => ({
+  featureId: 'test_feature',
+  featureName: 'Test Feature',
+  featureDescription: 'A test feature',
+  taskType: 'text_embedding',
+  recommendedEndpoints: [],
+  ...overrides,
+});
+
+const createEndpointInfo = (id: string): InferenceInferenceEndpointInfo =>
+  ({
+    inference_id: id,
+    task_type: 'text_embedding',
+    service: 'elasticsearch',
+  } as InferenceInferenceEndpointInfo);
+
+const createSoRepo = (
+  features: InferenceSettingsAttributes['features'] | 'not_found' = []
+): ISavedObjectsRepository =>
+  ({
+    get: jest.fn().mockImplementation(() => {
+      if (features === 'not_found') {
+        throw SavedObjectsErrorHelpers.createGenericNotFoundError('inference-settings', 'default');
+      }
+      return {
+        id: 'default',
+        type: 'inference-settings',
+        attributes: { features },
+      } as SavedObject<InferenceSettingsAttributes>;
+    }),
+  } as unknown as ISavedObjectsRepository);
+
+const createEsClient = (
+  endpointMap: Record<string, InferenceInferenceEndpointInfo | 'not_found'> = {}
+): ElasticsearchClient =>
+  ({
+    inference: {
+      get: jest.fn().mockImplementation(({ inference_id: id }: { inference_id: string }) => {
+        const entry = endpointMap[id];
+        if (entry === 'not_found') {
+          const err = new Error('Not found') as any;
+          err.statusCode = 404;
+          throw err;
+        }
+        return Promise.resolve({ endpoints: entry ? [entry] : [] });
+      }),
+    },
+  } as unknown as ElasticsearchClient);
+
+describe('InferenceEndpoints', () => {
+  let registry: InferenceFeatureRegistry;
+
+  beforeEach(() => {
+    registry = new InferenceFeatureRegistry();
+  });
+
+  const makeEndpoints = (
+    soRepo: ISavedObjectsRepository,
+    esClient: ElasticsearchClient
+  ): InferenceEndpoints => new InferenceEndpoints(registry, soRepo, esClient);
+
+  it('throws when featureId is not registered', async () => {
+    const ep = makeEndpoints(createSoRepo(), createEsClient());
+    await expect(ep.getForFeature('unknown')).rejects.toThrow('not registered');
+  });
+
+  it('returns empty array when no endpoints resolved', async () => {
+    registry.register(createValidFeature({ featureId: 'f1' }));
+    const ep = makeEndpoints(createSoRepo(), createEsClient());
+    await expect(ep.getForFeature('f1')).resolves.toEqual([]);
+  });
+
+  it('returns hydrated endpoints from SO override', async () => {
+    registry.register(createValidFeature({ featureId: 'f1' }));
+    const info = createEndpointInfo('ep1');
+    const ep = makeEndpoints(
+      createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'ep1' }] }]),
+      createEsClient({ ep1: info })
+    );
+    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+  });
+
+  it('returns hydrated endpoints from recommendedEndpoints', async () => {
+    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
+    const info = createEndpointInfo('rec1');
+    const ep = makeEndpoints(createSoRepo(), createEsClient({ rec1: info }));
+    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+  });
+
+  it('walks the fallback chain to parent recommendedEndpoints', async () => {
+    registry.register(createValidFeature({ featureId: 'parent', recommendedEndpoints: ['prec1'] }));
+    registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
+    const info = createEndpointInfo('prec1');
+    const ep = makeEndpoints(createSoRepo(), createEsClient({ prec1: info }));
+    await expect(ep.getForFeature('child')).resolves.toEqual([info]);
+  });
+
+  it('walks the full chain: child -> parent -> grandparent', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'grandparent', recommendedEndpoints: ['gp_ep'] })
+    );
+    registry.register(createValidFeature({ featureId: 'parent', parentFeatureId: 'grandparent' }));
+    registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
+    const info = createEndpointInfo('gp_ep');
+    const ep = makeEndpoints(createSoRepo(), createEsClient({ gp_ep: info }));
+    await expect(ep.getForFeature('child')).resolves.toEqual([info]);
+  });
+
+  it('prefers SO override over recommendedEndpoints', async () => {
+    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
+    const soInfo = createEndpointInfo('so_ep');
+    const ep = makeEndpoints(
+      createSoRepo([{ feature_id: 'f1', endpoints: [{ id: 'so_ep' }] }]),
+      createEsClient({ so_ep: soInfo, rec1: createEndpointInfo('rec1') })
+    );
+    await expect(ep.getForFeature('f1')).resolves.toEqual([soInfo]);
+  });
+
+  it('skips SO entry with empty endpoints and falls through to recommended', async () => {
+    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
+    const info = createEndpointInfo('rec1');
+    const ep = makeEndpoints(
+      createSoRepo([{ feature_id: 'f1', endpoints: [] }]),
+      createEsClient({ rec1: info })
+    );
+    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+  });
+
+  it('handles SO 404 and falls through to recommended', async () => {
+    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['rec1'] }));
+    const info = createEndpointInfo('rec1');
+    const ep = makeEndpoints(createSoRepo('not_found'), createEsClient({ rec1: info }));
+    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+  });
+
+  it('skips ES endpoints that no longer exist (404) without failing', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'f1', recommendedEndpoints: ['ep1', 'ep2'] })
+    );
+    const info = createEndpointInfo('ep2');
+    const ep = makeEndpoints(createSoRepo(), createEsClient({ ep1: 'not_found', ep2: info }));
+    await expect(ep.getForFeature('f1')).resolves.toEqual([info]);
+  });
+
+  it('propagates non-404 ES errors', async () => {
+    registry.register(createValidFeature({ featureId: 'f1', recommendedEndpoints: ['ep1'] }));
+    const esClient = {
+      inference: {
+        get: jest
+          .fn()
+          .mockRejectedValue(Object.assign(new Error('ES unavailable'), { statusCode: 503 })),
+      },
+    } as unknown as ElasticsearchClient;
+    const ep = makeEndpoints(createSoRepo(), esClient);
+    await expect(ep.getForFeature('f1')).rejects.toThrow('ES unavailable');
+  });
+
+  it('propagates non-404 SO errors', async () => {
+    registry.register(createValidFeature({ featureId: 'f1' }));
+    const soRepo = {
+      get: jest.fn().mockRejectedValue(new Error('Connection refused')),
+    } as unknown as ISavedObjectsRepository;
+    const ep = makeEndpoints(soRepo, createEsClient());
+    await expect(ep.getForFeature('f1')).rejects.toThrow('Connection refused');
+  });
+
+  it('detects cycles and returns empty array', async () => {
+    registry.register(createValidFeature({ featureId: 'a' }));
+    registry.register(createValidFeature({ featureId: 'b', parentFeatureId: 'a' }));
+    // Inject cycle
+    (registry as any).features.get('a').parentFeatureId = 'b';
+    const ep = makeEndpoints(createSoRepo(), createEsClient());
+    await expect(ep.getForFeature('a')).resolves.toEqual([]);
+  });
+});

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -210,4 +210,115 @@ describe('getForFeature', () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain('Cyclic dependency');
   });
+
+  it('prefers child recommendedEndpoints over parent recommendedEndpoints', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'parent', recommendedEndpoints: ['parent_ep'] })
+    );
+    registry.register(
+      createValidFeature({
+        featureId: 'child',
+        parentFeatureId: 'parent',
+        recommendedEndpoints: ['child_ep'],
+      })
+    );
+    const info = createEndpointInfo('child_ep');
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient(),
+        createEsClient({ child_ep: info, parent_ep: createEndpointInfo('parent_ep') }),
+        'child'
+      )
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+  });
+
+  it('uses first recommendedEndpoints found in chain when child has none', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'grandparent', recommendedEndpoints: ['gp_ep'] })
+    );
+    registry.register(
+      createValidFeature({
+        featureId: 'parent',
+        parentFeatureId: 'grandparent',
+        recommendedEndpoints: ['parent_ep'],
+      })
+    );
+    registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
+    const info = createEndpointInfo('parent_ep');
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient(),
+        createEsClient({ parent_ep: info, gp_ep: createEndpointInfo('gp_ep') }),
+        'child'
+      )
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+  });
+
+  it('prefers parent SO override over child recommendedEndpoints', async () => {
+    registry.register(createValidFeature({ featureId: 'parent' }));
+    registry.register(
+      createValidFeature({
+        featureId: 'child',
+        parentFeatureId: 'parent',
+        recommendedEndpoints: ['child_ep'],
+      })
+    );
+    const soInfo = createEndpointInfo('so_ep');
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient([{ feature_id: 'parent', endpoints: [{ id: 'so_ep' }] }]),
+        createEsClient({ so_ep: soInfo, child_ep: createEndpointInfo('child_ep') }),
+        'child'
+      )
+    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+  });
+
+  it('uses grandparent recommendedEndpoints when parent has none', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'grandparent', recommendedEndpoints: ['gp_ep'] })
+    );
+    registry.register(createValidFeature({ featureId: 'parent', parentFeatureId: 'grandparent' }));
+    registry.register(createValidFeature({ featureId: 'child', parentFeatureId: 'parent' }));
+    const info = createEndpointInfo('gp_ep');
+    await expect(
+      getForFeature(registry, createSoClient(), createEsClient({ gp_ep: info }), 'child')
+    ).resolves.toEqual({ endpoints: [info], warnings: [] });
+  });
+
+  it('prefers grandparent SO override over all recommendedEndpoints', async () => {
+    registry.register(
+      createValidFeature({ featureId: 'grandparent', recommendedEndpoints: ['gp_rec'] })
+    );
+    registry.register(
+      createValidFeature({
+        featureId: 'parent',
+        parentFeatureId: 'grandparent',
+        recommendedEndpoints: ['parent_rec'],
+      })
+    );
+    registry.register(
+      createValidFeature({
+        featureId: 'child',
+        parentFeatureId: 'parent',
+        recommendedEndpoints: ['child_rec'],
+      })
+    );
+    const soInfo = createEndpointInfo('gp_so');
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient([{ feature_id: 'grandparent', endpoints: [{ id: 'gp_so' }] }]),
+        createEsClient({
+          gp_so: soInfo,
+          child_rec: createEndpointInfo('child_rec'),
+          parent_rec: createEndpointInfo('parent_rec'),
+          gp_rec: createEndpointInfo('gp_rec'),
+        }),
+        'child'
+      )
+    ).resolves.toEqual({ endpoints: [soInfo], warnings: [] });
+  });
 });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, ISavedObjectsRepository } from '@kbn/core/server';
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
@@ -14,117 +14,136 @@ import type { InferenceSettingsAttributes } from '../common/types';
 import type { InferenceFeatureRegistry } from './inference_feature_registry';
 import type { ResolvedInferenceEndpoints } from './types';
 
-export class InferenceEndpoints {
-  constructor(
-    private readonly registry: InferenceFeatureRegistry,
-    private readonly soRepo: ISavedObjectsRepository,
-    private readonly esClient: ElasticsearchClient
-  ) {}
+/**
+ * Returns the resolved inference endpoints for a feature.
+ * Walks the fallback chain (admin SO override → recommendedEndpoints → parent feature)
+ * and fetches full endpoint objects from Elasticsearch.
+ *
+ * @param registry - The feature registry to look up feature configs.
+ * @param soClient - A scoped saved objects client.
+ * @param esClient - A scoped Elasticsearch client.
+ * @param featureId - The feature to resolve endpoints for.
+ * @throws If `featureId` is not registered.
+ */
+export const getForFeature = async (
+  registry: InferenceFeatureRegistry,
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  featureId: string
+): Promise<ResolvedInferenceEndpoints> => {
+  const endpointIds = await resolveEndpointIds(registry, soClient, featureId);
+  if (endpointIds.length === 0) {
+    return { endpoints: [], warnings: [] };
+  }
+  return fetchEndpoints(esClient, endpointIds);
+};
 
-  /**
-   * Returns the resolved inference endpoints for a feature.
-   * Walks the fallback chain (admin SO override → recommendedEndpoints → parent feature)
-   * and fetches full endpoint objects from Elasticsearch.
-   *
-   * @param featureId - The feature to resolve endpoints for.
-   * @throws If `featureId` is not registered.
-   */
-  async getForFeature(featureId: string): Promise<ResolvedInferenceEndpoints> {
-    const endpointIds = await this.resolveEndpointIds(featureId);
-    if (endpointIds.length === 0) {
-      return { endpoints: [], warnings: [] };
-    }
-    return this.fetchEndpoints(endpointIds);
+const resolveEndpointIds = async (
+  registry: InferenceFeatureRegistry,
+  soClient: SavedObjectsClientContract,
+  featureId: string
+): Promise<string[]> => {
+  if (!registry.get(featureId)) {
+    throw new Error(
+      i18n.translate('xpack.searchInferenceEndpoints.endpoints.featureNotFound', {
+        defaultMessage: 'Feature with id "{featureId}" is not registered.',
+        values: { featureId },
+      })
+    );
   }
 
-  private async resolveEndpointIds(featureId: string): Promise<string[]> {
-    if (!this.registry.get(featureId)) {
-      throw new Error(
-        i18n.translate('xpack.searchInferenceEndpoints.endpoints.featureNotFound', {
-          defaultMessage: 'Feature with id "{featureId}" is not registered.',
-          values: { featureId },
+  const soFeatures = await readSettingsFeatures(soClient);
+  const soFeaturesMap = new Map(soFeatures.map((f) => [f.feature_id, f]));
+
+  // Walk the fallback chain for the feature:
+  // 1. Check for an admin-configured SO override for the current feature
+  // 2. Fall back to the feature's recommendedEndpoints
+  // 3. If neither exists, follow the parentFeatureId link and repeat
+  // The visited set prevents infinite loops from circular parent references.
+  const visited = new Set<string>();
+  let currentId = featureId;
+
+  while (!visited.has(currentId)) {
+    visited.add(currentId);
+    const current = registry.get(currentId);
+    if (!current) {
+      break;
+    }
+
+    const soEntry = soFeaturesMap.get(currentId);
+    if (soEntry && soEntry.endpoints.length > 0) {
+      return soEntry.endpoints.map((e) => e.id);
+    }
+
+    if (current.recommendedEndpoints.length > 0) {
+      return current.recommendedEndpoints;
+    }
+
+    if (current.parentFeatureId) {
+      currentId = current.parentFeatureId;
+    } else {
+      break;
+    }
+  }
+
+  return [];
+};
+
+/**
+ * Fetches full inference endpoint objects from Elasticsearch by their IDs.
+ * Returns the successfully fetched endpoints and warnings for any that were not found (404).
+ * Non-404 errors are propagated.
+ */
+const fetchEndpoints = async (
+  esClient: ElasticsearchClient,
+  ids: string[]
+): Promise<ResolvedInferenceEndpoints> => {
+  const endpoints: InferenceInferenceEndpointInfo[] = [];
+  const warnings: string[] = [];
+
+  const results = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const response = await esClient.inference.get({ inference_id: id });
+        return { id, endpoint: response.endpoints[0] ?? null };
+      } catch (e) {
+        if (e?.statusCode === 404) {
+          return { id, endpoint: null };
+        }
+        throw e;
+      }
+    })
+  );
+
+  for (const { id, endpoint } of results) {
+    if (endpoint) {
+      endpoints.push(endpoint);
+    } else {
+      warnings.push(
+        i18n.translate('xpack.searchInferenceEndpoints.endpoints.endpointNotFound', {
+          defaultMessage: 'Inference endpoint "{endpointId}" was not found in Elasticsearch.',
+          values: { endpointId: id },
         })
       );
     }
-
-    const soFeatures = await this.readSettingsFeatures();
-    const soFeaturesMap = new Map(soFeatures.map((f) => [f.feature_id, f]));
-
-    const visited = new Set<string>();
-    let currentId = featureId;
-
-    while (!visited.has(currentId)) {
-      visited.add(currentId);
-      const current = this.registry.get(currentId);
-      if (!current) {
-        break;
-      }
-
-      const soEntry = soFeaturesMap.get(currentId);
-      if (soEntry && soEntry.endpoints.length > 0) {
-        return soEntry.endpoints.map((e) => e.id);
-      }
-
-      if (current.recommendedEndpoints.length > 0) {
-        return current.recommendedEndpoints;
-      }
-
-      if (current.parentFeatureId) {
-        currentId = current.parentFeatureId;
-      } else {
-        break;
-      }
-    }
-
-    return [];
   }
 
-  private async fetchEndpoints(ids: string[]): Promise<ResolvedInferenceEndpoints> {
-    const endpoints: InferenceInferenceEndpointInfo[] = [];
-    const warnings: string[] = [];
+  return { endpoints, warnings };
+};
 
-    const results = await Promise.all(
-      ids.map(async (id) => {
-        try {
-          const response = await this.esClient.inference.get({ inference_id: id });
-          return { id, endpoint: response.endpoints[0] ?? null };
-        } catch (e) {
-          if (e?.statusCode === 404) {
-            return { id, endpoint: null };
-          }
-          throw e;
-        }
-      })
+const readSettingsFeatures = async (
+  soClient: SavedObjectsClientContract
+): Promise<InferenceSettingsAttributes['features']> => {
+  try {
+    const so = await soClient.get<InferenceSettingsAttributes>(
+      INFERENCE_SETTINGS_SO_TYPE,
+      INFERENCE_SETTINGS_ID
     );
-
-    for (const { id, endpoint } of results) {
-      if (endpoint) {
-        endpoints.push(endpoint);
-      } else {
-        warnings.push(
-          i18n.translate('xpack.searchInferenceEndpoints.endpoints.endpointNotFound', {
-            defaultMessage: 'Inference endpoint "{endpointId}" was not found in Elasticsearch.',
-            values: { endpointId: id },
-          })
-        );
-      }
+    return so.attributes.features ?? [];
+  } catch (e) {
+    if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+      return [];
     }
-
-    return { endpoints, warnings };
+    throw e;
   }
-
-  private async readSettingsFeatures(): Promise<InferenceSettingsAttributes['features']> {
-    try {
-      const so = await this.soRepo.get<InferenceSettingsAttributes>(
-        INFERENCE_SETTINGS_SO_TYPE,
-        INFERENCE_SETTINGS_ID
-      );
-      return so.attributes.features ?? [];
-    } catch (e) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
-        return [];
-      }
-      throw e;
-    }
-  }
-}
+};

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -12,6 +12,7 @@ import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/
 import { INFERENCE_SETTINGS_SO_TYPE, INFERENCE_SETTINGS_ID } from '../common/constants';
 import type { InferenceSettingsAttributes } from '../common/types';
 import type { InferenceFeatureRegistry } from './inference_feature_registry';
+import type { ResolvedInferenceEndpoints } from './types';
 
 export class InferenceEndpoints {
   constructor(
@@ -28,10 +29,10 @@ export class InferenceEndpoints {
    * @param featureId - The feature to resolve endpoints for.
    * @throws If `featureId` is not registered.
    */
-  async getForFeature(featureId: string): Promise<InferenceInferenceEndpointInfo[]> {
+  async getForFeature(featureId: string): Promise<ResolvedInferenceEndpoints> {
     const endpointIds = await this.resolveEndpointIds(featureId);
     if (endpointIds.length === 0) {
-      return [];
+      return { endpoints: [], warnings: [] };
     }
     return this.fetchEndpoints(endpointIds);
   }
@@ -78,21 +79,38 @@ export class InferenceEndpoints {
     return [];
   }
 
-  private async fetchEndpoints(ids: string[]): Promise<InferenceInferenceEndpointInfo[]> {
+  private async fetchEndpoints(ids: string[]): Promise<ResolvedInferenceEndpoints> {
+    const endpoints: InferenceInferenceEndpointInfo[] = [];
+    const warnings: string[] = [];
+
     const results = await Promise.all(
       ids.map(async (id) => {
         try {
-          const { endpoints } = await this.esClient.inference.get({ inference_id: id });
-          return endpoints[0] ?? null;
+          const response = await this.esClient.inference.get({ inference_id: id });
+          return { id, endpoint: response.endpoints[0] ?? null };
         } catch (e) {
           if (e?.statusCode === 404) {
-            return null;
+            return { id, endpoint: null };
           }
           throw e;
         }
       })
     );
-    return results.filter((ep): ep is InferenceInferenceEndpointInfo => ep !== null);
+
+    for (const { id, endpoint } of results) {
+      if (endpoint) {
+        endpoints.push(endpoint);
+      } else {
+        warnings.push(
+          i18n.translate('xpack.searchInferenceEndpoints.endpoints.endpointNotFound', {
+            defaultMessage: 'Inference endpoint "{endpointId}" was not found in Elasticsearch.',
+            values: { endpointId: id },
+          })
+        );
+      }
+    }
+
+    return { endpoints, warnings };
   }
 
   private async readSettingsFeatures(): Promise<InferenceSettingsAttributes['features']> {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -31,18 +31,31 @@ export const getForFeature = async (
   esClient: ElasticsearchClient,
   featureId: string
 ): Promise<ResolvedInferenceEndpoints> => {
-  const endpointIds = await resolveEndpointIds(registry, soClient, featureId);
-  if (endpointIds.length === 0) {
-    return { endpoints: [], warnings: [] };
+  const { ids, warnings: resolveWarnings } = await resolveEndpointIds(
+    registry,
+    soClient,
+    featureId
+  );
+  if (ids.length === 0) {
+    return { endpoints: [], warnings: resolveWarnings };
   }
-  return fetchEndpoints(esClient, endpointIds);
+  const result = await fetchEndpoints(esClient, ids);
+  return {
+    endpoints: result.endpoints,
+    warnings: [...resolveWarnings, ...result.warnings],
+  };
 };
+
+interface ResolvedEndpointIds {
+  ids: string[];
+  warnings: string[];
+}
 
 const resolveEndpointIds = async (
   registry: InferenceFeatureRegistry,
   soClient: SavedObjectsClientContract,
   featureId: string
-): Promise<string[]> => {
+): Promise<ResolvedEndpointIds> => {
   if (!registry.get(featureId)) {
     throw new Error(
       i18n.translate('xpack.searchInferenceEndpoints.endpoints.featureNotFound', {
@@ -63,7 +76,20 @@ const resolveEndpointIds = async (
   const visited = new Set<string>();
   let currentId = featureId;
 
-  while (!visited.has(currentId)) {
+  while (true) {
+    if (visited.has(currentId)) {
+      return {
+        ids: [],
+        warnings: [
+          i18n.translate('xpack.searchInferenceEndpoints.endpoints.cyclicDependency', {
+            defaultMessage:
+              'Cyclic dependency detected in feature fallback chain: "{featureId}" references back to "{currentId}".',
+            values: { featureId, currentId },
+          }),
+        ],
+      };
+    }
+
     visited.add(currentId);
     const current = registry.get(currentId);
     if (!current) {
@@ -72,11 +98,11 @@ const resolveEndpointIds = async (
 
     const soEntry = soFeaturesMap.get(currentId);
     if (soEntry && soEntry.endpoints.length > 0) {
-      return soEntry.endpoints.map((e) => e.id);
+      return { ids: soEntry.endpoints.map((e) => e.id), warnings: [] };
     }
 
     if (current.recommendedEndpoints.length > 0) {
-      return current.recommendedEndpoints;
+      return { ids: current.recommendedEndpoints, warnings: [] };
     }
 
     if (current.parentFeatureId) {
@@ -86,7 +112,7 @@ const resolveEndpointIds = async (
     }
   }
 
-  return [];
+  return { ids: [], warnings: [] };
 };
 
 /**

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import type { ElasticsearchClient, ISavedObjectsRepository } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
@@ -27,7 +27,7 @@ import type { ResolvedInferenceEndpoints } from './types';
  */
 export const getForFeature = async (
   registry: InferenceFeatureRegistry,
-  soClient: SavedObjectsClientContract,
+  soClient: ISavedObjectsRepository,
   esClient: ElasticsearchClient,
   featureId: string
 ): Promise<ResolvedInferenceEndpoints> => {
@@ -53,7 +53,7 @@ interface ResolvedEndpointIds {
 
 const resolveEndpointIds = async (
   registry: InferenceFeatureRegistry,
-  soClient: SavedObjectsClientContract,
+  soClient: ISavedObjectsRepository,
   featureId: string
 ): Promise<ResolvedEndpointIds> => {
   if (!registry.get(featureId)) {
@@ -158,7 +158,7 @@ const fetchEndpoints = async (
 };
 
 const readSettingsFeatures = async (
-  soClient: SavedObjectsClientContract
+  soClient: ISavedObjectsRepository
 ): Promise<InferenceSettingsAttributes['features']> => {
   try {
     const so = await soClient.get<InferenceSettingsAttributes>(

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, ISavedObjectsRepository } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
+import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import { INFERENCE_SETTINGS_SO_TYPE, INFERENCE_SETTINGS_ID } from '../common/constants';
+import type { InferenceSettingsAttributes } from '../common/types';
+import type { InferenceFeatureRegistry } from './inference_feature_registry';
+
+export class InferenceEndpoints {
+  constructor(
+    private readonly registry: InferenceFeatureRegistry,
+    private readonly soRepo: ISavedObjectsRepository,
+    private readonly esClient: ElasticsearchClient
+  ) {}
+
+  /**
+   * Returns the resolved inference endpoints for a feature.
+   * Walks the fallback chain (admin SO override → recommendedEndpoints → parent feature)
+   * and fetches full endpoint objects from Elasticsearch.
+   *
+   * @param featureId - The feature to resolve endpoints for.
+   * @throws If `featureId` is not registered.
+   */
+  async getForFeature(featureId: string): Promise<InferenceInferenceEndpointInfo[]> {
+    const endpointIds = await this.resolveEndpointIds(featureId);
+    if (endpointIds.length === 0) {
+      return [];
+    }
+    return this.fetchEndpoints(endpointIds);
+  }
+
+  private async resolveEndpointIds(featureId: string): Promise<string[]> {
+    if (!this.registry.get(featureId)) {
+      throw new Error(
+        i18n.translate('xpack.searchInferenceEndpoints.endpoints.featureNotFound', {
+          defaultMessage: 'Feature with id "{featureId}" is not registered.',
+          values: { featureId },
+        })
+      );
+    }
+
+    const soFeatures = await this.readSettingsFeatures();
+    const soFeaturesMap = new Map(soFeatures.map((f) => [f.feature_id, f]));
+
+    const visited = new Set<string>();
+    let currentId = featureId;
+
+    while (!visited.has(currentId)) {
+      visited.add(currentId);
+      const current = this.registry.get(currentId);
+      if (!current) {
+        break;
+      }
+
+      const soEntry = soFeaturesMap.get(currentId);
+      if (soEntry && soEntry.endpoints.length > 0) {
+        return soEntry.endpoints.map((e) => e.id);
+      }
+
+      if (current.recommendedEndpoints.length > 0) {
+        return current.recommendedEndpoints;
+      }
+
+      if (current.parentFeatureId) {
+        currentId = current.parentFeatureId;
+      } else {
+        break;
+      }
+    }
+
+    return [];
+  }
+
+  private async fetchEndpoints(ids: string[]): Promise<InferenceInferenceEndpointInfo[]> {
+    const results = await Promise.all(
+      ids.map(async (id) => {
+        try {
+          const { endpoints } = await this.esClient.inference.get({ inference_id: id });
+          return endpoints[0] ?? null;
+        } catch (e) {
+          if (e?.statusCode === 404) {
+            return null;
+          }
+          throw e;
+        }
+      })
+    );
+    return results.filter((ep): ep is InferenceInferenceEndpointInfo => ep !== null);
+  }
+
+  private async readSettingsFeatures(): Promise<InferenceSettingsAttributes['features']> {
+    try {
+      const so = await this.soRepo.get<InferenceSettingsAttributes>(
+        INFERENCE_SETTINGS_SO_TYPE,
+        INFERENCE_SETTINGS_ID
+      );
+      return so.attributes.features ?? [];
+    } catch (e) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        return [];
+      }
+      throw e;
+    }
+  }
+}

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -8,7 +8,7 @@
 import type { ElasticsearchClient, ISavedObjectsRepository } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import type { InferenceInferenceEndpointInfo } from '@elastic/elasticsearch/lib/api/types';
+import { type InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
 import { INFERENCE_SETTINGS_SO_TYPE, INFERENCE_SETTINGS_ID } from '../common/constants';
 import type { InferenceSettingsAttributes } from '../common/types';
 import type { InferenceFeatureRegistry } from './inference_feature_registry';
@@ -135,14 +135,14 @@ const resolveEndpointIds = async (
 
 /**
  * Fetches full inference endpoint objects from Elasticsearch by their IDs.
- * Returns the successfully fetched endpoints and warnings for any that were not found (404).
+ * Returns the successfully fetched endpoints as InferenceConnector and warnings for any that were not found (404).
  * Non-404 errors are propagated.
  */
 const fetchEndpoints = async (
   esClient: ElasticsearchClient,
   ids: string[]
 ): Promise<ResolvedInferenceEndpoints> => {
-  const endpoints: InferenceInferenceEndpointInfo[] = [];
+  const endpoints: InferenceConnector[] = [];
   const warnings: string[] = [];
 
   const results = await Promise.all(
@@ -161,7 +161,24 @@ const fetchEndpoints = async (
 
   for (const { id, endpoint } of results) {
     if (endpoint) {
-      endpoints.push(endpoint);
+      const serviceSettings = endpoint.service_settings as Record<string, unknown> | undefined;
+      const connector: InferenceConnector = {
+        type: InferenceConnectorType.Inference,
+        name: endpoint.inference_id,
+        connectorId: endpoint.inference_id,
+        config: {
+          inferenceId: endpoint.inference_id,
+          providerConfig: {
+            model_id: serviceSettings?.model_id,
+          },
+          taskType: endpoint.task_type,
+          service: endpoint.service,
+          serviceSettings,
+        },
+        capabilities: {},
+        isInferenceEndpoint: true,
+      };
+      endpoints.push(connector);
     } else {
       warnings.push(
         i18n.translate('xpack.searchInferenceEndpoints.endpoints.endpointNotFound', {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -56,7 +56,8 @@ const resolveEndpointIds = async (
   soClient: ISavedObjectsRepository,
   featureId: string
 ): Promise<ResolvedEndpointIds> => {
-  if (!registry.get(featureId)) {
+  let current = registry.get(featureId);
+  if (!current) {
     throw new Error(
       i18n.translate('xpack.searchInferenceEndpoints.endpoints.featureNotFound', {
         defaultMessage: 'Feature with id "{featureId}" is not registered.',
@@ -64,55 +65,72 @@ const resolveEndpointIds = async (
       })
     );
   }
-
+  let recEntry = current.recommendedEndpoints?.length
+    ? { featureId: current.featureId, recommendedEndpoints: current.recommendedEndpoints }
+    : undefined;
   const soFeatures = await readSettingsFeatures(soClient);
   const soFeaturesMap = new Map(soFeatures.map((f) => [f.feature_id, f]));
 
   // Walk the fallback chain for the feature:
   // 1. Check for an admin-configured SO override for the current feature
-  // 2. Fall back to the feature's recommendedEndpoints
-  // 3. If neither exists, follow the parentFeatureId link and repeat
+  // 2. Follow the parentFeatureId link and repeat
+  // 3. Fall back to the feature's recommendedEndpoints
   // The visited set prevents infinite loops from circular parent references.
   const visited = new Set<string>();
   let currentId = featureId;
 
-  while (true) {
-    if (visited.has(currentId)) {
-      return {
-        ids: [],
-        warnings: [
-          i18n.translate('xpack.searchInferenceEndpoints.endpoints.cyclicDependency', {
-            defaultMessage:
-              'Cyclic dependency detected in feature fallback chain: "{featureId}" references back to "{currentId}".',
-            values: { featureId, currentId },
-          }),
-        ],
-      };
-    }
+  const initialSoEntry = soFeaturesMap.get(currentId);
+  if (initialSoEntry && initialSoEntry.endpoints.length > 0) {
+    return { ids: initialSoEntry.endpoints.map((e) => e.id), warnings: [] };
+  }
 
-    visited.add(currentId);
-    const current = registry.get(currentId);
-    if (!current) {
-      break;
-    }
+  visited.add(currentId);
+  if (current.parentFeatureId) {
+    currentId = current?.parentFeatureId;
 
-    const soEntry = soFeaturesMap.get(currentId);
-    if (soEntry && soEntry.endpoints.length > 0) {
-      return { ids: soEntry.endpoints.map((e) => e.id), warnings: [] };
-    }
+    while (true) {
+      if (visited.has(currentId)) {
+        return {
+          ids: [],
+          warnings: [
+            i18n.translate('xpack.searchInferenceEndpoints.endpoints.cyclicDependency', {
+              defaultMessage:
+                'Cyclic dependency detected in feature fallback chain: "{featureId}" references back to "{currentId}".',
+              values: { featureId, currentId },
+            }),
+          ],
+        };
+      }
 
-    if (current.recommendedEndpoints.length > 0) {
-      return { ids: current.recommendedEndpoints, warnings: [] };
-    }
+      visited.add(currentId);
+      current = registry.get(currentId);
+      if (!current) {
+        break;
+      }
+      if (!recEntry && current.recommendedEndpoints.length) {
+        recEntry = {
+          featureId: current.featureId,
+          recommendedEndpoints: current.recommendedEndpoints,
+        };
+      }
 
-    if (current.parentFeatureId) {
-      currentId = current.parentFeatureId;
-    } else {
-      break;
+      const soEntry = soFeaturesMap.get(currentId);
+      if (soEntry && soEntry.endpoints.length > 0) {
+        return { ids: soEntry.endpoints.map((e) => e.id), warnings: [] };
+      }
+
+      if (current.parentFeatureId) {
+        currentId = current.parentFeatureId;
+      } else {
+        break;
+      }
     }
   }
 
-  return { ids: [], warnings: [] };
+  return {
+    ids: recEntry?.recommendedEndpoints ?? [],
+    warnings: [],
+  };
 };
 
 /**

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
@@ -19,6 +19,7 @@ import type { SearchInferenceEndpointsConfig } from './config';
 import { DynamicConnectorsPoller } from './lib/dynamic_connectors';
 import { defineRoutes } from './routes';
 import { InferenceFeatureRegistry } from './inference_feature_registry';
+import { InferenceEndpoints } from './inference_endpoints';
 import { createInferenceSettingsSavedObjectType } from './saved_objects/inference_settings';
 import type {
   SearchInferenceEndpointsPluginSetup,
@@ -125,11 +126,18 @@ export class SearchInferenceEndpointsPlugin
       this.dynamicConnectorsPoller.start();
     }
 
+    const internalRepo = core.savedObjects.createInternalRepository([INFERENCE_SETTINGS_SO_TYPE]);
+    const esClient = core.elasticsearch.client.asInternalUser;
+    const endpoints = new InferenceEndpoints(this.featureRegistry, internalRepo, esClient);
+
     return {
       features: {
         get: this.featureRegistry.get.bind(this.featureRegistry),
         getAll: this.featureRegistry.getAll.bind(this.featureRegistry),
         register: this.featureRegistry.register.bind(this.featureRegistry),
+      },
+      endpoints: {
+        getForFeature: endpoints.getForFeature.bind(endpoints),
       },
     };
   }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
@@ -8,6 +8,7 @@
 import type {
   CoreSetup,
   CoreStart,
+  KibanaRequest,
   Logger,
   Plugin,
   PluginInitializerContext,
@@ -19,7 +20,7 @@ import type { SearchInferenceEndpointsConfig } from './config';
 import { DynamicConnectorsPoller } from './lib/dynamic_connectors';
 import { defineRoutes } from './routes';
 import { InferenceFeatureRegistry } from './inference_feature_registry';
-import { InferenceEndpoints } from './inference_endpoints';
+import { getForFeature } from './inference_endpoints';
 import { createInferenceSettingsSavedObjectType } from './saved_objects/inference_settings';
 import type {
   SearchInferenceEndpointsPluginSetup,
@@ -126,18 +127,25 @@ export class SearchInferenceEndpointsPlugin
       this.dynamicConnectorsPoller.start();
     }
 
-    const internalRepo = core.savedObjects.createInternalRepository([INFERENCE_SETTINGS_SO_TYPE]);
-    const esClient = core.elasticsearch.client.asInternalUser;
-    const endpoints = new InferenceEndpoints(this.featureRegistry, internalRepo, esClient);
+    const featureRegistry = this.featureRegistry;
 
     return {
       features: {
-        get: this.featureRegistry.get.bind(this.featureRegistry),
-        getAll: this.featureRegistry.getAll.bind(this.featureRegistry),
-        register: this.featureRegistry.register.bind(this.featureRegistry),
+        get: featureRegistry.get.bind(featureRegistry),
+        getAll: featureRegistry.getAll.bind(featureRegistry),
+        register: featureRegistry.register.bind(featureRegistry),
       },
       endpoints: {
-        getForFeature: endpoints.getForFeature.bind(endpoints),
+        asScoped: (request: KibanaRequest) => {
+          const esClient = core.elasticsearch.client.asScoped(request).asCurrentUser;
+          const soClient = core.savedObjects.getScopedClient(request, {
+            includedHiddenTypes: [INFERENCE_SETTINGS_SO_TYPE],
+          });
+          return {
+            getForFeature: (featureId: string) =>
+              getForFeature(featureRegistry, soClient, esClient, featureId),
+          };
+        },
       },
     };
   }

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/plugin.ts
@@ -8,7 +8,6 @@
 import type {
   CoreSetup,
   CoreStart,
-  KibanaRequest,
   Logger,
   Plugin,
   PluginInitializerContext,
@@ -136,15 +135,10 @@ export class SearchInferenceEndpointsPlugin
         register: featureRegistry.register.bind(featureRegistry),
       },
       endpoints: {
-        asScoped: (request: KibanaRequest) => {
-          const esClient = core.elasticsearch.client.asScoped(request).asCurrentUser;
-          const soClient = core.savedObjects.getScopedClient(request, {
-            includedHiddenTypes: [INFERENCE_SETTINGS_SO_TYPE],
-          });
-          return {
-            getForFeature: (featureId: string) =>
-              getForFeature(featureRegistry, soClient, esClient, featureId),
-          };
+        getForFeature: (featureId: string) => {
+          const esClient = core.elasticsearch.client.asInternalUser;
+          const soClient = core.savedObjects.createInternalRepository([INFERENCE_SETTINGS_SO_TYPE]);
+          return getForFeature(featureRegistry, soClient, esClient, featureId);
         },
       },
     };

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -7,12 +7,10 @@
 
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import type {
-  InferenceInferenceEndpointInfo,
-  InferenceTaskType,
-} from '@elastic/elasticsearch/lib/api/types';
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
+import type { InferenceConnector } from '@kbn/inference-common';
 
-export type { InferenceInferenceEndpointInfo, InferenceTaskType };
+export type { InferenceTaskType, InferenceConnector };
 
 export interface InferenceFeatureConfig {
   featureId: string;
@@ -40,7 +38,7 @@ export interface SearchInferenceEndpointsPluginSetup {
 }
 
 export interface ResolvedInferenceEndpoints {
-  endpoints: InferenceInferenceEndpointInfo[];
+  endpoints: InferenceConnector[];
   warnings: string[];
 }
 

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { KibanaRequest } from '@kbn/core/server';
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type {
@@ -45,12 +44,8 @@ export interface ResolvedInferenceEndpoints {
   warnings: string[];
 }
 
-export interface ScopedInferenceEndpointsClient {
-  getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
-}
-
 export interface InferenceEndpointsContract {
-  asScoped: (request: KibanaRequest) => ScopedInferenceEndpointsClient;
+  getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
 }
 
 export interface SearchInferenceEndpointsPluginStart {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -7,9 +7,12 @@
 
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  InferenceInferenceEndpointInfo,
+  InferenceTaskType,
+} from '@elastic/elasticsearch/lib/api/types';
 
-export type { InferenceTaskType };
+export type { InferenceInferenceEndpointInfo, InferenceTaskType };
 
 export interface InferenceFeatureConfig {
   featureId: string;
@@ -36,8 +39,13 @@ export interface SearchInferenceEndpointsPluginSetup {
   features: InferenceFeatureRegistryContract;
 }
 
+export interface InferenceEndpointsContract {
+  getForFeature: (featureId: string) => Promise<InferenceInferenceEndpointInfo[]>;
+}
+
 export interface SearchInferenceEndpointsPluginStart {
   features: InferenceFeatureRegistryStartContract;
+  endpoints: InferenceEndpointsContract;
 }
 
 export interface SearchInferenceEndpointsPluginStartDependencies {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { KibanaRequest } from '@kbn/core/server';
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type {
@@ -44,8 +45,12 @@ export interface ResolvedInferenceEndpoints {
   warnings: string[];
 }
 
-export interface InferenceEndpointsContract {
+export interface ScopedInferenceEndpointsClient {
   getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
+}
+
+export interface InferenceEndpointsContract {
+  asScoped: (request: KibanaRequest) => ScopedInferenceEndpointsClient;
 }
 
 export interface SearchInferenceEndpointsPluginStart {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -39,8 +39,13 @@ export interface SearchInferenceEndpointsPluginSetup {
   features: InferenceFeatureRegistryContract;
 }
 
+export interface ResolvedInferenceEndpoints {
+  endpoints: InferenceInferenceEndpointInfo[];
+  warnings: string[];
+}
+
 export interface InferenceEndpointsContract {
-  getForFeature: (featureId: string) => Promise<InferenceInferenceEndpointInfo[]>;
+  getForFeature: (featureId: string) => Promise<ResolvedInferenceEndpoints>;
 }
 
 export interface SearchInferenceEndpointsPluginStart {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/tsconfig.json
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/tsconfig.json
@@ -44,7 +44,8 @@
     "@kbn/logging-mocks",
     "@kbn/cloud-connect-plugin",
     "@kbn/core-logging-server-mocks",
-    "@kbn/core-security-server"
+    "@kbn/core-security-server",
+    "@kbn/inference-common"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
## Summary

Adds `endpoints.getForFeature(featureId);` endpoint.

From given featureID we get the endpoint ids and check if they exist and gracefully falls back.


Created using Cursor and Claude guided by @efegurkan

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

