### PR TITLE
Add optional onClick to UserMenuLink

### DIFF
--- a/x-pack/platform/packages/shared/security/plugin_types_public/src/nav_control/nav_control_service.ts
+++ b/x-pack/platform/packages/shared/security/plugin_types_public/src/nav_control/nav_control_service.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IconType } from '@elastic/eui';
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import type { Observable } from 'rxjs';
 
 export interface UserMenuLink {
@@ -15,6 +15,7 @@ export interface UserMenuLink {
   href: string;
   order?: number;
   setAsProfile?: boolean;
+  onClick?: (event: MouseEvent<Element>) => void;
   /** Render a custom ReactNode instead of the default <EuiContextMenuItem /> */
   content?: ReactNode | ((args: { closePopover: () => void }) => ReactNode);
 }

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_component.tsx
@@ -15,7 +15,7 @@ import {
   EuiLoadingSpinner,
   EuiPopover,
 } from '@elastic/eui';
-import type { FunctionComponent, ReactNode } from 'react';
+import type { FunctionComponent, MouseEvent, ReactNode } from 'react';
 import React, { Fragment, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
@@ -28,8 +28,9 @@ import { UserAvatar, type UserProfileAvatarData } from '@kbn/user-profile-compon
 import { getUserDisplayName, isUserAnonymous } from '../../common/model';
 import { useCurrentUser, useUserProfile } from '../components';
 
-type ContextMenuItem = Omit<EuiContextMenuPanelItemDescriptor, 'content'> & {
+type ContextMenuItem = Omit<EuiContextMenuPanelItemDescriptor, 'content' | 'onClick'> & {
   content?: ReactNode | ((args: { closePopover: () => void }) => ReactNode);
+  onClick?: (event: MouseEvent<Element>) => void;
 };
 
 interface ContextMenuProps {
@@ -55,6 +56,7 @@ const ContextMenuContent = ({ items, closePopover }: ContextMenuProps) => {
               icon={item.icon}
               size="s"
               href={item.href}
+              onClick={item.onClick}
               data-test-subj={item['data-test-subj']}
             >
               {item.name}
@@ -115,10 +117,11 @@ export const SecurityNavControl: FunctionComponent<SecurityNavControlProps> = ({
   if (userMenuLinks.length) {
     const userMenuLinkMenuItems = userMenuLinks
       .sort(({ order: orderA = Infinity }, { order: orderB = Infinity }) => orderA - orderB)
-      .map(({ label, iconType, href, content }: UserMenuLink) => ({
+      .map(({ label, iconType, href, onClick, content }: UserMenuLink) => ({
         name: label,
         icon: <EuiIcon type={iconType} size="m" />,
         href,
+        onClick,
         'data-test-subj': `userMenuLink__${label}`,
         content,
       }));


### PR DESCRIPTION
## Summary

This PR adds an optional `onClick` property to `UserMenuLink`. For the upcoming [sidenav customization project
](https://github.com/elastic/kibana-team/issues/2874) and possibly for 1Feedback follow-ups we'll be adding items to the user menu that behave as buttons. While `content` property would allow for that, it adds a lot of unnecessary overhead that can be avoided by allowing `onClick` on `UserMenuLink`.

