### PR TITLE
[8.19] Fix Failing test: Profiling API Integration tests (cloud)  - Profiling API tests flamegraph.spec.ts cloud Loading profiling data Flamegraph api With data returns correct AddressOrLine

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/profiling/tests/flamegraph.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration/profiling/tests/flamegraph.spec.ts
@@ -27,8 +27,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   const end = new Date('2023-03-17T01:00:30.000Z').getTime();
 
   registry.when('Flamegraph api', { config: 'cloud' }, () => {
-    // Failing: See https://github.com/elastic/kibana/issues/229739
-    describe.skip('With data', () => {
+    describe('With data', () => {
       let flamegraph: BaseFlameGraph;
       before(async () => {
         await setupProfiling(bettertest, log);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229739

## Summary

- Re-enabled API tests flamegraphs

Ran them 55 times and never failed 

[temp_file20260317_135231.txt](https://github.com/user-attachments/files/26057079/temp_file20260317_135231.txt)



