### PR TITLE
Risk Level Chart With Watchlist Filtering

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/constants.ts
@@ -5,7 +5,18 @@
  * 2.0.
  */
 
+import { i18n } from '@kbn/i18n';
+
 export const WATCHLISTS_URL = `/api/entity_analytics/watchlists` as const;
 export const WATCHLISTS_MANAGEMENT_URL = `${WATCHLISTS_URL}/management` as const;
 export const WATCHLISTS_DATA_SOURCE_URL = `${WATCHLISTS_URL}/{watchlist_id}/entity_source` as const;
 export const WATCHLISTS_DATA_SOURCE_LIST_URL = `${WATCHLISTS_DATA_SOURCE_URL}/list` as const;
+
+export const PREBUILT_WATCHLIST_NAMES: Record<string, string> = {
+  'prebuilt-priv': i18n.translate(
+    'xpack.securitySolution.entityAnalytics.watchlists.prebuiltPrivName',
+    {
+      defaultMessage: 'Privileged Users',
+    }
+  ),
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/constants.ts
@@ -16,7 +16,7 @@ export const PREBUILT_WATCHLIST_NAMES: Record<string, string> = {
   'prebuilt-priv': i18n.translate(
     'xpack.securitySolution.entityAnalytics.watchlists.prebuiltPrivName',
     {
-      defaultMessage: 'Privileged Users',
+      defaultMessage: 'Privileged User',
     }
   ),
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/watchlists/utils.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ENTITY_ANALYTICS_WATCHLISTS_PREFIX = '.entity-analytics.watchlists';
+
+export const getIndexForWatchlist = (watchlistName: string, namespace: string) =>
+  `${ENTITY_ANALYTICS_WATCHLISTS_PREFIX}.${watchlistName}-${namespace}`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_get_watchlists.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { useEntityAnalyticsRoutes } from '../api';
+
+export const useGetWatchlists = () => {
+  const { fetchWatchlists } = useEntityAnalyticsRoutes();
+
+  return useQuery({
+    queryKey: ['watchlists'],
+    queryFn: ({ signal }) => fetchWatchlists({ signal }),
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { RiskScoreDonutChart } from './risk_score_donut_chart';
+import { useWatchlistRiskLevelsQuery } from './watchlists/hooks/use_watchlist_risk_levels_query';
+import { RiskSeverity } from '../../../common/search_strategy';
+import { PREBUILT_WATCHLIST_NAMES } from '../../../common/entity_analytics/watchlists/constants';
+import { useSpaceId } from '../../common/hooks/use_space_id';
+import { RiskLevelBreakdownTable } from './threat_hunting/risk_level_breakdown_table';
+import { useCombinedRiskScoreKpi } from './threat_hunting/use_combined_risk_score_kpi';
+
+interface DynamicRiskLevelPanelProps {
+  watchlistId?: string;
+  skip?: boolean;
+}
+
+export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
+  watchlistId,
+  skip = false,
+}) => {
+  const spaceId = useSpaceId();
+  const hasWatchlist = !!watchlistId;
+
+  // Always call both hooks, but use `skip` to prevent unnecessary network requests
+  const combinedRiskStats = useCombinedRiskScoreKpi(skip || hasWatchlist);
+  const watchlistRiskStats = useWatchlistRiskLevelsQuery({
+    watchlistId: watchlistId ?? '',
+    skip: skip || !hasWatchlist,
+    spaceId: spaceId ?? '',
+  });
+
+  const severityCount = useMemo(() => {
+    if (hasWatchlist) {
+      return {
+        [RiskSeverity.Critical]:
+          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
+        [RiskSeverity.High]:
+          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
+        [RiskSeverity.Moderate]:
+          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
+        [RiskSeverity.Low]:
+          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
+        [RiskSeverity.Unknown]:
+          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Unknown)?.count ?? 0,
+      };
+    }
+    return combinedRiskStats.severityCount;
+  }, [hasWatchlist, combinedRiskStats.severityCount, watchlistRiskStats.records]);
+
+  const loading = hasWatchlist ? watchlistRiskStats.isLoading : combinedRiskStats.loading;
+  const isModuleDisabled = hasWatchlist
+    ? !watchlistRiskStats.hasEngineBeenInstalled
+    : combinedRiskStats.isModuleDisabled;
+
+  if (isModuleDisabled && !loading) {
+    return null;
+  }
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h3>
+            {hasWatchlist ? (
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.watchlistTitle"
+                defaultMessage="{watchlistName} risk levels"
+                values={{
+                  watchlistName: PREBUILT_WATCHLIST_NAMES[watchlistId] ?? watchlistId,
+                }}
+              />
+            ) : (
+              <FormattedMessage
+                id="xpack.securitySolution.entityAnalytics.dynamicRiskLevel.entityTitle"
+                defaultMessage="Entity risk levels"
+              />
+            )}
+          </h3>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup alignItems="center" gutterSize="l" responsive={false}>
+          <EuiFlexItem grow={4}>
+            <RiskLevelBreakdownTable severityCount={severityCount} loading={loading} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={1}>
+            <RiskScoreDonutChart severityCount={severityCount} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
@@ -15,6 +15,7 @@ import { PREBUILT_WATCHLIST_NAMES } from '../../../common/entity_analytics/watch
 import { useSpaceId } from '../../common/hooks/use_space_id';
 import { RiskLevelBreakdownTable } from './threat_hunting/risk_level_breakdown_table';
 import { useCombinedRiskScoreKpi } from './threat_hunting/use_combined_risk_score_kpi';
+import { useKibana } from '../../common/lib/kibana';
 
 interface DynamicRiskLevelPanelProps {
   watchlistId?: string;
@@ -27,37 +28,41 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
 }) => {
   const spaceId = useSpaceId();
   const hasWatchlist = !!watchlistId;
+  const { uiSettings } = useKibana().services;
+  const isEntityStoreV2Enabled = uiSettings.get<boolean>('securitySolution:entityStoreEnableV2');
+
+  const useLegacyCombined = !hasWatchlist && !isEntityStoreV2Enabled;
 
   // Always call both hooks, but use `skip` to prevent unnecessary network requests
-  const combinedRiskStats = useCombinedRiskScoreKpi(skip || hasWatchlist);
+  const combinedRiskStats = useCombinedRiskScoreKpi(skip || !useLegacyCombined);
   const watchlistRiskStats = useWatchlistRiskLevelsQuery({
     watchlistId: watchlistId ?? '',
-    skip: skip || !hasWatchlist,
+    skip: skip || useLegacyCombined,
     spaceId: spaceId ?? '',
   });
 
   const severityCount = useMemo(() => {
-    if (hasWatchlist) {
-      return {
-        [RiskSeverity.Critical]:
-          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
-        [RiskSeverity.High]:
-          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
-        [RiskSeverity.Moderate]:
-          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
-        [RiskSeverity.Low]:
-          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
-        [RiskSeverity.Unknown]:
-          watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Unknown)?.count ?? 0,
-      };
+    if (useLegacyCombined) {
+      return combinedRiskStats.severityCount;
     }
-    return combinedRiskStats.severityCount;
-  }, [hasWatchlist, combinedRiskStats.severityCount, watchlistRiskStats.records]);
+    return {
+      [RiskSeverity.Critical]:
+        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
+      [RiskSeverity.High]:
+        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
+      [RiskSeverity.Moderate]:
+        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
+      [RiskSeverity.Low]:
+        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
+      [RiskSeverity.Unknown]:
+        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Unknown)?.count ?? 0,
+    };
+  }, [useLegacyCombined, combinedRiskStats.severityCount, watchlistRiskStats.records]);
 
-  const loading = hasWatchlist ? watchlistRiskStats.isLoading : combinedRiskStats.loading;
-  const isModuleDisabled = hasWatchlist
-    ? !watchlistRiskStats.hasEngineBeenInstalled
-    : combinedRiskStats.isModuleDisabled;
+  const loading = useLegacyCombined ? combinedRiskStats.loading : watchlistRiskStats.isLoading;
+  const isModuleDisabled = useLegacyCombined
+    ? combinedRiskStats.isModuleDisabled
+    : !watchlistRiskStats.hasEngineBeenInstalled;
 
   if (isModuleDisabled && !loading) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/dynamic_risk_level_panel.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RiskScoreDonutChart } from './risk_score_donut_chart';
-import { useWatchlistRiskLevelsQuery } from './watchlists/hooks/use_watchlist_risk_levels_query';
+import { useRiskLevelsEsqlQuery } from './watchlists/hooks/use_risk_levels_esql_query';
 import { RiskSeverity } from '../../../common/search_strategy';
 import { PREBUILT_WATCHLIST_NAMES } from '../../../common/entity_analytics/watchlists/constants';
 import { useSpaceId } from '../../common/hooks/use_space_id';
@@ -31,38 +31,38 @@ export const DynamicRiskLevelPanel: React.FC<DynamicRiskLevelPanelProps> = ({
   const { uiSettings } = useKibana().services;
   const isEntityStoreV2Enabled = uiSettings.get<boolean>('securitySolution:entityStoreEnableV2');
 
-  const useLegacyCombined = !hasWatchlist && !isEntityStoreV2Enabled;
+  const useLegacy = !isEntityStoreV2Enabled;
 
   // Always call both hooks, but use `skip` to prevent unnecessary network requests
-  const combinedRiskStats = useCombinedRiskScoreKpi(skip || !useLegacyCombined);
-  const watchlistRiskStats = useWatchlistRiskLevelsQuery({
+  const combinedRiskStats = useCombinedRiskScoreKpi(skip || !useLegacy);
+  const riskLevelsStats = useRiskLevelsEsqlQuery({
     watchlistId: watchlistId ?? '',
-    skip: skip || useLegacyCombined,
+    skip: skip || useLegacy,
     spaceId: spaceId ?? '',
   });
 
   const severityCount = useMemo(() => {
-    if (useLegacyCombined) {
+    if (useLegacy) {
       return combinedRiskStats.severityCount;
     }
     return {
       [RiskSeverity.Critical]:
-        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
+        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Critical)?.count ?? 0,
       [RiskSeverity.High]:
-        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
+        riskLevelsStats.records.find((r) => r.level === RiskSeverity.High)?.count ?? 0,
       [RiskSeverity.Moderate]:
-        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
+        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Moderate)?.count ?? 0,
       [RiskSeverity.Low]:
-        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
+        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Low)?.count ?? 0,
       [RiskSeverity.Unknown]:
-        watchlistRiskStats.records.find((r) => r.level === RiskSeverity.Unknown)?.count ?? 0,
+        riskLevelsStats.records.find((r) => r.level === RiskSeverity.Unknown)?.count ?? 0,
     };
-  }, [useLegacyCombined, combinedRiskStats.severityCount, watchlistRiskStats.records]);
+  }, [useLegacy, combinedRiskStats.severityCount, riskLevelsStats.records]);
 
-  const loading = useLegacyCombined ? combinedRiskStats.loading : watchlistRiskStats.isLoading;
-  const isModuleDisabled = useLegacyCombined
+  const loading = useLegacy ? combinedRiskStats.loading : riskLevelsStats.isLoading;
+  const isModuleDisabled = useLegacy
     ? combinedRiskStats.isModuleDisabled
-    : !watchlistRiskStats.hasEngineBeenInstalled;
+    : !riskLevelsStats.hasEngineBeenInstalled;
 
   if (isModuleDisabled && !loading) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/privileged_user_monitoring/components/privileged_users_table/columns.tsx
@@ -353,7 +353,7 @@ export const buildPrivilegedUsersTableColumns = (
   getPrivilegedUserColumn(),
   getRiskScoreColumn(euiTheme),
   getAssetCriticalityColumn(),
+  getAlertDistributionColumn(),
   getLabelColumn(),
   getDataSourceColumn(),
-  getAlertDistributionColumn(),
 ];

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/threat_hunting_entities_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/threat_hunting/threat_hunting_entities_table.tsx
@@ -15,12 +15,17 @@ import {
   EuiBadge,
   EuiText,
   EuiIcon,
+  EuiLoadingSpinner,
+  EuiLink,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { noop, get } from 'lodash/fp';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { SecurityPageName, useNavigation } from '@kbn/security-solution-navigation';
+import { encode } from '@kbn/rison';
+import { DistributionBar } from '@kbn/security-solution-distribution-bar';
 import { useErrorToast } from '../../../common/hooks/use_error_toast';
 import { useQueryInspector } from '../../../common/components/page/manage_query';
 import { Direction } from '../../../../common/search_strategy/common';
@@ -28,8 +33,7 @@ import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
 import type { Criteria, Columns } from '../../../explore/components/paginated_table';
 import { PaginatedTable } from '../../../explore/components/paginated_table';
-import type { EntityType } from '../../../../common/entity_analytics/types';
-import { EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
+import { EntityType, EntityTypeToIdentifierField } from '../../../../common/entity_analytics/types';
 import {
   EntityTypeToLevelField,
   EntityTypeToScoreField,
@@ -55,6 +59,23 @@ import {
   EntityPanelKeyByType,
   EntityPanelParamByType,
 } from '../../../flyout/entity_details/shared/constants';
+import { ALERTS_QUERY_NAMES } from '../../../detections/containers/detection_engine/alerts/constants';
+import type { AlertsByStatusAgg } from '../../../overview/components/detection_response/alerts_by_status/types';
+import { useSignalIndex } from '../../../detections/containers/detection_engine/alerts/use_signal_index';
+import {
+  getAlertsByStatusQuery,
+  parseAlertsData,
+} from '../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
+import { useQueryAlerts } from '../../../detections/containers/detection_engine/alerts/use_query';
+import { formatPageFilterSearchParam } from '../../../../common/utils/format_page_filter_search_param';
+import { URL_PARAM_KEY } from '../../../common/hooks/constants';
+import {
+  OPEN_IN_ALERTS_TITLE_STATUS,
+  OPEN_IN_ALERTS_TITLE_USERNAME,
+  OPEN_IN_ALERTS_TITLE_HOSTNAME,
+} from '../../../overview/components/detection_response/translations';
+import { FILTER_ACKNOWLEDGED, FILTER_OPEN } from '../../../../common/types';
+import { getFormattedAlertStats } from '../../../flyout/document_details/shared/components/alert_count_insight';
 
 const THREAT_HUNTING_TABLE_ID = 'threat-hunting-table';
 
@@ -117,11 +138,102 @@ const getRiskScoreColors = (
   }
 };
 
+const EntityAlertDistribution: React.FC<{ entityType: EntityType; entityName: string }> = ({
+  entityType,
+  entityName,
+}) => {
+  const { signalIndexName } = useSignalIndex();
+  const { from, to } = useGlobalTime();
+  const { euiTheme } = useEuiTheme();
+
+  const fieldName = EntityTypeToIdentifierField[entityType] || 'entity.id';
+
+  const { data, setQuery: setAlertsQuery } = useQueryAlerts<{}, AlertsByStatusAgg>({
+    query: getAlertsByStatusQuery({
+      from,
+      to,
+      entityFilter: { field: fieldName, value: entityName },
+    }),
+    indexName: signalIndexName,
+    queryName: ALERTS_QUERY_NAMES.BY_STATUS,
+  });
+
+  useEffect(() => {
+    setAlertsQuery(
+      getAlertsByStatusQuery({
+        from,
+        to,
+        entityFilter: { field: fieldName, value: entityName },
+      })
+    );
+  }, [setAlertsQuery, from, to, fieldName, entityName]);
+
+  const { navigateTo } = useNavigation();
+
+  if (!data) return <EuiLoadingSpinner size="m" />;
+
+  const alertsData = parseAlertsData(data);
+  const alertStats = getFormattedAlertStats(alertsData, euiTheme);
+
+  const alertCount = (alertsData?.open?.total ?? 0) + (alertsData?.acknowledged?.total ?? 0);
+
+  const timerange = encode({
+    global: {
+      [URL_PARAM_KEY.timerange]: {
+        kind: 'absolute',
+        from,
+        to,
+      },
+    },
+  });
+
+  const titleForEntity =
+    entityType === EntityType.host ? OPEN_IN_ALERTS_TITLE_HOSTNAME : OPEN_IN_ALERTS_TITLE_USERNAME;
+
+  const filters = [
+    {
+      title: titleForEntity,
+      selected_options: [entityName],
+      field_name: fieldName,
+    },
+    {
+      title: OPEN_IN_ALERTS_TITLE_STATUS,
+      selected_options: [FILTER_OPEN, FILTER_ACKNOWLEDGED],
+      field_name: 'kibana.alert.workflow_status',
+    },
+  ];
+
+  const urlFilterParams = encode(formatPageFilterSearchParam(filters));
+  const timerangePath = timerange ? `&timerange=${timerange}` : '';
+
+  const openAlertsPage = () => {
+    navigateTo({
+      deepLinkId: SecurityPageName.alerts,
+      path: `?${URL_PARAM_KEY.pageFilter}=${urlFilterParams}${timerangePath}`,
+      openInNewTab: true,
+    });
+  };
+
+  return (
+    <EuiFlexGroup direction="row">
+      <EuiFlexItem>
+        <DistributionBar
+          stats={alertStats}
+          hideLastTooltip
+          data-test-subj="threat-hunting-alerts-distribution-bar"
+        />
+      </EuiFlexItem>
+      <EuiBadge color="hollow">{<EuiLink onClick={openAlertsPage}>{alertCount}</EuiLink>}</EuiBadge>
+    </EuiFlexGroup>
+  );
+};
+
 export type ThreatHuntingEntitiesColumns = [
   Columns<Entity>,
   Columns<string, Entity>,
   Columns<string | undefined, Entity>,
   Columns<CriticalityLevels, Entity>,
+  Columns<Entity>,
   Columns<Entity>,
   Columns<Entity>,
   Columns<string, Entity>
@@ -255,40 +367,7 @@ const useThreatHuntingColumns = (): ThreatHuntingEntitiesColumns => {
           </span>
         );
       },
-      width: '25%',
-    },
-    {
-      field: 'entity.source',
-      name: (
-        <FormattedMessage
-          id="xpack.securitySolution.entityAnalytics.threatHunting.sourceColumn.title"
-          defaultMessage="Source"
-        />
-      ),
-      width: '25%',
-      truncateText: { lines: 2 },
-      render: (source: string | undefined) => {
-        if (source != null) {
-          return sourceFieldToText(source);
-        }
-        return getEmptyTagValue();
-      },
-    },
-    {
-      field: 'asset.criticality',
-      name: (
-        <FormattedMessage
-          id="xpack.securitySolution.entityAnalytics.threatHunting.criticalityColumn.title"
-          defaultMessage="Criticality"
-        />
-      ),
-      width: '10%',
-      render: (criticality: CriticalityLevels) => {
-        if (criticality != null) {
-          return <span>{CRITICALITY_LEVEL_TITLE[criticality]}</span>;
-        }
-        return getEmptyTagValue();
-      },
+      width: '20%',
     },
     {
       name: (
@@ -363,16 +442,63 @@ const useThreatHuntingColumns = (): ThreatHuntingEntitiesColumns => {
       },
     },
     {
+      field: 'asset.criticality',
+      name: (
+        <FormattedMessage
+          id="xpack.securitySolution.entityAnalytics.threatHunting.criticalityColumn.title"
+          defaultMessage="Asset Criticality"
+        />
+      ),
+      width: '10%',
+      render: (criticality: CriticalityLevels) => {
+        if (criticality != null) {
+          return <span>{CRITICALITY_LEVEL_TITLE[criticality]}</span>;
+        }
+        return getEmptyTagValue();
+      },
+    },
+    {
+      name: (
+        <FormattedMessage
+          id="xpack.securitySolution.entityAnalytics.threatHunting.alertsColumn.title"
+          defaultMessage="Alerts"
+        />
+      ),
+      render: (entity: Entity) => {
+        const entityType = getEntityType(entity);
+        const entityName = entity.entity.name;
+        if (!entityName) return getEmptyTagValue();
+        return <EntityAlertDistribution entityType={entityType} entityName={entityName} />;
+      },
+    },
+    {
+      field: 'entity.source',
+      name: (
+        <FormattedMessage
+          id="xpack.securitySolution.entityAnalytics.threatHunting.sourceColumn.title"
+          defaultMessage="Source"
+        />
+      ),
+      width: '15%',
+      truncateText: { lines: 2 },
+      render: (source: string | undefined) => {
+        if (source != null) {
+          return sourceFieldToText(source);
+        }
+        return getEmptyTagValue();
+      },
+    },
+    {
       field: '@timestamp',
       name: (
         <FormattedMessage
           id="xpack.securitySolution.entityAnalytics.threatHunting.lastUpdateColumn.title"
-          defaultMessage="Last Update"
+          defaultMessage="Last Seen"
         />
       ),
       sortable: true,
-      render: (lastUpdate: string) => {
-        return <FormattedRelativePreferenceDate value={lastUpdate} />;
+      render: (lastSeen: string) => {
+        return <FormattedRelativePreferenceDate value={lastSeen} />;
       },
       width: '15%',
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RiskSeverity } from '../../../../../common/search_strategy';
+
+export interface WatchlistRiskLevelsQueryResult extends Record<string, string | number> {
+  level: RiskSeverity;
+  count: number;
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_risk_levels_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_risk_levels_esql_query.ts
@@ -15,16 +15,12 @@ import { useRiskEngineStatus } from '../../../api/hooks/use_risk_engine_status';
 import { useErrorToast } from '../../../../common/hooks/use_error_toast';
 import { useEsqlGlobalFilterQuery } from '../../../../common/hooks/esql/use_esql_global_filter';
 import { useKibana } from '../../../../common/lib/kibana';
-import { useGetDefaultRiskIndex } from '../../../hooks/use_get_default_risk_index';
 import type { WatchlistRiskLevelsQueryResult } from './types';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
-import {
-  getWatchlistRiskLevelsQueryBody,
-  getWatchlistRiskLevelsQueryBodyV2,
-} from '../queries/watchlist_risk_level_esql_query';
+import { getWatchlistRiskLevelsQueryBodyV2 } from '../queries/watchlist_risk_level_esql_query';
 import { PREBUILT_WATCHLIST_NAMES } from '../../../../../common/entity_analytics/watchlists/constants';
 
-export const useWatchlistRiskLevelsQuery = ({
+export const useRiskLevelsEsqlQuery = ({
   watchlistId,
   skip,
   spaceId,
@@ -33,24 +29,17 @@ export const useWatchlistRiskLevelsQuery = ({
   skip?: boolean;
   spaceId: string;
 }) => {
-  const { data, uiSettings } = useKibana().services;
-  const isEntityStoreV2Enabled = uiSettings.get<boolean>('securitySolution:entityStoreEnableV2');
+  const { data } = useKibana().services;
 
-  const v1Index = useGetDefaultRiskIndex(true); // only latest
-  const v2Index = `.entities.v2.latest.security_${spaceId}`;
-  const index = isEntityStoreV2Enabled ? v2Index : v1Index;
+  const index = `.entities.v2.latest.security_${spaceId}`;
 
   const filterQuery = useEsqlGlobalFilterQuery();
 
   const watchlistName = watchlistId
     ? PREBUILT_WATCHLIST_NAMES[watchlistId] ?? watchlistId
-    : undefined;
-  const query = isEntityStoreV2Enabled
-    ? `FROM ${index} ${getWatchlistRiskLevelsQueryBodyV2(watchlistName)}`
-    : `FROM ${index} ${getWatchlistRiskLevelsQueryBody(spaceId, watchlistId)}`;
+    : undefined; // This is using a map due to name formatting adhering to indexPattern naming conventions
+  const query = `FROM ${index} ${getWatchlistRiskLevelsQueryBodyV2(watchlistName)}`;
 
-  // eslint-disable-next-line no-console
-  console.log('query', query);
   const {
     data: riskEngineStatus,
     isFetching: isStatusLoading,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_watchlist_risk_levels_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_watchlist_risk_levels_query.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useMemo } from 'react';
+import { getESQLResults, prettifyQuery } from '@kbn/esql-utils';
+import { useQuery } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
+import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
+import { useRiskEngineStatus } from '../../../api/hooks/use_risk_engine_status';
+import { useErrorToast } from '../../../../common/hooks/use_error_toast';
+import { useEsqlGlobalFilterQuery } from '../../../../common/hooks/esql/use_esql_global_filter';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useGetDefaultRiskIndex } from '../../../hooks/use_get_default_risk_index';
+import type { WatchlistRiskLevelsQueryResult } from './types';
+import { esqlResponseToRecords } from '../../../../common/utils/esql';
+import { getWatchlistRiskLevelsQueryBody } from '../queries/watchlist_risk_level_esql_query';
+
+export const useWatchlistRiskLevelsQuery = ({
+  watchlistId,
+  skip,
+  spaceId,
+}: {
+  watchlistId: string;
+  skip: boolean;
+  spaceId: string;
+}) => {
+  const { data } = useKibana().services;
+
+  const index = useGetDefaultRiskIndex(true); // only latest
+  const filterQuery = useEsqlGlobalFilterQuery();
+
+  const query = `FROM ${index} ${getWatchlistRiskLevelsQueryBody(watchlistId, spaceId)}`;
+
+  const {
+    data: riskEngineStatus,
+    isFetching: isStatusLoading,
+    refetch: refetchEngineStatus,
+  } = useRiskEngineStatus();
+
+  const {
+    isRefetching,
+    data: result,
+    error,
+    isError,
+    refetch,
+  } = useQuery<
+    {
+      response: ESQLSearchResponse;
+      params: ESQLSearchParams;
+    },
+    SecurityAppError
+  >(
+    [], // query doesn't need a key since it is only run when refetch is called
+    async ({ signal }) =>
+      getESQLResults({
+        esqlQuery: query,
+        search: data.search.search,
+        signal,
+        filter: filterQuery,
+      }),
+    {
+      keepPreviousData: true,
+      enabled: false,
+      retry: 1, // retry once on failure
+    }
+  );
+
+  // Hide unknown index errors from UI because they index might take some time to be created
+  const filteredError = error && !error.message.includes('Unknown index') ? error : undefined;
+
+  useErrorToast(
+    i18n.translate('xpack.securitySolution.entityAnalytics.watchlists.riskLevels.queryError', {
+      defaultMessage: 'There was an error loading the data',
+    }),
+    filteredError
+  );
+
+  const response = result?.response;
+
+  const inspect = useMemo(() => {
+    return {
+      dsl: [JSON.stringify({ index: index ? [index] : [''], body: prettifyQuery(query) }, null, 2)],
+      response: response ? [JSON.stringify(response, null, 2)] : [],
+    };
+  }, [index, query, response]);
+
+  // Fetch risk score when components mounts or when the risk engine status changes
+  useEffect(() => {
+    if (!skip && !isStatusLoading && riskEngineStatus?.risk_engine_status !== 'NOT_INSTALLED') {
+      refetch();
+    }
+  }, [riskEngineStatus, isStatusLoading, refetch, skip]);
+
+  return {
+    records: esqlResponseToRecords<WatchlistRiskLevelsQueryResult>(response),
+    isLoading: isRefetching || isStatusLoading,
+    refetch: refetchEngineStatus, // refetching the status will force the risk score to be fetched,
+    inspect,
+    error,
+    isRefetching,
+    isError,
+    hasEngineBeenInstalled: riskEngineStatus?.risk_engine_status !== 'NOT_INSTALLED',
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_watchlist_risk_levels_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/hooks/use_watchlist_risk_levels_query.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { getESQLResults, prettifyQuery } from '@kbn/esql-utils';
 import { useQuery } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
@@ -18,29 +18,48 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { useGetDefaultRiskIndex } from '../../../hooks/use_get_default_risk_index';
 import type { WatchlistRiskLevelsQueryResult } from './types';
 import { esqlResponseToRecords } from '../../../../common/utils/esql';
-import { getWatchlistRiskLevelsQueryBody } from '../queries/watchlist_risk_level_esql_query';
+import {
+  getWatchlistRiskLevelsQueryBody,
+  getWatchlistRiskLevelsQueryBodyV2,
+} from '../queries/watchlist_risk_level_esql_query';
+import { PREBUILT_WATCHLIST_NAMES } from '../../../../../common/entity_analytics/watchlists/constants';
 
 export const useWatchlistRiskLevelsQuery = ({
   watchlistId,
   skip,
   spaceId,
 }: {
-  watchlistId: string;
-  skip: boolean;
+  watchlistId?: string;
+  skip?: boolean;
   spaceId: string;
 }) => {
-  const { data } = useKibana().services;
+  const { data, uiSettings } = useKibana().services;
+  const isEntityStoreV2Enabled = uiSettings.get<boolean>('securitySolution:entityStoreEnableV2');
 
-  const index = useGetDefaultRiskIndex(true); // only latest
+  const v1Index = useGetDefaultRiskIndex(true); // only latest
+  const v2Index = `.entities.v2.latest.security_${spaceId}`;
+  const index = isEntityStoreV2Enabled ? v2Index : v1Index;
+
   const filterQuery = useEsqlGlobalFilterQuery();
 
-  const query = `FROM ${index} ${getWatchlistRiskLevelsQueryBody(watchlistId, spaceId)}`;
+  const watchlistName = watchlistId
+    ? PREBUILT_WATCHLIST_NAMES[watchlistId] ?? watchlistId
+    : undefined;
+  const query = isEntityStoreV2Enabled
+    ? `FROM ${index} ${getWatchlistRiskLevelsQueryBodyV2(watchlistName)}`
+    : `FROM ${index} ${getWatchlistRiskLevelsQueryBody(spaceId, watchlistId)}`;
 
+  // eslint-disable-next-line no-console
+  console.log('query', query);
   const {
     data: riskEngineStatus,
     isFetching: isStatusLoading,
     refetch: refetchEngineStatus,
   } = useRiskEngineStatus();
+
+  const isEnabled =
+    !skip && !isStatusLoading && riskEngineStatus?.risk_engine_status !== 'NOT_INSTALLED';
+  const queryKey = useMemo(() => ['watchlistRiskLevels', query, filterQuery], [query, filterQuery]);
 
   const {
     isRefetching,
@@ -55,7 +74,7 @@ export const useWatchlistRiskLevelsQuery = ({
     },
     SecurityAppError
   >(
-    [], // query doesn't need a key since it is only run when refetch is called
+    queryKey,
     async ({ signal }) =>
       getESQLResults({
         esqlQuery: query,
@@ -65,7 +84,7 @@ export const useWatchlistRiskLevelsQuery = ({
       }),
     {
       keepPreviousData: true,
-      enabled: false,
+      enabled: isEnabled,
       retry: 1, // retry once on failure
     }
   );
@@ -89,17 +108,15 @@ export const useWatchlistRiskLevelsQuery = ({
     };
   }, [index, query, response]);
 
-  // Fetch risk score when components mounts or when the risk engine status changes
-  useEffect(() => {
-    if (!skip && !isStatusLoading && riskEngineStatus?.risk_engine_status !== 'NOT_INSTALLED') {
-      refetch();
-    }
-  }, [riskEngineStatus, isStatusLoading, refetch, skip]);
+  const handleRefetch = () => {
+    refetchEngineStatus();
+    refetch();
+  };
 
   return {
     records: esqlResponseToRecords<WatchlistRiskLevelsQueryResult>(response),
     isLoading: isRefetching || isStatusLoading,
-    refetch: refetchEngineStatus, // refetching the status will force the risk score to be fetched,
+    refetch: handleRefetch,
     inspect,
     error,
     isRefetching,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/helpers.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getPrivilegedMonitorUsersIndex } from '../../../../../common/entity_analytics/privileged_user_monitoring/utils';
+import { getIndexForWatchlist } from '../../../../../common/entity_analytics/watchlists/utils';
+
+export const getWatchlistJoin = (watchlistId: string, namespace: string) => {
+  if (watchlistId === 'prebuilt-priv') {
+    return `| RENAME @timestamp AS event_timestamp
+  | LOOKUP JOIN ${getPrivilegedMonitorUsersIndex(namespace)} ON user.name
+  | RENAME event_timestamp AS @timestamp
+  | WHERE user.is_privileged == true`;
+  }
+
+  // Assuming regular watchlists are also joined on user.name for user risk panels.
+  // In the future, this might need to dynamically join on host.name depending on the watchlist entity type.
+  return `| RENAME @timestamp AS event_timestamp
+  | LOOKUP JOIN ${getIndexForWatchlist(watchlistId, namespace)} ON user.name
+  | RENAME event_timestamp AS @timestamp`; // TODO: this is not a guarantee. Ask Tiago / Mark for this one.
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RiskScoreFields } from '../../../../../common/search_strategy';
+import { getWatchlistJoin } from './helpers';
+
+export const getWatchlistRiskLevelsQueryBody = (watchlistId: string, namespace: string) => `
+| WHERE ${RiskScoreFields.userName} IS NOT NULL
+${getWatchlistJoin(watchlistId, namespace)}
+| STATS count = COUNT_DISTINCT(${RiskScoreFields.userName}) BY ${RiskScoreFields.userRisk}
+| RENAME ${RiskScoreFields.userRisk} AS level`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
@@ -5,15 +5,6 @@
  * 2.0.
  */
 
-import { RiskScoreFields } from '../../../../../common/search_strategy';
-import { getWatchlistJoin } from './helpers';
-
-export const getWatchlistRiskLevelsQueryBody = (namespace: string, watchlistId?: string) => `
-| WHERE ${RiskScoreFields.userName} IS NOT NULL
-${watchlistId ? getWatchlistJoin(watchlistId, namespace) : ''}
-| STATS count = COUNT_DISTINCT(${RiskScoreFields.userName}) BY ${RiskScoreFields.userRisk}
-| RENAME ${RiskScoreFields.userRisk} AS level`;
-
 export const getWatchlistRiskLevelsQueryBodyV2 = (watchlistName?: string) => `
 | WHERE  entity.EngineMetadata.Type IN ("user", "host", "service")${
   watchlistName ? ` AND entity.attributes.watchlists == "${watchlistName}"` : ''

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/queries/watchlist_risk_level_esql_query.ts
@@ -8,8 +8,15 @@
 import { RiskScoreFields } from '../../../../../common/search_strategy';
 import { getWatchlistJoin } from './helpers';
 
-export const getWatchlistRiskLevelsQueryBody = (watchlistId: string, namespace: string) => `
+export const getWatchlistRiskLevelsQueryBody = (namespace: string, watchlistId?: string) => `
 | WHERE ${RiskScoreFields.userName} IS NOT NULL
-${getWatchlistJoin(watchlistId, namespace)}
+${watchlistId ? getWatchlistJoin(watchlistId, namespace) : ''}
 | STATS count = COUNT_DISTINCT(${RiskScoreFields.userName}) BY ${RiskScoreFields.userRisk}
 | RENAME ${RiskScoreFields.userRisk} AS level`;
+
+export const getWatchlistRiskLevelsQueryBodyV2 = (watchlistName?: string) => `
+| WHERE  entity.EngineMetadata.Type IN ("user", "host", "service")${
+  watchlistName ? ` AND entity.attributes.watchlists == "${watchlistName}"` : ''
+}
+| STATS count = COUNT(*) BY entity.risk.calculated_level
+| RENAME entity.risk.calculated_level AS level`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/watchlist_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/watchlist_filter.tsx
@@ -11,23 +11,18 @@ import { EuiIcon, EuiComboBox, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useLocation } from 'react-router-dom';
 
 import { useNavigation } from '../../../common/lib/kibana';
+import { useGetWatchlists } from '../../api/hooks/use_get_watchlists';
 import {
   ENTITY_ANALYTICS_THREAT_HUNTING_PATH,
   ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
 } from '../../../../common/constants';
 import {
-  WATCHLIST_CUSTOM_C_LEVEL_USERS_LABEL,
-  WATCHLIST_CUSTOM_HIGH_RISK_USERS_LABEL,
-  WATCHLIST_CUSTOM_WATCHLIST_3_LABEL,
   WATCHLIST_FILTER_LABEL,
   WATCHLIST_FILTER_PLACEHOLDER,
   WATCHLIST_GROUP_CUSTOM_LABEL,
   WATCHLIST_GROUP_PREBUILT_LABEL,
   WATCHLIST_ICON_GEAR_ARIA_LABEL,
   WATCHLIST_ICON_PIN_ARIA_LABEL,
-  WATCHLIST_PREBUILT_DEPARTING_EMPLOYEES_LABEL,
-  WATCHLIST_PREBUILT_PRIVILEGED_USERS_LABEL,
-  WATCHLIST_PREBUILT_UNAUTHORIZED_LLM_ACCESS_LABEL,
 } from './translations';
 import type { WatchlistItem, WatchlistOption } from './types';
 
@@ -35,33 +30,7 @@ interface WatchlistFilterProps {
   onChangeSelectedId?: (id: string) => void;
 }
 
-// TODO: demo purposes, replace with management API data https://github.com/elastic/security-team/issues/15463?issue=elastic%7Csecurity-team%7C15981
-const WATCHLIST_OPTIONS: WatchlistOption[] = [
-  {
-    prepend: (
-      <EuiIcon type="pin" aria-label={WATCHLIST_ICON_PIN_ARIA_LABEL} style={{ marginRight: 8 }} />
-    ),
-    id: 'group-prebuilt',
-    label: WATCHLIST_GROUP_PREBUILT_LABEL,
-    isGroupLabelOption: true,
-  },
-  { id: 'prebuilt-priv', label: WATCHLIST_PREBUILT_PRIVILEGED_USERS_LABEL },
-  { id: 'prebuilt-llm', label: WATCHLIST_PREBUILT_UNAUTHORIZED_LLM_ACCESS_LABEL },
-  { id: 'prebuilt-depart', label: WATCHLIST_PREBUILT_DEPARTING_EMPLOYEES_LABEL },
-
-  {
-    prepend: (
-      <EuiIcon type="gear" aria-label={WATCHLIST_ICON_GEAR_ARIA_LABEL} style={{ marginRight: 8 }} />
-    ),
-    id: 'group-custom',
-    label: WATCHLIST_GROUP_CUSTOM_LABEL,
-    isGroupLabelOption: true,
-  },
-  { id: 'custom-clevel', label: WATCHLIST_CUSTOM_C_LEVEL_USERS_LABEL },
-  { id: 'custom-highrisk', label: WATCHLIST_CUSTOM_HIGH_RISK_USERS_LABEL },
-  { id: 'custom-3', label: WATCHLIST_CUSTOM_WATCHLIST_3_LABEL },
-];
-
+// TODO: remove this when backend route available for mapping specific prebuilt watchlists to routes
 const WATCHLIST_ROUTE_MAP: Record<string, string> = {
   'prebuilt-priv': ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
 };
@@ -71,8 +40,61 @@ const ROUTE_TO_WATCHLIST_MAP: Record<string, string> = Object.fromEntries(
 ) as Record<string, string>;
 
 export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) => {
-  // TODO: replace data with watchlist management API https://github.com/elastic/security-team/issues/15463?issue=elastic%7Csecurity-team%7C15981
-  const options = WATCHLIST_OPTIONS;
+  const { data: watchlists, isLoading } = useGetWatchlists();
+
+  const options = useMemo<WatchlistOption[]>(() => {
+    if (!watchlists) return [];
+
+    const prebuilt: WatchlistOption[] = [
+      {
+        prepend: (
+          <EuiIcon
+            type="pin"
+            aria-label={WATCHLIST_ICON_PIN_ARIA_LABEL}
+            style={{ marginRight: 8 }}
+          />
+        ),
+        id: 'group-prebuilt',
+        label: WATCHLIST_GROUP_PREBUILT_LABEL,
+        isGroupLabelOption: true,
+      },
+    ];
+
+    const custom: WatchlistOption[] = [
+      {
+        prepend: (
+          <EuiIcon
+            type="gear"
+            aria-label={WATCHLIST_ICON_GEAR_ARIA_LABEL}
+            style={{ marginRight: 8 }}
+          />
+        ),
+        id: 'group-custom',
+        label: WATCHLIST_GROUP_CUSTOM_LABEL,
+        isGroupLabelOption: true,
+      },
+    ];
+
+    watchlists.forEach((watchlist) => {
+      const option: WatchlistItem = {
+        id: watchlist.name, // Changed to match by name
+        label: watchlist.name,
+      };
+
+      if (watchlist.managed) {
+        prebuilt.push(option);
+      } else {
+        custom.push(option);
+      }
+    });
+
+    // Only show groups if they have items
+    const result: WatchlistOption[] = [];
+    if (prebuilt.length > 1) result.push(...prebuilt);
+    if (custom.length > 1) result.push(...custom);
+
+    return result;
+  }, [watchlists]);
 
   const { pathname } = useLocation();
 
@@ -101,6 +123,7 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
 
       navigateTo({
         path: nextPath,
+        state: { retainFilters: true }, // Add this to preserve global filters/time range on navigation
       });
     },
     [navigateTo]
@@ -114,8 +137,20 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
 
       if (newlySelected?.id) {
         onChangeSelectedId?.(newlySelected.id);
+
+        const mappedPath = WATCHLIST_ROUTE_MAP[newlySelected.id];
+        // eslint-disable-next-line no-console
+        console.log(
+          `[Watchlist Filter] Selected ID: "${newlySelected.id}". ` +
+            `Available mappings: ${JSON.stringify(WATCHLIST_ROUTE_MAP)}. ` +
+            `Would map to Privileged User Monitoring? ${
+              mappedPath === ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH ? 'YES' : 'NO'
+            }`
+        );
+
         navigateToWatchlist(newlySelected.id);
       } else {
+        onChangeSelectedId?.('');
         navigateToWatchlist(undefined);
       }
     },
@@ -135,6 +170,7 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
           selectedOptions={selected ? [selected] : []}
           onChange={onChangeComboBox}
           isClearable={true}
+          isLoading={isLoading}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/watchlist_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/watchlists/watchlist_filter.tsx
@@ -5,17 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import { EuiIcon, EuiComboBox, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { useLocation } from 'react-router-dom';
 
-import { useNavigation } from '../../../common/lib/kibana';
 import { useGetWatchlists } from '../../api/hooks/use_get_watchlists';
-import {
-  ENTITY_ANALYTICS_THREAT_HUNTING_PATH,
-  ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
-} from '../../../../common/constants';
 import {
   WATCHLIST_FILTER_LABEL,
   WATCHLIST_FILTER_PLACEHOLDER,
@@ -25,22 +19,21 @@ import {
   WATCHLIST_ICON_PIN_ARIA_LABEL,
 } from './translations';
 import type { WatchlistItem, WatchlistOption } from './types';
+import { PREBUILT_WATCHLIST_NAMES } from '../../../../common/entity_analytics/watchlists/constants';
 
 interface WatchlistFilterProps {
-  onChangeSelectedId?: (id: string) => void;
+  onChangeSelectedId?: (id: string | undefined) => void;
+  selectedId?: string;
 }
 
-// TODO: remove this when backend route available for mapping specific prebuilt watchlists to routes
-const WATCHLIST_ROUTE_MAP: Record<string, string> = {
-  'prebuilt-priv': ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH,
-};
-
-const ROUTE_TO_WATCHLIST_MAP: Record<string, string> = Object.fromEntries(
-  Object.entries(WATCHLIST_ROUTE_MAP).map(([id, path]) => [path, id])
-) as Record<string, string>;
-
-export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) => {
+export const WatchlistFilter = ({
+  onChangeSelectedId,
+  selectedId: propSelectedId,
+}: WatchlistFilterProps) => {
   const { data: watchlists, isLoading } = useGetWatchlists();
+
+  const [internalSelectedId, setInternalSelectedId] = useState<string | undefined>();
+  const currentSelectedId = propSelectedId !== undefined ? propSelectedId : internalSelectedId;
 
   const options = useMemo<WatchlistOption[]>(() => {
     if (!watchlists) return [];
@@ -78,7 +71,7 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
     watchlists.forEach((watchlist) => {
       const option: WatchlistItem = {
         id: watchlist.name, // Changed to match by name
-        label: watchlist.name,
+        label: PREBUILT_WATCHLIST_NAMES[watchlist.name] ?? watchlist.name,
       };
 
       if (watchlist.managed) {
@@ -96,10 +89,6 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
     return result;
   }, [watchlists]);
 
-  const { pathname } = useLocation();
-
-  const { navigateTo } = useNavigation();
-
   const getItemById = useCallback(
     (id?: string) =>
       options.find(
@@ -108,25 +97,9 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
     [options]
   );
 
-  const selectedIdFromRoute = useMemo(() => ROUTE_TO_WATCHLIST_MAP[pathname], [pathname]);
-
   const selected = useMemo(
-    () => (selectedIdFromRoute ? getItemById(selectedIdFromRoute) : null),
-    [getItemById, selectedIdFromRoute]
-  );
-
-  const navigateToWatchlist = useCallback(
-    (watchlistId?: string) => {
-      const isCleared = !watchlistId;
-      const mappedPath = watchlistId ? WATCHLIST_ROUTE_MAP[watchlistId] : undefined;
-      const nextPath = !isCleared && mappedPath ? mappedPath : ENTITY_ANALYTICS_THREAT_HUNTING_PATH;
-
-      navigateTo({
-        path: nextPath,
-        state: { retainFilters: true }, // Add this to preserve global filters/time range on navigation
-      });
-    },
-    [navigateTo]
+    () => (currentSelectedId ? getItemById(currentSelectedId) : null),
+    [getItemById, currentSelectedId]
   );
 
   const onChangeComboBox = useCallback(
@@ -135,26 +108,11 @@ export const WatchlistFilter = ({ onChangeSelectedId }: WatchlistFilterProps) =>
         | WatchlistItem
         | undefined;
 
-      if (newlySelected?.id) {
-        onChangeSelectedId?.(newlySelected.id);
-
-        const mappedPath = WATCHLIST_ROUTE_MAP[newlySelected.id];
-        // eslint-disable-next-line no-console
-        console.log(
-          `[Watchlist Filter] Selected ID: "${newlySelected.id}". ` +
-            `Available mappings: ${JSON.stringify(WATCHLIST_ROUTE_MAP)}. ` +
-            `Would map to Privileged User Monitoring? ${
-              mappedPath === ENTITY_ANALYTICS_PRIVILEGED_USER_MONITORING_PATH ? 'YES' : 'NO'
-            }`
-        );
-
-        navigateToWatchlist(newlySelected.id);
-      } else {
-        onChangeSelectedId?.('');
-        navigateToWatchlist(undefined);
-      }
+      const newId = newlySelected?.id;
+      setInternalSelectedId(newId);
+      onChangeSelectedId?.(newId);
     },
-    [onChangeSelectedId, navigateToWatchlist]
+    [onChangeSelectedId]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_threat_hunting_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_threat_hunting_page.test.tsx
@@ -36,8 +36,8 @@ jest.mock('../../data_view_manager/hooks/use_data_view', () => ({
   })),
 }));
 
-jest.mock('../components/threat_hunting/combined_risk_donut_chart', () => ({
-  CombinedRiskDonutChart: () => (
+jest.mock('../components/dynamic_risk_level_panel', () => ({
+  DynamicRiskLevelPanel: () => (
     <div data-test-subj="combined-risk-donut-chart">{'Donut Chart'}</div>
   ),
 }));

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_threat_hunting_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_threat_hunting_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiPanel } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SecurityPageName } from '../../app/types';
@@ -21,7 +21,7 @@ import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { PageLoader } from '../../common/components/page_loader';
 import { PageScope } from '../../data_view_manager/constants';
-import { CombinedRiskDonutChart } from '../components/threat_hunting/combined_risk_donut_chart';
+import { DynamicRiskLevelPanel } from '../components/dynamic_risk_level_panel';
 import { AnomaliesPlaceholderPanel } from '../components/threat_hunting/anomalies_placeholder_panel';
 import { ThreatHuntingEntitiesTable } from '../components/threat_hunting/threat_hunting_entities_table';
 import { WatchlistFilter } from '../components/watchlists/watchlist_filter';
@@ -39,6 +39,8 @@ export const EntityThreatHuntingPage = () => {
     () => (newDataViewPickerEnabled ? status !== 'ready' : oldIsSourcererLoading),
     [newDataViewPickerEnabled, oldIsSourcererLoading, status]
   );
+
+  const [selectedWatchlistId, setSelectedWatchlistId] = useState<string | undefined>();
 
   const indicesExist = useMemo(
     () => (newDataViewPickerEnabled ? !!dataView?.matchedIndices?.length : oldIndicesExist),
@@ -73,7 +75,7 @@ export const EntityThreatHuntingPage = () => {
               defaultMessage="Entity Threat Hunting"
             />
           }
-          rightSideItems={[<WatchlistFilter />]}
+          rightSideItems={[<WatchlistFilter onChangeSelectedId={setSelectedWatchlistId} />]}
         />
 
         {isSourcererLoading ? (
@@ -85,7 +87,7 @@ export const EntityThreatHuntingPage = () => {
               <EuiPanel hasBorder>
                 <EuiFlexGroup responsive={false} gutterSize="l">
                   <EuiFlexItem grow={1}>
-                    <CombinedRiskDonutChart />
+                    <DynamicRiskLevelPanel watchlistId={selectedWatchlistId} />
                   </EuiFlexItem>
                   <EuiFlexItem grow={1}>
                     <AnomaliesPlaceholderPanel />

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/index.tsx
@@ -45,6 +45,7 @@ import type {
 import type { TlsColumns } from '../../network/components/tls_table/columns';
 import type { UncommonProcessTableColumns } from '../../hosts/components/uncommon_process_table/columns';
 import type { HostRiskScoreColumns } from '../../../entity_analytics/components/host_risk_score_table';
+import type { ThreatHuntingEntitiesColumns } from '../../../entity_analytics/components/threat_hunting/threat_hunting_entities_table';
 
 import type { UsersColumns } from '../../network/components/users_table/columns';
 import { HeaderSection } from '../../../common/components/header_section';
@@ -98,7 +99,8 @@ declare type BasicTableColumns =
   | UncommonProcessTableColumns
   | UsersColumns
   | UsersTableColumns
-  | EntitiesListColumns;
+  | EntitiesListColumns
+  | ThreatHuntingEntitiesColumns;
 
 export declare type SiemTables = BasicTableProps<BasicTableColumns>;
 


### PR DESCRIPTION
## Summary 

This PR hooks up the global Watchlist filter to the new Watchlists API and introduces a dynamic, ES|QL Risk Level panel that updates based on watchlist selection using entity store v2 index. 

Additionally, this PR adds the alerts column to the entities table on threat hunting page / entity analytics dashboard and renames the Criticality column to Asset Criticality; Last Update to Last Seen column and re-orders columns to closer match original design: https://github.com/elastic/security-team/issues/14550

### Demo: Risk Panels Filtering 
https://github.com/user-attachments/assets/8b1be94d-b06c-4b35-9e77-5f229b22c241

**Testing Steps** 

0. Feature Flags to enable: `xpack.securitySolution.enableExperimental: ['entityThreatHuntingEnabled', 'entityAnalyticsWatchlistEnabled']`
1. Document Generator command: `yarn start  privmon-quick` (to populate privmon data)
2. Document Generator command: `yarn start entity-store` (to populate entities for threat hunting page)
3. To test this locally, you must create a "prebuilt" watchlist via Dev Tools (where managed: true signifies prebuilt):
```
 POST kbn:/api/entity_analytics/watchlists
  {
      "name": "prebuilt-priv",
      "description": "Prebuilt Privmon",
      "riskModifier": 10,
      "managed": true
  }
```
4. Head over to threat hunting page - select privileged users from dropdown, compare results on the risk chart to those on the privmon page. They should be the same - queries below. 
5. Clear filter, note donut chart should show original entities risks. 
6. ... Have a Donut 🍩 thank you for testing! 

** 🔍  Queries to compare, using dev tools:** 

**No Watchlist Selection:** 
```
POST /_query?format=txt
{
  "query": """
    FROM .entities.v2.latest.security_default
    | WHERE entity.EngineMetadata.Type IN ("user", "host", "service")
    | STATS count = COUNT(*) BY entity.risk.calculated_level
    | RENAME entity.risk.calculated_level AS level
  """
}
```

**Privileged User Watchlist Selection:**
```
POST /_query?format=txt
{
  "query": """
    FROM .entities.v2.latest.security_default
    | WHERE entity.EngineMetadata.Type IN ("user", "host", "service") AND entity.attributes.watchlists == "Privileged Users"
    | STATS count = COUNT(*) BY entity.risk.calculated_level
    | RENAME entity.risk.calculated_level AS level
  """
}
```

**Note:** The backend for the prebuilt Privmon watchlist is not fully hooked up yet, so the ES|QL query for prebuilt-priv is hardcoded to fall back to the legacy privmon internal index for now.

**Pending Question:** The ES|QL query currently joins on `user.name`. This works for **medium-confidence** entities, but for **high-confidence IDP entities**, the identifier might be `user.email` or `user.id` or `user.name`. I have an open thread discussing if the Risk Score documents will be updated to include these alternative identifiers to ensure the JOIN works.


### Screenshot: Updated Entities Table 
<img width="1882" height="1107" alt="image" src="https://github.com/user-attachments/assets/f193e997-f426-4975-a92b-7338096a1102" />

#### Screenshot: Previous Entities Table 
<img width="1383" height="529" alt="image" src="https://github.com/user-attachments/assets/595c1464-34e0-4f3c-afd0-c65e804c30ba" />




