### PR TITLE
[es_snapshots/build] Skip native launcher

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -76,6 +76,8 @@ echo "--- Build Elasticsearch"
   :distribution:archives:linux-aarch64-tar:assemble \
   :distribution:archives:linux-tar:assemble \
   :distribution:archives:windows-zip:assemble \
+  -x :distribution:tools:server-launcher:nativeImageLinuxX64 \
+  -x :distribution:tools:server-launcher:nativeImageLinuxAarch64 \
   --parallel
 
 echo "--- Create distribution archives"

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -91,7 +91,9 @@ docker images "docker.elastic.co/elasticsearch/elasticsearch" --format "{{.Tag}}
 docker images "docker.elastic.co/elasticsearch/elasticsearch" --format "{{.Tag}}" | xargs -n1 bash -c 'docker save docker.elastic.co/elasticsearch/elasticsearch:${0} | gzip > ../es-build/elasticsearch-${0}-docker-image.tar.gz'
 
 echo "--- Create kibana-ci docker cloud image archives"
-./gradlew :distribution:docker:cloud-ess-docker-export:assemble && {
+./gradlew :distribution:docker:cloud-ess-docker-export:assemble \
+  -x :distribution:tools:server-launcher:nativeImageLinuxX64 \
+  -x :distribution:tools:server-launcher:nativeImageLinuxAarch64 && {
   ES_CLOUD_ID=$(docker images "docker.elastic.co/elasticsearch/elasticsearch-cloud-ess" --format "{{.ID}}")
   ES_CLOUD_VERSION=$(docker images "docker.elastic.co/elasticsearch/elasticsearch-cloud-ess" --format "{{.Tag}}")
   KIBANA_ES_CLOUD_VERSION="$ES_CLOUD_VERSION-$ELASTICSEARCH_GIT_COMMIT"


### PR DESCRIPTION
Skips the optional elasticsearch native launcher build step introduced in https://github.com/elastic/elasticsearch/pull/143712.  We're running this build using docker-in-docker and required host filesystem paths are not available.

As a follow up, we can look into splitting the docker build (the DinD portion) out from of the native build.

Fixes https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/7896
Test build https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/7899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process for distribution and cloud image packages by streamlining compilation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->