### PR TITLE
[9.3] [FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs (#255294)

### DIFF
--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/kibana_server/kibana_server.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/kibana_server/kibana_server.ts
@@ -18,6 +18,7 @@ export function KibanaServerProvider({ getService }: FtrProviderContext): KbnCli
   const lifecycle = getService('lifecycle');
   const url = Url.format(config.get('servers.kibana'));
   const defaults = config.get('uiSettings.defaults');
+  const globalDefaults = config.get('uiSettings.globalDefaults');
 
   const kbn = new KbnClient({
     log,
@@ -29,6 +30,12 @@ export function KibanaServerProvider({ getService }: FtrProviderContext): KbnCli
   if (defaults) {
     lifecycle.beforeTests.add(async () => {
       await kbn.uiSettings.update(defaults);
+    });
+  }
+
+  if (globalDefaults) {
+    lifecycle.beforeTests.add(async () => {
+      await kbn.uiSettings.updateGlobal(globalDefaults);
     });
   }
 

--- a/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_test_runner/lib/config/schema.ts
@@ -309,6 +309,7 @@ export const schema = Joi.object()
     uiSettings: Joi.object()
       .keys({
         defaults: Joi.object().unknown(true),
+        globalDefaults: Joi.object().unknown(true),
       })
       .default(),
 

--- a/x-pack/platform/test/functional/apps/spaces/config.ts
+++ b/x-pack/platform/test/functional/apps/spaces/config.ts
@@ -16,5 +16,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     esTestCluster: {
       ...functionalConfig.get('esTestCluster'),
     },
+    uiSettings: {
+      ...functionalConfig.get('uiSettings'),
+      globalDefaults: {
+        ...functionalConfig.get('uiSettings.globalDefaults'),
+        hideAnnouncements: false,
+      },
+    },
   };
 }

--- a/x-pack/platform/test/functional/config.base.ts
+++ b/x-pack/platform/test/functional/config.base.ts
@@ -59,6 +59,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         'accessibility:disableAnimations': true,
         'dateFormat:tz': 'UTC',
       },
+      globalDefaults: {
+        // Disable tours globally for all tests
+        hideAnnouncements: true,
+      },
     },
     // the apps section defines the urls that
     // `PageObjects.common.navigateTo(appKey)` will use.

--- a/x-pack/platform/test/serverless/functional/config.base.ts
+++ b/x-pack/platform/test/serverless/functional/config.base.ts
@@ -56,6 +56,10 @@ export function createTestConfig<
           'accessibility:disableAnimations': true,
           'dateFormat:tz': 'UTC',
         },
+        globalDefaults: {
+          // Disable tours globally for all tests
+          hideAnnouncements: true,
+        },
       },
       // the apps section defines the urls that
       // `PageObjects.common.navigateTo(appKey)` will use.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs (#255294)](https://github.com/elastic/kibana/pull/255294)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Oskamp","email":"robert.oskamp@elastic.co"},"sourceCommit":{"committedDate":"2026-02-27T18:59:52Z","message":"[FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs (#255294)\n\n## Summary\n\nFixes Discover's \"Switch modes per tab\" tour (introduced in #254183)\nappearing during serverless FTR tests running against cloud/MKI\nenvironments, causing test failures.\n\n## Problem\n\nThe `hideAnnouncements` setting that suppresses tours in FTR tests was\nconfigured exclusively via Kibana server startup args:\n\n```\n--uiSettings.globalOverrides.hideAnnouncements=true\n```\n\n\nThis works for local FTR runs where FTR starts and controls the Kibana\nserver. However, when running against cloud/MKI environments, the Kibana\nserver is pre-existing and `kbnTestServer.serverArgs` are [completely\nignored](https://github.com/elastic/kibana/blob/main/x-pack/platform/test/serverless/README.md#run-tests-on-mki).\nAs a result, `hideAnnouncements` stays at its default value of `false`,\n`tours.isEnabled()` returns `true`, and tours interfere with tests.\n\nScout already handles this correctly by setting the global UI setting\nvia the Kibana API in a worker fixture\n(`kbnClient.uiSettings.updateGlobal({ hideAnnouncements: true })`),\nwhich works regardless of whether the server is local or cloud-managed.\nFTR had no equivalent mechanism for global settings.\n\n## Fix\n\nThis PR adds a `uiSettings.globalDefaults` option to the FTR config\nschema, alongside the existing `uiSettings.defaults`. When present,\n`KibanaServerProvider` applies these settings via\n`kbn.uiSettings.updateGlobal()` in the `lifecycle.beforeTests` hook — an\nAPI call that works against both locally-started and cloud-managed\nKibana instances.\n\nAll three FTR base configs now declare `hideAnnouncements: true` in\n`globalDefaults`, and the redundant\n`--uiSettings.globalOverrides.hideAnnouncements=true` server args have\nbeen removed since `globalDefaults` subsumes their purpose.\n\n### Why `globalDefaults` instead of reusing `defaults`?\n\nAdding `hideAnnouncements` to the existing `uiSettings.defaults` would\nsuppress tours today, since the `ToursService.isEnabled()` checks both\nglobal and namespace-scoped settings. However:\n\n- **The namespace-scoped `hideAnnouncements` is deprecated** and slated\nfor removal in Kibana 10.0. Once removed, a namespace-only setting would\nstop suppressing tours.\n- **Namespace settings are space-scoped.** `uiSettings.defaults` only\napplies to the default space. Tests running in custom spaces would not\nhave tours suppressed. Global settings apply across all spaces.\n- **Semantic parity.** The server arg it replaces\n(`globalOverrides.hideAnnouncements`) set the global setting. The\nAPI-based equivalent should target the same scope.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `kbn-test/.../config/schema.ts` | Add `globalDefaults` to `uiSettings`\nschema |\n| `kbn-ftr-common-functional-services/.../kibana_server.ts` | Apply\n`globalDefaults` via `updateGlobal()` in `beforeTests` |\n| `x-pack/platform/test/serverless/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/apps/spaces/config.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n\n> **Note:** `src/platform/test/functional/config.base.js` has\nintentionally not been changed as it ran into issues where the global\ndefaults were reset between some tests. This will be investigated in a\nfollow-up, but it's not required to unblock the MKI runs.","sha":"ba3d02060a6deffee50f8d233876b35178e8aeb3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.4.0","v9.3.3","v9.2.8"],"title":"[FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs","number":255294,"url":"https://github.com/elastic/kibana/pull/255294","mergeCommit":{"message":"[FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs (#255294)\n\n## Summary\n\nFixes Discover's \"Switch modes per tab\" tour (introduced in #254183)\nappearing during serverless FTR tests running against cloud/MKI\nenvironments, causing test failures.\n\n## Problem\n\nThe `hideAnnouncements` setting that suppresses tours in FTR tests was\nconfigured exclusively via Kibana server startup args:\n\n```\n--uiSettings.globalOverrides.hideAnnouncements=true\n```\n\n\nThis works for local FTR runs where FTR starts and controls the Kibana\nserver. However, when running against cloud/MKI environments, the Kibana\nserver is pre-existing and `kbnTestServer.serverArgs` are [completely\nignored](https://github.com/elastic/kibana/blob/main/x-pack/platform/test/serverless/README.md#run-tests-on-mki).\nAs a result, `hideAnnouncements` stays at its default value of `false`,\n`tours.isEnabled()` returns `true`, and tours interfere with tests.\n\nScout already handles this correctly by setting the global UI setting\nvia the Kibana API in a worker fixture\n(`kbnClient.uiSettings.updateGlobal({ hideAnnouncements: true })`),\nwhich works regardless of whether the server is local or cloud-managed.\nFTR had no equivalent mechanism for global settings.\n\n## Fix\n\nThis PR adds a `uiSettings.globalDefaults` option to the FTR config\nschema, alongside the existing `uiSettings.defaults`. When present,\n`KibanaServerProvider` applies these settings via\n`kbn.uiSettings.updateGlobal()` in the `lifecycle.beforeTests` hook — an\nAPI call that works against both locally-started and cloud-managed\nKibana instances.\n\nAll three FTR base configs now declare `hideAnnouncements: true` in\n`globalDefaults`, and the redundant\n`--uiSettings.globalOverrides.hideAnnouncements=true` server args have\nbeen removed since `globalDefaults` subsumes their purpose.\n\n### Why `globalDefaults` instead of reusing `defaults`?\n\nAdding `hideAnnouncements` to the existing `uiSettings.defaults` would\nsuppress tours today, since the `ToursService.isEnabled()` checks both\nglobal and namespace-scoped settings. However:\n\n- **The namespace-scoped `hideAnnouncements` is deprecated** and slated\nfor removal in Kibana 10.0. Once removed, a namespace-only setting would\nstop suppressing tours.\n- **Namespace settings are space-scoped.** `uiSettings.defaults` only\napplies to the default space. Tests running in custom spaces would not\nhave tours suppressed. Global settings apply across all spaces.\n- **Semantic parity.** The server arg it replaces\n(`globalOverrides.hideAnnouncements`) set the global setting. The\nAPI-based equivalent should target the same scope.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `kbn-test/.../config/schema.ts` | Add `globalDefaults` to `uiSettings`\nschema |\n| `kbn-ftr-common-functional-services/.../kibana_server.ts` | Apply\n`globalDefaults` via `updateGlobal()` in `beforeTests` |\n| `x-pack/platform/test/serverless/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/apps/spaces/config.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n\n> **Note:** `src/platform/test/functional/config.base.js` has\nintentionally not been changed as it ran into issues where the global\ndefaults were reset between some tests. This will be investigated in a\nfollow-up, but it's not required to unblock the MKI runs.","sha":"ba3d02060a6deffee50f8d233876b35178e8aeb3"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255294","number":255294,"mergeCommit":{"message":"[FTR] Add uiSettings.globalDefaults to fix hideAnnouncements for cloud runs (#255294)\n\n## Summary\n\nFixes Discover's \"Switch modes per tab\" tour (introduced in #254183)\nappearing during serverless FTR tests running against cloud/MKI\nenvironments, causing test failures.\n\n## Problem\n\nThe `hideAnnouncements` setting that suppresses tours in FTR tests was\nconfigured exclusively via Kibana server startup args:\n\n```\n--uiSettings.globalOverrides.hideAnnouncements=true\n```\n\n\nThis works for local FTR runs where FTR starts and controls the Kibana\nserver. However, when running against cloud/MKI environments, the Kibana\nserver is pre-existing and `kbnTestServer.serverArgs` are [completely\nignored](https://github.com/elastic/kibana/blob/main/x-pack/platform/test/serverless/README.md#run-tests-on-mki).\nAs a result, `hideAnnouncements` stays at its default value of `false`,\n`tours.isEnabled()` returns `true`, and tours interfere with tests.\n\nScout already handles this correctly by setting the global UI setting\nvia the Kibana API in a worker fixture\n(`kbnClient.uiSettings.updateGlobal({ hideAnnouncements: true })`),\nwhich works regardless of whether the server is local or cloud-managed.\nFTR had no equivalent mechanism for global settings.\n\n## Fix\n\nThis PR adds a `uiSettings.globalDefaults` option to the FTR config\nschema, alongside the existing `uiSettings.defaults`. When present,\n`KibanaServerProvider` applies these settings via\n`kbn.uiSettings.updateGlobal()` in the `lifecycle.beforeTests` hook — an\nAPI call that works against both locally-started and cloud-managed\nKibana instances.\n\nAll three FTR base configs now declare `hideAnnouncements: true` in\n`globalDefaults`, and the redundant\n`--uiSettings.globalOverrides.hideAnnouncements=true` server args have\nbeen removed since `globalDefaults` subsumes their purpose.\n\n### Why `globalDefaults` instead of reusing `defaults`?\n\nAdding `hideAnnouncements` to the existing `uiSettings.defaults` would\nsuppress tours today, since the `ToursService.isEnabled()` checks both\nglobal and namespace-scoped settings. However:\n\n- **The namespace-scoped `hideAnnouncements` is deprecated** and slated\nfor removal in Kibana 10.0. Once removed, a namespace-only setting would\nstop suppressing tours.\n- **Namespace settings are space-scoped.** `uiSettings.defaults` only\napplies to the default space. Tests running in custom spaces would not\nhave tours suppressed. Global settings apply across all spaces.\n- **Semantic parity.** The server arg it replaces\n(`globalOverrides.hideAnnouncements`) set the global setting. The\nAPI-based equivalent should target the same scope.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `kbn-test/.../config/schema.ts` | Add `globalDefaults` to `uiSettings`\nschema |\n| `kbn-ftr-common-functional-services/.../kibana_server.ts` | Apply\n`globalDefaults` via `updateGlobal()` in `beforeTests` |\n| `x-pack/platform/test/serverless/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/config.base.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n| `x-pack/platform/test/functional/apps/spaces/config.ts` | Add\n`globalDefaults.hideAnnouncements`, remove server arg |\n\n> **Note:** `src/platform/test/functional/config.base.js` has\nintentionally not been changed as it ran into issues where the global\ndefaults were reset between some tests. This will be investigated in a\nfollow-up, but it's not required to unblock the MKI runs.","sha":"ba3d02060a6deffee50f8d233876b35178e8aeb3"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->