### PR TITLE
[ES|QL] Small changes in extensions logic

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_menu/help_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_menu/help_popover.tsx
@@ -96,14 +96,10 @@ export const HelpPopover: React.FC<{
 
     const getDataViewForQuery = async () => {
       const currentQuery = currentQueryRef.current;
-      if (!currentQuery) {
-        resetDataviewDerived();
-        return;
-      }
       try {
         const dataView = await getESQLAdHocDataview({
           dataViewsService: data.dataViews,
-          query: currentQuery,
+          query: currentQuery || '',
           http,
         });
         if (!isMounted) return;
@@ -142,7 +138,7 @@ export const HelpPopover: React.FC<{
   useEffect(() => {
     let cancelled = false;
     const getESQLExtensions = async () => {
-      if (!activeSolutionId) {
+      if (!activeSolutionId || !queryForRecommendedQueries) {
         return;
       }
 

--- a/src/platform/packages/private/kbn-esql-editor/src/editor_menu/help_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_menu/help_popover.tsx
@@ -142,7 +142,7 @@ export const HelpPopover: React.FC<{
   useEffect(() => {
     let cancelled = false;
     const getESQLExtensions = async () => {
-      if (!activeSolutionId || !queryForRecommendedQueries) {
+      if (!activeSolutionId) {
         return;
       }
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/extensions.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/callbacks/extensions.ts
@@ -18,11 +18,6 @@ interface EditorExtensions {
   recommendedFields: RecommendedField[];
 }
 
-const defaultExtensions: EditorExtensions = {
-  recommendedQueries: [],
-  recommendedFields: [],
-};
-
 /**
  * Single-pass analysis of the query string: parses the AST once and returns
  * whether the source is complete, the index pattern, and the command name.
@@ -95,7 +90,8 @@ export const getEditorExtensions = (
 ): Promise<EditorExtensions> => {
   const analysis = analyzeSourceQuery(queryString);
   if (!analysis) {
-    return Promise.resolve(defaultExtensions);
+    // Still fetch from the server so standalone queries are returned
+    return cachedGetEditorExtensions(http, '_', activeSolutionId);
   }
   // Normalize to a minimal query so the HTTP URL is always identical for a
   // given index pattern — even when the cache triggers a background refresh

--- a/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/index.test.ts
@@ -685,7 +685,7 @@ describe('ESQLExtensionsRegistry', () => {
   });
 
   describe('isStandalone flag', () => {
-    it('should not return standalone queries when the source command does not match', () => {
+    it('should return standalone queries even when the source command does not match', () => {
       availableDatasources = {
         indices: [{ name: 'logs-2023' }, { name: 'metrics-*' }],
         data_streams: [],
@@ -709,7 +709,7 @@ describe('ESQLExtensionsRegistry', () => {
         availableDatasources,
         'oblt'
       );
-      expect(logsResult).toEqual([dynamicQuery]);
+      expect(logsResult).toEqual([dynamicQuery, staticQuery]);
     });
 
     it('should not return standalone queries for a different solution ID', () => {

--- a/src/platform/plugins/shared/esql/server/extensions_registry/index.ts
+++ b/src/platform/plugins/shared/esql/server/extensions_registry/index.ts
@@ -192,7 +192,7 @@ export class ESQLExtensionsRegistry {
     const currentSourceCommand = getSourceCommandFromESQLQuery(queryString);
 
     const filteredQueries = matchedQueries.filter((recommendedQuery) => {
-      if (!currentSourceCommand) {
+      if (!currentSourceCommand || recommendedQuery.isStandalone) {
         return true;
       }
 


### PR DESCRIPTION
## Summary

Two changes here:

- Standalone queries are now exempt from source command filtering, so a TS standalone query isn't filtered out when the query uses FROM (miscommunication problem)
- Allows to send standalone queries if the editor is empty (for the help popover)

<img width="1656" height="381" alt="image" src="https://github.com/user-attachments/assets/a22d62e8-aed2-4b59-ab49-8bc6ed368619" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




