### PR TITLE
[@kbn/eslint-config] Configure expect-expect rule to recognize assertion helper functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1623,6 +1623,10 @@ module.exports = {
         },
       },
       rules: {
+        'playwright/expect-expect': [
+          'warn',
+          { assertFunctionPatterns: ['^expect.*', '^assert.*', '^verify.*'] },
+        ],
         'playwright/no-commented-out-tests': 'error',
         'playwright/no-conditional-expect': 'error',
         'playwright/no-conditional-in-test': 'warn',


### PR DESCRIPTION
## Summary

The `playwright/expect-expect` ESLint rule flags Scout tests that delegate assertions to helper functions (e.g. `expectPageHasTitle(...)`) as having no assertions. This configures the rule's `assertFunctionPatterns` option so that functions following common assertion naming conventions are recognized as valid assertion functions, removing the need for `eslint-disable` comments.

## Changes

- Configure `playwright/expect-expect` with `assertFunctionPatterns: ['^expect.*', '^assert.*', '^verify.*']` in the Scout ESLint override
- Functions starting with `expect`, `assert`, or `verify` are now treated as assertion helpers and no longer trigger the warning