### PR TITLE
[EDR Workflows][Osquery] Add shared table toolbar components and redesign saved queries list

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/common/use_bulk_get_user_profiles.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/common/use_bulk_get_user_profiles.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@kbn/react-query';
+import { useKibana } from './lib/kibana';
+import { useGenericBulkGetUserProfiles } from './use_bulk_get_user_profiles';
+
+jest.mock('./lib/kibana');
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return Wrapper;
+};
+
+const MOCK_PROFILES = [
+  { uid: 'uid-1', user: { username: 'admin', full_name: 'Admin User' }, data: { avatar: {} } },
+  { uid: 'uid-2', user: { username: 'user1', full_name: 'User One' }, data: { avatar: {} } },
+];
+
+describe('useGenericBulkGetUserProfiles', () => {
+  let mockBulkGet: jest.Mock;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBulkGet = jest.fn().mockResolvedValue(MOCK_PROFILES);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+      logger: { log: () => null, warn: () => null, error: () => null },
+    });
+
+    useKibanaMock.mockReturnValue({
+      services: {
+        userProfile: { bulkGet: mockBulkGet },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+  });
+
+  it('fetches profiles and returns a map keyed by uid', async () => {
+    const { result } = renderHook(() => useGenericBulkGetUserProfiles(['uid-1', 'uid-2']), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.profilesMap.size).toBe(2));
+
+    expect(result.current.profilesMap.get('uid-1')?.user.username).toBe('admin');
+    expect(result.current.profilesMap.get('uid-2')?.user.username).toBe('user1');
+  });
+
+  it('calls bulkGet with deduplicated and sorted uids', async () => {
+    const { result } = renderHook(
+      () => useGenericBulkGetUserProfiles(['uid-2', 'uid-1', 'uid-2', 'uid-1']),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.profilesMap.size).toBe(2));
+
+    expect(mockBulkGet).toHaveBeenCalledTimes(1);
+    const calledUids = Array.from(mockBulkGet.mock.calls[0][0].uids);
+    expect(calledUids).toEqual(['uid-1', 'uid-2']);
+  });
+
+  it('does not call bulkGet when uids array is empty', () => {
+    renderHook(() => useGenericBulkGetUserProfiles([]), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockBulkGet).not.toHaveBeenCalled();
+  });
+
+  it('returns empty map and isLoading false when uids are empty', () => {
+    const { result } = renderHook(() => useGenericBulkGetUserProfiles([]), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.profilesMap.size).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('requests avatar data path', async () => {
+    mockBulkGet.mockResolvedValue([MOCK_PROFILES[0]]);
+
+    const { result } = renderHook(() => useGenericBulkGetUserProfiles(['uid-1']), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.profilesMap.size).toBe(1));
+
+    expect(mockBulkGet).toHaveBeenCalledWith({
+      uids: new Set(['uid-1']),
+      dataPath: 'avatar',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/common/use_bulk_get_user_profiles.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/common/use_bulk_get_user_profiles.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRef, useMemo } from 'react';
+import { useQuery } from '@kbn/react-query';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { useKibana } from './lib/kibana';
+
+/**
+ * Generic hook to bulk-fetch user profiles by UIDs.
+ * Unlike the history-specific version in actions/use_user_profiles.ts,
+ * this accepts raw UID strings and can be used with any data source
+ * (packs, saved queries, etc.).
+ */
+export const useGenericBulkGetUserProfiles = (uids: string[]) => {
+  const { userProfile } = useKibana().services;
+
+  const prevKeyRef = useRef('');
+  const stableUids = useMemo(() => {
+    const deduped = [...new Set(uids)].sort();
+    const key = deduped.join(',');
+    if (key === prevKeyRef.current) {
+      return prevKeyRef.current.split(',').filter(Boolean);
+    }
+
+    prevKeyRef.current = key;
+
+    return deduped;
+  }, [uids]);
+
+  const { data: userProfiles, isLoading } = useQuery<UserProfileWithAvatar[]>(
+    ['useGenericBulkGetUserProfiles', ...stableUids],
+    () => userProfile.bulkGet({ uids: new Set(stableUids), dataPath: 'avatar' }),
+    {
+      enabled: stableUids.length > 0,
+      staleTime: Infinity,
+      retry: false,
+      keepPreviousData: true,
+    }
+  );
+
+  const profilesMap = useMemo(() => {
+    if (!userProfiles) return new Map<string, UserProfileWithAvatar>();
+
+    return new Map(userProfiles.map((profile) => [profile.uid, profile]));
+  }, [userProfiles]);
+
+  return { profilesMap, isLoading: isLoading && stableUids.length > 0 };
+};

--- a/x-pack/platform/plugins/shared/osquery/public/components/main_navigation.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/main_navigation.tsx
@@ -64,33 +64,47 @@ export const MainNavigation = () => {
     permissions.writeLiveQueries ||
     (permissions.runSavedQueries && (permissions.readSavedQueries || permissions.readPacks));
 
+  const isSubRoute = useMemo(() => {
+    const segments = location.pathname.split('/').filter(Boolean);
+
+    return segments.length > 1;
+  }, [location.pathname]);
+
   if (isHistoryEnabled) {
+    const topBar = (
+      <div css={topBarCss}>
+        <EuiFlexGroup gutterSize="none" justifyContent="flexEnd" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s" direction="row" alignItems="center">
+              {isFeedbackEnabled && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    href="https://ela.st/osquery-feedback"
+                    target="_blank"
+                    aria-label={feedbackButtonLabel}
+                    iconType="popout"
+                    iconSide="right"
+                    color="primary"
+                    size="s"
+                  >
+                    {feedbackButtonLabel}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+              <ManageIntegrationLink />
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+    );
+
+    if (isSubRoute) {
+      return topBar;
+    }
+
     return (
       <>
-        <div css={topBarCss}>
-          <EuiFlexGroup gutterSize="none" justifyContent="flexEnd" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiFlexGroup gutterSize="s" direction="row" alignItems="center">
-                {isFeedbackEnabled && (
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      href="https://ela.st/osquery-feedback"
-                      target="_blank"
-                      aria-label={feedbackButtonLabel}
-                      iconType="popout"
-                      iconSide="right"
-                      color="primary"
-                      size="s"
-                    >
-                      {feedbackButtonLabel}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                )}
-                <ManageIntegrationLink />
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </div>
+        {topBar}
         <div css={navCss}>
           <EuiSpacer size="l" />
           <EuiFlexGroup gutterSize="l" alignItems="center">

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/column_picker_popover.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/column_picker_popover.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { EuiButtonEmpty, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const POPOVER_WIDTH = 250;
+const POPOVER_CONTENT_STYLE = { width: POPOVER_WIDTH };
+
+const COLUMNS_LABEL = i18n.translate('xpack.osquery.tableToolbar.columnsLabel', {
+  defaultMessage: 'Columns',
+});
+
+export interface ColumnConfig {
+  id: string;
+  label: string;
+}
+
+interface ColumnPickerPopoverProps {
+  columns: ColumnConfig[];
+  visibleColumns: string[];
+  onVisibleColumnsChange: (columnIds: string[]) => void;
+  'data-test-subj'?: string;
+}
+
+const ColumnPickerPopoverComponent: React.FC<ColumnPickerPopoverProps> = ({
+  columns,
+  visibleColumns,
+  onVisibleColumnsChange,
+  'data-test-subj': dataTestSubj = 'column-picker',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectableOptions = useMemo<EuiSelectableOption[]>(() => {
+    const visibleSet = new Set(visibleColumns);
+
+    return columns.map(({ id, label }) => ({
+      label,
+      key: id,
+      checked: visibleSet.has(id) ? 'on' : undefined,
+    }));
+  }, [columns, visibleColumns]);
+
+  const handleChange = useCallback(
+    (newOptions: EuiSelectableOption[]) => {
+      const newVisible = newOptions.filter((opt) => opt.checked === 'on').map((opt) => opt.key!);
+      onVisibleColumnsChange(newVisible);
+    },
+    [onVisibleColumnsChange]
+  );
+
+  const togglePopover = useCallback(() => setIsOpen((prev) => !prev), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+  const panelProps = useMemo(
+    () => ({ 'data-test-subj': `${dataTestSubj}-popover` }),
+    [dataTestSubj]
+  );
+
+  const buttonLabel = i18n.translate('xpack.osquery.tableToolbar.columnsCountLabel', {
+    defaultMessage: 'Columns: {count}',
+    values: { count: visibleColumns.length },
+  });
+
+  const triggerButton = (
+    <EuiButtonEmpty
+      size="xs"
+      iconType="listAdd"
+      onClick={togglePopover}
+      data-test-subj={`${dataTestSubj}-button`}
+    >
+      {buttonLabel}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      ownFocus
+      button={triggerButton}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      repositionOnScroll
+      panelProps={panelProps}
+    >
+      <EuiSelectable aria-label={COLUMNS_LABEL} options={selectableOptions} onChange={handleChange}>
+        {(list) => (
+          <div style={POPOVER_CONTENT_STYLE}>
+            <EuiPopoverTitle paddingSize="s">{COLUMNS_LABEL}</EuiPopoverTitle>
+            {list}
+          </div>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
+ColumnPickerPopoverComponent.displayName = 'ColumnPickerPopover';
+
+export const ColumnPickerPopover = React.memo(ColumnPickerPopoverComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/created_by_filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/created_by_filter_popover.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import {
+  EuiFilterButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { UserAvatar } from '@kbn/user-profile-components';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
+const POPOVER_WIDTH = 300;
+
+const CREATED_BY_LABEL = i18n.translate('xpack.osquery.tableToolbar.createdByLabel', {
+  defaultMessage: 'Created by',
+});
+
+const SEARCH_USERS_PLACEHOLDER = i18n.translate(
+  'xpack.osquery.tableToolbar.searchUsersPlaceholder',
+  { defaultMessage: 'Search users' }
+);
+
+const POPOVER_CONTENT_STYLE = { width: POPOVER_WIDTH };
+
+interface CreatedByFilterPopoverProps {
+  /** Unique creator usernames extracted from current page data */
+  creators: string[];
+  selectedCreators: string[];
+  onSelectionChange: (creators: string[]) => void;
+  profilesMap: Map<string, UserProfileWithAvatar>;
+  'data-test-subj'?: string;
+}
+
+const toSelectableOption = (
+  username: string,
+  isSelected: boolean,
+  usernameToProfile: Map<string, UserProfileWithAvatar>
+): EuiSelectableOption => {
+  const profile = usernameToProfile.get(username);
+  const user = profile?.user ?? { username };
+  const displayName = profile?.user.full_name || username;
+
+  return {
+    label: displayName,
+    key: username,
+    checked: isSelected ? 'on' : undefined,
+    prepend: <UserAvatar user={user} avatar={profile?.data?.avatar} size="s" />,
+  };
+};
+
+const CreatedByFilterPopoverComponent: React.FC<CreatedByFilterPopoverProps> = ({
+  creators,
+  selectedCreators,
+  onSelectionChange,
+  profilesMap,
+  'data-test-subj': dataTestSubj = 'created-by-filter',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const usernameToProfile = useMemo(() => {
+    const map = new Map<string, UserProfileWithAvatar>();
+    for (const p of profilesMap.values()) {
+      map.set(p.user.username, p);
+    }
+
+    return map;
+  }, [profilesMap]);
+
+  const selectableOptions = useMemo(() => {
+    const selectedSet = new Set(selectedCreators);
+    const allCreators = Array.from(new Set([...creators, ...selectedCreators]));
+
+    return allCreators
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .map((username) => toSelectableOption(username, selectedSet.has(username), usernameToProfile));
+  }, [creators, selectedCreators, usernameToProfile]);
+
+  const handleChange = useCallback(
+    (_: EuiSelectableOption[], __: unknown, changedOption: EuiSelectableOption) => {
+      const username = changedOption.key!;
+      const isRemoving = selectedCreators.includes(username);
+      const updated = isRemoving
+        ? selectedCreators.filter((c) => c !== username)
+        : [...selectedCreators, username];
+      onSelectionChange(updated);
+    },
+    [selectedCreators, onSelectionChange]
+  );
+
+  const togglePopover = useCallback(() => setIsOpen((prev) => !prev), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+  const panelProps = useMemo(
+    () => ({ 'data-test-subj': `${dataTestSubj}-popover` }),
+    [dataTestSubj]
+  );
+
+  const searchProps = useMemo(
+    () => ({
+      placeholder: SEARCH_USERS_PLACEHOLDER,
+    }),
+    []
+  );
+
+  const triggerButton = (
+    <EuiFilterButton
+      iconType="arrowDown"
+      onClick={togglePopover}
+      isSelected={isOpen}
+      hasActiveFilters={selectedCreators.length > 0}
+      numActiveFilters={selectedCreators.length}
+      data-test-subj={`${dataTestSubj}-button`}
+    >
+      {CREATED_BY_LABEL}
+    </EuiFilterButton>
+  );
+
+  return (
+    <EuiPopover
+      ownFocus
+      button={triggerButton}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      repositionOnScroll
+      panelProps={panelProps}
+    >
+      <EuiSelectable
+        searchable
+        searchProps={searchProps}
+        aria-label={CREATED_BY_LABEL}
+        options={selectableOptions}
+        onChange={handleChange}
+        emptyMessage={i18n.translate('xpack.osquery.tableToolbar.noUsersAvailable', {
+          defaultMessage: 'No users available',
+        })}
+        noMatchesMessage={i18n.translate('xpack.osquery.tableToolbar.noUsersMatch', {
+          defaultMessage: 'No users match search',
+        })}
+      >
+        {(list, search) => (
+          <div style={POPOVER_CONTENT_STYLE}>
+            <EuiPopoverTitle paddingSize="s">
+              <EuiFlexGroup gutterSize="s" responsive={false}>
+                <EuiFlexItem>{search}</EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiPopoverTitle>
+            {list}
+          </div>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
+CreatedByFilterPopoverComponent.displayName = 'CreatedByFilterPopover';
+
+export const CreatedByFilterPopover = React.memo(CreatedByFilterPopoverComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/created_by_filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/created_by_filter_popover.tsx
@@ -82,7 +82,9 @@ const CreatedByFilterPopoverComponent: React.FC<CreatedByFilterPopoverProps> = (
 
     return allCreators
       .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
-      .map((username) => toSelectableOption(username, selectedSet.has(username), usernameToProfile));
+      .map((username) =>
+        toSelectableOption(username, selectedSet.has(username), usernameToProfile)
+      );
   }, [creators, selectedCreators, usernameToProfile]);
 
   const handleChange = useCallback(

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/enabled_filter_buttons.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/enabled_filter_buttons.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EnabledFilterButtons } from './enabled_filter_buttons';
+import type { EnabledFilter } from './enabled_filter_buttons';
+
+const renderComponent = (props: Partial<{ value: EnabledFilter; onChange: jest.Mock }> = {}) => {
+  const defaultProps = {
+    value: undefined as EnabledFilter,
+    onChange: jest.fn(),
+    ...props,
+  };
+
+  return { ...render(React.createElement(EnabledFilterButtons, defaultProps)), ...defaultProps };
+};
+
+describe('EnabledFilterButtons', () => {
+  it('renders enabled and disabled buttons', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('enabled-filter-enabled')).toBeInTheDocument();
+    expect(screen.getByTestId('enabled-filter-disabled')).toBeInTheDocument();
+  });
+
+  it('calls onChange with "true" when enabled button is clicked and no filter is active', () => {
+    const { onChange } = renderComponent({ value: undefined });
+
+    fireEvent.click(screen.getByTestId('enabled-filter-enabled'));
+
+    expect(onChange).toHaveBeenCalledWith('true');
+  });
+
+  it('calls onChange with undefined when enabled button is clicked and enabled filter is active (toggle off)', () => {
+    const { onChange } = renderComponent({ value: 'true' });
+
+    fireEvent.click(screen.getByTestId('enabled-filter-enabled'));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onChange with "false" when disabled button is clicked and no filter is active', () => {
+    const { onChange } = renderComponent({ value: undefined });
+
+    fireEvent.click(screen.getByTestId('enabled-filter-disabled'));
+
+    expect(onChange).toHaveBeenCalledWith('false');
+  });
+
+  it('calls onChange with undefined when disabled button is clicked and disabled filter is active (toggle off)', () => {
+    const { onChange } = renderComponent({ value: 'false' });
+
+    fireEvent.click(screen.getByTestId('enabled-filter-disabled'));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onChange with "true" when switching from disabled to enabled', () => {
+    const { onChange } = renderComponent({ value: 'false' });
+
+    fireEvent.click(screen.getByTestId('enabled-filter-enabled'));
+
+    expect(onChange).toHaveBeenCalledWith('true');
+  });
+
+  it('uses custom data-test-subj prefix', () => {
+    render(
+      React.createElement(EnabledFilterButtons, {
+        value: undefined,
+        onChange: jest.fn(),
+        'data-test-subj': 'packs-status',
+      })
+    );
+
+    expect(screen.getByTestId('packs-status-enabled')).toBeInTheDocument();
+    expect(screen.getByTestId('packs-status-disabled')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/enabled_filter_buttons.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/enabled_filter_buttons.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { EuiFilterButton, EuiFilterGroup } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export type EnabledFilter = 'true' | 'false' | undefined;
+
+const ENABLED_LABEL = i18n.translate('xpack.osquery.tableToolbar.enabledLabel', {
+  defaultMessage: 'Enabled',
+});
+
+const DISABLED_LABEL = i18n.translate('xpack.osquery.tableToolbar.disabledLabel', {
+  defaultMessage: 'Disabled',
+});
+
+interface EnabledFilterButtonsProps {
+  value: EnabledFilter;
+  onChange: (value: EnabledFilter) => void;
+  'data-test-subj'?: string;
+}
+
+const EnabledFilterButtonsComponent: React.FC<EnabledFilterButtonsProps> = ({
+  value,
+  onChange,
+  'data-test-subj': dataTestSubj = 'enabled-filter',
+}) => {
+  const handleEnabledClick = useCallback(() => {
+    onChange(value === 'true' ? undefined : 'true');
+  }, [value, onChange]);
+
+  const handleDisabledClick = useCallback(() => {
+    onChange(value === 'false' ? undefined : 'false');
+  }, [value, onChange]);
+
+  return (
+    <EuiFilterGroup>
+      <EuiFilterButton
+        hasActiveFilters={value === 'true'}
+        onClick={handleEnabledClick}
+        data-test-subj={`${dataTestSubj}-enabled`}
+      >
+        {ENABLED_LABEL}
+      </EuiFilterButton>
+      <EuiFilterButton
+        hasActiveFilters={value === 'false'}
+        onClick={handleDisabledClick}
+        data-test-subj={`${dataTestSubj}-disabled`}
+      >
+        {DISABLED_LABEL}
+      </EuiFilterButton>
+    </EuiFilterGroup>
+  );
+};
+
+EnabledFilterButtonsComponent.displayName = 'EnabledFilterButtons';
+
+export const EnabledFilterButtons = React.memo(EnabledFilterButtonsComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/index.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { TableToolbar } from './table_toolbar';
+export { SelectableFilterPopover } from './selectable_filter_popover';
+export type { FilterOption } from './selectable_filter_popover';
+export { CreatedByFilterPopover } from './created_by_filter_popover';
+export { EnabledFilterButtons } from './enabled_filter_buttons';
+export type { EnabledFilter } from './enabled_filter_buttons';
+export { ColumnPickerPopover } from './column_picker_popover';
+export type { ColumnConfig } from './column_picker_popover';
+export { SortFieldsPopover } from './sort_fields_popover';
+export type { SortFieldConfig, SortDirection } from './sort_fields_popover';

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/selectable_filter_popover.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/selectable_filter_popover.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SelectableFilterPopover } from './selectable_filter_popover';
+import type { FilterOption } from './selectable_filter_popover';
+
+const OPTIONS: FilterOption[] = [
+  { key: 'alpha', label: 'Alpha' },
+  { key: 'beta', label: 'Beta' },
+  { key: 'gamma', label: 'Gamma' },
+];
+
+const renderComponent = (
+  props: Partial<{
+    options: FilterOption[];
+    selectedKeys: string[];
+    onSelectionChange: jest.Mock;
+  }> = {}
+) => {
+  const defaultProps = {
+    label: 'Test filter',
+    options: OPTIONS,
+    selectedKeys: [] as string[],
+    onSelectionChange: jest.fn(),
+    'data-test-subj': 'test-filter',
+    ...props,
+  };
+
+  return {
+    ...render(React.createElement(SelectableFilterPopover, defaultProps)),
+    ...defaultProps,
+  };
+};
+
+describe('SelectableFilterPopover', () => {
+  it('renders the filter button with the label', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('test-filter-button')).toHaveTextContent('Test filter');
+  });
+
+  it('opens the popover when the button is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('test-filter-button'));
+
+    expect(screen.getByTestId('test-filter-popover')).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+  });
+
+  it('calls onSelectionChange with the selected key when an option is clicked', () => {
+    const { onSelectionChange } = renderComponent();
+
+    fireEvent.click(screen.getByTestId('test-filter-button'));
+    fireEvent.click(screen.getByText('Beta'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['beta']);
+  });
+
+  it('calls onSelectionChange with key removed when deselecting', () => {
+    const { onSelectionChange } = renderComponent({ selectedKeys: ['alpha', 'beta'] });
+
+    fireEvent.click(screen.getByTestId('test-filter-button'));
+    fireEvent.click(screen.getByText('Alpha'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['beta']);
+  });
+
+  it('appends to existing selection when selecting a new option', () => {
+    const { onSelectionChange } = renderComponent({ selectedKeys: ['alpha'] });
+
+    fireEvent.click(screen.getByTestId('test-filter-button'));
+    fireEvent.click(screen.getByText('Gamma'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['alpha', 'gamma']);
+  });
+
+  it('shows active filter count on the button when options are selected', () => {
+    renderComponent({ selectedKeys: ['alpha', 'gamma'] });
+
+    const button = screen.getByTestId('test-filter-button');
+    expect(button).toHaveTextContent('2');
+  });
+
+  it('shows no active count when nothing is selected', () => {
+    renderComponent({ selectedKeys: [] });
+
+    const button = screen.getByTestId('test-filter-button');
+    expect(button).toHaveTextContent('Test filter');
+    expect(button).not.toHaveTextContent(/\d/);
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/selectable_filter_popover.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/selectable_filter_popover.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import { EuiFilterButton, EuiPopover, EuiSelectable } from '@elastic/eui';
+
+const POPOVER_CONTENT_STYLE = { width: 250 };
+
+export interface FilterOption {
+  key: string;
+  label: string;
+}
+
+interface SelectableFilterPopoverProps {
+  label: string;
+  options: FilterOption[];
+  selectedKeys: string[];
+  onSelectionChange: (keys: string[]) => void;
+  isLoading?: boolean;
+  'data-test-subj'?: string;
+}
+
+const SelectableFilterPopoverComponent: React.FC<SelectableFilterPopoverProps> = ({
+  label,
+  options,
+  selectedKeys,
+  onSelectionChange,
+  isLoading,
+  'data-test-subj': dataTestSubj,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectableOptions = useMemo<EuiSelectableOption[]>(() => {
+    const selectedSet = new Set(selectedKeys);
+
+    return options.map(({ key, label: optionLabel }) => ({
+      label: optionLabel,
+      key,
+      checked: selectedSet.has(key) ? 'on' : undefined,
+    }));
+  }, [options, selectedKeys]);
+
+  const handleChange = useCallback(
+    (_: EuiSelectableOption[], __: unknown, changedOption: EuiSelectableOption) => {
+      const key = changedOption.key!;
+      const isRemoving = selectedKeys.includes(key);
+      const updated = isRemoving ? selectedKeys.filter((k) => k !== key) : [...selectedKeys, key];
+      onSelectionChange(updated);
+    },
+    [selectedKeys, onSelectionChange]
+  );
+
+  const togglePopover = useCallback(() => setIsOpen((prev) => !prev), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+  const panelProps = useMemo(
+    () => (dataTestSubj ? { 'data-test-subj': `${dataTestSubj}-popover` } : undefined),
+    [dataTestSubj]
+  );
+
+  const activeCount = selectedKeys.length;
+
+  const triggerButton = (
+    <EuiFilterButton
+      iconType="arrowDown"
+      onClick={togglePopover}
+      isLoading={isLoading}
+      isSelected={isOpen}
+      hasActiveFilters={activeCount > 0}
+      numActiveFilters={activeCount}
+      data-test-subj={dataTestSubj ? `${dataTestSubj}-button` : undefined}
+    >
+      {label}
+    </EuiFilterButton>
+  );
+
+  return (
+    <EuiPopover
+      ownFocus
+      button={triggerButton}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      repositionOnScroll
+      panelProps={panelProps}
+    >
+      <EuiSelectable aria-label={label} options={selectableOptions} onChange={handleChange}>
+        {(list) => <div style={POPOVER_CONTENT_STYLE}>{list}</div>}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};
+
+SelectableFilterPopoverComponent.displayName = 'SelectableFilterPopover';
+
+export const SelectableFilterPopover = React.memo(SelectableFilterPopoverComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/sort_fields_popover.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/sort_fields_popover.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { EuiSelectableOption } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  EuiButtonGroup,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const POPOVER_WIDTH = 250;
+const POPOVER_CONTENT_STYLE = { width: POPOVER_WIDTH };
+
+const SORT_LABEL = i18n.translate('xpack.osquery.tableToolbar.sortLabel', {
+  defaultMessage: 'Sort',
+});
+
+const SORT_FIELDS_LABEL = i18n.translate('xpack.osquery.tableToolbar.sortFieldsLabel', {
+  defaultMessage: 'Sort fields',
+});
+
+const SORT_DIRECTION_PREFIX = 'sort-direction';
+
+const DIRECTION_OPTIONS = [
+  {
+    id: `${SORT_DIRECTION_PREFIX}-asc`,
+    label: i18n.translate('xpack.osquery.tableToolbar.sortAscLabel', {
+      defaultMessage: 'Asc',
+    }),
+  },
+  {
+    id: `${SORT_DIRECTION_PREFIX}-desc`,
+    label: i18n.translate('xpack.osquery.tableToolbar.sortDescLabel', {
+      defaultMessage: 'Desc',
+    }),
+  },
+];
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortFieldConfig {
+  id: string;
+  label: string;
+}
+
+interface SortFieldsPopoverProps {
+  fields: SortFieldConfig[];
+  sortField: string;
+  sortDirection: SortDirection;
+  onSortChange: (field: string, direction: SortDirection) => void;
+  'data-test-subj'?: string;
+}
+
+const SortFieldsPopoverComponent: React.FC<SortFieldsPopoverProps> = ({
+  fields,
+  sortField,
+  sortDirection,
+  onSortChange,
+  'data-test-subj': dataTestSubj = 'sort-fields',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectableOptions = useMemo<EuiSelectableOption[]>(
+    () =>
+      fields.map(({ id, label }) => ({
+        label,
+        key: id,
+        checked: sortField === id ? 'on' : undefined,
+      })),
+    [fields, sortField]
+  );
+
+  const handleFieldChange = useCallback(
+    (_: EuiSelectableOption[], __: unknown, changedOption: EuiSelectableOption) => {
+      const newField = changedOption.key!;
+      if (newField !== sortField) {
+        onSortChange(newField, sortDirection);
+      }
+    },
+    [sortField, sortDirection, onSortChange]
+  );
+
+  const handleDirectionChange = useCallback(
+    (optionId: string) => {
+      const direction = optionId === `${SORT_DIRECTION_PREFIX}-asc` ? 'asc' : 'desc';
+      onSortChange(sortField, direction);
+    },
+    [sortField, onSortChange]
+  );
+
+  const togglePopover = useCallback(() => setIsOpen((prev) => !prev), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
+  const panelProps = useMemo(
+    () => ({ 'data-test-subj': `${dataTestSubj}-popover` }),
+    [dataTestSubj]
+  );
+
+  const selectedDirectionId = `${SORT_DIRECTION_PREFIX}-${sortDirection}`;
+
+  const triggerButton = (
+    <EuiButtonEmpty
+      size="xs"
+      iconType="sortable"
+      onClick={togglePopover}
+      data-test-subj={`${dataTestSubj}-button`}
+    >
+      {SORT_FIELDS_LABEL}
+    </EuiButtonEmpty>
+  );
+
+  return (
+    <EuiPopover
+      ownFocus
+      button={triggerButton}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      repositionOnScroll
+      panelProps={panelProps}
+    >
+      <div style={POPOVER_CONTENT_STYLE}>
+        <EuiPopoverTitle paddingSize="s">
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem>{SORT_LABEL}</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonGroup
+                legend={SORT_LABEL}
+                options={DIRECTION_OPTIONS}
+                idSelected={selectedDirectionId}
+                onChange={handleDirectionChange}
+                buttonSize="compressed"
+                data-test-subj={`${dataTestSubj}-direction`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPopoverTitle>
+        <EuiSelectable
+          aria-label={SORT_LABEL}
+          options={selectableOptions}
+          onChange={handleFieldChange}
+          singleSelection
+        >
+          {(list) => list}
+        </EuiSelectable>
+      </div>
+    </EuiPopover>
+  );
+};
+
+SortFieldsPopoverComponent.displayName = 'SortFieldsPopover';
+
+export const SortFieldsPopover = React.memo(SortFieldsPopoverComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/table_toolbar.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/components/table_toolbar/table_toolbar.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { css } from '@emotion/react';
+import { EuiFieldSearch, EuiFilterGroup, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { CreatedByFilterPopover } from './created_by_filter_popover';
+import { EnabledFilterButtons } from './enabled_filter_buttons';
+import { ColumnPickerPopover } from './column_picker_popover';
+import { SortFieldsPopover } from './sort_fields_popover';
+import type { EnabledFilter } from './enabled_filter_buttons';
+import type { ColumnConfig } from './column_picker_popover';
+import type { SortFieldConfig, SortDirection } from './sort_fields_popover';
+
+const searchFieldCss = css`
+  min-width: 300px;
+`;
+
+interface TableToolbarProps {
+  searchPlaceholder: string;
+  searchValue: string;
+  onSearchSubmit: (value: string) => void;
+
+  creators: string[];
+  selectedCreators: string[];
+  onSelectedCreatorsChange: (creators: string[]) => void;
+  profilesMap: Map<string, UserProfileWithAvatar>;
+
+  enabledFilter?: EnabledFilter;
+  onEnabledFilterChange?: (value: EnabledFilter) => void;
+  showEnabledFilter?: boolean;
+
+  columnConfigs: ColumnConfig[];
+  visibleColumns: string[];
+  onVisibleColumnsChange: (columnIds: string[]) => void;
+
+  sortFields: SortFieldConfig[];
+  sortField: string;
+  sortDirection: SortDirection;
+  onSortChange: (field: string, direction: SortDirection) => void;
+
+  actionButton?: React.ReactNode;
+
+  'data-test-subj'?: string;
+}
+
+const TableToolbarComponent: React.FC<TableToolbarProps> = ({
+  searchPlaceholder,
+  searchValue,
+  onSearchSubmit,
+  creators,
+  selectedCreators,
+  onSelectedCreatorsChange,
+  profilesMap,
+  enabledFilter,
+  onEnabledFilterChange,
+  showEnabledFilter = false,
+  columnConfigs,
+  visibleColumns,
+  onVisibleColumnsChange,
+  sortFields,
+  sortField,
+  sortDirection,
+  onSortChange,
+  actionButton,
+  'data-test-subj': dataTestSubj = 'table-toolbar',
+}) => {
+  const [localSearch, setLocalSearch] = useState(searchValue);
+
+  useEffect(() => {
+    setLocalSearch(searchValue);
+  }, [searchValue]);
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setLocalSearch(e.target.value);
+      if (e.target.value === '') {
+        onSearchSubmit('');
+      }
+    },
+    [onSearchSubmit]
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        onSearchSubmit(localSearch);
+      }
+    },
+    [localSearch, onSearchSubmit]
+  );
+
+  return (
+    <>
+      <EuiFlexGroup gutterSize="m" responsive={false} wrap alignItems="center">
+        <EuiFlexItem grow={3} css={searchFieldCss}>
+          <EuiFieldSearch
+            fullWidth
+            placeholder={searchPlaceholder}
+            value={localSearch}
+            onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
+            isClearable
+            data-test-subj={`${dataTestSubj}-search`}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFilterGroup>
+            <CreatedByFilterPopover
+              creators={creators}
+              selectedCreators={selectedCreators}
+              onSelectionChange={onSelectedCreatorsChange}
+              profilesMap={profilesMap}
+              data-test-subj={`${dataTestSubj}-created-by`}
+            />
+          </EuiFilterGroup>
+        </EuiFlexItem>
+        {showEnabledFilter && onEnabledFilterChange && (
+          <EuiFlexItem grow={false}>
+            <EnabledFilterButtons
+              value={enabledFilter}
+              onChange={onEnabledFilterChange}
+              data-test-subj={`${dataTestSubj}-enabled`}
+            />
+          </EuiFlexItem>
+        )}
+        {actionButton && <EuiFlexItem grow={false}>{actionButton}</EuiFlexItem>}
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
+        <EuiFlexItem grow={false}>
+          <ColumnPickerPopover
+            columns={columnConfigs}
+            visibleColumns={visibleColumns}
+            onVisibleColumnsChange={onVisibleColumnsChange}
+            data-test-subj={`${dataTestSubj}-columns`}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <SortFieldsPopover
+            fields={sortFields}
+            sortField={sortField}
+            sortDirection={sortDirection}
+            onSortChange={onSortChange}
+            data-test-subj={`${dataTestSubj}-sort`}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+TableToolbarComponent.displayName = 'TableToolbar';
+
+export const TableToolbar = React.memo(TableToolbarComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/edit/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/edit/index.tsx
@@ -8,13 +8,15 @@
 import {
   EuiButtonEmpty,
   EuiButton,
+  EuiCallOut,
+  EuiConfirmModal,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiConfirmModal,
+  EuiSpacer,
   EuiText,
-  EuiCallOut,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import type { UseEuiTheme } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
 import React, { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -33,6 +35,15 @@ import { useIsExperimentalFeatureEnabled } from '../../../common/experimental_fe
 const euiCalloutCss = {
   margin: '10px',
 };
+
+const fullWidthContentCss = ({ euiTheme }: UseEuiTheme) => ({
+  padding: `0 ${euiTheme.size.l}`,
+  flex: 1,
+  minWidth: 0,
+  maxWidth: 1200,
+  margin: '0 auto',
+  width: '100%',
+});
 
 const EditSavedQueryPageComponent = () => {
   const confirmModalTitleId = useGeneratedHtmlId();
@@ -75,58 +86,55 @@ const EditSavedQueryPageComponent = () => {
     copySavedQueryMutation.mutateAsync();
   }, [copySavedQueryMutation]);
 
-  const LeftColumn = useMemo(
+  const backLink = useMemo(
     () => (
-      <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
-        <EuiFlexItem>
-          <EuiButtonEmpty iconType="arrowLeft" {...savedQueryListProps} flush="left" size="xs">
-            <FormattedMessage
-              id="xpack.osquery.editSavedQuery.viewSavedQueriesListTitle"
-              defaultMessage="View all saved queries"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText>
-            <h1>
-              {viewMode ? (
-                <>
-                  <FormattedMessage
-                    id="xpack.osquery.viewSavedQuery.pageTitle"
-                    defaultMessage='"{savedQueryId}" details'
-                    // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-                    values={{
-                      savedQueryId: savedQueryDetails?.id ?? '',
-                    }}
-                  />
-                  {elasticPrebuiltQuery && (
-                    <EuiCallOut announceOnMount css={euiCalloutCss} size="s">
-                      <FormattedMessage
-                        id="xpack.osquery.viewSavedQuery.prebuiltInfo"
-                        defaultMessage="This is a prebuilt Elastic query, and it cannot be edited."
-                      />
-                    </EuiCallOut>
-                  )}
-                </>
-              ) : (
-                <FormattedMessage
-                  id="xpack.osquery.editSavedQuery.pageTitle"
-                  defaultMessage='Edit "{savedQueryId}"'
-                  // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
-                  values={{
-                    savedQueryId: savedQueryDetails?.id ?? '',
-                  }}
-                />
-              )}
-            </h1>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiButtonEmpty iconType="arrowLeft" {...savedQueryListProps} flush="left" size="xs">
+        <FormattedMessage
+          id="xpack.osquery.editSavedQuery.viewSavedQueriesListTitle"
+          defaultMessage="View all saved queries"
+        />
+      </EuiButtonEmpty>
     ),
-    [elasticPrebuiltQuery, savedQueryDetails?.id, savedQueryListProps, viewMode]
+    [savedQueryListProps]
   );
 
-  const RightColumn = useMemo(
+  const titleContent = useMemo(() => {
+    if (viewMode) {
+      return (
+        <>
+          <FormattedMessage
+            id="xpack.osquery.viewSavedQuery.pageTitle"
+            defaultMessage='"{savedQueryId}" details'
+            // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+            values={{
+              savedQueryId: savedQueryDetails?.id ?? '',
+            }}
+          />
+          {elasticPrebuiltQuery && (
+            <EuiCallOut announceOnMount css={euiCalloutCss} size="s">
+              <FormattedMessage
+                id="xpack.osquery.viewSavedQuery.prebuiltInfo"
+                defaultMessage="This is a prebuilt Elastic query, and it cannot be edited."
+              />
+            </EuiCallOut>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <FormattedMessage
+        id="xpack.osquery.editSavedQuery.pageTitle"
+        defaultMessage='Edit "{savedQueryId}"'
+        // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
+        values={{
+          savedQueryId: savedQueryDetails?.id ?? '',
+        }}
+      />
+    );
+  }, [elasticPrebuiltQuery, savedQueryDetails?.id, viewMode]);
+
+  const actionButtons = useMemo(
     () => (
       <EuiFlexGroup gutterSize="s">
         {queryHistoryRework && permissions.writeSavedQueries && (
@@ -173,7 +181,108 @@ const EditSavedQueryPageComponent = () => {
     [updateSavedQueryMutation]
   );
 
+  const deleteModal = isDeleteModalVisible ? (
+    <EuiConfirmModal
+      aria-labelledby={confirmModalTitleId}
+      titleProps={titleProps}
+      title={
+        <FormattedMessage
+          id="xpack.osquery.deleteSavedQuery.confirmationModal.title"
+          defaultMessage="Are you sure you want to delete this query?"
+        />
+      }
+      onCancel={handleCloseDeleteConfirmationModal}
+      onConfirm={handleDeleteConfirmClick}
+      cancelButtonText={
+        <FormattedMessage
+          id="xpack.osquery.deleteSavedQuery.confirmationModal.cancelButtonLabel"
+          defaultMessage="Cancel"
+        />
+      }
+      confirmButtonText={
+        <FormattedMessage
+          id="xpack.osquery.deleteSavedQuery.confirmationModal.confirmButtonLabel"
+          defaultMessage="Confirm"
+        />
+      }
+      buttonColor="danger"
+      defaultFocusedButton="confirm"
+    >
+      <FormattedMessage
+        id="xpack.osquery.deleteSavedQuery.confirmationModal.body"
+        defaultMessage="You're about to delete this query. Are you sure you want to do this?"
+      />
+    </EuiConfirmModal>
+  ) : null;
+
+  const showActionButtons = permissions.writeSavedQueries && (queryHistoryRework || !viewMode);
+
+  const formContent = !isLoading &&
+    !isEmpty(savedQueryDetails) &&
+    savedQueryDetails?.saved_object_id === savedQueryId && (
+      <EditSavedQueryForm
+        key={savedQueryId}
+        defaultValue={savedQueryDetails}
+        handleSubmit={handleSubmit}
+        viewMode={viewMode}
+      />
+    );
+
   if (isLoading) return null;
+
+  if (queryHistoryRework) {
+    if (error) {
+      return (
+        <div css={fullWidthContentCss}>
+          <EuiSpacer size="l" />
+          {backLink}
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            title={i18n.translate('xpack.osquery.editSavedQuery.loadError.title', {
+              defaultMessage: 'Failed to load saved query',
+            })}
+            color="danger"
+            iconType="error"
+          >
+            <FormattedMessage
+              id="xpack.osquery.editSavedQuery.loadError.body"
+              defaultMessage="The saved query could not be loaded. Please try again later."
+            />
+          </EuiCallOut>
+        </div>
+      );
+    }
+
+    return (
+      <div css={fullWidthContentCss}>
+        <EuiSpacer size="l" />
+        {backLink}
+        <EuiSpacer size="m" />
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiText>
+              <h1>{titleContent}</h1>
+            </EuiText>
+          </EuiFlexItem>
+          {showActionButtons && <EuiFlexItem grow={false}>{actionButtons}</EuiFlexItem>}
+        </EuiFlexGroup>
+        <EuiSpacer size="l" />
+        {formContent}
+        {deleteModal}
+      </div>
+    );
+  }
+
+  const LeftColumn = (
+    <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
+      <EuiFlexItem>{backLink}</EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText>
+          <h1>{titleContent}</h1>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
 
   if (error) {
     return (
@@ -197,54 +306,11 @@ const EditSavedQueryPageComponent = () => {
   return (
     <WithHeaderLayout
       leftColumn={LeftColumn}
-      rightColumn={
-        permissions.writeSavedQueries && (queryHistoryRework || !viewMode) ? RightColumn : undefined
-      }
+      rightColumn={showActionButtons ? actionButtons : undefined}
       rightColumnGrow={false}
     >
-      {!isLoading &&
-        !isEmpty(savedQueryDetails) &&
-        savedQueryDetails?.saved_object_id === savedQueryId && (
-          <EditSavedQueryForm
-            key={savedQueryId}
-            defaultValue={savedQueryDetails}
-            handleSubmit={handleSubmit}
-            viewMode={viewMode}
-          />
-        )}
-      {isDeleteModalVisible ? (
-        <EuiConfirmModal
-          aria-labelledby={confirmModalTitleId}
-          titleProps={titleProps}
-          title={
-            <FormattedMessage
-              id="xpack.osquery.deleteSavedQuery.confirmationModal.title"
-              defaultMessage="Are you sure you want to delete this query?"
-            />
-          }
-          onCancel={handleCloseDeleteConfirmationModal}
-          onConfirm={handleDeleteConfirmClick}
-          cancelButtonText={
-            <FormattedMessage
-              id="xpack.osquery.deleteSavedQuery.confirmationModal.cancelButtonLabel"
-              defaultMessage="Cancel"
-            />
-          }
-          confirmButtonText={
-            <FormattedMessage
-              id="xpack.osquery.deleteSavedQuery.confirmationModal.confirmButtonLabel"
-              defaultMessage="Confirm"
-            />
-          }
-          buttonColor="danger"
-          defaultFocusedButton="confirm"
-        >
-          <FormattedMessage
-            id="xpack.osquery.deleteSavedQuery.confirmationModal.body"
-            defaultMessage="You're about to delete this query. Are you sure you want to do this?"
-          />
-        </EuiConfirmModal>
-      ) : null}
+      {formContent}
+      {deleteModal}
     </WithHeaderLayout>
   );
 };

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/index.tsx
@@ -8,14 +8,16 @@
 import moment from 'moment-timezone';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
-  EuiInMemoryTable,
   EuiButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiInMemoryTable,
+  EuiSpacer,
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
+import type { UseEuiTheme } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -31,6 +33,7 @@ import { useIsExperimentalFeatureEnabled } from '../../../common/experimental_fe
 import { useSavedQueries } from '../../../saved_queries/use_saved_queries';
 import { usePersistedPageSize, PAGE_SIZE_OPTIONS } from '../../../common/use_persisted_page_size';
 import { SavedQueryRowActions } from './saved_query_row_actions';
+import { SavedQueriesTable } from './saved_queries_table';
 
 export interface SavedQuerySO {
   name: string;
@@ -41,8 +44,10 @@ export interface SavedQuerySO {
   timeout?: number;
   ecs_mapping: ECSMapping;
   created_by?: string;
+  created_by_profile_uid?: string;
   updated_at: string;
   updated_by?: string;
+  updated_by_profile_uid?: string;
   prebuilt?: boolean;
 }
 
@@ -143,6 +148,12 @@ const EditButtonComponent: React.FC<EditButtonProps> = ({
 
 const EditButton = React.memo(EditButtonComponent);
 
+const fullWidthContentCss = ({ euiTheme }: UseEuiTheme) => ({
+  padding: `0 ${euiTheme.size.l}`,
+  flex: 1,
+  minWidth: 0,
+});
+
 const SavedQueriesPageComponent = () => {
   const permissions = useKibana().services.application.capabilities.osquery;
   const queryHistoryRework = useIsExperimentalFeatureEnabled('queryHistoryRework');
@@ -170,7 +181,7 @@ const SavedQueriesPageComponent = () => {
     [permissions.runSavedQueries]
   );
 
-  const renderUpdatedAt = useCallback((updatedAt: any, item: any) => {
+  const renderUpdatedAt = useCallback((updatedAt: string, item: SavedQuerySO) => {
     if (!updatedAt) return '-';
 
     const updatedBy = item.updated_by !== item.created_by ? ` @ ${item.updated_by}` : '';
@@ -280,25 +291,7 @@ const SavedQueriesPageComponent = () => {
     [sortDirection, sortField]
   );
 
-  const LeftColumn = useMemo(
-    () => (
-      <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
-        <EuiFlexItem>
-          <EuiText>
-            <h1>
-              <FormattedMessage
-                id="xpack.osquery.savedQueryList.pageTitle"
-                defaultMessage="Saved queries"
-              />
-            </h1>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    ),
-    []
-  );
-
-  const RightColumn = useMemo(
+  const addSavedQueryButton = useMemo(
     () => (
       <EuiButton
         fill
@@ -315,8 +308,36 @@ const SavedQueriesPageComponent = () => {
     [permissions.writeSavedQueries, newQueryLinkProps]
   );
 
+  if (queryHistoryRework) {
+    return (
+      <div css={fullWidthContentCss}>
+        <EuiSpacer size="l" />
+        <SavedQueriesTable />
+      </div>
+    );
+  }
+
+  const LeftColumn = (
+    <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
+      <EuiFlexItem>
+        <EuiText>
+          <h1>
+            <FormattedMessage
+              id="xpack.osquery.savedQueryList.pageTitle"
+              defaultMessage="Saved queries"
+            />
+          </h1>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
   return (
-    <WithHeaderLayout leftColumn={LeftColumn} rightColumn={RightColumn} rightColumnGrow={false}>
+    <WithHeaderLayout
+      leftColumn={LeftColumn}
+      rightColumn={addSavedQueryButton}
+      rightColumnGrow={false}
+    >
       {data?.data && (
         <EuiInMemoryTable
           items={data?.data}

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/saved_queries_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/saved_queries_table.tsx
@@ -1,0 +1,422 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { CriteriaWithPagination, EuiBasicTableColumn } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexItem,
+  EuiSkeletonText,
+  EuiSpacer,
+  EuiToolTip,
+} from '@elastic/eui';
+import moment from 'moment-timezone';
+import { i18n } from '@kbn/i18n';
+import { useHistory } from 'react-router-dom';
+import deepEqual from 'fast-deep-equal';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { QUERY_TIMEOUT } from '../../../../common/constants';
+import { useKibana, useRouterNavigate } from '../../../common/lib/kibana';
+import { usePersistedPageSize, PAGE_SIZE_OPTIONS } from '../../../common/use_persisted_page_size';
+import { useSavedQueries } from '../../../saved_queries/use_saved_queries';
+import { useGenericBulkGetUserProfiles } from '../../../common/use_bulk_get_user_profiles';
+import { RunByColumn } from '../../../actions/components/run_by_column';
+import { TableToolbar } from '../../../components/table_toolbar';
+import type { SortDirection } from '../../../components/table_toolbar';
+import { SavedQueryRowActions } from './saved_query_row_actions';
+import type { SavedQuerySO } from '.';
+
+const EMPTY_ARRAY: SavedQuerySO[] = [];
+
+const SEARCH_PLACEHOLDER = i18n.translate('xpack.osquery.savedQueryList.searchPlaceholder', {
+  defaultMessage: 'Search by query ID or description',
+});
+
+const ALL_COLUMN_IDS = ['id', 'description', 'created_by', 'updated_at'] as const;
+
+const COLUMN_CONFIGS = [
+  {
+    id: 'id',
+    label: i18n.translate('xpack.osquery.savedQueries.table.queryIdColumnTitle', {
+      defaultMessage: 'Query ID',
+    }),
+  },
+  {
+    id: 'description',
+    label: i18n.translate('xpack.osquery.savedQueries.table.descriptionColumnTitle', {
+      defaultMessage: 'Description',
+    }),
+  },
+  {
+    id: 'created_by',
+    label: i18n.translate('xpack.osquery.savedQueries.table.createdByColumnTitle', {
+      defaultMessage: 'Created by',
+    }),
+  },
+  {
+    id: 'updated_at',
+    label: i18n.translate('xpack.osquery.savedQueries.table.updatedAtColumnTitle', {
+      defaultMessage: 'Last updated at',
+    }),
+  },
+];
+
+const SORT_FIELDS = [
+  {
+    id: 'id',
+    label: i18n.translate('xpack.osquery.savedQueries.sort.queryIdLabel', {
+      defaultMessage: 'Query ID',
+    }),
+  },
+  {
+    id: 'updated_at',
+    label: i18n.translate('xpack.osquery.savedQueries.sort.updatedAtLabel', {
+      defaultMessage: 'Last updated at',
+    }),
+  },
+];
+
+const RUN_QUERY_PERMISSION_DENIED = i18n.translate(
+  'xpack.osquery.savedQueryList.permissionDeniedRunTooltip',
+  { defaultMessage: 'You do not have sufficient permissions to run this query.' }
+);
+
+interface PlayButtonProps {
+  disabled: boolean;
+  savedQuery: SavedQuerySO;
+}
+
+const PlayButtonComponent: React.FC<PlayButtonProps> = ({ disabled = false, savedQuery }) => {
+  const { push } = useHistory();
+
+  const handlePlayClick = useCallback(
+    () =>
+      push('/new', {
+        form: {
+          savedQueryId: savedQuery.id,
+          query: savedQuery.query,
+          ecs_mapping: savedQuery.ecs_mapping,
+          timeout: savedQuery.timeout ?? QUERY_TIMEOUT.DEFAULT,
+        },
+      }),
+    [push, savedQuery]
+  );
+
+  const playText = useMemo(
+    () =>
+      i18n.translate('xpack.osquery.savedQueryList.queriesTable.runActionAriaLabel', {
+        defaultMessage: 'Run {savedQueryName}',
+        values: { savedQueryName: savedQuery.id },
+      }),
+    [savedQuery]
+  );
+
+  const tooltipContent = disabled ? RUN_QUERY_PERMISSION_DENIED : playText;
+
+  return (
+    <EuiToolTip position="top" content={tooltipContent}>
+      <EuiButtonIcon
+        color="primary"
+        iconType="play"
+        isDisabled={disabled}
+        onClick={handlePlayClick}
+        aria-label={playText}
+      />
+    </EuiToolTip>
+  );
+};
+
+const PlayButton = React.memo(PlayButtonComponent, deepEqual);
+
+const updatedAtCss = {
+  whiteSpace: 'nowrap' as const,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+};
+
+const SavedQueriesTableComponent = () => {
+  const permissions = useKibana().services.application.capabilities.osquery;
+  const newQueryLinkProps = useRouterNavigate('saved_queries/new');
+
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = usePersistedPageSize();
+  const [sortField, setSortField] = useState('updated_at');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [searchValue, setSearchValue] = useState('');
+  const [selectedCreators, setSelectedCreators] = useState<string[]>([]);
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([...ALL_COLUMN_IDS]);
+
+  const createdByParam = selectedCreators.length > 0 ? selectedCreators.join(',') : undefined;
+
+  const { data, isLoading, isFetching } = useSavedQueries({
+    pageIndex,
+    pageSize,
+    sortField,
+    sortOrder: sortDirection,
+    search: searchValue || undefined,
+    createdBy: createdByParam,
+  });
+
+  const items = useMemo(() => data?.data ?? EMPTY_ARRAY, [data?.data]);
+  const totalItemCount = data?.total ?? 0;
+
+  const profileUids = useMemo(
+    () => items.map((item) => item.created_by_profile_uid).filter(Boolean) as string[],
+    [items]
+  );
+
+  const { profilesMap, isLoading: isLoadingProfiles } = useGenericBulkGetUserProfiles(profileUids);
+
+  const creators = useMemo(() => {
+    const set = new Set<string>();
+    for (const item of items) {
+      if (item.created_by) {
+        set.add(item.created_by);
+      }
+    }
+
+    return Array.from(set);
+  }, [items]);
+
+  const handleSearchSubmit = useCallback((value: string) => {
+    setSearchValue(value);
+    setPageIndex(0);
+  }, []);
+
+  const handleSelectedCreatorsChange = useCallback((newCreators: string[]) => {
+    setSelectedCreators(newCreators);
+    setPageIndex(0);
+  }, []);
+
+  const handleSortChange = useCallback((field: string, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+    setPageIndex(0);
+  }, []);
+
+  const handlePageSizeChange = useCallback(
+    (size: number) => {
+      setPageSize(size);
+      setPageIndex(0);
+    },
+    [setPageSize]
+  );
+
+  const renderPlayAction = useCallback(
+    (item: SavedQuerySO) => (
+      <PlayButton savedQuery={item} disabled={!permissions.runSavedQueries} />
+    ),
+    [permissions.runSavedQueries]
+  );
+
+  const renderCreatedByColumn = useCallback(
+    (_: unknown, item: SavedQuerySO) => (
+      <RunByColumn
+        userId={item.created_by}
+        userProfileUid={item.created_by_profile_uid}
+        profilesMap={profilesMap}
+        isLoadingProfiles={isLoadingProfiles}
+      />
+    ),
+    [profilesMap, isLoadingProfiles]
+  );
+
+  const renderDescriptionColumn = useCallback((description?: string) => {
+    if (!description) return <>-</>;
+    const content = description.length > 80 ? `${description.substring(0, 80)}...` : description;
+
+    return (
+      <EuiToolTip content={<EuiFlexItem>{description}</EuiFlexItem>}>
+        <EuiFlexItem grow={false}>{content}</EuiFlexItem>
+      </EuiToolTip>
+    );
+  }, []);
+
+  const renderUpdatedAt = useCallback((updatedAt: string) => {
+    if (!updatedAt) return <>-</>;
+
+    return (
+      <EuiToolTip content={moment(updatedAt).format('llll')}>
+        <span tabIndex={0} css={updatedAtCss}>
+          {moment(updatedAt).fromNow()}
+        </span>
+      </EuiToolTip>
+    );
+  }, []);
+
+  const visibleSet = useMemo(() => new Set(visibleColumns), [visibleColumns]);
+
+  const columns = useMemo(() => {
+    const cols: Array<EuiBasicTableColumn<SavedQuerySO>> = [
+      {
+        name: i18n.translate('xpack.osquery.savedQueries.table.actionsColumnTitle', {
+          defaultMessage: 'Actions',
+        }),
+        width: '75px',
+        render: (item: SavedQuerySO) => renderPlayAction(item),
+      },
+    ];
+
+    if (visibleSet.has('id')) {
+      cols.push({
+        field: 'id',
+        name: i18n.translate('xpack.osquery.savedQueries.table.queryIdColumnTitle', {
+          defaultMessage: 'Query ID',
+        }),
+        sortable: true,
+        truncateText: true,
+      });
+    }
+
+    if (visibleSet.has('description')) {
+      cols.push({
+        field: 'description',
+        name: i18n.translate('xpack.osquery.savedQueries.table.descriptionColumnTitle', {
+          defaultMessage: 'Description',
+        }),
+        render: renderDescriptionColumn,
+        truncateText: true,
+      });
+    }
+
+    if (visibleSet.has('created_by')) {
+      cols.push({
+        field: 'created_by',
+        name: i18n.translate('xpack.osquery.savedQueries.table.createdByColumnTitle', {
+          defaultMessage: 'Created by',
+        }),
+        render: renderCreatedByColumn,
+        width: '200px',
+      });
+    }
+
+    if (visibleSet.has('updated_at')) {
+      cols.push({
+        field: 'updated_at',
+        name: i18n.translate('xpack.osquery.savedQueries.table.updatedAtColumnTitle', {
+          defaultMessage: 'Last updated at',
+        }),
+        sortable: true,
+        render: renderUpdatedAt,
+        width: '180px',
+      });
+    }
+
+    cols.push({
+      width: '40px',
+      render: (item: SavedQuerySO) => <SavedQueryRowActions item={item} />,
+    });
+
+    return cols;
+  }, [
+    visibleSet,
+    renderPlayAction,
+    renderCreatedByColumn,
+    renderDescriptionColumn,
+    renderUpdatedAt,
+  ]);
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+      totalItemCount,
+      pageSizeOptions: [...PAGE_SIZE_OPTIONS],
+    }),
+    [pageIndex, pageSize, totalItemCount]
+  );
+
+  const sorting = useMemo(
+    () => ({
+      sort: {
+        field: sortField as keyof SavedQuerySO,
+        direction: sortDirection,
+      },
+    }),
+    [sortField, sortDirection]
+  );
+
+  const onTableChange = useCallback(
+    ({ page, sort }: CriteriaWithPagination<SavedQuerySO>) => {
+      if (page) {
+        setPageIndex(page.index);
+        if (page.size !== pageSize) {
+          handlePageSizeChange(page.size);
+        }
+      }
+
+      if (sort) {
+        setSortField(sort.field as string);
+        setSortDirection(sort.direction);
+      }
+    },
+    [pageSize, handlePageSizeChange]
+  );
+
+  const saveQueryButton = useMemo(
+    () => (
+      <EuiButton
+        fill
+        {...newQueryLinkProps}
+        iconType="plusInCircle"
+        isDisabled={!permissions.writeSavedQueries}
+      >
+        <FormattedMessage
+          id="xpack.osquery.savedQueryList.saveQueryButtonLabel"
+          defaultMessage="Save query"
+        />
+      </EuiButton>
+    ),
+    [permissions.writeSavedQueries, newQueryLinkProps]
+  );
+
+  if (isLoading) {
+    return <EuiSkeletonText lines={10} />;
+  }
+
+  return (
+    <>
+      <TableToolbar
+        searchPlaceholder={SEARCH_PLACEHOLDER}
+        searchValue={searchValue}
+        onSearchSubmit={handleSearchSubmit}
+        creators={creators}
+        selectedCreators={selectedCreators}
+        onSelectedCreatorsChange={handleSelectedCreatorsChange}
+        profilesMap={profilesMap}
+        columnConfigs={COLUMN_CONFIGS}
+        visibleColumns={visibleColumns}
+        onVisibleColumnsChange={setVisibleColumns}
+        sortFields={SORT_FIELDS}
+        sortField={sortField}
+        sortDirection={sortDirection}
+        onSortChange={handleSortChange}
+        actionButton={saveQueryButton}
+        data-test-subj="saved-queries-toolbar"
+      />
+      <EuiSpacer size="s" />
+      <EuiBasicTable<SavedQuerySO>
+        items={items}
+        itemId="saved_object_id"
+        columns={columns}
+        pagination={pagination}
+        sorting={sorting}
+        onChange={onTableChange}
+        loading={isFetching && !isLoading}
+        tableCaption={i18n.translate('xpack.osquery.savedQueryList.queriesTable.tableCaption', {
+          defaultMessage: 'Saved queries',
+        })}
+        data-test-subj="savedQueriesTable"
+      />
+    </>
+  );
+};
+
+export const SavedQueriesTable = React.memo(SavedQueriesTableComponent);
+SavedQueriesTable.displayName = 'SavedQueriesTable';

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/new/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/new/index.tsx
@@ -5,53 +5,87 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
+import type { UseEuiTheme } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useRouterNavigate } from '../../../common/lib/kibana';
 import { WithHeaderLayout } from '../../../components/layouts';
 import { useBreadcrumbs } from '../../../common/hooks/use_breadcrumbs';
+import { useIsExperimentalFeatureEnabled } from '../../../common/experimental_features_context';
 import { NewSavedQueryForm } from './form';
 import { useCreateSavedQuery } from '../../../saved_queries/use_create_saved_query';
 
+const contentCss = ({ euiTheme }: UseEuiTheme) => ({
+  padding: `0 ${euiTheme.size.l}`,
+  flex: 1,
+  minWidth: 0,
+  maxWidth: 1200,
+  margin: '0 auto',
+  width: '100%',
+});
+
 const NewSavedQueryPageComponent = () => {
+  const isHistoryEnabled = useIsExperimentalFeatureEnabled('queryHistoryRework');
   useBreadcrumbs('saved_query_new');
   const savedQueryListProps = useRouterNavigate('saved_queries');
 
   const { mutateAsync } = useCreateSavedQuery({ withRedirect: true });
-
-  const LeftColumn = useMemo(
-    () => (
-      <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
-        <EuiFlexItem>
-          <EuiButtonEmpty iconType="arrowLeft" {...savedQueryListProps} flush="left" size="xs">
-            <FormattedMessage
-              id="xpack.osquery.addSavedQuery.viewSavedQueriesListTitle"
-              defaultMessage="View all saved queries"
-            />
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText>
-            <h1>
-              <FormattedMessage
-                id="xpack.osquery.addSavedQuery.pageTitle"
-                defaultMessage="Add saved query"
-              />
-            </h1>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    ),
-    [savedQueryListProps]
-  );
 
   const handleSubmit = useCallback(
     async (payload: any) => {
       await mutateAsync(payload);
     },
     [mutateAsync]
+  );
+
+  const backLink = useMemo(
+    () => (
+      <EuiButtonEmpty iconType="arrowLeft" {...savedQueryListProps} flush="left" size="xs">
+        <FormattedMessage
+          id="xpack.osquery.addSavedQuery.viewSavedQueriesListTitle"
+          defaultMessage="View all saved queries"
+        />
+      </EuiButtonEmpty>
+    ),
+    [savedQueryListProps]
+  );
+
+  if (isHistoryEnabled) {
+    return (
+      <div css={contentCss}>
+        <EuiSpacer size="l" />
+        {backLink}
+        <EuiSpacer size="m" />
+        <EuiText>
+          <h1>
+            <FormattedMessage
+              id="xpack.osquery.addSavedQuery.pageTitle"
+              defaultMessage="Add saved query"
+            />
+          </h1>
+        </EuiText>
+        <EuiSpacer size="l" />
+        <NewSavedQueryForm handleSubmit={handleSubmit} />
+      </div>
+    );
+  }
+
+  const LeftColumn = (
+    <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="m">
+      <EuiFlexItem>{backLink}</EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText>
+          <h1>
+            <FormattedMessage
+              id="xpack.osquery.addSavedQuery.pageTitle"
+              defaultMessage="Add saved query"
+            />
+          </h1>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_saved_queries.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_saved_queries.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@kbn/react-query';
+import { useKibana } from '../common/lib/kibana';
+import { useSavedQueries } from './use_saved_queries';
+
+jest.mock('../common/lib/kibana');
+jest.mock('../common/hooks/use_error_toast', () => ({
+  useErrorToast: () => jest.fn(),
+}));
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return Wrapper;
+};
+
+const MOCK_RESPONSE = {
+  total: 2,
+  perPage: 10,
+  page: 1,
+  data: [
+    {
+      saved_object_id: 'sq-1',
+      id: 'my-query',
+      description: 'A test query',
+      query: 'SELECT 1',
+      created_by: 'admin',
+      created_by_profile_uid: 'uid-1',
+      updated_at: '2026-01-01T00:00:00Z',
+      updated_by: 'admin',
+    },
+    {
+      saved_object_id: 'sq-2',
+      id: 'another-query',
+      description: 'Another query',
+      query: 'SELECT 2',
+      created_by: 'user1',
+      updated_at: '2026-01-02T00:00:00Z',
+      updated_by: 'user1',
+    },
+  ],
+};
+
+describe('useSavedQueries', () => {
+  let mockHttp: { get: jest.Mock };
+  let mockToasts: { addSuccess: jest.Mock; addError: jest.Mock; remove: jest.Mock };
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHttp = { get: jest.fn().mockResolvedValue(MOCK_RESPONSE) };
+    mockToasts = { addSuccess: jest.fn(), addError: jest.fn(), remove: jest.fn() };
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+      logger: { log: () => null, warn: () => null, error: () => null },
+    });
+
+    useKibanaMock.mockReturnValue({
+      services: {
+        http: mockHttp,
+        notifications: { toasts: mockToasts },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+  });
+
+  it('fetches saved queries with default parameters', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: {
+        page: 1,
+        pageSize: 10000,
+        sort: 'updated_at',
+        sortOrder: 'desc',
+      },
+    });
+
+    expect(result.current.data).toEqual(MOCK_RESPONSE);
+  });
+
+  it('passes search parameter when provided', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false, search: 'my-query' }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: expect.objectContaining({ search: 'my-query' }),
+    });
+  });
+
+  it('passes createdBy parameter when provided', async () => {
+    const { result } = renderHook(
+      () => useSavedQueries({ isLive: false, createdBy: 'admin,user1' }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: expect.objectContaining({ createdBy: 'admin,user1' }),
+    });
+  });
+
+  it('omits search and createdBy when not provided', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const callQuery = mockHttp.get.mock.calls[0][1].query;
+    expect(callQuery).not.toHaveProperty('search');
+    expect(callQuery).not.toHaveProperty('createdBy');
+  });
+
+  it('passes custom pagination and sort parameters', async () => {
+    const { result } = renderHook(
+      () =>
+        useSavedQueries({
+          isLive: false,
+          pageIndex: 2,
+          pageSize: 25,
+          sortField: 'id',
+          sortOrder: 'asc',
+        }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: {
+        page: 3,
+        pageSize: 25,
+        sort: 'id',
+        sortOrder: 'asc',
+      },
+    });
+  });
+
+  it('omits empty search string', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false, search: '' }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const callQuery = mockHttp.get.mock.calls[0][1].query;
+    expect(callQuery).not.toHaveProperty('search');
+  });
+
+  it('strips wildcard and special characters from search', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false, search: 'my*query?' }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: expect.objectContaining({ search: 'myquery' }),
+    });
+  });
+
+  it('omits search when it contains only special characters', async () => {
+    const { result } = renderHook(() => useSavedQueries({ isLive: false, search: '***' }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const callQuery = mockHttp.get.mock.calls[0][1].query;
+    expect(callQuery).not.toHaveProperty('search');
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_saved_queries.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/use_saved_queries.ts
@@ -13,15 +13,33 @@ import { useErrorToast } from '../common/hooks/use_error_toast';
 import { SAVED_QUERIES_ID } from './constants';
 import type { SavedQuerySO } from '../routes/saved_queries/list';
 
+const sanitizeSearch = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  const sanitized = value.replace(/[*?\\{}()|"<>]/g, '').trim();
+
+  return sanitized || undefined;
+};
+
 export const useSavedQueries = ({
   isLive = false,
   pageIndex = 0,
   pageSize = 10000,
   sortField = 'updated_at',
   sortOrder = 'desc',
+  search,
+  createdBy,
+}: {
+  isLive?: boolean;
+  pageIndex?: number;
+  pageSize?: number;
+  sortField?: string;
+  sortOrder?: string;
+  search?: string;
+  createdBy?: string;
 }) => {
   const { http } = useKibana().services;
   const setErrorToast = useErrorToast();
+  const sanitizedSearch = sanitizeSearch(search);
 
   return useQuery<
     {
@@ -32,11 +50,18 @@ export const useSavedQueries = ({
     },
     { body: { error: string; message: string } }
   >(
-    [SAVED_QUERIES_ID, { pageIndex, pageSize, sortField, sortOrder }],
+    [SAVED_QUERIES_ID, { pageIndex, pageSize, sortField, sortOrder, search, createdBy }],
     () =>
       http.get('/api/osquery/saved_queries', {
         version: API_VERSIONS.public.v1,
-        query: { page: pageIndex + 1, pageSize, sort: sortField, sortOrder },
+        query: {
+          page: pageIndex + 1,
+          pageSize,
+          sort: sortField,
+          sortOrder,
+          ...(sanitizedSearch && { search: sanitizedSearch }),
+          ...(createdBy && { createdBy }),
+        },
       }),
     {
       keepPreviousData: true,

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.test.ts
@@ -155,7 +155,9 @@ describe('findSavedQueryRoute', () => {
 
     const findArgs = mockSavedObjectsClient.find.mock.calls[0][0];
     expect(findArgs.filter).toContain('osquery-saved-query.attributes.id: test\\<script\\>*');
-    expect(findArgs.filter).toContain('osquery-saved-query.attributes.description: test\\<script\\>*');
+    expect(findArgs.filter).toContain(
+      'osquery-saved-query.attributes.description: test\\<script\\>*'
+    );
   });
 
   it('builds createdBy filter for a single user', async () => {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.test.ts
@@ -114,7 +114,7 @@ describe('findSavedQueryRoute', () => {
     expect(body.data[0].updated_by_profile_uid).toBe('uid-1');
   });
 
-  it('passes search and searchFields when search param provided', async () => {
+  it('builds search filter with KQL wildcards on id and description', async () => {
     setupRoute();
 
     const mockRequest = httpServerMock.createKibanaRequest({
@@ -125,11 +125,12 @@ describe('findSavedQueryRoute', () => {
     await routeHandler({} as any, mockRequest, mockResponse);
 
     const findArgs = mockSavedObjectsClient.find.mock.calls[0][0];
-    expect(findArgs.search).toBe('windows');
-    expect(findArgs.searchFields).toEqual(['id', 'description']);
+    expect(findArgs.search).toBeUndefined();
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.id: windows*');
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.description: windows*');
   });
 
-  it('does not pass search or searchFields when search param is absent', async () => {
+  it('does not pass filter when no search or createdBy provided', async () => {
     setupRoute();
 
     const mockRequest = httpServerMock.createKibanaRequest({ query: {} });
@@ -139,7 +140,22 @@ describe('findSavedQueryRoute', () => {
 
     const findArgs = mockSavedObjectsClient.find.mock.calls[0][0];
     expect(findArgs.search).toBeUndefined();
-    expect(findArgs.searchFields).toBeUndefined();
+    expect(findArgs.filter).toBeUndefined();
+  });
+
+  it('escapes special characters in search term with escapeKuery', async () => {
+    setupRoute();
+
+    const mockRequest = httpServerMock.createKibanaRequest({
+      query: { search: 'test<script>' },
+    });
+    const mockResponse = httpServerMock.createResponseFactory();
+
+    await routeHandler({} as any, mockRequest, mockResponse);
+
+    const findArgs = mockSavedObjectsClient.find.mock.calls[0][0];
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.id: test\\<script\\>*');
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.description: test\\<script\\>*');
   });
 
   it('builds createdBy filter for a single user', async () => {
@@ -172,16 +188,20 @@ describe('findSavedQueryRoute', () => {
     );
   });
 
-  it('does not pass filter when no createdBy provided', async () => {
+  it('combines search and createdBy into a single AND filter', async () => {
     setupRoute();
 
-    const mockRequest = httpServerMock.createKibanaRequest({ query: {} });
+    const mockRequest = httpServerMock.createKibanaRequest({
+      query: { search: 'windows', createdBy: 'elastic' },
+    });
     const mockResponse = httpServerMock.createResponseFactory();
 
     await routeHandler({} as any, mockRequest, mockResponse);
 
     const findArgs = mockSavedObjectsClient.find.mock.calls[0][0];
-    expect(findArgs.filter).toBeUndefined();
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.id: windows*');
+    expect(findArgs.filter).toContain('osquery-saved-query.attributes.created_by: "elastic"');
+    expect(findArgs.filter).toContain(' AND ');
   });
 
   it('returns null profile_uid for legacy saved queries', async () => {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
@@ -8,7 +8,7 @@
 import type { IRouter } from '@kbn/core/server';
 
 import { omit } from 'lodash';
-import { escapeQuotes } from '@kbn/es-query';
+import { escapeQuotes, escapeKuery } from '@kbn/es-query';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-utils';
 import { createInternalSavedObjectsClientForSpaceId } from '../../utils/get_internal_saved_object_client';
 import { buildRouteValidation } from '../../utils/build_validation/route_validation';
@@ -66,16 +66,23 @@ export const findSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAppC
             filters.push(`(${userFilters.join(' OR ')})`);
           }
 
+          if (request.query.search) {
+            const searchTerm = escapeKuery(request.query.search.trim());
+            if (searchTerm) {
+              const searchFilter = [
+                `${savedQuerySavedObjectType}.attributes.id: ${searchTerm}*`,
+                `${savedQuerySavedObjectType}.attributes.description: ${searchTerm}*`,
+              ].join(' OR ');
+              filters.push(`(${searchFilter})`);
+            }
+          }
+
           const savedQueries = await spaceScopedClient.find<SavedQuerySavedObject>({
             type: savedQuerySavedObjectType,
             page: request.query.page || 1,
             perPage: request.query.pageSize,
             sortField: request.query.sort || 'id',
             sortOrder: request.query.sortOrder || 'desc',
-            ...(request.query.search && {
-              search: request.query.search,
-              searchFields: ['id', 'description'],
-            }),
             ...(filters.length && { filter: filters.join(' AND ') }),
           });
 


### PR DESCRIPTION
Adds shared table toolbar components and redesigns the saved queries list page behind the `queryHistoryRework` feature flag.

**Shared toolbar components** (`components/table_toolbar/`):

- `SelectableFilterPopover` — generic multi-select filter
- `CreatedByFilterPopover` — user filter with avatars from current page data
- `EnabledFilterButtons` — enabled/disabled toggle (for packs, used in follow-up)
- `ColumnPickerPopover` — show/hide columns ("Columns: N")
- `SortFieldsPopover` — sort field + direction picker
- `TableToolbar` — composed container with two-row layout

**Saved queries table redesign** (`routes/saved_queries/list/`):

- `EuiBasicTable` with server-side pagination, sorting, search, and filtering (replaces `EuiInMemoryTable`)
- Created-by filter popover with user avatars via `useGenericBulkGetUserProfiles`
- Column visibility toggling and sort popover
- "Save query" action button in toolbar
- Row actions via kebab menu (edit, duplicate, delete)

**Server-side search fix**:

- Replaced SO `search`/`searchFields` with KQL filter using wildcards — fixes 400 errors on `keyword` fields (`id`)
- Uses `escapeKuery` from `@kbn/es-query` for proper KQL escaping

**Layout cleanup** (behind feature flag):

- New/edit saved query pages skip `WithHeaderLayout` — renders clean layout matching pack pages
- `MainNavigation` hides title + tabs on sub-routes (new/edit/details)

All changes gated behind `queryHistoryRework` feature flag — old UI untouched when flag is off.

Closes https://github.com/elastic/security-team/issues/16312
Closes https://github.com/elastic/security-team/issues/16314


https://github.com/user-attachments/assets/d4ee723b-1e5f-4467-ae5c-025dc5e7d23a

