### PR TITLE
[8.19] Skip Failing test: Profiling API Integration tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration/profiling/tests/flamegraph.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration/profiling/tests/flamegraph.spec.ts
@@ -27,7 +27,8 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
   const end = new Date('2023-03-17T01:00:30.000Z').getTime();
 
   registry.when('Flamegraph api', { config: 'cloud' }, () => {
-    describe('With data', () => {
+    // Failing: See https://github.com/elastic/kibana/issues/229739
+    describe.skip('With data', () => {
       let flamegraph: BaseFlameGraph;
       before(async () => {
         await setupProfiling(bettertest, log);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/229739

## Summary

- Decided to skip tests because even after carefully testing manually and in the CI over 50 times (details [here](https://github.com/elastic/kibana/pull/258125)) we still didn't manage to fix the tests. Decided to follow [this comment](https://github.com/elastic/kibana/issues/229739#issuecomment-3229108529) and skip the tests for 8.19 only.