### PR TITLE
[Entity Store] Adding check privileges API

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -36,6 +36,7 @@ export const ENTITY_STORE_ROUTES = {
   STATUS: `${ENTITY_STORE_BASE_ROUTE}/status`,
   START: `${ENTITY_STORE_BASE_ROUTE}/start`,
   STOP: `${ENTITY_STORE_BASE_ROUTE}/stop`,
+  CHECK_PRIVILEGES: `${ENTITY_STORE_BASE_ROUTE}/check_privileges`,
   FORCE_LOG_EXTRACTION: `${ENTITY_STORE_BASE_ROUTE}/{entityType}/force_log_extraction`,
   FORCE_HISTORY_SNAPSHOT: `${ENTITY_STORE_BASE_ROUTE}/force_history_snapshot`,
   CRUD_UPSERT: `${ENTITY_STORE_BASE_ROUTE}/entities/{entityType}`,

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/check_privileges.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { IKibanaResponse } from '@kbn/core-http-server';
+import { ENTITY_STORE_ROUTES } from '../../../common';
+import { API_VERSIONS, DEFAULT_ENTITY_STORE_PERMISSIONS } from '../constants';
+import type { EntityStorePluginRouter } from '../../types';
+import { wrapMiddlewares } from '../middleware';
+import { getLatestEntitiesIndexName } from '../../domain/asset_manager/latest_index';
+import { checkAndFormatPrivileges } from './utils/check_and_format_privileges';
+
+export function registerCheckPrivileges(router: EntityStorePluginRouter) {
+  router.versioned
+    .get({
+      path: ENTITY_STORE_ROUTES.CHECK_PRIVILEGES,
+      access: 'internal',
+      security: {
+        authz: DEFAULT_ENTITY_STORE_PERMISSIONS,
+      },
+      enableQueryVersion: true,
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v2,
+        validate: false,
+      },
+      wrapMiddlewares(async (ctx, req, res): Promise<IKibanaResponse> => {
+        const entityStoreCtx = await ctx.entityStore;
+        const security = entityStoreCtx.security;
+        const spaceId = entityStoreCtx.namespace;
+        const entitiesIndexPattern = getLatestEntitiesIndexName(spaceId);
+
+        const response = await checkAndFormatPrivileges({
+          indexPattern: entitiesIndexPattern,
+          request: req,
+          security,
+          privilegesToCheck: {
+            elasticsearch: {
+              cluster: [],
+              index: {
+                [entitiesIndexPattern]: ['read', 'write'],
+              },
+            },
+          },
+        });
+
+        return res.ok({
+          body: response,
+        });
+      })
+    );
+}

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/index.ts
@@ -25,3 +25,4 @@ export { registerStopMaintainer } from './entity_maintainers/stop';
 export { registerGetMaintainers } from './entity_maintainers/get_maintainers';
 export { registerInitMaintainers } from './entity_maintainers/init';
 export { registerRunMaintainer } from './entity_maintainers/run';
+export { registerCheckPrivileges } from './check_privileges';

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatPrivileges, hasReadWritePermissions } from './check_and_format_privileges';
+
+const TEST_INDEX_PATTERN = 'test-index-pattern-*';
+describe('formatPrivileges', () => {
+  it('should correctly format elasticsearch index privileges', () => {
+    const privileges = {
+      elasticsearch: {
+        cluster: [],
+        index: {
+          index1: [
+            {
+              privilege: 'read',
+              authorized: true,
+            },
+            {
+              privilege: 'write',
+              authorized: true,
+            },
+          ],
+          index2: [
+            {
+              privilege: 'read',
+              authorized: true,
+            },
+            {
+              privilege: 'write',
+              authorized: true,
+            },
+          ],
+        },
+      },
+      kibana: [],
+    };
+
+    const result = formatPrivileges(privileges);
+
+    expect(result).toEqual({
+      elasticsearch: {
+        index: {
+          index1: {
+            read: true,
+            write: true,
+          },
+          index2: {
+            read: true,
+            write: true,
+          },
+        },
+      },
+      kibana: {},
+    });
+  });
+
+  it('should correctly format elasticsearch cluster privileges', () => {
+    const privileges = {
+      elasticsearch: {
+        cluster: [
+          {
+            privilege: 'manage',
+            authorized: true,
+          },
+          {
+            privilege: 'monitor',
+            authorized: true,
+          },
+        ],
+        index: {},
+      },
+      kibana: [],
+    };
+
+    const result = formatPrivileges(privileges);
+
+    expect(result).toEqual({
+      elasticsearch: {
+        cluster: {
+          manage: true,
+          monitor: true,
+        },
+      },
+      kibana: {},
+    });
+  });
+
+  it('should correctly format elasticsearch cluster and index privileges', () => {
+    const privileges = {
+      elasticsearch: {
+        cluster: [
+          {
+            privilege: 'manage',
+            authorized: true,
+          },
+          {
+            privilege: 'monitor',
+            authorized: true,
+          },
+        ],
+        index: {
+          index1: [
+            {
+              privilege: 'read',
+              authorized: true,
+            },
+            {
+              privilege: 'write',
+              authorized: true,
+            },
+          ],
+          index2: [
+            {
+              privilege: 'read',
+              authorized: true,
+            },
+            {
+              privilege: 'write',
+              authorized: true,
+            },
+          ],
+        },
+      },
+      kibana: [],
+    };
+
+    const result = formatPrivileges(privileges);
+
+    expect(result).toEqual({
+      elasticsearch: {
+        cluster: {
+          manage: true,
+          monitor: true,
+        },
+        index: {
+          index1: {
+            read: true,
+            write: true,
+          },
+          index2: {
+            read: true,
+            write: true,
+          },
+        },
+      },
+      kibana: {},
+    });
+  });
+
+  it('should correctly extract read and write permissions from elasticsearch cluster privileges', () => {
+    const privileges = {
+      elasticsearch: {
+        cluster: [
+          {
+            privilege: 'read',
+            authorized: true,
+          },
+          {
+            privilege: 'write',
+            authorized: false,
+          },
+        ],
+        index: {},
+      },
+      kibana: [],
+    };
+
+    const result = hasReadWritePermissions(privileges.elasticsearch);
+
+    expect(result).toEqual({
+      has_read_permissions: true,
+      has_write_permissions: false,
+    });
+  });
+  it('should correctly extract read and write permissions from elasticsearch index privileges', () => {
+    const privileges = {
+      elasticsearch: {
+        cluster: [],
+        index: {
+          [TEST_INDEX_PATTERN]: [
+            {
+              privilege: 'read',
+              authorized: true,
+            },
+            {
+              privilege: 'write',
+              authorized: false,
+            },
+          ],
+        },
+      },
+      kibana: [],
+    };
+
+    const result = hasReadWritePermissions(privileges.elasticsearch, TEST_INDEX_PATTERN);
+
+    expect(result).toEqual({
+      has_read_permissions: true,
+      has_write_permissions: false,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/apis/utils/check_and_format_privileges.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { z } from '@kbn/zod/v4';
+import type { KibanaRequest } from '@kbn/core/server';
+import type {
+  CheckPrivilegesPayload,
+  CheckPrivilegesResponse,
+  SecurityPluginStart,
+} from '@kbn/security-plugin/server';
+
+export type Privileges = z.infer<typeof Privileges>;
+export const Privileges = z.object({
+  has_all_required: z.boolean(),
+  has_read_permissions: z.boolean().optional(),
+  has_write_permissions: z.boolean().optional(),
+  privileges: z.object({
+    elasticsearch: z.object({
+      cluster: z.object({}).catchall(z.boolean()).optional(),
+      index: z.object({}).catchall(z.object({}).catchall(z.boolean())).optional(),
+    }),
+    kibana: z.object({}).catchall(z.boolean()).optional(),
+  }),
+});
+
+const groupPrivilegesByName = <PrivilegeName extends string>(
+  privileges: Array<{
+    privilege: PrivilegeName;
+    authorized: boolean;
+  }>
+): Record<PrivilegeName, boolean> => {
+  return privileges.reduce<Record<string, boolean>>((acc, { privilege, authorized }) => {
+    acc[privilege] = authorized;
+    return acc;
+  }, {});
+};
+
+export const formatPrivileges = (
+  privileges: CheckPrivilegesResponse['privileges']
+): Privileges['privileges'] => {
+  const clusterPrivilegesByPrivilege = groupPrivilegesByName(privileges.elasticsearch.cluster);
+  const kibanaPrivilegesByPrivilege = groupPrivilegesByName(privileges.kibana);
+
+  const indexPrivilegesByIndex = Object.entries(privileges.elasticsearch.index).reduce<
+    Record<string, Record<string, boolean>>
+  >((acc, [index, indexPrivileges]) => {
+    acc[index] = groupPrivilegesByName(indexPrivileges);
+    return acc;
+  }, {});
+
+  return {
+    elasticsearch: {
+      ...(Object.keys(indexPrivilegesByIndex).length > 0
+        ? {
+            index: indexPrivilegesByIndex,
+          }
+        : {}),
+      ...(Object.keys(clusterPrivilegesByPrivilege).length > 0
+        ? {
+            cluster: clusterPrivilegesByPrivilege,
+          }
+        : {}),
+    },
+    kibana: {
+      ...(Object.keys(kibanaPrivilegesByPrivilege).length > 0 ? kibanaPrivilegesByPrivilege : {}),
+    },
+  };
+};
+
+interface CheckAndFormatPrivilegesOpts {
+  indexPattern: string;
+  request: KibanaRequest;
+  security: SecurityPluginStart;
+  privilegesToCheck: CheckPrivilegesPayload;
+}
+
+export async function checkAndFormatPrivileges({
+  request,
+  security,
+  privilegesToCheck,
+  indexPattern,
+}: CheckAndFormatPrivilegesOpts): Promise<Privileges> {
+  const checkPrivileges = security.authz.checkPrivilegesDynamicallyWithRequest(request);
+  const { privileges, hasAllRequested } = await checkPrivileges(privilegesToCheck);
+
+  return {
+    privileges: formatPrivileges(privileges),
+    has_all_required: hasAllRequested,
+    ...hasReadWritePermissions(privileges.elasticsearch, indexPattern),
+  };
+}
+
+export const hasReadWritePermissions = (
+  { index, cluster }: CheckPrivilegesResponse['privileges']['elasticsearch'],
+  indexKey = ''
+) => {
+  const has =
+    (type: string) =>
+    ({ privilege, authorized }: { privilege: string; authorized: boolean }) =>
+      privilege === type && authorized;
+  return {
+    has_read_permissions: index[indexKey]?.some(has('read')) || cluster.some(has('read')),
+
+    has_write_permissions: index[indexKey]?.some(has('write')) || cluster.some(has('write')),
+  };
+};

--- a/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/routes/register_routes.ts
@@ -26,6 +26,7 @@ import {
   registerResolutionUnlink,
   registerResolutionGroup,
   registerUpdate,
+  registerCheckPrivileges,
 } from './apis';
 import type { EntityStorePluginRouter } from '../types';
 
@@ -37,6 +38,7 @@ export function registerRoutes(router: EntityStorePluginRouter) {
   registerForceLogExtraction(router);
   registerForceCcsExtractToUpdates(router);
   registerForceHistorySnapshot(router);
+  registerCheckPrivileges(router);
   registerCRUDUpsert(router);
   registerCRUDUpsertBulk(router);
   registerCRUDDelete(router);

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/constants.ts
@@ -43,6 +43,7 @@ export const ENTITY_STORE_ROUTES = {
     `internal/security/entity_store/entity_maintainers/stop/${id}`,
   ENTITY_MAINTAINERS_RUN: (id: string) =>
     `internal/security/entity_store/entity_maintainers/run/${id}`,
+  CHECK_PRIVILEGES: 'internal/security/entity_store/check_privileges',
 } as const;
 
 export const ENTITY_STORE_TAGS = [...tags.stateful.classic, ...tags.serverless.security.complete];

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/check_privileges.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apiTest } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/api';
+import { COMMON_HEADERS, ENTITY_STORE_ROUTES, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+import { getLatestEntitiesIndexName } from '../../../../server/domain/asset_manager/latest_index';
+
+apiTest.describe('Entity Store check privileges API', { tag: ENTITY_STORE_TAGS }, () => {
+  const ENTITIES_INDEX = getLatestEntitiesIndexName('default');
+
+  apiTest.beforeAll(async ({ kbnClient }) => {
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+  });
+
+  apiTest('Should return full privileges for admin user', async ({ apiClient, samlAuth }) => {
+    const { cookieHeader } = await samlAuth.asInteractiveUser('admin');
+
+    const response = await apiClient.get(ENTITY_STORE_ROUTES.CHECK_PRIVILEGES, {
+      headers: { ...cookieHeader, ...COMMON_HEADERS },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(200);
+    expect(response.body).toMatchObject({
+      has_all_required: true,
+      has_read_permissions: true,
+      has_write_permissions: true,
+    });
+  });
+
+  apiTest(
+    'Should deny access for user without securitySolution privilege',
+    async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asInteractiveUser({
+        elasticsearch: { cluster: [] },
+        kibana: [{ base: [], feature: { discover: ['all'] }, spaces: ['*'] }],
+      });
+
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...COMMON_HEADERS },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(403);
+    }
+  );
+
+  apiTest(
+    'Should return no index permissions for user with securitySolution privilege but no index access',
+    async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asInteractiveUser({
+        elasticsearch: { cluster: [] },
+        kibana: [
+          {
+            base: [],
+            feature: { siemV5: ['all'] },
+            spaces: ['default'],
+          },
+        ],
+      });
+
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...COMMON_HEADERS },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(200);
+      expect(response.body).toMatchObject({
+        has_all_required: false,
+        has_read_permissions: false,
+        has_write_permissions: false,
+      });
+    }
+  );
+
+  apiTest(
+    'Should return limited privileges for user with read-only access to entities index',
+    async ({ apiClient, samlAuth }) => {
+      const { cookieHeader } = await samlAuth.asInteractiveUser({
+        elasticsearch: {
+          cluster: [],
+          indices: [{ names: [ENTITIES_INDEX], privileges: ['read'] }],
+        },
+        kibana: [
+          {
+            base: [],
+            feature: { siemV5: ['all'] },
+            spaces: ['*'],
+          },
+        ],
+      });
+
+      const response = await apiClient.get(ENTITY_STORE_ROUTES.CHECK_PRIVILEGES, {
+        headers: { ...cookieHeader, ...COMMON_HEADERS },
+        responseType: 'json',
+      });
+
+      expect(response).toHaveStatusCode(200);
+      expect(response.body).toMatchObject({
+        has_all_required: false,
+        has_read_permissions: true,
+        has_write_permissions: false,
+      });
+    }
+  );
+});


### PR DESCRIPTION
## Summary

As part of moving the asset criticality features to work off of the entity store, we are deprecating the asset criticality APIs. One of these APIs is the `privileges` API which checks the user's permissions against the `.asset-criticality.asset-criticality-*` index. This is used in the client code to determine whether users are able to edit the asset criticality for an entity in different entity flyouts.

We need a similar privilege check against the entity store since any asset criticality updates will be modifying the entity store indices. This PR adds that API

## To Verify

1. Start ES and Kibana and enable the entity store V2
2. Create different roles and users with different levels of elasticsearch access to the entity v2 indices
3. For each user, run `curl -k -X GET -H 'Content-Type: application/json' -H 'x-elastic-internal-origin: Kibana' -H 'kbn-xsrf: true' -H 'elastic-api-version: 2' https://{user}:{pw}@localhost:5601/internal/security/entity_store/check_privileges` and see the correct permissions returned.