### PR TITLE
[ci] Make auto-approve token configurable per whitelist rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3204,6 +3204,10 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.github/workflows/deploy-my-kibana.yml   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
+# Appex QA to own auto-generated scout metadata
+/**/scout/.meta/** @kibanamachine @elastic/appex-qa
+/**/scout_*/.meta/** @kibanamachine @elastic/appex-qa
+
 # These files influence agent behavior and are loaded into every new agent session.
 # Changes here can have repo-wide impact (what instructions/tools/context an agent sees), so require
 # tech lead review by default.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3204,10 +3204,6 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.github/workflows/deploy-my-kibana.yml   @elastic/observablt-robots @elastic/kibana-operations
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
-# Appex QA to own auto-generated scout metadata
-/**/scout/.meta/** @kibanamachine @elastic/appex-qa
-/**/scout_*/.meta/** @kibanamachine @elastic/appex-qa
-
 # These files influence agent behavior and are loaded into every new agent session.
 # Changes here can have repo-wide impact (what instructions/tools/context an agent sees), so require
 # tech lead review by default.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3205,8 +3205,8 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 /.github/workflows/undeploy-my-kibana.yml @elastic/observablt-robots @elastic/kibana-operations
 
 # Appex QA to own auto-generated scout metadata
-/**/scout/.meta/** @kibanamachine @elastic/appex-qa
-/**/scout_*/.meta/** @kibanamachine @elastic/appex-qa
+/**/scout/.meta/**
+/**/scout_*/.meta/**
 
 # These files influence agent behavior and are loaded into every new agent session.
 # Changes here can have repo-wide impact (what instructions/tools/context an agent sees), so require

--- a/.github/workflows/auto-approve-machine-prs.yml
+++ b/.github/workflows/auto-approve-machine-prs.yml
@@ -10,9 +10,6 @@ on:
     types:
       - opened
 
-permissions:
-  pull-requests: write
-
 jobs:
   approve:
     name: Auto-approve machine PR

--- a/.github/workflows/auto-approve-machine-prs.yml
+++ b/.github/workflows/auto-approve-machine-prs.yml
@@ -1,11 +1,17 @@
 # Generic auto-approve for machine-created PRs.
 # Add new rules to the whitelist in the check step; approval runs when any rule matches.
+# Each rule can optionally specify a `token` field to control the approving identity:
+#   'kibana' - approve as kibanamachine using KIBANAMACHINE_TOKEN
+#   'github' - approve as github-actions[bot] using the default GITHUB_TOKEN
 name: Auto-approve machine PRs
 
 on:
   pull_request_target:
     types:
       - opened
+
+permissions:
+  pull-requests: write
 
 jobs:
   approve:
@@ -23,10 +29,10 @@ jobs:
             const baseRef = context.payload.pull_request.base.ref;
 
             const whitelist = [
-              // { user: 'kibanamachine', branchPrefix: 'api_docs', baseMatch: /^main$/ },
-              // { user: 'kibanamachine', branchPrefix: 'backport', baseNotMatch: /^main$/ },
-              { user: 'kibanamachine', branchPrefix: 'scout_metadata_update' },
-              // { user: 'elasticmachine', branchPrefix: 'update-bundled-packages', paths: ['fleet_packages.json'] },
+              // { user: 'kibanamachine', branchPrefix: 'api_docs', baseMatch: /^main$/, token: 'kibana' },
+              // { user: 'kibanamachine', branchPrefix: 'backport', baseNotMatch: /^main$/, token: 'kibana' },
+              { user: 'kibanamachine', branchPrefix: 'scout_metadata_update', token: 'github' },
+              // { user: 'elasticmachine', branchPrefix: 'update-bundled-packages', paths: ['fleet_packages.json'], token: 'kibana' },
             ];
 
             // Fetch the list of changed files in the PR
@@ -39,7 +45,7 @@ jobs:
             const changedFiles = files.data.map(file => file.filename);
             core.info(`Changed files: ${changedFiles.join(', ')}`);
 
-            const matches = whitelist.some((rule) => {
+            const matchedRule = whitelist.find((rule) => {
               if (rule.user !== user) return false;
               if (!headRef.startsWith(rule.branchPrefix)) return false;
               if (rule.baseMatch && !rule.baseMatch.test(baseRef)) return false;
@@ -47,7 +53,7 @@ jobs:
 
               // If paths is specified, verify at least one changed file matches
               if (rule.paths) {
-                const hasMatchingFile = changedFiles.some(file => 
+                const hasMatchingFile = changedFiles.some(file =>
                   rule.paths.some(path => {
                     // Support glob patterns
                     if (path.includes('*')) {
@@ -66,9 +72,13 @@ jobs:
               return true;
             });
 
-            core.setOutput('should_approve', matches ? 'true' : 'false');
+            core.setOutput('should_approve', matchedRule ? 'true' : 'false');
+            core.setOutput('token', matchedRule?.token ?? 'kibana');
 
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
-        if: steps.check.outputs.should_approve == 'true'
+        if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'github'
+
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'kibana'
         with:
           github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}

--- a/.github/workflows/auto-approve-machine-prs.yml
+++ b/.github/workflows/auto-approve-machine-prs.yml
@@ -77,6 +77,8 @@ jobs:
 
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'github'
+        with:
+          github-token: ${{ github.token }}
 
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'kibana'


### PR DESCRIPTION
## Summary

Follow-up to #256650. The scout metadata update pipeline (#252560) creates PRs as `kibanamachine`, which means `kibanamachine` cannot also approve them (GitHub blocks self-approval). The solution is to use `github-actions[bot]` (via the default `GITHUB_TOKEN`) as the approver for scout metadata PRs instead.

This PR makes the approving identity configurable per whitelist rule in the `auto-approve-machine-prs` workflow, and removes the `CODEOWNERS` entries for scout `.meta` files (required so that `github-actions[bot]` can satisfy the review requirement without needing to be a member of `@elastic/appex-qa`).

### Changes

**`.github/workflows/auto-approve-machine-prs.yml`**
- Each whitelist rule can now specify a `token` field:
  - `'kibana'` (default) — approve as `kibanamachine` via `KIBANAMACHINE_TOKEN`
  - `'github'` — approve as `github-actions[bot]` via the default `GITHUB_TOKEN`
- `scout_metadata_update` rule now uses `token: 'github'`
- Changed `whitelist.some()` → `whitelist.find()` to access the matched rule's token
- Split the single approve step into two mutually exclusive steps based on the `token` output
- Added `token` to the commented-out example rules for documentation

**`.github/CODEOWNERS`**
- Removed `/**/scout/.meta/**` and `/**/scout_*/.meta/**` ownership entries so that `github-actions[bot]` can satisfy the review requirement on auto-generated scout metadata PRs

### Related
- #252560 — original scout metadata pipeline
- #254182 — first round of fixes
- #256650 — second round of fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated repository ownership rules to clarify delegated day-to-day edit permissions and tech-lead oversight for agent-related content.
* Enhanced the automated approval workflow to support token-based routing for conditional approval paths, improving delegation and review gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->