### PR TITLE
Update entity linking to Discover instead of Logs Explorer

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
@@ -158,7 +158,7 @@ export function getEntityLinkingInstructions({ urlPrefix }: { urlPrefix: string 
   | Dependencies | [Dependencies](${urlPrefix}/app/apm/services/<serviceName>/dependencies) | "View [Dependencies](${urlPrefix}/app/apm/services/catalog-api/dependencies) to identify upstream issues." |
   | Alert | [<alertId>](${urlPrefix}/app/observability/alerts/<alertId>) | "Alert [alert-uuid-123](${urlPrefix}/app/observability/alerts/alert-uuid-123) was triggered." |
   | Alert Rules | [<alertRuleId>](${urlPrefix}/app/observability/alerts/rules/<alertRuleId>) | "Alert Rule [alert-uuid-123](${urlPrefix}/app/observability/alerts/rules/alert-uuid-123)." |
-  | Logs Explorer | [Logs](${urlPrefix}/app/logs) | "View [Logs](${urlPrefix}/app/logs) to investigate the issue further." |
+  | Discover | [Discover](${urlPrefix}/app/discover) | "View [Discover](${urlPrefix}/app/discover) to investigate the issue further." |
   </entity_linking>
 `);
 }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/server/agent/register_observability_agent.ts
@@ -158,7 +158,7 @@ export function getEntityLinkingInstructions({ urlPrefix }: { urlPrefix: string 
   | Dependencies | [Dependencies](${urlPrefix}/app/apm/services/<serviceName>/dependencies) | "View [Dependencies](${urlPrefix}/app/apm/services/catalog-api/dependencies) to identify upstream issues." |
   | Alert | [<alertId>](${urlPrefix}/app/observability/alerts/<alertId>) | "Alert [alert-uuid-123](${urlPrefix}/app/observability/alerts/alert-uuid-123) was triggered." |
   | Alert Rules | [<alertRuleId>](${urlPrefix}/app/observability/alerts/rules/<alertRuleId>) | "Alert Rule [alert-uuid-123](${urlPrefix}/app/observability/alerts/rules/alert-uuid-123)." |
-  | Discover | [Discover](${urlPrefix}/app/discover) | "View [Discover](${urlPrefix}/app/discover) to investigate the issue further." |
+  | Discover | [Discover](${urlPrefix}/app/discover) | "Go to [Discover](${urlPrefix}/app/discover) to investigate the issue further." |
   </entity_linking>
 `);
 }


### PR DESCRIPTION
Closes [#531](https://github.com/elastic/obs-ai-team/issues/531)

Update the  entity linking instructions so link points to Discover instead of legacy Logs Explorer.
