### PR TITLE
[Agent Builder] add built-in skills allow-list

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -90,6 +90,9 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'automatic_troubleshooting',
   'entity-analytics',
   'alert-analysis',
+
+  // O11Y
+  'observability.log-search',
 ] as const;
 
 export type AgentBuilderBuiltinSkill = (typeof AGENT_BUILDER_BUILTIN_SKILLS)[number];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -72,3 +72,28 @@ export const isAllowedBuiltinTool = (toolName: string) => {
 export const isAllowedBuiltinAgent = (agentName: string) => {
   return (AGENT_BUILDER_BUILTIN_AGENTS as readonly string[]).includes(agentName);
 };
+
+/**
+ * This is a manually maintained list of all built-in skills registered in Agent Builder.
+ * The intention is to force a code review from the Agent Builder team when any team adds a new skill.
+ */
+export const AGENT_BUILDER_BUILTIN_SKILLS = [
+  // Platform
+  'data-exploration',
+  'visualization-creation',
+
+  // Platform – Dashboard
+  'dashboard-management',
+
+  // Security Solution
+  'find-security-ml-jobs',
+  'automatic_troubleshooting',
+  'entity-analytics',
+  'alert-analysis',
+] as const;
+
+export type AgentBuilderBuiltinSkill = (typeof AGENT_BUILDER_BUILTIN_SKILLS)[number];
+
+export const isAllowedBuiltinSkill = (skillId: string) => {
+  return (AGENT_BUILDER_BUILTIN_SKILLS as readonly string[]).includes(skillId);
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
@@ -50,7 +50,6 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
     skills: {
       getRegistry: jest.fn(),
       register: jest.fn(),
-      unregister: jest.fn(),
     },
     execution: {
       executeAgent: jest.fn(),

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -232,7 +232,6 @@ export class AgentBuilderPlugin
       skills: {
         getRegistry: skills.getRegistry.bind(skills),
         register: skills.registerSkill.bind(skills),
-        unregister: skills.unregisterSkill.bind(skills),
       },
       execution: {
         executeAgent: execution.executeAgent.bind(execution),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/skills/skill_service.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/skills/skill_service.test.ts
@@ -17,6 +17,10 @@ jest.mock('@kbn/agent-builder-server/skills', () => {
   };
 });
 
+jest.mock('@kbn/agent-builder-server/allow_lists', () => ({
+  isAllowedBuiltinSkill: jest.fn().mockReturnValue(true),
+}));
+
 jest.mock('../runner/store/volumes/skills/utils', () => ({
   getSkillEntryPath: jest.fn(({ skill }) => `${skill.basePath}/${skill.name}/SKILL.md`),
 }));
@@ -65,6 +69,18 @@ describe('createSkillService', () => {
 
       const skill = createMockSkillDefinition();
       expect(() => registerSkill(skill)).not.toThrow();
+    });
+
+    it('throws when registering a skill id not in the allow-list', () => {
+      const { isAllowedBuiltinSkill } = jest.requireMock('@kbn/agent-builder-server/allow_lists');
+      isAllowedBuiltinSkill.mockReturnValueOnce(false);
+
+      const service = createSkillService();
+      const { registerSkill } = service.setup();
+
+      expect(() => registerSkill(createMockSkillDefinition({ id: 'unlisted-skill' }))).toThrow(
+        'Built-in skill with id "unlisted-skill" is not in the list of allowed built-in skills.'
+      );
     });
 
     it('throws when registering duplicate skill id', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/skills/skill_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/skills/skill_service.ts
@@ -10,6 +10,7 @@ import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { SkillDefinition } from '@kbn/agent-builder-server/skills';
 import { validateSkillDefinition } from '@kbn/agent-builder-server/skills';
+import { isAllowedBuiltinSkill } from '@kbn/agent-builder-server/allow_lists';
 import type { ToolRegistry } from '@kbn/agent-builder-server';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import { getSkillEntryPath } from '../runner/store/volumes/skills/utils';
@@ -41,14 +42,6 @@ export interface SkillServiceStart {
    * existed at creation time.
    */
   registerSkill(skill: SkillDefinition): Promise<void>;
-
-  /**
-   * Unregister a previously registered skill by ID.
-   *
-   * Returns `true` if the skill was found and removed, `false` otherwise.
-   * Serialized with `registerSkill` to avoid races.
-   */
-  unregisterSkill(skillId: string): Promise<boolean>;
 }
 
 export interface SkillService {
@@ -80,6 +73,12 @@ class SkillServiceImpl implements SkillService {
   setup(): SkillServiceSetup {
     return {
       registerSkill: (skill) => {
+        if (!isAllowedBuiltinSkill(skill.id)) {
+          throw new Error(
+            `Built-in skill with id "${skill.id}" is not in the list of allowed built-in skills.
+             Please add it to the list of allowed built-in skills in the "@kbn/agent-builder-server/allow_lists.ts" file.`
+          );
+        }
         if (this.skills.has(skill.id)) {
           throw new Error(`Skill type with id ${skill.id} already registered`);
         }
@@ -141,21 +140,6 @@ class SkillServiceImpl implements SkillService {
           }
           this.skillFullPaths.add(fullPath);
           this.skills.set(skill.id, skill);
-        });
-        this.mutationQueue = op.catch(() => {});
-        return op;
-      },
-      unregisterSkill: (skillId) => {
-        const op = this.mutationQueue.then(async () => {
-          const skill = this.skills.get(skillId);
-          if (!skill) {
-            return false;
-          }
-
-          const fullPath = getSkillEntryPath({ skill });
-          this.skillFullPaths.delete(fullPath);
-          this.skills.delete(skillId);
-          return true;
         });
         this.mutationQueue = op.catch(() => {});
         return op;

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/runner.ts
@@ -163,7 +163,6 @@ export const createSkillServiceStartMock = (): SkillServiceStartMock => {
   return {
     getRegistry: jest.fn().mockResolvedValue(createSkillRegistryMock()),
     registerSkill: jest.fn().mockResolvedValue(undefined),
-    unregisterSkill: jest.fn().mockResolvedValue(false),
   };
 };
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -99,11 +99,6 @@ export interface SkillsStart {
    * Only affects future conversations (existing ones snapshot skills at creation time).
    */
   register: (skill: SkillDefinition) => Promise<void>;
-  /**
-   * Unregister a previously registered skill by ID.
-   * Returns true if the skill was found and removed.
-   */
-  unregister: (skillId: string) => Promise<boolean>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/13408

Keep track of registered built-in skills, similar to what we do for tools and agents