### PR TITLE
[8.19] [ML] Anomaly Detection Single Metric Viewer Rules flyout state update fix (#257196)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/__snapshots__/scope_expression.test.js.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/__snapshots__/scope_expression.test.js.snap
@@ -20,6 +20,7 @@ exports[`ScopeExpression renders when empty list of filter IDs is supplied 1`] =
         <input
           checked=""
           class="euiCheckbox__input emotion-euiCheckbox__input"
+          data-test-subj="mlScopeCheckbox_domain"
           id="scope_cb_domain"
           type="checkbox"
         />
@@ -67,6 +68,7 @@ exports[`ScopeExpression renders when enabled set to false 1`] = `
         />
         <input
           class="euiCheckbox__input emotion-euiCheckbox__input"
+          data-test-subj="mlScopeCheckbox_domain"
           id="scope_cb_domain"
           type="checkbox"
         />
@@ -139,6 +141,7 @@ exports[`ScopeExpression renders when filter ID and type supplied 1`] = `
         <input
           checked=""
           class="euiCheckbox__input emotion-euiCheckbox__input"
+          data-test-subj="mlScopeCheckbox_domain"
           id="scope_cb_domain"
           type="checkbox"
         />
@@ -211,6 +214,7 @@ exports[`ScopeExpression renders when no filter ID or type supplied 1`] = `
         <input
           checked=""
           class="euiCheckbox__input emotion-euiCheckbox__input"
+          data-test-subj="mlScopeCheckbox_domain"
           id="scope_cb_domain"
           type="checkbox"
         />

--- a/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/__snapshots__/scope_section.test.js.snap
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/__snapshots__/scope_section.test.js.snap
@@ -115,6 +115,7 @@ exports[`ScopeSection renders when enabled with no scope supplied 1`] = `
           />
           <input
             class="euiCheckbox__input emotion-euiCheckbox__input"
+            data-test-subj="mlScopeCheckbox_domain"
             id="scope_cb_domain"
             type="checkbox"
           />
@@ -227,6 +228,7 @@ exports[`ScopeSection renders when enabled with scope supplied 1`] = `
           <input
             checked=""
             class="euiCheckbox__input emotion-euiCheckbox__input"
+            data-test-subj="mlScopeCheckbox_domain"
             id="scope_cb_domain"
             type="checkbox"
           />

--- a/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.js
@@ -60,7 +60,6 @@ class RuleEditorFlyoutUI extends Component {
   static propTypes = {
     setShowFunction: PropTypes.func.isRequired,
     unsetShowFunction: PropTypes.func.isRequired,
-    selectedJob: PropTypes.object,
   };
 
   constructor(props) {
@@ -103,7 +102,7 @@ class RuleEditorFlyoutUI extends Component {
 
   showFlyout = (anomaly) => {
     let ruleIndex = -1;
-    const job = this.props.selectedJob ?? this.mlJobService.getJob(anomaly.jobId);
+    const job = this.mlJobService.getJob(anomaly.jobId);
     if (job === undefined) {
       // No details found for this job, display an error and
       // don't open the Flyout as no edits can be made without the job.
@@ -509,8 +508,12 @@ class RuleEditorFlyoutUI extends Component {
 
     if (ruleIndex === -1) {
       flyout = (
-        <EuiFlyout onClose={this.closeFlyout} aria-labelledby="flyoutTitle">
-          <EuiFlyoutHeader hasBorder={true}>
+        <EuiFlyout
+          onClose={this.closeFlyout}
+          aria-labelledby="flyoutTitle"
+          data-test-subj="mlRuleEditorFlyout"
+        >
+          <EuiFlyoutHeader hasBorder={true} data-test-subj="mlRuleEditorEditRulesTitle">
             <EuiTitle size="m">
               <h1 id="flyoutTitle">
                 <FormattedMessage

--- a/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.test.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.test.js
@@ -6,43 +6,43 @@
  */
 
 // Mock the services required for reading and writing job data.
+const mockGetJob = jest.fn(() => ({
+  job_id: 'farequote_no_by',
+  description: 'Overall response time',
+  analysis_config: {
+    bucket_span: '5m',
+    detectors: [
+      {
+        detector_description: 'mean(responsetime)',
+        function: 'mean',
+        field_name: 'responsetime',
+        detector_index: 0,
+      },
+      {
+        detector_description: 'min(responsetime)',
+        function: 'max',
+        field_name: 'responsetime',
+        detector_index: 1,
+        custom_rules: [
+          {
+            actions: ['skip_result'],
+            conditions: [
+              {
+                applies_to: 'diff_from_typical',
+                operator: 'lte',
+                value: 123,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}));
+
 jest.mock('../../services/job_service', () => ({
   mlJobServiceFactory: () => ({
-    getJob: () => {
-      return {
-        job_id: 'farequote_no_by',
-        description: 'Overall response time',
-        analysis_config: {
-          bucket_span: '5m',
-          detectors: [
-            {
-              detector_description: 'mean(responsetime)',
-              function: 'mean',
-              field_name: 'responsetime',
-              detector_index: 0,
-            },
-            {
-              detector_description: 'min(responsetime)',
-              function: 'max',
-              field_name: 'responsetime',
-              detector_index: 1,
-              custom_rules: [
-                {
-                  actions: ['skip_result'],
-                  conditions: [
-                    {
-                      applies_to: 'diff_from_typical',
-                      operator: 'lte',
-                      value: 123,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      };
-    },
+    getJob: mockGetJob,
   }),
 }));
 jest.mock('../../capabilities/check_capabilities', () => ({
@@ -95,8 +95,31 @@ describe('RuleEditorFlyout', () => {
     },
   });
 
+  const anomaly = {
+    jobId: 'farequote_no_by',
+    detectorIndex: 0,
+    source: { function: 'mean' },
+  };
+
   test(`don't render when not opened`, () => {
     const { container } = renderWithI18n(<RuleEditorFlyout {...getRequiredProps()} />);
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('showFlyout reads job from mlJobService using the anomaly jobId', () => {
+    let capturedShowFlyout;
+    const props = {
+      ...getRequiredProps(),
+      setShowFunction: (fn) => {
+        capturedShowFlyout = fn;
+      },
+    };
+
+    renderWithI18n(<RuleEditorFlyout {...props} />);
+
+    capturedShowFlyout(anomaly, {});
+
+    // mlJobService.getJob should have been called with the anomaly's jobId
+    expect(mockGetJob).toHaveBeenCalledWith(anomaly.jobId);
   });
 });

--- a/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/scope_expression.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/scope_expression.js
@@ -121,6 +121,7 @@ export class ScopeExpression extends Component {
         <EuiFlexItem grow={false}>
           <EuiCheckbox
             id={`scope_cb_${fieldName}`}
+            data-test-subj={`mlScopeCheckbox_${fieldName}`}
             checked={enabled}
             onChange={this.onEnableChange}
           />

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
@@ -2020,7 +2020,6 @@ class TimeseriesChartIntl extends Component {
     return (
       <>
         <RuleEditorFlyout
-          selectedJob={this.props.selectedJob}
           setShowFunction={this.setShowRuleEditorFlyoutFunction}
           unsetShowFunction={this.unsetShowRuleEditorFlyoutFunction}
         />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ML] Anomaly Detection Single Metric Viewer Rules flyout state update fix (#257196)](https://github.com/elastic/kibana/pull/257196)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Krasocki","email":"104936644+KodeRad@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-18T10:02:28Z","message":"[ML] Anomaly Detection Single Metric Viewer Rules flyout state update fix (#257196)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/227569\n\nThis PR:\n- Ensures that the flyout with Rules has the latest updated job object.\nThanks to that, there is no need to reload the page to see the changes\nafter new rule is created in the timeseries chart or existing rule is\ndeleted.\n- Adds unit test\n- Covers this functionality as a part of existing FTR test\n\n#### Video\n\n\nhttps://github.com/user-attachments/assets/843f0819-de5e-41d2-aceb-f62d0ea73778\n\n\n#### Implementation details:\n\nRoot cause\n\n\n`x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.js`\nline 107\n\n`const job = this.props.selectedJob ??\nthis.mlJobService.getJob(anomaly.jobId);`\n\n- `this.props.selectedJob` is always truthy (passed from\n`TimeseriesChartIntl.props.selectedJob`)\n- After a save/delete, `refreshJob()` updates the singleton's cached\njob, but the parent (TimeSeriesExplorer) never re-renders\n- So `this.props.selectedJob` remains the old object reference with\noutdated custom_rules\n- The nullish coalescing `??` never reaches `mlJobService.getJob()`\nwhich would return the fresh data\n\nProposed fix\n\nOne-line change: Swap the priority in `showFlyout` to prefer\n`mlJobService.getJob()` (fresh) over `this.props.selectedJob`\n(potentially stale):\n\n`const job = this.mlJobService.getJob(anomaly.jobId) ??\nthis.props.selectedJob;`\n\nThis works because:\n- `mlJobService` is a singleton; `refreshJob()` already updates it after\nevery save/delete\n- `getJob()` returns the fresh job object\n- Falls back to selectedJob prop only if `getJob()` returns undefined\n(edge case safety)\n- No changes needed in parent components\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1b5d3a673fc8139efc16184fe4a6cfe07e6c4ff9","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:Anomaly Detection","Team:ML","backport:version","v9.4.0","v8.19.13","v9.2.7","v9.3.2"],"title":"[ML] Anomaly Detection Single Metric Viewer: fixes update of job rules flyout","number":257196,"url":"https://github.com/elastic/kibana/pull/257196","mergeCommit":{"message":"[ML] Anomaly Detection Single Metric Viewer Rules flyout state update fix (#257196)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/227569\n\nThis PR:\n- Ensures that the flyout with Rules has the latest updated job object.\nThanks to that, there is no need to reload the page to see the changes\nafter new rule is created in the timeseries chart or existing rule is\ndeleted.\n- Adds unit test\n- Covers this functionality as a part of existing FTR test\n\n#### Video\n\n\nhttps://github.com/user-attachments/assets/843f0819-de5e-41d2-aceb-f62d0ea73778\n\n\n#### Implementation details:\n\nRoot cause\n\n\n`x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.js`\nline 107\n\n`const job = this.props.selectedJob ??\nthis.mlJobService.getJob(anomaly.jobId);`\n\n- `this.props.selectedJob` is always truthy (passed from\n`TimeseriesChartIntl.props.selectedJob`)\n- After a save/delete, `refreshJob()` updates the singleton's cached\njob, but the parent (TimeSeriesExplorer) never re-renders\n- So `this.props.selectedJob` remains the old object reference with\noutdated custom_rules\n- The nullish coalescing `??` never reaches `mlJobService.getJob()`\nwhich would return the fresh data\n\nProposed fix\n\nOne-line change: Swap the priority in `showFlyout` to prefer\n`mlJobService.getJob()` (fresh) over `this.props.selectedJob`\n(potentially stale):\n\n`const job = this.mlJobService.getJob(anomaly.jobId) ??\nthis.props.selectedJob;`\n\nThis works because:\n- `mlJobService` is a singleton; `refreshJob()` already updates it after\nevery save/delete\n- `getJob()` returns the fresh job object\n- Falls back to selectedJob prop only if `getJob()` returns undefined\n(edge case safety)\n- No changes needed in parent components\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1b5d3a673fc8139efc16184fe4a6cfe07e6c4ff9"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257196","number":257196,"mergeCommit":{"message":"[ML] Anomaly Detection Single Metric Viewer Rules flyout state update fix (#257196)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/227569\n\nThis PR:\n- Ensures that the flyout with Rules has the latest updated job object.\nThanks to that, there is no need to reload the page to see the changes\nafter new rule is created in the timeseries chart or existing rule is\ndeleted.\n- Adds unit test\n- Covers this functionality as a part of existing FTR test\n\n#### Video\n\n\nhttps://github.com/user-attachments/assets/843f0819-de5e-41d2-aceb-f62d0ea73778\n\n\n#### Implementation details:\n\nRoot cause\n\n\n`x-pack/platform/plugins/shared/ml/public/application/components/rule_editor/rule_editor_flyout.js`\nline 107\n\n`const job = this.props.selectedJob ??\nthis.mlJobService.getJob(anomaly.jobId);`\n\n- `this.props.selectedJob` is always truthy (passed from\n`TimeseriesChartIntl.props.selectedJob`)\n- After a save/delete, `refreshJob()` updates the singleton's cached\njob, but the parent (TimeSeriesExplorer) never re-renders\n- So `this.props.selectedJob` remains the old object reference with\noutdated custom_rules\n- The nullish coalescing `??` never reaches `mlJobService.getJob()`\nwhich would return the fresh data\n\nProposed fix\n\nOne-line change: Swap the priority in `showFlyout` to prefer\n`mlJobService.getJob()` (fresh) over `this.props.selectedJob`\n(potentially stale):\n\n`const job = this.mlJobService.getJob(anomaly.jobId) ??\nthis.props.selectedJob;`\n\nThis works because:\n- `mlJobService` is a singleton; `refreshJob()` already updates it after\nevery save/delete\n- `getJob()` returns the fresh job object\n- Falls back to selectedJob prop only if `getJob()` returns undefined\n(edge case safety)\n- No changes needed in parent components\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1b5d3a673fc8139efc16184fe4a6cfe07e6c4ff9"}},{"branch":"8.19","label":"v8.19.13","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258297","number":258297,"state":"OPEN"},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258298","number":258298,"state":"OPEN"}]}] BACKPORT-->