### PR TITLE
Add dynamic workflow selection to notification policy form

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBox, EuiFormRow } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useEffect, useState } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { useDebouncedValue } from '@kbn/react-hooks';
+import { useFetchWorkflows } from '../../../../hooks/use_fetch_workflows';
+import type { NotificationPolicyFormState } from '../types';
+
+interface SelectedWorkflow {
+  id: string;
+  name: string;
+}
+
+export const WorkflowSelector = () => {
+  const { control } = useFormContext<NotificationPolicyFormState>();
+  const destinations = useWatch({ control, name: 'destinations' });
+
+  const [selectedWorkflows, setSelectedWorkflows] = useState<SelectedWorkflow[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(searchQuery, 300);
+
+  const { data: workflowsData, isLoading } = useFetchWorkflows({ query: debouncedQuery });
+
+  useEffect(() => {
+    if (selectedWorkflows.length > 0 || destinations.length === 0 || !workflowsData) {
+      return;
+    }
+
+    const workflowsById = new Map(workflowsData.results.map((w) => [w.id, w.name]));
+    setSelectedWorkflows(
+      destinations.map((d) => ({ id: d.id, name: workflowsById.get(d.id) ?? d.id }))
+    );
+  }, [destinations, workflowsData, selectedWorkflows.length]);
+
+  const workflowOptions = (workflowsData?.results ?? []).map((w) => ({
+    label: w.name,
+    value: w.id,
+  }));
+
+  return (
+    <Controller
+      name="destinations"
+      control={control}
+      rules={{
+        validate: (value) =>
+          value.length > 0
+            ? true
+            : i18n.translate('xpack.alertingV2.notificationPolicy.form.destination.required', {
+                defaultMessage: 'At least one destination is required',
+              }),
+      }}
+      render={({ field, fieldState: { error } }) => (
+        <EuiFormRow
+          label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination', {
+            defaultMessage: 'Destinations',
+          })}
+          isInvalid={!!error}
+          error={error?.message}
+        >
+          <EuiComboBox
+            fullWidth
+            async
+            isLoading={isLoading}
+            isInvalid={!!error}
+            data-test-subj="destinationsInput"
+            placeholder={i18n.translate(
+              'xpack.alertingV2.notificationPolicy.form.destination.placeholder',
+              { defaultMessage: 'Search and select workflows' }
+            )}
+            selectedOptions={selectedWorkflows.map((w) => ({ label: w.name, value: w.id }))}
+            onSearchChange={setSearchQuery}
+            onChange={(options) => {
+              setSelectedWorkflows(options.map((o) => ({ id: o.value as string, name: o.label })));
+              field.onChange(
+                options.map((o) => ({ type: 'workflow' as const, id: o.value as string }))
+              );
+            }}
+            options={workflowOptions}
+          />
+        </EuiFormRow>
+      )}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
@@ -8,12 +8,6 @@
 import { i18n } from '@kbn/i18n';
 import type { NotificationPolicyFormState } from './types';
 
-export const WORKFLOW_OPTIONS = [
-  { value: 'workflow-1', label: 'Slack notification workflow' },
-  { value: 'workflow-2', label: 'PagerDuty escalation workflow' },
-  { value: 'workflow-3', label: 'Email digest workflow' },
-];
-
 export const FREQUENCY_OPTIONS = [
   {
     value: 'immediate',
@@ -38,5 +32,5 @@ export const DEFAULT_FORM_STATE: NotificationPolicyFormState = {
   groupBy: [],
   ruleLabels: [],
   frequency: { type: 'immediate' },
-  destinations: [{ type: 'workflow', id: 'workflow-1' }],
+  destinations: [],
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
@@ -14,6 +14,13 @@ import { DEFAULT_FORM_STATE } from './constants';
 import { NotificationPolicyForm } from './notification_policy_form';
 import type { NotificationPolicyFormState } from './types';
 
+jest.mock('../../../hooks/use_fetch_workflows', () => ({
+  useFetchWorkflows: () => ({
+    data: { results: [], total: 0, page: 1, size: 100 },
+    isLoading: false,
+  }),
+}));
+
 const renderForm = (defaultValues: NotificationPolicyFormState = DEFAULT_FORM_STATE) => {
   const TestComponent = () => {
     const methods = useForm<NotificationPolicyFormState>({

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
@@ -20,8 +20,9 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { FREQUENCY_OPTIONS, THROTTLE_INTERVAL_PATTERN, WORKFLOW_OPTIONS } from './constants';
-import type { NotificationPolicyDestination, NotificationPolicyFormState } from './types';
+import { FREQUENCY_OPTIONS, THROTTLE_INTERVAL_PATTERN } from './constants';
+import { WorkflowSelector } from './components/workflow_selector';
+import type { NotificationPolicyFormState } from './types';
 
 export const NotificationPolicyForm = () => {
   const { control } = useFormContext<NotificationPolicyFormState>();
@@ -367,49 +368,7 @@ export const NotificationPolicyForm = () => {
           </EuiTitle>
         </EuiSplitPanel.Inner>
         <EuiSplitPanel.Inner>
-          <Controller
-            name="destinations"
-            control={control}
-            rules={{
-              validate: (value) =>
-                value.length > 0
-                  ? true
-                  : i18n.translate(
-                      'xpack.alertingV2.notificationPolicy.form.destination.required',
-                      { defaultMessage: 'At least one destination is required' }
-                    ),
-            }}
-            render={({ field, fieldState: { error } }) => (
-              <EuiFormRow
-                label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination', {
-                  defaultMessage: 'Destinations',
-                })}
-                isInvalid={!!error}
-                error={error?.message}
-              >
-                <EuiComboBox
-                  fullWidth
-                  isInvalid={!!error}
-                  data-test-subj="destinationsInput"
-                  placeholder={i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.destination.placeholder',
-                    { defaultMessage: 'Add destination' }
-                  )}
-                  selectedOptions={field.value.map((d: NotificationPolicyDestination) => {
-                    const workflow = WORKFLOW_OPTIONS.find((w) => w.value === d.id);
-                    return {
-                      label: workflow?.label ?? '',
-                      value: workflow?.value ?? '',
-                    };
-                  })}
-                  onChange={(options) => {
-                    field.onChange(options.map((o) => ({ type: 'workflow', id: o.value })));
-                  }}
-                  options={WORKFLOW_OPTIONS}
-                />
-              </EuiFormRow>
-            )}
-          />
+          <WorkflowSelector />
         </EuiSplitPanel.Inner>
       </EuiSplitPanel.Outer>
     </>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.test.ts
@@ -76,7 +76,7 @@ describe('useNotificationPolicyForm', () => {
       expect(onSubmitCreate).toHaveBeenCalledWith({
         name: 'My policy',
         description: 'A description',
-        destinations: [{ type: 'workflow', id: 'workflow-1' }],
+        destinations: [],
       });
     });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form_flyout/notification_policy_form_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form_flyout/notification_policy_form_flyout.test.tsx
@@ -6,11 +6,34 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { NotificationPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { I18nProvider } from '@kbn/i18n-react';
 import { NotificationPolicyFormFlyout } from './notification_policy_form_flyout';
+
+jest.mock('../../../hooks/use_fetch_workflows', () => ({
+  useFetchWorkflows: () => ({
+    data: {
+      results: [
+        {
+          id: 'wf-1',
+          name: 'Test Workflow',
+          description: '',
+          enabled: true,
+          definition: null,
+          createdAt: '',
+          history: [],
+          valid: true,
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 100,
+    },
+    isLoading: false,
+  }),
+}));
 
 const TEST_SUBJ = {
   title: 'title',
@@ -68,6 +91,11 @@ describe('NotificationPolicyFormFlyout', () => {
     await user.type(screen.getByTestId(TEST_SUBJ.descriptionInput), 'Description from test');
     await user.tab();
 
+    // Select a workflow destination (required field)
+    const destinationsCombo = screen.getByTestId('destinationsInput');
+    await user.click(within(destinationsCombo).getByRole('combobox'));
+    await user.click(await screen.findByRole('option', { name: 'Test Workflow' }));
+
     const saveButton = screen.getByTestId(TEST_SUBJ.submitButton);
     await waitFor(() => expect(saveButton).toBeEnabled());
     await user.click(saveButton);
@@ -76,7 +104,7 @@ describe('NotificationPolicyFormFlyout', () => {
     expect(onSave).toHaveBeenCalledWith({
       name: 'Policy from test',
       description: 'Description from test',
-      destinations: [{ type: 'workflow', id: 'workflow-1' }],
+      destinations: [{ type: 'workflow', id: 'wf-1' }],
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/__storybook_mocks__/use_fetch_workflows.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/__storybook_mocks__/use_fetch_workflows.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UseQueryResult } from '@kbn/react-query';
+import type { WorkflowListDto } from '@kbn/workflows';
+
+const MOCK_WORKFLOWS: WorkflowListDto = {
+  page: 1,
+  size: 100,
+  total: 3,
+  results: [
+    {
+      id: 'workflow-1',
+      name: 'Slack notification workflow',
+      description: 'Sends alerts to Slack',
+      enabled: true,
+      definition: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      history: [],
+      valid: true,
+    },
+    {
+      id: 'workflow-2',
+      name: 'PagerDuty escalation workflow',
+      description: 'Escalates to PagerDuty',
+      enabled: true,
+      definition: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      history: [],
+      valid: true,
+    },
+    {
+      id: 'workflow-3',
+      name: 'Email digest workflow',
+      description: 'Sends email digests',
+      enabled: true,
+      definition: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      history: [],
+      valid: true,
+    },
+  ],
+};
+
+export const useFetchWorkflows = () =>
+  ({ data: MOCK_WORKFLOWS, isLoading: false } as UseQueryResult<WorkflowListDto, Error>);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/query_key_factory.ts
@@ -15,6 +15,12 @@ export const ruleKeys = {
   delete: () => [...ruleKeys.all, 'delete'] as const,
 };
 
+export const workflowKeys = {
+  all: ['workflow'] as const,
+  searches: () => [...workflowKeys.all, 'search'] as const,
+  search: (params: { query: string }) => [...workflowKeys.searches(), params] as const,
+};
+
 export const notificationPolicyKeys = {
   all: ['notificationPolicy'] as const,
   create: () => [...notificationPolicyKeys.all, 'create'] as const,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { i18n } from '@kbn/i18n';
+import type { WorkflowListDto } from '@kbn/workflows';
+import { WorkflowsApi } from '../services/workflows_api';
+import { workflowKeys } from './query_key_factory';
+
+interface UseFetchWorkflowsParams {
+  query: string;
+}
+
+export const useFetchWorkflows = ({ query }: UseFetchWorkflowsParams) => {
+  const workflowsApi = useService(WorkflowsApi);
+  const { toasts } = useService(CoreStart('notifications'));
+
+  return useQuery<WorkflowListDto, Error>({
+    queryKey: workflowKeys.search({ query }),
+    queryFn: () => workflowsApi.searchWorkflows({ query, size: 100, page: 1 }),
+    refetchOnWindowFocus: false,
+    keepPreviousData: true,
+    onError: (error: Error) => {
+      toasts.addError(error, {
+        title: i18n.translate('xpack.alertingV2.workflows.fetchError', {
+          defaultMessage: 'Failed to load workflows',
+        }),
+      });
+    },
+  });
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_update_notification_policy.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_update_notification_policy.ts
@@ -28,8 +28,9 @@ export const useUpdateNotificationPolicy = () => {
   return useMutation<NotificationPolicyResponse, Error, UpdateNotificationPolicyVariables>({
     mutationKey: notificationPolicyKeys.update(),
     mutationFn: ({ id, data }) => notificationPoliciesApi.updateNotificationPolicy(id, data),
-    onSuccess: () => {
+    onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: notificationPolicyKeys.lists(), exact: false });
+      queryClient.invalidateQueries({ queryKey: notificationPolicyKeys.detail(id), exact: false });
       toasts.addSuccess(
         i18n.translate('xpack.alertingV2.notificationPolicy.updateSuccess', {
           defaultMessage: 'Notification policy updated successfully',

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -13,10 +13,12 @@ import { mountAlertingV2App } from './main';
 import { ALERTING_V2_APP_ID } from './constants';
 import { NotificationPoliciesApi } from './services/notification_policies_api';
 import { RulesApi } from './services/rules_api';
+import { WorkflowsApi } from './services/workflows_api';
 
 export const module = new ContainerModule(({ bind }) => {
   bind(RulesApi).toSelf().inSingletonScope();
   bind(NotificationPoliciesApi).toSelf().inSingletonScope();
+  bind(WorkflowsApi).toSelf().inSingletonScope();
   bind(OnSetup).toConstantValue((container) => {
     const getStartServices = container.get(CoreSetup('getStartServices'));
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/workflows_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/workflows_api.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { inject, injectable } from 'inversify';
+import type { HttpStart } from '@kbn/core/public';
+import { CoreStart } from '@kbn/core-di-browser';
+import type { WorkflowsSearchParams, WorkflowListDto } from '@kbn/workflows';
+
+@injectable()
+export class WorkflowsApi {
+  constructor(@inject(CoreStart('http')) private readonly http: HttpStart) {}
+
+  public async searchWorkflows(params: WorkflowsSearchParams): Promise<WorkflowListDto> {
+    return this.http.post<WorkflowListDto>('/api/workflows/search', {
+      body: JSON.stringify(params),
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
+++ b/x-pack/platform/plugins/shared/alerting_v2/tsconfig.json
@@ -63,7 +63,8 @@
     "@kbn/workflows",
     "@kbn/core-http-server-utils",
     "@kbn/eval-kql",
-    "@kbn/react-query"
+    "@kbn/react-query",
+    "@kbn/react-hooks"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
## Summary
resolves https://github.com/elastic/rna-program/issues/187

This PR adds dynamic workflow selection to the notification policy form, replacing hardcoded static options. Users can now search and select from real workflows fetched via the existing `/api/workflows/search` API.

### Changes

- **`WorkflowsApi` service** — New injectable service wrapping the workflows search API endpoint
- **`useFetchWorkflows` hook** — React Query hook for fetching workflows with debounced search
- **`WorkflowSelector` component** — Extracted into its own component with local state management
- **Query key factory** — Extended with workflow-specific cache keys
- **Form integration** — Updated notification policy form to use dynamic workflow selection
- **Storybook mock** — Added `__storybook_mocks__/use_fetch_workflows.ts` for Storybook preview

### Key Design Decisions

1. **No hook prop injection** — Uses Kibana's built-in `__storybook_mocks__` mechanism to mock the hook in Storybook without prop drilling
2. **Workflow name caching** — Pre-selected workflows in edit mode display their names via a `useEffect` that hydrates from the API response
3. **useState over useRef** — Selected workflows stored directly in state as `{ id, name }` objects instead of a Map

### Tests

All 18 existing tests pass. No new tests added (existing test mocking pattern maintained).

### Verification

- `yarn test:jest x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/ --no-coverage` ✅
- `node scripts/check_changes.ts` ✅
- Storybook builds and renders both CreateMode and EditMode stories ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)