### PR TITLE
[Alerting v2] [Rule authoring] Add max value validation to recovering_count

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
@@ -404,6 +404,15 @@ describe('createRuleDataSchema', () => {
       expect(result.success).toBe(false);
     });
 
+    it('rejects recovering_count greater than 1000', () => {
+      const result = createRuleDataSchema.safeParse({
+        ...validCreateData,
+        state_transition: { recovering_count: 1001 },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
     it('rejects an invalid pending_operator', () => {
       const result = createRuleDataSchema.safeParse({
         ...validCreateData,
@@ -691,6 +700,14 @@ describe('updateRuleDataSchema', () => {
     it('rejects pending_count greater than 1000', () => {
       const result = updateRuleDataSchema.safeParse({
         state_transition: { pending_count: 1001 },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects recovering_count greater than 1000', () => {
+      const result = updateRuleDataSchema.safeParse({
+        state_transition: { recovering_count: 1001 },
       });
 
       expect(result.success).toBe(false);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.ts
@@ -128,6 +128,7 @@ const stateTransitionSchema = z
       .number()
       .int()
       .min(0)
+      .max(MAX_CONSECUTIVE_BREACHES)
       .optional()
       .describe('Consecutive recoveries before inactive.'),
     recovering_timeframe: durationSchema


### PR DESCRIPTION
## Summary

Applies the missing `.max(MAX_CONSECUTIVE_BREACHES)` constraint to the `recovering_count` field in the server-side Zod schema, closing a validation gap where a direct API call could submit an arbitrarily large value that would pass server-side validation undetected.

**Problem:** `pending_count` correctly enforced `.max(MAX_CONSECUTIVE_BREACHES)` (1000) in both the client form validation and the server-side schema. `recovering_count` had the same client-side max enforced, but the server-side schema was missing `.max(MAX_CONSECUTIVE_BREACHES)`, meaning the constraint could be bypassed entirely via a direct API call.

**Solution:** Add `.max(MAX_CONSECUTIVE_BREACHES)` to the `recovering_count` field in `stateTransitionSchema` in `rule_data_schema.ts`, making it consistent with `pending_count`. The fix applies to both `createRuleDataSchema` and `updateRuleDataSchema` since both share the same `stateTransitionSchema` definition.

## Test plan

- [x] Unit tests pass for all modified files (80 tests)
- [x] New test: `rejects recovering_count greater than 1000` added to `createRuleDataSchema` suite
- [x] New test: `rejects recovering_count greater than 1000` added to `updateRuleDataSchema` suite