### PR TITLE
[ResponseOps] Fixes x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts flaky test

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
@@ -78,10 +78,12 @@ export default function createAlertSeverityTests({ getService }: FtrProviderCont
         allAlertDocs.push(alertDocs[0]._source!);
 
         // Run another execution
-        await supertest
-          .post(`${getUrlPrefix(space.id)}/internal/alerting/rule/${ruleId}/_run_soon`)
-          .set('kbn-xsrf', 'foo')
-          .expect(204);
+        await retry.try(async () => {
+          await supertest
+            .post(`${getUrlPrefix(space.id)}/internal/alerting/rule/${ruleId}/_run_soon`)
+            .set('kbn-xsrf', 'foo')
+            .expect(204);
+        });
       }
 
       // Verify action group and previous action group are set as expected


### PR DESCRIPTION
## Summary

Resolves flakiness for https://github.com/elastic/kibana/issues/232564

I had unskipped this test, and then the issue reopened for flakiness with run_soon returning 200s instead of 204s.
