### PR TITLE
[@kbn/discover-enhanced-plugin] Fix flaky aiops bundle detection in CDP perf test

### DIFF
--- a/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/test/scout/ui/tests/discover_cdp_perf.spec.ts
@@ -52,8 +52,8 @@ test.describe(
       const currentUrl = page.url();
       expect(currentUrl).toContain('app/discover#/');
 
-      // Ensure all JS bundles are loaded
-      await perfTracker.waitForJsLoad(cdp);
+      // Ensure all JS bundles are loaded (longer timeout to account for lazy-loaded plugins like aiops)
+      await perfTracker.waitForJsLoad(cdp, 5000);
 
       // Collect and validate stats
       const stats = perfTracker.collectJsBundleStats(currentUrl);


### PR DESCRIPTION
## Summary

The Discover CDP perf test ("collects and validates JS Bundles loaded on page") occasionally failed in CI (e.g. 1/25 runs) because the expected "aiops" plugin bundle was missing from the captured list. The aiops plugin is lazily loaded by Discover; the default 2s idle timeout in `waitForJsLoad` was sometimes too short for that request to be initiated and captured.

## Changes

- Increase `waitForJsLoad` timeout from 2s to 5s in the bundle-validation test so lazy-loaded plugins (e.g. aiops) are consistently captured before stats are collected.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->