### PR TITLE
[Lens as code] Move rangesOperation meta id to right place

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.ts
@@ -310,67 +310,70 @@ export const bucketHistogramOperationSchema = schema.object(
   { meta: { id: 'histogramOperation', title: 'Histogram Operation' } }
 );
 
-export const bucketRangesOperationSchema = schema.object({
-  operation: schema.literal('range'),
-  ...formatSchema,
-  ...labelSharedProp,
-  /**
-   * Label for the operation
-   */
-  label: schema.maybe(
-    schema.string({
+export const bucketRangesOperationSchema = schema.object(
+  {
+    operation: schema.literal('range'),
+    ...formatSchema,
+    ...labelSharedProp,
+    /**
+     * Label for the operation
+     */
+    label: schema.maybe(
+      schema.string({
+        meta: {
+          description: 'Label for the operation',
+        },
+      })
+    ),
+    /**
+     * Field to be used for the range
+     */
+    field: schema.string({
       meta: {
-        description: 'Label for the operation',
+        description: 'Field to be used for the range',
       },
-    })
-  ),
-  /**
-   * Field to be used for the range
-   */
-  field: schema.string({
-    meta: {
-      description: 'Field to be used for the range',
-    },
-  }),
-  /**
-   * Ranges
-   */
-  ranges: schema.arrayOf(
-    schema.object({
-      /**
-       * Less than or equal to
-       */
-      lte: schema.maybe(
-        schema.number({
-          meta: {
-            description: 'Less than or equal to',
-          },
-        })
-      ),
-      /**
-       * Greater than
-       */
-      gt: schema.maybe(
-        schema.number({
-          meta: {
-            description: 'Greater than',
-          },
-        })
-      ),
-      /**
-       * Label
-       */
-      label: schema.maybe(
-        schema.string({
-          meta: {
-            description: 'Label',
-          },
-        })
-      ),
     }),
-    { maxSize: 100, meta: { id: 'rangesOperation', title: 'Ranges Operation' } }
-  ),
-});
+    /**
+     * Ranges
+     */
+    ranges: schema.arrayOf(
+      schema.object({
+        /**
+         * Less than or equal to
+         */
+        lte: schema.maybe(
+          schema.number({
+            meta: {
+              description: 'Less than or equal to',
+            },
+          })
+        ),
+        /**
+         * Greater than
+         */
+        gt: schema.maybe(
+          schema.number({
+            meta: {
+              description: 'Greater than',
+            },
+          })
+        ),
+        /**
+         * Label
+         */
+        label: schema.maybe(
+          schema.string({
+            meta: {
+              description: 'Label',
+            },
+          })
+        ),
+      }),
+      { maxSize: 100 }
+    ),
+  },
+  { meta: { id: 'rangesOperation', title: 'Ranges Operation' } }
+);
 
 export const bucketOperationDefinitionSchema = schema.oneOf([
   bucketDateHistogramOperationSchema,


### PR DESCRIPTION
## Summary

Fixes #257037 

Range operation was getting inlined in OpenAPI output because its `meta.id` was in the wrong place.

