### PR TITLE
[9.2][kbn_pm] Only install scripts when yarn integrity changes (#255175)

### DIFF
--- a/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -111,7 +111,9 @@ export const command = {
     });
 
     await time('run install scripts', async () => {
-      await runInstallScripts(log, { quiet });
+      if (shouldInstall) {
+        await runInstallScripts(log, { quiet });
+      }
     });
 
     await time('pre-build webpack bundles for packages', async () => {


### PR DESCRIPTION
Backports #255175.  

Note that timing is skipped on main, while here will continue to report.  This is consistent other checks in this file on this branch.