### PR TITLE
[Agent Builder] Fix index: false searchability issues

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.test.ts
@@ -167,6 +167,30 @@ describe('relevanceSearch', () => {
       );
     });
 
+    it('filters out fields with searchable set to false', async () => {
+      resolveResourceMock.mockResolvedValue({
+        fields: [
+          { path: 'content', type: 'text', meta: {}, searchable: true },
+          { path: 'non_indexed', type: 'text', meta: {}, searchable: false },
+          { path: 'embedding', type: 'semantic_text', meta: {}, searchable: false },
+        ],
+      });
+
+      await relevanceSearch({
+        term: 'test',
+        target: 'my-index',
+        esClient,
+        model,
+        logger,
+      });
+
+      expect(performMatchSearchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: [{ path: 'content', type: 'text', meta: {}, searchable: true }],
+        })
+      );
+    });
+
     it('throws an error when no searchable text fields are found', async () => {
       resolveResourceMock.mockResolvedValue({
         fields: [

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/relevance_search.ts
@@ -38,7 +38,9 @@ export const relevanceSearch = async ({
 }): Promise<RelevanceSearchResponse> => {
   const { fields } = await resolveResource({ resourceName: target, esClient });
 
-  const selectedFields = fields.filter((field) => SEARCHABLE_TEXT_FIELD_TYPES.has(field.type));
+  const selectedFields = fields.filter(
+    (field) => SEARCHABLE_TEXT_FIELD_TYPES.has(field.type) && field.searchable !== false
+  );
 
   if (selectedFields.length === 0) {
     throw new Error('No searchable text fields found, aborting search.');

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/ccs.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/ccs.test.ts
@@ -111,8 +111,8 @@ describe('getFieldsFromFieldCaps', () => {
     });
 
     expect(fields.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
-      { path: 'message', type: 'text', meta: {} },
-      { path: 'status', type: 'keyword', meta: {} },
+      { path: 'message', type: 'text', meta: {}, searchable: true },
+      { path: 'status', type: 'keyword', meta: {}, searchable: true },
     ]);
   });
 });
@@ -160,7 +160,9 @@ describe('getIndexFields', () => {
     });
     expect(result['my-index'].rawMapping).toBeDefined();
     expect(result['my-index'].rawMapping?._meta?.description).toBe('test index');
-    expect(result['my-index'].fields).toEqual([{ path: 'message', type: 'text', meta: {} }]);
+    expect(result['my-index'].fields).toEqual([
+      { path: 'message', type: 'text', meta: {}, searchable: true },
+    ]);
   });
 
   it('returns fields without rawMapping for CCS indices via _field_caps API', async () => {
@@ -184,7 +186,9 @@ describe('getIndexFields', () => {
     });
     expect(getIndexMappingsMock).not.toHaveBeenCalled();
     expect(result['remote:logs'].rawMapping).toBeUndefined();
-    expect(result['remote:logs'].fields).toEqual([{ path: 'status', type: 'keyword', meta: {} }]);
+    expect(result['remote:logs'].fields).toEqual([
+      { path: 'status', type: 'keyword', meta: {}, searchable: true },
+    ]);
   });
 
   it('handles a mix of local and CCS indices', async () => {
@@ -220,11 +224,13 @@ describe('getIndexFields', () => {
     expect(esClient.fieldCaps).toHaveBeenCalled();
 
     expect(result['local-index'].rawMapping).toBeDefined();
-    expect(result['local-index'].fields).toEqual([{ path: 'name', type: 'keyword', meta: {} }]);
+    expect(result['local-index'].fields).toEqual([
+      { path: 'name', type: 'keyword', meta: {}, searchable: true },
+    ]);
 
     expect(result['cluster:remote-index'].rawMapping).toBeUndefined();
     expect(result['cluster:remote-index'].fields).toEqual([
-      { path: 'timestamp', type: 'date', meta: {} },
+      { path: 'timestamp', type: 'date', meta: {}, searchable: true },
     ]);
   });
 

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/field_caps.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/field_caps.test.ts
@@ -53,11 +53,13 @@ describe('processFieldCapsResponse', () => {
         path: 'category',
         type: 'keyword',
         meta: {},
+        searchable: true,
       },
       {
         path: 'content',
         type: 'text',
         meta: {},
+        searchable: true,
       },
     ]);
   });
@@ -83,11 +85,13 @@ describe('processFieldCapsResponse', () => {
     expect(processed.fields.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
       {
         meta: {},
+        searchable: true,
         path: '_not_internal',
         type: 'boolean',
       },
       {
         meta: {},
+        searchable: true,
         path: 'content',
         type: 'text',
       },
@@ -113,8 +117,40 @@ describe('processFieldCapsResponse', () => {
     expect(processed.fields.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
       {
         meta: {},
+        searchable: true,
         path: 'content',
         type: 'text',
+      },
+    ]);
+  });
+
+  it('preserves the searchable property from field caps', () => {
+    const response: FieldCapsResponse = {
+      indices: ['index_1'],
+      fields: {
+        content: {
+          text: caps({ type: 'text', searchable: true }),
+        },
+        non_searchable: {
+          text: caps({ type: 'text', searchable: false }),
+        },
+      },
+    };
+
+    const processed = processFieldCapsResponse(response);
+
+    expect(processed.fields.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
+      {
+        path: 'content',
+        type: 'text',
+        meta: {},
+        searchable: true,
+      },
+      {
+        path: 'non_searchable',
+        type: 'text',
+        meta: {},
+        searchable: false,
       },
     ]);
   });
@@ -139,11 +175,13 @@ describe('processFieldCapsResponse', () => {
         path: 'content',
         type: 'text',
         meta: { description: 'content', role: 'retrieval' },
+        searchable: true,
       },
       {
         path: 'description',
         type: 'text',
         meta: { description: 'desc1,desc2' },
+        searchable: true,
       },
     ]);
   });
@@ -163,8 +201,8 @@ describe('processFieldCapsResponsePerIndex', () => {
     const result = processFieldCapsResponsePerIndex(response);
 
     expect(result).toEqual({
-      index_a: [{ path: 'status', type: 'keyword', meta: {} }],
-      index_b: [{ path: 'status', type: 'keyword', meta: {} }],
+      index_a: [{ path: 'status', type: 'keyword', meta: {}, searchable: true }],
+      index_b: [{ path: 'status', type: 'keyword', meta: {}, searchable: true }],
     });
   });
 
@@ -189,12 +227,12 @@ describe('processFieldCapsResponsePerIndex', () => {
     const sortByPath = (a: { path: string }, b: { path: string }) => a.path.localeCompare(b.path);
 
     expect(result.index_a.sort(sortByPath)).toEqual([
-      { path: 'only_a', type: 'text', meta: {} },
-      { path: 'shared', type: 'keyword', meta: {} },
+      { path: 'only_a', type: 'text', meta: {}, searchable: true },
+      { path: 'shared', type: 'keyword', meta: {}, searchable: true },
     ]);
     expect(result.index_b.sort(sortByPath)).toEqual([
-      { path: 'only_b', type: 'long', meta: {} },
-      { path: 'shared', type: 'keyword', meta: {} },
+      { path: 'only_b', type: 'long', meta: {}, searchable: true },
+      { path: 'shared', type: 'keyword', meta: {}, searchable: true },
     ]);
   });
 
@@ -211,8 +249,12 @@ describe('processFieldCapsResponsePerIndex', () => {
 
     const result = processFieldCapsResponsePerIndex(response);
 
-    expect(result.index_a).toEqual([{ path: 'status', type: 'keyword', meta: {} }]);
-    expect(result.index_b).toEqual([{ path: 'status', type: 'integer', meta: {} }]);
+    expect(result.index_a).toEqual([
+      { path: 'status', type: 'keyword', meta: {}, searchable: true },
+    ]);
+    expect(result.index_b).toEqual([
+      { path: 'status', type: 'integer', meta: {}, searchable: true },
+    ]);
   });
 
   it('excludes internal fields (type starting with _)', () => {
@@ -230,7 +272,7 @@ describe('processFieldCapsResponsePerIndex', () => {
 
     const result = processFieldCapsResponsePerIndex(response);
 
-    expect(result.index_a).toEqual([{ path: 'content', type: 'text', meta: {} }]);
+    expect(result.index_a).toEqual([{ path: 'content', type: 'text', meta: {}, searchable: true }]);
   });
 
   it('preserves field meta', () => {
@@ -246,7 +288,7 @@ describe('processFieldCapsResponsePerIndex', () => {
     const result = processFieldCapsResponsePerIndex(response);
 
     expect(result.index_a).toEqual([
-      { path: 'content', type: 'text', meta: { description: 'main content' } },
+      { path: 'content', type: 'text', meta: { description: 'main content' }, searchable: true },
     ]);
   });
 
@@ -262,7 +304,7 @@ describe('processFieldCapsResponsePerIndex', () => {
 
     const result = processFieldCapsResponsePerIndex(response);
 
-    expect(result.index_a).toEqual([{ path: 'only_a', type: 'text', meta: {} }]);
+    expect(result.index_a).toEqual([{ path: 'only_a', type: 'text', meta: {}, searchable: true }]);
     expect(result.index_b).toEqual([]);
   });
 });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/field_caps.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/field_caps.ts
@@ -75,7 +75,12 @@ export const processFieldCapsResponsePerIndex = (
       }
 
       const meta = extractMeta(capability);
-      const field: MappingField = { path, type: capability.type, meta };
+      const field: MappingField = {
+        path,
+        type: capability.type,
+        meta,
+        searchable: capability.searchable,
+      };
 
       const targetIndices =
         capability.indices == null
@@ -118,5 +123,6 @@ const processField = (
     path,
     type: fieldCaps.type,
     meta,
+    searchable: fieldCaps.searchable,
   };
 };

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.test.ts
@@ -33,26 +33,31 @@ describe('flattenMapping', () => {
     expect(flattened).toEqual([
       {
         meta: {},
+        searchable: true,
         path: 'foo',
         type: 'text',
       },
       {
         meta: {},
+        searchable: true,
         path: 'foo.bar',
         type: 'keyword',
       },
       {
         meta: {},
+        searchable: true,
         path: 'obj',
         type: 'object',
       },
       {
         meta: {},
+        searchable: true,
         path: 'obj.nested',
         type: 'object',
       },
       {
         meta: {},
+        searchable: true,
         path: 'obj.sub',
         type: 'text',
       },
@@ -80,6 +85,7 @@ describe('flattenMapping', () => {
     expect(flattened).toEqual([
       {
         meta: {},
+        searchable: true,
         path: 'bar',
         type: 'object',
       },
@@ -87,6 +93,7 @@ describe('flattenMapping', () => {
         meta: {
           other: 'other',
         },
+        searchable: true,
         path: 'bar.sub',
         type: 'text',
       },
@@ -94,6 +101,7 @@ describe('flattenMapping', () => {
         meta: {
           description: 'some desc',
         },
+        searchable: true,
         path: 'foo',
         type: 'text',
       },
@@ -134,33 +142,70 @@ describe('flattenMapping', () => {
     expect(flattened).toEqual([
       {
         meta: {},
+        searchable: true,
         path: 'body',
         type: 'text',
       },
       {
         meta: {},
+        searchable: true,
         path: 'body.keyword',
         type: 'keyword',
       },
       {
         meta: {},
+        searchable: true,
         path: 'body.semantic_elser',
         type: 'semantic_text',
       },
       {
         meta: {},
+        searchable: true,
         path: 'title',
         type: 'text',
       },
       {
         meta: {},
+        searchable: true,
         path: 'title.raw',
         type: 'keyword',
       },
       {
         meta: {},
+        searchable: true,
         path: 'title.sub',
         type: 'integer',
+      },
+    ]);
+  });
+
+  it('marks fields with index: false as not searchable', () => {
+    const mapping: MappingTypeMapping = {
+      properties: {
+        searchable_field: {
+          type: 'text',
+        },
+        non_searchable_field: {
+          type: 'text',
+          index: false,
+        },
+      },
+    };
+
+    const flattened = flattenMapping(mapping).sort((a, b) => a.path.localeCompare(b.path));
+
+    expect(flattened).toEqual([
+      {
+        meta: {},
+        searchable: false,
+        path: 'non_searchable_field',
+        type: 'text',
+      },
+      {
+        meta: {},
+        searchable: true,
+        path: 'searchable_field',
+        type: 'text',
       },
     ]);
   });
@@ -182,11 +227,13 @@ describe('flattenMapping', () => {
     expect(flattened).toEqual([
       {
         meta: {},
+        searchable: true,
         path: '_internal',
         type: 'keyword',
       },
       {
         meta: {},
+        searchable: true,
         path: 'foo',
         type: 'text',
       },

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/flatten_mapping.ts
@@ -11,6 +11,7 @@ import type { MappingField } from './types';
 interface MappingProperties {
   [key: string]: {
     type?: string; // Leaf field (e.g., "text", "keyword", etc.)
+    index?: boolean; // Whether the field is indexed (searchable)
     properties?: MappingProperties; // Nested object fields
     fields?: MappingProperties; // Multi-fields (alternative analyzers/types)
     meta?: Record<string, string>; // meta
@@ -35,6 +36,7 @@ export const flattenMapping = (mapping: MappingTypeMapping): MappingField[] => {
           type: value.type,
           path: fieldPath,
           meta: value.meta ?? {},
+          searchable: value.index !== false,
         });
       }
       if (value.properties) {

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/mappings/types.ts
@@ -15,4 +15,6 @@ export interface MappingField {
   type: string;
   /** meta attached to the field */
   meta: Record<string, string>;
+  /** whether the field is searchable (defaults to true when not set) */
+  searchable?: boolean;
 }

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/resources/resolve_resource.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/resources/resolve_resource.test.ts
@@ -152,7 +152,7 @@ describe('resolveResource', () => {
       expect(result).toEqual({
         name: 'my-local-index',
         type: EsResourceType.index,
-        fields: [{ path: 'title', type: 'text', meta: {} }],
+        fields: [{ path: 'title', type: 'text', meta: {}, searchable: true }],
         description: 'A test index',
       });
     });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/257930
Supersedes https://github.com/elastic/kibana/pull/257934

Ensures that text fields are searchable before calling them in the relevance search tool. 

In order to keep the flattened fields overall, we had to propagate whether fields were searchable from field caps. This is because while the RRF can omit fields and just search `*` where it will do the right thing. This could be simplified once the retrievers are updated to support CCS. 

Coded with the assistance of Claude Code + Opus 4.6. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added searchable property to field metadata, enabling fields to be marked as searchable or non-searchable in search operations.

* **Tests**
  * Extended test coverage for field searchability filtering and field metadata propagation throughout search utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->