### PR TITLE
[kbn/ts-type-check-oblt-cli] incremental correctness + UX improvements

### DIFF
--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.test.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.test.ts
@@ -398,41 +398,88 @@ describe('resolveRestoreStrategy', () => {
   });
 
   describe('Phase 1.5 — cache-invalidation file detection', () => {
-    it('cleans artifacts and returns shouldRestore: false when invalidation files changed', async () => {
-      // Artifacts on disk with a known state SHA.
+    const mockedExeca = jest.requireMock('execa') as jest.Mock;
+
+    it('cleans artifacts and resets state when invalidation files changed', async () => {
       accessSpy.mockResolvedValue(undefined);
       readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
 
-      // Simulate yarn.lock having changed between known-sha and HEAD.
-      const mockedExeca = jest.requireMock('execa') as jest.Mock;
-      mockedExeca.mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
+      // Phase 1.5: yarn.lock changed; Phase 1.5 GCS archive check: also changed.
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: 'yarn.lock\n' })
+        .mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
 
       const log = createLog();
-      const result = await resolveRestoreStrategy(log, []);
+      await resolveRestoreStrategy(log, []);
 
-      // Must wipe local artifacts so tsc does a full cold rebuild.
       expect(mockedCleanTypeCheckArtifacts).toHaveBeenCalledTimes(1);
-      // Must reset the state SHA so the next run starts fresh.
       expect(writeFileSpy).toHaveBeenCalledWith(
         expect.stringContaining('kbn-ts-type-check-oblt-artifacts.sha'),
         '',
         'utf8'
       );
+    });
+
+    it('restores from a compatible GCS archive when local artifacts were invalidated', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+
+      // Phase 1.5: local state stale; GCS archive built after the change — clean.
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: 'yarn.lock\n' })
+        .mockResolvedValueOnce({ stdout: '' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(mockedCleanTypeCheckArtifacts).toHaveBeenCalledTimes(1);
+      expect(result.shouldRestore).toBe(true);
+      expect(result.bestSha).toBe('ancestor-sha');
+    });
+
+    it('falls back to cold rebuild when GCS archive also predates the invalidating change', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+
+      // Both local state and GCS archive predate the yarn.lock change.
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: 'yarn.lock\n' })
+        .mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
       expect(result.shouldRestore).toBe(false);
+      expect(result.bestSha).toBeUndefined();
+    });
+
+    it('falls back to cold rebuild when GCS has no archive after local invalidation', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      gcsListMock.mockResolvedValue({ shas: new Set(), elapsedMs: 0 });
+
+      mockedExeca.mockResolvedValueOnce({ stdout: '.nvmrc\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(result.bestSha).toBeUndefined();
     });
 
     it('does not reach Phase 2 (detectStaleArtifacts) when invalidation files changed', async () => {
       accessSpy.mockResolvedValue(undefined);
       readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
 
-      const mockedExeca = jest.requireMock('execa') as jest.Mock;
-      mockedExeca.mockResolvedValueOnce({ stdout: '.nvmrc\n' });
+      // Phase 1.5: stale; GCS archive also stale → cold rebuild, no Phase 2.
+      mockedExeca
+        .mockResolvedValueOnce({ stdout: '.nvmrc\n' })
+        .mockResolvedValueOnce({ stdout: '.nvmrc\n' });
 
       const log = createLog();
       await resolveRestoreStrategy(log, []);
 
       expect(detectStaleArtifacts).not.toHaveBeenCalled();
-      expect(gcsListMock).not.toHaveBeenCalled();
     });
 
     it('proceeds to Phase 2 when no invalidation files changed', async () => {
@@ -444,7 +491,6 @@ describe('resolveRestoreStrategy', () => {
       await resolveRestoreStrategy(log, []);
 
       expect(mockedCleanTypeCheckArtifacts).not.toHaveBeenCalled();
-      // Phase 2 ran — detectStaleArtifacts was called.
       expect(detectStaleArtifacts).toHaveBeenCalled();
     });
   });
@@ -517,6 +563,65 @@ describe('resolveRestoreStrategy', () => {
       await resolveRestoreStrategy(log, []);
 
       expect(unlinkSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GCS archive node_modules safety check', () => {
+    const mockedExeca = jest.requireMock('execa') as jest.Mock;
+
+    it('skips restore when no local artifacts exist but archive has a node_modules change', async () => {
+      // Default beforeEach: no local artifacts, GCS has 'ancestor-sha'.
+      // Simulate yarn.lock changing between ancestor-sha and HEAD.
+      mockedExeca.mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(result.bestSha).toBeUndefined();
+      expect(log.warning).toHaveBeenCalledWith(expect.stringContaining('ancestor-sha'));
+    });
+
+    it('skips restore when local state is unknown but archive has a node_modules change', async () => {
+      // Artifacts exist on disk, but no state SHA.
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock(null, ['some/tsconfig.json']));
+
+      // Simulate .nvmrc changing between ancestor-sha and HEAD.
+      mockedExeca.mockResolvedValueOnce({ stdout: '.nvmrc\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(result.bestSha).toBeUndefined();
+      expect(log.warning).toHaveBeenCalledWith(expect.stringContaining('ancestor-sha'));
+    });
+
+    it('skips restore in Phase 3 when GCS archive reduces count but has a node_modules change', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+
+      // Local: 11 stale projects (above threshold), GCS: 2 stale → GCS would help.
+      detectStaleArtifacts
+        .mockResolvedValueOnce(
+          new Set(Array.from({ length: 11 }, (_, i) => `/repo/p${i}/tsconfig.type_check.json`))
+        )
+        .mockResolvedValueOnce(
+          new Set([`/repo/p0/tsconfig.type_check.json`, `/repo/p1/tsconfig.type_check.json`])
+        );
+
+      // Phase 1.5 git diff (localStateSha → HEAD): clean.
+      mockedExeca.mockResolvedValueOnce({ stdout: '' });
+      // Phase 3 archive validity check (ancestor-sha → HEAD): yarn.lock changed.
+      mockedExeca.mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(result.bestSha).toBeUndefined();
+      expect(log.warning).toHaveBeenCalledWith(expect.stringContaining('ancestor-sha'));
     });
   });
 

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.test.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.test.ts
@@ -17,6 +17,7 @@ import { LocalFileSystem } from './file_system/local_file_system';
 import { GcsFileSystem } from './file_system/gcs_file_system';
 import {
   buildCandidateShaList,
+  cleanTypeCheckArtifacts,
   getPullRequestNumber,
   isCiEnvironment,
   readRecentCommitShas,
@@ -26,6 +27,7 @@ import {
 
 jest.mock('./utils', () => ({
   buildCandidateShaList: jest.fn(),
+  cleanTypeCheckArtifacts: jest.fn().mockResolvedValue(undefined),
   getPullRequestNumber: jest.fn(),
   isCiEnvironment: jest.fn(),
   readRecentCommitShas: jest.fn(),
@@ -56,6 +58,9 @@ jest.mock('execa', () => jest.fn().mockResolvedValue({ stdout: '' }));
 
 const mockedBuildCandidateShaList = buildCandidateShaList as jest.MockedFunction<
   typeof buildCandidateShaList
+>;
+const mockedCleanTypeCheckArtifacts = cleanTypeCheckArtifacts as jest.MockedFunction<
+  typeof cleanTypeCheckArtifacts
 >;
 const mockedGetPullRequestNumber = getPullRequestNumber as jest.MockedFunction<
   typeof getPullRequestNumber
@@ -254,6 +259,7 @@ describe('resolveRestoreStrategy', () => {
   let writeFileSpy: jest.SpyInstance;
   let mkdirSpy: jest.SpyInstance;
   let accessSpy: jest.SpyInstance;
+  let unlinkSpy: jest.SpyInstance;
 
   // Returns a readFile mock that returns a sha from the state file and a valid
   // tsconfig list from the config-paths.json file.
@@ -295,6 +301,7 @@ describe('resolveRestoreStrategy', () => {
     writeFileSpy = jest.spyOn(Fs.promises, 'writeFile').mockResolvedValue(undefined);
     mkdirSpy = jest.spyOn(Fs.promises, 'mkdir').mockResolvedValue(undefined);
     accessSpy = jest.spyOn(Fs.promises, 'access').mockRejectedValue(new Error('ENOENT'));
+    unlinkSpy = jest.spyOn(Fs.promises, 'unlink').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -302,6 +309,7 @@ describe('resolveRestoreStrategy', () => {
     writeFileSpy.mockRestore();
     mkdirSpy.mockRestore();
     accessSpy.mockRestore();
+    unlinkSpy.mockRestore();
   });
 
   it('returns shouldRestore: true with bestSha when no local artifacts exist', async () => {
@@ -387,6 +395,129 @@ describe('resolveRestoreStrategy', () => {
     expect(detectStaleArtifacts).toHaveBeenCalledWith(
       expect.objectContaining({ fromCommit: 'known-sha' })
     );
+  });
+
+  describe('Phase 1.5 — cache-invalidation file detection', () => {
+    it('cleans artifacts and returns shouldRestore: false when invalidation files changed', async () => {
+      // Artifacts on disk with a known state SHA.
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+
+      // Simulate yarn.lock having changed between known-sha and HEAD.
+      const mockedExeca = jest.requireMock('execa') as jest.Mock;
+      mockedExeca.mockResolvedValueOnce({ stdout: 'yarn.lock\n' });
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      // Must wipe local artifacts so tsc does a full cold rebuild.
+      expect(mockedCleanTypeCheckArtifacts).toHaveBeenCalledTimes(1);
+      // Must reset the state SHA so the next run starts fresh.
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        expect.stringContaining('kbn-ts-type-check-oblt-artifacts.sha'),
+        '',
+        'utf8'
+      );
+      expect(result.shouldRestore).toBe(false);
+    });
+
+    it('does not reach Phase 2 (detectStaleArtifacts) when invalidation files changed', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+
+      const mockedExeca = jest.requireMock('execa') as jest.Mock;
+      mockedExeca.mockResolvedValueOnce({ stdout: '.nvmrc\n' });
+
+      const log = createLog();
+      await resolveRestoreStrategy(log, []);
+
+      expect(detectStaleArtifacts).not.toHaveBeenCalled();
+      expect(gcsListMock).not.toHaveBeenCalled();
+    });
+
+    it('proceeds to Phase 2 when no invalidation files changed', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      // execa default returns { stdout: '' } — no changed files.
+
+      const log = createLog();
+      await resolveRestoreStrategy(log, []);
+
+      expect(mockedCleanTypeCheckArtifacts).not.toHaveBeenCalled();
+      // Phase 2 ran — detectStaleArtifacts was called.
+      expect(detectStaleArtifacts).toHaveBeenCalled();
+    });
+  });
+
+  describe('.tsbuildinfo invalidation', () => {
+    const staleProjectPaths = ['p1', 'p2', 'p3', 'p4', 'p5'].map(
+      (p) => `/repo/${p}/tsconfig.type_check.json`
+    );
+    const expectedUnlinkPaths = staleProjectPaths.map(
+      (p) => `/repo/${p.split('/')[2]}/target/types/tsconfig.type_check.tsbuildinfo`
+    );
+
+    it('invalidates .tsbuildinfo for stale projects within the rebuild threshold', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      detectStaleArtifacts.mockResolvedValue(new Set(staleProjectPaths));
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      // One unlink call per stale project's .tsbuildinfo.
+      expect(unlinkSpy).toHaveBeenCalledTimes(staleProjectPaths.length);
+      for (const expectedPath of expectedUnlinkPaths) {
+        expect(unlinkSpy).toHaveBeenCalledWith(expectedPath);
+      }
+    });
+
+    it('invalidates .tsbuildinfo when above threshold but GCS has no matching archive', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      gcsListMock.mockResolvedValue({ shas: new Set(), elapsedMs: 0 });
+      const largeStalePaths = Array.from(
+        { length: 11 },
+        (_, i) => `/repo/p${i}/tsconfig.type_check.json`
+      );
+      detectStaleArtifacts.mockResolvedValue(new Set(largeStalePaths));
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(unlinkSpy).toHaveBeenCalledTimes(largeStalePaths.length);
+    });
+
+    it('invalidates .tsbuildinfo when GCS archive does not reduce the rebuild count', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      const largeStalePaths = Array.from(
+        { length: 11 },
+        (_, i) => `/repo/p${i}/tsconfig.type_check.json`
+      );
+      const staleSet = new Set(largeStalePaths);
+      // Both local and GCS checks return the same stale set → GCS won't help.
+      detectStaleArtifacts.mockResolvedValueOnce(staleSet).mockResolvedValueOnce(staleSet);
+
+      const log = createLog();
+      const result = await resolveRestoreStrategy(log, []);
+
+      expect(result.shouldRestore).toBe(false);
+      expect(unlinkSpy).toHaveBeenCalledTimes(largeStalePaths.length);
+    });
+
+    it('does NOT invalidate .tsbuildinfo when artifacts are fully up-to-date', async () => {
+      accessSpy.mockResolvedValue(undefined);
+      readFileSpy.mockImplementation(makeReadFileMock('known-sha', ['some/tsconfig.json']));
+      detectStaleArtifacts.mockResolvedValue(new Set());
+
+      const log = createLog();
+      await resolveRestoreStrategy(log, []);
+
+      expect(unlinkSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('returns shouldRestore: false when above threshold but GCS has no matching archive', async () => {

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
@@ -331,8 +331,13 @@ export async function resolveRestoreStrategy(
 
   if (effectiveRebuildSet.size <= STALE_RESTORE_THRESHOLD) {
     log.info(
-      `[Cache check] ✓ Cache freshness is good — only ${effectiveRebuildSet.size} project(s) ` +
-        `need rebuilding.`
+      `[Cache check] ✓ Cache freshness is good${
+        effectiveRebuildSet.size === 1
+          ? ' — only one project needs rebuilding'
+          : effectiveRebuildSet.size > 1
+          ? ' — only ${effectiveRebuildSet.size} projects need rechecking'
+          : ' — no projects need rechecking'
+      }`
     );
     // Invalidate .tsbuildinfo for stale projects so tsc is forced to recheck
     // them. Without this, tsc may treat a project as "up-to-date" if its source
@@ -393,6 +398,18 @@ export async function resolveRestoreStrategy(
   await invalidateTsBuildInfoFiles(effectiveRebuildSet, log);
 
   return { shouldRestore: false, bestSha: undefined };
+}
+
+/** Maps each project's typeCheckConfigPath to the set of its direct dependency typeCheckConfigPaths. */
+export function buildForwardDependencyMap(tsProjects: TsProject[]): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const p of tsProjects) {
+    map.set(
+      p.typeCheckConfigPath,
+      new Set(p.getKbnRefs(tsProjects).map((dep) => dep.typeCheckConfigPath))
+    );
+  }
+  return map;
 }
 
 export function buildReverseDependencyMap(tsProjects: TsProject[]): Map<string, Set<string>> {

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
@@ -11,6 +11,7 @@ import { REPO_ROOT } from '@kbn/repo-info';
 import type { SomeDevLog } from '@kbn/some-dev-log';
 import type { TsProject } from '@kbn/ts-projects';
 import execa from 'execa';
+import { asyncForEachWithLimit } from '@kbn/std';
 import {
   ARTIFACTS_STATE_FILE,
   CACHE_INVALIDATION_FILES,
@@ -21,6 +22,7 @@ import { GcsFileSystem } from './file_system/gcs_file_system';
 import { LocalFileSystem } from './file_system/local_file_system';
 import {
   buildCandidateShaList,
+  cleanTypeCheckArtifacts,
   getPullRequestNumber,
   isCiEnvironment,
   readMainBranchCommitShas,
@@ -32,6 +34,76 @@ import { detectStaleArtifacts } from './detect_stale_artifacts';
 import { isCacheServerAvailable, tryRestoreFromCacheServer } from './cache_server_client';
 
 const STALE_RESTORE_THRESHOLD = 10;
+
+/**
+ * Deletes the .tsbuildinfo file for each project in the given set of
+ * tsconfig.type_check.json paths. This forces tsc to re-type-check those
+ * projects on the next --build run even when their source file hashes still
+ * match the stored .tsbuildinfo — which can happen when a historical
+ * successful compilation is on disk but the code has since become invalid
+ * (e.g. a dependency's re-exported API changed without the re-export file
+ * itself changing).
+ *
+ * Only deletes the .tsbuildinfo; the compiled .d.ts outputs in target/types
+ * are left intact so other projects can still reference them.
+ */
+async function invalidateTsBuildInfoFiles(
+  projectPaths: Set<string>,
+  log: SomeDevLog
+): Promise<void> {
+  let deleted = 0;
+
+  await asyncForEachWithLimit([...projectPaths], 20, async (tsConfigPath) => {
+    const projectDir = Path.dirname(tsConfigPath);
+    const tsBuildInfoPath = Path.join(
+      projectDir,
+      'target',
+      'types',
+      'tsconfig.type_check.tsbuildinfo'
+    );
+
+    try {
+      await Fs.promises.unlink(tsBuildInfoPath);
+      deleted++;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        log.verbose(
+          `[Cache] Could not delete ${tsBuildInfoPath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+  });
+
+  if (deleted > 0) {
+    log.verbose(
+      `[Cache] Invalidated ${deleted} stale .tsbuildinfo file(s) to force tsc to recheck them.`
+    );
+  }
+}
+
+/**
+ * Returns the subset of CACHE_INVALIDATION_FILES that changed between the
+ * given commit SHA and HEAD. Used to detect whether local build artifacts
+ * were created against different node_modules (e.g. after a yarn.lock update)
+ * and therefore can no longer be trusted for incremental tsc correctness.
+ */
+async function getChangedInvalidationFiles(fromSha: string): Promise<string[]> {
+  try {
+    const { stdout } = await execa(
+      'git',
+      ['diff', '--name-only', fromSha, 'HEAD', '--', ...CACHE_INVALIDATION_FILES],
+      { cwd: REPO_ROOT }
+    );
+    return stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Writes the given commit SHA to the per-clone state file, recording what
@@ -206,6 +278,27 @@ export async function resolveRestoreStrategy(
     return { shouldRestore: true, bestSha, staleProjects: [] };
   }
 
+  // Phase 1.5: cache-invalidation file check — git diff, no network I/O.
+  // Changes to yarn.lock, .nvmrc, or .node-version mean node_modules may have
+  // changed since the local artifacts were built. tsc's .tsbuildinfo incremental
+  // check compares the hashes of dependency .d.ts outputs in target/types — if
+  // those outputs are still from the old node_modules version, tsc considers
+  // downstream projects "up-to-date" without rechecking them, silently masking
+  // type errors (e.g. Zod v3 → v4 API incompatibilities).
+  // When invalidation files changed, wipe the local artifacts so tsc is forced
+  // to perform a full rebuild from scratch.
+  const changedInvalidationFiles = await getChangedInvalidationFiles(localStateSha);
+  if (changedInvalidationFiles.length > 0) {
+    log.warning(
+      `[Cache check] Cache-invalidation file(s) changed since ${localStateSha.slice(0, 12)}: ` +
+        `${changedInvalidationFiles.join(', ')}. ` +
+        `Local artifacts may be stale — cleaning them so tsc performs a full rebuild.`
+    );
+    await cleanTypeCheckArtifacts(log);
+    await writeArtifactsState('');
+    return { shouldRestore: false };
+  }
+
   // Phase 2: staleness check — git diff, no network I/O.
   // Staleness is computed from the local state SHA (what the artifacts on disk
   // actually correspond to) — NOT the GCS ancestor. Using the GCS ancestor would
@@ -241,6 +334,11 @@ export async function resolveRestoreStrategy(
       `[Cache check] ✓ Cache freshness is good — only ${effectiveRebuildSet.size} project(s) ` +
         `need rebuilding.`
     );
+    // Invalidate .tsbuildinfo for stale projects so tsc is forced to recheck
+    // them. Without this, tsc may treat a project as "up-to-date" if its source
+    // file hashes match a historical successful build, even when the code is
+    // now invalid (e.g. a dependency's API changed in the same zod package version).
+    await invalidateTsBuildInfoFiles(effectiveRebuildSet, log);
     return { shouldRestore: false, bestSha: undefined };
   }
 
@@ -251,6 +349,7 @@ export async function resolveRestoreStrategy(
     log.info(
       `[Cache check] No GCS archive found — proceeding with ${effectiveRebuildSet.size} local rebuilds.`
     );
+    await invalidateTsBuildInfoFiles(effectiveRebuildSet, log);
     return { shouldRestore: false };
   }
 
@@ -287,6 +386,11 @@ export async function resolveRestoreStrategy(
     `[Cache check] ✓ GCS archive (${bestGcsSha.slice(0, 12)}) would not reduce the rebuild ` +
       `count (${gcsEffectiveCount} vs ${effectiveRebuildSet.size} locally) — skipping restore.`
   );
+
+  // GCS restore would not help, but we still need to ensure tsc rechecks the
+  // stale projects. Invalidate their .tsbuildinfo files so tsc cannot treat
+  // them as up-to-date based on a historical (possibly incorrect) build.
+  await invalidateTsBuildInfoFiles(effectiveRebuildSet, log);
 
   return { shouldRestore: false, bestSha: undefined };
 }

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
@@ -395,7 +395,7 @@ export async function resolveRestoreStrategy(
   return { shouldRestore: false, bestSha: undefined };
 }
 
-function buildReverseDependencyMap(tsProjects: TsProject[]): Map<string, Set<string>> {
+export function buildReverseDependencyMap(tsProjects: TsProject[]): Map<string, Set<string>> {
   const reverseDeps = new Map<string, Set<string>>();
 
   for (const project of tsProjects) {

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
@@ -106,6 +106,28 @@ async function getChangedInvalidationFiles(fromSha: string): Promise<string[]> {
 }
 
 /**
+ * Returns true if any cache-invalidation file changed between the given commit
+ * SHA and HEAD, meaning the GCS archive at that SHA was built against a
+ * different node_modules and cannot be safely used as incremental tsc input.
+ * Logs a warning when the check fires so the reason is visible to the user.
+ */
+async function archiveInvalidatedByNodeModulesChange(
+  archiveSha: string,
+  log: SomeDevLog
+): Promise<boolean> {
+  const changed = await getChangedInvalidationFiles(archiveSha);
+  if (changed.length > 0) {
+    log.warning(
+      `[Cache check] Cache-invalidation file(s) changed since archive ${archiveSha.slice(0, 12)}: ` +
+        `${changed.join(', ')}. ` +
+        `The archive was built against a different node_modules — skipping restore.`
+    );
+    return true;
+  }
+  return false;
+}
+
+/**
  * Writes the given commit SHA to the per-clone state file, recording what
  * commit the local TypeScript build artifacts currently correspond to.
  * Called after a GCS restore and after each successful tsc run.
@@ -254,7 +276,10 @@ export async function resolveRestoreStrategy(
 
     if (!bestSha) {
       log.info('[Cache check] No GCS archive available — tsc will build from scratch.');
+      return { shouldRestore: false };
+    }
 
+    if (await archiveInvalidatedByNodeModulesChange(bestSha, log)) {
       return { shouldRestore: false };
     }
 
@@ -271,7 +296,10 @@ export async function resolveRestoreStrategy(
 
     if (!bestSha) {
       log.info('[Cache check] No GCS archive available — tsc will handle staleness incrementally.');
+      return { shouldRestore: false };
+    }
 
+    if (await archiveInvalidatedByNodeModulesChange(bestSha, log)) {
       return { shouldRestore: false };
     }
 
@@ -285,18 +313,35 @@ export async function resolveRestoreStrategy(
   // those outputs are still from the old node_modules version, tsc considers
   // downstream projects "up-to-date" without rechecking them, silently masking
   // type errors (e.g. Zod v3 → v4 API incompatibilities).
-  // When invalidation files changed, wipe the local artifacts so tsc is forced
-  // to perform a full rebuild from scratch.
+  // When invalidation files changed, wipe the local artifacts, then check if GCS
+  // has an archive built *after* the invalidating change (which would be safe to
+  // restore). If not, tsc rebuilds everything from scratch.
   const changedInvalidationFiles = await getChangedInvalidationFiles(localStateSha);
   if (changedInvalidationFiles.length > 0) {
     log.warning(
       `[Cache check] Cache-invalidation file(s) changed since ${localStateSha.slice(0, 12)}: ` +
         `${changedInvalidationFiles.join(', ')}. ` +
-        `Local artifacts may be stale — cleaning them so tsc performs a full rebuild.`
+        `Local artifacts may be stale — cleaning them.`
     );
     await cleanTypeCheckArtifacts(log);
     await writeArtifactsState('');
-    return { shouldRestore: false };
+
+    const bestSha = await resolveBestGcsSha(log, gcsFs);
+
+    if (!bestSha) {
+      log.info('[Cache check] No GCS archive available — tsc will build from scratch.');
+      return { shouldRestore: false };
+    }
+
+    if (await archiveInvalidatedByNodeModulesChange(bestSha, log)) {
+      log.info('[Cache check] GCS archive also predates the change — tsc will build from scratch.');
+      return { shouldRestore: false };
+    }
+
+    log.info(
+      `[Cache check] Found compatible GCS archive at ${bestSha.slice(0, 12)} — will restore.`
+    );
+    return { shouldRestore: true, bestSha, staleProjects: [] };
   }
 
   // Phase 2: staleness check — git diff, no network I/O.
@@ -377,6 +422,11 @@ export async function resolveRestoreStrategy(
   }
 
   if (gcsEffectiveCount < effectiveRebuildSet.size) {
+    if (await archiveInvalidatedByNodeModulesChange(bestGcsSha, log)) {
+      log.info('[Cache check] Skipping restore — tsc will rebuild locally with current artifacts.');
+      return { shouldRestore: false };
+    }
+
     log.info(
       `[Cache check] Having archive for ${bestGcsSha.slice(0, 12)} would reduce rebuild count ` +
         `from ${effectiveRebuildSet.size} to ${gcsEffectiveCount} — will restore.`

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/cache/restore_ts_build_artifacts.ts
@@ -118,7 +118,10 @@ async function archiveInvalidatedByNodeModulesChange(
   const changed = await getChangedInvalidationFiles(archiveSha);
   if (changed.length > 0) {
     log.warning(
-      `[Cache check] Cache-invalidation file(s) changed since archive ${archiveSha.slice(0, 12)}: ` +
+      `[Cache check] Cache-invalidation file(s) changed since archive ${archiveSha.slice(
+        0,
+        12
+      )}: ` +
         `${changed.join(', ')}. ` +
         `The archive was built against a different node_modules — skipping restore.`
     );

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.test.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.test.ts
@@ -376,7 +376,7 @@ describe('type_check orchestration', () => {
       );
     });
 
-    it('writes the HEAD SHA to the state file after a successful full pass', async () => {
+    it('writes the HEAD SHA to the state file after the full pass succeeds', async () => {
       resolveCurrentCommitSha.mockResolvedValueOnce('abc123def456');
 
       const log = createLog();
@@ -388,7 +388,15 @@ describe('type_check orchestration', () => {
       expect(writeArtifactsState).toHaveBeenCalledWith('abc123def456');
     });
 
-    it('does not write state file when the full pass fails', async () => {
+    it('writes the HEAD SHA to the state file even when the full pass fails', async () => {
+      // Writing state on failure is intentional: tsc --build writes a fresh
+      // .tsbuildinfo for every project it processes (including ones with errors).
+      // If we skip the state write, the next run will call detectStaleArtifacts
+      // from the old archive SHA, see all post-archive projects as stale, delete
+      // their .tsbuildinfo via invalidateTsBuildInfoFiles, and force tsc to
+      // rebuild them from scratch — including projects that already had 0 errors.
+      resolveCurrentCommitSha.mockResolvedValueOnce('abc123def456');
+
       const log = createLog();
       const procRunner = createProcRunner();
       const flagsReader = makeFlagsReader();
@@ -397,7 +405,7 @@ describe('type_check orchestration', () => {
 
       await expect(runCallback({ log, flagsReader, procRunner })).rejects.toThrow();
 
-      expect(writeArtifactsState).not.toHaveBeenCalled();
+      expect(writeArtifactsState).toHaveBeenCalledWith('abc123def456');
     });
 
     it('does not write state file when --project filter is used', async () => {

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/run_type_check_cli.ts
@@ -135,10 +135,24 @@ run(
     }
 
     // ── Record freshness state ───────────────────────────────────────────────────
-    // After a successful full tsc run the local artifacts are up-to-date with HEAD.
-    // Writing the SHA allows subsequent runs to accurately compute staleness without
-    // relying on the (now-absent) GCS ancestor as a proxy.
-    if (!didTypeCheckFail && !projectFilter && !isCiEnvironment()) {
+    // After any full tsc run (success or failure) the local .tsbuildinfo files
+    // correspond to HEAD's sources. Writing the SHA here — even on failure —
+    // prevents the next run from re-invalidating projects tsc already processed.
+    //
+    // Why it is safe to write on failure:
+    //   tsc --build writes a .tsbuildinfo for every project it processes,
+    //   regardless of whether that project had errors. On the next run tsc reads
+    //   each .tsbuildinfo and decides whether to rebuild:
+    //     • project with no errors whose sources are unchanged → up-to-date, skipped
+    //     • project with stored errors whose sources are unchanged → errors replayed
+    //       from .tsbuildinfo (no recompile), which is what we want
+    //     • project whose sources changed → rebuilt from scratch
+    //   If we leave the state at the GCS archive SHA instead, resolveRestoreStrategy
+    //   will call detectStaleArtifacts(from: archiveSha, to: HEAD) on the next run,
+    //   see all post-archive projects as stale, call invalidateTsBuildInfoFiles to
+    //   delete their .tsbuildinfo, and force tsc to rebuild them all — including
+    //   projects that were already correct in the previous run.
+    if (!projectFilter && !isCiEnvironment()) {
       try {
         const headSha = await resolveCurrentCommitSha();
         if (headSha) {

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -117,7 +117,14 @@ export async function runTscFastPass({
     return { depCount, dependentCount };
   });
 
-  const totalAffectedDownstream = perProject.reduce((sum, p) => sum + p.dependentCount, 0);
+  // Union of each changed project's full forward closure = all projects tsc -b will touch.
+  const firstPassProjectCount = configPaths.reduce((acc, configPath) => {
+    const abs = Path.resolve(REPO_ROOT, configPath);
+    for (const p of computeEffectiveRebuildSet(new Set([abs]), forwardDeps)) {
+      acc.add(p);
+    }
+    return acc;
+  }, new Set<string>()).size;
 
   const tableRows = perProject.map(({ depCount, dependentCount }, i) => [
     projectNames[i],
@@ -135,14 +142,7 @@ export async function runTscFastPass({
     log.info(`[TypeCheck] ${line}`);
   }
 
-  log.info(
-    `[TypeCheck] [First pass] Checking ${affectedRefs.size} changed ${
-      multi ? 'projects' : 'project'
-    } with ${multi ? 'their' : 'its'} upstream dependencies for fast feedback` +
-      ` (${totalAffectedDownstream} downstream ${
-        totalAffectedDownstream === 1 ? 'project' : 'projects'
-      } also affected)...`
-  );
+  log.info(`[TypeCheck] [First pass] Checking ${firstPassProjectCount} projects...`);
 
   const success = await runTsc({
     log,

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -17,6 +17,7 @@ import type { TsProject } from '@kbn/ts-projects';
 import { getChangedFiles, getAffectedProjectRefs } from './root_refs_config';
 import { TscProgressTracker } from './tsc_progress_tracker';
 import {
+  buildForwardDependencyMap,
   buildReverseDependencyMap,
   computeEffectiveRebuildSet,
 } from '../cache/restore_ts_build_artifacts';
@@ -103,29 +104,37 @@ export async function runTscFastPass({
   });
   const multi = affectedRefs.size > 1;
 
+  const forwardDeps = buildForwardDependencyMap(projects);
   const reverseDeps = buildReverseDependencyMap(projects);
-  const dependentCounts = configPaths.map((configPath) => {
-    const absolutePath = Path.resolve(REPO_ROOT, configPath);
-    // computeEffectiveRebuildSet includes the root itself, so subtract 1.
-    return computeEffectiveRebuildSet(new Set([absolutePath]), reverseDeps).size - 1;
+
+  // For each changed project compute both directions of the dep graph.
+  // Counts exclude the root project itself.
+  const perProject = configPaths.map((configPath) => {
+    const abs = Path.resolve(REPO_ROOT, configPath);
+    const depCount = computeEffectiveRebuildSet(new Set([abs]), forwardDeps).size - 1;
+    const dependentCount = computeEffectiveRebuildSet(new Set([abs]), reverseDeps).size - 1;
+    return { depCount, dependentCount };
   });
 
-  let dependentCount = 0;
+  const totalAffectedDownstream = perProject.reduce((sum, p) => sum + p.dependentCount, 0);
 
   log.info(`[TypeCheck] ${affectedRefs.size} changed ${multi ? 'projects' : 'project'}:`);
   for (let i = 0; i < projectNames.length; i++) {
-    const n = dependentCounts[i];
-    dependentCount += n;
-    const suffix = n > 0 ? ` ==> ${n} dependent${n === 1 ? '' : 's'}` : ' ==> no dependents';
-    log.info(`[TypeCheck]   - ${projectNames[i]}${suffix}`);
+    const { depCount, dependentCount } = perProject[i];
+    const depsStr = depCount === 1 ? '1 dependency' : `${depCount} dependencies`;
+    const deptsStr =
+      dependentCount === 0
+        ? 'no dependents'
+        : `${dependentCount} dependent${dependentCount === 1 ? '' : 's'}`;
+    log.info(`[TypeCheck]   - ${projectNames[i]} (${depsStr}) ==> ${deptsStr}`);
   }
 
   log.info(
     `[TypeCheck] [First pass] Checking ${affectedRefs.size} changed ${
       multi ? 'projects' : 'project'
     } with ${multi ? 'their' : 'its'} upstream dependencies for fast feedback` +
-      ` (${dependentCount} downstream ${
-        dependentCount === 1 ? 'project' : 'projects'
+      ` (${totalAffectedDownstream} downstream ${
+        totalAffectedDownstream === 1 ? 'project' : 'projects'
       } also affected)...`
   );
 

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -110,9 +110,12 @@ export async function runTscFastPass({
     return computeEffectiveRebuildSet(new Set([absolutePath]), reverseDeps).size - 1;
   });
 
+  let dependentCount = 0;
+
   log.info(`[TypeCheck] ${affectedRefs.size} changed ${multi ? 'projects' : 'project'}:`);
   for (let i = 0; i < projectNames.length; i++) {
     const n = dependentCounts[i];
+    dependentCount += n;
     const suffix = n > 0 ? ` ==> ${n} dependent${n === 1 ? '' : 's'}` : ' ==> no dependents';
     log.info(`[TypeCheck]   - ${projectNames[i]}${suffix}`);
   }
@@ -120,9 +123,10 @@ export async function runTscFastPass({
   log.info(
     `[TypeCheck] [First pass] Checking ${affectedRefs.size} changed ${
       multi ? 'projects' : 'project'
-    } first (${projectNames.join(', ')}) with ${
-      multi ? 'their' : 'its'
-    } dependencies for fast feedback...`
+    } with ${multi ? 'their' : 'its'} upstream dependencies for fast feedback` +
+      ` (${dependentCount} downstream ${
+        dependentCount === 1 ? 'project' : 'projects'
+      } also affected)...`
   );
 
   const success = await runTsc({
@@ -192,11 +196,11 @@ async function runTscWithProgress({
     );
   } else if (result.exitCode === 0) {
     log.info(
-      `[${type}] Type checked ${totalProjects} projects successfully in ${elapsed} (${builtProjects} built, ${skippedProjects} up-to-date).`
+      `[TypeCheck] [${type}] Type checked ${totalProjects} projects successfully in ${elapsed} (${builtProjects} built, ${skippedProjects} up-to-date).`
     );
   } else {
     log.error(
-      `[${type}] Type check failed after ${elapsed} (${completedProjects}/${totalProjects} projects).`
+      `[TypeCheck] [${type}] Type check failed after ${elapsed} (${completedProjects}/${totalProjects} projects).`
     );
   }
 

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -16,6 +16,10 @@ import type { TsProject } from '@kbn/ts-projects';
 
 import { getChangedFiles, getAffectedProjectRefs } from './root_refs_config';
 import { TscProgressTracker } from './tsc_progress_tracker';
+import {
+  buildReverseDependencyMap,
+  computeEffectiveRebuildSet,
+} from '../cache/restore_ts_build_artifacts';
 
 interface TscRunOptions {
   type?: 'Full pass' | 'First pass';
@@ -98,6 +102,20 @@ export async function runTscFastPass({
     return parts.length >= 2 ? parts[parts.length - 2] : c;
   });
   const multi = affectedRefs.size > 1;
+
+  const reverseDeps = buildReverseDependencyMap(projects);
+  const dependentCounts = configPaths.map((configPath) => {
+    const absolutePath = Path.resolve(REPO_ROOT, configPath);
+    // computeEffectiveRebuildSet includes the root itself, so subtract 1.
+    return computeEffectiveRebuildSet(new Set([absolutePath]), reverseDeps).size - 1;
+  });
+
+  log.info(`[TypeCheck] ${affectedRefs.size} changed ${multi ? 'projects' : 'project'}:`);
+  for (let i = 0; i < projectNames.length; i++) {
+    const n = dependentCounts[i];
+    const suffix = n > 0 ? ` ==> ${n} dependent${n === 1 ? '' : 's'}` : ' ==> no dependents';
+    log.info(`[TypeCheck]   - ${projectNames[i]}${suffix}`);
+  }
 
   log.info(
     `[TypeCheck] [First pass] Checking ${affectedRefs.size} changed ${

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -22,6 +22,31 @@ import {
   computeEffectiveRebuildSet,
 } from '../cache/restore_ts_build_artifacts';
 
+/**
+ * Renders a simple Unicode box table. Returns one string per row (including
+ * borders) so callers can pass each line to `log.info` independently —
+ * the consistent logger prefix keeps the box borders in column.
+ */
+function formatTable(headers: readonly string[], rows: readonly string[][]): string[] {
+  const colWidths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length))
+  );
+
+  const border = (l: string, mid: string, r: string) =>
+    l + colWidths.map((w) => '─'.repeat(w + 2)).join(mid) + r;
+
+  const dataRow = (cells: readonly string[]) =>
+    '│ ' + cells.map((c, i) => c.padEnd(colWidths[i])).join(' │ ') + ' │';
+
+  return [
+    border('┌', '┬', '┐'),
+    dataRow(headers),
+    border('├', '┼', '┤'),
+    ...rows.map(dataRow),
+    border('└', '┴', '┘'),
+  ];
+}
+
 interface TscRunOptions {
   type?: 'Full pass' | 'First pass';
   log: SomeDevLog;
@@ -118,15 +143,15 @@ export async function runTscFastPass({
 
   const totalAffectedDownstream = perProject.reduce((sum, p) => sum + p.dependentCount, 0);
 
+  const tableRows = perProject.map(({ depCount, dependentCount }, i) => [
+    projectNames[i],
+    String(depCount),
+    dependentCount === 0 ? '—' : String(dependentCount),
+  ]);
+
   log.info(`[TypeCheck] ${affectedRefs.size} changed ${multi ? 'projects' : 'project'}:`);
-  for (let i = 0; i < projectNames.length; i++) {
-    const { depCount, dependentCount } = perProject[i];
-    const depsStr = depCount === 1 ? '1 dependency' : `${depCount} dependencies`;
-    const deptsStr =
-      dependentCount === 0
-        ? 'no dependents'
-        : `${dependentCount} dependent${dependentCount === 1 ? '' : 's'}`;
-    log.info(`[TypeCheck]   - ${projectNames[i]} (${depsStr}) ==> ${deptsStr}`);
+  for (const line of formatTable(['Project', 'Dependencies', 'Dependents'], tableRows)) {
+    log.info(`[TypeCheck] ${line}`);
   }
 
   log.info(

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/run_tsc.ts
@@ -14,6 +14,7 @@ import type { SomeDevLog } from '@kbn/some-dev-log';
 import type { ProcRunner } from '@kbn/dev-proc-runner';
 import type { TsProject } from '@kbn/ts-projects';
 
+import { table, getBorderCharacters } from 'table';
 import { getChangedFiles, getAffectedProjectRefs } from './root_refs_config';
 import { TscProgressTracker } from './tsc_progress_tracker';
 import {
@@ -21,31 +22,6 @@ import {
   buildReverseDependencyMap,
   computeEffectiveRebuildSet,
 } from '../cache/restore_ts_build_artifacts';
-
-/**
- * Renders a simple Unicode box table. Returns one string per row (including
- * borders) so callers can pass each line to `log.info` independently —
- * the consistent logger prefix keeps the box borders in column.
- */
-function formatTable(headers: readonly string[], rows: readonly string[][]): string[] {
-  const colWidths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length))
-  );
-
-  const border = (l: string, mid: string, r: string) =>
-    l + colWidths.map((w) => '─'.repeat(w + 2)).join(mid) + r;
-
-  const dataRow = (cells: readonly string[]) =>
-    '│ ' + cells.map((c, i) => c.padEnd(colWidths[i])).join(' │ ') + ' │';
-
-  return [
-    border('┌', '┬', '┐'),
-    dataRow(headers),
-    border('├', '┼', '┤'),
-    ...rows.map(dataRow),
-    border('└', '┴', '┘'),
-  ];
-}
 
 interface TscRunOptions {
   type?: 'Full pass' | 'First pass';
@@ -149,8 +125,13 @@ export async function runTscFastPass({
     dependentCount === 0 ? '—' : String(dependentCount),
   ]);
 
+  const tableOutput = table([['Project', 'Dependencies', 'Dependents'], ...tableRows], {
+    border: getBorderCharacters('norc'),
+    drawHorizontalLine: (i, rowCount) => i === 0 || i === 1 || i === rowCount,
+  });
+
   log.info(`[TypeCheck] ${affectedRefs.size} changed ${multi ? 'projects' : 'project'}:`);
-  for (const line of formatTable(['Project', 'Dependencies', 'Dependents'], tableRows)) {
+  for (const line of tableOutput.trimEnd().split('\n')) {
     log.info(`[TypeCheck] ${line}`);
   }
 

--- a/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/tsc_progress_tracker.ts
+++ b/x-pack/solutions/observability/packages/kbn-ts-type-check-oblt-cli/src/tsc/tsc_progress_tracker.ts
@@ -27,6 +27,7 @@ export class TscProgressTracker {
   private completedProjects = 0;
   private builtProjects = 0;
   private skippedProjects = 0;
+  private errorCount = 0;
   private parsingProjectList = false;
   private barStarted = false;
   private readonly errorLines: string[] = [];
@@ -36,7 +37,7 @@ export class TscProgressTracker {
   private readonly bar = new SingleBar({
     barsize: 30,
     format:
-      ' Type checking [{bar}] {value}/{total} projects | {elapsed} | {built} needed to be rechecked | Checking {project}',
+      ' Type checking [{bar}] {value}/{total} projects | {elapsed} | {built} needed to be rechecked | {errors} errors found | Checking {project}',
     hideCursor: true,
     clearOnComplete: true,
   });
@@ -88,6 +89,7 @@ export class TscProgressTracker {
           status: '',
           built: 0,
           skipped: 0,
+          errors: 0,
         });
         this.barStarted = true;
       }
@@ -131,12 +133,25 @@ export class TscProgressTracker {
     const trimmed = plain.trim();
     if (trimmed.length > 0 && !isVerboseNoise(trimmed)) {
       this.errorLines.push(line);
+      if (/\berror TS\d+:/.test(plain)) {
+        this.errorCount++;
+        if (this.barStarted) {
+          this.bar.update({ errors: this.errorCount });
+        }
+      }
     }
   }
 
   /** Feed a stderr line from tsc into the tracker. */
   addStderrLine(line: string) {
     this.errorLines.push(line);
+    const plain = stripAnsi(line);
+    if (/\berror TS\d+:/.test(plain)) {
+      this.errorCount++;
+      if (this.barStarted) {
+        this.bar.update({ errors: this.errorCount });
+      }
+    }
   }
 
   /** Stop the timer and finalize the progress bar. */
@@ -164,6 +179,7 @@ export class TscProgressTracker {
       completedProjects: this.completedProjects,
       builtProjects: this.builtProjects,
       skippedProjects: this.skippedProjects,
+      errorCount: this.errorCount,
       elapsed: this.formatElapsed(),
     };
   }


### PR DESCRIPTION
## Summary

<img width="1132" height="225" alt="Screenshot 2026-03-17 at 22 59 29" src="https://github.com/user-attachments/assets/407fec43-7a8f-446d-9254-3851b1c49759" />

These are some bug fixes and usability improvements to the type check package.

### UX improvements

- **Changed-projects breakdown** — before the first pass, a table is logged showing each changed project alongside its upstream dependency count and downstream dependent count, giving a quick sense of how "heavy" the type check will be.

- **Live error count in progress bar** — the type check progress bar now shows a running error count (`25 errors found`) so failures are already visible before the run completes.


### Bug fixes

- **`.tsbuildinfo` invalidation** — after checking the cache state and determining that a GCS restore would not meaningfully reduce the rebuild count, the `.tsbuildinfo` files for stale projects are deleted so `tsc` is forced to recheck them rather than silently trusting outdated incremental state.

- **Phase 1.5: cache-invalidation file detection** — before the staleness check, `yarn.lock`, `.nvmrc`, and `.node-version` are diffed against the local artifact SHA. If any changed, local artifacts are wiped and GCS is queried for a compatible archive built after the invalidating change. If none exists, `tsc` performs a full cold rebuild. This prevents stale target/types outputs from masking type errors after a `node_modules` change.

- **Incremental skip after partial failure** — the artifact state SHA is now written after every full `tsc` pass, regardless of success. This lets a subsequent run skip packages that already type-checked correctly, rather than rechecking everything from scratch.

- **GCS archive node_modules safety check** — before restoring a GCS archive (whether local artifacts are missing, state is unknown, or GCS reduces the rebuild count), the archive SHA is now also checked against the same invalidation files. If they changed since the archive was built, the restore is skipped to avoid importing artifacts from a different `node_modules` state.