### PR TITLE
Fixing share to space jest test click issue

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/share_saved_objects_to_space/components/share_to_space_flyout_internal.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/share_saved_objects_to_space/components/share_to_space_flyout_internal.test.tsx
@@ -159,9 +159,10 @@ function changeSpaceSelection(wrapper: ReactWrapper, selectedSpaces: string[]) {
 }
 
 async function clickButton(wrapper: ReactWrapper, button: 'continue' | 'save' | 'copy') {
+  wrapper.update();
   const buttonNode = findTestSubject(wrapper, `sts-${button}-button`);
   await act(async () => {
-    buttonNode.simulate('click');
+    buttonNode.first().simulate('click');
     await nextTick();
     wrapper.update();
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/254145

Fixing flaky jest test where simulate('click') would try to click 2 items




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->