### PR TITLE
[8.19] [Search][A11y] Add aria label to multi select filter  (#257896)

### DIFF
--- a/x-pack/solutions/search/plugins/search_inference_endpoints/common/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/common/translations.ts
@@ -100,9 +100,22 @@ export const SERVICE_PROVIDER = i18n.translate('xpack.searchInferenceEndpoints.s
   defaultMessage: 'Service',
 });
 
+export const SERVICE_PROVIDER_ARIA_LABEL = i18n.translate(
+  'xpack.searchInferenceEndpoints.serviceProvider.ariaLabel',
+  {
+    defaultMessage: 'Service Provider Options',
+  }
+);
+
 export const TASK_TYPE = i18n.translate('xpack.searchInferenceEndpoints.taskType', {
   defaultMessage: 'Type',
 });
+export const TASK_TYPE_ARIA_LABEL = i18n.translate(
+  'xpack.searchInferenceEndpoints.taskType.ariaLabel',
+  {
+    defaultMessage: 'Task Type Options',
+  }
+);
 
 export const TRAINED_MODELS_STAT_GATHER_FAILED = i18n.translate(
   'xpack.searchInferenceEndpoints.actions.trainedModelsStatGatherFailed',

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.test.tsx
@@ -18,14 +18,24 @@ describe('MultiSelectFilter', () => {
 
   it('should render the filter button with the provided label', () => {
     const { getByText } = render(
-      <MultiSelectFilter onChange={() => {}} options={options} buttonLabel="Filter Options" />
+      <MultiSelectFilter
+        onChange={() => {}}
+        options={options}
+        buttonLabel="Filter Options"
+        ariaLabel="Filter Options"
+      />
     );
     expect(getByText('Filter Options')).toBeInTheDocument();
   });
 
   it('should toggle the popover when the filter button is clicked', async () => {
     const { getByText, queryByText } = render(
-      <MultiSelectFilter onChange={() => {}} options={options} buttonLabel="Filter Options" />
+      <MultiSelectFilter
+        onChange={() => {}}
+        options={options}
+        buttonLabel="Filter Options"
+        ariaLabel="Filter Options"
+      />
     );
     fireEvent.click(getByText('Filter Options'));
     expect(queryByText('Option 1')).toBeInTheDocument();
@@ -37,7 +47,12 @@ describe('MultiSelectFilter', () => {
 
   it('should render the provided options', async () => {
     const { getByText } = render(
-      <MultiSelectFilter onChange={() => {}} options={options} buttonLabel="Filter Options" />
+      <MultiSelectFilter
+        onChange={() => {}}
+        options={options}
+        buttonLabel="Filter Options"
+        ariaLabel="Filter Options"
+      />
     );
 
     fireEvent.click(getByText('Filter Options'));
@@ -52,7 +67,12 @@ describe('MultiSelectFilter', () => {
   it('should call the onChange function with the updated options when an option is clicked', async () => {
     const onChange = jest.fn();
     const { getByText } = render(
-      <MultiSelectFilter onChange={onChange} options={options} buttonLabel="Filter Options" />
+      <MultiSelectFilter
+        onChange={onChange}
+        options={options}
+        buttonLabel="Filter Options"
+        ariaLabel="Filter Options"
+      />
     );
 
     fireEvent.click(getByText('Filter Options'));

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.tsx
@@ -29,6 +29,7 @@ export interface MultiSelectFilterOption {
 
 interface UseFilterParams {
   buttonLabel?: string;
+  ariaLabel?: string;
   onChange: (newOptions: MultiSelectFilterOption[]) => void;
   options: MultiSelectFilterOption[];
   renderOption?: (option: MultiSelectFilterOption) => React.ReactNode;
@@ -38,6 +39,7 @@ interface UseFilterParams {
 
 export const MultiSelectFilter: React.FC<UseFilterParams> = ({
   buttonLabel,
+  ariaLabel,
   onChange,
   options: rawOptions,
   selectedOptionKeys = [],
@@ -60,6 +62,7 @@ export const MultiSelectFilter: React.FC<UseFilterParams> = ({
     <EuiFilterGroup data-test-subj={dataTestSubj}>
       <EuiPopover
         ownFocus
+        aria-label={ariaLabel}
         button={
           <EuiFilterButton
             iconType={'arrowDown'}

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/service_provider_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/service_provider_filter.tsx
@@ -41,6 +41,7 @@ export const ServiceProviderFilter: React.FC<Props> = ({
   return (
     <MultiSelectFilter
       buttonLabel={i18n.SERVICE_PROVIDER}
+      ariaLabel={i18n.SERVICE_PROVIDER_ARIA_LABEL}
       onChange={onSystemFilterChange}
       options={filteredOptions}
       renderOption={(option) => option.label}

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/task_type_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/task_type_filter.tsx
@@ -37,6 +37,7 @@ export const TaskTypeFilter: React.FC<Props> = ({ optionKeys, onChange, uniqueTa
   return (
     <MultiSelectFilter
       buttonLabel={i18n.TASK_TYPE}
+      ariaLabel={i18n.TASK_TYPE_ARIA_LABEL}
       onChange={onSystemFilterChange}
       options={filteredOptions}
       renderOption={(option) => option.label}

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/translations.ts
@@ -7,7 +7,12 @@
 
 import { i18n } from '@kbn/i18n';
 
-export { SERVICE_PROVIDER, TASK_TYPE, SERVICE_PROVIDER_ARIA_LABEL, TASK_TYPE_ARIA_LABEL,} from '../../../../common/translations';
+export {
+  SERVICE_PROVIDER,
+  TASK_TYPE,
+  SERVICE_PROVIDER_ARIA_LABEL,
+  TASK_TYPE_ARIA_LABEL,
+} from '../../../../common/translations';
 
 export const EMPTY_FILTER_MESSAGE = i18n.translate(
   'xpack.searchInferenceEndpoints.filter.emptyMessage',

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/translations.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 
-export { SERVICE_PROVIDER, TASK_TYPE } from '../../../../common/translations';
+export { SERVICE_PROVIDER, TASK_TYPE, SERVICE_PROVIDER_ARIA_LABEL, TASK_TYPE_ARIA_LABEL,} from '../../../../common/translations';
 
 export const EMPTY_FILTER_MESSAGE = i18n.translate(
   'xpack.searchInferenceEndpoints.filter.emptyMessage',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search][A11y] Add aria label to multi select filter  (#257896)](https://github.com/elastic/kibana/pull/257896)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-17T15:25:09Z","message":"[Search][A11y] Add aria label to multi select filter  (#257896)\n\n## Summary\n\nCurrently there is no aria label in EuiPopver multi select filter\noption, causing mac voice over to show only group. Added aria label to\nPopover component in this PR.\n\n**Note:** The issue  is reproduced Safari browser\n**BEFORE in main branch**\n\n\nhttps://github.com/user-attachments/assets/159316e1-5f40-4b8b-a8f6-f97ecad2caf5\n\n\n**AFTER**\n\n\nhttps://github.com/user-attachments/assets/e1471761-d8d1-4498-82c8-f4289e77331b\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Added ARIA labels for Service Provider and Task Type filters to\nimprove screen reader accessibility.\n  * Exposed the new ARIA label translations for public use.\n\n* **Tests**\n  * Updated tests to include the ARIA label prop for filter components.\n","sha":"ff3093b0d1ba9cd059b77e7f37b99c938aadea6f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","backport:all-open","v9.4.0"],"title":"[Search][A11y] Add aria label to multi select filter ","number":257896,"url":"https://github.com/elastic/kibana/pull/257896","mergeCommit":{"message":"[Search][A11y] Add aria label to multi select filter  (#257896)\n\n## Summary\n\nCurrently there is no aria label in EuiPopver multi select filter\noption, causing mac voice over to show only group. Added aria label to\nPopover component in this PR.\n\n**Note:** The issue  is reproduced Safari browser\n**BEFORE in main branch**\n\n\nhttps://github.com/user-attachments/assets/159316e1-5f40-4b8b-a8f6-f97ecad2caf5\n\n\n**AFTER**\n\n\nhttps://github.com/user-attachments/assets/e1471761-d8d1-4498-82c8-f4289e77331b\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Added ARIA labels for Service Provider and Task Type filters to\nimprove screen reader accessibility.\n  * Exposed the new ARIA label translations for public use.\n\n* **Tests**\n  * Updated tests to include the ARIA label prop for filter components.\n","sha":"ff3093b0d1ba9cd059b77e7f37b99c938aadea6f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257896","number":257896,"mergeCommit":{"message":"[Search][A11y] Add aria label to multi select filter  (#257896)\n\n## Summary\n\nCurrently there is no aria label in EuiPopver multi select filter\noption, causing mac voice over to show only group. Added aria label to\nPopover component in this PR.\n\n**Note:** The issue  is reproduced Safari browser\n**BEFORE in main branch**\n\n\nhttps://github.com/user-attachments/assets/159316e1-5f40-4b8b-a8f6-f97ecad2caf5\n\n\n**AFTER**\n\n\nhttps://github.com/user-attachments/assets/e1471761-d8d1-4498-82c8-f4289e77331b\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Added ARIA labels for Service Provider and Task Type filters to\nimprove screen reader accessibility.\n  * Exposed the new ARIA label translations for public use.\n\n* **Tests**\n  * Updated tests to include the ARIA label prop for filter components.\n","sha":"ff3093b0d1ba9cd059b77e7f37b99c938aadea6f"}},{"url":"https://github.com/elastic/kibana/pull/258201","number":258201,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->