### PR TITLE
escape html characters in truncated fields

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/converters/truncate.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/truncate.test.ts
@@ -42,6 +42,44 @@ describe('String TruncateFormat', () => {
     expect(truncate.convert('This is some text')).toBe('Thi...');
   });
 
+  test('html context escapes angle brackets in XML/HTML content', () => {
+    // https://github.com/elastic/kibana/issues/257948
+    const truncateFormat = new TruncateFormat({ fieldLength: 100 }, jest.fn());
+
+    expect(
+      truncateFormat.convert(
+        '<root><item><name>Hello World</name><value>12345</value></item></root>',
+        HTML_CONTEXT_TYPE
+      )
+    ).toBe(
+      '&lt;root&gt;&lt;item&gt;&lt;name&gt;Hello World&lt;/name&gt;&lt;value&gt;12345&lt;/value&gt;&lt;/item&gt;&lt;/root&gt;'
+    );
+  });
+
+  test('html context escapes and truncates XML/HTML content', () => {
+    // https://github.com/elastic/kibana/issues/257948
+    const truncateFormat = new TruncateFormat({ fieldLength: 10 }, jest.fn());
+
+    expect(
+      truncateFormat.convert(
+        '<root><item><name>Hello World</name></item></root>',
+        HTML_CONTEXT_TYPE
+      )
+    ).toBe('&lt;root&gt;&lt;ite...');
+  });
+
+  test('text context preserves XML/HTML tags as-is', () => {
+    // https://github.com/elastic/kibana/issues/257948
+    const truncateFormat = new TruncateFormat({ fieldLength: 100 }, jest.fn());
+
+    expect(
+      truncateFormat.convert(
+        '<root><item><name>Hello World</name></item></root>',
+        TEXT_CONTEXT_TYPE
+      )
+    ).toBe('<root><item><name>Hello World</name></item></root>');
+  });
+
   test('missing value', () => {
     const truncate = new TruncateFormat({ fieldLength: 3.2 }, jest.fn());
 

--- a/src/platform/plugins/shared/field_formats/common/converters/truncate.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/truncate.ts
@@ -8,7 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { truncate } from 'lodash';
+import { truncate, escape } from 'lodash';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { FieldFormat } from '../field_format';
 import type { TextContextTypeConvert, HtmlContextTypeConvert } from '../types';
@@ -47,6 +47,6 @@ export class TruncateFormat extends FieldFormat {
       return missing;
     }
 
-    return this.textConvert(val, options);
+    return escape(this.textConvert(val, options));
   };
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/257948

Escape HTML and XML characters when truncating a field in a dataview:

<img width="1015" height="1073" alt="Screenshot from 2026-03-16 18-24-57" src="https://github.com/user-attachments/assets/85001864-f0c3-4695-84a5-99627842779b" />
<img width="1538" height="126" alt="Screenshot from 2026-03-16 18-23-41" src="https://github.com/user-attachments/assets/91083b97-178a-4213-a40a-90c7c1362fa4" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


## Release note
Fixes truncation of HTML/XML fields in dataviews