### PR TITLE
[9.2] [9.3][Canvas] Fix lens transforms (#257224)

### DIFF
--- a/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_in.test.ts
+++ b/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_in.test.ts
@@ -45,7 +45,7 @@ jest.mock('../kibana_services', () => ({
   embeddableService: {
     getTransforms: jest.fn((type: string) => {
       switch (type) {
-        case 'lens-dashboard-app':
+        case 'lens':
           return { transformIn: mockLensTransformIn };
         case 'visualization':
           return { transformIn: mockVisualizationTransformIn };
@@ -82,7 +82,7 @@ describe('transformWorkpadIn', () => {
       },
     ]);
 
-    expect(embeddableService?.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+    expect(embeddableService?.getTransforms).toHaveBeenCalledWith('lens');
     expect(mockLensTransformIn).toHaveBeenCalledWith({
       savedObjectId: 'test-id',
       title: 'Test lens embeddable',

--- a/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_in.ts
+++ b/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_in.ts
@@ -28,10 +28,7 @@ export const transformWorkpadIn = (
         if (fn.function === 'embeddable') {
           const embeddableConfig = decode(fn.arguments.config[0] as string);
           const embeddableType = fn.arguments.type[0] as string;
-          // Temporary escape hatch for lens as code
-          // TODO remove when lens as code transforms are ready for production
-          const transformType = embeddableType === 'lens' ? 'lens-dashboard-app' : embeddableType;
-          const transforms = embeddableService.getTransforms(transformType);
+          const transforms = embeddableService.getTransforms(embeddableType);
 
           try {
             if (transforms?.transformIn) {

--- a/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_out.test.ts
+++ b/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_out.test.ts
@@ -36,7 +36,7 @@ jest.mock('../kibana_services', () => ({
   embeddableService: {
     getTransforms: jest.fn((type: string) => {
       switch (type) {
-        case 'lens-dashboard-app':
+        case 'lens':
           return mockLensTransforms;
         case 'visualization':
           return mockVisualizationTransforms;
@@ -81,7 +81,7 @@ describe('transformWorkpadOut', () => {
         title: 'Test lens embeddable',
         savedObjectId: 'test-id',
       });
-      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens');
       expect(mockLensTransforms.transformOut).toHaveBeenCalledWith(
         { title: 'Test lens embeddable', savedObjectId: 'test-id' },
         [{ id: 'test-id', name: 'savedObjectRef', type: 'lens' }]
@@ -142,7 +142,7 @@ describe('legacy expressions', () => {
         timeRange: DEFAULT_TIME_RANGE,
         savedObjectId: 'lens-id',
       });
-      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens');
       expect(mockLensTransforms.transformOut).toHaveBeenCalledWith(
         { timeRange: DEFAULT_TIME_RANGE, savedObjectId: 'savedLens.id' },
         [{ id: 'lens-id', name: 'savedObjectRef', type: 'lens' }]
@@ -161,7 +161,7 @@ describe('legacy expressions', () => {
         title: 'My Lens',
         savedObjectId: 'lens-id',
       });
-      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens');
       expect(mockLensTransforms.transformOut).toHaveBeenCalledWith(
         { timeRange: DEFAULT_TIME_RANGE, title: 'My Lens', savedObjectId: 'savedLens.id' },
         [{ id: 'lens-id', name: 'savedObjectRef', type: 'lens' }]
@@ -180,7 +180,7 @@ describe('legacy expressions', () => {
         timeRange: { from: 'now-7d', to: 'now' },
         savedObjectId: 'lens-id',
       });
-      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens');
       expect(mockLensTransforms.transformOut).toHaveBeenCalledWith(
         { timeRange: { from: 'now-7d', to: 'now' }, savedObjectId: 'savedLens.id' },
         [{ id: 'lens-id', name: 'savedObjectRef', type: 'lens' }]
@@ -198,7 +198,7 @@ describe('legacy expressions', () => {
         timeRange: DEFAULT_TIME_RANGE,
         savedObjectId: 'lens-id',
       });
-      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens-dashboard-app');
+      expect(embeddableService.getTransforms).toHaveBeenCalledWith('lens');
       expect(mockLensTransforms.transformOut).toHaveBeenCalledWith(
         { timeRange: DEFAULT_TIME_RANGE, savedObjectId: 'lens-id' },
         []

--- a/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_out.ts
+++ b/x-pack/platform/plugins/private/canvas/server/embeddable/transform_workpad_out.ts
@@ -122,10 +122,7 @@ export function transformWorkpadOut(
 
         const embeddableConfig = decode(fn.arguments.config[0] as string);
         const embeddableType = fn.arguments.type[0] as string;
-        // Temporary escape hatch for lens as code
-        // TODO remove when lens as code transforms are ready for production
-        const transformType = embeddableType === 'lens' ? 'lens-dashboard-app' : embeddableType;
-        const transforms = embeddableService.getTransforms(transformType);
+        const transforms = embeddableService.getTransforms(embeddableType);
 
         try {
           // / BWC: Legacy Canvas embeddables have a savedObjectId and incorrect reference names,


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.3` to `9.2`:
 - [[9.3][Canvas] Fix lens transforms (#257224)](https://github.com/elastic/kibana/pull/255201)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Catherine Liu","email":"catherine.liu@elastic.co"},"sourceCommit":{"committedDate":"2026-03-11T17:31:11Z","message":"[9.3][Canvas] Fix lens transforms (#257224)\n\n## Summary\n\nFollow up to #252191.\n\nThis PR targets 9.3. This replaces mention of the `lens-dashboard-app`\ntemporary lens transforms introduced in 9.4 and accesses the correct\n`lens` transforms.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"28bd0d1904f1b6b7a92330bfaac54eb376558da7"},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip","ci:build-docker-fips"],"title":"Update docker.elastic.co/wolfi/chainguard-base-fips:latest Docker digest to fa87627 (9.3)","number":255201,"url":"https://github.com/elastic/kibana/pull/255201"},"sourceBranch":"9.3","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->