### PR TITLE
skip tests consistently failing on ECH

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_editor_role.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_editor_role.spec.ts
@@ -16,7 +16,12 @@ test.describe('When the user has Editor built-in role', { tag: tags.stateful.cla
     browserAuth,
     pageObjects,
     page,
+    config,
   }) => {
+    test.skip(
+      config.isCloud === true,
+      `This scenario is not working as expected on ECH for 'Editor' role`
+    );
     // Mock the fleet setup API to indicate fleet server is ready
     await page.route('**/api/fleet/agents/setup', (route) =>
       route.fulfill({

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts
@@ -40,6 +40,10 @@ test.describe(
       page,
       config,
     }) => {
+      test.skip(
+        config.isCloud === true && config.serverless === false,
+        `This scenario is not working as expected on ECH`
+      );
       // In the empty state without AI connectors, the Technical Preview badge should be hidden
       await expect(page.getByText('Extract fields from your data')).toBeVisible();
       // Only check for hidden badge in stateful mode - in serverless/production environments,


### PR DESCRIPTION
## Summary

Both tests consistently fail on **ECH** for the latest stateful snapshot build.

```
Location: x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_editor_role.spec.ts

TimeoutError: page.waitForSelector: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('[data-test-subj="fleetSetupLoading"]') to be hidden
    25 × locator resolved to visible <div data-test-subj="fleetSetupLoading" class="euiPanel euiPanel--transparent euiEmptyPrompt css-1a83b8y-euiPanel-m-transparent-euiEmptyPrompt-vertical">…</div>

    at Object.waitForSelector (src/platform/packages/shared/kbn-scout/src/playwright/fixtures/scope/test/scout_page/single_thread.ts:69:27)
    at Proxy.waitForPageToLoad (x-pack/platform/plugins/shared/fleet/test/scout/ui/fixtures/page_objects/fleet_home.ts:25:30)
    at x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_editor_role.spec.ts:38:5
```

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/afd32288-e540-4997-a934-549c55ba232d" />



```
Location: x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts

Error: expect(locator).toBeHidden() failed

Locator:  getByText('Technical Preview')
Expected: hidden
Received: visible
Timeout:  10000ms

Call log:
  - Expect "toBeHidden" with timeout 10000ms
  - waiting for getByText('Technical Preview')
    14 × locator resolved to <span tabindex="0" role="button" class="euiBetaBadge css-17pfqx0-euiBetaBadge-hollow-s-middle">Technical Preview</span>
       - unexpected value "visible"

    at x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_processing/create_steps.spec.ts:50:59
```

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c3920329-98b5-466f-9d15-1a6e8963dbad" />





