### PR TITLE
[Streams] On mount component fill state with initial ES|QL if available

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/query_streams/query_stream_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/query_streams/query_stream_flyout.tsx
@@ -72,7 +72,7 @@ export function QueryStreamFlyout({
   const { formState, register, handleSubmit, setValue, watch } = useForm<FormState>({
     defaultValues: {
       name: initialName,
-      esqlQuery: '',
+      esqlQuery: initialEsql ?? '',
     },
   });
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/256968

## Summary

This fixes the test at `x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/edit_query_stream.spec.ts` which was relying on Monaco being filled with data on mount, instead of waiting on `useEffect`.  

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->