### PR TITLE
[Agent Builder] Default Elastic capabilities for persisted default agent

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { AgentType, AgentVisibility } from '@kbn/agent-builder-common';
+import { agentBuilderDefaultAgentId, AgentType, AgentVisibility } from '@kbn/agent-builder-common';
 import type { AgentCreateRequest, AgentUpdateRequest } from '../../../../../common/agents';
 import type { AgentProperties } from './storage';
 import type { Document } from './converters';
@@ -117,6 +117,17 @@ describe('fromEs', () => {
     const definition = fromEs(document);
 
     expect(definition.configuration.skill_ids).toEqual(['skill-1', 'skill-2']);
+    expect(definition.configuration.enable_elastic_capabilities).toBe(true);
+  });
+
+  it('defaults enable_elastic_capabilities to true for default agent when missing', () => {
+    const document = getSampleDoc();
+    document._source!.id = agentBuilderDefaultAgentId;
+    // @ts-ignore testing missing field
+    delete document._source!.config!.enable_elastic_capabilities;
+
+    const definition = fromEs(document);
+
     expect(definition.configuration.enable_elastic_capabilities).toBe(true);
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/persisted/client/converters.ts
@@ -6,7 +6,7 @@
  */
 
 import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
-import { AgentType, AgentVisibility } from '@kbn/agent-builder-common';
+import { agentBuilderDefaultAgentId, AgentType, AgentVisibility } from '@kbn/agent-builder-common';
 import type { UserIdAndName } from '@kbn/agent-builder-common';
 import type { AgentCreateRequest, AgentUpdateRequest } from '../../../../../common/agents';
 import type { AgentConfigurationProperties, AgentProperties } from './storage';
@@ -24,9 +24,11 @@ export const fromEs = (document: Document): PersistedAgentDefinition => {
   const configuration: AgentConfigurationProperties =
     document._source.configuration ?? document._source.config;
 
+  // backward compatibility with M1 - we check the document id.
+  const resolvedId = document._source.id ?? document._id;
+
   return {
-    // backward compatibility with M1 - we check the document id.
-    id: document._source.id ?? document._id,
+    id: resolvedId,
     type: document._source.type,
     name: document._source.name,
     description: document._source.description,
@@ -45,7 +47,9 @@ export const fromEs = (document: Document): PersistedAgentDefinition => {
       instructions: configuration.instructions,
       tools: configuration.tools,
       skill_ids: configuration.skill_ids,
-      enable_elastic_capabilities: configuration.enable_elastic_capabilities,
+      enable_elastic_capabilities:
+        configuration.enable_elastic_capabilities ??
+        (resolvedId === agentBuilderDefaultAgentId ? true : undefined),
       workflow_ids: configuration.workflow_ids,
     },
   };


### PR DESCRIPTION
When the persisted default agent predates the enable_elastic_capabilities flag, treat a missing value as true to preserve expected default-agent behavior.