### PR TITLE
[Shared UX][DateRangePicker] Missing parts

### DIFF
--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
@@ -25,14 +25,15 @@ export const FORMAT_TIME_ONLY = 'HH:mm';
 /** Date format without year, used when start and end fall in the same year (e.g. "Feb 3, 14:30") */
 export const FORMAT_NO_YEAR = 'MMM D, HH:mm';
 
-/** Delimiter between start and end when the user types a range (e.g. "now-1d to now") */
-export const DATE_RANGE_INPUT_DELIMITER = 'to';
+/** Delimiter between start and end when the user types a range (e.g. "now-1d - now") */
+export const DATE_RANGE_INPUT_DELIMITER = '-';
 
 /** Delimiter used in the display text between start and end (e.g. "Feb 3 → Feb 10") */
 export const DATE_RANGE_DISPLAY_DELIMITER = '→';
 
 /** Maps single-character date-math units to their full English names (e.g. "d" → "day") */
 export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
+  ms: 'millisecond',
   s: 'second',
   m: 'minute',
   h: 'hour',
@@ -41,15 +42,6 @@ export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
   M: 'month',
   y: 'year',
 };
-
-/** Reverse of {@link UNIT_SHORT_TO_FULL_MAP}, also includes plural forms (e.g. "days" → "d") */
-export const UNIT_FULL_TO_SHORT_MAP: Record<string, string> = Object.entries(
-  UNIT_SHORT_TO_FULL_MAP
-).reduce((acc, [short, full]) => {
-  acc[full] = short;
-  acc[`${full}s`] = short;
-  return acc;
-}, {} as Record<string, string>);
 
 /** Selector for focusable elements */
 export const FOCUSABLE_SELECTOR =

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
@@ -43,6 +43,23 @@ export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
   y: 'year',
 };
 
+/**
+ * Maps each date-math offset unit to the unit used for rounding (`/X` suffix).
+ *
+ * Sub-day units promote one step up (`ms→s`, `s→m`, `m→h`), except `h→h`
+ * which keeps the hour boundary. Day-and-above units all normalise to `/d`.
+ */
+export const ROUND_UNIT_MAP: Record<string, string> = {
+  ms: 's',
+  s: 'm',
+  m: 'h',
+  h: 'h',
+  d: 'd',
+  w: 'd',
+  M: 'd',
+  y: 'd',
+};
+
 /** Selector for focusable elements */
 export const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/constants.ts
@@ -52,7 +52,7 @@ export const UNIT_SHORT_TO_FULL_MAP: Record<string, string> = {
 export const ROUND_UNIT_MAP: Record<string, string> = {
   ms: 's',
   s: 'm',
-  m: 'h',
+  m: 'm',
   h: 'h',
   d: 'd',
   w: 'd',

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
@@ -51,6 +51,7 @@ export const Playground: Story = {
       { start: 'now-3M', end: 'now', label: 'Last 3 months' },
       { start: 'now-1y', end: 'now', label: 'Last 1 year' },
     ],
+    timeZone: 'Europe/Amsterdam',
   },
   render: (args) => <StatefulDateRangePicker {...args} />,
 };
@@ -63,6 +64,7 @@ export const Presets: Story = {
       { start: 'now-1h', end: 'now', label: 'Last 1 hour' },
       { start: 'now/d', end: 'now/d', label: 'Today' },
     ],
+    timeZone: 'Europe/Amsterdam',
     onPresetSave: action('onPresetSave'),
     onPresetDelete: action('onPresetDelete'),
   },

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.stories.tsx
@@ -16,6 +16,7 @@ import {
   type DateRangePickerProps,
   type DateRangePickerOnChangeProps,
 } from './date_range_picker';
+import type { DateRangePickerSettings } from './types';
 import type { TimeRangeBoundsOption } from './types';
 
 const meta: Meta<DateRangePickerProps> = {
@@ -28,6 +29,8 @@ const meta: Meta<DateRangePickerProps> = {
   args: {
     onChange: action('onChange'),
     onInputChange: action('onInputChange'),
+    settings: { roundRelativeTime: true },
+    onSettingsChange: action('onSettingsChange'),
   },
 };
 
@@ -72,6 +75,7 @@ function StatefulDateRangePicker(props: DateRangePickerProps) {
   const [invalid, setInvalid] = useState<boolean>(false);
   const [recents, setRecents] = useState<TimeRangeBoundsOption[]>([]);
   const [presets, setPresets] = useState<TimeRangeBoundsOption[]>(props.presets ?? []);
+  const [settings, setSettings] = useState<DateRangePickerSettings>(props.settings);
   const { onChange, onPresetSave, onPresetDelete, onInputChange, ...rest } = props;
 
   const handleOnChange = (args: DateRangePickerOnChangeProps) => {
@@ -126,6 +130,8 @@ function StatefulDateRangePicker(props: DateRangePickerProps) {
       onInputChange={handleInputChange}
       onPresetSave={onPresetSave ? handlePresetSave : undefined}
       onPresetDelete={onPresetDelete ? handlePresetDelete : undefined}
+      settings={settings}
+      onSettingsChange={setSettings}
     />
   );
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.test.tsx
@@ -15,6 +15,8 @@ import { DateRangePicker, type DateRangePickerProps } from './date_range_picker'
 const defaultProps: DateRangePickerProps = {
   defaultValue: 'last 20 minutes',
   onChange: () => {},
+  settings: { roundRelativeTime: false },
+  onSettingsChange: () => {},
 };
 
 describe('DateRangePicker', () => {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
@@ -138,6 +138,12 @@ export interface DateRangePickerProps {
   settings: DateRangePickerSettings;
   /** Called when the user changes a setting in the settings panel. */
   onSettingsChange: (settings: DateRangePickerSettings) => void;
+  /**
+   * A valid time zone name, from the IANA database, e.g. "America/Los_Angeles".
+   * This is only informational, it won't affect how dates are handled.
+   * @link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+   */
+  timeZone?: string;
 }
 
 export interface DateRangePickerOnChangeProps extends TimeRangeBounds {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
@@ -12,7 +12,12 @@ import React, { useMemo, type ComponentType } from 'react';
 import type { SerializedStyles } from '@emotion/react';
 import type { IconType } from '@elastic/eui';
 
-import type { TimeRangeBounds, TimeRangeBoundsOption, CalendarOptions } from './types';
+import type {
+  TimeRangeBounds,
+  TimeRangeBoundsOption,
+  CalendarOptions,
+  DateRangePickerSettings,
+} from './types';
 import type { TimeWindowButtonsConfig } from './date_range_picker_time_window_buttons';
 import { DateRangePickerProvider } from './date_range_picker_context';
 import { DateRangePickerLayout } from './date_range_picker_layout';
@@ -26,6 +31,7 @@ import { MainPanel } from './panels/main_panel';
 import { CalendarPanel } from './panels/calendar_panel';
 import { CustomTimeRangePanel } from './panels/custom_time_range_panel';
 import { DocumentationPanel } from './panels/documentation_panel';
+import { SettingsPanel } from './panels/settings_panel';
 import { ExamplePanel, ExampleNestedPanel } from './panels/example_panel';
 
 const DEFAULT_PANEL_ID = 'main' as const;
@@ -128,6 +134,10 @@ export interface DateRangePickerProps {
   onPresetDelete?: (option: TimeRangeBoundsOption) => void;
   /** Calendar-specific options (e.g. first day of week). */
   calendarOptions?: CalendarOptions;
+  /** Current picker settings (e.g. rounding, refresh). */
+  settings: DateRangePickerSettings;
+  /** Called when the user changes a setting in the settings panel. */
+  onSettingsChange: (settings: DateRangePickerSettings) => void;
 }
 
 export interface DateRangePickerOnChangeProps extends TimeRangeBounds {
@@ -176,6 +186,9 @@ export function DateRangePicker({
             </DateRangePickerPanel>
             <DateRangePickerPanel id={DocumentationPanel.PANEL_ID}>
               <DocumentationPanel />
+            </DateRangePickerPanel>
+            <DateRangePickerPanel id={SettingsPanel.PANEL_ID}>
+              <SettingsPanel />
             </DateRangePickerPanel>
             {panels.map(({ id, component: Component }) => (
               <DateRangePickerPanel key={id} id={id}>

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker.tsx
@@ -25,6 +25,7 @@ import {
 import { MainPanel } from './panels/main_panel';
 import { CalendarPanel } from './panels/calendar_panel';
 import { CustomTimeRangePanel } from './panels/custom_time_range_panel';
+import { DocumentationPanel } from './panels/documentation_panel';
 import { ExamplePanel, ExampleNestedPanel } from './panels/example_panel';
 
 const DEFAULT_PANEL_ID = 'main' as const;
@@ -172,6 +173,9 @@ export function DateRangePicker({
             </DateRangePickerPanel>
             <DateRangePickerPanel id={CustomTimeRangePanel.PANEL_ID}>
               <CustomTimeRangePanel />
+            </DateRangePickerPanel>
+            <DateRangePickerPanel id={DocumentationPanel.PANEL_ID}>
+              <DocumentationPanel />
             </DateRangePickerPanel>
             {panels.map(({ id, component: Component }) => (
               <DateRangePickerPanel key={id} id={id}>

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
@@ -158,7 +158,10 @@ export function DateRangePickerProvider({
   const isEditingRef = useRef(isEditing);
   isEditingRef.current = isEditing;
   const [text, setText] = useState<string>(() => value ?? defaultValue ?? '');
-  const timeRange: TimeRange = useMemo(() => textToTimeRange(text), [text]);
+  const timeRange: TimeRange = useMemo(
+    () => textToTimeRange(text, { presets, dateFormat }),
+    [text, presets, dateFormat]
+  );
   const displayText = useMemo(
     () => timeRangeToDisplayText(timeRange, { dateFormat }),
     [dateFormat, timeRange]

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
@@ -28,6 +28,7 @@ import type {
   TimeRange,
   InitialFocus,
   CalendarOptions,
+  DateRangePickerSettings,
 } from './types';
 import { DATE_RANGE_INPUT_DELIMITER } from './constants';
 import { textToTimeRange } from './parse';
@@ -110,6 +111,10 @@ interface DateRangePickerInternalContextValue extends DateRangePickerContextValu
   isLoading: boolean;
   /** Calendar-specific options (e.g. first day of week). */
   calendarOptions?: CalendarOptions;
+  /** Current picker settings (e.g. rounding, refresh). */
+  settings: DateRangePickerSettings;
+  /** Called when the user changes a setting in the settings panel. */
+  onSettingsChange: (settings: DateRangePickerSettings) => void;
 }
 
 const DateRangePickerContext = createContext<DateRangePickerInternalContextValue | null>(null);
@@ -148,6 +153,8 @@ export function DateRangePickerProvider({
   onInputChange,
   width = 'auto',
   calendarOptions,
+  settings = { roundRelativeTime: true },
+  onSettingsChange,
 }: PropsWithChildren<DateRangePickerProps>) {
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -159,8 +166,9 @@ export function DateRangePickerProvider({
   isEditingRef.current = isEditing;
   const [text, setText] = useState<string>(() => value ?? defaultValue ?? '');
   const timeRange: TimeRange = useMemo(
-    () => textToTimeRange(text, { presets, dateFormat }),
-    [text, presets, dateFormat]
+    () =>
+      textToTimeRange(text, { presets, dateFormat, roundRelativeTime: settings.roundRelativeTime }),
+    [text, presets, dateFormat, settings]
   );
   const displayText = useMemo(
     () => timeRangeToDisplayText(timeRange, { dateFormat }),
@@ -267,6 +275,8 @@ export function DateRangePickerProvider({
       disabled,
       isLoading,
       calendarOptions,
+      settings,
+      onSettingsChange,
     }),
     [
       text,
@@ -291,6 +301,8 @@ export function DateRangePickerProvider({
       disabled,
       isLoading,
       calendarOptions,
+      settings,
+      onSettingsChange,
     ]
   );
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_context.tsx
@@ -115,6 +115,11 @@ interface DateRangePickerInternalContextValue extends DateRangePickerContextValu
   settings: DateRangePickerSettings;
   /** Called when the user changes a setting in the settings panel. */
   onSettingsChange: (settings: DateRangePickerSettings) => void;
+  /**
+   * A valid time zone name from the IANA database, e.g. "America/Los_Angeles".
+   * Displayed informally in the panel footer.
+   */
+  timeZone?: string;
 }
 
 const DateRangePickerContext = createContext<DateRangePickerInternalContextValue | null>(null);
@@ -155,6 +160,7 @@ export function DateRangePickerProvider({
   calendarOptions,
   settings = { roundRelativeTime: true },
   onSettingsChange,
+  timeZone,
 }: PropsWithChildren<DateRangePickerProps>) {
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -277,6 +283,7 @@ export function DateRangePickerProvider({
       calendarOptions,
       settings,
       onSettingsChange,
+      timeZone,
     }),
     [
       text,
@@ -303,6 +310,7 @@ export function DateRangePickerProvider({
       calendarOptions,
       settings,
       onSettingsChange,
+      timeZone,
     ]
   );
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
@@ -25,9 +25,15 @@ const openEditing = () => {
   return screen.getByTestId('dateRangePickerInput');
 };
 
+/** Flush EuiPopover's internal 250ms close-transition setTimeout. */
+const waitForPopoverClose = () =>
+  waitFor(() => {
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
 describe('DateRangePickerControl', () => {
   describe('editing mode', () => {
-    it('enters editing mode on control button click', () => {
+    it('enters editing mode on control button click', async () => {
       renderWithEuiTheme(<DateRangePicker {...defaultProps} onChange={() => {}} />);
 
       expect(screen.getByTestId('dateRangePickerControlButton')).toBeInTheDocument();
@@ -37,9 +43,12 @@ describe('DateRangePickerControl', () => {
 
       expect(input).toHaveFocus();
       expect(screen.queryByTestId('dateRangePickerControlButton')).not.toBeInTheDocument();
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+      await waitForPopoverClose();
     });
 
-    it('submits on Enter and returns to idle mode', () => {
+    it('submits on Enter and returns to idle mode', async () => {
       const onChange = jest.fn();
       renderWithEuiTheme(<DateRangePicker {...defaultProps} onChange={onChange} />);
 
@@ -50,9 +59,10 @@ describe('DateRangePickerControl', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('dateRangePickerControlButton')).toBeInTheDocument();
       expect(screen.queryByTestId('dateRangePickerInput')).not.toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
-    it('cancels on Escape and returns to idle mode', () => {
+    it('cancels on Escape and returns to idle mode', async () => {
       const onChange = jest.fn();
       renderWithEuiTheme(<DateRangePicker {...defaultProps} onChange={onChange} />);
 
@@ -63,9 +73,10 @@ describe('DateRangePickerControl', () => {
       expect(onChange).not.toHaveBeenCalled();
       expect(screen.getByTestId('dateRangePickerControlButton')).toBeInTheDocument();
       expect(screen.queryByTestId('dateRangePickerInput')).not.toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
-    it('restores previous text on Escape after typing', () => {
+    it('restores previous text on Escape after typing', async () => {
       renderWithEuiTheme(<DateRangePicker {...defaultProps} />);
 
       const input = openEditing();
@@ -75,9 +86,10 @@ describe('DateRangePickerControl', () => {
 
       const button = screen.getByTestId('dateRangePickerControlButton');
       expect(button).toHaveTextContent('Last 20 minutes');
+      await waitForPopoverClose();
     });
 
-    it('calls onInputChange when typing and clearing input', () => {
+    it('calls onInputChange when typing and clearing input', async () => {
       const onInputChange = jest.fn();
       renderWithEuiTheme(<DateRangePicker {...defaultProps} onInputChange={onInputChange} />);
 
@@ -88,9 +100,12 @@ describe('DateRangePickerControl', () => {
 
       fireEvent.click(screen.getByLabelText('Clear input'));
       expect(onInputChange).toHaveBeenCalledWith('');
+
+      fireEvent.keyDown(screen.getByTestId('dateRangePickerInput'), { key: 'Escape' });
+      await waitForPopoverClose();
     });
 
-    it('closes on outside click and returns to idle mode', () => {
+    it('closes on outside click and returns to idle mode', async () => {
       const onChange = jest.fn();
       renderWithEuiTheme(<DateRangePicker {...defaultProps} onChange={onChange} />);
 
@@ -102,9 +117,10 @@ describe('DateRangePickerControl', () => {
       expect(onChange).not.toHaveBeenCalled();
       expect(screen.getByTestId('dateRangePickerControlButton')).toBeInTheDocument();
       expect(screen.queryByTestId('dateRangePickerInput')).not.toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
-    it('exits editing and restores text on Shift+Tab from the first tabbable', () => {
+    it('exits editing and restores text on Shift+Tab from the first tabbable', async () => {
       renderWithEuiTheme(<DateRangePicker {...defaultProps} />);
 
       const input = openEditing();
@@ -115,9 +131,10 @@ describe('DateRangePickerControl', () => {
         'Last 20 minutes'
       );
       expect(screen.queryByTestId('dateRangePickerInput')).not.toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
-    it('exits editing and restores text on Tab from the last tabbable', () => {
+    it('exits editing and restores text on Tab from the last tabbable', async () => {
       renderWithEuiTheme(<DateRangePicker {...defaultProps} />);
 
       const input = openEditing();
@@ -131,11 +148,12 @@ describe('DateRangePickerControl', () => {
         'Last 20 minutes'
       );
       expect(screen.queryByTestId('dateRangePickerInput')).not.toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
     it.each(['ArrowDown', 'ArrowUp'] as const)(
       'moves focus into the dialog on %s and back to button on Escape',
-      (arrowKey) => {
+      async (arrowKey) => {
         renderWithEuiTheme(<DateRangePicker {...defaultProps} />);
 
         const input = openEditing();
@@ -147,10 +165,11 @@ describe('DateRangePickerControl', () => {
         fireEvent.keyDown(dialog, { key: 'Escape' });
 
         expect(screen.getByTestId('dateRangePickerControlButton')).toHaveFocus();
+        await waitForPopoverClose();
       }
     );
 
-    it('traps focus within the dialog panel on Tab', () => {
+    it('traps focus within the dialog panel on Tab', async () => {
       renderWithEuiTheme(<DateRangePicker {...defaultProps} />);
 
       const input = openEditing();
@@ -169,6 +188,9 @@ describe('DateRangePickerControl', () => {
 
       fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
       expect(last).toHaveFocus();
+
+      fireEvent.keyDown(dialog, { key: 'Escape' });
+      await waitForPopoverClose();
     });
 
     it('opens popover when entering editing mode and closes it when exiting', async () => {
@@ -258,6 +280,9 @@ describe('DateRangePickerControl', () => {
       await waitFor(() => {
         expect(input).toHaveValue('last 5 minutes');
       });
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+      await waitForPopoverClose();
     });
 
     it('restores to latest value on cancel after external value change during editing', async () => {
@@ -269,9 +294,10 @@ describe('DateRangePickerControl', () => {
       fireEvent.keyDown(input, { key: 'Escape' });
 
       expect(screen.getByTestId('dateRangePickerControlButton')).toHaveTextContent('Last 1 hour');
+      await waitForPopoverClose();
     });
 
-    it('calls onChange on Enter in controlled mode', () => {
+    it('calls onChange on Enter in controlled mode', async () => {
       const onChange = jest.fn();
       renderPicker({ value: 'last 20 minutes', onChange });
 
@@ -280,6 +306,7 @@ describe('DateRangePickerControl', () => {
 
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId('dateRangePickerControlButton')).toBeInTheDocument();
+      await waitForPopoverClose();
     });
 
     it('preserves text when controlled value is removed', () => {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_control.test.tsx
@@ -18,6 +18,8 @@ import { DateRangePicker, type DateRangePickerProps } from './date_range_picker'
 const defaultProps: DateRangePickerProps = {
   defaultValue: 'last 20 minutes',
   onChange: () => {},
+  settings: { roundRelativeTime: false },
+  onSettingsChange: () => {},
 };
 
 const openEditing = () => {
@@ -248,35 +250,48 @@ describe('DateRangePickerControl', () => {
   });
 
   describe('controlled mode (value prop)', () => {
+    const controlledDefaults = {
+      settings: { roundRelativeTime: false },
+      onSettingsChange: () => {},
+    } as const;
+
     const renderPicker = (props: DateRangePickerProps) =>
       renderWithEuiTheme(<DateRangePicker {...props} />);
 
     it('renders with initial value', () => {
-      renderPicker({ value: 'last 20 minutes', onChange: () => {} });
+      renderPicker({ value: 'last 20 minutes', onChange: () => {}, ...controlledDefaults });
       expect(screen.getByTestId('dateRangePickerControlButton')).toHaveTextContent(
         'Last 20 minutes'
       );
     });
 
     it('updates displayed text when value changes while idle', async () => {
-      const { rerender } = renderPicker({ value: 'last 20 minutes', onChange: () => {} });
+      const { rerender } = renderPicker({
+        value: 'last 20 minutes',
+        onChange: () => {},
+        ...controlledDefaults,
+      });
       expect(screen.getByTestId('dateRangePickerControlButton')).toHaveTextContent(
         'Last 20 minutes'
       );
 
-      rerender(<DateRangePicker value="last 1 hour" onChange={() => {}} />);
+      rerender(<DateRangePicker value="last 1 hour" onChange={() => {}} {...controlledDefaults} />);
       await waitFor(() => {
         expect(screen.getByTestId('dateRangePickerControlButton')).toHaveTextContent('Last 1 hour');
       });
     });
 
     it('does not overwrite user input when value changes during editing', async () => {
-      const { rerender } = renderPicker({ value: 'last 20 minutes', onChange: () => {} });
+      const { rerender } = renderPicker({
+        value: 'last 20 minutes',
+        onChange: () => {},
+        ...controlledDefaults,
+      });
       const input = openEditing();
       fireEvent.change(input, { target: { value: 'last 5 minutes' } });
       expect(input).toHaveValue('last 5 minutes');
 
-      rerender(<DateRangePicker value="last 1 hour" onChange={() => {}} />);
+      rerender(<DateRangePicker value="last 1 hour" onChange={() => {}} {...controlledDefaults} />);
       await waitFor(() => {
         expect(input).toHaveValue('last 5 minutes');
       });
@@ -286,11 +301,19 @@ describe('DateRangePickerControl', () => {
     });
 
     it('restores to latest value on cancel after external value change during editing', async () => {
-      const { rerender } = renderPicker({ value: 'last 20 minutes', onChange: () => {} });
+      const { rerender } = renderPicker({
+        value: 'last 20 minutes',
+        onChange: () => {},
+        ...controlledDefaults,
+      });
       const input = openEditing();
       fireEvent.change(input, { target: { value: 'something typed' } });
 
-      await act(async () => rerender(<DateRangePicker value="last 1 hour" onChange={() => {}} />));
+      await act(async () =>
+        rerender(
+          <DateRangePicker value="last 1 hour" onChange={() => {}} {...controlledDefaults} />
+        )
+      );
       fireEvent.keyDown(input, { key: 'Escape' });
 
       expect(screen.getByTestId('dateRangePickerControlButton')).toHaveTextContent('Last 1 hour');
@@ -299,7 +322,7 @@ describe('DateRangePickerControl', () => {
 
     it('calls onChange on Enter in controlled mode', async () => {
       const onChange = jest.fn();
-      renderPicker({ value: 'last 20 minutes', onChange });
+      renderPicker({ value: 'last 20 minutes', onChange, ...controlledDefaults });
 
       const input = openEditing();
       fireEvent.keyDown(input, { key: 'Enter' });
@@ -318,6 +341,8 @@ describe('DateRangePickerControl', () => {
             <DateRangePicker
               {...(controlled ? { value: 'last 1 hour' } : {})}
               onChange={() => {}}
+              settings={{ roundRelativeTime: false }}
+              onSettingsChange={() => {}}
             />
           </EuiThemeProvider>
         );

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_panel_ui.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_panel_ui.tsx
@@ -9,7 +9,16 @@
 
 import React from 'react';
 import type { ReactNode, PropsWithChildren, ButtonHTMLAttributes, MouseEventHandler } from 'react';
-import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  EuiFlexGroup,
+  EuiIcon,
+  EuiLink,
+  EuiMarkdownFormat,
+  EuiText,
+  useEuiFontSize,
+  useEuiTheme,
+} from '@elastic/eui';
 import type { IconType } from '@elastic/eui';
 
 import { useDateRangePickerPanelNavigation } from './date_range_picker_panel_navigation';
@@ -132,6 +141,61 @@ export const PanelBodySection = ({
     <div css={[styles.root, spacing[spacingSide]]} className={className}>
       {children}
     </div>
+  );
+};
+
+export interface PanelBodySectionInfoProps {
+  /** Optional bold heading rendered as an h3. */
+  heading?: string;
+  /** Markdown content rendered with EuiMarkdownFormat. */
+  markdown: string;
+  /** Label for an optional external link shown below the markdown. Requires `linkHref`. */
+  linkLabel?: string;
+  /** href for the optional external link. Requires `linkLabel`. */
+  linkHref?: string;
+  /** @default 's' */
+  textSize?: 'xs' | 's';
+}
+
+/** An info block within `PanelBody`: optional bold heading, markdown content, and an optional external link. */
+export const PanelBodySectionInfo = ({
+  heading,
+  markdown,
+  linkLabel,
+  linkHref,
+  textSize = 's',
+}: PanelBodySectionInfoProps) => {
+  const { euiTheme } = useEuiTheme();
+  const font = useEuiFontSize(textSize);
+  const headingStyles = css`
+    font-size: ${font.fontSize};
+    line-height: ${font.lineHeight};
+    font-weight: ${euiTheme.font.weight.bold};
+  `;
+
+  return (
+    <EuiFlexGroup gutterSize="s" direction="column">
+      {heading && <h3 css={headingStyles}>{heading}</h3>}
+      <EuiMarkdownFormat
+        color="text"
+        textSize={textSize}
+        css={css`
+          .euiCode {
+            color: ${euiTheme.colors.textSubdued};
+            font-weight: ${euiTheme.font.weight.semiBold};
+          }
+        `}
+      >
+        {markdown}
+      </EuiMarkdownFormat>
+      {linkLabel && linkHref && (
+        <EuiText size="xs">
+          <EuiLink href={linkHref} target="_blank" external>
+            {linkLabel}
+          </EuiLink>
+        </EuiText>
+      )}
+    </EuiFlexGroup>
   );
 };
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_time_window_buttons.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/date_range_picker_time_window_buttons.test.tsx
@@ -24,6 +24,8 @@ function renderPicker(overrides: Partial<DateRangePickerProps> = {}) {
     defaultValue: '-15m to now',
     onChange,
     showTimeWindowButtons: true,
+    settings: { roundRelativeTime: false },
+    onSettingsChange: () => {},
     ...overrides,
   };
   const result = renderWithEuiTheme(<DateRangePicker {...props} />);

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/hooks/use_time_zone_display.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/hooks/use_time_zone_display.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+
+/**
+ * Given an IANA time zone name (e.g. "Europe/Brussels") and an optional reference
+ * date, returns a human-readable display string like "GMT+01:00 – Europe/Brussels"
+ * or "GMT-05:00 – America/New_York (EST)", or `null` when no time zone is provided
+ * or the name is unrecognised.
+ *
+ * When `date` is provided its value is used to resolve the UTC offset and DST
+ * abbreviation; otherwise the current moment is used.
+ */
+export const useTimeZoneDisplay = (
+  timeZone: string | undefined,
+  date?: Date | null
+): string | null => {
+  return useMemo(() => {
+    if (!timeZone) return null;
+    try {
+      const refDate = date ?? new Date();
+
+      const offsetParts = new Intl.DateTimeFormat('en', {
+        timeZone,
+        timeZoneName: 'longOffset',
+      }).formatToParts(refDate);
+      const offset = offsetParts.find((p) => p.type === 'timeZoneName')?.value ?? null;
+      if (!offset) return null;
+
+      const abbrParts = new Intl.DateTimeFormat('en', {
+        timeZone,
+        timeZoneName: 'short',
+      }).formatToParts(refDate);
+      const abbr = abbrParts.find((p) => p.type === 'timeZoneName')?.value ?? null;
+
+      // Only keep alphabetic abbreviations that are useful, like "EST" or "CET"
+      const isAbbrAlphabetic = abbr !== null && /^[A-Z]/.test(abbr);
+      const isAbbrDifferent = offset.substring(0, 3) !== abbr?.substring(0, 3);
+
+      return isAbbrAlphabetic && isAbbrDifferent
+        ? `${offset} \u2013 ${timeZone} (${abbr})`
+        : `${offset} \u2013 ${timeZone}`;
+    } catch {
+      return null;
+    }
+  }, [timeZone, date]);
+};

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/index.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/index.ts
@@ -14,6 +14,7 @@ export type {
   DateRangePickerPanelConfig,
   TimeWindowButtonsConfig,
 } from './date_range_picker';
+export type { DateRangePickerSettings } from './types';
 export { useDateRangePickerContext } from './date_range_picker_context';
 export type { DateRangePickerContextValue } from './date_range_picker_context';
 export { useDateRangePickerPanelNavigation } from './date_range_picker_panel_navigation';

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/calendar_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/calendar_panel.tsx
@@ -173,6 +173,8 @@ export function CalendarPanel() {
           type: [DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE],
           isNaturalLanguage: false,
           isInvalid: false,
+          startOffset: null,
+          endOffset: null,
         }),
       });
     }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/custom_time_range_panel.test.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/custom_time_range_panel.test.tsx
@@ -69,6 +69,8 @@ const TestHarness = ({
       defaultValue={defaultValue}
       onChange={onChange}
       onPresetSave={onPresetSave}
+      settings={{ roundRelativeTime: false }}
+      onSettingsChange={() => {}}
     >
       <DateRangePickerPanelNavigationProvider defaultPanelId="main" panelDescriptors={[]}>
         <CurrentTextProbe />
@@ -200,17 +202,17 @@ describe('CustomTimeRangePanel', () => {
         target: { value: '15' },
       });
 
-      expect(screen.getByTestId('currentDateRangeText')).toHaveTextContent('-15m to now');
+      expect(screen.getByTestId('currentDateRangeText')).toHaveTextContent('-15m - now');
     });
 
     it('emits the literal "now" in the input for the Now type', () => {
-      // Default: start=RELATIVE 15m, end=NOW. Switching start to Now produces "now to now".
+      // Default: start=RELATIVE 15m, end=NOW. Switching start to Now produces "now - now".
       renderCustomTimeRangePanel({ defaultValue: '-15m' });
       openCustomPanel();
 
       fireEvent.click(within(getStartFieldset()).getByText('Now'));
 
-      expect(screen.getByTestId('currentDateRangeText')).toHaveTextContent('now to now');
+      expect(screen.getByTestId('currentDateRangeText')).toHaveTextContent('now - now');
     });
 
     it('updates the panel UI when the input text changes to a valid range', () => {
@@ -218,7 +220,7 @@ describe('CustomTimeRangePanel', () => {
       openCustomPanel();
 
       fireEvent.change(screen.getByLabelText('Set picker text'), {
-        target: { value: 'now-30m to now' },
+        target: { value: 'now-30m - now' },
       });
 
       expect(within(getStartFieldset()).getByLabelText('Count')).toHaveValue(30);
@@ -268,7 +270,7 @@ describe('CustomTimeRangePanel', () => {
       expect(onPresetSave).toHaveBeenCalledWith({
         start: 'now-15m',
         end: 'now',
-        label: '-15m to now',
+        label: '-15m - now',
       });
     });
   });

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/custom_time_range_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/custom_time_range_panel.tsx
@@ -475,10 +475,12 @@ function deriveInitialState(
     }
   }
 
+  const isValidDate = date != null && !isNaN(date.getTime());
+
   return {
     type: DATE_TYPE_ABSOLUTE,
     relativeOffset: DEFAULT_RELATIVE,
-    absoluteText: date
+    absoluteText: isValidDate
       ? moment(date).format(DEFAULT_DATE_FORMAT)
       : dateString || formatAbsolute(null),
   };

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/documentation_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/documentation_panel.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+
+import { EuiFlexGroup, EuiLink, EuiText } from '@elastic/eui';
+
+import {
+  PanelContainer,
+  PanelHeader,
+  PanelBody,
+  PanelBodySection,
+  PanelBodySectionInfo,
+  SubPanelHeading,
+} from '../date_range_picker_panel_ui';
+import { documentationPanelTexts } from '../translations';
+
+// TODO add real URL
+const DETAILED_DOCS_URL = 'https://www.elastic.co/';
+
+const Content = () => (
+  <EuiFlexGroup gutterSize="m" direction="column">
+    <PanelBodySectionInfo markdown={documentationPanelTexts.intro} />
+    <PanelBodySectionInfo
+      heading={documentationPanelTexts.absoluteHeading}
+      markdown={documentationPanelTexts.absoluteBody}
+    />
+    <PanelBodySectionInfo
+      heading={documentationPanelTexts.relativeHeading}
+      markdown={documentationPanelTexts.relativeBody}
+    />
+    <PanelBodySectionInfo
+      heading={documentationPanelTexts.combinationsHeading}
+      markdown={documentationPanelTexts.combinationsBody}
+    />
+    <EuiText size="s">
+      <EuiLink href={DETAILED_DOCS_URL} target="_blank" external>
+        {documentationPanelTexts.detailedDocumentationLink}
+      </EuiLink>
+    </EuiText>
+  </EuiFlexGroup>
+);
+
+/**
+ * A panel for end-user documention about the component.
+ */
+export function DocumentationPanel() {
+  return (
+    <PanelContainer>
+      <PanelHeader>
+        <SubPanelHeading>{documentationPanelTexts.heading}</SubPanelHeading>
+      </PanelHeader>
+      <PanelBody spacingSide="both">
+        <PanelBodySection>
+          <Content />
+        </PanelBodySection>
+      </PanelBody>
+    </PanelContainer>
+  );
+}
+DocumentationPanel.PANEL_ID = 'documentation-panel';

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.styles.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.styles.ts
@@ -27,6 +27,10 @@ export const mainPanelStyles = ({ euiTheme }: UseEuiTheme) => {
     position: sticky;
     bottom: 0px;
   `;
+  const documentationButtonWrapper = css`
+    padding-inline: ${euiTheme.size.s};
+    margin-block-start: calc(${euiTheme.size.s} * 2);
+  `;
 
-  return { root, tabs, list, stickyBottom };
+  return { root, tabs, list, stickyBottom, documentationButtonWrapper };
 };

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
@@ -9,7 +9,15 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { EuiButton, EuiButtonIcon, EuiTab, EuiTabs, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiTab,
+  EuiTabs,
+  EuiToolTip,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
 
 import type { TimeRangeBoundsOption } from '../types';
 import {
@@ -28,6 +36,7 @@ import { mainPanelStyles } from './main_panel.styles';
 import { getOptionDisplayLabel, getOptionShorthand, getOptionInputText } from '../utils';
 import { mainPanelTexts } from '../translations';
 import { panelDividerStyles } from '../date_range_picker_panel_ui.styles';
+import { useTimeZoneDisplay } from '../hooks/use_time_zone_display';
 
 interface OptionsListProps {
   /** Options to render as list items. */
@@ -153,8 +162,9 @@ const DocumentationButton = () => {
 };
 
 export function MainPanel() {
-  const { onPresetSave, timeRange, applyRange } = useDateRangePickerContext();
+  const { onPresetSave, timeRange, applyRange, timeZone } = useDateRangePickerContext();
   const { navigateTo } = useDateRangePickerPanelNavigation();
+  const timeZoneDisplay = useTimeZoneDisplay(timeZone, timeRange.startDate);
   const euiThemeContext = useEuiTheme();
 
   const handlePresetSave = useCallback(() => {
@@ -206,6 +216,11 @@ export function MainPanel() {
           size="s"
           onClick={() => navigateTo(SettingsPanel.PANEL_ID)}
         />
+        {timeZoneDisplay && (
+          <EuiText color="subdued" size="xs" component="span">
+            {timeZoneDisplay}
+          </EuiText>
+        )}
       </PanelFooter>
     </PanelContainer>
   );

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { EuiButtonIcon, EuiTab, EuiTabs, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { EuiButton, EuiButtonIcon, EuiTab, EuiTabs, EuiToolTip, useEuiTheme } from '@elastic/eui';
 
 import type { TimeRangeBoundsOption } from '../types';
 import {
@@ -20,6 +20,7 @@ import {
   PanelListItem,
   PanelNavItem,
 } from '../date_range_picker_panel_ui';
+import { DocumentationPanel } from './documentation_panel';
 import { useDateRangePickerContext } from '../date_range_picker_context';
 import { useDateRangePickerPanelNavigation } from '../date_range_picker_panel_navigation';
 import { mainPanelStyles } from './main_panel.styles';
@@ -131,6 +132,25 @@ const SubPanelMenu = () => {
   );
 };
 
+const DocumentationButton = () => {
+  const { navigateTo } = useDateRangePickerPanelNavigation();
+  const euiThemeContext = useEuiTheme();
+  const styles = mainPanelStyles(euiThemeContext);
+
+  return (
+    <div css={styles.documentationButtonWrapper}>
+      <EuiButton
+        size="s"
+        iconType="documentation"
+        fullWidth
+        onClick={() => navigateTo(DocumentationPanel.PANEL_ID)}
+      >
+        Discover allowed formats and shorthands
+      </EuiButton>
+    </div>
+  );
+};
+
 export function MainPanel() {
   const { onPresetSave, timeRange, applyRange } = useDateRangePickerContext();
   const euiThemeContext = useEuiTheme();
@@ -155,6 +175,7 @@ export function MainPanel() {
     <PanelContainer>
       <PanelBody>
         <PanelBodySection spacingSide="none">
+          {timeRange.value === '' && <DocumentationButton />}
           <PresetsRecentTabs />
         </PanelBodySection>
         <PanelBodySection spacingSide="none" css={styles.stickyBottom}>

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/main_panel.tsx
@@ -21,6 +21,7 @@ import {
   PanelNavItem,
 } from '../date_range_picker_panel_ui';
 import { DocumentationPanel } from './documentation_panel';
+import { SettingsPanel } from './settings_panel';
 import { useDateRangePickerContext } from '../date_range_picker_context';
 import { useDateRangePickerPanelNavigation } from '../date_range_picker_panel_navigation';
 import { mainPanelStyles } from './main_panel.styles';
@@ -153,6 +154,7 @@ const DocumentationButton = () => {
 
 export function MainPanel() {
   const { onPresetSave, timeRange, applyRange } = useDateRangePickerContext();
+  const { navigateTo } = useDateRangePickerPanelNavigation();
   const euiThemeContext = useEuiTheme();
 
   const handlePresetSave = useCallback(() => {
@@ -167,10 +169,6 @@ export function MainPanel() {
   const styles = mainPanelStyles(euiThemeContext);
   const dividerStyles = panelDividerStyles(euiThemeContext);
 
-  // temporary dev-only flag to show the footer conditionally
-  // TODO remove as we make progress and add content to it
-  const _showFooter = typeof onPresetSave === 'function';
-
   return (
     <PanelContainer>
       <PanelBody>
@@ -183,26 +181,32 @@ export function MainPanel() {
           <SubPanelMenu />
         </PanelBodySection>
       </PanelBody>
-      {_showFooter && (
-        <PanelFooter
-          primaryAction={
-            // @ts-ignore onPresetSave is optional at the consumer level (_showFooter is temporary)
-            onPresetSave ? (
-              <EuiToolTip content={mainPanelTexts.savePresetTooltip} disableScreenReaderOutput>
-                <EuiButtonIcon
-                  aria-label={mainPanelTexts.savePresetTooltip}
-                  iconType="save"
-                  display="base"
-                  color="text"
-                  size="s"
-                  disabled={timeRange.isInvalid}
-                  onClick={handlePresetSave}
-                />
-              </EuiToolTip>
-            ) : undefined
-          }
+      <PanelFooter
+        primaryAction={
+          onPresetSave ? (
+            <EuiToolTip content={mainPanelTexts.savePresetTooltip} disableScreenReaderOutput>
+              <EuiButtonIcon
+                aria-label={mainPanelTexts.savePresetTooltip}
+                iconType="save"
+                display="base"
+                color="text"
+                size="s"
+                disabled={timeRange.isInvalid}
+                onClick={handlePresetSave}
+              />
+            </EuiToolTip>
+          ) : undefined
+        }
+      >
+        <EuiButtonIcon
+          aria-label={mainPanelTexts.settingsAriaLabel}
+          iconType="gear"
+          display="base"
+          color="text"
+          size="s"
+          onClick={() => navigateTo(SettingsPanel.PANEL_ID)}
         />
-      )}
+      </PanelFooter>
     </PanelContainer>
   );
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/settings_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/panels/settings_panel.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+
+import { EuiFlexGroup, EuiSwitch, EuiFormRow } from '@elastic/eui';
+
+import {
+  PanelContainer,
+  PanelHeader,
+  PanelBody,
+  PanelBodySection,
+  PanelBodySectionInfo,
+  SubPanelHeading,
+} from '../date_range_picker_panel_ui';
+import { useDateRangePickerContext } from '../date_range_picker_context';
+import { settingsPanelTexts } from '../translations';
+
+// TODO replace with real Kibana advanced settings URL
+const ADVANCED_SETTINGS_URL = '/app/management/kibana/settings';
+
+/**
+ * Settings panel for the date range picker, accessible from the main panel gear button.
+ */
+export function SettingsPanel() {
+  const { settings, onSettingsChange } = useDateRangePickerContext();
+
+  const handleRoundRelativeTimeChange = useCallback(() => {
+    onSettingsChange({ ...settings, roundRelativeTime: !settings.roundRelativeTime });
+  }, [settings, onSettingsChange]);
+
+  return (
+    <PanelContainer>
+      <PanelHeader>
+        <SubPanelHeading>{settingsPanelTexts.heading}</SubPanelHeading>
+      </PanelHeader>
+      <PanelBody spacingSide="both">
+        <PanelBodySection>
+          <EuiFlexGroup gutterSize="l" direction="column">
+            <EuiFormRow helpText={settingsPanelTexts.roundRelativeTimeDescription}>
+              <EuiSwitch
+                label={settingsPanelTexts.roundRelativeTimeLabel}
+                checked={settings.roundRelativeTime}
+                onChange={handleRoundRelativeTimeChange}
+                compressed
+              />
+            </EuiFormRow>
+            <PanelBodySectionInfo
+              heading={settingsPanelTexts.timeFormatHeading}
+              markdown={settingsPanelTexts.timeFormatDescription}
+              linkLabel={settingsPanelTexts.advancedSettingsLink}
+              linkHref={ADVANCED_SETTINGS_URL}
+            />
+            <PanelBodySectionInfo
+              heading={settingsPanelTexts.newTimePickerHeading}
+              markdown={settingsPanelTexts.newTimePickerDescription}
+              linkLabel={settingsPanelTexts.advancedSettingsLink}
+              linkHref={ADVANCED_SETTINGS_URL}
+            />
+          </EuiFlexGroup>
+        </PanelBodySection>
+      </PanelBody>
+    </PanelContainer>
+  );
+}
+SettingsPanel.PANEL_ID = 'settings-panel';

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/index.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/index.ts
@@ -7,5 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { textToTimeRange } from './parse_text';
+export { textToTimeRange, matchPreset } from './parse_text';
 export type { TimeRangeTransformOptions } from '../types';

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
@@ -7,11 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { textToTimeRange } from './parse_text';
+import { textToTimeRange, matchPreset } from './parse_text';
 import { DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW, DATE_TYPE_RELATIVE } from '../constants';
-import { toLocalPreciseString } from '../utils';
-
-// :warning: This is not exhaustive and it's not aiming at 100% coverage, it's a start!
+import { getOptionInputText, toLocalPreciseString } from '../utils';
 
 describe('textToTimeRange', () => {
   it('returns invalid results for empty input', () => {
@@ -23,6 +21,8 @@ describe('textToTimeRange', () => {
     expect(range.startDate).toBeNull();
     expect(range.endDate).toBeNull();
     expect(range.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE]);
+    expect(range.startOffset).toBeNull();
+    expect(range.endOffset).toBeNull();
   });
 
   it('matches preset labels case-insensitively', () => {
@@ -76,20 +76,20 @@ describe('textToTimeRange', () => {
     expect(range.isInvalid).toBe(false);
   });
 
-  it('parses ranges using default and custom delimiters', () => {
-    const absolute = textToTimeRange('2016-02-03 to 2026-02-03');
+  it('parses ranges using built-in and custom delimiters', () => {
+    const withTo = textToTimeRange('2016-02-03 to 2026-02-03');
 
-    expect(absolute.start).toBe('2016-02-03');
-    expect(absolute.end).toBe('2026-02-03');
-    expect(absolute.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE]);
-    expect(absolute.isInvalid).toBe(false);
+    expect(withTo.start).toBe('2016-02-03');
+    expect(withTo.end).toBe('2026-02-03');
+    expect(withTo.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE]);
+    expect(withTo.isInvalid).toBe(false);
 
-    const custom = textToTimeRange('-1d until now', { delimiter: 'until' });
+    const withUntil = textToTimeRange('-1d until now');
 
-    expect(custom.start).toBe('now-1d');
-    expect(custom.end).toBe('now');
-    expect(custom.type).toEqual([DATE_TYPE_RELATIVE, DATE_TYPE_NOW]);
-    expect(custom.isInvalid).toBe(false);
+    expect(withUntil.start).toBe('now-1d');
+    expect(withUntil.end).toBe('now');
+    expect(withUntil.type).toEqual([DATE_TYPE_RELATIVE, DATE_TYPE_NOW]);
+    expect(withUntil.isInvalid).toBe(false);
   });
 
   it('returns invalid for unparseable ranges', () => {
@@ -126,5 +126,320 @@ describe('textToTimeRange', () => {
 
     expect(range.isInvalid).toBe(false);
     expect(range.startDate?.getTime()).toBe(original.getTime());
+  });
+
+  describe('shorthands', () => {
+    it.each([
+      ['7d', 'now-7d', 'now'],
+      ['-7d', 'now-7d', 'now'],
+      ['now-7d', 'now-7d', 'now'],
+      ['+7d', 'now', 'now+7d'],
+      ['now+7d', 'now', 'now+7d'],
+      ['-7d/d', 'now-7d/d', 'now'],
+      ['500ms', 'now-500ms', 'now'],
+      ['7min', 'now-7m', 'now'],
+      ['3mos', 'now-3M', 'now'],
+      ['7hrs', 'now-7h', 'now'],
+      ['2wks', 'now-2w', 'now'],
+      ['1yr', 'now-1y', 'now'],
+    ])('parses "%s" into start=%s end=%s', (text, start, end) => {
+      const range = textToTimeRange(text);
+
+      expect(range.start).toBe(start);
+      expect(range.end).toBe(end);
+      expect(range.isInvalid).toBe(false);
+      expect(range.isNaturalLanguage).toBe(false);
+    });
+
+    it('does not parse bare numbers as shorthand (no unit = not shorthand)', () => {
+      const range = textToTimeRange('7');
+      expect(range.start).not.toBe('now-7m');
+    });
+  });
+
+  describe('named ranges', () => {
+    it.each([
+      ['yesterday', 'now-1d/d', 'now-1d/d'],
+      ['tomorrow', 'now+1d/d', 'now+1d/d'],
+      ['this week', 'now/w', 'now/w'],
+      ['this month', 'now/M', 'now/M'],
+      ['this year', 'now/y', 'now/y'],
+      ['last week', 'now-1w/w', 'now-1w/w'],
+      ['last month', 'now-1M/M', 'now-1M/M'],
+      ['last year', 'now-1y/y', 'now-1y/y'],
+    ])('parses "%s"', (text, start, end) => {
+      const range = textToTimeRange(text);
+
+      expect(range.isNaturalLanguage).toBe(true);
+      expect(range.start).toBe(start);
+      expect(range.end).toBe(end);
+      expect(range.isInvalid).toBe(false);
+    });
+  });
+
+  describe('natural instant (future)', () => {
+    it.each([
+      ['7 minutes from now', 'now', 'now+7m'],
+      ['in 7 minutes', 'now', 'now+7m'],
+      ['in 3 days', 'now', 'now+3d'],
+    ])('parses "%s"', (text, start, end) => {
+      const range = textToTimeRange(text);
+
+      expect(range.start).toBe(start);
+      expect(range.end).toBe(end);
+      expect(range.isInvalid).toBe(false);
+      expect(range.isNaturalLanguage).toBe(false);
+    });
+  });
+
+  it('parses future natural duration "next 7 days"', () => {
+    const range = textToTimeRange('next 7 days');
+
+    expect(range.isNaturalLanguage).toBe(true);
+    expect(range.start).toBe('now');
+    expect(range.end).toBe('now+7d');
+    expect(range.isInvalid).toBe(false);
+  });
+
+  describe('unix timestamps', () => {
+    it('parses 10-digit seconds timestamp', () => {
+      const range = textToTimeRange('1454529600');
+
+      expect(range.start).toBe(new Date(1454529600 * 1000).toISOString());
+      expect(range.end).toBe('now');
+      expect(range.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW]);
+      expect(range.isInvalid).toBe(false);
+    });
+
+    it('parses 13-digit milliseconds timestamp', () => {
+      const range = textToTimeRange('1454529600000');
+
+      expect(range.start).toBe(new Date(1454529600000).toISOString());
+      expect(range.end).toBe('now');
+      expect(range.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW]);
+      expect(range.isInvalid).toBe(false);
+    });
+  });
+
+  describe('universal dash delimiter', () => {
+    it('splits on dash surrounded by spaces', () => {
+      const range = textToTimeRange('now-7d - now');
+
+      expect(range.start).toBe('now-7d');
+      expect(range.end).toBe('now');
+      expect(range.type).toEqual([DATE_TYPE_RELATIVE, DATE_TYPE_NOW]);
+      expect(range.isInvalid).toBe(false);
+    });
+  });
+
+  describe('type combinations', () => {
+    it.each([
+      ['now-7d to now', DATE_TYPE_RELATIVE, DATE_TYPE_NOW],
+      ['now to now+7d', DATE_TYPE_NOW, DATE_TYPE_RELATIVE],
+      ['2016-02-03 to now', DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW],
+      ['now to 2030-02-03', DATE_TYPE_NOW, DATE_TYPE_ABSOLUTE],
+      ['now-7d to now-1d', DATE_TYPE_RELATIVE, DATE_TYPE_RELATIVE],
+      ['2016-02-03 to 2026-02-03', DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE],
+      ['now-7d to 2030-02-03', DATE_TYPE_RELATIVE, DATE_TYPE_ABSOLUTE],
+      ['2016-02-03 to now+7d', DATE_TYPE_ABSOLUTE, DATE_TYPE_RELATIVE],
+    ])('"%s" -> [%s, %s]', (text, startType, endType) => {
+      const range = textToTimeRange(text);
+
+      expect(range.type).toEqual([startType, endType]);
+      expect(range.isInvalid).toBe(false);
+    });
+  });
+
+  describe('forgiving absolute dates', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2025-07-15T12:00:00.000Z'));
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it.each([
+      ['Nov 10 2025 12:34', { year: 2025, month: 10, day: 10, hour: 12, minute: 34 }],
+      ['Nov 10 2025', { year: 2025, month: 10, day: 10, hour: 0, minute: 0 }],
+      ['Nov 10', { year: 2025, month: 10, day: 10, hour: 0, minute: 0 }],
+      ['Nov', { year: 2025, month: 10, day: 1, hour: 0, minute: 0 }],
+    ])('parses partial input "%s"', (text, expected) => {
+      const range = textToTimeRange(text);
+
+      expect(range.start).toBe(text);
+      expect(range.end).toBe('now');
+      expect(range.type).toEqual([DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW]);
+
+      const d = range.startDate!;
+      expect(d).toBeInstanceOf(Date);
+      expect(d.getFullYear()).toBe(expected.year);
+      expect(d.getMonth()).toBe(expected.month);
+      expect(d.getDate()).toBe(expected.day);
+      expect(d.getHours()).toBe(expected.hour);
+      expect(d.getMinutes()).toBe(expected.minute);
+    });
+
+    it('does not mangle ISO dates with non-strict parsing', () => {
+      const range = textToTimeRange('1970-01-01');
+
+      expect(range.isInvalid).toBe(false);
+      expect(range.startDate!.getFullYear()).toBe(1970);
+      expect(range.startDate!.getMonth()).toBe(0);
+      expect(range.startDate!.getDate()).toBe(1);
+    });
+
+    it('still rejects gibberish', () => {
+      expect(textToTimeRange('hello world').isInvalid).toBe(true);
+      expect(textToTimeRange('not a date').isInvalid).toBe(true);
+    });
+  });
+
+  describe('date offset', () => {
+    it('populates startOffset for relative start', () => {
+      const range = textToTimeRange('-7d');
+
+      expect(range.startOffset).toEqual({ count: -7, unit: 'd' });
+      expect(range.endOffset).toBeNull();
+    });
+
+    it('populates endOffset for relative end', () => {
+      const range = textToTimeRange('+3d');
+
+      expect(range.startOffset).toBeNull();
+      expect(range.endOffset).toEqual({ count: 3, unit: 'd' });
+    });
+
+    it('populates both offsets for relative-relative range', () => {
+      const range = textToTimeRange('now-7d to now-1d');
+
+      expect(range.startOffset).toEqual({ count: -7, unit: 'd' });
+      expect(range.endOffset).toEqual({ count: -1, unit: 'd' });
+    });
+
+    it('includes roundTo when rounding is present', () => {
+      const range = textToTimeRange('-7d/d');
+
+      expect(range.startOffset).toEqual({ count: -7, unit: 'd', roundTo: 'd' });
+    });
+
+    it('returns null offsets for absolute dates', () => {
+      const range = textToTimeRange('2016-02-03 to 2026-02-03');
+
+      expect(range.startOffset).toBeNull();
+      expect(range.endOffset).toBeNull();
+    });
+
+    it('returns null offsets for NOW type', () => {
+      const range = textToTimeRange('now to now+7d');
+
+      expect(range.startOffset).toBeNull();
+      expect(range.endOffset).toEqual({ count: 7, unit: 'd' });
+    });
+
+    it('populates offset for ms unit', () => {
+      const range = textToTimeRange('500ms');
+
+      expect(range.startOffset).toEqual({ count: -500, unit: 'ms' });
+    });
+
+    it('populates offset from preset with relative bounds', () => {
+      const presets = [{ label: 'Quick 15m', start: 'now-15m', end: 'now' }];
+      const range = textToTimeRange('Quick 15m', { presets });
+
+      expect(range.startOffset).toEqual({ count: -15, unit: 'm' });
+      expect(range.endOffset).toBeNull();
+    });
+  });
+
+  describe('unit case sensitivity (resolveUnit)', () => {
+    it('resolves uppercase M as month', () => {
+      const range = textToTimeRange('7 M ago');
+
+      expect(range.start).toBe('now-7M');
+      expect(range.isInvalid).toBe(false);
+    });
+
+    it('resolves lowercase m as minute', () => {
+      const range = textToTimeRange('7 m ago');
+
+      expect(range.start).toBe('now-7m');
+      expect(range.isInvalid).toBe(false);
+    });
+
+    it('resolves "months" as M and "minutes" as m', () => {
+      const monthRange = textToTimeRange('3 months ago');
+      expect(monthRange.start).toBe('now-3M');
+
+      const minuteRange = textToTimeRange('3 minutes ago');
+      expect(minuteRange.start).toBe('now-3m');
+    });
+
+    it('resolves shorthand aliases: min -> m, mos -> M', () => {
+      const minRange = textToTimeRange('5min');
+      expect(minRange.start).toBe('now-5m');
+
+      const mosRange = textToTimeRange('5mos');
+      expect(mosRange.start).toBe('now-5M');
+    });
+  });
+
+  describe('round-trip through getOptionInputText', () => {
+    it.each([
+      ['relative to now', 'now-15m', 'now'],
+      ['now to relative', 'now', 'now+7d'],
+      ['relative to relative', 'now-7d', 'now-1d'],
+    ])('%s: parse(getOptionInputText({%s, %s})) produces same bounds', (_label, start, end) => {
+      const inputText = getOptionInputText({ start, end });
+      const range = textToTimeRange(inputText);
+
+      expect(range.isInvalid).toBe(false);
+      expect(range.start).toBe(start);
+      expect(range.end).toBe(end);
+    });
+
+    it('round-trips a preset label', () => {
+      const presets = [{ label: 'Last 15 Minutes', start: 'now-15m', end: 'now' }];
+      const inputText = getOptionInputText(presets[0]);
+      const range = textToTimeRange(inputText, { presets });
+
+      expect(range.isInvalid).toBe(false);
+      expect(range.start).toBe('now-15m');
+      expect(range.end).toBe('now');
+    });
+
+    it('round-trips named ranges', () => {
+      const namedRanges: Array<{ start: string; end: string }> = [
+        { start: 'now/d', end: 'now/d' },
+        { start: 'now-1d/d', end: 'now-1d/d' },
+        { start: 'now/w', end: 'now/w' },
+      ];
+
+      for (const bounds of namedRanges) {
+        const inputText = getOptionInputText(bounds);
+        const range = textToTimeRange(inputText);
+
+        expect(range.isInvalid).toBe(false);
+        expect(range.start).toBe(bounds.start);
+        expect(range.end).toBe(bounds.end);
+      }
+    });
+  });
+});
+
+describe('matchPreset', () => {
+  const presets = [
+    { label: 'Last 15 Minutes', start: 'now-15m', end: 'now' },
+    { label: 'Today', start: 'now/d', end: 'now/d' },
+  ];
+
+  it('matches case-insensitively', () => {
+    expect(matchPreset('last 15 minutes', presets)).toBe(presets[0]);
+    expect(matchPreset('TODAY', presets)).toBe(presets[1]);
+  });
+
+  it('returns undefined for no match', () => {
+    expect(matchPreset('no match', presets)).toBeUndefined();
   });
 });

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
@@ -385,6 +385,142 @@ describe('textToTimeRange', () => {
     });
   });
 
+  describe('roundRelativeTime', () => {
+    const opts = (round: boolean) => ({ roundRelativeTime: round });
+
+    describe('true — adds rounding', () => {
+      it.each([
+        ['last 7 days', 'now-7d/d', 'now'],
+        ['last 2 weeks', 'now-2w/d', 'now'],
+        ['last 3 months', 'now-3M/d', 'now'],
+        ['last 1 year', 'now-1y/d', 'now'],
+      ])('natural duration (day+) "%s" → start=%s', (text, start, end) => {
+        const range = textToTimeRange(text, opts(true));
+
+        expect(range.start).toBe(start);
+        expect(range.end).toBe(end);
+        expect(range.value).toBe(text);
+      });
+
+      it.each([
+        ['last 30 minutes', 'now-30m/h', 'now'],
+        ['last 3 hours', 'now-3h/h', 'now'],
+        ['last 10 seconds', 'now-10s/m', 'now'],
+        ['last 500 milliseconds', 'now-500ms/s', 'now'],
+      ])('natural duration (sub-day) "%s" → start=%s', (text, start, end) => {
+        const range = textToTimeRange(text, opts(true));
+
+        expect(range.start).toBe(start);
+        expect(range.end).toBe(end);
+        expect(range.value).toBe(text);
+      });
+
+      it.each([
+        ['-7d', 'now-7d/d'],
+        ['7d', 'now-7d/d'],
+        ['30m', 'now-30m/h'],
+        ['3h', 'now-3h/h'],
+        ['500ms', 'now-500ms/s'],
+      ])('shorthand "%s" → start=%s', (text, start) => {
+        const range = textToTimeRange(text, opts(true));
+
+        expect(range.start).toBe(start);
+        expect(range.end).toBe('now');
+        expect(range.value).toBe(text);
+      });
+
+      it.each([
+        ['now-30m to now', 'now-30m/h', 'now'],
+        ['-7d to now', 'now-7d/d', 'now'],
+        ['now-3h to now-1h', 'now-3h/h', 'now-1h'],
+      ])('delimiter-split "%s" → start=%s end=%s', (text, start, end) => {
+        const range = textToTimeRange(text, opts(true));
+
+        expect(range.start).toBe(start);
+        expect(range.end).toBe(end);
+        expect(range.value).toBe(text);
+      });
+
+      it.each([
+        ['-3w/w', 'now-3w/w'],
+        ['-60s/h', 'now-60s/h'],
+        ['-7d/M', 'now-7d/M'],
+      ])('preserves existing rounding "%s" even when it differs from inferred', (text, start) => {
+        const range = textToTimeRange(text, opts(true));
+
+        expect(range.start).toBe(start);
+      });
+
+      it('rounds future start in delimiter-split path', () => {
+        const range = textToTimeRange('now+3d to now+7d', opts(true));
+
+        expect(range.start).toBe('now+3d/d');
+        expect(range.end).toBe('now+7d');
+      });
+    });
+
+    describe('true — no-op cases', () => {
+      it('does not round bare "now" as start', () => {
+        const range = textToTimeRange('+7d', opts(true));
+
+        expect(range.start).toBe('now');
+        expect(range.end).toBe('now+7d');
+      });
+
+      it('does not round future natural duration start', () => {
+        const range = textToTimeRange('next 7 days', opts(true));
+
+        expect(range.start).toBe('now');
+        expect(range.end).toBe('now+7d');
+      });
+
+      it('does not affect named ranges', () => {
+        const range = textToTimeRange('today', opts(true));
+
+        expect(range.start).toBe('now/d');
+        expect(range.end).toBe('now/d');
+      });
+
+      it('does not affect preset matches', () => {
+        const presets = [{ label: 'Last 15 Minutes', start: 'now-15m', end: 'now' }];
+        const range = textToTimeRange('Last 15 Minutes', { presets, roundRelativeTime: true });
+
+        expect(range.start).toBe('now-15m');
+        expect(range.end).toBe('now');
+      });
+
+      it('never modifies end', () => {
+        const range = textToTimeRange('now-7d to now-1d', opts(true));
+
+        expect(range.end).toBe('now-1d');
+      });
+    });
+
+    describe('false — strips rounding', () => {
+      it('removes existing rounding suffix', () => {
+        const range = textToTimeRange('-7d/d', opts(false));
+
+        expect(range.start).toBe('now-7d');
+      });
+
+      it('is a no-op when no rounding is present', () => {
+        const range = textToTimeRange('-7d', opts(false));
+
+        expect(range.start).toBe('now-7d');
+      });
+    });
+
+    describe('undefined (default) — no transformation', () => {
+      it('leaves start as-is', () => {
+        const withRound = textToTimeRange('-7d/d');
+        expect(withRound.start).toBe('now-7d/d');
+
+        const withoutRound = textToTimeRange('-7d');
+        expect(withoutRound.start).toBe('now-7d');
+      });
+    });
+  });
+
   describe('round-trip through getOptionInputText', () => {
     it.each([
       ['relative to now', 'now-15m', 'now'],

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.test.ts
@@ -403,7 +403,7 @@ describe('textToTimeRange', () => {
       });
 
       it.each([
-        ['last 30 minutes', 'now-30m/h', 'now'],
+        ['last 30 minutes', 'now-30m/m', 'now'],
         ['last 3 hours', 'now-3h/h', 'now'],
         ['last 10 seconds', 'now-10s/m', 'now'],
         ['last 500 milliseconds', 'now-500ms/s', 'now'],
@@ -418,7 +418,7 @@ describe('textToTimeRange', () => {
       it.each([
         ['-7d', 'now-7d/d'],
         ['7d', 'now-7d/d'],
-        ['30m', 'now-30m/h'],
+        ['30m', 'now-30m/m'],
         ['3h', 'now-3h/h'],
         ['500ms', 'now-500ms/s'],
       ])('shorthand "%s" → start=%s', (text, start) => {
@@ -430,7 +430,7 @@ describe('textToTimeRange', () => {
       });
 
       it.each([
-        ['now-30m to now', 'now-30m/h', 'now'],
+        ['now-30m to now', 'now-30m/m', 'now'],
         ['-7d to now', 'now-7d/d', 'now'],
         ['now-3h to now-1h', 'now-3h/h', 'now-1h'],
       ])('delimiter-split "%s" → start=%s end=%s', (text, start, end) => {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -390,7 +390,12 @@ function dateStringToDate(
     if (forgiving.isValid()) return forgiving.toDate();
   }
 
-  if (/^(now|[+-]|\d)/.test(dateString)) {
+  // Only send ISO dates and datemath expressions to dateMath.parse; other
+  // strings (e.g. "2025-01-01 to") would fall through to moment(string)
+  // without an explicit format, triggering a deprecation warning.
+  const isIsoDate = /^\d{4}-\d{2}-\d{2}(T|\s+\d|$)/.test(dateString);
+  const isDateMath = dateString === 'now' || /^now[/|+-]/.test(dateString);
+  if (isIsoDate || isDateMath) {
     const parsed = dateMath.parse(dateString, options);
     return parsed?.isValid() ? parsed.toDate() : null;
   }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -10,80 +10,384 @@
 import dateMath from '@elastic/datemath';
 import moment from 'moment';
 
-import {
-  DATE_TYPE_ABSOLUTE,
-  DATE_TYPE_NOW,
-  DATE_TYPE_RELATIVE,
-  DATE_RANGE_INPUT_DELIMITER,
-  DEFAULT_DATE_FORMAT,
-  FORMAT_NO_YEAR,
-  UNIT_FULL_TO_SHORT_MAP,
-} from '../constants';
-import type { DateType, DateString, TimeRange, TimeRangeTransformOptions } from '../types';
+import { DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW, DATE_TYPE_RELATIVE } from '../constants';
+import type {
+  DateType,
+  DateString,
+  DateOffset,
+  TimeUnit,
+  TimeRange,
+  TimeRangeTransformOptions,
+  TimeRangeBoundsOption,
+} from '../types';
 import { isValidTimeRange } from '../utils';
 
+// ---------------------------------------------------------------------------
+// Parser config (English-only, not exposed to consumers)
+// ---------------------------------------------------------------------------
+
+interface ParserConfig {
+  nowKeyword: string;
+  delimiters: string[];
+  namedRanges: Record<string, { start: string; end: string }>;
+  unitAliases: Record<string, TimeUnit>;
+  durationTemplates: { past: string[]; future: string[] };
+  instantTemplates: { past: string[]; future: string[] };
+  absoluteFormats: string[];
+}
+
+const DEFAULT_CONFIG: ParserConfig = {
+  nowKeyword: 'now',
+  delimiters: ['to', 'until'],
+  namedRanges: {
+    today: { start: 'now/d', end: 'now/d' },
+    yesterday: { start: 'now-1d/d', end: 'now-1d/d' },
+    tomorrow: { start: 'now+1d/d', end: 'now+1d/d' },
+    'this week': { start: 'now/w', end: 'now/w' },
+    'this month': { start: 'now/M', end: 'now/M' },
+    'this year': { start: 'now/y', end: 'now/y' },
+    'last week': { start: 'now-1w/w', end: 'now-1w/w' },
+    'last month': { start: 'now-1M/M', end: 'now-1M/M' },
+    'last year': { start: 'now-1y/y', end: 'now-1y/y' },
+  },
+  unitAliases: {
+    ms: 'ms',
+    s: 's',
+    m: 'm',
+    h: 'h',
+    d: 'd',
+    w: 'w',
+    M: 'M',
+    y: 'y',
+    millisecond: 'ms',
+    milliseconds: 'ms',
+    second: 's',
+    seconds: 's',
+    sec: 's',
+    secs: 's',
+    minute: 'm',
+    minutes: 'm',
+    min: 'm',
+    mins: 'm',
+    hour: 'h',
+    hours: 'h',
+    hr: 'h',
+    hrs: 'h',
+    day: 'd',
+    days: 'd',
+    week: 'w',
+    weeks: 'w',
+    wk: 'w',
+    wks: 'w',
+    month: 'M',
+    months: 'M',
+    mo: 'M',
+    mos: 'M',
+    year: 'y',
+    years: 'y',
+    yr: 'y',
+    yrs: 'y',
+  },
+  durationTemplates: {
+    past: ['last {count} {unit}'],
+    future: ['next {count} {unit}'],
+  },
+  instantTemplates: {
+    past: ['{count} {unit} ago'],
+    future: ['{count} {unit} from now', 'in {count} {unit}'],
+  },
+  absoluteFormats: [
+    'MMM D YYYY, HH:mm',
+    'MMM D, HH:mm',
+    'MMM D YYYY',
+    'MMM D, YYYY',
+    'MMM D',
+    'ddd, DD MMM YYYY HH:mm:ss ZZ',
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Compiled config (cached by object identity)
+// ---------------------------------------------------------------------------
+
+interface CompiledTemplate {
+  regex: RegExp;
+  countGroup: number;
+  unitGroup: number;
+}
+
+interface CompiledConfig {
+  shorthandRegex: RegExp;
+  durationPast: CompiledTemplate[];
+  durationFuture: CompiledTemplate[];
+  instantPast: CompiledTemplate[];
+  instantFuture: CompiledTemplate[];
+  absoluteFormats: string[];
+  delimiterPatterns: RegExp[];
+}
+
+const configCache = new WeakMap<ParserConfig, CompiledConfig>();
+
+const escapeRegExp = (input: string) => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/** Builds a regex that splits text on a word delimiter surrounded by whitespace. */
+function buildDelimiterPattern(delimiter: string): RegExp | null {
+  const trimmed = delimiter.trim();
+  return trimmed ? new RegExp(`^(.+?)\\s+${escapeRegExp(trimmed)}\\s+(.+)$`) : null;
+}
+
 /**
- * Creates a TimeRange, automatically computing `isInvalid` from the range fields.
+ * Converts a natural-language template (e.g. `'{count} {unit} ago'`)
+ * into a regex, tracking capture-group positions for count and unit.
  */
-function buildTimeRange(fields: Omit<TimeRange, 'isInvalid'>): TimeRange {
-  const range: TimeRange = { ...fields, isInvalid: true };
+function compileTemplate(template: string): CompiledTemplate {
+  const parts = template.split(/(\{count}|\{unit})/);
+  let pattern = '';
+  let groupIdx = 0;
+  let countGroup = -1;
+  let unitGroup = -1;
+
+  for (const part of parts) {
+    if (part === '{count}') {
+      countGroup = ++groupIdx;
+      pattern += '(\\d+)';
+    } else if (part === '{unit}') {
+      unitGroup = ++groupIdx;
+      pattern += '(\\w+)';
+    } else {
+      pattern += escapeRegExp(part).replace(/ /g, '\\s+');
+    }
+  }
+
+  return { regex: new RegExp(`^${pattern}$`, 'i'), countGroup, unitGroup };
+}
+
+function compileConfig(config: ParserConfig): CompiledConfig {
+  const unitKeys = Object.keys(config.unitAliases)
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join('|');
+
+  const delimiterPatterns = [...config.delimiters, '-']
+    .map(buildDelimiterPattern)
+    .filter((p): p is RegExp => p !== null);
+
+  return {
+    shorthandRegex: new RegExp(`^(now)?([+-]?)(\\d+)(${unitKeys})(\\/[smhdwMy])?$`),
+    durationPast: config.durationTemplates.past.map(compileTemplate),
+    durationFuture: config.durationTemplates.future.map(compileTemplate),
+    instantPast: config.instantTemplates.past.map(compileTemplate),
+    instantFuture: config.instantTemplates.future.map(compileTemplate),
+    absoluteFormats: config.absoluteFormats,
+    delimiterPatterns,
+  };
+}
+
+function getCompiledConfig(config: ParserConfig): CompiledConfig {
+  let compiled = configCache.get(config);
+  if (!compiled) {
+    compiled = compileConfig(config);
+    configCache.set(config, compiled);
+  }
+  return compiled;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Matches text against preset labels (case-insensitive). */
+export function matchPreset(
+  text: string,
+  presets: TimeRangeBoundsOption[]
+): TimeRangeBoundsOption | undefined {
+  const lower = text.trim().toLowerCase();
+  return presets.find((preset) => preset.label?.toLowerCase() === lower);
+}
+
+/**
+ * Parses free-form text into a structured {@link TimeRange}.
+ *
+ * Supports presets, named ranges, natural durations/instants,
+ * shorthand datemath, unix timestamps, and absolute dates.
+ */
+export function textToTimeRange(text: string, options?: TimeRangeTransformOptions): TimeRange {
+  const trimmed = text.trim();
+  if (!trimmed) return buildInvalidRange(text);
+
+  const config = DEFAULT_CONFIG;
+  const compiled = getCompiledConfig(config);
+  const { presets = [], delimiter, dateFormat } = options ?? {};
+  const formats = dateFormat ? [dateFormat, ...compiled.absoluteFormats] : compiled.absoluteFormats;
+
+  // (1) Preset label match
+  const preset = matchPreset(trimmed, presets);
+  if (preset) {
+    return buildRange(text, preset.start, preset.end, formats, true);
+  }
+
+  // (2) Named range ("today", "yesterday", "this week", ...)
+  const named = config.namedRanges[trimmed.toLowerCase()];
+  if (named) {
+    return buildRange(text, named.start, named.end, formats, true);
+  }
+
+  // (3) Natural duration ("last 7 minutes", "next 3 days")
+  const duration = matchNaturalDuration(trimmed, config, compiled);
+  if (duration) {
+    return buildRange(text, duration.start, duration.end, formats, true);
+  }
+
+  // (4) Try splitting on delimiters (config + universal dash + extra)
+  const parts = trySplit(trimmed, compiled, delimiter);
+  if (parts) {
+    const startDateString = instantToDateString(parts[0], config, compiled, formats);
+    const endDateString = instantToDateString(parts[1], config, compiled, formats);
+    if (startDateString && endDateString) {
+      return buildRange(text, startDateString, endDateString, formats, false);
+    }
+    return buildInvalidRange(text);
+  }
+
+  // (5) Single instant (no delimiter found)
+  const dateString = instantToDateString(trimmed, config, compiled, formats);
+  if (!dateString) return buildInvalidRange(text);
+
+  if (dateString.startsWith('now+')) {
+    return buildRange(text, 'now', dateString, formats, false);
+  }
+  return buildRange(text, dateString, 'now', formats, false);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Resolves a user-typed unit string through aliases (exact first, then lowercase). */
+function resolveUnit(text: string, aliases: Record<string, TimeUnit>): TimeUnit | null {
+  return aliases[text] ?? aliases[text.toLowerCase()] ?? null;
+}
+
+/** Parses a unix timestamp string (10-digit seconds or 13-digit milliseconds) to a `Date`. */
+function unixTimestampToDate(text: string): Date | null {
+  if (/^\d{10}$/.test(text)) return new Date(parseInt(text, 10) * 1000);
+  if (/^\d{13}$/.test(text)) return new Date(parseInt(text, 10));
+  return null;
+}
+
+function dateStringToType(dateString: DateString): DateType {
+  if (dateString === 'now') return DATE_TYPE_NOW;
+  if (dateString.includes('now')) return DATE_TYPE_RELATIVE;
+  return DATE_TYPE_ABSOLUTE;
+}
+
+/** Extracts a structured {@link DateOffset} from a datemath string like `now-7d/d`. */
+function dateStringToOffset(dateString: DateString): DateOffset | null {
+  const match = dateString.match(/^now([+-])(\d+)([a-zA-Z]+)(?:\/([smhdwMy]))?$/);
+  if (!match) return null;
+  const [, operator, digits, unit, roundUnit] = match;
+  return {
+    count: operator === '-' ? -parseInt(digits, 10) : parseInt(digits, 10),
+    unit: unit as TimeUnit,
+    ...(roundUnit ? { roundTo: roundUnit as TimeUnit } : {}),
+  };
+}
+
+/**
+ * Converts a single text fragment into a {@link DateString}.
+ * Tries (in order): "now", shorthand, natural instant, unix timestamp,
+ * absolute formats, and finally dateMath/ISO fallback.
+ */
+function instantToDateString(
+  text: string,
+  config: ParserConfig,
+  compiled: CompiledConfig,
+  formats: string[]
+): DateString | null {
+  const trimmed = text.trim();
+
+  if (trimmed.toLowerCase() === config.nowKeyword) return 'now';
+
+  // Shorthand: "7d", "-7d", "+7d", "now-7d/d", "500ms"
+  const shorthandMatch = trimmed.match(compiled.shorthandRegex);
+  if (shorthandMatch) {
+    const unit = resolveUnit(shorthandMatch[4], config.unitAliases);
+    if (unit) {
+      const operator = shorthandMatch[2] === '+' ? '+' : '-';
+      return `now${operator}${shorthandMatch[3]}${unit}${shorthandMatch[5] ?? ''}`;
+    }
+  }
+
+  // Natural instant: "7 minutes ago", "in 7 minutes"
+  const instant = matchNaturalInstant(trimmed, config, compiled);
+  if (instant) return instant;
+
+  const unixDate = unixTimestampToDate(trimmed);
+  if (unixDate) return unixDate.toISOString();
+
+  // Absolute date / dateMath / ISO fallback
+  if (dateStringToDate(trimmed, formats) !== null) return trimmed;
+
+  return null;
+}
+
+/**
+ * Converts a {@link DateString} to a `Date`, returning `null` if unrecognised.
+ *
+ * Handles absolute formats (strict then forgiving), ISO 8601, and datemath.
+ * Unix timestamps are handled upstream by `instantToDateString` before this is called.
+ */
+function dateStringToDate(
+  dateString: DateString,
+  formats: string[],
+  options?: { roundUp?: boolean }
+): Date | null {
+  const strict = moment(dateString, formats, true);
+  if (strict.isValid()) return strict.toDate();
+
+  if (formats.length && !moment(dateString, moment.ISO_8601, true).isValid()) {
+    const forgiving = moment(dateString, formats);
+    if (forgiving.isValid()) return forgiving.toDate();
+  }
+
+  if (/^(now|[+-]|\d)/.test(dateString)) {
+    return dateMath.parse(dateString, options)?.toDate() ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Builds a complete {@link TimeRange} from start/end datemath strings,
+ * resolving dates, types, and offsets automatically.
+ */
+function buildRange(
+  text: string,
+  start: DateString,
+  end: DateString,
+  formats: string[],
+  isNaturalLanguage: boolean
+): TimeRange {
+  const startType = dateStringToType(start);
+  const endType = dateStringToType(end);
+  const range: TimeRange = {
+    value: text,
+    start,
+    end,
+    startDate: dateStringToDate(start, formats),
+    endDate: dateStringToDate(end, formats, { roundUp: true }),
+    type: [startType, endType],
+    isNaturalLanguage,
+    startOffset: startType === DATE_TYPE_RELATIVE ? dateStringToOffset(start) : null,
+    endOffset: endType === DATE_TYPE_RELATIVE ? dateStringToOffset(end) : null,
+    isInvalid: true,
+  };
   range.isInvalid = !isValidTimeRange(range);
   return range;
 }
 
-// Shorthand: "-7m", "+7d", "now-7m", "now+7d/d"
-const SHORTHAND_REGEX = /^(now)?([+-])(\d+)([smhdwMy])(\/[smhdwMy])?$/i;
-
-// (works because parsing of end is done with `roundUp` true)
-const NAMED_RANGES: Record<string, { start: string; end: string }> = {
-  today: { start: 'now/d', end: 'now/d' },
-  yesterday: { start: 'now-1d/d', end: 'now-1d/d' },
-  tomorrow: { start: 'now+1d/d', end: 'now+1d/d' },
-};
-
-// "last 7 minutes" or "next 7 minutes"
-const NATURAL_DURATION_REGEX = /^(last|next)\s+(\d+)\s+(\w+)$/i;
-
-// "7 minutes ago" or "7 minutes from now"
-const NATURAL_INSTANT_REGEX = /^(\d+)\s+(\w+)\s+(ago|from now)$/i;
-
-// TODO this will change when we improve "forgivingness"
-// see https://github.com/elastic/eui/pull/9199
-const SUPPORTED_DATE_FORMATS = [
-  DEFAULT_DATE_FORMAT, // 'MMM D YYYY, HH:mm'
-  FORMAT_NO_YEAR, // 'MMM D, HH:mm'
-  'MMM D YYYY', // e.g. "Feb 3 2016"
-  'MMM D, YYYY', // e.g. "feb 3, 2016"
-  'YYYY-MM-DD',
-  'YYYY-MM-DDTHH:mm:ss.SSS',
-  'YYYY-MM-DDTHH:mm:ss.SSSZ',
-  'YYYY-MM-DDTHH:mm:ssZ',
-  'YYYY-MM-DDTHH:mm',
-];
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const getDelimiterPattern = (delimiter: string) => {
-  const normalized = delimiter.trim();
-  if (!normalized) {
-    return null;
-  }
-
-  return new RegExp(`^(.+?)\\s+${escapeRegExp(normalized)}\\s+(.+)$`);
-};
-
-/**
- * Main parsing function to transform text into a time range
- *
- * TODO: Move preset matching out of this function into a separate step (e.g. `matchPreset`),
- * so this function stays focused on text parsing only.
- */
-export function textToTimeRange(text: string, options?: TimeRangeTransformOptions): TimeRange {
-  const trimmed = text.trim();
-  const { presets = [], delimiter = DATE_RANGE_INPUT_DELIMITER } = options ?? {};
-  const delimiterPattern = getDelimiterPattern(delimiter);
-
-  const invalidResult: TimeRange = {
+function buildInvalidRange(text: string): TimeRange {
+  return {
     value: text,
     start: '',
     end: '',
@@ -92,205 +396,89 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
     type: [DATE_TYPE_ABSOLUTE, DATE_TYPE_ABSOLUTE],
     isNaturalLanguage: false,
     isInvalid: true,
+    startOffset: null,
+    endOffset: null,
   };
-
-  if (!trimmed) {
-    return invalidResult;
-  }
-
-  // (1) Check if text matches a preset label (case insensitive)
-
-  const matchedPreset = presets.find(
-    (preset) => preset.label?.toLowerCase() === trimmed.toLowerCase()
-  );
-  if (matchedPreset) {
-    return buildTimeRange({
-      value: text,
-      start: matchedPreset.start,
-      end: matchedPreset.end,
-      startDate: parseDateStringToDate(matchedPreset.start),
-      endDate: parseDateStringToDate(matchedPreset.end, { roundUp: true }),
-      type: [dateStringToDateType(matchedPreset.start), dateStringToDateType(matchedPreset.end)],
-      isNaturalLanguage: true,
-    });
-  }
-
-  // (2) Check if it's a single value (no delimiter)
-
-  const delimiterMatch = delimiterPattern ? trimmed.match(delimiterPattern) : null;
-  if (!delimiterMatch) {
-    // Try natural duration: "last 7 minutes", "today", etc.
-    const naturalDuration = getTimeRangeBoundsFromNaturalDuration(trimmed);
-    if (naturalDuration) {
-      return buildTimeRange({
-        value: text,
-        start: naturalDuration.start,
-        end: naturalDuration.end,
-        startDate: parseDateStringToDate(naturalDuration.start),
-        endDate: parseDateStringToDate(naturalDuration.end, { roundUp: true }),
-        type: [
-          dateStringToDateType(naturalDuration.start),
-          dateStringToDateType(naturalDuration.end),
-        ],
-        isNaturalLanguage: true,
-      });
-    }
-
-    // Try as a single instant (treat as start, with end = now)
-    const singleInstant = textInstantToDateString(trimmed);
-    if (singleInstant) {
-      // future shorthand exception (start = now)
-      if (SHORTHAND_REGEX.test(singleInstant) && singleInstant.startsWith('now+')) {
-        return buildTimeRange({
-          value: text,
-          start: 'now',
-          end: singleInstant,
-          startDate: new Date(), // now
-          endDate: parseDateStringToDate(singleInstant),
-          type: [DATE_TYPE_NOW, dateStringToDateType(singleInstant)],
-          isNaturalLanguage: false,
-        });
-      }
-      return buildTimeRange({
-        value: text,
-        start: singleInstant,
-        end: 'now',
-        startDate: parseDateStringToDate(singleInstant),
-        endDate: new Date(), // now
-        type: [dateStringToDateType(singleInstant), DATE_TYPE_NOW],
-        isNaturalLanguage: false,
-      });
-    }
-
-    return invalidResult;
-  }
-
-  // (3) Parse as a range with delimiter
-
-  const startText = delimiterMatch[1].trim();
-  const endText = delimiterMatch[2].trim();
-
-  if (!startText || !endText) {
-    return invalidResult;
-  }
-
-  const start = textInstantToDateString(startText.trim());
-  const end = textInstantToDateString(endText.trim());
-
-  if (!start || !end) {
-    return invalidResult;
-  }
-
-  return buildTimeRange({
-    value: text,
-    start,
-    end,
-    startDate: parseDateStringToDate(start),
-    endDate: parseDateStringToDate(end, { roundUp: true }),
-    type: [dateStringToDateType(start), dateStringToDateType(end)],
-    isNaturalLanguage: false,
-  });
 }
 
-function getTimeRangeBoundsFromNaturalDuration(
-  text: string
+/**
+ * Attempts to split text into two parts using available delimiters.
+ * Tries in order: extra delimiter, then compiled config + universal dash patterns.
+ */
+function trySplit(text: string, compiled: CompiledConfig, extra?: string): [string, string] | null {
+  const patterns = extra
+    ? [buildDelimiterPattern(extra), ...compiled.delimiterPatterns].filter(
+        (p): p is RegExp => p !== null
+      )
+    : compiled.delimiterPatterns;
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match && match[1].trim() && match[2].trim()) {
+      return [match[1].trim(), match[2].trim()];
+    }
+  }
+  return null;
+}
+
+/** Tries each compiled template against the text, returning the first successful match or `null`. */
+function matchTemplates(
+  text: string,
+  templates: CompiledTemplate[],
+  aliases: Record<string, TimeUnit>,
+  buildResult: (count: string, unit: TimeUnit) => string
+): string | null {
+  for (const t of templates) {
+    const match = text.match(t.regex);
+    if (match) {
+      const unit = resolveUnit(match[t.unitGroup], aliases);
+      if (unit) return buildResult(match[t.countGroup], unit);
+    }
+  }
+  return null;
+}
+
+function matchNaturalDuration(
+  text: string,
+  config: ParserConfig,
+  compiled: CompiledConfig
 ): { start: DateString; end: DateString } | null {
-  const trimmed = text.trim().toLowerCase();
+  const past = matchTemplates(
+    text,
+    compiled.durationPast,
+    config.unitAliases,
+    (count, unit) => `now-${count}${unit}`
+  );
+  if (past) return { start: past, end: 'now' };
 
-  // Check named ranges first
-  if (NAMED_RANGES[trimmed]) {
-    return NAMED_RANGES[trimmed];
-  }
-
-  // "last 7 minutes" or "next 7 days"
-  const match = trimmed.match(NATURAL_DURATION_REGEX);
-  if (match) {
-    const [, direction, count, unitWord] = match;
-    const unit = UNIT_FULL_TO_SHORT_MAP[unitWord.toLowerCase()];
-    if (unit) {
-      if (direction === 'last') {
-        return { start: `now-${count}${unit}`, end: 'now' };
-      }
-      return { start: 'now', end: `now+${count}${unit}` };
-    }
-  }
+  const future = matchTemplates(
+    text,
+    compiled.durationFuture,
+    config.unitAliases,
+    (count, unit) => `now+${count}${unit}`
+  );
+  if (future) return { start: 'now', end: future };
 
   return null;
 }
 
-function textInstantToDateString(text: string): DateString | null {
-  const trimmed = text.trim();
-  const normalized = trimmed.toLowerCase();
-
-  // "now"
-  if (normalized === 'now') {
-    return 'now';
-  }
-
-  // Shorthand: "-7m", "+7d", "now-7m/d"
-  const shorthandMatch = trimmed.match(SHORTHAND_REGEX);
-  if (shorthandMatch) {
-    const [, , operator, count, unit, round = ''] = shorthandMatch;
-    return `now${operator}${count}${unit}${round}`;
-  }
-
-  // Natural instant: "7 minutes ago" -> now-7m
-  const instantMatch = normalized.match(NATURAL_INSTANT_REGEX);
-  if (instantMatch) {
-    const [, count, unitWord, direction] = instantMatch;
-    const unit = UNIT_FULL_TO_SHORT_MAP[unitWord.toLowerCase()];
-    if (unit) {
-      const operator = direction === 'ago' ? '-' : '+';
-      return `now${operator}${count}${unit}`;
-    }
-  }
-
-  // Try parsing as absolute date with explicit display formats first
-  const parsedWithFormat = moment(trimmed, SUPPORTED_DATE_FORMATS, true);
-  if (parsedWithFormat.isValid()) {
-    return trimmed; // Return original, it's valid
-  }
-
-  // Only try dateMath for strings that look like ISO dates (YYYY-MM-DD…) or
-  // datemath expressions (now/d, now||+1d, …). Bare `now` and shorthand like
-  // `now-7m` or `+7d` are already handled above. A loose prefix check here
-  // would let strings like "2025-01-01 to" through to dateMath.parse, which
-  // internally calls moment(string) without an explicit format and triggers a
-  // deprecation warning for non-ISO/RFC 2822 input.
-  const isIsoDate = /^\d{4}-\d{2}-\d{2}([T|]|$)/.test(trimmed);
-  const isDateMath = /^now[/|+-]/.test(trimmed);
-  if (!isIsoDate && !isDateMath) {
-    return null;
-  }
-
-  const parsed = dateMath.parse(trimmed);
-  if (parsed?.isValid()) {
-    return trimmed; // Return original, it's valid
-  }
-
-  return null;
-}
-
-/**
- * Parses a DateString to a Date. Uses explicit formats for absolute display
- * strings to avoid moment's deprecated fallback for non-ISO input.
- */
-function parseDateStringToDate(
-  dateString: DateString,
-  options?: { roundUp?: boolean }
-): Date | null {
-  const parsedWithFormat = moment(dateString, SUPPORTED_DATE_FORMATS, true);
-  if (parsedWithFormat.isValid()) {
-    return parsedWithFormat.toDate();
-  }
-  return dateMath.parse(dateString, options)?.toDate() ?? null;
-}
-
-/**
- * Determines the type of a date string
- */
-function dateStringToDateType(dateString: DateString): DateType {
-  if (dateString === 'now') return DATE_TYPE_NOW;
-  if (dateString.includes('now')) return DATE_TYPE_RELATIVE;
-  return DATE_TYPE_ABSOLUTE;
+function matchNaturalInstant(
+  text: string,
+  config: ParserConfig,
+  compiled: CompiledConfig
+): DateString | null {
+  return (
+    matchTemplates(
+      text,
+      compiled.instantPast,
+      config.unitAliases,
+      (count, unit) => `now-${count}${unit}`
+    ) ??
+    matchTemplates(
+      text,
+      compiled.instantFuture,
+      config.unitAliases,
+      (count, unit) => `now+${count}${unit}`
+    )
+  );
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -391,7 +391,8 @@ function dateStringToDate(
   }
 
   if (/^(now|[+-]|\d)/.test(dateString)) {
-    return dateMath.parse(dateString, options)?.toDate() ?? null;
+    const parsed = dateMath.parse(dateString, options);
+    return parsed?.isValid() ? parsed.toDate() : null;
   }
 
   return null;

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/parse/parse_text.ts
@@ -10,7 +10,12 @@
 import dateMath from '@elastic/datemath';
 import moment from 'moment';
 
-import { DATE_TYPE_ABSOLUTE, DATE_TYPE_NOW, DATE_TYPE_RELATIVE } from '../constants';
+import {
+  DATE_TYPE_ABSOLUTE,
+  DATE_TYPE_NOW,
+  DATE_TYPE_RELATIVE,
+  ROUND_UNIT_MAP,
+} from '../constants';
 import type {
   DateType,
   DateString,
@@ -217,7 +222,7 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
 
   const config = DEFAULT_CONFIG;
   const compiled = getCompiledConfig(config);
-  const { presets = [], delimiter, dateFormat } = options ?? {};
+  const { presets = [], delimiter, dateFormat, roundRelativeTime } = options ?? {};
   const formats = dateFormat ? [dateFormat, ...compiled.absoluteFormats] : compiled.absoluteFormats;
 
   // (1) Preset label match
@@ -235,7 +240,8 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
   // (3) Natural duration ("last 7 minutes", "next 3 days")
   const duration = matchNaturalDuration(trimmed, config, compiled);
   if (duration) {
-    return buildRange(text, duration.start, duration.end, formats, true);
+    const roundedStart = applyStartBoundRounding(duration.start, roundRelativeTime);
+    return buildRange(text, roundedStart, duration.end, formats, true);
   }
 
   // (4) Try splitting on delimiters (config + universal dash + extra)
@@ -244,7 +250,8 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
     const startDateString = instantToDateString(parts[0], config, compiled, formats);
     const endDateString = instantToDateString(parts[1], config, compiled, formats);
     if (startDateString && endDateString) {
-      return buildRange(text, startDateString, endDateString, formats, false);
+      const roundedStart = applyStartBoundRounding(startDateString, roundRelativeTime);
+      return buildRange(text, roundedStart, endDateString, formats, false);
     }
     return buildInvalidRange(text);
   }
@@ -256,7 +263,8 @@ export function textToTimeRange(text: string, options?: TimeRangeTransformOption
   if (dateString.startsWith('now+')) {
     return buildRange(text, 'now', dateString, formats, false);
   }
-  return buildRange(text, dateString, 'now', formats, false);
+  const roundedStart = applyStartBoundRounding(dateString, roundRelativeTime);
+  return buildRange(text, roundedStart, 'now', formats, false);
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +299,38 @@ function dateStringToOffset(dateString: DateString): DateOffset | null {
     unit: unit as TimeUnit,
     ...(roundUnit ? { roundTo: roundUnit as TimeUnit } : {}),
   };
+}
+
+/**
+ * Applies or strips the rounding suffix on a relative datemath `start` string.
+ *
+ * - `true` — keeps existing rounding; when absent, appends `/{roundUnit}`
+ *   inferred from the offset unit via {@link ROUND_UNIT_MAP}.
+ * - `false` — removes any trailing rounding suffix.
+ * - `undefined` — returns the string unchanged.
+ *
+ * Bare `'now'` and non-relative strings are always returned as-is.
+ */
+function applyStartBoundRounding(
+  start: DateString,
+  roundRelativeTime: boolean | undefined
+): DateString {
+  if (roundRelativeTime === undefined) return start;
+  if (start === 'now' || !start.includes('now')) return start;
+
+  const offset = dateStringToOffset(start);
+  if (!offset) return start;
+
+  if (roundRelativeTime === false) {
+    return start.replace(/\/[smhdwMy]$/, '');
+  }
+
+  if (offset.roundTo) return start;
+
+  const roundUnit = ROUND_UNIT_MAP[offset.unit];
+  if (!roundUnit) return start;
+
+  return `${start}/${roundUnit}`;
 }
 
 /**

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
@@ -129,46 +129,6 @@ export const documentationPanelTexts = {
   ),
 };
 
-export const settingsPanelTexts = {
-  heading: i18n.translate('sharedUXPackages.dateRangePicker.settingsPanel.heading', {
-    defaultMessage: 'Settings',
-  }),
-  roundRelativeTimeLabel: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel',
-    { defaultMessage: 'Round relative time ranges' }
-  ),
-  roundRelativeTimeDescription: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeDescription',
-    { defaultMessage: 'Relative ranges round to the nearest full unit (minute, hour, etc.)' }
-  ),
-  timeFormatHeading: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading',
-    { defaultMessage: 'Time format and zone' }
-  ),
-  timeFormatDescription: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription',
-    {
-      defaultMessage:
-        'Time zone and format can be set by the space administrator in Advanced settings and affect all the users of this space.',
-    }
-  ),
-  advancedSettingsLink: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.advancedSettingsLink',
-    { defaultMessage: 'Advanced settings' }
-  ),
-  newTimePickerHeading: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerHeading',
-    { defaultMessage: 'New time picker' }
-  ),
-  newTimePickerDescription: i18n.translate(
-    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerDescription',
-    {
-      defaultMessage:
-        'Don\'t like new time picker UX? Opt out from it in advanced settings under "".',
-    }
-  ),
-};
-
 export const customTimeRangePanelTexts = {
   heading: i18n.translate('sharedUXPackages.dateRangePicker.customTimeRangePanel.heading', {
     defaultMessage: 'Custom time range',
@@ -258,6 +218,46 @@ export const customTimeRangePanelTexts = {
       defaultMessage: '{unit}s from now',
       values: { unit },
     }),
+};
+
+export const settingsPanelTexts = {
+  heading: i18n.translate('sharedUXPackages.dateRangePicker.settingsPanel.heading', {
+    defaultMessage: 'Settings',
+  }),
+  roundRelativeTimeLabel: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel',
+    { defaultMessage: 'Round relative time ranges' }
+  ),
+  roundRelativeTimeDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeDescription',
+    { defaultMessage: 'Relative ranges round to the nearest full unit (minute, hour, etc.)' }
+  ),
+  timeFormatHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading',
+    { defaultMessage: 'Time format and zone' }
+  ),
+  timeFormatDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription',
+    {
+      defaultMessage:
+        'Time zone and format can be set by the space administrator in Advanced settings and affect all the users of this space.',
+    }
+  ),
+  advancedSettingsLink: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.advancedSettingsLink',
+    { defaultMessage: 'Advanced settings' }
+  ),
+  newTimePickerHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerHeading',
+    { defaultMessage: 'New time picker' }
+  ),
+  newTimePickerDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerDescription',
+    {
+      defaultMessage:
+        'Don\'t like new time picker UX? Opt out from it in advanced settings under "".',
+    }
+  ),
 };
 
 export const mainPanelTexts = {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
@@ -129,6 +129,46 @@ export const documentationPanelTexts = {
   ),
 };
 
+export const settingsPanelTexts = {
+  heading: i18n.translate('sharedUXPackages.dateRangePicker.settingsPanel.heading', {
+    defaultMessage: 'Settings',
+  }),
+  roundRelativeTimeLabel: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeLabel',
+    { defaultMessage: 'Round relative time ranges' }
+  ),
+  roundRelativeTimeDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.roundRelativeTimeDescription',
+    { defaultMessage: 'Relative ranges round to the nearest full unit (minute, hour, etc.)' }
+  ),
+  timeFormatHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatHeading',
+    { defaultMessage: 'Time format and zone' }
+  ),
+  timeFormatDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.timeFormatDescription',
+    {
+      defaultMessage:
+        'Time zone and format can be set by the space administrator in Advanced settings and affect all the users of this space.',
+    }
+  ),
+  advancedSettingsLink: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.advancedSettingsLink',
+    { defaultMessage: 'Advanced settings' }
+  ),
+  newTimePickerHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerHeading',
+    { defaultMessage: 'New time picker' }
+  ),
+  newTimePickerDescription: i18n.translate(
+    'sharedUXPackages.dateRangePicker.settingsPanel.newTimePickerDescription',
+    {
+      defaultMessage:
+        'Don\'t like new time picker UX? Opt out from it in advanced settings under "".',
+    }
+  ),
+};
+
 export const customTimeRangePanelTexts = {
   heading: i18n.translate('sharedUXPackages.dateRangePicker.customTimeRangePanel.heading', {
     defaultMessage: 'Custom time range',
@@ -242,5 +282,9 @@ export const mainPanelTexts = {
   deletePresetAriaLabel: i18n.translate(
     'sharedUXPackages.dateRangePicker.mainPanel.deletePresetAriaLabel',
     { defaultMessage: 'Delete preset' }
+  ),
+  settingsAriaLabel: i18n.translate(
+    'sharedUXPackages.dateRangePicker.mainPanel.settingsAriaLabel',
+    { defaultMessage: 'Settings' }
   ),
 };

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/translations.ts
@@ -88,6 +88,47 @@ export const calendarPanelTexts = {
   ),
 };
 
+export const documentationPanelTexts = {
+  heading: i18n.translate('sharedUXPackages.dateRangePicker.documentationPanel.heading', {
+    defaultMessage: 'Documentation',
+  }),
+  intro: i18n.translate('sharedUXPackages.dateRangePicker.documentationPanel.intro', {
+    defaultMessage:
+      'Type `to` to split start and end dates, otherwise the input will consider it just a one day range.',
+  }),
+  absoluteHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.documentationPanel.absoluteHeading',
+    { defaultMessage: 'Absolute time formats' }
+  ),
+  absoluteBody: i18n.translate('sharedUXPackages.dateRangePicker.documentationPanel.absoluteBody', {
+    defaultMessage:
+      'Use formats like `Dec 1, 2025, 00:00` (default), `2025-12-01` (ISO 8601), `Fri, 1 Dec 2025 00:00:00 GMT` (RFC 2822), `1760665383890` (unix timestamp), `1st of January, 2025` or just `Jan 1st, 2025`.',
+  }),
+  relativeHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.documentationPanel.relativeHeading',
+    { defaultMessage: 'Relative time' }
+  ),
+  relativeBody: i18n.translate('sharedUXPackages.dateRangePicker.documentationPanel.relativeBody', {
+    defaultMessage:
+      'Type `-5m`, `past 5 min`, `last 5 minutes` or any combination with words `last`, `next`, `ago`, `from now` etc.',
+  }),
+  combinationsHeading: i18n.translate(
+    'sharedUXPackages.dateRangePicker.documentationPanel.combinationsHeading',
+    { defaultMessage: 'Custom combinations' }
+  ),
+  combinationsBody: i18n.translate(
+    'sharedUXPackages.dateRangePicker.documentationPanel.combinationsBody',
+    {
+      defaultMessage:
+        'Custom time ranges are combinations of the aforementioned formats, e.g. `now to Fri, 1 Dec 2025 00:00:00 GMT` or `-12d to now`.',
+    }
+  ),
+  detailedDocumentationLink: i18n.translate(
+    'sharedUXPackages.dateRangePicker.documentationPanel.detailedDocumentationLink',
+    { defaultMessage: 'Detailed documentation' }
+  ),
+};
+
 export const customTimeRangePanelTexts = {
   heading: i18n.translate('sharedUXPackages.dateRangePicker.customTimeRangePanel.heading', {
     defaultMessage: 'Custom time range',

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -13,16 +13,16 @@ import type { DATE_TYPE_ABSOLUTE, DATE_TYPE_RELATIVE, DATE_TYPE_NOW } from './co
 
 export type DateType = typeof DATE_TYPE_ABSOLUTE | typeof DATE_TYPE_RELATIVE | typeof DATE_TYPE_NOW;
 
-/** Canonical date-math time units */
+/** Single-character date-math time unit (e.g. `'d'` for days, `'M'` for months). */
 export type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y';
 
-/** Structured offset extracted from a relative date-math string like `now-7d/d` */
+/** Structured offset extracted from a relative date-math string like `now-7d/d`. */
 export interface DateOffset {
   /** Signed offset. Negative = past, positive = future. */
   count: number;
-  /** Time unit for the offset */
+  /** Time unit for the offset. */
   unit: TimeUnit;
-  /** Optional rounding unit (the `/d` in `now-1d/d`) */
+  /** Optional rounding unit (the `/d` in `now-1d/d`). */
   roundTo?: TimeUnit;
 }
 
@@ -53,6 +53,19 @@ export interface CalendarOptions {
    * @default 0
    */
   firstDayOfWeek?: 0 | 1;
+}
+
+/** Canonical date-math time units */
+export type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y';
+
+/** Structured offset extracted from a relative date-math string like `now-7d/d` */
+export interface DateOffset {
+  /** Signed offset. Negative = past, positive = future. */
+  count: number;
+  /** Time unit for the offset */
+  unit: TimeUnit;
+  /** Optional rounding unit (the `/d` in `now-1d/d`) */
+  roundTo?: TimeUnit;
 }
 
 export interface TimeRangeTransformOptions {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -90,6 +90,16 @@ export interface TimeRangeTransformOptions {
   roundRelativeTime?: boolean;
 }
 
+/** User-facing settings exposed by the date range picker settings panel. */
+export interface DateRangePickerSettings {
+  /**
+   * When true, relative time ranges round to the nearest full unit
+   * (e.g. minute, hour, day).
+   * @default true
+   */
+  roundRelativeTime: boolean;
+}
+
 export interface TimeRange {
   value: string;
   start: DateString;

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -55,9 +55,27 @@ export interface CalendarOptions {
   firstDayOfWeek?: 0 | 1;
 }
 
+/** Canonical date-math time units */
+export type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y';
+
+/** Structured offset extracted from a relative date-math string like `now-7d/d` */
+export interface DateOffset {
+  /** Signed offset. Negative = past, positive = future. */
+  count: number;
+  /** Time unit for the offset */
+  unit: TimeUnit;
+  /** Optional rounding unit (the `/d` in `now-1d/d`) */
+  roundTo?: TimeUnit;
+}
+
 export interface TimeRangeTransformOptions {
   presets?: TimeRangeBoundsOption[];
+  /** Additional accepted delimiter (on top of the built-in `'to'`, `'until'`, and `'-'`) */
   delimiter?: string;
+  /**
+   * Format string used for both displaying and parsing absolute dates.
+   * Prepended to built-in formats so custom-formatted dates round-trip correctly.
+   */
   dateFormat?: string;
 }
 
@@ -70,4 +88,8 @@ export interface TimeRange {
   type: [DateType, DateType];
   isNaturalLanguage: boolean;
   isInvalid: boolean;
+  /** Non-null only when the start bound is RELATIVE */
+  startOffset: DateOffset | null;
+  /** Non-null only when the end bound is RELATIVE */
+  endOffset: DateOffset | null;
 }

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -77,6 +77,17 @@ export interface TimeRangeTransformOptions {
    * Prepended to built-in formats so custom-formatted dates round-trip correctly.
    */
   dateFormat?: string;
+  /**
+   * Controls rounding of the start bound for relative time ranges.
+   * Only affects relative `start` bounds (strings containing `now`);
+   * future ranges where start is bare `now` are unaffected.
+   * - `true`: keep existing rounding; if absent, infer it from the offset
+   *   unit (`/d` for day-and-above, next-unit-up for sub-day units).
+   * - `false`: strip any rounding suffix.
+   * - `undefined`: leave the start string as-is.
+   * @default undefined
+   */
+  roundRelativeTime?: boolean;
 }
 
 export interface TimeRange {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/types.ts
@@ -13,16 +13,16 @@ import type { DATE_TYPE_ABSOLUTE, DATE_TYPE_RELATIVE, DATE_TYPE_NOW } from './co
 
 export type DateType = typeof DATE_TYPE_ABSOLUTE | typeof DATE_TYPE_RELATIVE | typeof DATE_TYPE_NOW;
 
-/** Single-character date-math time unit (e.g. `'d'` for days, `'M'` for months). */
+/** Canonical date-math time units */
 export type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y';
 
-/** Structured offset extracted from a relative date-math string like `now-7d/d`. */
+/** Structured offset extracted from a relative date-math string like `now-7d/d` */
 export interface DateOffset {
   /** Signed offset. Negative = past, positive = future. */
   count: number;
-  /** Time unit for the offset. */
+  /** Time unit for the offset */
   unit: TimeUnit;
-  /** Optional rounding unit (the `/d` in `now-1d/d`). */
+  /** Optional rounding unit (the `/d` in `now-1d/d`) */
   roundTo?: TimeUnit;
 }
 
@@ -53,19 +53,6 @@ export interface CalendarOptions {
    * @default 0
    */
   firstDayOfWeek?: 0 | 1;
-}
-
-/** Canonical date-math time units */
-export type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y';
-
-/** Structured offset extracted from a relative date-math string like `now-7d/d` */
-export interface DateOffset {
-  /** Signed offset. Negative = past, positive = future. */
-  count: number;
-  /** Time unit for the offset */
-  unit: TimeUnit;
-  /** Optional rounding unit (the `/d` in `now-1d/d`) */
-  roundTo?: TimeUnit;
 }
 
 export interface TimeRangeTransformOptions {

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/utils.test.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/utils.test.ts
@@ -46,6 +46,8 @@ describe('isValidTimeRange', () => {
     type: [DATE_TYPE_RELATIVE, DATE_TYPE_NOW],
     isNaturalLanguage: false,
     isInvalid: true,
+    startOffset: null,
+    endOffset: null,
   });
 
   it('returns false when a date is missing', () => {
@@ -114,7 +116,7 @@ describe('getOptionShorthand', () => {
   });
 
   it('combines both offsets when neither is now', () => {
-    expect(getOptionShorthand({ start: 'now-7d', end: 'now-1d' })).toBe('-7d to -1d');
+    expect(getOptionShorthand({ start: 'now-7d', end: 'now-1d' })).toBe('-7d - -1d');
   });
 
   it('returns null when a bound has rounding', () => {
@@ -152,11 +154,11 @@ describe('getOptionInputText', () => {
   });
 
   it('joins both fragments with delimiter when neither bound is now', () => {
-    expect(getOptionInputText({ start: 'now-7d', end: 'now-1d' })).toBe('-7d to -1d');
+    expect(getOptionInputText({ start: 'now-7d', end: 'now-1d' })).toBe('-7d - -1d');
   });
 
   it('keeps bounds as-is when now prefix cannot be stripped', () => {
-    expect(getOptionInputText({ start: 'now/d', end: 'now/d' })).toBe('now/d to now/d');
+    expect(getOptionInputText({ start: 'now/d', end: 'now/d' })).toBe('now/d - now/d');
   });
 
   it('returns now when both bounds are now', () => {
@@ -168,7 +170,7 @@ describe('formatDateRange', () => {
   it('formats two dates with the standard delimiter', () => {
     const start = new Date(2026, 1, 10, 10, 15, 30, 500);
     const end = new Date(2026, 1, 11, 23, 30, 0, 0);
-    expect(formatDateRange(start, end)).toBe('2026-02-10T10:15:30.500 to 2026-02-11T23:30:00.000');
+    expect(formatDateRange(start, end)).toBe('2026-02-10T10:15:30.500 - 2026-02-11T23:30:00.000');
   });
 
   it('uses local time (no Z suffix)', () => {
@@ -181,7 +183,7 @@ describe('formatDateRange', () => {
   it('handles same-day ranges', () => {
     const start = new Date(2026, 2, 5, 9, 0, 0, 0);
     const end = new Date(2026, 2, 5, 17, 0, 0, 0);
-    expect(formatDateRange(start, end)).toBe('2026-03-05T09:00:00.000 to 2026-03-05T17:00:00.000');
+    expect(formatDateRange(start, end)).toBe('2026-03-05T09:00:00.000 - 2026-03-05T17:00:00.000');
   });
 });
 

--- a/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/utils.ts
+++ b/src/platform/packages/shared/shared-ux/datetime/kbn-date-range-picker/utils.ts
@@ -82,7 +82,7 @@ export function getOptionDisplayLabel(option: TimeRangeBoundsOption): string {
  * @example
  * getOptionShorthand({ start: 'now-15m', end: 'now' }) // "-15m"
  * getOptionShorthand({ start: 'now', end: 'now+3d' })  // "+3d"
- * getOptionShorthand({ start: 'now-7d', end: 'now-1d' }) // "-7d to -1d"
+ * getOptionShorthand({ start: 'now-7d', end: 'now-1d' }) // "-7d - -1d"
  * getOptionShorthand({ start: '2025-01-01', end: 'now' }) // null
  */
 export function getOptionShorthand(option: TimeRangeBoundsOption): string | null {
@@ -96,7 +96,7 @@ export function getOptionShorthand(option: TimeRangeBoundsOption): string | null
   if (startOffset === 'now') return endOffset;
   if (endOffset === 'now') return startOffset;
 
-  return `${startOffset} to ${endOffset}`;
+  return `${startOffset} ${DATE_RANGE_INPUT_DELIMITER} ${endOffset}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> the `DateRangePicker` component this is touching will be in Technical Preview

This PR adds the missing parts to make `DateRangePicker` feature-complete to start a QA process.

Resolves https://github.com/elastic/eui-private/issues/515 🔒 
Resolves https://github.com/elastic/eui-private/issues/516 🔒 
Resolves https://github.com/elastic/eui-private/issues/517 🔒 
Resolves https://github.com/elastic/eui-private/issues/519 🔒 

Changes outlines right below.

### Changes

#### Parser small improvements

https://github.com/elastic/kibana/pull/258229/commits/838c6c34b0dc844f2c90ddf30512ee0311df9354

- make the input more forgiving with absolute dates (see [eui/#9199](https://github.com/elastic/eui/pull/9199))
- use a dash as default delimiter e.g. `feb 1 - feb 3`, also supporting others e.g. `to` or `until`
- support shorthand-specific unit forms while still being handling date math as before e.g. `-6M` and `-6mos` are the same
- a bit better test coverage
- matches presets _before_ parsing, as expected
- add an option to round relative times (wired up with settings) https://github.com/elastic/kibana/pull/258229/commits/45618eaf12e7f11966a6566cdc498c71b7208dda

##### QA suggestion
* [x] verify input is forgiving with absolute dates in RFC 2822-ish
* [x] verify dash works as a delimiter, also `to` and `until`
* [x] verify shorthand units for minutes and months works in strict dateMath and our custom syntax `min` -> `m`, `mos` -> `M`
* [x] presets are matched correctly, both by typing and selecting from the list

#### Documentation panel

https://github.com/elastic/kibana/pull/258229/commits/0b3c5d51b7676ea329825ade501f391d0df2f6ad

- a button to navigate to it is visible when the input is cleared
- contents are not final

##### QA suggestion
* [x] verify the button shows when the input clears and navigates correctly

#### Settings panel and `settings` / `onSettingsChange` props 

https://github.com/elastic/kibana/pull/258229/commits/13ad3438908da49b10d22f9cc76ae3e8351321ea

- can be opened via the gear icon button on the footer
- features only one setting, "Round relative time ranges" → `roundRelativeTime`
- introduces mandatory `settings` and `onSettingsChange` props

##### QA suggestion
* [x] verify toggling "Round relative time ranges" works as expected (rounding is applied when "on", to the start bound only)

#### Time zone in main panel

https://github.com/elastic/kibana/pull/258229/commits/fc69e8b1dfe27bedf5697cb805109764015507d6

- display the time zone in the main panel's footer
- does not handle `Browser` as a value, this will be fixed separately
- no tests for now

##### QA suggestion
* [x] verify the time zone is displayed as expected (if no valid iana name passed, it shouldn't show)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



