### PR TITLE
[Entity Analytics] Updating `CODEOWNERS` for entity analytics tools and skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2625,7 +2625,7 @@ x-pack/solutions/security/test/security_solution_api_integration/test_suites/sou
 ## NOTE: It's important to keep this above other teams' sections because test automation doesn't process
 ## the CODEOWNERS file correctly. See https://github.com/elastic/kibana/issues/173307#issuecomment-1855858929
 /x-pack/solutions/security/test/security_solution_cypress/.cursor/rules/flaky_test_doctor.mdc @elastic/security-engineering-productivity
-/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration @elastic/security-engineering-productivity   
+/x-pack/solutions/security/plugins/security_solution/.agents/skills/cypress-to-scout-migration @elastic/security-engineering-productivity
 /x-pack/solutions/security/plugins/security_solution/.agents/skills/flaky-test-doctor @elastic/security-engineering-productivity
 /x-pack/solutions/security/plugins/security_solution/.agents/skills/scout-best-practices-reviewer @elastic/security-engineering-productivity
 /x-pack/solutions/security/test/security_solution_cypress/* @elastic/security-engineering-productivity
@@ -2975,6 +2975,8 @@ x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insight
 /x-pack/solutions/security/packages/test-api-clients/supertest/endpoint_management.gen.ts @elastic/security-defend-workflows
 /x-pack/solutions/security/packages/test-api-clients/supertest/osquery.gen.ts @elastic/security-defend-workflows
 /x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting @elastic/security-defend-workflows
+/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/entity_analytics @elastic/security-entity-analytics
+/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics @elastic/security-entity-analytics
 /src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_endpoint @elastic/security-defend-workflows
 /src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/evals_entity_analytics @elastic/security-entity-analytics
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_risk_score_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_risk_score_tool.test.ts
@@ -7,19 +7,19 @@
 
 import { ToolResultType, type ErrorResult, type OtherResult } from '@kbn/agent-builder-common';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
-import { DEFAULT_ALERTS_INDEX } from '../../../common/constants';
-import { getRiskIndex } from '../../../common/search_strategy/security_solution/risk_score/common';
+import { DEFAULT_ALERTS_INDEX } from '../../../../common/constants';
+import { getRiskIndex } from '../../../../common/search_strategy/security_solution/risk_score/common';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import {
   createToolAvailabilityContext,
   createToolHandlerContext,
   createToolTestMocks,
   setupMockCoreStartServices,
-} from '../__mocks__/test_helpers';
+} from '../../__mocks__/test_helpers';
 import { entityRiskScoreTool } from './entity_risk_score_tool';
-import { createGetRiskScores } from '../../lib/entity_analytics/risk_score/get_risk_score';
+import { createGetRiskScores } from '../../../lib/entity_analytics/risk_score/get_risk_score';
 
-jest.mock('../../lib/entity_analytics/risk_score/get_risk_score');
+jest.mock('../../../lib/entity_analytics/risk_score/get_risk_score');
 
 const mockCreateGetRiskScores = createGetRiskScores as jest.Mock;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_risk_score_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/entity_risk_score_tool.ts
@@ -11,14 +11,14 @@ import { ToolType, ToolResultType } from '@kbn/agent-builder-common';
 import type { BuiltinToolDefinition, ToolAvailabilityContext } from '@kbn/agent-builder-server';
 import { getToolResultId } from '@kbn/agent-builder-server/tools';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
-import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
-import type { EntityRiskScoreRecord } from '../../../common/api/entity_analytics/common';
-import { createGetRiskScores } from '../../lib/entity_analytics/risk_score/get_risk_score';
-import type { EntityType } from '../../../common/entity_analytics/types';
-import { DEFAULT_ALERTS_INDEX, ESSENTIAL_ALERT_FIELDS } from '../../../common/constants';
-import { getRiskIndex } from '../../../common/search_strategy/security_solution/risk_score/common';
-import { securityTool } from './constants';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import type { EntityRiskScoreRecord } from '../../../../common/api/entity_analytics/common';
+import { createGetRiskScores } from '../../../lib/entity_analytics/risk_score/get_risk_score';
+import type { EntityType } from '../../../../common/entity_analytics/types';
+import { DEFAULT_ALERTS_INDEX, ESSENTIAL_ALERT_FIELDS } from '../../../../common/constants';
+import { getRiskIndex } from '../../../../common/search_strategy/security_solution/risk_score/common';
+import { securityTool } from '../constants';
 
 const entityRiskScoreSchema = z.object({
   identifierType: z

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.test.ts
@@ -8,17 +8,17 @@
 import { ToolResultType, type ErrorResult, type EsqlResults } from '@kbn/agent-builder-common';
 import { executeEsql } from '@kbn/agent-builder-genai-utils';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
-import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import {
   createToolAvailabilityContext,
   createToolHandlerContext,
   createToolTestMocks,
   setupMockCoreStartServices,
-} from '../__mocks__/test_helpers';
-import type { ExperimentalFeatures } from '../../../common';
+} from '../../__mocks__/test_helpers';
+import type { ExperimentalFeatures } from '../../../../common';
 import { getEntityTool } from './get_entity_tool';
 
-jest.mock('../utils/get_agent_builder_resource_availability', () => ({
+jest.mock('../../utils/get_agent_builder_resource_availability', () => ({
   getAgentBuilderResourceAvailability: jest.fn(),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/get_entity_tool.ts
@@ -16,13 +16,13 @@ import {
 } from '@kbn/entity-store/server';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { ExperimentalFeatures } from '../../../common';
-import { IdentifierType } from '../../../common/api/entity_analytics/common/common.gen';
-import { DEFAULT_ALERTS_INDEX, ESSENTIAL_ALERT_FIELDS } from '../../../common/constants';
-import { getRiskScoreTimeSeriesIndex } from '../../../common/entity_analytics/risk_engine/indices';
-import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
-import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
-import { securityTool } from './constants';
+import type { ExperimentalFeatures } from '../../../../common';
+import { IdentifierType } from '../../../../common/api/entity_analytics/common/common.gen';
+import { DEFAULT_ALERTS_INDEX, ESSENTIAL_ALERT_FIELDS } from '../../../../common/constants';
+import { getRiskScoreTimeSeriesIndex } from '../../../../common/entity_analytics/risk_engine/indices';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import { securityTool } from '../constants';
 
 const ENTITY_STORE_RISK_SCORE_NORMALIZED_FIELD = 'entity.risk.calculated_score_norm';
 const ENTITY_STORE_ENTITY_TYPE_FIELD = 'entity.EngineMetadata.Type';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { entityRiskScoreTool, SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from './entity_risk_score_tool';
+export { getEntityTool, SECURITY_GET_ENTITY_TOOL_ID } from './get_entity_tool';
+export { searchEntitiesTool, SECURITY_SEARCH_ENTITIES_TOOL_ID } from './search_entities_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.test.ts
@@ -8,17 +8,17 @@
 import { ToolResultType, type ErrorResult, type EsqlResults } from '@kbn/agent-builder-common';
 import { executeEsql } from '@kbn/agent-builder-genai-utils';
 import type { ToolHandlerStandardReturn } from '@kbn/agent-builder-server/tools';
-import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
 import {
   createToolAvailabilityContext,
   createToolHandlerContext,
   createToolTestMocks,
   setupMockCoreStartServices,
-} from '../__mocks__/test_helpers';
-import type { ExperimentalFeatures } from '../../../common';
+} from '../../__mocks__/test_helpers';
+import type { ExperimentalFeatures } from '../../../../common';
 import { searchEntitiesTool } from './search_entities_tool';
 
-jest.mock('../utils/get_agent_builder_resource_availability', () => ({
+jest.mock('../../utils/get_agent_builder_resource_availability', () => ({
   getAgentBuilderResourceAvailability: jest.fn(),
 }));
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/entity_analytics/search_entities_tool.ts
@@ -18,12 +18,12 @@ import type { Logger } from '@kbn/logging';
 import {
   IdentifierType,
   EntityRiskLevels,
-} from '../../../common/api/entity_analytics/common/common.gen';
-import type { ExperimentalFeatures } from '../../../common';
-import { AssetCriticalityLevel } from '../../../common/api/entity_analytics/asset_criticality/common.gen';
-import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
-import { getAgentBuilderResourceAvailability } from '../utils/get_agent_builder_resource_availability';
-import { securityTool } from './constants';
+} from '../../../../common/api/entity_analytics/common/common.gen';
+import type { ExperimentalFeatures } from '../../../../common';
+import { AssetCriticalityLevel } from '../../../../common/api/entity_analytics/asset_criticality/common.gen';
+import type { SecuritySolutionPluginCoreSetupDependencies } from '../../../plugin_contract';
+import { getAgentBuilderResourceAvailability } from '../../utils/get_agent_builder_resource_availability';
+import { securityTool } from '../constants';
 
 const ENTITY_STORE_KEEP_FIELDS = [
   '@timestamp',

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/index.ts
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-export { entityRiskScoreTool, SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from './entity_risk_score_tool';
+export {
+  entityRiskScoreTool,
+  SECURITY_ENTITY_RISK_SCORE_TOOL_ID,
+  getEntityTool,
+  SECURITY_GET_ENTITY_TOOL_ID,
+  searchEntitiesTool,
+  SECURITY_SEARCH_ENTITIES_TOOL_ID,
+} from './entity_analytics';
 export {
   attackDiscoverySearchTool,
   SECURITY_ATTACK_DISCOVERY_SEARCH_TOOL_ID,
@@ -16,5 +23,3 @@ export {
   createDetectionRuleTool,
   SECURITY_CREATE_DETECTION_RULE_TOOL_ID,
 } from './create_detection_rule_tool';
-export { getEntityTool, SECURITY_GET_ENTITY_TOOL_ID } from './get_entity_tool';
-export { searchEntitiesTool, SECURITY_SEARCH_ENTITIES_TOOL_ID } from './search_entities_tool';

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/register_tools.ts
@@ -10,11 +10,9 @@ import type { Logger } from '@kbn/logging';
 import type { ExperimentalFeatures } from '../../../common';
 import { securityLabsSearchTool } from './security_labs_search_tool';
 import { attackDiscoverySearchTool } from './attack_discovery_search_tool';
-import { entityRiskScoreTool } from './entity_risk_score_tool';
-import { getEntityTool } from './get_entity_tool';
+import { entityRiskScoreTool, getEntityTool, searchEntitiesTool } from './entity_analytics';
 import { alertsTool } from './alerts_tool';
 import { createDetectionRuleTool } from './create_detection_rule_tool';
-import { searchEntitiesTool } from './search_entities_tool';
 import type { SecuritySolutionPluginCoreSetupDependencies } from '../../plugin_contract';
 
 /**


### PR DESCRIPTION
## Summary

Updating `CODEOWNERS` file for entity analytics tools and skills so the EA team will get pinged for changes.