### PR TITLE
[Osquery] Fix wrong timeout value in UI

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/constants.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/constants.ts
@@ -36,7 +36,7 @@ export const API_VERSIONS = {
 
 export enum QUERY_TIMEOUT {
   DEFAULT = 60, // 60 seconds
-  MAX = 60 * 60 * 24, // 24 hours
+  MAX = 900, // 15 minutes (matches backend inRangeRt(60, 60 * 15))
 }
 
 export const MAX_TAGS_PER_ACTION = 20;

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/live_query.cy.ts
@@ -37,12 +37,12 @@ describe('ALL - Live Query', { tags: ['@ess', '@serverless'] }, () => {
     cy.contains('Query is a required field').should('not.exist');
     checkResults();
     getAdvancedButton().click();
-    fillInQueryTimeout('86410');
+    fillInQueryTimeout('901');
     submitQuery();
-    cy.contains('The timeout value must be 86400 seconds or or lower.');
+    cy.contains('The timeout value must be 900 seconds or lower.');
     fillInQueryTimeout('890');
     submitQuery();
-    cy.contains('The timeout value must be 86400 seconds or or lower.').should('not.exist');
+    cy.contains('The timeout value must be 900 seconds or lower.').should('not.exist');
     typeInOsqueryFieldInput('days{downArrow}{enter}');
     submitQuery();
     cy.contains('ECS field is required.');

--- a/x-pack/platform/plugins/shared/osquery/public/form/timeout_field.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/form/timeout_field.tsx
@@ -63,8 +63,7 @@ const TimeoutFieldComponent = ({ euiFieldProps }: TimeoutFieldProps) => {
             <EuiIconTip
               content={i18n.translate('xpack.osquery.liveQuery.timeoutHint', {
                 defaultMessage:
-                  'Default and minimum: 60 seconds. Maximum: {maxSeconds} seconds. Increase this value if your query needs more time to run.',
-                values: { maxSeconds: QUERY_TIMEOUT.MAX },
+                  'The default and minimum timeout period is 60 seconds. Increase this value if your query needs more time to run.',
               })}
             />
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/osquery/public/form/timeout_field.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/form/timeout_field.tsx
@@ -35,7 +35,7 @@ const TimeoutFieldComponent = ({ euiFieldProps }: TimeoutFieldProps) => {
 
         if (currentValue > QUERY_TIMEOUT.MAX) {
           return i18n.translate('xpack.osquery.pack.queryFlyoutForm.timeoutFieldMaxNumberError', {
-            defaultMessage: 'The timeout value must be {timeoutInSeconds} seconds or or lower. ',
+            defaultMessage: 'The timeout value must be {timeoutInSeconds} seconds or lower.',
             values: { timeoutInSeconds: QUERY_TIMEOUT.MAX },
           });
         }
@@ -63,7 +63,8 @@ const TimeoutFieldComponent = ({ euiFieldProps }: TimeoutFieldProps) => {
             <EuiIconTip
               content={i18n.translate('xpack.osquery.liveQuery.timeoutHint', {
                 defaultMessage:
-                  'The default and minimum timeout period is 60 seconds. Increase this value if your query needs more time to run.',
+                  'Default and minimum: 60 seconds. Maximum: {maxSeconds} seconds. Increase this value if your query needs more time to run.',
+                values: { maxSeconds: QUERY_TIMEOUT.MAX },
               })}
             />
           </EuiFlexItem>


### PR DESCRIPTION
Fixes wrongly used UI timeout limit. 

<img width="1355" height="608" alt="Screenshot 2026-03-17 at 13 18 57" src="https://github.com/user-attachments/assets/bd826261-5df4-47bf-ba59-061a28759147" />


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->