### PR TITLE
[Lens as code] Add valueDisplay meta id

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/partition_shared.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/partition_shared.ts
@@ -33,7 +33,13 @@ export const valueDisplaySchema = schema.maybe(
         })
       ),
     },
-    { meta: { id: 'valueDisplay', title: 'Value Display', description: 'Configuration for displaying values in chart cells' } }
+    {
+      meta: {
+        id: 'valueDisplay',
+        title: 'Value Display',
+        description: 'Configuration for displaying values in chart cells',
+      },
+    }
   )
 );
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/partition_shared.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/partition_shared.ts
@@ -33,7 +33,7 @@ export const valueDisplaySchema = schema.maybe(
         })
       ),
     },
-    { meta: { description: 'Configuration for displaying values in chart cells' } }
+    { meta: { id: 'valueDisplay', title: 'Value Display', description: 'Configuration for displaying values in chart cells' } }
   )
 );
 


### PR DESCRIPTION
## Summary

Closes #257038 

Eliminates duplication of `valueDisplay` in OpenAPI output by adding a `meta.id`

