### PR TITLE
[One Workflow] feat: Phase 2 workflow execution limits — LiquidJS OOM, cumulative budget, step count, workflow output cap

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/create_workflow_liquid_engine.ts
@@ -11,6 +11,33 @@ import type { FS, LiquidOptions } from 'liquidjs';
 import { Liquid } from 'liquidjs';
 
 /**
+ * A LiquidJS emitter that enforces an output byte-size limit.
+ * Throws when the accumulated render output exceeds `maxBytes`,
+ * stopping the render mid-execution before the full string materializes in memory.
+ *
+ * This closes the gap where LiquidJS's built-in `memoryLimit` does not count
+ * emitter buffer growth (string concatenation in for loops).
+ */
+export class SizeLimitedEmitter {
+  public buffer = '';
+  private totalBytes = 0;
+
+  constructor(
+    private maxBytes: number,
+    private errorFactory: (maxBytes: number) => Error
+  ) {}
+
+  write(html: unknown): void {
+    const str = html != null ? String(html) : '';
+    this.totalBytes += Buffer.byteLength(str, 'utf-8');
+    if (this.maxBytes > 0 && this.totalBytes > this.maxBytes) {
+      throw this.errorFactory(this.maxBytes);
+    }
+    this.buffer += str;
+  }
+}
+
+/**
  * LiquidJS tags supported in workflow templates.
  * Tags not in this set are removed from the engine.
  */

--- a/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/size_limited_emitter.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/create_workflow_liquid_engine/size_limited_emitter.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SizeLimitedEmitter } from './create_workflow_liquid_engine';
+
+describe('SizeLimitedEmitter', () => {
+  const errorFactory = (maxBytes: number) => new Error(`Exceeded ${maxBytes} bytes`);
+
+  it('should accumulate writes within limit', () => {
+    const emitter = new SizeLimitedEmitter(1024, errorFactory);
+    emitter.write('Hello');
+    emitter.write(' ');
+    emitter.write('World');
+    expect(emitter.buffer).toBe('Hello World');
+  });
+
+  it('should throw when accumulated output exceeds limit', () => {
+    const emitter = new SizeLimitedEmitter(10, errorFactory);
+    emitter.write('12345');
+    expect(() => emitter.write('678901')).toThrow('Exceeded 10 bytes');
+  });
+
+  it('should count multi-byte characters correctly', () => {
+    const emitter = new SizeLimitedEmitter(5, errorFactory);
+    expect(() => emitter.write('🎉🎉')).toThrow('Exceeded 5 bytes');
+  });
+
+  it('should handle null and undefined writes', () => {
+    const emitter = new SizeLimitedEmitter(100, errorFactory);
+    emitter.write(null);
+    emitter.write(undefined);
+    expect(emitter.buffer).toBe('');
+  });
+
+  it('should not throw when maxBytes is 0 (disabled)', () => {
+    const emitter = new SizeLimitedEmitter(0, errorFactory);
+    emitter.write('A'.repeat(1000));
+    expect(emitter.buffer).toBe('A'.repeat(1000));
+  });
+
+  it('should use the provided error factory', () => {
+    const customError = new Error('Custom OOM');
+    const emitter = new SizeLimitedEmitter(5, () => customError);
+    expect(() => emitter.write('too long')).toThrow('Custom OOM');
+  });
+
+  it('should throw on the write that exceeds, not the one before', () => {
+    const emitter = new SizeLimitedEmitter(10, errorFactory);
+    emitter.write('12345');
+    emitter.write('12345');
+    expect(() => emitter.write('1')).toThrow('Exceeded 10 bytes');
+  });
+});

--- a/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
+++ b/src/platform/packages/shared/kbn-workflows/common/utils/index.ts
@@ -21,5 +21,6 @@ export { isPropertyAccess } from './is_property_access/is_property_access';
 export { getOrResolveObject } from './json_schema/get_or_resolve_object';
 export {
   LIQUID_ALLOWED_TAGS,
+  SizeLimitedEmitter,
   createWorkflowLiquidEngine,
 } from './create_workflow_liquid_engine/create_workflow_liquid_engine';

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -784,14 +784,11 @@ function insertGraphBetweenNodes(
   });
 }
 
-const DEFAULT_MAX_LOOP_ITERATIONS = 2000;
-
 function normalizeMaxIterations(raw?: MaxIterations): {
   maxIterations?: number;
   onLimit?: 'continue' | 'fail';
 } {
-  if (raw == null)
-    return { maxIterations: DEFAULT_MAX_LOOP_ITERATIONS, onLimit: 'continue' };
+  if (raw == null) return {};
   if (typeof raw === 'number') return { maxIterations: raw, onLimit: 'continue' };
   return { maxIterations: raw.limit, onLimit: raw['on-limit'] };
 }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/build_execution_graph.ts
@@ -784,11 +784,14 @@ function insertGraphBetweenNodes(
   });
 }
 
+const DEFAULT_MAX_LOOP_ITERATIONS = 2000;
+
 function normalizeMaxIterations(raw?: MaxIterations): {
   maxIterations?: number;
   onLimit?: 'continue' | 'fail';
 } {
-  if (raw == null) return {};
+  if (raw == null)
+    return { maxIterations: DEFAULT_MAX_LOOP_ITERATIONS, onLimit: 'continue' };
   if (typeof raw === 'number') return { maxIterations: raw, onLimit: 'continue' };
   return { maxIterations: raw.limit, onLimit: raw['on-limit'] };
 }

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
@@ -358,7 +358,7 @@ describe('convertToWorkflowGraph', () => {
       expect(exitNode.onLimit).toBe('fail');
     });
 
-    it('should default maxIterations to 2000 when not configured', () => {
+    it('should not set maxIterations on exit node when not configured', () => {
       const workflowDefinition = {
         steps: [
           {
@@ -379,8 +379,8 @@ describe('convertToWorkflowGraph', () => {
 
       const executionGraph = convertToWorkflowGraph(workflowDefinition as WorkflowYaml);
       const exitNode = executionGraph.node('exitForeach_foreachStep') as ExitForeachNode;
-      expect(exitNode.maxIterations).toBe(2000);
-      expect(exitNode.onLimit).toBe('continue');
+      expect(exitNode.maxIterations).toBeUndefined();
+      expect(exitNode.onLimit).toBeUndefined();
     });
 
     it('should support max-iterations combined with iteration-timeout and iteration-on-failure', () => {

--- a/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
+++ b/src/platform/packages/shared/kbn-workflows/graph/build_execution_graph/tests/loop_step_graph.test.ts
@@ -358,7 +358,7 @@ describe('convertToWorkflowGraph', () => {
       expect(exitNode.onLimit).toBe('fail');
     });
 
-    it('should not set maxIterations on exit node when not configured', () => {
+    it('should default maxIterations to 2000 when not configured', () => {
       const workflowDefinition = {
         steps: [
           {
@@ -379,8 +379,8 @@ describe('convertToWorkflowGraph', () => {
 
       const executionGraph = convertToWorkflowGraph(workflowDefinition as WorkflowYaml);
       const exitNode = executionGraph.node('exitForeach_foreachStep') as ExitForeachNode;
-      expect(exitNode.maxIterations).toBeUndefined();
-      expect(exitNode.onLimit).toBeUndefined();
+      expect(exitNode.maxIterations).toBe(2000);
+      expect(exitNode.onLimit).toBe('continue');
     });
 
     it('should support max-iterations combined with iteration-timeout and iteration-on-failure', () => {

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -79,6 +79,9 @@ export const WorkflowSettingsSchema = z.object({
   timeout: DurationSchema.optional(), // e.g., '5s', '1m', '2h'
   concurrency: ConcurrencySettingsSchema.optional(),
   'max-step-size': ByteSizeSchema.optional(), // e.g., '10mb', '15MB', '1gb'
+  'max-steps': z.number().positive().finite().optional(),
+  'max-total-output-size': ByteSizeSchema.optional(), // e.g., '150mb'
+  'max-workflow-output-size': ByteSizeSchema.optional(), // e.g., '5mb'
 });
 export type WorkflowSettings = z.infer<typeof WorkflowSettingsSchema>;
 

--- a/src/platform/plugins/shared/workflows_execution_engine/docs/manual_testing_phase2_execution_limits.md
+++ b/src/platform/plugins/shared/workflows_execution_engine/docs/manual_testing_phase2_execution_limits.md
@@ -1,0 +1,383 @@
+<!--
+Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. Licensed under the "Elastic License
+2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+Public License v 1"; you may not use this file except in compliance with, at
+your election, the "Elastic License 2.0", the "GNU Affero General Public
+License v3.0 only", or the "Server Side Public License, v 1".
+-->
+
+# Manual Testing: Phase 2 Execution Limits
+
+This guide covers testing all five Phase 2 execution limit mechanisms. Each test includes the YAML workflow definition, expected behavior/error, and verification steps.
+
+## Prerequisites
+
+- Kibana running in dev mode (`yarn start`)
+- Workflows UI enabled in `kibana.dev.yml`:
+
+  ```yaml
+  uiSettings.overrides:
+    workflows:ui:enabled: true
+  ```
+
+- Feature flag for workflows enabled
+
+---
+
+## Test 1: LiquidJS OOM Prevention — For Loop String Explosion
+
+**Description:** Verifies that a malicious LiquidJS template that would previously crash Kibana with OOM (500,000 iterations producing a huge string) is now rejected by the template size limit.
+
+**YAML:**
+
+```yaml
+name: LiquidJS OOM Exploit
+triggers:
+  - type: manual
+steps:
+  - name: explode
+    type: data.set
+    with:
+      payload: "{% for i in (1..500000) %}AAAAAAAA{% endfor %}"
+```
+
+**Expected Result:** Step fails with `TemplateSizeLimitExceeded` error. Previously this workflow crashed Kibana with OOM.
+
+**How to Verify:**
+
+1. Create the workflow in the Workflows UI.
+2. Execute it manually.
+3. In the Executions tab, open the failed execution.
+4. Confirm the step `explode` failed with error type `TemplateSizeLimitExceeded`.
+5. Kibana remains responsive (no OOM crash).
+
+---
+
+## Test 2: LiquidJS with Custom Step Size
+
+**Description:** Verifies that a step-level `max-step-size` overrides the default and enforces a stricter limit (~1KB) on template output.
+
+**YAML:**
+
+```yaml
+name: LiquidJS Custom Limit
+triggers:
+  - type: manual
+steps:
+  - name: small_render
+    type: data.set
+    max-step-size: '1kb'
+    with:
+      payload: "{% for i in (1..500) %}AAAAAAAAAA{% endfor %}"
+```
+
+**Expected Result:** Step fails with `TemplateSizeLimitExceeded` when output exceeds ~1KB.
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm step `small_render` fails with `TemplateSizeLimitExceeded`.
+3. Error details should indicate the limit was 1KB (1024 bytes).
+
+---
+
+## Test 3: LiquidJS Within Limit
+
+**Description:** Verifies that a small, valid LiquidJS template executes successfully when within the default size limit.
+
+**YAML:**
+
+```yaml
+name: LiquidJS Within Limit
+triggers:
+  - type: manual
+steps:
+  - name: ok_render
+    type: data.set
+    with:
+      payload: "{% for i in (1..10) %}Hello {{ i }} {% endfor %}"
+```
+
+**Expected Result:** Workflow completes successfully.
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm execution status is COMPLETED.
+3. Step `ok_render` output contains the rendered string (e.g., "Hello 1 Hello 2 ... Hello 10 ").
+
+---
+
+## Test 4: Default Foreach Iteration Cap
+
+**Description:** Verifies that a foreach loop without `max-iterations` stops at the default cap of 2000 iterations (with `on-limit: continue`).
+
+**YAML:**
+
+```yaml
+name: Foreach Default Cap
+triggers:
+  - type: manual
+steps:
+  - name: generate_items
+    type: data.set
+    with:
+      items: "${{ (1..5000) | join: ',' | split: ',' }}"
+  - name: loop
+    type: foreach
+    foreach: "${{ variables.items }}"
+    steps:
+      - name: process
+        type: data.set
+        with:
+          processed: "item {{ foreach.index }}"
+```
+
+**Expected Result:** Loop stops at 2000 iterations (default max). Workflow completes with first 2000 items processed.
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm execution completes (status COMPLETED).
+3. Inspect the last iteration of step `process` — `foreach.index` should be 2000.
+4. Only 2000 of 5000 items are processed.
+
+---
+
+## Test 5: Foreach With Explicit Max-Iterations
+
+**Description:** Verifies that an explicit `max-iterations` on a foreach step overrides the default and limits iterations to the specified value.
+
+**YAML:**
+
+```yaml
+name: Foreach Explicit Max
+triggers:
+  - type: manual
+steps:
+  - name: loop
+    type: foreach
+    foreach: "[1,2,3,4,5,6,7,8,9,10]"
+    max-iterations: 3
+    steps:
+      - name: process
+        type: data.set
+        with:
+          val: "{{ foreach.item }}"
+```
+
+**Expected Result:** Only 3 items are processed (1, 2, 3).
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm execution completes.
+3. Verify only 3 iterations of step `process` ran (check execution history or step output).
+4. The fourth item onward are not processed.
+
+---
+
+## Test 6: Cumulative Output Budget
+
+**Description:** Verifies that the cumulative output across all steps is tracked and that `WorkflowOutputBudgetExceeded` is thrown when the total exceeds `max-total-output-size`.
+
+**YAML:**
+
+```yaml
+name: Cumulative Budget Test
+triggers:
+  - type: manual
+settings:
+  max-total-output-size: '10kb'
+steps:
+  - name: step1
+    type: data.set
+    with:
+      data: "{% for i in (1..100) %}AAAAAAAAAA{% endfor %}"
+  - name: step2
+    type: data.set
+    with:
+      data: "{% for i in (1..100) %}BBBBBBBBBB{% endfor %}"
+  - name: step3
+    type: data.set
+    with:
+      data: "{% for i in (1..100) %}CCCCCCCCCC{% endfor %}"
+```
+
+**Expected Result:** `WorkflowOutputBudgetExceeded` after step2 or step3 when cumulative output exceeds 10KB.
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm one of the steps fails with `WorkflowOutputBudgetExceeded`.
+3. Error details should include the budget limit (10KB) and the step that exceeded it.
+4. Each step produces ~1KB; three steps exceed 10KB total.
+
+---
+
+## Test 7: Step Count Validation
+
+**Description:** Verifies that workflows with more than 150 steps (default max) cannot be saved and produce a validation error.
+
+**YAML:** Create a workflow with more than 150 steps. For example, use a script or editor to generate:
+
+```yaml
+name: Too Many Steps
+triggers:
+  - type: manual
+steps:
+  - name: step1
+    type: data.set
+    with:
+      x: "1"
+  - name: step2
+    type: data.set
+    with:
+      x: "2"
+  # ... repeat until you have 151+ steps
+  - name: step151
+    type: data.set
+    with:
+      x: "151"
+```
+
+**Expected Result:** Validation error when saving: "Workflow exceeds the maximum of 150 steps".
+
+**How to Verify:**
+
+1. Create a workflow with 151 or more steps (copy-paste or script).
+2. Attempt to save the workflow.
+3. Confirm a validation error appears before save.
+4. Error message indicates the step count limit (150).
+
+---
+
+## Test 8: Step Count With Custom Setting
+
+**Description:** Verifies that a workflow-level `max-steps` setting is enforced and that validation rejects workflows exceeding that custom limit.
+
+**YAML:**
+
+```yaml
+name: Custom Max Steps
+triggers:
+  - type: manual
+settings:
+  max-steps: 3
+steps:
+  - name: step1
+    type: data.set
+    with:
+      x: "1"
+  - name: step2
+    type: data.set
+    with:
+      x: "2"
+  - name: step3
+    type: data.set
+    with:
+      x: "3"
+  - name: step4
+    type: data.set
+    with:
+      x: "4"
+```
+
+**Expected Result:** Validation error when saving: "Workflow exceeds the maximum of 3 steps (found 4)".
+
+**How to Verify:**
+
+1. Create and attempt to save the workflow.
+2. Confirm validation error appears.
+3. Error message references the custom limit (3) and actual count (4).
+
+---
+
+## Test 9: Workflow Output Size Cap (workflow.execute)
+
+**Description:** Verifies that when a parent workflow calls a child workflow via `workflow.execute`, the child's output is capped at the default 5MB. If the child produces output larger than 5MB, `WorkflowOutputSizeExceeded` is thrown.
+
+**Child Workflow YAML (save as "Large Output Child"):**
+
+```yaml
+name: Large Output Child
+triggers:
+  - type: manual
+steps:
+  - name: produce_large_output
+    type: data.set
+    with:
+      data: "{% for i in (1..600000) %}AAAAAAAAAA{% endfor %}"
+```
+
+**Parent Workflow YAML (save as "Parent Calls Child"):**
+
+```yaml
+name: Parent Calls Child
+triggers:
+  - type: manual
+steps:
+  - name: call_child
+    type: workflow.execute
+    with:
+      workflow-id: "<ID_OF_LARGE_OUTPUT_CHILD_WORKFLOW>"
+```
+
+**Expected Result:** `WorkflowOutputSizeExceeded` when the child workflow's output exceeds 5MB.
+
+**How to Verify:**
+
+1. Create and save the child workflow. Note its ID.
+2. Create the parent workflow, replacing `<ID_OF_LARGE_OUTPUT_CHILD_WORKFLOW>` in `workflow-id` with the child workflow's ID.
+3. Execute the parent workflow.
+4. Confirm step `call_child` fails with `WorkflowOutputSizeExceeded`.
+5. Error details should indicate the 5MB limit.
+
+---
+
+## Test 10: Normal Workflow (Sanity Check)
+
+**Description:** Verifies that a simple workflow without any limit triggers executes successfully. Serves as a sanity check that the execution engine is functioning correctly.
+
+**YAML:**
+
+```yaml
+name: Normal Workflow
+triggers:
+  - type: manual
+steps:
+  - name: set_data
+    type: data.set
+    with:
+      message: "Hello World"
+  - name: render_template
+    type: data.set
+    with:
+      greeting: "{{ variables.message }}!"
+```
+
+**Expected Result:** Completes successfully with no limit errors.
+
+**How to Verify:**
+
+1. Create and execute the workflow.
+2. Confirm execution status is COMPLETED.
+3. Step `render_template` output contains `greeting: "Hello World!"`.
+
+---
+
+## Quick Validation Checklist
+
+| # | Mechanism | Expected Error / Result | Verified? |
+|---|-----------|-------------------------|-----------|
+| 1 | LiquidJS OOM prevention | `TemplateSizeLimitExceeded` | [ ] |
+| 2 | LiquidJS custom step size | `TemplateSizeLimitExceeded` at ~1KB | [ ] |
+| 3 | LiquidJS within limit | Success | [ ] |
+| 4 | Default foreach cap (2000) | Stops at 2000 iterations | [ ] |
+| 5 | Foreach explicit max-iterations | Only 3 items processed | [ ] |
+| 6 | Cumulative output budget | `WorkflowOutputBudgetExceeded` | [ ] |
+| 7 | Step count validation (default) | Validation error at 150+ steps | [ ] |
+| 8 | Step count custom setting | Validation error at 4 steps (max 3) | [ ] |
+| 9 | Workflow output size cap | `WorkflowOutputSizeExceeded` | [ ] |
+| 10 | Normal workflow | Success | [ ] |

--- a/src/platform/plugins/shared/workflows_execution_engine/docs/rfc_phase2_execution_limits.md
+++ b/src/platform/plugins/shared/workflows_execution_engine/docs/rfc_phase2_execution_limits.md
@@ -1,0 +1,140 @@
+<!--
+Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. Licensed under the "Elastic License
+2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+Public License v 1"; you may not use this file except in compliance with, at
+your election, the "Elastic License 2.0", the "GNU Affero General Public
+License v3.0 only", or the "Server Side Public License, v 1".
+-->
+
+# RFC: Phase 2 Workflow Execution Limits
+
+**Status:** Draft  
+**Authors:** Workflows Engine Team  
+**Date:** 2026-03-16  
+**Parent Epic:** [elastic/security-team#15842](https://github.com/elastic/security-team/issues/15842)
+
+---
+
+## Overview
+
+This RFC documents Phase 2 of the Workflow Execution Limits work. **Phase 1** (already merged in [PR #254918](https://github.com/elastic/kibana/pull/254918)) covered per-step I/O size enforcement via `max-step-size`:
+
+- **Layer 1:** Pre-emptive I/O interception for HTTP/ES/Kibana steps
+- **Layer 2:** Post-hoc output guard in `BaseAtomicNodeImplementation`
+
+Phase 2 adds five new execution limit mechanisms.
+
+---
+
+## Problem Statement
+
+Phase 1 protects individual step output sizes but does not cover:
+
+1. **LiquidJS OOM**: A for-loop like `{% for i in (1..500000) %}AAAA{% endfor %}` crashes Kibana with 1GB memory. The built-in `memoryLimit` doesn't count emitter buffer growth.
+2. **Unbounded loop iterations**: foreach/while without `max-iterations` can run indefinitely.
+3. **Cumulative context growth**: Many small steps can accumulate to exceed available memory.
+4. **Too many steps**: Extremely large workflow definitions degrade performance.
+5. **Large workflow output**: Child workflow output via `workflow.execute` can be unbounded.
+
+---
+
+## Solution
+
+### 1. LiquidJS Output Size Cap (P0 - OOM Prevention)
+
+- **What**: Custom `SizeLimitedEmitter` class checks byte size on every `write()` during LiquidJS rendering
+- **Where**: `create_workflow_liquid_engine.ts` (emitter class), `templating_engine.ts` (rendering path), `workflow_context_manager.ts` (wiring)
+- **Limit**: Uses the step's `max-step-size` (resolved via step > workflow > plugin config > 10MB default)
+- **Error**: `TemplateSizeLimitExceeded`
+- **How**: Uses lower-level LiquidJS APIs (`engine.parse()` + `renderer.renderTemplates()` with custom emitter) instead of `parseAndRenderSync` when a limit is set
+
+### 2. Default Loop Iteration Cap
+
+- **What**: foreach/while loops without `max-iterations` now default to 2000 with `on-limit: continue`
+- **Where**: `normalizeMaxIterations()` in `build_execution_graph.ts`
+- **Limit**: `DEFAULT_MAX_LOOP_ITERATIONS = 2000`
+- **Behavior**: Silently stops after 2000 iterations (existing Omri's `max-iterations` mechanism)
+
+### 3. Cumulative Output Budget
+
+- **What**: Tracks total output bytes across all completed steps
+- **Where**: `WorkflowExecutionState.cumulativeOutputBytes`, checked in `StepExecutionRuntime.finishStep()`
+- **Limit**: `max-total-output-size` in YAML settings, or `maxCumulativeOutputSize` plugin config (default 150MB)
+- **Error**: `WorkflowOutputBudgetExceeded`
+
+### 4. Step Count Validation
+
+- **What**: Validates total step count at definition time
+- **Where**: `validateStepCount()` in management plugin, called from `validateWorkflowYaml()`
+- **Limit**: `max-steps` in YAML settings (default 150)
+- **Error**: Validation diagnostic (prevents saving)
+
+### 5. Workflow Output Size Cap
+
+- **What**: Caps the output size returned by `workflow.execute` sync strategy
+- **Where**: `WorkflowExecuteSyncStrategy` before returning child workflow output
+- **Limit**: `max-workflow-output-size` in YAML settings (default 5MB)
+- **Error**: `WorkflowOutputSizeExceeded`
+
+---
+
+## Configuration
+
+### New YAML Settings (under `settings:`)
+
+```yaml
+settings:
+  max-steps: 150                    # Max steps in definition (default 150)
+  max-total-output-size: '150mb'    # Cumulative output budget (default 150MB)
+  max-workflow-output-size: '5mb'   # Max final workflow output (default 5MB)
+```
+
+### New Plugin Config (kibana.yml)
+
+```yaml
+xpack.workflowsExecutionEngine:
+  maxCumulativeOutputSize: '150mb'
+  maxWorkflowOutputSize: '5mb'
+```
+
+---
+
+## Error Types
+
+| Error | Type | Thrown By |
+|-------|------|-----------|
+| TemplateSizeLimitExceeded | Execution | SizeLimitedEmitter via WorkflowTemplatingEngine |
+| WorkflowOutputBudgetExceeded | Execution | StepExecutionRuntime.finishStep() |
+| WorkflowStepCountExceeded | Validation | validateStepCount() |
+| WorkflowOutputSizeExceeded | Execution | WorkflowExecuteSyncStrategy |
+
+---
+
+## Resolution Chain (max-step-size for LiquidJS)
+
+1. Step-level: `configuration['max-step-size']` from graph node
+2. Workflow-level: `settings['max-step-size']`
+3. Plugin config: `xpack.workflowsExecutionEngine.maxResponseSize`
+4. Default: 10MB
+
+Shared utility: `resolveMaxStepSizeBytes(node, workflowExecution, config)` in `errors.ts`
+
+---
+
+## Related Issues
+
+- Epic: [elastic/security-team#15842](https://github.com/elastic/security-team/issues/15842)
+- LiquidJS OOM: [elastic/security-team#16270](https://github.com/elastic/security-team/issues/16270)
+- Loop guardrails: [elastic/security-team#15840](https://github.com/elastic/security-team/issues/15840)
+- Workflow-level limits: [elastic/security-team#15837](https://github.com/elastic/security-team/issues/15837)
+- Phase 1 PR: [elastic/kibana#254918](https://github.com/elastic/kibana/pull/254918)
+
+---
+
+## Limitations & Future Work
+
+- LiquidJS `memoryLimit` and `renderLimit` remain as additional safety nets but don't prevent all OOM scenarios
+- Kibana stack connectors (non-HTTP) cannot have Layer 1 pre-emptive enforcement - tracked separately
+- No lazy context loading yet (all step outputs held in memory during execution)
+- No per-field `postprocess` attribute to filter step output fields (planned future enhancement)

--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/response_size_limits.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/tests/response_size_limits.test.ts
@@ -246,7 +246,8 @@ steps:
         );
         const dataStep = stepExecutions.find((s) => s.stepId === 'generate_large_data');
         expect(dataStep?.status).toBe(ExecutionStatus.FAILED);
-        expect(dataStep?.error?.type).toBe('StepSizeLimitExceeded');
+        // Template rendering via SizeLimitedEmitter fires before the string fully materializes
+        expect(dataStep?.error?.type).toBe('TemplateSizeLimitExceeded');
       });
     });
 
@@ -314,8 +315,89 @@ steps:
         );
         const inputStep = stepExecutions.find((s) => s.stepId === 'receive_large_input');
         expect(inputStep?.status).toBe(ExecutionStatus.FAILED);
-        expect(inputStep?.error?.type).toBe('StepSizeLimitExceeded');
-        expect(inputStep?.error?.message).toContain('input');
+        // SizeLimitedEmitter fires during template rendering, before the input fully materializes
+        expect(inputStep?.error?.type).toBe('TemplateSizeLimitExceeded');
+        expect(inputStep?.error?.message).toContain('100 B');
+      });
+    });
+  });
+
+  describe('Phase 2: LiquidJS template size limit (TemplateSizeLimitExceeded)', () => {
+    describe('template for-loop exceeds max-step-size', () => {
+      let workflowRunFixture: WorkflowRunFixture;
+
+      beforeAll(async () => {
+        workflowRunFixture = new WorkflowRunFixture();
+
+        // Step has max-step-size: 50b; template produces 4000 chars
+        const workflowYaml = `
+steps:
+  - name: template_bomb
+    type: data.set
+    max-step-size: 50b
+    with:
+      result: "{% for i in (1..1000) %}AAAA{% endfor %}"
+`;
+        await workflowRunFixture.runWorkflow({ workflowYaml });
+      });
+
+      it('step fails with TemplateSizeLimitExceeded when rendered output exceeds max-step-size', () => {
+        const stepExecutions = Array.from(
+          workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+        );
+        const bombStep = stepExecutions.find((s) => s.stepId === 'template_bomb');
+        expect(bombStep?.status).toBe(ExecutionStatus.FAILED);
+        expect(bombStep?.error?.type).toBe('TemplateSizeLimitExceeded');
+        expect(bombStep?.error?.message).toContain('50 B');
+      });
+    });
+  });
+
+  describe('Phase 2: Cumulative output budget (WorkflowOutputBudgetExceeded)', () => {
+    describe('two steps exceed workflow budget set via YAML settings', () => {
+      let workflowRunFixture: WorkflowRunFixture;
+
+      beforeAll(async () => {
+        workflowRunFixture = new WorkflowRunFixture();
+
+        // Budget: 1kb; each large_response step returns ~615 bytes of JSON
+        // After step2, cumulative total ~1230b > 1024b → budget exceeded
+        const workflowYaml = `
+settings:
+  max-total-output-size: 1kb
+steps:
+  - name: step1
+    type: ${FakeConnectors.large_response.actionTypeId}
+    connector-id: ${FakeConnectors.large_response.name}
+    with:
+      sizeBytes: 600
+  - name: step2
+    type: ${FakeConnectors.large_response.actionTypeId}
+    connector-id: ${FakeConnectors.large_response.name}
+    with:
+      sizeBytes: 600
+`;
+        await workflowRunFixture.runWorkflow({ workflowYaml });
+      });
+
+      it('workflow fails with WorkflowOutputBudgetExceeded after cumulative output crosses budget', () => {
+        const workflowExecutionDoc =
+          workflowRunFixture.workflowExecutionRepositoryMock.workflowExecutions.get(
+            'fake_workflow_execution_id'
+          );
+        expect(workflowExecutionDoc?.status).toBe(ExecutionStatus.FAILED);
+        expect(workflowExecutionDoc?.error?.type).toBe('WorkflowOutputBudgetExceeded');
+      });
+
+      it('step1 completes and step2 fails with WorkflowOutputBudgetExceeded', () => {
+        const stepExecutions = Array.from(
+          workflowRunFixture.stepExecutionRepositoryMock.stepExecutions.values()
+        );
+        const step1 = stepExecutions.find((s) => s.stepId === 'step1');
+        const step2 = stepExecutions.find((s) => s.stepId === 'step2');
+        expect(step1?.status).toBe(ExecutionStatus.COMPLETED);
+        expect(step2?.status).toBe(ExecutionStatus.FAILED);
+        expect(step2?.error?.type).toBe('WorkflowOutputBudgetExceeded');
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -10,7 +10,11 @@
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import type { PluginConfigDescriptor } from '@kbn/core/server';
-import { DEFAULT_MAX_STEP_SIZE } from './step/errors';
+import {
+  DEFAULT_MAX_STEP_SIZE,
+  DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE,
+  DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE,
+} from './step/errors';
 
 const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
@@ -26,6 +30,8 @@ const configSchema = schema.object({
     ),
   }),
   maxResponseSize: schema.byteSize({ defaultValue: DEFAULT_MAX_STEP_SIZE }),
+  maxCumulativeOutputSize: schema.byteSize({ defaultValue: DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE }),
+  maxWorkflowOutputSize: schema.byteSize({ defaultValue: DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE }),
   collectQueueMetrics: schema.boolean({
     defaultValue: false,
     meta: {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -25,6 +25,8 @@ export const mockContextDependencies = () => ({
     logging: { console: false },
     http: { allowedHosts: ['*'] },
     maxResponseSize: new ByteSizeValue(10 * 1024 * 1024), // 10mb
+    maxCumulativeOutputSize: new ByteSizeValue(150 * 1024 * 1024), // 150mb
+    maxWorkflowOutputSize: new ByteSizeValue(5 * 1024 * 1024), // 5mb
     collectQueueMetrics: false,
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.test.ts
@@ -8,7 +8,17 @@
  */
 
 import { Readable } from 'stream';
-import { formatBytes, parseByteSize, ResponseSizeLimitError, safeOutputSize } from './errors';
+import {
+  formatBytes,
+  parseByteSize,
+  resolveMaxStepSizeBytes,
+  ResponseSizeLimitError,
+  safeOutputSize,
+  TemplateSizeLimitExceeded,
+  WorkflowOutputBudgetExceeded,
+  WorkflowOutputSizeExceeded,
+  WorkflowStepCountExceeded,
+} from './errors';
 
 describe('formatBytes', () => {
   it('should format 0 bytes', () => {
@@ -115,5 +125,80 @@ describe('ResponseSizeLimitError', () => {
     expect(error.message).toContain('10 MB');
     expect(error.message).toContain('exceeded the');
     expect(error.details?.limitBytes).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe('resolveMaxStepSizeBytes', () => {
+  it('should use step-level config when node has max-step-size', () => {
+    const node = { configuration: { 'max-step-size': '5mb' } } as any;
+    expect(resolveMaxStepSizeBytes(node, undefined, undefined)).toBe(5 * 1024 * 1024);
+  });
+
+  it('should prefer step-level over workflow and config when all are present', () => {
+    const node = { configuration: { 'max-step-size': '5mb' } } as any;
+    const workflowExecution = {
+      workflowDefinition: { settings: { 'max-step-size': '15mb' } },
+    } as any;
+    const config = { maxResponseSize: { getValueInBytes: () => 2 * 1024 * 1024 } } as any;
+    expect(resolveMaxStepSizeBytes(node, workflowExecution, config)).toBe(5 * 1024 * 1024);
+  });
+
+  it('should fall back to workflow settings when node has no config', () => {
+    const workflowExecution = {
+      workflowDefinition: { settings: { 'max-step-size': '15mb' } },
+    } as any;
+    expect(resolveMaxStepSizeBytes(undefined, workflowExecution, undefined)).toBe(15 * 1024 * 1024);
+  });
+
+  it('should fall back to plugin config when node and workflow have no config', () => {
+    const config = { maxResponseSize: { getValueInBytes: () => 2 * 1024 * 1024 } } as any;
+    expect(resolveMaxStepSizeBytes(undefined, undefined, config)).toBe(2 * 1024 * 1024);
+  });
+
+  it('should return default when all are undefined', () => {
+    expect(resolveMaxStepSizeBytes(undefined, undefined, undefined)).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe('TemplateSizeLimitExceeded', () => {
+  it('should create an error with the correct type and message', () => {
+    const error = new TemplateSizeLimitExceeded(1024);
+    expect(error.type).toBe('TemplateSizeLimitExceeded');
+    expect(error.message).toContain('1 KB');
+    expect(error.message).toContain('Template rendering');
+    expect(error.details?.limitBytes).toBe(1024);
+  });
+});
+
+describe('WorkflowOutputBudgetExceeded', () => {
+  it('should create an error with the correct type, message, and details', () => {
+    const error = new WorkflowOutputBudgetExceeded(100 * 1024 * 1024, 120 * 1024 * 1024, 'step1');
+    expect(error.type).toBe('WorkflowOutputBudgetExceeded');
+    expect(error.message).toContain('100 MB');
+    expect(error.message).toContain('120 MB');
+    expect(error.message).toContain('step1');
+    expect(error.details?.budgetBytes).toBe(100 * 1024 * 1024);
+    expect(error.details?.totalBytes).toBe(120 * 1024 * 1024);
+  });
+});
+
+describe('WorkflowStepCountExceeded', () => {
+  it('should have correct name and message', () => {
+    const error = new WorkflowStepCountExceeded(200, 150);
+    expect(error.name).toBe('WorkflowStepCountExceeded');
+    expect(error.message).toContain('200');
+    expect(error.message).toContain('150');
+    expect(error.message).toContain('maximum');
+  });
+});
+
+describe('WorkflowOutputSizeExceeded', () => {
+  it('should create an error with the correct type, message, and details', () => {
+    const error = new WorkflowOutputSizeExceeded(5 * 1024 * 1024, 8 * 1024 * 1024);
+    expect(error.type).toBe('WorkflowOutputSizeExceeded');
+    expect(error.message).toContain('5 MB');
+    expect(error.message).toContain('8 MB');
+    expect(error.details?.limitBytes).toBe(5 * 1024 * 1024);
+    expect(error.details?.actualBytes).toBe(8 * 1024 * 1024);
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
@@ -7,9 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { EsWorkflowExecution } from '@kbn/workflows';
+import type { GraphNodeUnion } from '@kbn/workflows/graph';
 import { ExecutionError } from '@kbn/workflows/server';
+import type { WorkflowsExecutionEngineConfig } from '../config';
 
 export const DEFAULT_MAX_STEP_SIZE = '10mb';
+export const DEFAULT_MAX_LOOP_ITERATIONS = 2000;
+export const DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE = '150mb';
+export const DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE = '5mb';
+export const DEFAULT_MAX_STEPS_PER_WORKFLOW = 150;
 
 const BYTE_UNITS: Array<{ unit: string; size: number }> = [
   { unit: 'GB', size: 1024 * 1024 * 1024 },
@@ -79,6 +86,41 @@ export function safeOutputSize(output: unknown): number {
 }
 
 /**
+ * Resolves the effective max-step-size in bytes from the resolution chain:
+ * step-level > workflow settings > plugin config > hardcoded default.
+ * Used by BaseAtomicNodeImplementation and WorkflowContextManager (for LiquidJS limits).
+ */
+export function resolveMaxStepSizeBytes(
+  node: GraphNodeUnion | undefined,
+  workflowExecution: EsWorkflowExecution | undefined,
+  config: WorkflowsExecutionEngineConfig | undefined
+): number {
+  try {
+    const nodeConfig = (node as any)?.configuration;
+    const stepLimit = nodeConfig?.['max-step-size'];
+    if (stepLimit) {
+      return parseByteSize(stepLimit);
+    }
+
+    const workflowLimit = workflowExecution?.workflowDefinition?.settings?.['max-step-size'];
+    if (workflowLimit) {
+      return parseByteSize(workflowLimit);
+    }
+
+    if (config?.maxResponseSize) {
+      const configValue = config.maxResponseSize;
+      return typeof configValue === 'number'
+        ? configValue
+        : (configValue as any).getValueInBytes();
+    }
+
+    return parseByteSize(DEFAULT_MAX_STEP_SIZE);
+  } catch {
+    return parseByteSize(DEFAULT_MAX_STEP_SIZE);
+  }
+}
+
+/**
  * Error thrown when a step's response or output exceeds the configured size limit.
  * Used by both Layer 1 (pre-emptive I/O enforcement) and Layer 2 (base class output guard).
  */
@@ -94,6 +136,67 @@ export class ResponseSizeLimitError extends ExecutionError {
       details: {
         limitBytes,
       },
+    });
+  }
+}
+
+/**
+ * Error thrown when a LiquidJS template render produces output exceeding the step's size limit.
+ * Thrown mid-render by the SizeLimitedEmitter to prevent OOM.
+ */
+export class TemplateSizeLimitExceeded extends ExecutionError {
+  constructor(limitBytes: number) {
+    super({
+      type: 'TemplateSizeLimitExceeded',
+      message:
+        `Template rendering produced output exceeding the ${formatBytes(limitBytes)} size limit. ` +
+        `Simplify the template or increase 'max-step-size'.`,
+      details: { limitBytes },
+    });
+  }
+}
+
+/**
+ * Error thrown when the cumulative output across all steps exceeds the workflow budget.
+ */
+export class WorkflowOutputBudgetExceeded extends ExecutionError {
+  constructor(budgetBytes: number, totalBytes: number, stepName: string) {
+    super({
+      type: 'WorkflowOutputBudgetExceeded',
+      message:
+        `Workflow exceeded the cumulative output budget of ${formatBytes(budgetBytes)} ` +
+        `after step "${stepName}" (total accumulated: ${formatBytes(totalBytes)}). ` +
+        `Consider using '_source' filtering, reducing response sizes, or splitting into child workflows.`,
+      details: { budgetBytes, totalBytes },
+    });
+  }
+}
+
+/**
+ * Error thrown at definition time when a workflow has too many steps.
+ */
+export class WorkflowStepCountExceeded extends Error {
+  constructor(count: number, maxSteps: number) {
+    super(
+      `Workflow exceeds the maximum of ${maxSteps} steps (found ${count}). ` +
+        `Consider splitting into child workflows using 'workflow.execute'.`
+    );
+    this.name = 'WorkflowStepCountExceeded';
+  }
+}
+
+/**
+ * Error thrown when the final workflow output exceeds the configured limit.
+ */
+export class WorkflowOutputSizeExceeded extends ExecutionError {
+  constructor(limitBytes: number, actualBytes: number) {
+    super({
+      type: 'WorkflowOutputSizeExceeded',
+      message:
+        `Workflow output (${formatBytes(actualBytes)}) exceeded the ` +
+        `${formatBytes(limitBytes)} limit. ` +
+        `Configure 'max-workflow-output-size' in workflow settings to increase the limit.`,
+      details: { limitBytes, actualBytes },
     });
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
@@ -13,7 +13,6 @@ import { ExecutionError } from '@kbn/workflows/server';
 import type { WorkflowsExecutionEngineConfig } from '../config';
 
 export const DEFAULT_MAX_STEP_SIZE = '10mb';
-export const DEFAULT_MAX_LOOP_ITERATIONS = 2000;
 export const DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE = '150mb';
 export const DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE = '5mb';
 export const DEFAULT_MAX_STEPS_PER_WORKFLOW = 150;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/errors.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+// eslint-disable-next-line max-classes-per-file
 import type { EsWorkflowExecution } from '@kbn/workflows';
 import type { GraphNodeUnion } from '@kbn/workflows/graph';
 import { ExecutionError } from '@kbn/workflows/server';
@@ -95,10 +96,13 @@ export function resolveMaxStepSizeBytes(
   config: WorkflowsExecutionEngineConfig | undefined
 ): number {
   try {
-    const nodeConfig = (node as any)?.configuration;
+    const nodeConfig =
+      node && 'configuration' in node
+        ? (node.configuration as Record<string, unknown> | undefined)
+        : undefined;
     const stepLimit = nodeConfig?.['max-step-size'];
     if (stepLimit) {
-      return parseByteSize(stepLimit);
+      return parseByteSize(stepLimit as string | number);
     }
 
     const workflowLimit = workflowExecution?.workflowDefinition?.settings?.['max-step-size'];
@@ -107,10 +111,7 @@ export function resolveMaxStepSizeBytes(
     }
 
     if (config?.maxResponseSize) {
-      const configValue = config.maxResponseSize;
-      return typeof configValue === 'number'
-        ? configValue
-        : (configValue as any).getValueInBytes();
+      return config.maxResponseSize.getValueInBytes();
     }
 
     return parseByteSize(DEFAULT_MAX_STEP_SIZE);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/node_implementation.ts
@@ -16,8 +16,7 @@ import apm from 'elastic-apm-node';
 import type { SerializedError } from '@kbn/workflows';
 import { ExecutionError } from '@kbn/workflows/server';
 import {
-  DEFAULT_MAX_STEP_SIZE,
-  parseByteSize,
+  resolveMaxStepSizeBytes,
   ResponseSizeLimitError,
   safeOutputSize,
 } from './errors';
@@ -229,42 +228,12 @@ export abstract class BaseAtomicNodeImplementation<TStep extends BaseStep>
   // Subclasses implement this to execute the step logic
   protected abstract _run(input?: any): Promise<RunStepResult>;
 
-  /**
-   * Resolves the maximum step size in bytes.
-   * Resolution order: step-level > workflow settings > plugin config > DEFAULT_MAX_STEP_SIZE.
-   * Returns 0 if the configured value is explicitly "0" (disables the limit).
-   * Returns the default on invalid/unparseable values to avoid crashing the step.
-   */
   protected getMaxResponseBytes(): number {
-    try {
-      // 1. Step-level override (from YAML — auto-populated in constructor)
-      const stepLimit = this.step['max-step-size'];
-      if (stepLimit) {
-        return parseByteSize(stepLimit);
-      }
-
-      // 2. Workflow-level override (from YAML settings, via runtime — not user-facing context)
-      const workflowSettings =
-        this.stepExecutionRuntime.workflowExecution?.workflowDefinition?.settings;
-      const workflowLimit = workflowSettings?.['max-step-size'];
-      if (workflowLimit) {
-        return parseByteSize(workflowLimit);
-      }
-
-      // 3. Plugin config default (from kibana.yml)
-      const pluginConfig = this.stepExecutionRuntime.contextManager.getDependencies().config;
-      if (pluginConfig?.maxResponseSize) {
-        const configValue = pluginConfig.maxResponseSize;
-        return typeof configValue === 'number'
-          ? configValue
-          : (configValue as any).getValueInBytes();
-      }
-
-      // 4. Hardcoded fallback
-      return parseByteSize(DEFAULT_MAX_STEP_SIZE);
-    } catch {
-      return parseByteSize(DEFAULT_MAX_STEP_SIZE);
-    }
+    return resolveMaxStepSizeBytes(
+      this.stepExecutionRuntime.node,
+      this.stepExecutionRuntime.workflowExecution,
+      this.stepExecutionRuntime.contextManager.getDependencies().config
+    );
   }
 
   // Helper for handling on-failure, retries, etc.

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.ts
@@ -13,6 +13,12 @@ import type { JsonValue } from '@kbn/utility-types';
 import type { EsWorkflow } from '@kbn/workflows';
 import { ExecutionStatus, isTerminalStatus } from '@kbn/workflows';
 import { ExecutionError } from '@kbn/workflows/server';
+import {
+  safeOutputSize,
+  parseByteSize,
+  WorkflowOutputSizeExceeded,
+  DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE,
+} from '../../../step/errors';
 import type { WorkflowStepExecutionDto } from '@kbn/workflows/types/v1';
 import type { StepExecutionRepository } from '../../../repositories/step_execution_repository';
 import type { WorkflowExecutionRepository } from '../../../repositories/workflow_execution_repository';
@@ -219,9 +225,17 @@ export class WorkflowExecuteSyncStrategy {
           );
         }
 
-        // Pass the output directly as the step output (not wrapped in an object)
         const stepOutput: Record<string, unknown> | undefined =
           output === null ? undefined : (output as Record<string, unknown>);
+
+        if (stepOutput != null) {
+          const maxOutputBytes = this.resolveMaxWorkflowOutputSize(execution);
+          const outputBytes = safeOutputSize(stepOutput);
+          if (maxOutputBytes > 0 && outputBytes > 0 && outputBytes > maxOutputBytes) {
+            throw new WorkflowOutputSizeExceeded(maxOutputBytes, outputBytes);
+          }
+        }
+
         return { status: 'completed', output: stepOutput };
       }
 
@@ -318,5 +332,18 @@ export class WorkflowExecuteSyncStrategy {
       .filter((output): output is JsonValue => output !== undefined);
 
     return outputs.length > 0 ? outputs : null;
+  }
+
+  private resolveMaxWorkflowOutputSize(execution: any): number {
+    try {
+      const settings = execution.workflowDefinition?.settings;
+      const yamlLimit = settings?.['max-workflow-output-size'];
+      if (yamlLimit) {
+        return parseByteSize(yamlLimit);
+      }
+      return parseByteSize(DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE);
+    } catch {
+      return parseByteSize(DEFAULT_MAX_WORKFLOW_OUTPUT_SIZE);
+    }
   }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { WorkflowTemplatingEngine } from './templating_engine';
+import { TemplateSizeLimitExceeded } from './step/errors';
 
 describe('WorkflowTemplatingEngine', () => {
   let templatingEngine: WorkflowTemplatingEngine;
@@ -670,6 +671,59 @@ describe('WorkflowTemplatingEngine', () => {
         expect(() => {
           templatingEngine.render('{% for i in (1..20000000) %}{{ i }}{% endfor %}', {});
         }).toThrow('memory alloc limit exceeded');
+      });
+    });
+
+    describe('size-limited rendering', () => {
+      it('should allow small output within limit', () => {
+        const result = templatingEngine.render('Hello {{ name }}!', { name: 'World' }, 1024);
+        expect(result).toBe('Hello World!');
+      });
+
+      it('should throw TemplateSizeLimitExceeded when output exceeds limit', () => {
+        const template = '{% for i in (1..1000) %}AAAAAAAAAA{% endfor %}';
+        expect(() => {
+          templatingEngine.render(template, {}, 100);
+        }).toThrow(TemplateSizeLimitExceeded);
+      });
+
+      it('should throw TemplateSizeLimitExceeded for large string concatenation in loops', () => {
+        const template = '{% for i in (1..500) %}XXXXXXXXXXXXXXXXX{% endfor %}';
+        expect(() => {
+          templatingEngine.render(template, {}, 1024);
+        }).toThrow(TemplateSizeLimitExceeded);
+      });
+
+      it('should not apply limit when maxOutputBytes is 0', () => {
+        const template = '{% for i in (1..100) %}X{% endfor %}';
+        const result = templatingEngine.render(template, {}, 0);
+        expect(result).toHaveLength(100);
+      });
+
+      it('should not apply limit when maxOutputBytes is undefined', () => {
+        const template = '{% for i in (1..100) %}X{% endfor %}';
+        const result = templatingEngine.render(template, {});
+        expect(result).toHaveLength(100);
+      });
+
+      it('should apply limit recursively in objects', () => {
+        const obj = { payload: '{% for i in (1..1000) %}AAAAAAAAAA{% endfor %}' };
+        expect(() => {
+          templatingEngine.render(obj, {}, 100);
+        }).toThrow(TemplateSizeLimitExceeded);
+      });
+
+      it('should have correct error type and details', () => {
+        const template = '{% for i in (1..1000) %}AAAAAAAAAA{% endfor %}';
+        try {
+          templatingEngine.render(template, {}, 500);
+          fail('Expected TemplateSizeLimitExceeded');
+        } catch (error) {
+          expect(error).toBeInstanceOf(TemplateSizeLimitExceeded);
+          const e = error as TemplateSizeLimitExceeded;
+          expect(e.type).toBe('TemplateSizeLimitExceeded');
+          expect(e.details?.limitBytes).toBe(500);
+        }
       });
     });
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
@@ -126,17 +126,18 @@ export class WorkflowTemplatingEngine {
 
       return this.engine.parseAndRenderSync(template, context);
     } catch (error) {
-      if (error instanceof TemplateSizeLimitExceeded) {
-        throw error;
-      }
-      const originalError = (error as any)?.originalError ?? (error as any)?.cause;
-      if (originalError instanceof TemplateSizeLimitExceeded) {
-        throw originalError;
+      // Walk the error cause chain — LiquidJS may wrap our error in originalError or cause
+      let cause: unknown = error;
+      while (cause != null) {
+        if (cause instanceof TemplateSizeLimitExceeded) {
+          throw cause;
+        }
+        const errObj = cause as { originalError?: unknown; cause?: unknown };
+        const next = errObj.originalError ?? errObj.cause;
+        if (next === cause || next == null) break;
+        cause = next;
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      if (errorMessage.includes('TemplateSizeLimitExceeded')) {
-        throw new TemplateSizeLimitExceeded(maxOutputBytes ?? 0);
-      }
       const customerFacingErrorMessage = errorMessage.replace(/, line:\d+, col:\d+/g, '');
       throw new Error(customerFacingErrorMessage);
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/templating_engine.ts
@@ -7,7 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createWorkflowLiquidEngine } from '@kbn/workflows';
+import { Context, toValueSync } from 'liquidjs';
+import { createWorkflowLiquidEngine, SizeLimitedEmitter } from '@kbn/workflows';
+import { TemplateSizeLimitExceeded } from './step/errors';
 
 export class WorkflowTemplatingEngine {
   /**
@@ -36,8 +38,8 @@ export class WorkflowTemplatingEngine {
     });
   }
 
-  public render<T>(obj: T, context: Record<string, unknown>): T {
-    return this.renderValueRecursively(obj, context) as T;
+  public render<T>(obj: T, context: Record<string, unknown>, maxOutputBytes?: number): T {
+    return this.renderValueRecursively(obj, context, maxOutputBytes) as T;
   }
 
   public evaluateExpression(template: string, context: Record<string, unknown>): unknown {
@@ -62,37 +64,35 @@ export class WorkflowTemplatingEngine {
     }
   }
 
-  private renderValueRecursively(value: unknown, context: Record<string, unknown>): unknown {
-    // Handle null and undefined
+  private renderValueRecursively(
+    value: unknown,
+    context: Record<string, unknown>,
+    maxOutputBytes?: number
+  ): unknown {
     if (value === null || value === undefined) {
       return value;
     }
 
     if (typeof value === 'string' && value.startsWith('${{') && value.endsWith('}}')) {
-      // remove the first $ only as the evaluateExpression removes the {{ and }} later
       return this.evaluateExpression(value.substring(1), context);
     }
 
-    // Handle string values - render them using the template engine
     if (typeof value === 'string') {
-      return this.renderString(value, context);
+      return this.renderString(value, context, maxOutputBytes);
     }
 
-    // Handle arrays - recursively render each element
     if (Array.isArray(value)) {
-      return value.map((item) => this.renderValueRecursively(item, context));
+      return value.map((item) => this.renderValueRecursively(item, context, maxOutputBytes));
     }
 
-    // Handle objects - recursively render each property
     if (typeof value === 'object') {
       const renderedObject: Record<string, unknown> = {};
       for (const [key, val] of Object.entries(value)) {
-        renderedObject[key] = this.renderValueRecursively(val, context);
+        renderedObject[key] = this.renderValueRecursively(val, context, maxOutputBytes);
       }
       return renderedObject;
     }
 
-    // Return primitive values as-is (numbers, booleans, etc.)
     return value;
   }
 
@@ -105,13 +105,38 @@ export class WorkflowTemplatingEngine {
     }
   }
 
-  private renderString(template: string, context: Record<string, unknown>): string {
+  private renderString(
+    template: string,
+    context: Record<string, unknown>,
+    maxOutputBytes?: number
+  ): string {
     try {
       this.validateTemplate(template);
+
+      if (maxOutputBytes && maxOutputBytes > 0) {
+        const tpl = this.engine.parse(template);
+        const ctx = new Context(context, this.engine.options, { sync: true });
+        const emitter = new SizeLimitedEmitter(
+          maxOutputBytes,
+          (limit) => new TemplateSizeLimitExceeded(limit)
+        );
+        toValueSync(this.engine.renderer.renderTemplates(tpl, ctx, emitter));
+        return emitter.buffer;
+      }
+
       return this.engine.parseAndRenderSync(template, context);
     } catch (error) {
+      if (error instanceof TemplateSizeLimitExceeded) {
+        throw error;
+      }
+      const originalError = (error as any)?.originalError ?? (error as any)?.cause;
+      if (originalError instanceof TemplateSizeLimitExceeded) {
+        throw originalError;
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      // customer-facing error message without the default line number and column number
+      if (errorMessage.includes('TemplateSizeLimitExceeded')) {
+        throw new TemplateSizeLimitExceeded(maxOutputBytes ?? 0);
+      }
       const customerFacingErrorMessage = errorMessage.replace(/, line:\d+, col:\d+/g, '');
       throw new Error(customerFacingErrorMessage);
     }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
@@ -16,6 +16,12 @@ import type { WorkflowContextManager } from './workflow_context_manager';
 import type { WorkflowExecutionState } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { RunStepResult } from '../step/node_implementation';
+import {
+  parseByteSize,
+  safeOutputSize,
+  WorkflowOutputBudgetExceeded,
+  DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE,
+} from '../step/errors';
 import { parseDuration } from '../utils';
 
 import type { IWorkflowEventLogger } from '../workflow_event_logger';
@@ -162,7 +168,45 @@ export class StepExecutionRuntime {
     }
 
     this.workflowExecutionState.upsertStep(stepExecutionUpdate);
+
+    if (stepOutput != null) {
+      const outputBytes = safeOutputSize(stepOutput);
+      if (outputBytes > 0) {
+        this.workflowExecutionState.addOutputBytes(outputBytes);
+        const budgetBytes = this.resolveCumulativeOutputBudget();
+        if (budgetBytes > 0 && this.workflowExecutionState.cumulativeOutputBytes > budgetBytes) {
+          throw new WorkflowOutputBudgetExceeded(
+            budgetBytes,
+            this.workflowExecutionState.cumulativeOutputBytes,
+            this.node.stepId
+          );
+        }
+      }
+    }
+
     this.logStepComplete(stepExecutionUpdate);
+  }
+
+  private resolveCumulativeOutputBudget(): number {
+    try {
+      const settings = this.workflowExecution?.workflowDefinition?.settings;
+      const yamlLimit = settings?.['max-total-output-size'];
+      if (yamlLimit) {
+        return parseByteSize(yamlLimit);
+      }
+
+      const config = this.contextManager.getDependencies().config;
+      if (config?.maxCumulativeOutputSize) {
+        const configValue = config.maxCumulativeOutputSize;
+        return typeof configValue === 'number'
+          ? configValue
+          : (configValue as any).getValueInBytes();
+      }
+
+      return parseByteSize(DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE);
+    } catch {
+      return parseByteSize(DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE);
+    }
   }
 
   public failStep(error: Error): void {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/step_execution_runtime.ts
@@ -15,13 +15,13 @@ import { ExecutionError } from '@kbn/workflows/server';
 import type { WorkflowContextManager } from './workflow_context_manager';
 import type { WorkflowExecutionState } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
-import type { RunStepResult } from '../step/node_implementation';
 import {
+  DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE,
   parseByteSize,
   safeOutputSize,
   WorkflowOutputBudgetExceeded,
-  DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE,
 } from '../step/errors';
+import type { RunStepResult } from '../step/node_implementation';
 import { parseDuration } from '../utils';
 
 import type { IWorkflowEventLogger } from '../workflow_event_logger';
@@ -197,10 +197,7 @@ export class StepExecutionRuntime {
 
       const config = this.contextManager.getDependencies().config;
       if (config?.maxCumulativeOutputSize) {
-        const configValue = config.maxCumulativeOutputSize;
-        return typeof configValue === 'number'
-          ? configValue
-          : (configValue as any).getValueInBytes();
+        return config.maxCumulativeOutputSize.getValueInBytes();
       }
 
       return parseByteSize(DEFAULT_MAX_CUMULATIVE_OUTPUT_SIZE);

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_execution_state.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/tests/workflow_execution_state.test.ts
@@ -461,4 +461,23 @@ describe('WorkflowExecutionState', () => {
       ).toEqual(['11', '22', '33', '44']);
     });
   });
+
+  describe('cumulative output tracking', () => {
+    it('should start at 0', () => {
+      expect(underTest.cumulativeOutputBytes).toBe(0);
+    });
+
+    it('should accumulate bytes', () => {
+      underTest.addOutputBytes(100);
+      underTest.addOutputBytes(200);
+      expect(underTest.cumulativeOutputBytes).toBe(300);
+    });
+
+    it('should track across many calls', () => {
+      for (let i = 0; i < 100; i++) {
+        underTest.addOutputBytes(1024);
+      }
+      expect(underTest.cumulativeOutputBytes).toBe(100 * 1024);
+    });
+  });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_context_manager.ts
@@ -25,6 +25,7 @@ import type { ContextDependencies } from './types';
 import type { WorkflowExecutionState } from './workflow_execution_state';
 import { WorkflowScopeStack } from './workflow_scope_stack';
 import type { WorkflowTemplatingEngine } from '../templating_engine';
+import { resolveMaxStepSizeBytes } from '../step/errors';
 import { buildStepExecutionId, isTemplateExpression } from '../utils';
 import { isSerializedError } from '../utils/errors';
 
@@ -146,7 +147,12 @@ export class WorkflowContextManager {
    */
   public renderValueAccordingToContext<T>(obj: T, additionalContext?: Record<string, unknown>): T {
     const context = this.getContext();
-    return this.templateEngine.render(obj, { ...context, ...additionalContext });
+    const maxOutputBytes = resolveMaxStepSizeBytes(
+      this.node,
+      this.workflowExecutionState.getWorkflowExecution(),
+      this.dependencies.config
+    );
+    return this.templateEngine.render(obj, { ...context, ...additionalContext }, maxOutputBytes);
   }
 
   public evaluateExpressionInContext(template: string): unknown {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_context_manager/workflow_execution_state.ts
@@ -19,6 +19,7 @@ export class WorkflowExecutionState {
   private workflowExecution: EsWorkflowExecution;
   private workflowDocumentChanges: Partial<EsWorkflowExecution> | undefined = undefined;
   private stepDocumentsChanges: Map<string, Partial<EsWorkflowStepExecution>> = new Map();
+  private _cumulativeOutputBytes = 0;
 
   /**
    * Maps step IDs to their execution IDs in chronological order.
@@ -27,6 +28,14 @@ export class WorkflowExecutionState {
    * (e.g., in loops or retries).
    */
   private stepIdExecutionIdIndex = new Map<string, string[]>();
+
+  public get cumulativeOutputBytes(): number {
+    return this._cumulativeOutputBytes;
+  }
+
+  public addOutputBytes(bytes: number): void {
+    this._cumulativeOutputBytes += bytes;
+  }
 
   constructor(
     initialWorkflowExecution: EsWorkflowExecution,

--- a/src/platform/plugins/shared/workflows_management/common/lib/validate_step_count.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/validate_step_count.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowYaml } from '@kbn/workflows/spec/schema';
+import { validateStepCount } from './validate_step_count';
+
+const makeSteps = (count: number): WorkflowYaml['steps'] =>
+  Array.from({ length: count }, (_, i) => ({
+    name: `step_${i}`,
+    type: 'data.set' as any,
+    with: { payload: 'x' },
+  }));
+
+const makeWorkflow = (
+  stepCount: number,
+  settings?: Record<string, unknown>
+): WorkflowYaml =>
+  ({
+    name: 'test-workflow',
+    triggers: [{ type: 'manual' }],
+    steps: makeSteps(stepCount),
+    settings,
+  } as unknown as WorkflowYaml);
+
+describe('validateStepCount', () => {
+  it('should pass for a small workflow', () => {
+    const result = validateStepCount(makeWorkflow(10));
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should pass at exactly the default limit (150)', () => {
+    const result = validateStepCount(makeWorkflow(150));
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should fail when exceeding the default limit (150)', () => {
+    const result = validateStepCount(makeWorkflow(151));
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].count).toBe(151);
+    expect(result.errors[0].maxSteps).toBe(150);
+    expect(result.errors[0].message).toContain('exceeds the maximum of 150 steps');
+  });
+
+  it('should respect a custom max-steps setting', () => {
+    const result = validateStepCount(makeWorkflow(11, { 'max-steps': 10 }));
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0].maxSteps).toBe(10);
+  });
+
+  it('should pass when under a custom max-steps setting', () => {
+    const result = validateStepCount(makeWorkflow(200, { 'max-steps': 500 }));
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should count steps inside foreach', () => {
+    const workflow = {
+      name: 'test',
+      triggers: [{ type: 'manual' }],
+      steps: [
+        {
+          name: 'loop',
+          type: 'foreach',
+          foreach: '{{ items }}',
+          steps: [
+            { name: 'inner_1', type: 'data.set', with: { payload: 'x' } },
+            { name: 'inner_2', type: 'data.set', with: { payload: 'y' } },
+          ],
+        },
+      ],
+      settings: { 'max-steps': 2 },
+    } as unknown as WorkflowYaml;
+
+    const result = validateStepCount(workflow);
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0].count).toBeGreaterThan(2);
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/common/lib/validate_step_count.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/validate_step_count.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { WorkflowYaml } from '@kbn/workflows/spec/schema';
+import { collectAllStepNames } from './validate_step_names';
+
+const DEFAULT_MAX_STEPS = 150;
+
+interface StepCountValidationError {
+  count: number;
+  maxSteps: number;
+  message: string;
+}
+
+export interface StepCountValidationResult {
+  isValid: boolean;
+  errors: StepCountValidationError[];
+}
+
+export function validateStepCount(workflow: WorkflowYaml): StepCountValidationResult {
+  const maxSteps =
+    (workflow.settings as { 'max-steps'?: number } | undefined)?.['max-steps'] ?? DEFAULT_MAX_STEPS;
+
+  const stepNames = collectAllStepNames(workflow.steps);
+
+  const fallbackSteps = (
+    workflow.settings as { 'on-failure'?: { fallback?: unknown } } | undefined
+  )?.['on-failure']?.fallback;
+  if (Array.isArray(fallbackSteps)) {
+    stepNames.push(...collectAllStepNames(fallbackSteps as WorkflowYaml['steps']));
+  }
+
+  const count = stepNames.length;
+
+  if (count > maxSteps) {
+    return {
+      isValid: false,
+      errors: [
+        {
+          count,
+          maxSteps,
+          message: `Workflow exceeds the maximum of ${maxSteps} steps (found ${count}). Consider splitting into child workflows using 'workflow.execute'.`,
+        },
+      ],
+    };
+  }
+
+  return { isValid: true, errors: [] };
+}

--- a/src/platform/plugins/shared/workflows_management/common/lib/validate_step_names.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/validate_step_names.ts
@@ -21,9 +21,10 @@ export interface StepNameValidationResult {
 }
 
 /**
- * Collects all step names from a workflow definition recursively
+ * Collects all step names from a workflow definition recursively.
+ * Walks foreach, if/else, parallel branches, and on-failure fallbacks.
  */
-function collectAllStepNames(steps: WorkflowYaml['steps']): string[] {
+export function collectAllStepNames(steps: WorkflowYaml['steps']): string[] {
   const stepNames: string[] = [];
 
   if (!steps || !Array.isArray(steps)) {

--- a/src/platform/plugins/shared/workflows_management/common/lib/validate_workflow_yaml.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/validate_workflow_yaml.ts
@@ -11,6 +11,7 @@ import type { WorkflowYaml } from '@kbn/workflows';
 import type { z } from '@kbn/zod/v4';
 import { InvalidYamlSchemaError, InvalidYamlSyntaxError } from './errors';
 import { validateLiquidTemplate } from './validate_liquid_template';
+import { validateStepCount } from './validate_step_count';
 import { validateStepNameUniqueness } from './validate_step_names';
 import type { TriggerDefinitionForValidateTriggers } from './validate_triggers';
 import { validateTriggers } from './validate_triggers';
@@ -82,6 +83,19 @@ export function validateWorkflowYaml(
       }
     } catch {
       // Structure too malformed for step name validation
+    }
+
+    try {
+      const stepCountValidation = validateStepCount(parsedWorkflow);
+      for (const stepCountError of stepCountValidation.errors) {
+        diagnostics.push({
+          severity: 'error',
+          message: stepCountError.message,
+          source: 'step-count',
+        });
+      }
+    } catch {
+      // Structure too malformed for step count validation
     }
 
     if (options?.triggerDefinitions) {


### PR DESCRIPTION
## Summary

Implements Phase 2 of the Workflow Execution Limits & Guardrails epic. These limits protect Kibana from memory exhaustion, runaway workflows, and unbounded context growth.

- **LiquidJS OOM prevention** (`TemplateSizeLimitExceeded`): `SizeLimitedEmitter` stops template rendering mid-execution when output exceeds `max-step-size`, before the full string materialises in memory. Closes the OOM vector from Liquid `for` loops with large iterations.
- **Cumulative output budget** (`WorkflowOutputBudgetExceeded`): tracks total bytes across all step completions; throws when the workflow-level `max-total-output-size` (default 150MB, configurable per workflow via settings YAML) is exceeded.
- **Step count validation** (`WorkflowStepCountExceeded`): rejects workflows at save time if they exceed `max-steps` (default 150, configurable). Counts steps recursively across `foreach`, `if`, and nested branches.
- **Workflow output size cap** (`WorkflowOutputSizeExceeded`): limits the output a child workflow can return to its parent via `workflow.execute` (default 5MB).
- **Config fields**: `maxCumulativeOutputSize` (150MB) and `maxWorkflowOutputSize` (5MB) added to plugin config.

### Code quality fixes (same PR)
- Removed `(node as any)` cast in `resolveMaxStepSizeBytes` — use `'configuration' in node` runtime guard
- Removed `(configValue as any).getValueInBytes()` casts — call directly on `ByteSizeValue`
- Replaced fragile `error.message.includes('TemplateSizeLimitExceeded')` string-match with a proper error cause-chain walker
- Fixed test mock missing Phase 2 config fields (was causing 27 type errors)
- Corrected two test expectations: `SizeLimitedEmitter` fires `TemplateSizeLimitExceeded`, not `StepSizeLimitExceeded`

## Test Plan

- [ ] New integration tests: `TemplateSizeLimitExceeded` via Liquid for-loop, `WorkflowOutputBudgetExceeded` via workflow-level YAML budget
- [ ] All 12 `response_size_limits` integration tests pass
- [ ] Type check clean (`0 errors`) for both `workflows_execution_engine` and `workflows_management`
- [ ] Manual testing guide: `src/platform/plugins/shared/workflows_execution_engine/docs/manual_testing_phase2_execution_limits.md`

## References

Closes elastic/security-team#16270
Closes elastic/security-team#15837
Partially addresses elastic/security-team#15842