### PR TITLE
[Search] Remove exact_fuzzy option from Query Rules UI

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
@@ -149,13 +149,6 @@ export const QueryRuleMetadataEditor: React.FC<QueryRuleMetadataEditorProps> = (
                         ),
                       },
                       {
-                        value: 'exact_fuzzy',
-                        text: i18n.translate(
-                          'xpack.search.queryRulesetDetail.queryRuleFlyout.operatorExactFuzzy',
-                          { defaultMessage: 'exact fuzzy' }
-                        ),
-                      },
-                      {
                         value: 'fuzzy',
                         text: i18n.translate(
                           'xpack.search.queryRulesetDetail.queryRuleFlyout.operatorFuzzy',


### PR DESCRIPTION
## Summary

This removes the deprecated exact_fuzzy rule from the Query Rules UI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "exact_fuzzy" match type option from the query rule metadata editor to streamline available matching options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->