### PR TITLE
add connector attachment types

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
@@ -138,7 +138,7 @@ export interface VisualizationAttachmentData {
 export const CONNECTOR_TAG_PREFIX = 'connector:';
 
 export const connectorAttachmentToolSchema = z.object({
-  id: z.string(),
+  tool_id: z.string(),
   description: z.string(),
   configuration: z.object({
     workflow_id: z.string(),
@@ -165,7 +165,7 @@ export interface ConnectorAttachmentData {
   /** Workflow tools for this connector instance */
   tools: Array<{
     /** Tool ID */
-    id: string;
+    tool_id: string;
     /** Tool description from workflow YAML */
     description: string;
     /** Tool configuration */

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachment_types.ts
@@ -17,6 +17,7 @@ export enum AttachmentType {
   text = 'text',
   esql = 'esql',
   visualization = 'visualization',
+  connector = 'connector',
 }
 
 interface AttachmentDataMap {
@@ -24,6 +25,7 @@ interface AttachmentDataMap {
   [AttachmentType.text]: TextAttachmentData;
   [AttachmentType.screenContext]: ScreenContextAttachmentData;
   [AttachmentType.visualization]: VisualizationAttachmentData;
+  [AttachmentType.connector]: ConnectorAttachmentData;
 }
 
 export const esqlAttachmentDataSchema = z.object({
@@ -127,6 +129,51 @@ export interface VisualizationAttachmentData {
   esql: string;
   /** Optional time range for the visualization (e.g., { from: 'now-24h', to: 'now' }) */
   time_range?: { from: string; to: string };
+}
+
+/**
+ * Tag prefix used to associate tools with their parent connector instance.
+ * A tool tagged `connector:<connectorId>` belongs to that connector.
+ */
+export const CONNECTOR_TAG_PREFIX = 'connector:';
+
+export const connectorAttachmentToolSchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  configuration: z.object({
+    workflow_id: z.string(),
+  }),
+});
+
+export const connectorAttachmentDataSchema = z.object({
+  connector_id: z.string(),
+  connector_name: z.string(),
+  connector_type: z.string(),
+  tools: z.array(connectorAttachmentToolSchema),
+});
+
+/**
+ * Data for a connector attachment.
+ */
+export interface ConnectorAttachmentData {
+  /** The saved connector instance ID */
+  connector_id: string;
+  /** Human-readable connector name */
+  connector_name: string;
+  /** Action type ID (e.g., ".slack2", ".mcp") */
+  connector_type: string;
+  /** Workflow tools for this connector instance */
+  tools: Array<{
+    /** Tool ID */
+    id: string;
+    /** Tool description from workflow YAML */
+    description: string;
+    /** Tool configuration */
+    configuration: {
+      /** The workflow ID */
+      workflow_id: string;
+    };
+  }>;
 }
 
 export type AttachmentDataOf<Type extends AttachmentType> = AttachmentDataMap[Type];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
@@ -41,6 +41,7 @@ export type TextAttachment = Attachment<AttachmentType.text>;
 export type ScreenContextAttachment = Attachment<AttachmentType.screenContext>;
 export type EsqlAttachment = Attachment<AttachmentType.esql>;
 export type VisualizationAttachment = Attachment<AttachmentType.visualization>;
+export type ConnectorAttachment = Attachment<AttachmentType.connector>;
 
 /**
  * Input version of an attachment, where the id is optional

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
@@ -13,6 +13,7 @@ export type {
   ScreenContextAttachment,
   EsqlAttachment,
   VisualizationAttachment,
+  ConnectorAttachment,
 } from './attachments';
 
 export type {
@@ -28,12 +29,16 @@ export {
   esqlAttachmentDataSchema,
   screenContextAttachmentDataSchema,
   visualizationAttachmentDataSchema,
+  connectorAttachmentDataSchema,
+  connectorAttachmentToolSchema,
+  CONNECTOR_TAG_PREFIX,
   type TextAttachmentData,
   type ScreenContextAttachmentData,
   type TimeRange,
   screenContextTimeRangeSchema,
   type EsqlAttachmentData,
   type VisualizationAttachmentData,
+  type ConnectorAttachmentData,
 } from './attachment_types';
 
 export type {

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -193,6 +193,25 @@ export class AgentBuilderPlugin
       serviceManager: this.serviceManager,
       workflowsManagement: setupDeps.workflowsManagement,
       logger: this.logger.get('connector-lifecycle'),
+      smlIndexAttachment: async (params) => {
+        const [coreStart, startDeps] = await coreSetup.getStartServices();
+        const sml = this.serviceManager.internalStart?.sml;
+        if (!sml) return;
+        // Use the internal repository with the hidden 'action' type because
+        // connector saved objects are encrypted/hidden and not visible to
+        // scoped clients or default internal repositories.
+        const soClient = coreStart.savedObjects.createInternalRepository(['action']);
+        const spaceId = startDeps.spaces?.spacesService?.getSpaceId(params.request) ?? 'default';
+        await sml.indexAttachment({
+          originId: params.originId,
+          attachmentType: params.attachmentType,
+          action: params.action,
+          spaces: [spaceId],
+          esClient: coreStart.elasticsearch.client.asInternalUser,
+          savedObjectsClient: soClient,
+          logger: this.logger.get('services').get('sml'),
+        });
+      },
     });
 
     setupDeps.actions.registerConnectorLifecycleListener({

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import type {
+  CoreSetup,
+  CoreStart,
+  KibanaRequest,
+  Plugin,
+  PluginInitializerContext,
+} from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
@@ -36,6 +42,48 @@ import { createModelProviderFactory } from './services/runner/model_provider';
 import { registerSmlCrawlerTaskDefinition, scheduleSmlCrawlerTasks } from './services/sml';
 import { createSmlTools } from './services/tools/builtin/sml';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
+
+/**
+ * Creates the callback that indexes connector attachments into the SML.
+ * Extracted from the inline closure in plugin setup for readability.
+ */
+const createSmlIndexAttachmentFn = ({
+  getStartServices,
+  serviceManager,
+  logger,
+}: {
+  getStartServices: CoreSetup<
+    AgentBuilderStartDependencies,
+    AgentBuilderPluginStart
+  >['getStartServices'];
+  serviceManager: ServiceManager;
+  logger: Logger;
+}) => {
+  return async (params: {
+    request: KibanaRequest;
+    originId: string;
+    attachmentType: string;
+    action: string;
+  }) => {
+    const [coreStart, startDeps] = await getStartServices();
+    const sml = serviceManager.internalStart?.sml;
+    if (!sml) return;
+    // Use the internal repository with the hidden 'action' type because
+    // connector saved objects are encrypted/hidden and not visible to
+    // scoped clients or default internal repositories.
+    const soClient = coreStart.savedObjects.createInternalRepository(['action']);
+    const spaceId = startDeps.spaces?.spacesService?.getSpaceId(params.request) ?? 'default';
+    await sml.indexAttachment({
+      originId: params.originId,
+      attachmentType: params.attachmentType,
+      action: params.action,
+      spaces: [spaceId],
+      esClient: coreStart.elasticsearch.client.asInternalUser,
+      savedObjectsClient: soClient,
+      logger,
+    });
+  };
+};
 
 export class AgentBuilderPlugin
   implements
@@ -117,7 +165,7 @@ export class AgentBuilderPlugin
           elasticsearch: coreStart.elasticsearch,
           savedObjects: coreStart.savedObjects,
           uiSettings: coreStart.uiSettings,
-          logger: this.logger.get('services').get('sml'),
+          logger: this.logger.get('services.sml'),
         };
       },
     });
@@ -193,25 +241,11 @@ export class AgentBuilderPlugin
       serviceManager: this.serviceManager,
       workflowsManagement: setupDeps.workflowsManagement,
       logger: this.logger.get('connector-lifecycle'),
-      smlIndexAttachment: async (params) => {
-        const [coreStart, startDeps] = await coreSetup.getStartServices();
-        const sml = this.serviceManager.internalStart?.sml;
-        if (!sml) return;
-        // Use the internal repository with the hidden 'action' type because
-        // connector saved objects are encrypted/hidden and not visible to
-        // scoped clients or default internal repositories.
-        const soClient = coreStart.savedObjects.createInternalRepository(['action']);
-        const spaceId = startDeps.spaces?.spacesService?.getSpaceId(params.request) ?? 'default';
-        await sml.indexAttachment({
-          originId: params.originId,
-          attachmentType: params.attachmentType,
-          action: params.action,
-          spaces: [spaceId],
-          esClient: coreStart.elasticsearch.client.asInternalUser,
-          savedObjectsClient: soClient,
-          logger: this.logger.get('services').get('sml'),
-        });
-      },
+      smlIndexAttachmentFn: createSmlIndexAttachmentFn({
+        getStartServices: coreSetup.getStartServices,
+        serviceManager: this.serviceManager,
+        logger: this.logger.get('services.sml'),
+      }),
     });
 
     setupDeps.actions.registerConnectorLifecycleListener({
@@ -282,7 +316,7 @@ export class AgentBuilderPlugin
     scheduleSmlCrawlerTasks({
       taskManager,
       smlService: startServices.sml,
-      logger: this.logger.get('services').get('sml'),
+      logger: this.logger.get('services.sml'),
     }).catch((error) => {
       this.logger.error(`Failed to schedule SML crawler tasks: ${error.message}`);
     });
@@ -322,7 +356,7 @@ export class AgentBuilderPlugin
             spaces: [spaceId],
             esClient: elasticsearch.client.asInternalUser,
             savedObjectsClient: soClient,
-            logger: this.logger.get('services').get('sml'),
+            logger: this.logger.get('services.sml'),
           });
         },
       },

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -5,13 +5,7 @@
  * 2.0.
  */
 
-import type {
-  CoreSetup,
-  CoreStart,
-  KibanaRequest,
-  Plugin,
-  PluginInitializerContext,
-} from '@kbn/core/server';
+import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
@@ -42,48 +36,6 @@ import { createModelProviderFactory } from './services/runner/model_provider';
 import { registerSmlCrawlerTaskDefinition, scheduleSmlCrawlerTasks } from './services/sml';
 import { createSmlTools } from './services/tools/builtin/sml';
 import { createAdminPrivilegeSwitcher } from './capabilities/admin_privilege_switcher';
-
-/**
- * Creates the callback that indexes connector attachments into the SML.
- * Extracted from the inline closure in plugin setup for readability.
- */
-const createSmlIndexAttachmentFn = ({
-  getStartServices,
-  serviceManager,
-  logger,
-}: {
-  getStartServices: CoreSetup<
-    AgentBuilderStartDependencies,
-    AgentBuilderPluginStart
-  >['getStartServices'];
-  serviceManager: ServiceManager;
-  logger: Logger;
-}) => {
-  return async (params: {
-    request: KibanaRequest;
-    originId: string;
-    attachmentType: string;
-    action: string;
-  }) => {
-    const [coreStart, startDeps] = await getStartServices();
-    const sml = serviceManager.internalStart?.sml;
-    if (!sml) return;
-    // Use the internal repository with the hidden 'action' type because
-    // connector saved objects are encrypted/hidden and not visible to
-    // scoped clients or default internal repositories.
-    const soClient = coreStart.savedObjects.createInternalRepository(['action']);
-    const spaceId = startDeps.spaces?.spacesService?.getSpaceId(params.request) ?? 'default';
-    await sml.indexAttachment({
-      originId: params.originId,
-      attachmentType: params.attachmentType,
-      action: params.action,
-      spaces: [spaceId],
-      esClient: coreStart.elasticsearch.client.asInternalUser,
-      savedObjectsClient: soClient,
-      logger,
-    });
-  };
-};
 
 export class AgentBuilderPlugin
   implements
@@ -241,11 +193,7 @@ export class AgentBuilderPlugin
       serviceManager: this.serviceManager,
       workflowsManagement: setupDeps.workflowsManagement,
       logger: this.logger.get('connector-lifecycle'),
-      smlIndexAttachmentFn: createSmlIndexAttachmentFn({
-        getStartServices: coreSetup.getStartServices,
-        serviceManager: this.serviceManager,
-        logger: this.logger.get('services.sml'),
-      }),
+      getStartServices: coreSetup.getStartServices,
     });
 
     setupDeps.actions.registerConnectorLifecycleListener({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -62,9 +62,14 @@ const createMockUiSettingsClient = (connectorsEnabled = true) => ({
   }),
 });
 
+const createMockSmlService = () => ({
+  indexAttachment: jest.fn().mockResolvedValue(undefined),
+});
+
 const createMockServiceManager = (
   toolRegistry = createMockToolRegistry(),
-  uiSettingsClient = createMockUiSettingsClient()
+  uiSettingsClient = createMockUiSettingsClient(),
+  sml = createMockSmlService()
 ) => ({
   internalStart: {
     tools: {
@@ -76,8 +81,19 @@ const createMockServiceManager = (
     uiSettings: {
       asScopedToClient: jest.fn().mockReturnValue(uiSettingsClient),
     },
+    sml,
   },
 });
+
+const createMockGetStartServices = () =>
+  jest.fn().mockResolvedValue([
+    {
+      elasticsearch: { client: { asInternalUser: {} } },
+      savedObjects: { createInternalRepository: jest.fn().mockReturnValue({}) },
+    },
+    { spaces: { spacesService: { getSpaceId: jest.fn().mockReturnValue('default') } } },
+    {},
+  ]);
 
 const createBaseParams = (overrides = {}) => ({
   connectorId: 'connector-abc',
@@ -106,6 +122,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -122,6 +139,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(createBaseParams({ workflowTemplates: [] }) as any);
@@ -136,6 +154,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(createMockToolRegistry(), uiSettingsClient) as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -152,6 +171,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -175,33 +195,45 @@ describe('createConnectorLifecycleHandler', () => {
       );
     });
 
-    it('calls smlIndexAttachmentFn with create action after tool creation', async () => {
-      const smlIndexAttachmentFn = jest.fn().mockResolvedValue(undefined);
+    it('calls sml.indexAttachment with create action after tool creation', async () => {
+      const sml = createMockSmlService();
+      const serviceManager = createMockServiceManager(
+        createMockToolRegistry(),
+        createMockUiSettingsClient(),
+        sml
+      );
       const handler = createConnectorLifecycleHandler({
-        serviceManager: createMockServiceManager() as any,
+        serviceManager: serviceManager as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachmentFn,
+        getStartServices: createMockGetStartServices(),
       });
 
       const params = createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] });
       await handler.onPostCreate(params as any);
 
-      expect(smlIndexAttachmentFn).toHaveBeenCalledWith({
-        request: params.request,
-        originId: 'connector-abc',
-        attachmentType: AttachmentType.connector,
-        action: 'create',
-      });
+      expect(sml.indexAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originId: 'connector-abc',
+          attachmentType: AttachmentType.connector,
+          action: 'create',
+        })
+      );
     });
 
-    it('logs warning but does not throw when smlIndexAttachmentFn fails', async () => {
-      const smlIndexAttachmentFn = jest.fn().mockRejectedValue(new Error('SML error'));
+    it('logs warning but does not throw when sml.indexAttachment fails', async () => {
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML error'));
+      const serviceManager = createMockServiceManager(
+        createMockToolRegistry(),
+        createMockUiSettingsClient(),
+        sml
+      );
       const handler = createConnectorLifecycleHandler({
-        serviceManager: createMockServiceManager() as any,
+        serviceManager: serviceManager as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachmentFn,
+        getStartServices: createMockGetStartServices(),
       });
 
       await expect(
@@ -219,6 +251,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -237,6 +270,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -253,6 +287,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -271,6 +306,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await expect(
@@ -287,6 +323,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: { internalStart: undefined } as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostCreate(
@@ -319,6 +356,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any);
@@ -343,6 +381,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: workflowsManagement as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await handler.onPostDelete(createBaseParams() as any);
@@ -351,37 +390,49 @@ describe('createConnectorLifecycleHandler', () => {
       expect(workflowsManagement.management.deleteWorkflows).not.toHaveBeenCalled();
     });
 
-    it('calls smlIndexAttachmentFn with delete action after cleanup', async () => {
-      const smlIndexAttachmentFn = jest.fn().mockResolvedValue(undefined);
+    it('calls sml.indexAttachment with delete action after cleanup', async () => {
+      const sml = createMockSmlService();
       const toolRegistry = createMockToolRegistry();
       toolRegistry.list.mockResolvedValue([]);
+      const serviceManager = createMockServiceManager(
+        toolRegistry,
+        createMockUiSettingsClient(),
+        sml
+      );
       const handler = createConnectorLifecycleHandler({
-        serviceManager: createMockServiceManager(toolRegistry) as any,
+        serviceManager: serviceManager as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachmentFn,
+        getStartServices: createMockGetStartServices(),
       });
 
       const params = createBaseParams({ connectorType: '.test' });
       await handler.onPostDelete(params as any);
 
-      expect(smlIndexAttachmentFn).toHaveBeenCalledWith({
-        request: params.request,
-        originId: 'connector-abc',
-        attachmentType: AttachmentType.connector,
-        action: 'delete',
-      });
+      expect(sml.indexAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originId: 'connector-abc',
+          attachmentType: AttachmentType.connector,
+          action: 'delete',
+        })
+      );
     });
 
     it('logs warning but does not throw when SML delete fails', async () => {
-      const smlIndexAttachmentFn = jest.fn().mockRejectedValue(new Error('SML delete error'));
+      const sml = createMockSmlService();
+      sml.indexAttachment.mockRejectedValue(new Error('SML delete error'));
       const toolRegistry = createMockToolRegistry();
       toolRegistry.list.mockResolvedValue([]);
+      const serviceManager = createMockServiceManager(
+        toolRegistry,
+        createMockUiSettingsClient(),
+        sml
+      );
       const handler = createConnectorLifecycleHandler({
-        serviceManager: createMockServiceManager(toolRegistry) as any,
+        serviceManager: serviceManager as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachmentFn,
+        getStartServices: createMockGetStartServices(),
       });
 
       await expect(
@@ -400,6 +451,7 @@ describe('createConnectorLifecycleHandler', () => {
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
+        getStartServices: createMockGetStartServices(),
       });
 
       await expect(handler.onPostDelete(createBaseParams() as any)).resolves.toBeUndefined();

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -7,6 +7,7 @@
 
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { ToolType } from '@kbn/agent-builder-common';
+import { AttachmentType } from '@kbn/agent-builder-common/attachments';
 import { AGENT_BUILDER_CONNECTORS_ENABLED_SETTING_ID } from '@kbn/management-settings-ids';
 import { createConnectorLifecycleHandler } from './connector_lifecycle_handler';
 
@@ -174,33 +175,33 @@ describe('createConnectorLifecycleHandler', () => {
       );
     });
 
-    it('calls smlIndexAttachment with create action after tool creation', async () => {
-      const smlIndexAttachment = jest.fn().mockResolvedValue(undefined);
+    it('calls smlIndexAttachmentFn with create action after tool creation', async () => {
+      const smlIndexAttachmentFn = jest.fn().mockResolvedValue(undefined);
       const handler = createConnectorLifecycleHandler({
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachment,
+        smlIndexAttachmentFn,
       });
 
       const params = createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] });
       await handler.onPostCreate(params as any);
 
-      expect(smlIndexAttachment).toHaveBeenCalledWith({
+      expect(smlIndexAttachmentFn).toHaveBeenCalledWith({
         request: params.request,
         originId: 'connector-abc',
-        attachmentType: 'connector',
+        attachmentType: AttachmentType.connector,
         action: 'create',
       });
     });
 
-    it('logs warning but does not throw when smlIndexAttachment fails', async () => {
-      const smlIndexAttachment = jest.fn().mockRejectedValue(new Error('SML error'));
+    it('logs warning but does not throw when smlIndexAttachmentFn fails', async () => {
+      const smlIndexAttachmentFn = jest.fn().mockRejectedValue(new Error('SML error'));
       const handler = createConnectorLifecycleHandler({
         serviceManager: createMockServiceManager() as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachment,
+        smlIndexAttachmentFn,
       });
 
       await expect(
@@ -350,37 +351,37 @@ describe('createConnectorLifecycleHandler', () => {
       expect(workflowsManagement.management.deleteWorkflows).not.toHaveBeenCalled();
     });
 
-    it('calls smlIndexAttachment with delete action after cleanup', async () => {
-      const smlIndexAttachment = jest.fn().mockResolvedValue(undefined);
+    it('calls smlIndexAttachmentFn with delete action after cleanup', async () => {
+      const smlIndexAttachmentFn = jest.fn().mockResolvedValue(undefined);
       const toolRegistry = createMockToolRegistry();
       toolRegistry.list.mockResolvedValue([]);
       const handler = createConnectorLifecycleHandler({
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachment,
+        smlIndexAttachmentFn,
       });
 
       const params = createBaseParams({ connectorType: '.test' });
       await handler.onPostDelete(params as any);
 
-      expect(smlIndexAttachment).toHaveBeenCalledWith({
+      expect(smlIndexAttachmentFn).toHaveBeenCalledWith({
         request: params.request,
         originId: 'connector-abc',
-        attachmentType: 'connector',
+        attachmentType: AttachmentType.connector,
         action: 'delete',
       });
     });
 
     it('logs warning but does not throw when SML delete fails', async () => {
-      const smlIndexAttachment = jest.fn().mockRejectedValue(new Error('SML delete error'));
+      const smlIndexAttachmentFn = jest.fn().mockRejectedValue(new Error('SML delete error'));
       const toolRegistry = createMockToolRegistry();
       toolRegistry.list.mockResolvedValue([]);
       const handler = createConnectorLifecycleHandler({
         serviceManager: createMockServiceManager(toolRegistry) as any,
         workflowsManagement: createMockWorkflowsManagement() as any,
         logger,
-        smlIndexAttachment,
+        smlIndexAttachmentFn,
       });
 
       await expect(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -174,6 +174,44 @@ describe('createConnectorLifecycleHandler', () => {
       );
     });
 
+    it('calls smlIndexAttachment with create action after tool creation', async () => {
+      const smlIndexAttachment = jest.fn().mockResolvedValue(undefined);
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+        smlIndexAttachment,
+      });
+
+      const params = createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] });
+      await handler.onPostCreate(params as any);
+
+      expect(smlIndexAttachment).toHaveBeenCalledWith({
+        request: params.request,
+        originId: 'connector-abc',
+        attachmentType: 'connector',
+        action: 'create',
+      });
+    });
+
+    it('logs warning but does not throw when smlIndexAttachment fails', async () => {
+      const smlIndexAttachment = jest.fn().mockRejectedValue(new Error('SML error'));
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager() as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+        smlIndexAttachment,
+      });
+
+      await expect(
+        handler.onPostCreate(createBaseParams({ workflowTemplates: [SIMPLE_WORKFLOW_YAML] }) as any)
+      ).resolves.toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('failed to index connector')
+      );
+    });
+
     it('substitutes template variables with connector ID', async () => {
       const workflowsManagement = createMockWorkflowsManagement();
       const handler = createConnectorLifecycleHandler({
@@ -274,11 +312,6 @@ describe('createConnectorLifecycleHandler', () => {
           tags: ['connector', 'test', 'connector:connector-abc'],
           configuration: { workflow_id: 'wf-2' },
         },
-        {
-          id: 'tool-other',
-          tags: ['connector', 'test', 'connector:other-id'],
-          configuration: { workflow_id: 'wf-other' },
-        },
       ]);
       const workflowsManagement = createMockWorkflowsManagement();
       const handler = createConnectorLifecycleHandler({
@@ -289,10 +322,10 @@ describe('createConnectorLifecycleHandler', () => {
 
       await handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any);
 
+      expect(toolRegistry.list).toHaveBeenCalledWith({ tags: ['connector:connector-abc'] });
       expect(toolRegistry.delete).toHaveBeenCalledTimes(2);
       expect(toolRegistry.delete).toHaveBeenCalledWith('tool-1');
       expect(toolRegistry.delete).toHaveBeenCalledWith('tool-2');
-      expect(toolRegistry.delete).not.toHaveBeenCalledWith('tool-other');
 
       expect(workflowsManagement.management.deleteWorkflows).toHaveBeenCalledWith(
         ['wf-1', 'wf-2'],
@@ -315,6 +348,48 @@ describe('createConnectorLifecycleHandler', () => {
 
       expect(toolRegistry.delete).not.toHaveBeenCalled();
       expect(workflowsManagement.management.deleteWorkflows).not.toHaveBeenCalled();
+    });
+
+    it('calls smlIndexAttachment with delete action after cleanup', async () => {
+      const smlIndexAttachment = jest.fn().mockResolvedValue(undefined);
+      const toolRegistry = createMockToolRegistry();
+      toolRegistry.list.mockResolvedValue([]);
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+        smlIndexAttachment,
+      });
+
+      const params = createBaseParams({ connectorType: '.test' });
+      await handler.onPostDelete(params as any);
+
+      expect(smlIndexAttachment).toHaveBeenCalledWith({
+        request: params.request,
+        originId: 'connector-abc',
+        attachmentType: 'connector',
+        action: 'delete',
+      });
+    });
+
+    it('logs warning but does not throw when SML delete fails', async () => {
+      const smlIndexAttachment = jest.fn().mockRejectedValue(new Error('SML delete error'));
+      const toolRegistry = createMockToolRegistry();
+      toolRegistry.list.mockResolvedValue([]);
+      const handler = createConnectorLifecycleHandler({
+        serviceManager: createMockServiceManager(toolRegistry) as any,
+        workflowsManagement: createMockWorkflowsManagement() as any,
+        logger,
+        smlIndexAttachment,
+      });
+
+      await expect(
+        handler.onPostDelete(createBaseParams({ connectorType: '.test' }) as any)
+      ).resolves.toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('failed to remove connector')
+      );
     });
 
     it('logs error but does not throw on failure', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.test.ts
@@ -89,7 +89,7 @@ const createMockGetStartServices = () =>
   jest.fn().mockResolvedValue([
     {
       elasticsearch: { client: { asInternalUser: {} } },
-      savedObjects: { createInternalRepository: jest.fn().mockReturnValue({}) },
+      savedObjects: { getScopedClient: jest.fn().mockReturnValue({}) },
     },
     { spaces: { spacesService: { getSpaceId: jest.fn().mockReturnValue('default') } } },
     {},

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -10,6 +10,7 @@ import Mustache from 'mustache';
 import { parse } from 'yaml';
 import { trimStart } from 'lodash';
 import { ToolType } from '@kbn/agent-builder-common';
+import { CONNECTOR_TAG_PREFIX } from '@kbn/agent-builder-common/attachments';
 import { toolIdMaxLength } from '@kbn/agent-builder-common/tools';
 import type { Logger } from '@kbn/logging';
 import type { WorkflowYaml } from '@kbn/workflows';
@@ -18,16 +19,25 @@ import type {
   ConnectorLifecyclePostCreateParams,
   ConnectorLifecyclePostDeleteParams,
 } from '@kbn/actions-plugin/server';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
+import type { SmlIndexAction } from '../sml';
 import type { ServiceManager } from '..';
 
 const TEMPLATE_DELIMITERS: OpeningAndClosingTags = ['<%=', '%>'];
-const CONNECTOR_TAG_PREFIX = 'connector:';
+
+type SmlIndexAttachmentFn = (params: {
+  request: KibanaRequest;
+  originId: string;
+  attachmentType: string;
+  action: SmlIndexAction;
+}) => Promise<void>;
 
 interface ConnectorLifecycleHandlerDeps {
   serviceManager: ServiceManager;
   workflowsManagement?: WorkflowsServerPluginSetup;
   logger: Logger;
+  smlIndexAttachment?: SmlIndexAttachmentFn;
 }
 
 function renderWorkflowTemplate(
@@ -50,7 +60,7 @@ function slugify(input: string): string {
 }
 
 export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerDeps) {
-  const { serviceManager, workflowsManagement, logger } = deps;
+  const { serviceManager, workflowsManagement, logger, smlIndexAttachment } = deps;
 
   return {
     async onPostCreate(params: ConnectorLifecyclePostCreateParams): Promise<void> {
@@ -159,6 +169,25 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
             }
           })
         );
+
+        // Index the connector into SML for immediate discoverability
+        if (smlIndexAttachment) {
+          try {
+            await smlIndexAttachment({
+              request,
+              originId: connectorId,
+              attachmentType: 'connector',
+              action: 'create',
+            });
+            logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
+          } catch (smlError) {
+            logger.warn(
+              `Connector lifecycle: failed to index connector ${connectorId} into SML: ${
+                (smlError as Error).message
+              }`
+            );
+          }
+        }
       } catch (error) {
         logger.error(
           `Connector lifecycle: failed to create workflows/tools for connector ${connectorId}: ${error.message}`
@@ -183,11 +212,7 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
         const request = params.request;
         const toolRegistry = await internalServices.tools.getRegistry({ request });
         const connectorTag = `${CONNECTOR_TAG_PREFIX}${connectorId}`;
-
-        const tools = await toolRegistry.list();
-        const connectorTools = tools.filter(
-          (tool) => tool.tags && tool.tags.includes(connectorTag)
-        );
+        const connectorTools = await toolRegistry.list({ tags: [connectorTag] });
 
         // Collect workflow IDs before deleting tools, then delete both in parallel
         const workflowIds = connectorTools
@@ -213,6 +238,25 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
             : Promise.resolve();
 
         await Promise.all([deleteToolsPromise, deleteWorkflowsPromise]);
+
+        // Remove the connector from SML
+        if (smlIndexAttachment) {
+          try {
+            await smlIndexAttachment({
+              request,
+              originId: connectorId,
+              attachmentType: 'connector',
+              action: 'delete',
+            });
+            logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);
+          } catch (smlError) {
+            logger.warn(
+              `Connector lifecycle: failed to remove connector ${connectorId} from SML: ${
+                (smlError as Error).message
+              }`
+            );
+          }
+        }
       } catch (error) {
         logger.error(
           `Connector lifecycle: failed to clean up for connector ${connectorId}: ${error.message}`

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -10,7 +10,7 @@ import Mustache from 'mustache';
 import { parse } from 'yaml';
 import { trimStart } from 'lodash';
 import { ToolType } from '@kbn/agent-builder-common';
-import { CONNECTOR_TAG_PREFIX } from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, CONNECTOR_TAG_PREFIX } from '@kbn/agent-builder-common/attachments';
 import { toolIdMaxLength } from '@kbn/agent-builder-common/tools';
 import type { Logger } from '@kbn/logging';
 import type { WorkflowYaml } from '@kbn/workflows';
@@ -29,7 +29,7 @@ const TEMPLATE_DELIMITERS: OpeningAndClosingTags = ['<%=', '%>'];
 type SmlIndexAttachmentFn = (params: {
   request: KibanaRequest;
   originId: string;
-  attachmentType: string;
+  attachmentType: AttachmentType;
   action: SmlIndexAction;
 }) => Promise<void>;
 
@@ -37,7 +37,7 @@ interface ConnectorLifecycleHandlerDeps {
   serviceManager: ServiceManager;
   workflowsManagement?: WorkflowsServerPluginSetup;
   logger: Logger;
-  smlIndexAttachment?: SmlIndexAttachmentFn;
+  smlIndexAttachmentFn?: SmlIndexAttachmentFn;
 }
 
 function renderWorkflowTemplate(
@@ -60,7 +60,7 @@ function slugify(input: string): string {
 }
 
 export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerDeps) {
-  const { serviceManager, workflowsManagement, logger, smlIndexAttachment } = deps;
+  const { serviceManager, workflowsManagement, logger, smlIndexAttachmentFn } = deps;
 
   return {
     async onPostCreate(params: ConnectorLifecyclePostCreateParams): Promise<void> {
@@ -171,12 +171,12 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
         );
 
         // Index the connector into SML for immediate discoverability
-        if (smlIndexAttachment) {
+        if (smlIndexAttachmentFn) {
           try {
-            await smlIndexAttachment({
+            await smlIndexAttachmentFn({
               request,
               originId: connectorId,
-              attachmentType: 'connector',
+              attachmentType: AttachmentType.connector,
               action: 'create',
             });
             logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
@@ -240,12 +240,12 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
         await Promise.all([deleteToolsPromise, deleteWorkflowsPromise]);
 
         // Remove the connector from SML
-        if (smlIndexAttachment) {
+        if (smlIndexAttachmentFn) {
           try {
-            await smlIndexAttachment({
+            await smlIndexAttachmentFn({
               request,
               originId: connectorId,
-              attachmentType: 'connector',
+              attachmentType: AttachmentType.connector,
               action: 'delete',
             });
             logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -175,7 +175,9 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
               action: 'create',
               spaces: [spaceId],
               esClient: coreStart.elasticsearch.client.asInternalUser,
-              savedObjectsClient: coreStart.savedObjects.createInternalRepository(['action']),
+              savedObjectsClient: coreStart.savedObjects.getScopedClient(request, {
+                includedHiddenTypes: ['action'],
+              }),
               logger,
             });
             logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
@@ -250,7 +252,9 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
               action: 'delete',
               spaces: [spaceId],
               esClient: coreStart.elasticsearch.client.asInternalUser,
-              savedObjectsClient: coreStart.savedObjects.createInternalRepository(['action']),
+              savedObjectsClient: coreStart.savedObjects.getScopedClient(request, {
+                includedHiddenTypes: ['action'],
+              }),
               logger,
             });
             logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -19,25 +19,18 @@ import type {
   ConnectorLifecyclePostCreateParams,
   ConnectorLifecyclePostDeleteParams,
 } from '@kbn/actions-plugin/server';
-import type { KibanaRequest } from '@kbn/core-http-server';
+import type { CoreStart } from '@kbn/core/server';
 import type { WorkflowsServerPluginSetup } from '@kbn/workflows-management-plugin/server';
-import type { SmlIndexAction } from '../sml';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { ServiceManager } from '..';
 
 const TEMPLATE_DELIMITERS: OpeningAndClosingTags = ['<%=', '%>'];
-
-type SmlIndexAttachmentFn = (params: {
-  request: KibanaRequest;
-  originId: string;
-  attachmentType: AttachmentType;
-  action: SmlIndexAction;
-}) => Promise<void>;
 
 interface ConnectorLifecycleHandlerDeps {
   serviceManager: ServiceManager;
   workflowsManagement?: WorkflowsServerPluginSetup;
   logger: Logger;
-  smlIndexAttachmentFn?: SmlIndexAttachmentFn;
+  getStartServices: () => Promise<[CoreStart, { spaces?: SpacesPluginStart }, unknown]>;
 }
 
 function renderWorkflowTemplate(
@@ -60,7 +53,7 @@ function slugify(input: string): string {
 }
 
 export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerDeps) {
-  const { serviceManager, workflowsManagement, logger, smlIndexAttachmentFn } = deps;
+  const { serviceManager, workflowsManagement, logger, getStartServices } = deps;
 
   return {
     async onPostCreate(params: ConnectorLifecyclePostCreateParams): Promise<void> {
@@ -171,13 +164,19 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
         );
 
         // Index the connector into SML for immediate discoverability
-        if (smlIndexAttachmentFn) {
+        const sml = serviceManager.internalStart?.sml;
+        if (sml) {
           try {
-            await smlIndexAttachmentFn({
-              request,
+            const [coreStart, startDeps] = await getStartServices();
+            const spaceId = startDeps.spaces?.spacesService?.getSpaceId(request) ?? 'default';
+            await sml.indexAttachment({
               originId: connectorId,
               attachmentType: AttachmentType.connector,
               action: 'create',
+              spaces: [spaceId],
+              esClient: coreStart.elasticsearch.client.asInternalUser,
+              savedObjectsClient: coreStart.savedObjects.createInternalRepository(['action']),
+              logger,
             });
             logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
           } catch (smlError) {
@@ -240,13 +239,19 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
         await Promise.all([deleteToolsPromise, deleteWorkflowsPromise]);
 
         // Remove the connector from SML
-        if (smlIndexAttachmentFn) {
+        const sml = serviceManager.internalStart?.sml;
+        if (sml) {
           try {
-            await smlIndexAttachmentFn({
-              request,
+            const [coreStart, startDeps] = await getStartServices();
+            const spaceId = startDeps.spaces?.spacesService?.getSpaceId(request) ?? 'default';
+            await sml.indexAttachment({
               originId: connectorId,
               attachmentType: AttachmentType.connector,
               action: 'delete',
+              spaces: [spaceId],
+              esClient: coreStart.elasticsearch.client.asInternalUser,
+              savedObjectsClient: coreStart.savedObjects.createInternalRepository(['action']),
+              logger,
             });
             logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);
           } catch (smlError) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
@@ -95,7 +95,7 @@ export interface SmlTypeDefinition {
   toAttachment: (
     item: SmlDocument,
     context: SmlToAttachmentContext
-  ) => Promise<AttachmentInput | undefined>;
+  ) => Promise<AttachmentInput<string, unknown> | undefined>;
 
   /**
    * Optional: custom crawl interval for the crawler.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/moon.yml
@@ -41,6 +41,8 @@ dependsOn:
   - '@kbn/core-ui-settings-server-mocks'
   - '@kbn/share-plugin'
   - '@kbn/core-logging-server-mocks'
+  - '@kbn/connector-specs'
+  - '@kbn/core-saved-objects-api-server'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.test.ts
@@ -36,12 +36,12 @@ const validData: ConnectorAttachmentData = {
   connector_type: '.github',
   tools: [
     {
-      id: 'github.my-github.search_repos',
+      tool_id: 'github.my-github.search_repos',
       description: 'Search GitHub repositories',
       configuration: { workflow_id: 'workflow-1' },
     },
     {
-      id: 'github.my-github.create_issue',
+      tool_id: 'github.my-github.create_issue',
       description: 'Create a GitHub issue',
       configuration: { workflow_id: 'workflow-2' },
     },
@@ -99,7 +99,7 @@ describe('connector attachment type', () => {
     it('rejects tools with missing workflow_id', () => {
       const data = {
         ...validData,
-        tools: [{ id: 'tool-1', description: 'desc', configuration: {} }],
+        tools: [{ tool_id: 'tool-1', description: 'desc', configuration: {} }],
       };
       const result = connectorType.validate(data);
       expect(result).toEqual({ valid: false, error: expect.any(String) });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.test.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { Attachment } from '@kbn/agent-builder-common/attachments';
+import {
+  AttachmentType,
+  type ConnectorAttachmentData,
+} from '@kbn/agent-builder-common/attachments';
+import type { AgentFormattedAttachment } from '@kbn/agent-builder-server/attachments';
+import { getConnectorSpec } from '@kbn/connector-specs';
+import { createConnectorAttachmentType } from './connector';
+
+jest.mock('@kbn/connector-specs', () => ({
+  getConnectorSpec: jest.fn(),
+}));
+
+const getConnectorSpecMock = getConnectorSpec as jest.MockedFunction<typeof getConnectorSpec>;
+
+const createAttachment = (
+  data: ConnectorAttachmentData
+): Attachment<AttachmentType.connector, ConnectorAttachmentData> => ({
+  id: 'test-attachment-id',
+  type: AttachmentType.connector,
+  data,
+});
+
+const validData: ConnectorAttachmentData = {
+  connector_id: 'connector-123',
+  connector_name: 'My Github Connector',
+  connector_type: '.github',
+  tools: [
+    {
+      id: 'github.my-github.search_repos',
+      description: 'Search GitHub repositories',
+      configuration: { workflow_id: 'workflow-1' },
+    },
+    {
+      id: 'github.my-github.create_issue',
+      description: 'Create a GitHub issue',
+      configuration: { workflow_id: 'workflow-2' },
+    },
+  ],
+};
+
+const formatContext = {
+  request: httpServerMock.createKibanaRequest(),
+  spaceId: 'default',
+};
+
+describe('connector attachment type', () => {
+  const connectorType = createConnectorAttachmentType();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('validate', () => {
+    it('accepts valid connector data', () => {
+      const result = connectorType.validate(validData);
+      expect(result).toEqual({ valid: true, data: validData });
+    });
+
+    it('accepts valid data with empty tools array', () => {
+      const data = { ...validData, tools: [] };
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: true, data });
+    });
+
+    it('rejects data missing connector_id', () => {
+      const { connector_id: _, ...data } = validData;
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects data missing connector_name', () => {
+      const { connector_name: _, ...data } = validData;
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects data missing connector_type', () => {
+      const { connector_type: _, ...data } = validData;
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects data missing tools', () => {
+      const { tools: _, ...data } = validData;
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+
+    it('rejects tools with missing workflow_id', () => {
+      const data = {
+        ...validData,
+        tools: [{ id: 'tool-1', description: 'desc', configuration: {} }],
+      };
+      const result = connectorType.validate(data);
+      expect(result).toEqual({ valid: false, error: expect.any(String) });
+    });
+  });
+
+  describe('format', () => {
+    describe('getRepresentation', () => {
+      it('returns text with connector name and tool descriptions', () => {
+        getConnectorSpecMock.mockReturnValue(undefined);
+
+        const attachment = createAttachment(validData);
+        const formatted = connectorType.format(
+          attachment,
+          formatContext
+        ) as AgentFormattedAttachment;
+        const representation = formatted.getRepresentation!();
+
+        expect(representation).toEqual({
+          type: 'text',
+          value: expect.stringContaining('My Github Connector'),
+        });
+        expect((representation as { value: string }).value).toContain(
+          'github.my-github.search_repos'
+        );
+        expect((representation as { value: string }).value).toContain('Search GitHub repositories');
+        expect((representation as { value: string }).value).toContain(
+          'github.my-github.create_issue'
+        );
+        expect((representation as { value: string }).value).toContain('Create a GitHub issue');
+      });
+
+      it('uses metadata.description from connector spec when available', () => {
+        getConnectorSpecMock.mockReturnValue({
+          metadata: {
+            id: '.github',
+            displayName: 'GitHub',
+            description: 'Generic GitHub connector',
+            minimumLicense: 'enterprise',
+            supportedFeatureIds: [],
+          },
+          actions: {},
+        });
+
+        const attachment = createAttachment(validData);
+        const formatted = connectorType.format(
+          attachment,
+          formatContext
+        ) as AgentFormattedAttachment;
+        const representation = formatted.getRepresentation!() as { value: string };
+
+        expect(representation.value).toContain('Generic GitHub connector');
+      });
+
+      it('falls back to connector_type when no spec is found', () => {
+        getConnectorSpecMock.mockReturnValue(undefined);
+
+        const attachment = createAttachment(validData);
+        const formatted = connectorType.format(
+          attachment,
+          formatContext
+        ) as AgentFormattedAttachment;
+        const representation = formatted.getRepresentation!() as { value: string };
+
+        expect(representation.value).toContain('Description: .github');
+      });
+    });
+
+    describe('getBoundedTools', () => {
+      it('returns WorkflowAttachmentBoundedTool entries with correct type and config', () => {
+        const attachment = createAttachment(validData);
+        const formatted = connectorType.format(
+          attachment,
+          formatContext
+        ) as AgentFormattedAttachment;
+        const boundedTools = formatted.getBoundedTools!();
+
+        expect(boundedTools).toEqual([
+          {
+            id: 'github.my-github.search_repos',
+            type: ToolType.workflow,
+            description: 'Search GitHub repositories',
+            configuration: { workflow_id: 'workflow-1' },
+          },
+          {
+            id: 'github.my-github.create_issue',
+            type: ToolType.workflow,
+            description: 'Create a GitHub issue',
+            configuration: { workflow_id: 'workflow-2' },
+          },
+        ]);
+      });
+
+      it('returns empty array when tools array is empty', () => {
+        const attachment = createAttachment({ ...validData, tools: [] });
+        const formatted = connectorType.format(
+          attachment,
+          formatContext
+        ) as AgentFormattedAttachment;
+        const boundedTools = formatted.getBoundedTools!();
+
+        expect(boundedTools).toEqual([]);
+      });
+    });
+  });
+
+  describe('getTools', () => {
+    it('returns empty array', () => {
+      expect(connectorType.getTools!()).toEqual([]);
+    });
+  });
+
+  describe('getAgentDescription', () => {
+    it('returns a non-empty string', () => {
+      const description = connectorType.getAgentDescription!();
+      expect(typeof description).toBe('string');
+      expect(description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isReadonly', () => {
+    it('is true', () => {
+      expect(connectorType.isReadonly).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.ts
@@ -60,7 +60,7 @@ export const createConnectorAttachmentType = (): AttachmentTypeDefinition<
           if (tools.length > 0) {
             parts.push('Available tools:');
             for (const tool of tools) {
-              parts.push(`  - ${tool.id}: ${tool.description}`);
+              parts.push(`  - ${tool.tool_id}: ${tool.description}`);
             }
           }
 
@@ -69,7 +69,7 @@ export const createConnectorAttachmentType = (): AttachmentTypeDefinition<
 
         getBoundedTools: (): WorkflowAttachmentBoundedTool[] => {
           return tools.map((tool) => ({
-            id: tool.id,
+            id: tool.tool_id,
             type: ToolType.workflow,
             description: tool.description,
             configuration: { workflow_id: tool.configuration.workflow_id },

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/connector.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConnectorAttachmentData } from '@kbn/agent-builder-common/attachments';
+import {
+  AttachmentType,
+  connectorAttachmentDataSchema,
+} from '@kbn/agent-builder-common/attachments';
+import { ToolType } from '@kbn/agent-builder-common';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { WorkflowAttachmentBoundedTool } from '@kbn/agent-builder-server/attachments/tools';
+import { getConnectorSpec } from '@kbn/connector-specs';
+
+/**
+ * Creates the definition for the `connector` attachment type.
+ *
+ * Connector attachments represent a connector instance attached to a conversation,
+ * along with its workflow tools. The tools are embedded in the attachment data
+ * (populated by the connector lifecycle hook at creation time) so that
+ * `getBoundedTools()` is self-contained without needing tool registry access.
+ */
+export const createConnectorAttachmentType = (): AttachmentTypeDefinition<
+  AttachmentType.connector,
+  ConnectorAttachmentData
+> => {
+  return {
+    id: AttachmentType.connector,
+
+    isReadonly: true,
+
+    validate: (input) => {
+      const parseResult = connectorAttachmentDataSchema.safeParse(input);
+      if (parseResult.success) {
+        return { valid: true, data: parseResult.data };
+      }
+      return { valid: false, error: parseResult.error.message };
+    },
+
+    format: (attachment) => {
+      const {
+        connector_name: connectorName,
+        connector_type: connectorType,
+        tools,
+      } = attachment.data;
+
+      return {
+        getRepresentation: () => {
+          const spec = getConnectorSpec(connectorType);
+          const description = spec?.metadata.description ?? connectorType;
+
+          const parts: string[] = [
+            `Connector: ${connectorName} (${connectorType})`,
+            `Description: ${description}`,
+          ];
+
+          if (tools.length > 0) {
+            parts.push('Available tools:');
+            for (const tool of tools) {
+              parts.push(`  - ${tool.id}: ${tool.description}`);
+            }
+          }
+
+          return { type: 'text', value: parts.join('\n') };
+        },
+
+        getBoundedTools: (): WorkflowAttachmentBoundedTool[] => {
+          return tools.map((tool) => ({
+            id: tool.id,
+            type: ToolType.workflow,
+            description: tool.description,
+            configuration: { workflow_id: tool.configuration.workflow_id },
+          }));
+        },
+      };
+    },
+
+    getTools: () => [],
+
+    getAgentDescription: () => {
+      return 'A connector attachment represents an external service connector with its associated workflow tools. The tools provided by the connector can be used to interact with the external service.';
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
@@ -11,7 +11,11 @@ import { createTextAttachmentType } from './text';
 import { createEsqlAttachmentType } from './esql';
 import { createScreenContextAttachmentType } from './screen_context';
 import { createVisualizationAttachmentType } from './visualization';
+<<<<<<< HEAD
 import { createGraphAttachmentType } from './graph';
+=======
+import { createConnectorAttachmentType } from './connector';
+>>>>>>> 3069836570a4 (Add connector attachment type)
 import type {
   AgentBuilderPlatformPluginStart,
   PluginSetupDependencies,
@@ -33,6 +37,7 @@ export const registerAttachmentTypes = ({
     createEsqlAttachmentType(),
     createVisualizationAttachmentType(),
     createGraphAttachmentType(),
+    createConnectorAttachmentType(),
   ];
 
   attachmentTypes.forEach((attachmentType) => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/attachment_types/index.ts
@@ -11,11 +11,8 @@ import { createTextAttachmentType } from './text';
 import { createEsqlAttachmentType } from './esql';
 import { createScreenContextAttachmentType } from './screen_context';
 import { createVisualizationAttachmentType } from './visualization';
-<<<<<<< HEAD
 import { createGraphAttachmentType } from './graph';
-=======
 import { createConnectorAttachmentType } from './connector';
->>>>>>> 3069836570a4 (Add connector attachment type)
 import type {
   AgentBuilderPlatformPluginStart,
   PluginSetupDependencies,

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/plugin.ts
@@ -18,6 +18,7 @@ import { registerTools } from './tools';
 import { registerAttachmentTypes } from './attachment_types';
 import { registerSkills } from './skills';
 import { visualizationSmlType } from './sml_types/visualization';
+import { createConnectorSmlType } from './sml_types/connector';
 
 export class AgentBuilderPlatformPlugin
   implements
@@ -28,14 +29,10 @@ export class AgentBuilderPlatformPlugin
       PluginStartDependencies
     >
 {
-  // @ts-expect-error unused for now
   private logger: Logger;
-  // @ts-expect-error unused for now
-  private config: AgentBuilderConfig;
 
   constructor(context: PluginInitializerContext<PluginConfig>) {
     this.logger = context.logger.get();
-    this.config = context.config.get();
   }
 
   setup(
@@ -52,6 +49,19 @@ export class AgentBuilderPlatformPlugin
     });
     registerSkills(setupDeps.agentBuilder);
     setupDeps.agentBuilder.sml.registerType(visualizationSmlType);
+
+    const connectorSmlType = createConnectorSmlType({
+      getToolRegistry: async (request) => {
+        const [, startDeps] = await coreSetup.getStartServices();
+        return startDeps.agentBuilder.tools.getRegistry({ request });
+      },
+      getActionSavedObjectsClient: async () => {
+        const [coreStart] = await coreSetup.getStartServices();
+        return coreStart.savedObjects.createInternalRepository(['action']);
+      },
+      logger: this.logger.get('sml-connector'),
+    });
+    setupDeps.agentBuilder.sml.registerType(connectorSmlType);
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
@@ -229,12 +229,12 @@ describe('connectorSmlType', () => {
           connector_type: '.mcp',
           tools: [
             {
-              id: 'mcp.my-mcp.search',
+              tool_id: 'mcp.my-mcp.search',
               description: 'Search tool',
               configuration: { workflow_id: 'wf-1' },
             },
             {
-              id: 'mcp.my-mcp.fetch',
+              tool_id: 'mcp.my-mcp.fetch',
               description: 'Fetch tool',
               configuration: { workflow_id: 'wf-2' },
             },
@@ -315,7 +315,7 @@ describe('connectorSmlType', () => {
           connector_type: '.mcp',
           tools: [
             {
-              id: 'mcp.tool',
+              tool_id: 'mcp.tool',
               description: 'Tool without workflow_id',
               configuration: { workflow_id: '' },
             },

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
@@ -1,0 +1,345 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import type { SmlListItem } from '@kbn/agent-builder-plugin/server';
+import { AttachmentType } from '@kbn/agent-builder-common/attachments';
+import { createConnectorSmlType } from './connector';
+
+const WORKFLOW_YAML_WITH_TAG = `
+name: test.workflow
+description: A test workflow tool
+tags:
+  - agent-builder-tool
+steps:
+  - id: step1
+    type: action
+`;
+
+const WORKFLOW_YAML_WITHOUT_TAG = `
+name: test.other
+description: Not an AB tool
+tags:
+  - some-other-tag
+steps:
+  - id: step1
+    type: action
+`;
+
+jest.mock('@kbn/connector-specs', () => ({
+  getConnectorSpec: jest.fn(),
+  getWorkflowTemplatesForConnector: jest.fn(),
+}));
+
+const { getConnectorSpec, getWorkflowTemplatesForConnector } =
+  jest.requireMock('@kbn/connector-specs');
+
+const mockSavedObjectsClient = {
+  get: jest.fn(),
+};
+
+const mockToolRegistry = {
+  list: jest.fn(),
+};
+
+const mockGetToolRegistry = jest.fn().mockResolvedValue(mockToolRegistry);
+const mockGetActionSavedObjectsClient = jest.fn().mockResolvedValue(mockSavedObjectsClient);
+const mockLogger = loggingSystemMock.createLogger();
+
+const createContext = () => ({
+  logger: loggingSystemMock.createLogger(),
+});
+
+const createAttachmentContext = () => ({
+  request: {} as never,
+  spaceId: 'default',
+});
+
+async function collectPages(iterable: AsyncIterable<SmlListItem[]>): Promise<SmlListItem[]> {
+  const items: SmlListItem[] = [];
+  for await (const page of iterable) {
+    items.push(...page);
+  }
+  return items;
+}
+
+describe('connectorSmlType', () => {
+  const connectorSmlType = createConnectorSmlType({
+    getToolRegistry: mockGetToolRegistry,
+    getActionSavedObjectsClient: mockGetActionSavedObjectsClient,
+    logger: mockLogger,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('id', () => {
+    it('equals connector', () => {
+      expect(connectorSmlType.id).toBe('connector');
+    });
+  });
+
+  describe('list', () => {
+    it('yields nothing — connector indexing is event-driven only', async () => {
+      const result = await collectPages(connectorSmlType.list(createContext() as never));
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSmlData', () => {
+    it('returns chunk with connector name, description, and tool descriptions in content', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'My MCP Connector', actionTypeId: '.mcp' },
+        references: [],
+      });
+
+      getConnectorSpec.mockReturnValue({
+        metadata: {
+          id: '.mcp',
+          displayName: 'MCP',
+          description: 'Model Context Protocol connector',
+        },
+      });
+
+      getWorkflowTemplatesForConnector.mockReturnValue([
+        WORKFLOW_YAML_WITH_TAG,
+        WORKFLOW_YAML_WITHOUT_TAG,
+      ]);
+
+      const result = await connectorSmlType.getSmlData!('conn-1', createContext() as never);
+
+      expect(mockSavedObjectsClient.get).toHaveBeenCalledWith('action', 'conn-1');
+      expect(result).toEqual({
+        chunks: [
+          {
+            type: 'connector',
+            title: 'My MCP Connector',
+            content:
+              'My MCP Connector\nMCP\nModel Context Protocol connector\nA test workflow tool',
+            permissions: ['action:execute'],
+          },
+        ],
+      });
+    });
+
+    it('returns undefined on error and logs warning', async () => {
+      mockSavedObjectsClient.get.mockRejectedValue(new Error('Not found'));
+      const context = createContext();
+
+      const result = await connectorSmlType.getSmlData!('missing-conn', context as never);
+
+      expect(result).toBeUndefined();
+      expect(context.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to get data for 'missing-conn'")
+      );
+    });
+
+    it('deduplicates content parts when name and displayName overlap', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'MCP', actionTypeId: '.mcp' },
+        references: [],
+      });
+
+      getConnectorSpec.mockReturnValue({
+        metadata: {
+          id: '.mcp',
+          displayName: 'MCP',
+          description: 'Model Context Protocol connector',
+        },
+      });
+
+      getWorkflowTemplatesForConnector.mockReturnValue([]);
+
+      const result = await connectorSmlType.getSmlData!('conn-1', createContext() as never);
+
+      // 'MCP' should appear only once even though name === displayName
+      expect(result!.chunks[0].content).toBe('MCP\nModel Context Protocol connector');
+    });
+
+    it('handles missing optional fields gracefully', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'Basic Connector', actionTypeId: '.unknown' },
+        references: [],
+      });
+
+      getConnectorSpec.mockReturnValue(undefined);
+      getWorkflowTemplatesForConnector.mockReturnValue([WORKFLOW_YAML_WITH_TAG]);
+
+      const result = await connectorSmlType.getSmlData!('conn-1', createContext() as never);
+
+      expect(result!.chunks[0]).toEqual({
+        type: 'connector',
+        title: 'Basic Connector',
+        content: 'Basic Connector\n.unknown\nA test workflow tool',
+        permissions: ['action:execute'],
+      });
+    });
+  });
+
+  describe('toAttachment', () => {
+    it('returns connector attachment with correct shape and tools from registry', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'My MCP Connector', actionTypeId: '.mcp' },
+        references: [],
+      });
+
+      mockToolRegistry.list.mockResolvedValue([
+        {
+          id: 'mcp.my-mcp.search',
+          type: 'workflow',
+          description: 'Search tool',
+          readonly: false,
+          tags: ['connector', 'mcp', 'connector:conn-1'],
+          configuration: { workflow_id: 'wf-1' },
+        },
+        {
+          id: 'mcp.my-mcp.fetch',
+          type: 'workflow',
+          description: 'Fetch tool',
+          readonly: false,
+          tags: ['connector', 'mcp', 'connector:conn-1'],
+          configuration: { workflow_id: 'wf-2' },
+        },
+      ]);
+
+      const result = await connectorSmlType.toAttachment!(
+        { origin_id: 'conn-1' } as never,
+        createAttachmentContext() as never
+      );
+
+      expect(mockToolRegistry.list).toHaveBeenCalledWith({ tags: ['connector:conn-1'] });
+      expect(result).toEqual({
+        type: AttachmentType.connector,
+        data: {
+          connector_id: 'conn-1',
+          connector_name: 'My MCP Connector',
+          connector_type: '.mcp',
+          tools: [
+            {
+              id: 'mcp.my-mcp.search',
+              description: 'Search tool',
+              configuration: { workflow_id: 'wf-1' },
+            },
+            {
+              id: 'mcp.my-mcp.fetch',
+              description: 'Fetch tool',
+              configuration: { workflow_id: 'wf-2' },
+            },
+          ],
+        },
+      });
+    });
+
+    it('returns undefined and logs warning when connector is not found', async () => {
+      mockSavedObjectsClient.get.mockRejectedValue(new Error('Not found'));
+
+      const result = await connectorSmlType.toAttachment!(
+        { origin_id: 'missing-conn' } as never,
+        createAttachmentContext() as never
+      );
+
+      expect(result).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to convert 'missing-conn' to attachment")
+      );
+    });
+
+    it('returns attachment with empty tools when no tools match the connector tag', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'My Connector', actionTypeId: '.mcp' },
+        references: [],
+      });
+
+      mockToolRegistry.list.mockResolvedValue([]);
+
+      const result = await connectorSmlType.toAttachment!(
+        { origin_id: 'conn-1' } as never,
+        createAttachmentContext() as never
+      );
+
+      expect(result).toEqual({
+        type: AttachmentType.connector,
+        data: {
+          connector_id: 'conn-1',
+          connector_name: 'My Connector',
+          connector_type: '.mcp',
+          tools: [],
+        },
+      });
+    });
+
+    it('defaults workflow_id to empty string when tool configuration is missing it', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'Conn', actionTypeId: '.mcp' },
+        references: [],
+      });
+
+      mockToolRegistry.list.mockResolvedValue([
+        {
+          id: 'mcp.tool',
+          type: 'workflow',
+          description: 'Tool without workflow_id',
+          readonly: false,
+          tags: ['connector:conn-1'],
+          configuration: {},
+        },
+      ]);
+
+      const result = await connectorSmlType.toAttachment!(
+        { origin_id: 'conn-1' } as never,
+        createAttachmentContext() as never
+      );
+
+      expect(result).toEqual({
+        type: AttachmentType.connector,
+        data: {
+          connector_id: 'conn-1',
+          connector_name: 'Conn',
+          connector_type: '.mcp',
+          tools: [
+            {
+              id: 'mcp.tool',
+              description: 'Tool without workflow_id',
+              configuration: { workflow_id: '' },
+            },
+          ],
+        },
+      });
+    });
+
+    it('uses the correct tool registry scoped to request', async () => {
+      mockSavedObjectsClient.get.mockResolvedValue({
+        id: 'conn-1',
+        type: 'action',
+        attributes: { name: 'Conn', actionTypeId: '.mcp' },
+        references: [],
+      });
+      mockToolRegistry.list.mockResolvedValue([]);
+
+      const attachmentContext = createAttachmentContext();
+      await connectorSmlType.toAttachment!(
+        { origin_id: 'conn-1' } as never,
+        attachmentContext as never
+      );
+
+      expect(mockGetToolRegistry).toHaveBeenCalledWith(attachmentContext.request);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
@@ -121,7 +121,7 @@ export const createConnectorSmlType = (deps: ConnectorSmlTypeDeps): SmlTypeDefin
         const connectorTools = await toolRegistry.list({ tags: [connectorTag] });
 
         const tools: ConnectorAttachmentData['tools'] = connectorTools.map((tool) => ({
-          id: tool.id,
+          tool_id: tool.id,
           description: tool.description,
           configuration: {
             workflow_id:

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parse } from 'yaml';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/logging';
+import type { SmlTypeDefinition } from '@kbn/agent-builder-plugin/server';
+import type { ToolRegistry } from '@kbn/agent-builder-server';
+import type { ConnectorAttachmentData } from '@kbn/agent-builder-common/attachments';
+import { AttachmentType, CONNECTOR_TAG_PREFIX } from '@kbn/agent-builder-common/attachments';
+import { getConnectorSpec, getWorkflowTemplatesForConnector } from '@kbn/connector-specs';
+
+const CONNECTOR_SML_TYPE = 'connector';
+
+interface ConnectorSmlTypeDeps {
+  getToolRegistry: (request: KibanaRequest) => Promise<ToolRegistry>;
+  /**
+   * Returns a saved objects client that can read hidden `action` saved objects.
+   * The standard scoped client and default internal repository cannot access
+   * hidden types, so this factory creates one with `includedHiddenTypes: ['action']`.
+   */
+  getActionSavedObjectsClient: () => Promise<SavedObjectsClientContract>;
+  logger: Logger;
+}
+
+/**
+ * Parses a workflow YAML template and extracts metadata relevant to SML.
+ * Returns the tag check and description in a single parse pass.
+ */
+const parseWorkflowTemplate = (
+  yamlTemplate: string
+): { hasAgentBuilderToolTag: boolean; description?: string } => {
+  try {
+    const parsed = parse(yamlTemplate);
+    return {
+      hasAgentBuilderToolTag: parsed?.tags?.includes('agent-builder-tool') ?? false,
+      description: typeof parsed?.description === 'string' ? parsed.description : undefined,
+    };
+  } catch {
+    return { hasAgentBuilderToolTag: false };
+  }
+};
+
+/**
+ * Creates the SML type definition for connectors.
+ *
+ * Connectors are indexed into the SML exclusively via event-driven calls
+ * in the connector lifecycle handler (onPostCreate / onPostDelete).
+ * No crawling is needed — `list` yields nothing and `fetchFrequency` is omitted.
+ *
+ * A factory function is used because `toAttachment()` needs access to the tool
+ * registry, which requires a scoped request not available in the `SmlToAttachmentContext`.
+ */
+export const createConnectorSmlType = (deps: ConnectorSmlTypeDeps): SmlTypeDefinition => {
+  const { getToolRegistry, getActionSavedObjectsClient, logger } = deps;
+
+  return {
+    id: CONNECTOR_SML_TYPE,
+
+    // Connectors are indexed exclusively via event-driven lifecycle hooks.
+    // The list method yields nothing — no crawling is performed.
+    list: (_context) => ({
+      [Symbol.asyncIterator]: () => ({ next: async () => ({ done: true as const, value: [] }) }),
+    }),
+
+    getSmlData: async (originId, context) => {
+      try {
+        const soClient = await getActionSavedObjectsClient();
+        const so = await soClient.get('action', originId);
+        const attrs = so.attributes as { name?: string; actionTypeId?: string };
+        const name = attrs.name ?? originId;
+        const actionTypeId = attrs.actionTypeId ?? '';
+
+        const spec = getConnectorSpec(actionTypeId);
+        const displayName = spec?.metadata.displayName ?? actionTypeId;
+        const description = spec?.metadata.description ?? '';
+
+        const templates = getWorkflowTemplatesForConnector(actionTypeId);
+        const toolDescriptions = templates
+          .map(parseWorkflowTemplate)
+          .filter((t) => t.hasAgentBuilderToolTag && t.description)
+          .map((t) => t.description!);
+
+        const contentParts = [
+          ...new Set([name, displayName, description, ...toolDescriptions].filter(Boolean)),
+        ];
+
+        return {
+          chunks: [
+            {
+              type: CONNECTOR_SML_TYPE,
+              title: name,
+              content: contentParts.join('\n'),
+              permissions: ['action:execute'],
+            },
+          ],
+        };
+      } catch (error) {
+        context.logger.warn(
+          `SML connector: failed to get data for '${originId}': ${(error as Error).message}`
+        );
+        return undefined;
+      }
+    },
+
+    toAttachment: async (item, context) => {
+      try {
+        const soClient = await getActionSavedObjectsClient();
+        const so = await soClient.get('action', item.origin_id);
+        const attrs = so.attributes as { name?: string; actionTypeId?: string };
+        const connectorName = attrs.name ?? item.origin_id;
+        const connectorType = attrs.actionTypeId ?? '';
+
+        const toolRegistry = await getToolRegistry(context.request);
+        const connectorTag = `${CONNECTOR_TAG_PREFIX}${item.origin_id}`;
+        const connectorTools = await toolRegistry.list({ tags: [connectorTag] });
+
+        const tools: ConnectorAttachmentData['tools'] = connectorTools.map((tool) => ({
+          id: tool.id,
+          description: tool.description,
+          configuration: {
+            workflow_id:
+              ((tool.configuration as Record<string, unknown>)?.workflow_id as string) ?? '',
+          },
+        }));
+
+        const data: ConnectorAttachmentData = {
+          connector_id: item.origin_id,
+          connector_name: connectorName,
+          connector_type: connectorType,
+          tools,
+        };
+
+        return {
+          type: AttachmentType.connector,
+          data,
+        };
+      } catch (error) {
+        logger.warn(
+          `SML connector: failed to convert '${item.origin_id}' to attachment: ${
+            (error as Error).message
+          }`
+        );
+        return undefined;
+      }
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/visualization.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/visualization.test.ts
@@ -404,11 +404,12 @@ describe('visualizationSmlType', () => {
 
       expect(LensConfigBuilder).toHaveBeenCalled();
       expect(toAPIFormatMock).toHaveBeenCalled();
-      expect(result!.data.visualization).toEqual({
+      const data = result!.data as Record<string, unknown>;
+      expect(data.visualization).toEqual({
         type: 'lnsPie',
         layers: [{ id: 'layer1' }],
       });
-      expect(result!.data.chart_type).toBe('lnsPie');
+      expect(data.chart_type).toBe('lnsPie');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/tsconfig.json
@@ -3,16 +3,8 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": [
-    "../../../../../typings/**/*",
-    "common/**/*",
-    "public/**/*",
-    "server/**/*"
-  ],
-  "exclude": [
-    "target/**/*",
-    ".storybook/**/*.js"
-  ],
+  "include": ["../../../../../typings/**/*", "common/**/*", "public/**/*", "server/**/*"],
+  "exclude": ["target/**/*", ".storybook/**/*.js"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/logging",
@@ -38,5 +30,7 @@
     "@kbn/core-ui-settings-server-mocks",
     "@kbn/share-plugin",
     "@kbn/core-logging-server-mocks",
+    "@kbn/connector-specs",
+    "@kbn/core-saved-objects-api-server"
   ]
 }


### PR DESCRIPTION
## Summary

Lays the groundwork for chatting with connectors. While we can't nicely "attach" them until the "`@` thingy" is merged, we can get started. 

This PR introduces a new Connector Attachment Type, and a new SML Type definition for connectors. It then registers an instance of the connector to the SML (during connector creation via lifecycle hook). Then, at chat time, the user can prompt the agent to load the attachment, and then can chat with the tools (without having explicitly enabled the tools for the agent).

<img width="891" height="313" alt="Screenshot 2026-03-18 at 5 46 48 PM" src="https://github.com/user-attachments/assets/3ddd863b-3a97-4306-bf2a-2a0f6e9e9866" />

<img width="877" height="446" alt="Screenshot 2026-03-18 at 5 46 58 PM" src="https://github.com/user-attachments/assets/53589a62-f7e7-42d6-ad64-d4abab1061f5" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



