### PR TITLE
[EDR Workflows][Osquery] Disable tags for scheduled queries

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_queries_status_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_queries_status_table.tsx
@@ -462,6 +462,7 @@ const PackQueriesStatusTableComponent: React.FC<PackQueriesStatusTableProps> = (
           actionId={actionId}
           agentIds={agentIds}
           addToTimeline={addToTimeline}
+          isScheduled={!!scheduleId}
         />
       )}
       <EuiBasicTable

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
@@ -6,7 +6,14 @@
  */
 import React, { useCallback, useMemo, useState } from 'react';
 import type { UseEuiTheme } from '@elastic/eui';
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { AddToTimelineButton } from '../../timelines/add_to_timeline_button';
@@ -21,6 +28,11 @@ const ADD_TAGS_LABEL = i18n.translate('xpack.osquery.packResultsHeader.addTagsLa
   defaultMessage: 'Add tags',
 });
 
+const SCHEDULED_TAGS_DISABLED_LABEL = i18n.translate(
+  'xpack.osquery.packResultsHeader.scheduledTagsDisabledLabel',
+  { defaultMessage: 'Tags are not supported for scheduled queries' }
+);
+
 const EMPTY_TAGS: string[] = [];
 
 interface PackResultsHeadersProps {
@@ -28,6 +40,7 @@ interface PackResultsHeadersProps {
   queryIds: string[];
   agentIds?: string[];
   addToTimeline?: AddToTimelineHandler;
+  isScheduled?: boolean;
 }
 
 const resultsHeadingCss = ({ euiTheme }: UseEuiTheme) => ({
@@ -42,7 +55,7 @@ const iconsListCss = {
 };
 
 export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
-  ({ actionId, agentIds, queryIds, addToTimeline }) => {
+  ({ actionId, agentIds, queryIds, addToTimeline, isScheduled }) => {
     const iconProps = useMemo(() => ({ color: 'text', size: 'xs', iconSize: 'l' } as const), []);
     const isHistoryEnabled = useIsExperimentalFeatureEnabled('queryHistoryRework');
     const permissions = useKibana().services.application.capabilities.osquery;
@@ -51,7 +64,7 @@ export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
 
     const { data: liveQueryDetails } = useLiveQueryDetails({
       actionId,
-      skip: !showAddTags,
+      skip: !showAddTags || !!isScheduled,
     });
 
     const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
@@ -95,15 +108,20 @@ export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
                   </EuiFlexItem>
                   {showAddTags && (
                     <EuiFlexItem>
-                      <EuiButtonIcon
-                        iconType="tag"
-                        color="text"
-                        iconSize="l"
-                        size="xs"
-                        aria-label={ADD_TAGS_LABEL}
-                        onClick={handleOpenFlyout}
-                        data-test-subj="add-tags-button"
-                      />
+                      <EuiToolTip
+                        content={isScheduled ? SCHEDULED_TAGS_DISABLED_LABEL : ADD_TAGS_LABEL}
+                      >
+                        <EuiButtonIcon
+                          iconType="tag"
+                          color="text"
+                          iconSize="l"
+                          size="xs"
+                          aria-label={ADD_TAGS_LABEL}
+                          onClick={handleOpenFlyout}
+                          isDisabled={isScheduled}
+                          data-test-subj="add-tags-button"
+                        />
+                      </EuiToolTip>
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/osquery/scripts/create_actions/create_actions.ts
+++ b/x-pack/platform/plugins/shared/osquery/scripts/create_actions/create_actions.ts
@@ -402,6 +402,7 @@ interface ActionDocument {
   user_id?: string;
   user_profile_uid?: string;
   case_ids?: string[];
+  alert_ids?: string[];
   space_id: string;
   pack_id?: string;
   pack_name?: string;
@@ -542,6 +543,8 @@ function generateActionDocument(opts: {
   if (user) {
     action.user_id = user.userId;
     action.user_profile_uid = user.profileUid;
+  } else {
+    action.alert_ids = [uuidv4()];
   }
 
   if (opts.syntheticCases.length > 0 && Math.random() < opts.caseRatioValue) {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/live_query/update_action_tags_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/live_query/update_action_tags_route.ts
@@ -14,6 +14,7 @@ import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import {
   API_VERSIONS,
   ACTIONS_INDEX,
+  ACTION_RESPONSES_DATA_STREAM_INDEX,
   MAX_TAGS_PER_ACTION,
   MAX_TAG_LENGTH,
 } from '../../../common/constants';
@@ -126,6 +127,29 @@ export const updateActionTagsRoute = (
           const hit = searchResult.hits.hits[0];
 
           if (!hit) {
+            const scheduledCheck = await esClient.search({
+              index: `${ACTION_RESPONSES_DATA_STREAM_INDEX}-*`,
+              size: 0,
+              query: {
+                bool: {
+                  filter: [{ term: { schedule_id: request.params.id } }],
+                },
+              },
+            });
+
+            const totalHits = scheduledCheck.hits.total;
+            const scheduledCount =
+              typeof totalHits === 'number' ? totalHits : totalHits?.value ?? 0;
+
+            if (scheduledCount > 0) {
+              return response.badRequest({
+                body: {
+                  message:
+                    'Tags are not supported for scheduled query results. Tags can only be added to live queries and queries from rules.',
+                },
+              });
+            }
+
             return response.notFound({
               body: { message: `Action ${request.params.id} not found` },
             });

--- a/x-pack/platform/test/api_integration/apis/osquery/history_tags.ts
+++ b/x-pack/platform/test/api_integration/apis/osquery/history_tags.ts
@@ -16,6 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   const osqueryInternalApiVersion = '1';
 
   const actionIndex = '.logs-osquery_manager.actions-default';
+  const responsesIndex = 'logs-osquery_manager.action.responses-default';
 
   const createActionDoc = async (overrides: Record<string, unknown> = {}) => {
     const actionId = uuidv4();
@@ -58,12 +59,45 @@ export default function ({ getService }: FtrProviderContext) {
     });
   };
 
+  const createScheduledResponseDoc = async () => {
+    const scheduleId = uuidv4();
+
+    await es.index({
+      index: responsesIndex,
+      refresh: 'wait_for',
+      document: {
+        schedule_id: scheduleId,
+        schedule_execution_count: 1,
+        '@timestamp': new Date().toISOString(),
+        agent_id: 'test-agent-1',
+        action_response: { osquery: { count: 5 } },
+        space_id: 'default',
+      },
+    });
+
+    return scheduleId;
+  };
+
+  const deleteScheduledResponseDoc = async (scheduleId: string) => {
+    await es.deleteByQuery({
+      index: responsesIndex,
+      allow_no_indices: true,
+      ignore_unavailable: true,
+      refresh: true,
+      query: { term: { schedule_id: scheduleId } },
+    });
+  };
+
   describe('History tags', () => {
     const actionIds: string[] = [];
+    const scheduleIds: string[] = [];
 
     after(async () => {
       for (const id of actionIds) {
         await deleteActionDoc(id);
+      }
+      for (const id of scheduleIds) {
+        await deleteScheduledResponseDoc(id);
       }
     });
 
@@ -118,6 +152,20 @@ export default function ({ getService }: FtrProviderContext) {
           .send({ tags: ['test'] });
 
         expect(response.status).to.be(404);
+      });
+
+      it('rejects tagging a scheduled query with 400', async () => {
+        const scheduleId = await createScheduledResponseDoc();
+        scheduleIds.push(scheduleId);
+
+        const response = await supertest
+          .put(`/api/osquery/history/${scheduleId}/tags`)
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', osqueryPublicApiVersion)
+          .send({ tags: ['should-fail'] });
+
+        expect(response.status).to.be(400);
+        expect(response.body.message).to.contain('scheduled');
       });
 
       it('rejects more than 20 tags', async () => {


### PR DESCRIPTION
Disables tagging for scheduled queries — tags are only applicable to live and rule-triggered queries.

- API: `update_action_tags_route` now checks `action_input_type` (or falls back to source label) and returns 400 for scheduled queries
- UI: "Add tags" button is disabled with a tooltip for scheduled query rows
- Integration test added for the API guard
- Script fix: `create_actions` now sets `alert_ids` on rule-triggered actions so they appear as "Rule" source in the UI

<img width="1280" height="1071" alt="Screenshot 2026-03-17 at 13 04 45" src="https://github.com/user-attachments/assets/ba248fd5-561c-4f13-a446-40c5fda5223d" />
