### PR TITLE
[Lens as Code] Fix legend truncation issues

### DIFF
--- a/src/platform/packages/shared/kbn-lens-common/visualizations/partition/types.ts
+++ b/src/platform/packages/shared/kbn-lens-common/visualizations/partition/types.ts
@@ -36,13 +36,13 @@ export interface SharedPartitionLayerState {
   categoryDisplay: CategoryDisplayType;
   legendDisplay: LegendDisplayType;
   legendPosition?: Position;
+  legendSize?: LegendSize;
   legendStats?: PartitionLegendValue[];
+  truncateLegend?: boolean;
+  legendMaxLines?: number;
   nestedLegend?: boolean;
   percentDecimals?: number;
   emptySizeRatio?: number;
-  legendMaxLines?: number;
-  legendSize?: LegendSize;
-  truncateLegend?: boolean;
   colorMapping?: ColorMapping.Config;
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/heatmap/to_api.ts
@@ -13,8 +13,14 @@ import {
 } from '@kbn/lens-common';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { Reference } from '@kbn/content-management-utils';
+
 import { DEFAULT_LAYER_ID } from '../../../constants';
-import { getDatasourceLayers, getSharedChartLensStateToAPI, stripUndefined } from '../utils';
+import {
+  getDatasourceLayers,
+  getLegendTruncateAfterLines,
+  getSharedChartLensStateToAPI,
+  stripUndefined,
+} from '../utils';
 import type { HeatmapState } from '../../../schema';
 import { fromColorByValueLensStateToAPI } from '../../coloring';
 import { type LensAttributes } from '../../../types';
@@ -34,7 +40,7 @@ function getLegendProps(legend: HeatmapVisualizationState['legend']): HeatmapSta
     visible: legend.isVisible,
     position: legend.position,
     ...stripUndefined<HeatmapState['legend']>({
-      truncate_after_lines: legend.maxLines,
+      truncate_after_lines: getLegendTruncateAfterLines(legend),
       size: legend.legendSize,
     }),
   };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/partition.ts
@@ -36,6 +36,7 @@ import {
 import {
   getDatasourceLayers,
   getDataViewsMetadata,
+  getLegendTruncateAfterLines,
   getSharedChartAPIToLensState,
   getSharedChartLensStateToAPI,
   stripUndefined,
@@ -202,7 +203,7 @@ function convertAPILegendDisplayOption(
         nestedLegend: 'nested' in legend ? legend?.nested : undefined,
         legendSize: legend?.size,
         legendMaxLines: legend?.truncate_after_lines,
-        truncateLegend: legend?.truncate_after_lines != null,
+        truncateLegend: Boolean(legend?.truncate_after_lines),
       })
     : {};
   if (legend?.visible === 'auto' || legend?.visible == null) {
@@ -433,7 +434,7 @@ function fromLensStateToSharedPartitionAPI(
   const layerState = visualization.layers[0];
   const legend = stripUndefined({
     visible: layerState.legendDisplay === 'default' ? 'auto' : layerState.legendDisplay,
-    truncate_after_lines: layerState.legendMaxLines,
+    truncate_after_lines: getLegendTruncateAfterLines(layerState),
     nested: isStateWaffleChart(visualization) ? undefined : layerState.nestedLegend,
     size: layerState.legendSize,
   });

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getLegendTruncateAfterLines } from './utils';
+
+describe('utils', () => {
+  describe('getLegendTruncateAfterLines', () => {
+    it.each<
+      [input: Parameters<typeof getLegendTruncateAfterLines>['0'], expected: number | undefined]
+    >([
+      [{}, undefined],
+      // xy and heatmap
+      [{ shouldTruncate: true }, 1],
+      [{ shouldTruncate: true, maxLines: 1 }, 1],
+      [{ shouldTruncate: true, maxLines: 0 }, undefined],
+      [{ shouldTruncate: false, maxLines: 1 }, undefined],
+      [{ shouldTruncate: false, maxLines: 0 }, undefined],
+      [{ maxLines: 0 }, undefined],
+      [{ maxLines: 1 }, undefined],
+      // partition
+      [{ truncateLegend: true }, 1],
+      [{ truncateLegend: true, legendMaxLines: 1 }, 1],
+      [{ truncateLegend: true, legendMaxLines: 0 }, undefined],
+      [{ truncateLegend: false, legendMaxLines: 1 }, undefined],
+      [{ legendMaxLines: 1 }, undefined],
+      [{ truncateLegend: false, legendMaxLines: 0 }, undefined],
+      [{ legendMaxLines: 0 }, undefined],
+    ])('legend config of %j should return %s', (input, expected) => {
+      expect(getLegendTruncateAfterLines(input)).toBe(expected);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/utils.ts
@@ -9,15 +9,20 @@
 
 import { pickBy } from 'lodash';
 
+import type { TypeOf } from '@kbn/config-schema';
 import type {
   FormBasedLayer,
   GaugeVisualizationState,
+  HeatmapVisualizationState,
+  XYState,
   MetricVisualizationState,
+  SharedPartitionLayerState,
   TextBasedLayer,
 } from '@kbn/lens-common';
 
 import type { LensAttributes } from '../../types';
 import type { LensApiState } from '../../schema';
+import type { legendTruncateAfterLinesSchema } from '../../schema/shared';
 import { buildReferences, getAdhocDataviews, isTextBasedLayer, nonNullable } from '../utils';
 import { LENS_LAYER_SUFFIX } from '../constants';
 import type { APIAdHocDataView, APIDataView } from '../columns/types';
@@ -147,4 +152,24 @@ export function processMetricColumnsWithReferences<T extends AnyMetricLensStateC
   }
 
   return result;
+}
+
+type LegendTruncateAfterLines = TypeOf<typeof legendTruncateAfterLinesSchema>;
+
+export function getLegendTruncateAfterLines(
+  legend:
+    | Pick<XYState['legend'], 'shouldTruncate' | 'maxLines'>
+    | Pick<HeatmapVisualizationState['legend'], 'shouldTruncate' | 'maxLines'>
+    | Pick<SharedPartitionLayerState, 'truncateLegend' | 'legendMaxLines'>
+): LegendTruncateAfterLines {
+  if (!legend) return;
+
+  const { shouldTruncate, maxLines = 1 } =
+    'shouldTruncate' in legend
+      ? legend
+      : 'truncateLegend' in legend
+      ? { shouldTruncate: legend.truncateLegend, maxLines: legend.legendMaxLines }
+      : {};
+
+  return shouldTruncate && maxLines > 0 ? maxLines : undefined;
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/legend.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/legend.ts
@@ -10,7 +10,7 @@
 import { LegendLayout, LegendSize, type XYLegendValue } from '@kbn/chart-expressions-common';
 import type { XYState as XYLensState } from '@kbn/lens-common';
 import type { XYState } from '../../../schema';
-import { stripUndefined } from '../utils';
+import { getLegendTruncateAfterLines, stripUndefined } from '../utils';
 
 type OutsideLegendType = Extract<Required<XYState['legend']>, { inside: false }>;
 
@@ -184,7 +184,7 @@ export function convertLegendToAPIFormat(
 ): Pick<XYState, 'legend'> | {} {
   const legendOptions = stripUndefined({
     visibility: !legend.isVisible ? 'hidden' : legend.showSingleSeries ? 'auto' : 'visible',
-    truncate_after_lines: legend?.maxLines == null ? undefined : legend.maxLines,
+    truncate_after_lines: getLegendTruncateAfterLines(legend),
     statistics: legend?.legendStats?.length
       ? legend.legendStats.map(mapStatToSnakeCase)
       : undefined,


### PR DESCRIPTION
## Summary

Fixes issue with transformations of legend truncation properties for xy, heatmap and partition charts.

Fixes #258202

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.