### PR TITLE
[8.19] [Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
@@ -214,18 +214,18 @@ export const SharedLists = React.memo(() => {
 
   const handleExport = useCallback(
     ({
-      id,
-      listId,
-      name,
-      namespaceType,
-      includeExpiredExceptions,
-    }: {
-      id: string;
-      listId: string;
-      name: string;
-      namespaceType: NamespaceType;
-      includeExpiredExceptions: boolean;
-    }) =>
+        id,
+        listId,
+        name,
+        namespaceType,
+        includeExpiredExceptions,
+      }: {
+        id: string;
+        listId: string;
+        name: string;
+        namespaceType: NamespaceType;
+        includeExpiredExceptions: boolean;
+      }) =>
       async () => {
         await exportExceptionList({
           id,
@@ -293,16 +293,16 @@ export const SharedLists = React.memo(() => {
 
   const handleDuplicate = useCallback(
     ({
-      listId,
-      name,
-      namespaceType,
-      includeExpiredExceptions,
-    }: {
-      listId: string;
-      name: string;
-      namespaceType: NamespaceType;
-      includeExpiredExceptions: boolean;
-    }) =>
+        listId,
+        name,
+        namespaceType,
+        includeExpiredExceptions,
+      }: {
+        listId: string;
+        name: string;
+        namespaceType: NamespaceType;
+        includeExpiredExceptions: boolean;
+      }) =>
       async () => {
         await duplicateExceptionList({
           includeExpiredExceptions,

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { EuiSearchBarProps } from '@elastic/eui';
 import {
   EuiButton,
@@ -214,18 +214,18 @@ export const SharedLists = React.memo(() => {
 
   const handleExport = useCallback(
     ({
-        id,
-        listId,
-        name,
-        namespaceType,
-        includeExpiredExceptions,
-      }: {
-        id: string;
-        listId: string;
-        name: string;
-        namespaceType: NamespaceType;
-        includeExpiredExceptions: boolean;
-      }) =>
+      id,
+      listId,
+      name,
+      namespaceType,
+      includeExpiredExceptions,
+    }: {
+      id: string;
+      listId: string;
+      name: string;
+      namespaceType: NamespaceType;
+      includeExpiredExceptions: boolean;
+    }) =>
       async () => {
         await exportExceptionList({
           id,
@@ -293,16 +293,16 @@ export const SharedLists = React.memo(() => {
 
   const handleDuplicate = useCallback(
     ({
-        listId,
-        name,
-        namespaceType,
-        includeExpiredExceptions,
-      }: {
-        listId: string;
-        name: string;
-        namespaceType: NamespaceType;
-        includeExpiredExceptions: boolean;
-      }) =>
+      listId,
+      name,
+      namespaceType,
+      includeExpiredExceptions,
+    }: {
+      listId: string;
+      name: string;
+      namespaceType: NamespaceType;
+      includeExpiredExceptions: boolean;
+    }) =>
       async () => {
         await duplicateExceptionList({
           includeExpiredExceptions,
@@ -435,6 +435,8 @@ export const SharedLists = React.memo(() => {
   const [displayAddExceptionItemFlyout, setDisplayAddExceptionItemFlyout] = useState(false);
   const [displayCreateSharedListFlyout, setDisplayCreateSharedListFlyout] = useState(false);
 
+  const createButtonRef = useRef<HTMLButtonElement | null>(null);
+
   const onCreateButtonClick = () => setIsCreatePopoverOpen((isOpen) => !isOpen);
   const onCloseCreatePopover = () => {
     setDisplayAddExceptionItemFlyout(false);
@@ -494,7 +496,13 @@ export const SharedLists = React.memo(() => {
           <EuiPopover
             data-test-subj="manageExceptionListCreateButton"
             button={
-              <EuiButton iconType={'arrowDown'} onClick={onCreateButtonClick}>
+              <EuiButton
+                buttonRef={(node: HTMLButtonElement | null) => {
+                  createButtonRef.current = node;
+                }}
+                iconType={'arrowDown'}
+                onClick={onCreateButtonClick}
+              >
                 {i18n.CREATE_BUTTON}
               </EuiButton>
             }
@@ -542,7 +550,11 @@ export const SharedLists = React.memo(() => {
           http={http}
           addSuccess={addSuccess}
           addError={addError}
-          handleCloseFlyout={() => setDisplayCreateSharedListFlyout(false)}
+          handleCloseFlyout={() => {
+            setDisplayCreateSharedListFlyout(false);
+            // Without requestAnimationFrame, the flyout's cleanup resets focus before we can move it to the button.
+            requestAnimationFrame(() => createButtonRef.current?.focus());
+          }}
         />
       )}
 

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
@@ -48,6 +48,17 @@ jest.mock('../../../detections/containers/detection_engine/lists/use_lists_confi
   useListsConfig: jest.fn().mockReturnValue({ loading: false }),
 }));
 
+jest.mock('../../hooks/use_endpoint_exceptions_capability');
+jest.mock('../../components/create_shared_exception_list', () => ({
+  CreateSharedListFlyout: ({ handleCloseFlyout }: { handleCloseFlyout: () => void }) => (
+    <div data-test-subj="createSharedExceptionListFlyout">
+      <button type="button" data-test-subj="closeFlyoutButton" onClick={handleCloseFlyout}>
+        {'Close'}
+      </button>
+    </div>
+  ),
+}));
+
 describe('SharedLists', () => {
   const mockHistory = generateHistoryMock();
   const exceptionList1 = getExceptionListSchemaMock();
@@ -236,6 +247,40 @@ describe('SharedLists', () => {
       expect(allDeleteActions).toEqual([]);
       const allExportActions = wrapper.queryAllByTestId('sharedListOverflowCardActionItemExport');
       expect(allExportActions).toEqual([]);
+    });
+  });
+
+  it('returns focus to the create button when the create shared list flyout is closed', async () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      ...initialUserPrivilegesState(),
+      rulesPrivileges: {
+        rules: { read: true, edit: true },
+        exceptions: { read: true, edit: true },
+      },
+    });
+
+    const wrapper = render(
+      <TestProviders>
+        <SharedLists />
+      </TestProviders>
+    );
+
+    const createButtonText = wrapper.getByText('Create shared exception list');
+    const createButton = createButtonText.closest('button')!;
+    fireEvent.click(createButton);
+
+    const createListOption = wrapper.getByTestId('manageExceptionListCreateExceptionListButton');
+    fireEvent.click(createListOption);
+
+    await waitFor(() => {
+      expect(wrapper.getByTestId('createSharedExceptionListFlyout')).toBeInTheDocument();
+    });
+
+    const closeFlyoutButton = wrapper.getByTestId('closeFlyoutButton');
+    fireEvent.click(closeFlyoutButton);
+
+    await waitFor(() => {
+      expect(createButton).toHaveFocus();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/pages/shared_lists/shared_lists.test.tsx
@@ -251,13 +251,9 @@ describe('SharedLists', () => {
   });
 
   it('returns focus to the create button when the create shared list flyout is closed', async () => {
-    (useUserPrivileges as jest.Mock).mockReturnValue({
-      ...initialUserPrivilegesState(),
-      rulesPrivileges: {
-        rules: { read: true, edit: true },
-        exceptions: { read: true, edit: true },
-      },
-    });
+    (useUserData as jest.Mock).mockReturnValue([
+      { loading: false, canUserCRUD: true, canUserREAD: true },
+    ]);
 
     const wrapper = render(
       <TestProviders>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)](https://github.com/elastic/kibana/pull/257511)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Brooks","email":"hannah.brooks@elastic.co"},"sourceCommit":{"committedDate":"2026-03-17T18:22:46Z","message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:Detection Engine","a11y","v9.4.0","9.4 candidate"],"title":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout","number":257511,"url":"https://github.com/elastic/kibana/pull/257511","mergeCommit":{"message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257511","number":257511,"mergeCommit":{"message":"[Security Solution][Detection Engine] Fix Navigation For Shared Exception Lists Flyout (#257511)\n\n## Summary\n\nFixes issue [#227237](https://github.com/elastic/kibana/issues/227237).\n\nWhen we would create a new exception list from the flyout and proceeded\nto close the flyout, the focus would not return to the button that\nopened the flyout.\n\nThis PR implements a solution to force focus to return back to the\nbutton. I tested without `requestAnimationFrame` and it seems that the\ncleanup that `EuiFlyout` needs to complete before we can return focus\nand `requestAnimationFrame` ensures this happens.","sha":"2210107492ff1c10b9357f7b188453e3e6768004"}}]}] BACKPORT-->