### PR TITLE
[Dashboards] Fix dashboard save modal title

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/save_modal/open_save_modal.tsx
@@ -169,7 +169,7 @@ export async function openSaveModal({
             showCopyOnSave={false}
             onSave={onSaveAttempt}
             accessControl={accessControl}
-            customModalTitle={getCustomModalTitle(viewMode)}
+            customModalTitle={getCustomModalTitle(viewMode, lastSavedId)}
             showAccessContainer={shouldAddAccessControl}
           />
         );
@@ -183,8 +183,8 @@ export async function openSaveModal({
   }
 }
 
-function getCustomModalTitle(viewMode: ViewMode) {
-  if (viewMode === 'edit')
+function getCustomModalTitle(viewMode: ViewMode, lastSavedId: string | undefined) {
+  if (!lastSavedId || viewMode === 'edit')
     return i18n.translate('dashboard.topNav.editModeInteractiveSave.modalTitle', {
       defaultMessage: 'Save as new dashboard',
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/257898

When the dashboard agent plugin creates a new in-memory dashboard and the user clicks Save, the modal incorrectly shows "Duplicate dashboard" as its title. This happens because getCustomModalTitle only checks viewMode, and the agent renders dashboards in view mode. The fix adds a lastSavedId check so that new dashboards (without a saved object ID) always show "Save as new dashboard" regardless of view mode.