### PR TITLE
[Agent Builder] Migrate existing routes to new UX

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/edit/agent_form.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/edit/agent_form.tsx
@@ -213,7 +213,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
         buttonId: BUTTON_IDS.SAVE_AND_CHAT,
         navigateToListView: false,
       });
-      deferNavigateToAgentBuilderUrl(appPaths.chat.newWithAgent({ agentId: data.id }));
+      deferNavigateToAgentBuilderUrl(appPaths.agent.root({ agentId: data.id }));
     },
     [deferNavigateToAgentBuilderUrl, handleSave]
   );
@@ -394,7 +394,7 @@ export const AgentForm: React.FC<AgentFormProps> = ({ editingAgentId, onDelete }
         <EuiButton
           {...commonProps}
           onClick={() =>
-            navigateToAgentBuilderUrl(appPaths.chat.newWithAgent({ agentId: editingAgentId }))
+            navigateToAgentBuilderUrl(appPaths.agent.root({ agentId: editingAgentId }))
           }
         >
           {i18n.translate('xpack.agentBuilder.agents.form.chatButton', {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/list/agents_list.tsx
@@ -202,8 +202,7 @@ export const AgentsList: React.FC = () => {
           'data-test-subj': (agent) => `agentBuilderAgentsListChat-${agent.id}`,
           isPrimary: true,
           showOnHover: true,
-          href: (agent) =>
-            createAgentBuilderUrl(appPaths.chat.new, { [searchParamNames.agentId]: agent.id }),
+          href: (agent) => createAgentBuilderUrl(appPaths.agent.root({ agentId: agent.id })),
         },
         {
           type: 'icon',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/actions/start_new_conversation_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/actions/start_new_conversation_button.tsx
@@ -19,8 +19,6 @@ const NEW_CONVERSATION_BUTTON_LABEL = i18n.translate(
   }
 );
 
-const NEW_CONVERSATION_PATH = appPaths.chat.new;
-
 export const StartNewConversationButton: React.FC = () => {
   const { navigateToAgentBuilderUrl } = useNavigation();
   const { isEmbeddedContext, setConversationId } = useConversationContext();
@@ -29,7 +27,7 @@ export const StartNewConversationButton: React.FC = () => {
     if (isEmbeddedContext) {
       setConversationId?.(undefined);
     } else {
-      navigateToAgentBuilderUrl(NEW_CONVERSATION_PATH);
+      navigateToAgentBuilderUrl(appPaths.root);
     }
   }, [isEmbeddedContext, setConversationId, navigateToAgentBuilderUrl]);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/new_conversation_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/new_conversation_button.tsx
@@ -39,7 +39,7 @@ export const NewConversationButton: React.FC<NewConversationButtonProps> = ({ on
   const buttonProps = isEmbeddedContext
     ? {}
     : {
-        href: createAgentBuilderUrl(appPaths.chat.new),
+        href: createAgentBuilderUrl(appPaths.root),
       };
 
   const label = i18n.translate('xpack.agentBuilder.newConversationButton.ariaLabel', {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/input_actions/input_actions.tsx
@@ -8,6 +8,7 @@
 import { EuiFlexGroup, EuiFlexItem, EuiTourStep } from '@elastic/eui';
 import React from 'react';
 import { TourStep, useAgentBuilderTour } from '../../../../context/agent_builder_tour_context';
+import { useConversationContext } from '../../../../context/conversation/conversation_context';
 import { AgentSelector } from './agent_selector';
 import { ConversationActionButton } from './conversation_action_button';
 import { ConnectorSelector } from './connector_selector';
@@ -26,6 +27,7 @@ export const InputActions: React.FC<InputActionsProps> = ({
   agentId,
 }) => {
   const { getStepProps } = useAgentBuilderTour();
+  const { isEmbeddedContext } = useConversationContext();
 
   return (
     <EuiFlexItem grow={false}>
@@ -42,11 +44,13 @@ export const InputActions: React.FC<InputActionsProps> = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="m" responsive={false} alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiTourStep {...getStepProps(TourStep.AgentSelector)}>
-                <AgentSelector agentId={agentId} />
-              </EuiTourStep>
-            </EuiFlexItem>
+            {isEmbeddedContext && (
+              <EuiFlexItem grow={false}>
+                <EuiTourStep {...getStepProps(TourStep.AgentSelector)}>
+                  <AgentSelector agentId={agentId} />
+                </EuiTourStep>
+              </EuiFlexItem>
+            )}
             <EuiFlexItem grow={false}>
               <ConversationActionButton
                 onSubmit={onSubmit}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversations_history/conversations_history_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversations_history/conversations_history_list.tsx
@@ -114,7 +114,10 @@ export const ConversationHistoryList: React.FC<ConversationHistoryListProps> = (
       if (isEmbeddedContext) {
         setConversationId?.(conversation.id);
       } else {
-        navigateToAgentBuilderUrl(appPaths.chat.conversation({ conversationId: conversation.id }));
+        // Use legacy path - LegacyConversationRedirect fetches conversation and redirects to correct agent-scoped URL
+        navigateToAgentBuilderUrl(
+          appPaths.legacy.conversation({ conversationId: conversation.id })
+        );
       }
       onClose?.();
     },

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/agent_selector.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/agent_selector.tsx
@@ -22,6 +22,9 @@ const labels = {
   selectAgent: i18n.translate('xpack.agentBuilder.sidebar.agentSelector.selectAgent', {
     defaultMessage: 'Select agent',
   }),
+  deletedAgent: i18n.translate('xpack.agentBuilder.sidebar.agentSelector.deletedAgent', {
+    defaultMessage: '(Deleted agent)',
+  }),
 };
 
 interface AgentSelectorProps {
@@ -48,6 +51,15 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({ agentId, getNaviga
     text: agent.name,
   }));
 
+  const isAgentKnown = agents.some((agent) => agent.id === agentId);
+
+  // When viewing a conversation for a deleted agent, prepend a disabled placeholder
+  // so the select doesn't silently show the first valid agent as the selected value.
+  const options =
+    !isLoading && !isAgentKnown
+      ? [{ value: agentId, text: labels.deletedAgent, disabled: true }, ...agentOptions]
+      : agentOptions;
+
   return (
     <EuiFlexItem grow={false}>
       <EuiText size="xs" color="subdued">
@@ -58,7 +70,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({ agentId, getNaviga
       ) : (
         <EuiSelect
           compressed
-          options={agentOptions}
+          options={options}
           value={agentId}
           onChange={handleAgentChange}
           aria-label={labels.selectAgent}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
@@ -14,6 +14,8 @@ import { css } from '@emotion/react';
 
 import { storageKeys } from '../../../storage_keys';
 import { getSidebarViewForRoute, getAgentIdFromPath } from '../../../route_config';
+import { useAgentBuilderAgents } from '../../../hooks/agents/use_agents';
+import { useValidateAgentId } from '../../../hooks/agents/use_validate_agent_id';
 import { ConversationSidebarView } from './views/conversation_view';
 import { AgentSettingsSidebarView } from './views/agent_settings_view';
 import { ManageSidebarView } from './views/manage_view';
@@ -25,12 +27,15 @@ export const UnifiedSidebar: React.FC = () => {
   const sidebarView = getSidebarViewForRoute(location.pathname);
   const agentIdFromPath = getAgentIdFromPath(location.pathname);
   const [, setStoredAgentId] = useLocalStorage<string>(storageKeys.agentId);
+  const { isFetched: isAgentsFetched } = useAgentBuilderAgents();
+  const validateAgentId = useValidateAgentId();
 
   useEffect(() => {
-    if (agentIdFromPath) {
+    // Wait for agents to load before validating — prevents falsely skipping valid IDs during initial load
+    if (isAgentsFetched && agentIdFromPath && validateAgentId(agentIdFromPath)) {
       setStoredAgentId(agentIdFromPath);
     }
-  }, [agentIdFromPath, setStoredAgentId]);
+  }, [isAgentsFetched, agentIdFromPath, validateAgentId, setStoredAgentId]);
 
   const sidebarStyles = css`
     width: ${SIDEBAR_WIDTH}px;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/unified_sidebar.tsx
@@ -9,7 +9,7 @@ import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
-import { EuiPanel } from '@elastic/eui';
+import { EuiFlexGroup, EuiPanel } from '@elastic/eui';
 import { css } from '@emotion/react';
 
 import { storageKeys } from '../../../storage_keys';
@@ -18,7 +18,7 @@ import { ConversationSidebarView } from './views/conversation_view';
 import { AgentSettingsSidebarView } from './views/agent_settings_view';
 import { ManageSidebarView } from './views/manage_view';
 
-const SIDEBAR_WIDTH = 200;
+const SIDEBAR_WIDTH = 300;
 
 export const UnifiedSidebar: React.FC = () => {
   const location = useLocation();
@@ -34,23 +34,34 @@ export const UnifiedSidebar: React.FC = () => {
 
   const sidebarStyles = css`
     width: ${SIDEBAR_WIDTH}px;
-    min-width: ${SIDEBAR_WIDTH}px;
     height: 100%;
     border-radius: 0;
+    display: flex;
+    flex-direction: column;
+  `;
+
+  const sidebarContentStyles = css`
+    flex: 1;
+    position: relative;
+    overflow: hidden;
   `;
 
   return (
     <EuiPanel
       css={sidebarStyles}
-      paddingSize="m"
+      paddingSize="none"
       hasShadow={false}
       hasBorder
       role="navigation"
       aria-label="Agent Builder navigation"
     >
-      {sidebarView === 'conversation' && <ConversationSidebarView pathname={location.pathname} />}
-      {sidebarView === 'agentSettings' && <AgentSettingsSidebarView pathname={location.pathname} />}
-      {sidebarView === 'manage' && <ManageSidebarView pathname={location.pathname} />}
+      <EuiFlexGroup css={sidebarContentStyles}>
+        {sidebarView === 'conversation' && <ConversationSidebarView />}
+        {sidebarView === 'agentSettings' && (
+          <AgentSettingsSidebarView pathname={location.pathname} />
+        )}
+        {sidebarView === 'manage' && <ManageSidebarView pathname={location.pathname} />}
+      </EuiFlexGroup>
     </EuiPanel>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view.tsx
@@ -7,43 +7,77 @@
 
 import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiHorizontalRule } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiHorizontalRule, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 
 import { appPaths } from '../../../../utils/app_paths';
-import { getAgentIdFromPath } from '../../../../route_config';
+import { getAgentIdFromPath, getConversationIdFromPath } from '../../../../route_config';
 import { AgentSelector } from '../agent_selector';
+import { SidebarConversationList } from './sidebar_conversation_list';
 
 const labels = {
   customize: i18n.translate('xpack.agentBuilder.sidebar.conversation.customize', {
     defaultMessage: 'Customize',
   }),
-  conversationsTitle: i18n.translate('xpack.agentBuilder.sidebar.conversation.conversationsTitle', {
-    defaultMessage: 'Conversations',
-  }),
-  newConversation: i18n.translate('xpack.agentBuilder.sidebar.conversation.newConversation', {
-    defaultMessage: '+ New conversation',
-  }),
   manageComponents: i18n.translate('xpack.agentBuilder.sidebar.conversation.manageComponents', {
     defaultMessage: 'Manage components',
   }),
+  recentChats: i18n.translate('xpack.agentBuilder.sidebar.conversation.recentChats', {
+    defaultMessage: 'Recent chats',
+  }),
 };
 
-interface ConversationSidebarViewProps {
-  pathname: string;
-}
+// TODO: fix these values once the UI is complete for the header and footer or use a resizeObserver to get the height of the header and footer which is more dynamic
+const HEADER_HEIGHT = 120; // Agent selector (~56px) + Customize link (~18px) + hr margin (~16px)
+const FOOTER_HEIGHT = 50; // hr margin (~16px) + Manage link (~18px) + padding
 
-export const ConversationSidebarView: React.FC<ConversationSidebarViewProps> = ({ pathname }) => {
+const containerStyles = css`
+  position: relative;
+  height: 100%;
+  width: 100%;
+`;
+
+const linkStyles = css`
+  text-decoration: none;
+  color: inherit;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const ConversationSidebarView: React.FC = () => {
+  const { pathname } = useLocation();
   const agentId = getAgentIdFromPath(pathname) ?? 'elastic-ai-agent';
+  const conversationId = getConversationIdFromPath(pathname);
+  const { euiTheme } = useEuiTheme();
 
-  const linkStyles = css`
-    text-decoration: none;
-    color: inherit;
-    &:hover {
-      text-decoration: underline;
-    }
+  const headerStyles = css`
+    padding: ${euiTheme.size.base};
+  `;
+  const scrollableStyles = css`
+    position: absolute;
+    top: ${HEADER_HEIGHT}px;
+    bottom: ${FOOTER_HEIGHT}px;
+    padding: ${euiTheme.size.base};
+    left: 0;
+    right: 0;
+    overflow-y: auto;
+  `;
+
+  const footerStyles = css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: ${euiTheme.size.base};
+  `;
+
+  const recentChatsStyles = css`
+    padding: 0 ${euiTheme.size.s};
+    font-weight: ${euiTheme.font.weight.semiBold};
   `;
 
   const getNavigationPath = useCallback(
@@ -52,36 +86,49 @@ export const ConversationSidebarView: React.FC<ConversationSidebarViewProps> = (
   );
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
-      <AgentSelector agentId={agentId} getNavigationPath={getNavigationPath} />
+    <div css={containerStyles}>
+      {/* Header */}
+      <EuiFlexGroup direction="column" gutterSize="s" css={headerStyles}>
+        <EuiFlexItem grow={false}>
+          <AgentSelector agentId={agentId} getNavigationPath={getNavigationPath} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <Link to={appPaths.agent.instructions({ agentId })} css={linkStyles}>
+            <EuiText size="s">{labels.customize}</EuiText>
+          </Link>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiHorizontalRule margin="none" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-      <EuiFlexItem grow={false}>
-        <Link to={appPaths.agent.instructions({ agentId })} css={linkStyles}>
-          <EuiText size="s">{labels.customize}</EuiText>
-        </Link>
-      </EuiFlexItem>
+      {/* Scrollable conversation list */}
+      <div css={scrollableStyles}>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false} css={recentChatsStyles}>
+            <EuiText size="xs" color="disabled" css={{ fontWeight: euiTheme.font.weight.semiBold }}>
+              {labels.recentChats}
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <SidebarConversationList agentId={agentId} currentConversationId={conversationId} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
 
-      <EuiHorizontalRule margin="s" />
-
-      <EuiFlexItem grow={false}>
-        <EuiText size="xs" color="subdued">
-          <strong>{labels.conversationsTitle}</strong>
-        </EuiText>
-      </EuiFlexItem>
-
-      <EuiFlexItem grow={false}>
-        <Link to={appPaths.agent.root({ agentId })} css={linkStyles}>
-          <EuiText size="s">{labels.newConversation}</EuiText>
-        </Link>
-      </EuiFlexItem>
-
-      <EuiHorizontalRule margin="s" />
-
-      <EuiFlexItem grow={false}>
-        <Link to={appPaths.manage.agents} css={linkStyles}>
-          <EuiText size="s">{labels.manageComponents}</EuiText>
-        </Link>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      {/* Footer */}
+      <div css={footerStyles}>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiHorizontalRule margin="none" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <Link to={appPaths.manage.agents} css={linkStyles}>
+              <EuiText size="s">{labels.manageComponents}</EuiText>
+            </Link>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+    </div>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { useLocation } from 'react-router-dom';
 
@@ -15,6 +15,10 @@ import { i18n } from '@kbn/i18n';
 
 import { appPaths } from '../../../../utils/app_paths';
 import { getAgentIdFromPath, getConversationIdFromPath } from '../../../../route_config';
+import { useNavigation } from '../../../../hooks/use_navigation';
+import { useValidateAgentId } from '../../../../hooks/agents/use_validate_agent_id';
+import { useAgentBuilderAgents } from '../../../../hooks/agents/use_agents';
+import { useLastAgentId } from '../../../../hooks/use_last_agent_id';
 import { AgentSelector } from '../agent_selector';
 import { SidebarConversationList } from './sidebar_conversation_list';
 
@@ -53,6 +57,14 @@ export const ConversationSidebarView: React.FC = () => {
   const agentId = getAgentIdFromPath(pathname) ?? 'elastic-ai-agent';
   const conversationId = getConversationIdFromPath(pathname);
   const { euiTheme } = useEuiTheme();
+  const { navigateToAgentBuilderUrl } = useNavigation();
+  const validateAgentId = useValidateAgentId();
+  const { isFetched: isAgentsFetched } = useAgentBuilderAgents();
+  const lastAgentId = useLastAgentId();
+  const getNavigationPath = useCallback(
+    (newAgentId: string) => appPaths.agent.root({ agentId: newAgentId }),
+    []
+  );
 
   const headerStyles = css`
     padding: ${euiTheme.size.base};
@@ -80,10 +92,31 @@ export const ConversationSidebarView: React.FC = () => {
     font-weight: ${euiTheme.font.weight.semiBold};
   `;
 
-  const getNavigationPath = useCallback(
-    (newAgentId: string) => appPaths.agent.root({ agentId: newAgentId }),
-    []
-  );
+  useEffect(() => {
+    // Once agents have loaded, redirect to the last valid agent if the current agent ID
+    // is not recognised — but only when there is no conversation ID in the URL (new
+    // conversation route). Existing conversations for a deleted agent are intentionally
+    // shown read-only with the input disabled.
+
+    // We also check that lastAgentId itself is valid before redirecting: if local storage
+    // holds a stale/invalid ID too, navigating to it would trigger this effect again and
+    // cause an infinite redirect loop.
+    if (
+      isAgentsFetched &&
+      !conversationId &&
+      !validateAgentId(agentId) &&
+      validateAgentId(lastAgentId)
+    ) {
+      navigateToAgentBuilderUrl(appPaths.agent.root({ agentId: lastAgentId }));
+    }
+  }, [
+    isAgentsFetched,
+    conversationId,
+    agentId,
+    lastAgentId,
+    validateAgentId,
+    navigateToAgentBuilderUrl,
+  ]);
 
   return (
     <div css={containerStyles}>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/sidebar_conversation_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/sidebar_conversation_list.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom-v5-compat';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiTextTruncate,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+
+import { appPaths } from '../../../../utils/app_paths';
+import { useConversationList } from '../../../../hooks/use_conversation_list';
+
+interface SidebarConversationListProps {
+  agentId: string;
+  currentConversationId: string | undefined;
+}
+
+export const SidebarConversationList: React.FC<SidebarConversationListProps> = ({
+  agentId,
+  currentConversationId,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const { conversations = [], isLoading } = useConversationList({ agentId });
+
+  const sortedConversations = [...conversations].sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+  );
+
+  const linkStyles = css`
+    text-decoration: none;
+    padding: 6px ${euiTheme.size.s};
+    border-radius: ${euiTheme.border.radius.small};
+    color: ${euiTheme.colors.textParagraph};
+    font-size: ${euiTheme.font.scale.s}${euiTheme.font.defaultUnits};
+    &:hover {
+      text-decoration: underline;
+    }
+  `;
+
+  const activeLinkStyles = css`
+    ${linkStyles}
+    background-color: ${euiTheme.colors.backgroundLightPrimary};
+    color: ${euiTheme.colors.textPrimary};
+  `;
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="s" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      {sortedConversations.map((conversation) => {
+        const isActive = currentConversationId === conversation.id;
+        return (
+          <EuiFlexItem grow={false} key={conversation.id}>
+            <Link
+              to={appPaths.agent.conversations.byId({ agentId, conversationId: conversation.id })}
+              css={isActive ? activeLinkStyles : linkStyles}
+              data-test-subj={`agentBuilderSidebarConversation-${conversation.id}`}
+            >
+              <EuiTextTruncate text={conversation.title || conversation.id} />
+            </Link>
+          </EuiFlexItem>
+        );
+      })}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/routed_conversations_provider.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo, useEffect, useRef, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useQueryClient } from '@kbn/react-query';
 import { ConversationContext } from './conversation_context';
 import type { LocationState } from '../../hooks/use_navigation';
@@ -15,9 +14,8 @@ import { newConversationId } from '../../utils/new_conversation';
 import { appPaths } from '../../utils/app_paths';
 import { useNavigation } from '../../hooks/use_navigation';
 import { useAgentBuilderServices } from '../../hooks/use_agent_builder_service';
-import { useAgentBuilderAgents } from '../../hooks/agents/use_agents';
-import { searchParamNames } from '../../search_param_names';
 import { useConversationActions } from './use_conversation_actions';
+import { queryKeys } from '../../query_keys';
 
 interface RoutedConversationsProviderProps {
   children: React.ReactNode;
@@ -28,23 +26,23 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
 }) => {
   const queryClient = useQueryClient();
   const { conversationsService } = useAgentBuilderServices();
-  const { conversationId: conversationIdParam } = useParams<{ conversationId?: string }>();
+  const { conversationId: conversationIdParam, agentId: agentIdParam } = useParams<{
+    conversationId?: string;
+    agentId?: string;
+  }>();
 
   const conversationId = useMemo(() => {
     return conversationIdParam === newConversationId ? undefined : conversationIdParam;
   }, [conversationIdParam]);
 
+  const agentIdFromPath = agentIdParam;
+
   const location = useLocation<LocationState>();
   const shouldStickToBottom = location.state?.shouldStickToBottom ?? true;
   const initialMessage = location.state?.initialMessage;
 
-  // Get search params for agent ID syncing
-  const [searchParams] = useSearchParams();
-  const { agents } = useAgentBuilderAgents();
-
   const { navigateToAgentBuilderUrl } = useNavigation();
   const shouldAllowConversationRedirectRef = useRef(true);
-  const agentIdSyncedRef = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -53,17 +51,26 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
     };
   }, []);
 
+  // Clear new conversation cache when agent changes to ensure fresh state
+  useEffect(() => {
+    if (!conversationId) {
+      queryClient.removeQueries({ queryKey: queryKeys.conversations.byId(newConversationId) });
+    }
+  }, [agentIdFromPath, conversationId, queryClient]);
+
   const navigateToConversation = useCallback(
     ({ nextConversationId }: { nextConversationId: string }) => {
       // Navigate to the conversation if redirect is allowed
-      if (shouldAllowConversationRedirectRef.current) {
-        const path = appPaths.chat.conversation({ conversationId: nextConversationId });
-        const params = undefined;
+      if (shouldAllowConversationRedirectRef.current && agentIdFromPath) {
+        const path = appPaths.agent.conversations.byId({
+          agentId: agentIdFromPath,
+          conversationId: nextConversationId,
+        });
         const state = { shouldStickToBottom: false };
-        navigateToAgentBuilderUrl(path, params, state);
+        navigateToAgentBuilderUrl(path, undefined, state);
       }
     },
-    [shouldAllowConversationRedirectRef, navigateToAgentBuilderUrl]
+    [shouldAllowConversationRedirectRef, navigateToAgentBuilderUrl, agentIdFromPath]
   );
 
   const onConversationCreated = useCallback(
@@ -76,9 +83,8 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
   const onDeleteConversation = useCallback(
     ({ isCurrentConversation }: { isCurrentConversation: boolean }) => {
       if (isCurrentConversation) {
-        // If deleting current conversation, navigate to new conversation
-        const path = appPaths.chat.new;
-        navigateToAgentBuilderUrl(path, undefined, { shouldStickToBottom: true });
+        // If deleting current conversation, navigate to root (redirects to last used agent)
+        navigateToAgentBuilderUrl(appPaths.root, undefined, { shouldStickToBottom: true });
       }
     },
     [navigateToAgentBuilderUrl]
@@ -92,23 +98,6 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
     onDeleteConversation,
   });
 
-  // Handle agent ID syncing from URL params (moved from useSyncAgentId)
-  useEffect(() => {
-    if (agentIdSyncedRef.current || conversationId) {
-      return;
-    }
-
-    // If we don't have a selected agent id, check for a valid agent id in the search params
-    // This is used for the "chat with agent" action on the Agent pages
-    const agentIdParam = searchParams.get(searchParamNames.agentId);
-
-    if (agentIdParam && agents.some((agent) => agent.id === agentIdParam)) {
-      // Agent id passed to sync is valid, set it and mark as synced
-      conversationActions.setAgentId(agentIdParam);
-      agentIdSyncedRef.current = true;
-    }
-  }, [searchParams, agents, conversationId, conversationActions]);
-
   const contextValue = useMemo(
     () => ({
       conversationId,
@@ -117,8 +106,9 @@ export const RoutedConversationsProvider: React.FC<RoutedConversationsProviderPr
       conversationActions,
       initialMessage,
       autoSendInitialMessage: true,
+      agentId: agentIdFromPath,
     }),
-    [conversationId, shouldStickToBottom, conversationActions, initialMessage]
+    [conversationId, shouldStickToBottom, conversationActions, initialMessage, agentIdFromPath]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/hooks/use_conversation.ts
@@ -101,25 +101,22 @@ const useGetNewConversationAgentId = () => {
 export const useAgentId = () => {
   const { conversation } = useConversation();
   const context = useConversationContext();
-  const agentId = conversation?.agent_id;
   const conversationId = useConversationId();
   const isNewConversation = !conversationId;
   const getNewConversationAgentId = useGetNewConversationAgentId();
 
-  if (agentId) {
-    return agentId;
-  }
-
-  if (context.agentId) {
-    return context.agentId;
-  }
-
-  // For new conversations, agent id must be defined
+  // For new conversations, URL (context.agentId) is the source of truth
   if (isNewConversation) {
-    return getNewConversationAgentId();
+    return context.agentId ?? getNewConversationAgentId();
   }
 
-  return undefined;
+  // For existing conversations, use the conversation's stored agent_id
+  if (conversation?.agent_id) {
+    return conversation.agent_id;
+  }
+
+  // Fallback to context (URL) for edge cases
+  return context.agentId;
 };
 
 export const useConversationTitle = () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/conversations.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/conversations.tsx
@@ -15,7 +15,7 @@ export const AgentBuilderConversationsPage: React.FC = () => {
   useBreadcrumb([
     {
       text: labels.conversations.title,
-      path: appPaths.chat.new,
+      path: appPaths.root,
     },
   ]);
   return <AgentBuilderConversationsView />;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -13,6 +13,7 @@ import { RouteDisplay } from './components/common/route_display';
 import { AgentBuilderConversationsPage } from './pages/conversations';
 import { AgentBuilderAgentsPage } from './pages/agents';
 import { AgentBuilderAgentsCreate } from './pages/agent_create';
+import { AgentBuilderAgentsEdit } from './pages/agent_edit';
 import { AgentBuilderToolsPage } from './pages/tools';
 import { AgentBuilderToolCreatePage } from './pages/tool_create';
 import { AgentBuilderToolDetailsPage } from './pages/tool_details';
@@ -104,6 +105,11 @@ export const manageRoutes: RouteDefinition[] = [
     path: '/manage/agents/new',
     sidebarView: 'manage',
     element: <AgentBuilderAgentsCreate />,
+  },
+  {
+    path: '/manage/agents/:agentId',
+    sidebarView: 'manage',
+    element: <AgentBuilderAgentsEdit />,
   },
   {
     path: '/manage/tools',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -186,6 +186,11 @@ export const getAgentIdFromPath = (pathname: string): string | undefined => {
   return match ? match[1] : undefined;
 };
 
+export const getConversationIdFromPath = (pathname: string): string | undefined => {
+  const match = pathname.match(/^\/agents\/[^/]+\/conversations\/([^/]+)/);
+  return match ? match[1] : undefined;
+};
+
 export const getAgentSettingsNavItems = (
   agentId: string
 ): Array<{ label: string; path: string }> => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -10,6 +10,18 @@ import { matchPath } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 
 import { RouteDisplay } from './components/common/route_display';
+import { AgentBuilderConversationsPage } from './pages/conversations';
+import { AgentBuilderAgentsPage } from './pages/agents';
+import { AgentBuilderAgentsCreate } from './pages/agent_create';
+import { AgentBuilderToolsPage } from './pages/tools';
+import { AgentBuilderToolCreatePage } from './pages/tool_create';
+import { AgentBuilderToolDetailsPage } from './pages/tool_details';
+import { AgentBuilderBulkImportMcpToolsPage } from './pages/bulk_import_mcp_tools';
+import { AgentBuilderSkillsPage } from './pages/skills';
+import { AgentBuilderSkillCreatePage } from './pages/skill_create';
+import { AgentBuilderSkillDetailsPage } from './pages/skill_details';
+import { AgentBuilderPluginsPage } from './pages/plugins';
+import { AgentBuilderPluginDetailsPage } from './pages/plugin_details';
 
 export type SidebarView = 'conversation' | 'agentSettings' | 'manage';
 
@@ -47,7 +59,7 @@ export const agentRoutes: RouteDefinition[] = [
   {
     path: '/agents/:agentId/conversations/:conversationId',
     sidebarView: 'conversation',
-    element: <RouteDisplay />,
+    element: <AgentBuilderConversationsPage />,
   },
   {
     path: '/agents/:agentId/instructions',
@@ -77,7 +89,7 @@ export const agentRoutes: RouteDefinition[] = [
   {
     path: '/agents/:agentId',
     sidebarView: 'conversation',
-    element: <RouteDisplay />,
+    element: <AgentBuilderConversationsPage />,
   },
 ];
 
@@ -86,63 +98,63 @@ export const manageRoutes: RouteDefinition[] = [
     path: '/manage/agents',
     sidebarView: 'manage',
     navLabel: navLabels.agents,
-    element: <RouteDisplay />,
+    element: <AgentBuilderAgentsPage />,
   },
   {
     path: '/manage/agents/new',
     sidebarView: 'manage',
-    element: <RouteDisplay />,
+    element: <AgentBuilderAgentsCreate />,
   },
   {
     path: '/manage/tools',
     sidebarView: 'manage',
     navLabel: navLabels.tools,
-    element: <RouteDisplay />,
+    element: <AgentBuilderToolsPage />,
   },
   {
     path: '/manage/tools/new',
     sidebarView: 'manage',
-    element: <RouteDisplay />,
+    element: <AgentBuilderToolCreatePage />,
   },
   {
     path: '/manage/tools/bulk_import_mcp',
     sidebarView: 'manage',
-    element: <RouteDisplay />,
+    element: <AgentBuilderBulkImportMcpToolsPage />,
   },
   {
     path: '/manage/tools/:toolId',
     sidebarView: 'manage',
-    element: <RouteDisplay />,
+    element: <AgentBuilderToolDetailsPage />,
   },
   {
     path: '/manage/skills',
     sidebarView: 'manage',
     navLabel: navLabels.skills,
     isExperimental: true,
-    element: <RouteDisplay />,
+    element: <AgentBuilderSkillsPage />,
   },
   {
     path: '/manage/skills/new',
     sidebarView: 'manage',
     isExperimental: true,
-    element: <RouteDisplay />,
+    element: <AgentBuilderSkillCreatePage />,
   },
   {
     path: '/manage/skills/:skillId',
     sidebarView: 'manage',
     isExperimental: true,
-    element: <RouteDisplay />,
+    element: <AgentBuilderSkillDetailsPage />,
   },
   {
     path: '/manage/plugins',
     sidebarView: 'manage',
     navLabel: navLabels.plugins,
-    element: <RouteDisplay />,
+    element: <AgentBuilderPluginsPage />,
   },
   {
     path: '/manage/plugins/:pluginId',
     sidebarView: 'manage',
-    element: <RouteDisplay />,
+    element: <AgentBuilderPluginDetailsPage />,
   },
   {
     path: '/manage/connectors',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/routes.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/routes.tsx
@@ -30,7 +30,7 @@ export const AgentBuilderRoutes: React.FC<{}> = () => {
     <AppLayout>
       <Routes>
         {enabledRoutes.map((route) => (
-          <Route key={route.path} path={route.path}>
+          <Route key={route.path} path={route.path} exact>
             {route.element}
           </Route>
         ))}
@@ -40,8 +40,13 @@ export const AgentBuilderRoutes: React.FC<{}> = () => {
           <LegacyConversationRedirect />
         </Route>
 
+        {/* Redirect /agents to /agents/:lastAgentId */}
+        <Route path="/agents" exact>
+          <RootRedirect />
+        </Route>
+
         {/* Root route - redirect to last used agent */}
-        <Route path="/">
+        <Route path="/" exact>
           <RootRedirect />
         </Route>
       </Routes>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -29,6 +29,7 @@ export const appPaths = {
   manage: {
     agents: '/manage/agents',
     agentsNew: '/manage/agents/new',
+    agentDetails: ({ agentId }: { agentId: string }) => `/manage/agents/${agentId}`,
     tools: '/manage/tools',
     toolsNew: '/manage/tools/new',
     toolDetails: ({ toolId }: { toolId: string }) => `/manage/tools/${toolId}`,
@@ -39,5 +40,34 @@ export const appPaths = {
     plugins: '/manage/plugins',
     pluginDetails: ({ pluginId }: { pluginId: string }) => `/manage/plugins/${pluginId}`,
     connectors: '/manage/connectors',
+  },
+
+  // Backward compatibility aliases pointing to new manage routes
+  // TODO: Migrate consumers to use appPaths.manage.* directly and remove these aliases (this is jsut a shortcut for now)
+  chat: {
+    new: '/agents/elastic-default',
+    newWithAgent: ({ agentId }: { agentId: string }) => `/agents/${agentId}`,
+    conversation: ({ conversationId }: { conversationId: string }) =>
+      `/agents/elastic-default/conversations/${conversationId}`,
+  },
+  agents: {
+    list: '/manage/agents',
+    new: '/manage/agents/new',
+    edit: ({ agentId }: { agentId: string }) => `/manage/agents/${agentId}`,
+  },
+  tools: {
+    list: '/manage/tools',
+    new: '/manage/tools/new',
+    details: ({ toolId }: { toolId: string }) => `/manage/tools/${toolId}`,
+    bulkImportMcp: '/manage/tools/bulk_import_mcp',
+  },
+  skills: {
+    list: '/manage/skills',
+    new: '/manage/skills/new',
+    details: ({ skillId }: { skillId: string }) => `/manage/skills/${skillId}`,
+  },
+  plugins: {
+    list: '/manage/plugins',
+    details: ({ pluginId }: { pluginId: string }) => `/manage/plugins/${pluginId}`,
   },
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -42,13 +42,17 @@ export const appPaths = {
     connectors: '/manage/connectors',
   },
 
-  // Backward compatibility aliases pointing to new manage routes
-  // TODO: Migrate consumers to use appPaths.manage.* directly and remove these aliases (this is jsut a shortcut for now)
+  // Legacy paths - redirect to new structure via LegacyConversationRedirect
+  legacy: {
+    conversation: ({ conversationId }: { conversationId: string }) =>
+      `/conversations/${conversationId}`,
+  },
+
+  // Backward compatibility aliases pointing to new routes
+  // TODO: Migrate consumers to use appPaths.agent.* or appPaths.manage.* directly and remove these aliases
   chat: {
     new: '/agents/elastic-default',
     newWithAgent: ({ agentId }: { agentId: string }) => `/agents/${agentId}`,
-    conversation: ({ conversationId }: { conversationId: string }) =>
-      `/agents/elastic-default/conversations/${conversationId}`,
   },
   agents: {
     list: '/manage/agents',

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -50,10 +50,6 @@ export const appPaths = {
 
   // Backward compatibility aliases pointing to new routes
   // TODO: Migrate consumers to use appPaths.agent.* or appPaths.manage.* directly and remove these aliases
-  chat: {
-    new: '/agents/elastic-default',
-    newWithAgent: ({ agentId }: { agentId: string }) => `/agents/${agentId}`,
-  },
   agents: {
     list: '/manage/agents',
     new: '/manage/agents/new',


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13361

- Migrates the existing /tools, /skills routes etc. to be within the /manage/tools, /manage/skills routes etc.
- Fixes multiple small things related to react-query caching and agentId being a query parameter before - now it's in the path
- Adds the agent-scoped conversations to the conversation sidebar

See video below for an example of what's been migrated (note: there are still many routes that do not have a UI yet, this is deliberate and they will be handled in future PRs)

https://github.com/user-attachments/assets/6f143547-5cb8-456f-b5f2-9c511976f92c



