### PR TITLE
[Fleet] Improve error handling in debug API

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/debug/handler.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/debug/handler.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { OUTPUT_SAVED_OBJECT_TYPE } from '../../constants';
+
+import {
+  fetchIndexHandler,
+  fetchSavedObjectNamesHandler,
+  fetchSavedObjectsHandler,
+} from './handler';
+
+describe('Fleet debug handlers', () => {
+  const createMockResponse = () => ({
+    ok: jest.fn().mockImplementation((opts: { body?: unknown }) => ({ ...opts, statusCode: 200 })),
+    badRequest: jest.fn().mockImplementation((opts: { body?: { message?: string } }) => ({
+      ...opts,
+      statusCode: 400,
+    })),
+  });
+
+  describe('fetchIndexHandler', () => {
+    it('returns 400 when index is not allowed for debug', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: { client: { asInternalUser: esClient } },
+        }),
+        fleet: Promise.resolve({ internalSoClient: savedObjectsClientMock.create() }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchIndexHandler(
+        context,
+        { body: { index: 'other-index' } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({
+        body: { message: 'Index not allowed for debug.' },
+        statusCode: 400,
+      });
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 and calls fetchIndex when index is allowed', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      const searchResult = { hits: { hits: [] }, took: 0, _shards: {} };
+      esClient.search.mockResolvedValue(searchResult as any);
+
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: { client: { asInternalUser: esClient } },
+        }),
+        fleet: Promise.resolve({ internalSoClient: savedObjectsClientMock.create() }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchIndexHandler(
+        context,
+        { body: { index: '.fleet-agents' } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({ body: searchResult, statusCode: 200 });
+      expect(esClient.search).toHaveBeenCalledWith({ index: '.fleet-agents' });
+    });
+  });
+
+  describe('fetchSavedObjectsHandler', () => {
+    it('returns 400 when saved object type is not allowed for debug', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: {
+            client: {
+              asInternalUser: elasticsearchServiceMock.createClusterClient().asInternalUser,
+            },
+          },
+        }),
+        fleet: Promise.resolve({ internalSoClient: soClient }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchSavedObjectsHandler(
+        context,
+        { body: { type: 'dashboard', name: 'foo' } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({
+        body: { message: 'Saved object type not allowed for debug.' },
+        statusCode: 400,
+      });
+      expect(soClient.find).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 and calls fetchSavedObjects when type is allowed', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const findResult = { saved_objects: [], total: 0, page: 1, per_page: 20 };
+      soClient.find.mockResolvedValue(findResult as any);
+
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: {
+            client: {
+              asInternalUser: elasticsearchServiceMock.createClusterClient().asInternalUser,
+            },
+          },
+        }),
+        fleet: Promise.resolve({ internalSoClient: soClient }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchSavedObjectsHandler(
+        context,
+        { body: { type: OUTPUT_SAVED_OBJECT_TYPE, name: 'my-output' } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({ body: findResult, statusCode: 200 });
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: OUTPUT_SAVED_OBJECT_TYPE,
+        search: '"my-output"',
+        searchFields: ['name'],
+      });
+    });
+  });
+
+  describe('fetchSavedObjectNamesHandler', () => {
+    it('returns 400 when saved object type is not allowed for debug', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: {
+            client: {
+              asInternalUser: elasticsearchServiceMock.createClusterClient().asInternalUser,
+            },
+          },
+        }),
+        fleet: Promise.resolve({ internalSoClient: soClient }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchSavedObjectNamesHandler(
+        context,
+        { body: { type: 'action' } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({
+        body: { message: 'Saved object type not allowed for debug.' },
+        statusCode: 400,
+      });
+      expect(soClient.find).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 and calls fetchSavedObjectNames when type is allowed', async () => {
+      const soClient = savedObjectsClientMock.create();
+      const findResult = {
+        saved_objects: [],
+        total: 0,
+        page: 1,
+        per_page: 20,
+        aggregations: { names: { buckets: [] } },
+      };
+      soClient.find.mockResolvedValue(findResult as any);
+
+      const context = {
+        core: Promise.resolve({
+          elasticsearch: {
+            client: {
+              asInternalUser: elasticsearchServiceMock.createClusterClient().asInternalUser,
+            },
+          },
+        }),
+        fleet: Promise.resolve({ internalSoClient: soClient }),
+      } as any;
+      const response = createMockResponse();
+
+      const result = await fetchSavedObjectNamesHandler(
+        context,
+        { body: { type: OUTPUT_SAVED_OBJECT_TYPE } } as any,
+        response as any
+      );
+
+      expect(result).toEqual({ body: findResult, statusCode: 200 });
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: OUTPUT_SAVED_OBJECT_TYPE,
+        aggs: {
+          names: {
+            terms: { field: `${OUTPUT_SAVED_OBJECT_TYPE}.attributes.name` },
+          },
+        },
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/routes/debug/handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/debug/handler.ts
@@ -23,7 +23,7 @@ export const fetchIndexHandler: FleetRequestHandler<
   const coreContext = await context.core;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const res = await fetchIndex(esClient, request.body.index);
-  return response.ok({ body: res });
+  return res.ok ? response.ok({ body: res.body }) : response.badRequest({ body: res.body });
 };
 
 export const fetchSavedObjectsHandler: FleetRequestHandler<
@@ -33,7 +33,7 @@ export const fetchSavedObjectsHandler: FleetRequestHandler<
 > = async (context, request, response) => {
   const soClient = (await context.fleet).internalSoClient;
   const res = await fetchSavedObjects(soClient, request.body.type, request.body.name);
-  return response.ok({ body: res });
+  return res.ok ? response.ok({ body: res.body }) : response.badRequest({ body: res.body });
 };
 
 export const fetchSavedObjectNamesHandler: FleetRequestHandler<
@@ -43,5 +43,5 @@ export const fetchSavedObjectNamesHandler: FleetRequestHandler<
 > = async (context, request, response) => {
   const soClient = (await context.fleet).internalSoClient;
   const res = await fetchSavedObjectNames(soClient, request.body.type);
-  return response.ok({ body: res });
+  return res.ok ? response.ok({ body: res.body }) : response.badRequest({ body: res.body });
 };

--- a/x-pack/platform/plugins/shared/fleet/server/routes/debug/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/debug/index.ts
@@ -29,11 +29,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENTS.ALL,
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
-            FLEET_API_PRIVILEGES.SETTINGS.ALL,
-          ],
+          requiredPrivileges: [FLEET_API_PRIVILEGES.FLEET.ALL],
         },
       },
     })
@@ -51,11 +47,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENTS.ALL,
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
-            FLEET_API_PRIVILEGES.SETTINGS.ALL,
-          ],
+          requiredPrivileges: [FLEET_API_PRIVILEGES.FLEET.ALL],
         },
       },
     })
@@ -73,11 +65,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_API_PRIVILEGES.AGENTS.ALL,
-            FLEET_API_PRIVILEGES.AGENT_POLICIES.ALL,
-            FLEET_API_PRIVILEGES.SETTINGS.ALL,
-          ],
+          requiredPrivileges: [FLEET_API_PRIVILEGES.FLEET.ALL],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/fleet/server/services/debug/index.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/debug/index.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import { OUTPUT_SAVED_OBJECT_TYPE } from '../../constants';
+
+import { fetchIndex, fetchSavedObjectNames, fetchSavedObjects } from '.';
+
+describe('Fleet debug service', () => {
+  describe('fetchIndex', () => {
+    it('allows Fleet indices (prefix .fleet-)', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      esClient.search.mockResolvedValue({ hits: { hits: [] }, took: 0, _shards: {} } as any);
+
+      const res = await fetchIndex(esClient, '.fleet-agents');
+
+      expect(res.ok).toBe(true);
+      expect(esClient.search).toHaveBeenCalledWith({ index: '.fleet-agents' });
+    });
+
+    it('allows Fleet index patterns', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      esClient.search.mockResolvedValue({ hits: { hits: [] }, took: 0, _shards: {} } as any);
+
+      const res = await fetchIndex(esClient, '.fleet-fileds-fromhost-meta-*');
+
+      expect(res.ok).toBe(true);
+      expect(esClient.search).toHaveBeenCalledWith({ index: '.fleet-fileds-fromhost-meta-*' });
+    });
+
+    it('rejects non-Fleet indices with ok: false and message', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      const res1 = await fetchIndex(esClient, 'other-index');
+      expect(res1.ok).toBe(false);
+      expect(res1.body).toEqual({ message: 'Index not allowed for debug.' });
+
+      const res2 = await fetchIndex(esClient, 'disallowed-index');
+      expect(res2.ok).toBe(false);
+
+      const res3 = await fetchIndex(esClient, '.internal-*');
+      expect(res3.ok).toBe(false);
+
+      const res4 = await fetchIndex(esClient, 'logs-elastic_agent-*');
+      expect(res4.ok).toBe(false);
+
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+
+    it('rejects index without .fleet- prefix', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      const res = await fetchIndex(esClient, 'fleet-agents');
+      expect(res.ok).toBe(false);
+      expect(res.body).toEqual({ message: 'Index not allowed for debug.' });
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+
+    it('allows comma-separated list of Fleet indices', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+      esClient.search.mockResolvedValue({ hits: { hits: [] }, took: 0, _shards: {} } as any);
+
+      const res = await fetchIndex(esClient, '.fleet-agents,.fleet-actions');
+
+      expect(res.ok).toBe(true);
+      expect(esClient.search).toHaveBeenCalledWith({ index: '.fleet-agents,.fleet-actions' });
+    });
+
+    it('rejects comma-separated list when any segment is non-Fleet', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      const res1 = await fetchIndex(esClient, '.fleet-agents,other-index');
+      expect(res1.ok).toBe(false);
+      expect(res1.body).toEqual({ message: 'Index not allowed for debug.' });
+
+      const res2 = await fetchIndex(esClient, '.fleet-agents,  other-index');
+      expect(res2.ok).toBe(false);
+
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchSavedObjects', () => {
+    it('allows Fleet saved object types', async () => {
+      const soClient = savedObjectsClientMock.create();
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, page: 1, per_page: 20 });
+
+      const res = await fetchSavedObjects(soClient, OUTPUT_SAVED_OBJECT_TYPE, 'my-output');
+
+      expect(res.ok).toBe(true);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: OUTPUT_SAVED_OBJECT_TYPE,
+        search: '"my-output"',
+        searchFields: ['name'],
+      });
+    });
+
+    it('rejects non-Fleet saved object types with ok: false and message', async () => {
+      const soClient = savedObjectsClientMock.create();
+
+      const res1 = await fetchSavedObjects(soClient, 'action', '');
+      expect(res1.ok).toBe(false);
+      expect(res1.body).toEqual({ message: 'Saved object type not allowed for debug.' });
+
+      const res2 = await fetchSavedObjects(soClient, 'dashboard', '');
+      expect(res2.ok).toBe(false);
+
+      expect(soClient.find).not.toHaveBeenCalled();
+    });
+
+    it('uses Fleet escapeSearchQueryPhrase for name in search phrase', async () => {
+      const soClient = savedObjectsClientMock.create();
+      soClient.find.mockResolvedValue({ saved_objects: [], total: 0, page: 1, per_page: 20 });
+
+      const res = await fetchSavedObjects(soClient, OUTPUT_SAVED_OBJECT_TYPE, 'x" OR "y');
+
+      expect(res.ok).toBe(true);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: OUTPUT_SAVED_OBJECT_TYPE,
+        search: '"x\\" OR \\"y"',
+        searchFields: ['name'],
+      });
+    });
+  });
+
+  describe('fetchSavedObjectNames', () => {
+    it('allows Fleet saved object types', async () => {
+      const soClient = savedObjectsClientMock.create();
+      soClient.find.mockResolvedValue({
+        saved_objects: [],
+        total: 0,
+        page: 1,
+        per_page: 20,
+        aggregations: { names: { buckets: [] } },
+      } as any);
+
+      const res = await fetchSavedObjectNames(soClient, OUTPUT_SAVED_OBJECT_TYPE);
+
+      expect(res.ok).toBe(true);
+      expect(soClient.find).toHaveBeenCalledWith({
+        type: OUTPUT_SAVED_OBJECT_TYPE,
+        aggs: {
+          names: {
+            terms: { field: `${OUTPUT_SAVED_OBJECT_TYPE}.attributes.name` },
+          },
+        },
+      });
+    });
+
+    it('rejects non-Fleet saved object types with ok: false and message', async () => {
+      const soClient = savedObjectsClientMock.create();
+
+      const res = await fetchSavedObjectNames(soClient, 'action');
+      expect(res.ok).toBe(false);
+      expect(res.body).toEqual({ message: 'Saved object type not allowed for debug.' });
+
+      expect(soClient.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/debug/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/debug/index.ts
@@ -7,24 +7,102 @@
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 
-export async function fetchIndex(esClient: ElasticsearchClient, index: string) {
-  return esClient.search({ index });
+import { escapeSearchQueryPhrase } from '../saved_object';
+
+import {
+  AGENT_POLICY_SAVED_OBJECT_TYPE,
+  ASSETS_SAVED_OBJECT_TYPE,
+  CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+  DOWNLOAD_SOURCE_SAVED_OBJECT_TYPE,
+  FLEET_PROXY_SAVED_OBJECT_TYPE,
+  FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+  FLEET_SETUP_LOCK_TYPE,
+  GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+  LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+  LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
+  OUTPUT_SAVED_OBJECT_TYPE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  PACKAGES_SAVED_OBJECT_TYPE,
+  PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
+  SPACE_SETTINGS_SAVED_OBJECT_TYPE,
+  UNINSTALL_TOKENS_SAVED_OBJECT_TYPE,
+} from '../../constants';
+
+/** Indices supported by the Fleet debug index route use this prefix. */
+const FLEET_DEBUG_INDEX_PREFIX = '.fleet-';
+
+/** Fleet-owned saved object types supported by the Fleet debug saved_objects routes. */
+const FLEET_DEBUG_ALLOWED_SO_TYPES = new Set([
+  AGENT_POLICY_SAVED_OBJECT_TYPE,
+  ASSETS_SAVED_OBJECT_TYPE,
+  CLOUD_CONNECTOR_SAVED_OBJECT_TYPE,
+  DOWNLOAD_SOURCE_SAVED_OBJECT_TYPE,
+  FLEET_PROXY_SAVED_OBJECT_TYPE,
+  FLEET_SERVER_HOST_SAVED_OBJECT_TYPE,
+  FLEET_SETUP_LOCK_TYPE,
+  GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+  LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
+  LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE,
+  OUTPUT_SAVED_OBJECT_TYPE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  PACKAGES_SAVED_OBJECT_TYPE,
+  PRECONFIGURATION_DELETION_RECORD_SAVED_OBJECT_TYPE,
+  SPACE_SETTINGS_SAVED_OBJECT_TYPE,
+  UNINSTALL_TOKENS_SAVED_OBJECT_TYPE,
+]);
+
+export function isIndexAllowedForDebug(index: string): boolean {
+  const segments = index
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const allAllowed = segments.every((segment) => segment.startsWith(FLEET_DEBUG_INDEX_PREFIX));
+  return allAllowed && segments.length > 0;
+}
+
+export function isSavedObjectTypeAllowedForDebug(type: string): boolean {
+  return FLEET_DEBUG_ALLOWED_SO_TYPES.has(type);
+}
+
+export type DebugResult<T> = { ok: true; body: T } | { ok: false; body: { message: string } };
+
+export async function fetchIndex(
+  esClient: ElasticsearchClient,
+  index: string
+): Promise<DebugResult<Awaited<ReturnType<ElasticsearchClient['search']>>>> {
+  if (!isIndexAllowedForDebug(index)) {
+    return { ok: false, body: { message: 'Index not allowed for debug.' } };
+  }
+  const body = await esClient.search({ index });
+  return { ok: true, body };
 }
 
 export async function fetchSavedObjects(
   soClient: SavedObjectsClientContract,
   type: string,
   name: string
-) {
-  return soClient.find({
+): Promise<DebugResult<Awaited<ReturnType<SavedObjectsClientContract['find']>>>> {
+  if (!isSavedObjectTypeAllowedForDebug(type)) {
+    return { ok: false, body: { message: 'Saved object type not allowed for debug.' } };
+  }
+  const body = await soClient.find({
     type,
-    search: `\"${name}\"`, // Search for phrase
+    search: escapeSearchQueryPhrase(name),
     searchFields: ['name'], // SO type automatically inferred
   });
+  return { ok: true, body };
 }
 
-export async function fetchSavedObjectNames(soClient: SavedObjectsClientContract, type: string) {
-  return soClient.find({
+export async function fetchSavedObjectNames(
+  soClient: SavedObjectsClientContract,
+  type: string
+): Promise<DebugResult<Awaited<ReturnType<SavedObjectsClientContract['find']>>>> {
+  if (!isSavedObjectTypeAllowedForDebug(type)) {
+    return { ok: false, body: { message: 'Saved object type not allowed for debug.' } };
+  }
+  const body = await soClient.find({
     type,
     aggs: {
       names: {
@@ -32,4 +110,5 @@ export async function fetchSavedObjectNames(soClient: SavedObjectsClientContract
       },
     },
   });
+  return { ok: true, body };
 }


### PR DESCRIPTION
## Summary

Improve error handling and testing coverage in Fleet debug API.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->