### PR TITLE
Skip validating optional enums

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/form-generator/src/field_builder.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/form-generator/src/field_builder.test.tsx
@@ -243,6 +243,58 @@ describe('Field Builder', () => {
 
       expect(result?.message).toContain('First validation failed');
     });
+
+    it('should skip validation for optional fields with empty string value', () => {
+      const schema = z.enum(['option_a', 'option_b']).optional();
+      const path = 'field';
+
+      const field = getFieldFromSchema({ schema, path, formConfig, meta });
+      const result = field.validate(createValidationArg('', path));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should skip validation for optional fields with undefined value', () => {
+      const schema = z.enum(['option_a', 'option_b']).optional();
+      const path = 'field';
+
+      const field = getFieldFromSchema({ schema, path, formConfig, meta });
+      const result = field.validate(createValidationArg(undefined, path));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should skip validation for optional fields with null value', () => {
+      const schema = z.enum(['option_a', 'option_b']).optional();
+      const path = 'field';
+
+      const field = getFieldFromSchema({ schema, path, formConfig, meta });
+      const result = field.validate(createValidationArg(null, path));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should still validate optional fields with non-empty invalid values', () => {
+      const schema = z.enum(['option_a', 'option_b']).optional();
+      const path = 'field';
+
+      const field = getFieldFromSchema({ schema, path, formConfig, meta });
+      const result = field.validate(createValidationArg('invalid', path)) as ValidationError;
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('message');
+    });
+
+    it('should still validate required enum fields with empty string value', () => {
+      const schema = z.enum(['option_a', 'option_b']);
+      const path = 'field';
+
+      const field = getFieldFromSchema({ schema, path, formConfig, meta });
+      const result = field.validate(createValidationArg('', path)) as ValidationError;
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('message');
+    });
   });
 
   describe('renderField', () => {

--- a/x-pack/platform/packages/shared/response-ops/form-generator/src/field_builder.tsx
+++ b/x-pack/platform/packages/shared/response-ops/form-generator/src/field_builder.tsx
@@ -63,6 +63,15 @@ export const getFieldFromSchema = ({
     validate: (...args: Parameters<ValidationFunc>): ReturnType<ValidationFunc> => {
       const [{ value, path: formPath }] = args;
 
+      // Skip validation for optional fields when the value is empty.
+      // extractSchemaCore unwraps ZodOptional to get the inner schema, so the
+      // optional wrapper is no longer present during parse(). Without this
+      // check, empty values (e.g. "") would fail validation against the inner
+      // schema (e.g. ZodEnum) even though the field is not required.
+      if (isOptional && (value === undefined || value === null || value === '')) {
+        return undefined;
+      }
+
       try {
         schema.parse(value);
         return undefined;


### PR DESCRIPTION
## Summary

A recent PR introduced https://github.com/elastic/kibana/pull/255076/changes#diff-a845b8bfd267a8bb2d0dbfc5d1f86b392161544ca69cef1ee89cc4f79e3226e3R27-R30

```
    tokenEndpointAuthMethod: z
      .enum(['client_secret_post', 'client_secret_basic'])
      .meta({ label: i18n.OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_LABEL, hidden: true })
      .optional(),
```

To the OAuth Client Credentials implementation. This had the unfortunate side effect of causing all existing usages of that auth type to start failing form validation, with a message like:

```
There are errors in the form
```

This is because  when the form generator processes this field:
  1. `extractSchemaCore()` unwraps `ZodOptional` and returns the inner `ZodEnum` schema
  2. It sets `isOptional = true` but this flag is only used for rendering an "Optional" label
  3. The hidden field is initialized with an empty string `""`
  4. On validation, `ZodEnum.parse("")` fails because `""` is not one of the valid enum values
  5. Since the field is hidden, no error message is visible — users just see `"There are errors in the form"`


This PR adjusts the validation logic to to short-circuit in the edge case where an `isOptional` is empty, undefined, or null.

Alternatively, we could add ` defaults: { tokenEndpointAuthMethod: 'client_secret_post' }` to the ServiceNow, Salesforce, and Sharepoint Online connectors. And maybe make `tokenEndpointAuthMethod` required instead of optional. 

<img width="613" height="507" alt="image (6)" src="https://github.com/user-attachments/assets/43b776b6-159b-4c03-b851-145a1348afb3" />


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.





