### PR TITLE
[EDR Workflows][Osquery] Reorder history table columns to match mocks

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
@@ -413,6 +413,21 @@ const UnifiedHistoryTableComponent = () => {
   const columns = useMemo(
     () => [
       {
+        name: i18n.translate('xpack.osquery.liveQueryActions.table.actionsColumnTitle', {
+          defaultMessage: 'Actions',
+        }),
+        width: '120px',
+        actions: [
+          {
+            available: isPlayButtonAvailable,
+            render: renderPlayButton,
+          },
+          {
+            render: renderDetailsAction,
+          },
+        ],
+      },
+      {
         field: 'queryText',
         name: i18n.translate('xpack.osquery.liveQueryActions.table.queryColumnTitle', {
           defaultMessage: 'Query',
@@ -422,20 +437,20 @@ const UnifiedHistoryTableComponent = () => {
         render: renderQueryColumn,
       },
       {
-        field: 'totalRows',
-        name: i18n.translate('xpack.osquery.liveQueryActions.table.resultsColumnTitle', {
-          defaultMessage: 'Results',
-        }),
-        width: '120px',
-        render: renderResultsColumn,
-      },
-      {
         field: 'tags',
         name: i18n.translate('xpack.osquery.liveQueryActions.table.tagsColumnTitle', {
           defaultMessage: 'Tags',
         }),
         width: '100px',
         render: renderTagsColumn,
+      },
+      {
+        field: 'totalRows',
+        name: i18n.translate('xpack.osquery.liveQueryActions.table.resultsColumnTitle', {
+          defaultMessage: 'Results',
+        }),
+        width: '120px',
+        render: renderResultsColumn,
       },
       {
         field: 'source',
@@ -468,21 +483,6 @@ const UnifiedHistoryTableComponent = () => {
         }),
         width: '200px',
         render: renderRunByColumn,
-      },
-      {
-        name: i18n.translate('xpack.osquery.liveQueryActions.table.actionsColumnTitle', {
-          defaultMessage: 'Actions',
-        }),
-        width: '120px',
-        actions: [
-          {
-            available: isPlayButtonAvailable,
-            render: renderPlayButton,
-          },
-          {
-            render: renderDetailsAction,
-          },
-        ],
       },
     ],
     [


### PR DESCRIPTION
Reorders the unified history table columns to match the latest mock screenshots. The new order is: Actions, Query, Tags, Results, Source, Agents, Created at, Run by. This is a pure column reorder with no rendering or logic changes.

<img width="1316" height="652" alt="Screenshot 2026-03-16 at 13 05 22" src="https://github.com/user-attachments/assets/e3aa41ab-458a-4a88-bdb1-013b9ba4d89e" />
