### PR TITLE
[9.2] [kbn/test] extend kbnClient to apply global settings (#249937)

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/core_fixtures.ts
@@ -253,8 +253,9 @@ export const coreWorkerFixtures = base.extend<{}, CoreWorkerFixtures>({
         return { cookieValue, cookieHeader };
       };
 
-      // Hide the announcements (including the sidenav tour) in the default space
-      await kbnClient.uiSettings.update({ hideAnnouncements: true });
+      // Hide the announcements (including the sidenav tour) in advance to prevent
+      // it from interfering with test flows
+      await kbnClient.uiSettings.updateGlobal({ hideAnnouncements: true });
 
       await use({
         session,

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/worker/scout_space/parallel.ts
@@ -126,14 +126,6 @@ export const scoutSpaceParallelFixture = coreWorkerFixtures.extend<
         setDefaultTime,
       };
 
-      /**
-       * To hide the sidenav tour we need to enable 'hideAnnouncements' setting
-       * It should hide both space tour and sidenav tour.
-       * Currently it can be set only per space, so we set it right after new space is created.
-       * TODO: update if setting becomes global https://github.com/elastic/kibana/issues/234771
-       */
-      await kbnClient.uiSettings.update({ hideAnnouncements: true }, { space: spaceId });
-
       log.serviceMessage('scoutSpace', `New Kibana space '${spaceId}' created`);
       await use({ savedObjects, uiSettings, id: spaceId });
 

--- a/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_ui_settings.ts
+++ b/src/platform/packages/shared/kbn-test/src/kbn_client/kbn_client_ui_settings.ts
@@ -100,6 +100,22 @@ export class KbnClientUiSettings {
     });
   }
 
+  /**
+   * Update UI settings globally (like setting 'hideAnnouncements', 'theme:darkMode', etc)
+   */
+  async updateGlobal(updates: UiSettingValues) {
+    this.log.debug('applying global update to kibana config: %j', updates);
+
+    await this.requester.request({
+      path: `/internal/kibana/global_settings`,
+      method: 'POST',
+      body: {
+        changes: updates,
+      },
+      retries: 3,
+    });
+  }
+
   private async getAll({ space }: { space?: string } = {}) {
     const { data } = await this.requester.request<UiSettingsApiResponse>({
       path: pathWithSpace(space)`/internal/kibana/settings`,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[kbn/test] extend kbnClient to apply global settings (#249937)](https://github.com/elastic/kibana/pull/249937)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-01-22T11:14:55Z","message":"[kbn/test] extend kbnClient to apply global settings (#249937)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/248248\n\nThis PR extends `kbnClient` with `updateGlobal` method that calls\n`/internal/kibana/global_settings` to update settings globally.\n\nReason: Scout needs to disable side nav touring that blocks UI actions.\nLined PR allows us to set `hideAnnouncements: true` one time globally\ninstead of doing it per space.","sha":"ec9aa8d02cd84046cbc3da94c2d13059da700052","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"[kbn/test] extend kbnClient to apply global settings","number":249937,"url":"https://github.com/elastic/kibana/pull/249937","mergeCommit":{"message":"[kbn/test] extend kbnClient to apply global settings (#249937)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/248248\n\nThis PR extends `kbnClient` with `updateGlobal` method that calls\n`/internal/kibana/global_settings` to update settings globally.\n\nReason: Scout needs to disable side nav touring that blocks UI actions.\nLined PR allows us to set `hideAnnouncements: true` one time globally\ninstead of doing it per space.","sha":"ec9aa8d02cd84046cbc3da94c2d13059da700052"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/249937","number":249937,"mergeCommit":{"message":"[kbn/test] extend kbnClient to apply global settings (#249937)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/248248\n\nThis PR extends `kbnClient` with `updateGlobal` method that calls\n`/internal/kibana/global_settings` to update settings globally.\n\nReason: Scout needs to disable side nav touring that blocks UI actions.\nLined PR allows us to set `hideAnnouncements: true` one time globally\ninstead of doing it per space.","sha":"ec9aa8d02cd84046cbc3da94c2d13059da700052"}}]}] BACKPORT-->