### PR TITLE
[9.3] Fix failing test: Jest Tests - useDateRangeRedirect error handling swallows inactive history errors

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/hooks/use_date_range_redirect.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/hooks/use_date_range_redirect.test.ts
@@ -179,8 +179,7 @@ describe('useDateRangeRedirect', () => {
     });
   });
 
-  // Failing: See https://github.com/elastic/kibana/issues/257084
-  describe.skip('error handling', () => {
+  describe('error handling', () => {
     it('swallows inactive history errors', () => {
       setLocation('?otherParam=foo');
       mockReplace.mockImplementation(() => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/257084

## Summary

- This test was failing because https://github.com/elastic/kibana/pull/256427 wasn't merged exclusively for 9.3, after this was merged the tests started working again.