### PR TITLE
[ResponseOps][Connectors] Fix accessTokenUrl validation

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/index.test.ts
@@ -361,6 +361,58 @@ describe('config validation', () => {
       );
     });
 
+    test('throws if OAuth2 accessTokenUrl is not added to allowedHosts', () => {
+      const disallowedTokenUrl = 'http://token.not.in.allowlist/oauth';
+      const configUtils = {
+        ...actionsConfigMock.create(),
+        ensureUriAllowed: (uri: string) => {
+          if (uri === disallowedTokenUrl) {
+            throw new Error(
+              `target url "${disallowedTokenUrl}" is not added to the Kibana config xpack.actions.allowedHosts`
+            );
+          }
+        },
+      };
+
+      const config = {
+        method: 'post',
+        url: 'https://webhook.example/webhook',
+        hasAuth: true,
+        authType: AuthType.OAuth2ClientCredentials,
+        accessTokenUrl: disallowedTokenUrl,
+        clientId: 'client-id',
+      };
+
+      expect(() => {
+        validateConfig(connectorType, config, { configurationUtilities: configUtils });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"error validating connector type config: error validation webhook action config: target url \\"http://token.not.in.allowlist/oauth\\" is not added to the Kibana config xpack.actions.allowedHosts"`
+      );
+    });
+
+    test('calls ensureUriAllowed for main url and accessTokenUrl when OAuth2 config is valid', () => {
+      const configUtils = {
+        ...actionsConfigMock.create(),
+        ensureUriAllowed: jest.fn(),
+      };
+      const mainUrl = 'https://webhook.example/webhook';
+      const tokenUrl = 'https://token.example/oauth';
+      const config = {
+        method: 'post',
+        url: mainUrl,
+        hasAuth: true,
+        authType: AuthType.OAuth2ClientCredentials,
+        accessTokenUrl: tokenUrl,
+        clientId: 'client-id',
+      };
+
+      validateConfig(connectorType, config, { configurationUtilities: configUtils });
+
+      expect(configUtils.ensureUriAllowed).toHaveBeenCalledTimes(2);
+      expect(configUtils.ensureUriAllowed).toHaveBeenNthCalledWith(1, mainUrl);
+      expect(configUtils.ensureUriAllowed).toHaveBeenNthCalledWith(2, tokenUrl);
+    });
+
     test('throws when additionalFields is no valid JSON', async () => {
       const config = {
         method: 'post',

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/validations.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/webhook/validations.ts
@@ -96,11 +96,15 @@ function validateAdditionalFields(configObject: ConnectorTypeConfigType) {
   }
 }
 
-function validateOAuth2(configObject: ConnectorTypeConfigType) {
-  if (
-    configObject.authType === AuthType.OAuth2ClientCredentials &&
-    (!configObject.accessTokenUrl || !configObject.clientId)
-  ) {
+function validateOAuth2(
+  configObject: ConnectorTypeConfigType,
+  configurationUtilities: ActionsConfigurationUtilities
+) {
+  if (configObject.authType !== AuthType.OAuth2ClientCredentials) {
+    return;
+  }
+
+  if (!configObject.accessTokenUrl || !configObject.clientId) {
     const missingFields = [];
     if (!configObject.accessTokenUrl) {
       missingFields.push('Access Token URL (accessTokenUrl)');
@@ -118,6 +122,9 @@ function validateOAuth2(configObject: ConnectorTypeConfigType) {
       })
     );
   }
+
+  validateUrl(configObject.accessTokenUrl);
+  ensureUriAllowed(configObject.accessTokenUrl, configurationUtilities);
 }
 
 export function validateConnectorTypeConfig(
@@ -132,5 +139,5 @@ export function validateConnectorTypeConfig(
   validateAuthType(configObject);
   validateCertType(configObject, configurationUtilities);
   validateAdditionalFields(configObject);
-  validateOAuth2(configObject);
+  validateOAuth2(configObject, configurationUtilities);
 }

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
@@ -431,6 +431,32 @@ export default function webhookTest({ getService }: FtrProviderContext) {
       expect(result.message).to.match(/is not added to the Kibana config/);
     });
 
+    it('should reject OAuth2 webhook when accessTokenUrl host is not in allowedHosts', async () => {
+      const tokenUrl = 'http://oauth.mynonexistent.com/token';
+      const { body: result } = await supertest
+        .post('/api/actions/connector')
+        .set('kbn-xsrf', 'test')
+        .send({
+          name: 'OAuth2 Webhook disallowed token URL',
+          connector_type_id: '.webhook',
+          secrets: {
+            clientSecret: 'secret',
+          },
+          config: {
+            url: webhookSimulatorURL,
+            hasAuth: true,
+            authType: 'webhook-oauth2-client-credentials',
+            accessTokenUrl: tokenUrl,
+            clientId: 'client-id',
+          },
+        })
+        .expect(400);
+
+      expect(result.error).to.eql('Bad Request');
+      expect(result.message).to.contain(tokenUrl);
+      expect(result.message).to.match(/is not added to the Kibana config/);
+    });
+
     it('should handle unreachable webhook targets', async () => {
       const webhookActionId = await createWebhookAction(
         'http://some.non.existent.com/endpoint',


### PR DESCRIPTION
## 📄 Summary

Fix Webhook Connector `accessTokenUrl` validation

<details>
<summary>

## 🧪 Verification steps

</summary>

### ✅ Happy Path

- Create or update a Webhook connector with OAuth2 client credentials where both `url` and `accessTokenUrl` use hosts listed in `xpack.actions.allowedHosts`. Validation passes and the connector is saved.

### ⚡️ Edge Cases

- Webhook with OAuth2 and only main URL in allowedHosts: if `accessTokenUrl` host is not allowed, creation/update fails with a clear error.
- Webhook without OAuth2: behavior unchanged; only main URL is validated against allowedHosts.

### ❌ Failure Cases

- Create a Webhook connector with OAuth2 and an `accessTokenUrl` whose host is not in `xpack.actions.allowedHosts`. Expect 400 with message containing the token URL and "is not added to the Kibana config" (or similar wording from the actions plugin).

</details>

## ⏪ Backport rationale

Backporting to the track where the issue appeared

## Release Notes

Fix Webhook Connector `accessTokenUrl` validation

## ☑️ Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->