### PR TITLE
[Lens as code] Extract inlined response envelopes

### DIFF
--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/common.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/common.ts
@@ -41,5 +41,5 @@ export const lensResponseItemSchema = schema.object(
     data: schema.oneOf([lensApiStateSchema, lensItemDataSchemaV2]),
     meta: lensItemMetaSchema,
   },
-  { unknowns: 'forbid' }
+  { unknowns: 'forbid', meta: { id: 'visualizationResponse' } }
 );

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/get.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/get.ts
@@ -21,17 +21,12 @@ export const lensGetRequestParamsSchema = schema.object(
   { unknowns: 'forbid' }
 );
 
-export const lensGetResponseBodySchema = schema.object(
-  {
-    id: lensResponseItemSchema.getPropSchemas().id,
-    data: lensResponseItemSchema.getPropSchemas().data,
-    meta: schema.object(
-      {
-        ...lensCMGetResultSchema.getPropSchemas().meta.getPropSchemas(), // include CM meta data
-        ...lensResponseItemSchema.getPropSchemas().meta.getPropSchemas(),
-      },
-      { unknowns: 'forbid' }
-    ),
-  },
-  { unknowns: 'forbid' }
-);
+export const lensGetResponseBodySchema = lensResponseItemSchema.extends({
+  meta: schema.object(
+    {
+      ...lensCMGetResultSchema.getPropSchemas().meta.getPropSchemas(), // include CM meta data
+      ...lensResponseItemSchema.getPropSchemas().meta.getPropSchemas(),
+    },
+    { unknowns: 'forbid' }
+  ),
+});

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/search.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/search.ts
@@ -54,5 +54,5 @@ export const lensSearchResponseBodySchema = schema.object(
     data: schema.arrayOf(lensResponseItemSchema, { maxSize: 100 }),
     meta: lensSearchResponseMetaSchema,
   },
-  { unknowns: 'forbid' }
+  { unknowns: 'forbid', meta: { id: 'visualizationListResponse' } }
 );

--- a/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/update.ts
+++ b/x-pack/platform/plugins/shared/lens/server/api/routes/internal/visualizations/schema/update.ts
@@ -40,16 +40,4 @@ export const lensUpdateRequestBodySchema = schema.oneOf([
   lensItemDataSchemaV0, // Temporarily permit passing old v0 SO attributes on create
 ]);
 
-export const lensUpdateResponseBodySchema = schema.object(
-  {
-    id: lensResponseItemSchema.getPropSchemas().id,
-    data: lensResponseItemSchema.getPropSchemas().data,
-    meta: schema.object(
-      {
-        ...lensResponseItemSchema.getPropSchemas().meta.getPropSchemas(),
-      },
-      { unknowns: 'forbid' }
-    ),
-  },
-  { unknowns: 'forbid' }
-);
+export const lensUpdateResponseBodySchema = lensResponseItemSchema;


### PR DESCRIPTION
## Summary

Fixes #257039

This cleans up some inlining of `lensResponseItemSchema` on internal `get` and `update` endpoint schemas.

~@markov00 please confirm that this meets the issue acceptance criteria? Issue refers to 5 instances of this schema being inlined and I only found 2. I'm also unsure what we needed to rename `visualizationResponse` and `visualizationListResponse`~

**UPDATE:** Seems the original issue was referring to inlining and extraction on OpenAPI output. I've added `meta.id`s for `visualizationResponse` and `visualizationListResponse` where necessary
