### PR TITLE
[Security Solution] Fix enable/disable action for rules with non-migrated lastRun.outcomeMsg

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import type { SavedObject } from '@kbn/core-saved-objects-server';
+import type { RawRule } from '../../../../types';
 import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
 import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
 import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
@@ -114,7 +115,9 @@ describe('bulkDisableRules', () => {
   let actionsClient: jest.Mocked<ActionsClient>;
 
   const mockCreatePointInTimeFinderAsInternalUser = (
-    response = { saved_objects: [enabledRule1, enabledRule2] }
+    response: { saved_objects: Array<SavedObject<Partial<RawRule>>> } = {
+      saved_objects: [enabledRule1, enabledRule2],
+    }
   ) => {
     encryptedSavedObjects.createPointInTimeFinderDecryptedAsInternalUser = jest
       .fn()
@@ -552,6 +555,109 @@ describe('bulkDisableRules', () => {
       errors: [],
       rules: [returnedRuleForBulkDisable1, returnedRuleForBulkDisable2],
       total: 2,
+    });
+  });
+
+  describe('lastRun outcome message migration', () => {
+    test('migrates legacy string lastRun.outcomeMsg to string[] when bulk disabling', async () => {
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [
+          {
+            ...enabledRule1,
+            attributes: {
+              ...enabledRule1.attributes,
+              lastRun: {
+                outcome: 'failed',
+                // @ts-expect-error test legacy outcomeMsg migration
+                outcomeMsg: 'legacy message',
+              },
+            },
+          },
+          enabledRule2,
+        ],
+      });
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [disabledRuleForBulkDisable1, disabledRuleForBulkDisable2],
+      });
+
+      await rulesClient.bulkDisableRules({ filter: 'fake_filter' });
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'id1',
+            attributes: expect.objectContaining({
+              lastRun: {
+                outcome: 'failed',
+                outcomeMsg: ['legacy message'],
+              },
+            }),
+          }),
+        ]),
+        { overwrite: true }
+      );
+    });
+
+    test('leaves lastRun unchanged when outcomeMsg is already a string array', async () => {
+      const lastRun = {
+        outcome: 'succeeded' as const,
+        outcomeMsg: ['msg a', 'msg b'],
+        alertsCount: {
+          new: 0,
+          ignored: 0,
+          recovered: 0,
+          active: 0,
+        },
+      };
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [
+          {
+            ...enabledRule1,
+            attributes: {
+              ...enabledRule1.attributes,
+              lastRun,
+            },
+          },
+        ],
+      });
+      mockUnsecuredSavedObjectFind(1);
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [disabledRuleForBulkDisable1],
+      });
+
+      await rulesClient.bulkDisableRules({ filter: 'fake_filter' });
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'id1',
+            attributes: expect.objectContaining({
+              lastRun,
+            }),
+          }),
+        ]),
+        { overwrite: true }
+      );
+    });
+
+    test('does not add lastRun when the rule has no lastRun', async () => {
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [enabledRule1],
+      });
+      mockUnsecuredSavedObjectFind(1);
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [disabledRuleForBulkDisable1],
+      });
+
+      await rulesClient.bulkDisableRules({ filter: 'fake_filter' });
+
+      const bulkCreateObjects = unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+        id: string;
+        attributes: Record<string, unknown>;
+      }>;
+      const attributesForRule = bulkCreateObjects.find((o) => o.id === 'id1')?.attributes;
+      expect(attributesForRule).toBeDefined();
+      expect(attributesForRule).not.toHaveProperty('lastRun');
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_disable/bulk_disable_rules.ts
@@ -27,6 +27,7 @@ import {
   untrackRuleAlerts,
   updateMeta,
   bulkMigrateLegacyActions,
+  migrateLegacyLastRunOutcomeMsg,
 } from '../../../../rules_client/lib';
 import { transformRuleAttributesToRuleDomain, transformRuleDomainToRule } from '../../transforms';
 import type {
@@ -180,6 +181,9 @@ const bulkDisableRulesWithOCC = async (
                   : null,
               updatedBy: username,
               updatedAt: new Date().toISOString(),
+              ...(castedAttributes.lastRun
+                ? { lastRun: migrateLegacyLastRunOutcomeMsg(castedAttributes.lastRun) }
+                : {}),
             });
 
             rulesToDisable.push({

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
@@ -13,6 +13,8 @@ import {
   savedObjectsRepositoryMock,
   uiSettingsServiceMock,
 } from '@kbn/core/server/mocks';
+import type { SavedObject } from '@kbn/core/server';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
 import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';
@@ -118,7 +120,9 @@ describe('bulkEnableRules', () => {
   let actionsClient: jest.Mocked<ActionsClient>;
 
   const mockCreatePointInTimeFinderAsInternalUser = (
-    response = { saved_objects: [disabledRule1, disabledRule2] }
+    response: { saved_objects: Array<SavedObject<Partial<RawRule>>> } = {
+      saved_objects: [disabledRule1, disabledRule2],
+    }
   ) => {
     encryptedSavedObjects.createPointInTimeFinderDecryptedAsInternalUser = jest
       .fn()
@@ -672,6 +676,110 @@ describe('bulkEnableRules', () => {
       rules: [returnedRuleForBulkOps1],
       total: 2,
       taskIdsFailedToBeEnabled: [],
+    });
+  });
+
+  describe('lastRun outcome message migration', () => {
+    test('migrates legacy string lastRun.outcomeMsg to string[] when bulk enabling', async () => {
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [
+          {
+            ...disabledRule1,
+            attributes: {
+              ...disabledRule1.attributes,
+              lastRun: {
+                outcome: 'failed',
+                // @ts-expect-error test legacy outcomeMsg migration
+                outcomeMsg: 'legacy message',
+              },
+            },
+          },
+          disabledRule2,
+        ],
+      });
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [enabledRuleForBulkOps1, enabledRuleForBulkOps2],
+      });
+
+      await rulesClient.bulkEnableRules({ filter: 'fake_filter' });
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'id1',
+            attributes: expect.objectContaining({
+              lastRun: {
+                outcome: 'failed',
+                outcomeMsg: ['legacy message'],
+              },
+            }),
+          }),
+        ]),
+        { overwrite: true }
+      );
+    });
+
+    test('leaves lastRun unchanged when outcomeMsg is already a string array', async () => {
+      const lastRun = {
+        outcome: 'succeeded' as const,
+        outcomeMsg: ['msg a', 'msg b'],
+        alertsCount: {
+          new: 0,
+          ignored: 0,
+          recovered: 0,
+          active: 0,
+        },
+      };
+
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [
+          {
+            ...disabledRule1,
+            attributes: {
+              ...disabledRule1.attributes,
+              lastRun,
+            },
+          },
+        ],
+      });
+      mockUnsecuredSavedObjectFind(1);
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [enabledRuleForBulkOps1],
+      });
+
+      await rulesClient.bulkEnableRules({ filter: 'fake_filter' });
+
+      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'id1',
+            attributes: expect.objectContaining({
+              lastRun,
+            }),
+          }),
+        ]),
+        { overwrite: true }
+      );
+    });
+
+    test('does not add lastRun when the rule has no lastRun', async () => {
+      mockCreatePointInTimeFinderAsInternalUser({
+        saved_objects: [disabledRule1],
+      });
+      mockUnsecuredSavedObjectFind(1);
+      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
+        saved_objects: [enabledRuleForBulkOps1],
+      });
+
+      await rulesClient.bulkEnableRules({ filter: 'fake_filter' });
+
+      const bulkCreateObjects = unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0] as Array<{
+        id: string;
+        attributes: Record<string, unknown>;
+      }>;
+      const attributesForRule = bulkCreateObjects.find((o) => o.id === 'id1')?.attributes;
+      expect(attributesForRule).toBeDefined();
+      expect(attributesForRule).not.toHaveProperty('lastRun');
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.test.ts
@@ -14,7 +14,7 @@ import {
   uiSettingsServiceMock,
 } from '@kbn/core/server/mocks';
 import type { SavedObject } from '@kbn/core/server';
-import type { RawRule } from '@kbn/alerting-plugin/server/types';
+import type { RawRule } from '../../../../types';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { ruleTypeRegistryMock } from '../../../../rule_type_registry.mock';
 import { alertingAuthorizationMock } from '../../../../authorization/alerting_authorization.mock';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/bulk_enable/bulk_enable_rules.ts
@@ -37,6 +37,7 @@ import {
   createNewAPIKeySet,
   updateMetaAttributes,
   bulkMigrateLegacyActions,
+  migrateLegacyLastRunOutcomeMsg,
 } from '../../../../rules_client/lib';
 import type { RulesClientContext, BulkOperationError } from '../../../../rules_client/types';
 import { validateScheduleLimit } from '../get_schedule_frequency';
@@ -257,6 +258,9 @@ const bulkEnableRulesWithOCC = async (
                 warning: null,
               },
               scheduledTaskId: rule.id,
+              ...(rule.attributes.lastRun
+                ? { lastRun: migrateLegacyLastRunOutcomeMsg(rule.attributes.lastRun) }
+                : {}),
             });
 
             const shouldScheduleTask = await getShouldScheduleTask(

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/update/update_rule.ts
@@ -29,6 +29,7 @@ import {
   createNewAPIKeySet,
   updateMetaAttributes,
   bulkMigrateLegacyActions,
+  migrateLegacyLastRunOutcomeMsg,
 } from '../../../../rules_client/lib';
 import type { RuleParams } from '../../types';
 import type { UpdateRuleData } from './types';
@@ -414,26 +415,4 @@ async function updateRuleAttributes<Params extends RuleParams = never>({
   // TODO (http-versioning): Remove this cast, this enables us to move forward
   // without fixing all of other solution types
   return rule as SanitizedRule<Params>;
-}
-
-/**
- * Migrates legacy lastRun.outcomeMsg from string to string[]
- *
- * Rule SO schema forces lastRun.outcomeMsg to be string[].
- * However, some rules may have lastRun.outcomeMsg as string after upgrading from 7.x due to
- * lack of migration. lastRun.outcomeMsg schema change from string to string[] happened after
- * classical migrations were deprecated due to Serverless. And quite often it's not an issue
- * as lastRun is absent.
- */
-function migrateLegacyLastRunOutcomeMsg<LastRun extends { outcomeMsg?: unknown }>(
-  lastRun: LastRun
-): LastRun {
-  if (typeof lastRun.outcomeMsg === 'string') {
-    return {
-      ...lastRun,
-      outcomeMsg: [lastRun.outcomeMsg],
-    };
-  }
-
-  return lastRun;
 }

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/transforms/transform_rule_attributes_to_rule_domain.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/transforms/transform_rule_attributes_to_rule_domain.test.ts
@@ -9,7 +9,7 @@ import { RecoveredActionGroup } from '../../../../common';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { transformRuleAttributesToRuleDomain } from './transform_rule_attributes_to_rule_domain';
 import type { UntypedNormalizedRuleType } from '../../../rule_type_registry';
-import type { RawRuleAction } from '../../../types';
+import type { RawRuleAction, RawRuleLastRun } from '../../../types';
 
 const ruleType: jest.Mocked<UntypedNormalizedRuleType> = {
   id: 'test.rule-type',
@@ -239,5 +239,98 @@ describe('transformRuleAttributesToRuleDomain', () => {
         },
       }
     `);
+  });
+
+  describe('lastRun outcomeMsg migration', () => {
+    const references = [{ name: 'default-action-ref', type: 'action', id: 'default-action-id' }];
+
+    const baseRule = {
+      enabled: false,
+      tags: ['foo'],
+      createdBy: 'user',
+      createdAt: '2019-02-12T21:01:22.479Z',
+      updatedAt: '2019-02-12T21:01:22.479Z',
+      legacyId: null,
+      muteAll: false,
+      mutedInstanceIds: [],
+      snoozeSchedule: [],
+      alertTypeId: 'myType',
+      schedule: { interval: '1m' },
+      consumer: 'myApp',
+      scheduledTaskId: 'task-123',
+      executionStatus: {
+        lastExecutionDate: '2019-02-12T21:01:22.479Z',
+        status: 'pending' as const,
+        error: null,
+        warning: null,
+      },
+      params: {},
+      throttle: null,
+      notifyWhen: null,
+      actions: [defaultAction, systemAction],
+      name: 'my rule name',
+      revision: 0,
+      updatedBy: 'user',
+      apiKey: MOCK_API_KEY,
+      apiKeyOwner: 'user',
+      flapping: {
+        lookBackWindow: 20,
+        statusChangeThreshold: 20,
+      },
+    };
+
+    const transform = (rule: typeof baseRule & { lastRun?: RawRuleLastRun }) =>
+      transformRuleAttributesToRuleDomain(
+        rule,
+        {
+          id: '1',
+          logger,
+          ruleType,
+          references,
+        },
+        isSystemAction
+      );
+
+    it('migrates legacy string lastRun.outcomeMsg to string[]', () => {
+      const res = transform({
+        ...baseRule,
+        lastRun: {
+          outcome: 'failed' as const,
+          // @ts-expect-error test outcomeMsg migration
+          outcomeMsg: 'legacy message',
+        },
+      });
+
+      expect(res.lastRun).toEqual({
+        outcome: 'failed',
+        outcomeMsg: ['legacy message'],
+      });
+    });
+
+    it('preserves lastRun when outcomeMsg is already a string array', () => {
+      const lastRun = {
+        outcome: 'succeeded' as const,
+        outcomeMsg: ['a', 'b'],
+        alertsCount: {
+          new: 0,
+          ignored: 0,
+          recovered: 0,
+          active: 0,
+        },
+      };
+
+      const res = transform({
+        ...baseRule,
+        lastRun,
+      });
+
+      expect(res.lastRun).toBe(lastRun);
+    });
+
+    it('omits lastRun when the raw rule has no lastRun', () => {
+      const res = transform(baseRule);
+
+      expect(res).not.toHaveProperty('lastRun');
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/transforms/transform_rule_attributes_to_rule_domain.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/transforms/transform_rule_attributes_to_rule_domain.ts
@@ -7,6 +7,7 @@
 import { isEmpty } from 'lodash';
 import type { Logger } from '@kbn/core/server';
 import type { SavedObjectReference } from '@kbn/core/server';
+import { migrateLegacyLastRunOutcomeMsg } from '../../../rules_client/lib';
 import { ruleExecutionStatusValues } from '../constants';
 import { getRuleSnoozeEndTime } from '../../../lib';
 import type { RuleDomain, Monitoring, RuleParams } from '../types';
@@ -225,16 +226,7 @@ export const transformRuleAttributesToRuleDomain = <Params extends RuleParams = 
             : {}),
         }
       : {}),
-    ...(lastRun
-      ? {
-          lastRun: {
-            ...lastRun,
-            ...(lastRun.outcomeMsg && !Array.isArray(lastRun.outcomeMsg)
-              ? { outcomeMsg: lastRun.outcomeMsg ? [lastRun.outcomeMsg] : null }
-              : { outcomeMsg: lastRun.outcomeMsg }),
-          },
-        }
-      : {}),
+    ...(lastRun ? { lastRun: migrateLegacyLastRunOutcomeMsg(lastRun) } : {}),
     ...(esRule.nextRun ? { nextRun: new Date(esRule.nextRun) } : {}),
     ...(esRule.lastEnabledAt ? { lastEnabledAt: new Date(esRule.lastEnabledAt) } : {}),
     revision: esRule.revision,

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/index.ts
@@ -23,3 +23,4 @@ export { bulkMigrateLegacyActions } from './siem_legacy_actions/migrate_legacy_a
 export { formatLegacyActions } from './siem_legacy_actions/format_legacy_actions';
 export { addGeneratedActionValues } from './add_generated_action_values';
 export { incrementRevision } from './increment_revision';
+export { migrateLegacyLastRunOutcomeMsg } from './migrate_legacy_last_run_outcome_message';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/migrate_legacy_last_run_outcome_message.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/migrate_legacy_last_run_outcome_message.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { migrateLegacyLastRunOutcomeMsg } from './migrate_legacy_last_run_outcome_message';
+
+describe('migrateLegacyLastRunOutcomeMsg', () => {
+  it('wraps a string outcomeMsg in an array', () => {
+    const lastRun = { outcomeMsg: 'legacy message' as unknown };
+
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toEqual({
+      outcomeMsg: ['legacy message'],
+    });
+  });
+
+  it('preserves other lastRun fields when wrapping a string outcomeMsg', () => {
+    const lastRun = {
+      outcome: 'succeeded' as const,
+      outcomeMsg: 'only string' as unknown,
+    };
+
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toEqual({
+      outcome: 'succeeded',
+      outcomeMsg: ['only string'],
+    });
+  });
+
+  it('returns lastRun unchanged when outcomeMsg is already a string array', () => {
+    const lastRun = { outcomeMsg: ['a', 'b'] };
+
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toBe(lastRun);
+  });
+
+  it('returns lastRun unchanged when outcomeMsg is undefined', () => {
+    const lastRun = { outcome: 'failed' as const };
+
+    // @ts-expect-error test with lastRun.outcomeMsg = undefined
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toBe(lastRun);
+  });
+
+  it('returns lastRun unchanged when outcomeMsg is null', () => {
+    const lastRun = { outcomeMsg: null };
+
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toBe(lastRun);
+  });
+
+  it('returns lastRun unchanged when outcomeMsg is a non-string type', () => {
+    const lastRun = { outcomeMsg: 42 as unknown };
+
+    expect(migrateLegacyLastRunOutcomeMsg(lastRun)).toBe(lastRun);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/migrate_legacy_last_run_outcome_message.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/lib/migrate_legacy_last_run_outcome_message.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Migrates legacy lastRun.outcomeMsg from string to string[]
+ *
+ * Rule SO schema forces lastRun.outcomeMsg to be string[].
+ * However, some rules may have lastRun.outcomeMsg as string after upgrading from 7.x due to
+ * lack of migration. lastRun.outcomeMsg schema change from string to string[] happened after
+ * classical migrations were deprecated due to Serverless. And quite often it's not an issue
+ * as lastRun is absent.
+ */
+export function migrateLegacyLastRunOutcomeMsg<LastRun extends { outcomeMsg?: unknown }>(
+  lastRun: LastRun
+): LastRun {
+  if (typeof lastRun.outcomeMsg === 'string') {
+    return {
+      ...lastRun,
+      outcomeMsg: [lastRun.outcomeMsg],
+    };
+  }
+
+  return lastRun;
+}

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/test_helpers.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/test_helpers.ts
@@ -37,7 +37,7 @@ export const defaultRule = {
     consumer: 'fakeConsumer',
     alertTypeId: 'fakeType',
     schedule: { interval: '5m' },
-    actions: [] as unknown,
+    actions: [],
   },
   references: [],
   version: '1',
@@ -56,13 +56,15 @@ export const defaultRuleForBulkDelete = {
     consumer: 'fakeConsumer',
     alertTypeId: 'fakeType',
     schedule: { interval: '5m' },
-    actions: [] as unknown,
+    actions: [],
     executionStatus: {
-      lastExecutionDate: new Date('2019-02-12T21:01:22.000Z'),
-      status: 'pending',
+      lastExecutionDate: '2019-02-12T21:01:22.000Z',
+      status: 'pending' as const,
+      error: null,
+      warning: null,
     },
-    createdAt: new Date('2019-02-12T21:01:22.000Z'),
-    updatedAt: new Date('2019-02-12T21:01:22.000Z'),
+    createdAt: '2019-02-12T21:01:22.000Z',
+    updatedAt: '2019-02-12T21:01:22.000Z',
   },
   references: [],
   version: '1',
@@ -94,11 +96,13 @@ export const enabledRule1 = {
     scheduledTaskId: 'id1',
     apiKey: Buffer.from('123:abc').toString('base64'),
     executionStatus: {
-      lastExecutionDate: new Date('2019-02-12T21:01:22.000Z'),
-      status: 'pending',
+      lastExecutionDate: '2019-02-12T21:01:22.000Z',
+      status: 'pending' as const,
+      error: null,
+      warning: null,
     },
-    createdAt: new Date('2019-02-12T21:01:22.000Z'),
-    updatedAt: new Date('2019-02-12T21:01:22.000Z'),
+    createdAt: '2019-02-12T21:01:22.000Z',
+    updatedAt: '2019-02-12T21:01:22.000Z',
   },
 };
 
@@ -111,11 +115,13 @@ export const enabledRule2 = {
     scheduledTaskId: 'id2',
     apiKey: Buffer.from('321:abc').toString('base64'),
     executionStatus: {
-      lastExecutionDate: new Date('2019-02-12T21:01:22.000Z'),
-      status: 'pending',
+      lastExecutionDate: '2019-02-12T21:01:22.000Z',
+      status: 'pending' as const,
+      error: null,
+      warning: null,
     },
-    createdAt: new Date('2019-02-12T21:01:22.000Z'),
-    updatedAt: new Date('2019-02-12T21:01:22.000Z'),
+    createdAt: '2019-02-12T21:01:22.000Z',
+    updatedAt: '2019-02-12T21:01:22.000Z',
   },
 };
 
@@ -308,8 +314,10 @@ export const disabledRule1 = {
     scheduledTaskId: 'id1',
     apiKey: Buffer.from('123:abc').toString('base64'),
     executionStatus: {
-      lastExecutionDate: new Date('2019-02-12T21:01:22.000Z'),
-      status: 'pending',
+      lastExecutionDate: '2019-02-12T21:01:22.000Z',
+      status: 'pending' as const,
+      error: null,
+      warning: null,
     },
   },
 };
@@ -323,8 +331,10 @@ export const disabledRule2 = {
     scheduledTaskId: 'id2',
     apiKey: Buffer.from('321:abc').toString('base64'),
     executionStatus: {
-      lastExecutionDate: new Date('2019-02-12T21:01:22.000Z'),
-      status: 'pending',
+      lastExecutionDate: '2019-02-12T21:01:22.000Z',
+      status: 'pending' as const,
+      error: null,
+      warning: null,
     },
   },
 };
@@ -335,6 +345,7 @@ export const disabledRuleWithAction1 = {
     ...disabledRule1.attributes,
     actions: [
       {
+        uuid: 'test-uuid-1',
         group: 'default',
         actionTypeId: '1',
         actionRef: '1',
@@ -352,6 +363,7 @@ export const disabledRuleWithAction2 = {
     ...disabledRule2.attributes,
     actions: [
       {
+        uuid: 'test-uuid-2',
         group: 'default',
         actionTypeId: '1',
         actionRef: '1',

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/index.ts
@@ -26,6 +26,7 @@ export default function alertingTests({ loadTestFile, getService }: FtrProviderC
     loadTestFile(require.resolve('./unsnooze_internal'));
     loadTestFile(require.resolve('./bulk_edit'));
     loadTestFile(require.resolve('./bulk_disable'));
+    loadTestFile(require.resolve('./last_run_outcome_msg_migration'));
     loadTestFile(require.resolve('./capped_action_type'));
     loadTestFile(require.resolve('./scheduled_task_id'));
     loadTestFile(require.resolve('./run_soon'));

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { Spaces } from '../../../scenarios';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { getUrlPrefix, getTestRuleData, ObjectRemover, checkAAD } from '../../../../common/lib';
+
+/** Simulates 7.x documents where lastRun.outcomeMsg was stored as a string. */
+const LEGACY_OUTCOME_MSG = 'legacy outcome message string';
+
+export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProviderContext) {
+  const es = getService('es');
+  const supertest = getService('supertest');
+
+  describe('lastRun outcomeMsg migration', () => {
+    const objectRemover = new ObjectRemover(supertest);
+
+    afterEach(async () => {
+      await objectRemover.removeAll();
+    });
+
+    async function getAlertFromEs(ruleId: string): Promise<RawRule> {
+      const response = await es.get<{ alert: RawRule }>(
+        {
+          index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+          id: `alert:${ruleId}`,
+        },
+        { meta: true }
+      );
+      expect(response.statusCode).to.eql(200);
+      return response.body._source!.alert;
+    }
+
+    async function injectLegacyStringOutcomeMsg(ruleId: string) {
+      await es.update({
+        index: ALERTING_CASES_SAVED_OBJECT_INDEX,
+        id: `alert:${ruleId}`,
+        doc: {
+          alert: {
+            lastRun: {
+              outcome: 'failed',
+              outcomeMsg: LEGACY_OUTCOME_MSG,
+            },
+          },
+        },
+        refresh: 'wait_for',
+      });
+    }
+
+    it('migrates legacy string outcomeMsg when bulk disabling rules', async () => {
+      const { body: createdRule } = await supertest
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send(
+          getTestRuleData({
+            enabled: true,
+            schedule: { interval: '1d' },
+          })
+        )
+        .expect(200);
+      objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
+
+      await injectLegacyStringOutcomeMsg(createdRule.id);
+
+      const beforeBulk = await getAlertFromEs(createdRule.id);
+      expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
+        LEGACY_OUTCOME_MSG
+      );
+
+      await supertest
+        .patch(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rules/_bulk_disable`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          ids: [createdRule.id],
+        })
+        .expect(200);
+
+      const afterBulk = await getAlertFromEs(createdRule.id);
+      expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
+      expect(afterBulk.enabled).to.eql(false);
+
+      const { body: ruleFromApi } = await supertest
+        .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createdRule.id}`)
+        .set('kbn-xsrf', 'foo')
+        .expect(200);
+
+      expect(ruleFromApi.last_run?.outcome_msg).to.eql([LEGACY_OUTCOME_MSG]);
+
+      await checkAAD({
+        supertest,
+        spaceId: Spaces.space1.id,
+        type: RULE_SAVED_OBJECT_TYPE,
+        id: createdRule.id,
+      });
+    });
+
+    it('migrates legacy string outcomeMsg when bulk enabling rules', async () => {
+      const { body: createdRule } = await supertest
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .send(
+          getTestRuleData({
+            enabled: false,
+            schedule: { interval: '1d' },
+          })
+        )
+        .expect(200);
+      objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
+
+      await injectLegacyStringOutcomeMsg(createdRule.id);
+
+      const beforeBulk = await getAlertFromEs(createdRule.id);
+      expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
+        LEGACY_OUTCOME_MSG
+      );
+
+      await supertest
+        .patch(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rules/_bulk_enable`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          ids: [createdRule.id],
+        })
+        .expect(200);
+
+      const afterBulk = await getAlertFromEs(createdRule.id);
+      expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
+      expect(afterBulk.enabled).to.eql(true);
+
+      const { body: ruleFromApi } = await supertest
+        .get(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rule/${createdRule.id}`)
+        .set('kbn-xsrf', 'foo')
+        .expect(200);
+
+      expect(ruleFromApi.last_run?.outcome_msg).to.eql([LEGACY_OUTCOME_MSG]);
+
+      await checkAAD({
+        supertest,
+        spaceId: Spaces.space1.id,
+        type: RULE_SAVED_OBJECT_TYPE,
+        id: createdRule.id,
+      });
+    });
+  });
+}


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/177852**
**Relates to: https://github.com/elastic/kibana/pull/251164**

## Summary

This PR fixes an issue blocking enabling and disabling security rules with non-migrated `lastRun.outcomeMsg` field.

## Details

Some time ago Alerting Framework migrated `lastRun.outcomeMsg` from `string` to `string[]`. At that moment usual migrations were deprecated due to Serverless and model version migration wasn't ready yet. This migration went smoothly thanks to the according changes to the codebase. However, the changes didn't cover customers upgrading from `7.x` stack version and having something written to `lastRun.outcomeMsg`.

https://github.com/elastic/kibana/pull/251164 fixed the issue appearing in attempt to update prebuilt rules.

This PR fixes the left issue blocking enabling and disabling non-migrated security rules with `lastRun.outcomeMsg` type `string` field.

## Testing

- Start Kibana
- Log in under `system_indices_superuser` to be able to write to the system indices
- Create a rule by using the command below
- Enable/Disable the rule
- Perform any other bulk and non-bulk actions on the rule

ER: All actions should work without errors.

Without this fix enable/disable action will result in error.

<details>
  <summary>ES command to put a non-migrated rule</summary>
  
```
PUT .kibana_alerting_cases/_doc/alert:d62167ce-1022-4b2c-915d-024fe3e6e557
{
    "alert": {
      "name": "Test rule 1",
      "tags": [],
      "enabled": false,
      "alertTypeId": "siem.queryRule",
      "consumer": "siem",
      "legacyId": null,
      "schedule": {
        "interval": "5m"
      },
      "actions": [],
      "params": {
        "author": [],
        "description": "123",
        "falsePositives": [],
        "from": "now-6m",
        "ruleId": "5ecfb16d-5af2-4a31-b880-319a4a2ca92b",
        "immutable": false,
        "ruleSource": {
          "type": "internal"
        },
        "license": "",
        "outputIndex": "",
        "meta": {
          "kibana_siem_app_url": "http://localhost:5601/kbn/app/security"
        },
        "maxSignals": 100,
        "riskScore": 21,
        "riskScoreMapping": [],
        "severity": "low",
        "severityMapping": [],
        "threat": [],
        "to": "now",
        "references": [],
        "version": 1,
        "exceptionsList": [],
        "relatedIntegrations": [],
        "requiredFields": [],
        "setup": "",
        "type": "query",
        "language": "kuery",
        "index": [
          "apm-*-transaction*",
          "auditbeat-*",
          "endgame-*",
          "filebeat-*",
          "logs-*",
          "packetbeat-*",
          "traces-apm*",
          "winlogbeat-*",
          "-*elastic-cloud-logs-*"
        ],
        "query": "*:*",
        "filters": []
      },
      "mapped_params": {
        "risk_score": 21,
        "severity": "20-low"
      },
      "createdBy": "elastic",
      "updatedBy": "elastic",
      "createdAt": "2026-03-17T10:52:28.688Z",
      "updatedAt": "2026-03-17T10:52:28.688Z",
      "apiKey": null,
      "apiKeyOwner": null,
      "apiKeyCreatedByUser": null,
      "throttle": null,
      "notifyWhen": null,
      "muteAll": false,
      "mutedInstanceIds": [],
      "executionStatus": {
        "status": "pending",
        "lastExecutionDate": "2026-03-17T10:52:28.688Z"
      },
      "monitoring": {
        "run": {
          "history": [],
          "calculated_metrics": {
            "success_ratio": 0
          },
          "last_run": {
            "timestamp": "2026-03-17T10:52:28.688Z",
            "metrics": {
              "duration": 0,
              "total_search_duration_ms": null,
              "total_indexing_duration_ms": null,
              "total_alerts_detected": null,
              "total_alerts_created": null,
              "gap_duration_s": null
            }
          }
        }
      },
      "lastRun": {
        "outcome": "failed",
        "outcomeMsg": "security_exception: [security_exception] Reason: missing authentication credentials for REST request [/_security/user/_has_privileges], caused by: \"\"",
        "warning": "read",
        "alertsCount": {},
        "outcomeOrder": 20
    },
      "snoozeSchedule": [],
      "revision": 0,
      "running": false,
      "artifacts": {
        "dashboards": [],
        "investigation_guide": {
          "blob": ""
        }
      },
      "meta": {
        "versionApiKeyLastmodified": "9.4.0"
      }
    },
    "type": "alert",
    "references": [],
    "managed": false,
    "namespaces": [
      "default"
    ],
    "coreMigrationVersion": "8.8.0",
    "typeMigrationVersion": "10.10.0",
    "updated_at": "2026-03-17T10:52:28.688Z",
    "created_at": "2026-03-17T10:52:28.688Z"
  }
```
</details>



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->