### PR TITLE
Filter Agent Builder connectors on compatibility

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/pages/connectors.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/pages/connectors.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiPageTemplate, EuiBasicTable, EuiButton, EuiLink } from '@elastic/eui';
 import type { ActionConnector } from '@kbn/alerts-ui-shared';
+import { AgentBuilderConnectorFeatureId } from '@kbn/actions-plugin/common';
 import { useQueryClient } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
 import type { ConnectorItem } from '../../../common/http_api/tools';
@@ -71,6 +72,7 @@ export const AgentBuilderConnectorsPage: React.FC = () => {
       triggersActionsUi.getAddConnectorFlyout({
         onClose: createFlyoutState.closeFlyout,
         onConnectorCreated: handleConnectorCreated,
+        featureId: AgentBuilderConnectorFeatureId,
       }),
     [createFlyoutState.closeFlyout, handleConnectorCreated, triggersActionsUi]
   );

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -9,7 +9,10 @@ import { schema } from '@kbn/config-schema';
 import { listSearchSources } from '@kbn/agent-builder-genai-utils';
 import { CONNECTOR_ID as MCP_CONNECTOR_ID } from '@kbn/connector-schemas/mcp/constants';
 import type { ListToolsResponse } from '@kbn/mcp-client';
-import type { ActionTypeExecutorResult } from '@kbn/actions-plugin/common';
+import {
+  type ActionTypeExecutorResult,
+  AgentBuilderConnectorFeatureId,
+} from '@kbn/actions-plugin/common';
 import { isMcpTool, type McpToolDefinition } from '@kbn/agent-builder-common/tools';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
@@ -453,11 +456,16 @@ export function registerInternalToolsRoutes({
     wrapHandler(async (ctx, request, response) => {
       const [, pluginsStart] = await coreSetup.getStartServices();
       const actionsClient = await pluginsStart.actions.getActionsClientWithRequest(request);
-      const allConnectors = await actionsClient.getAll();
+      const [allConnectors, compatibleTypes] = await Promise.all([
+        actionsClient.getAll(),
+        actionsClient.listTypes({ featureId: AgentBuilderConnectorFeatureId }),
+      ]);
 
+      const compatibleTypeIds = new Set(compatibleTypes.map((t) => t.id));
       const { type } = request.query;
 
       const connectors: ConnectorItem[] = allConnectors
+        .filter((connector) => compatibleTypeIds.has(connector.actionTypeId))
         .filter((connector) => (type ? connector.actionTypeId === type : true))
         .map(toConnectorItem);
 


### PR DESCRIPTION
## Summary

Building off of https://github.com/elastic/kibana/pull/257491, this filters the new Agent Builder connector UI to only show connectors that we want there.

To enable:
```
POST kbn://internal/kibana/settings
{
   "changes": {
      "agentBuilder:connectorsEnabled": true
   }
}
```

## Before
<img width="1462" height="813" alt="Screenshot 2026-03-18 at 9 11 47 AM" src="https://github.com/user-attachments/assets/789c426d-f484-4bb0-a4ec-1830e37cbf99" />


## After
<img width="1428" height="815" alt="Screenshot 2026-03-18 at 9 13 23 AM" src="https://github.com/user-attachments/assets/4d540a8f-e9db-4e44-b01c-4d0d756fc638" />





