### PR TITLE
[Security Solution][Session View] small fix that prevents the session view details flyout to be shown when we actually want to show the alert details flyout

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -62,23 +62,16 @@ export const SessionView: FC = memo(() => {
   const { openPreviewPanel, closePreviewPanel } = useExpandableFlyoutApi();
   const openAlertDetailsPreview = useCallback(
     (alertId: string, alertIndex: string, onClose?: () => void) => {
-      // In the SessionView component, when the user clicks on the
-      // expand button to open a alert in the preview panel, this actually also selects the row and opens
-      // the detailed panel in preview.
-      // In order to NOT modify the SessionView code, the setTimeout here guarantees that the alert details preview
-      // will be opened in second, so that we have a correct order in the opened preview panels
-      setTimeout(() => {
-        openPreviewPanel({
-          id: DocumentDetailsPreviewPanelKey,
-          params: {
-            id: alertId,
-            indexName: alertIndex,
-            scopeId,
-            banner: ALERT_PREVIEW_BANNER,
-            isPreviewMode: true,
-          },
-        });
-      }, 100);
+      openPreviewPanel({
+        id: DocumentDetailsPreviewPanelKey,
+        params: {
+          id: alertId,
+          indexName: alertIndex,
+          scopeId,
+          banner: ALERT_PREVIEW_BANNER,
+          isPreviewMode: true,
+        },
+      });
       telemetry.reportEvent(DocumentEventTypes.DetailsFlyoutOpened, {
         location: scopeId,
         panel: 'preview',

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.test.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.test.tsx
@@ -119,10 +119,12 @@ describe('ProcessTreeAlerts component', () => {
 
     it('should execute onShowAlertDetails callback when clicking on expand button', async () => {
       const onShowAlertDetails = jest.fn();
+      const onClick = jest.fn();
       renderResult = mockedContext.render(
         <ProcessTreeAlert
           {...props}
           alert={mockAlertWithIndex}
+          onClick={onClick}
           onShowAlertDetails={onShowAlertDetails}
         />
       );
@@ -131,6 +133,7 @@ describe('ProcessTreeAlerts component', () => {
       expect(expandButton).toBeTruthy();
       expandButton?.click();
       expect(onShowAlertDetails).toHaveBeenCalledTimes(1);
+      expect(onClick).not.toHaveBeenCalled();
       expect(onShowAlertDetails.mock.calls[0]).toEqual([
         mockAlertWithIndex.kibana?.alert?.uuid,
         mockAlertWithIndex.kibana?.alert?.index,

--- a/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/process_tree_alert/index.tsx
@@ -57,11 +57,16 @@ export const ProcessTreeAlert = ({
     }
   }, [isInvestigated, uuid, selectAlert]);
 
-  const handleExpandClick = useCallback(() => {
-    if (uuid && index) {
-      onShowAlertDetails(uuid, index);
-    }
-  }, [index, onShowAlertDetails, uuid]);
+  const handleExpandClick = useCallback(
+    (evt: React.MouseEvent<HTMLButtonElement>) => {
+      evt.stopPropagation();
+      evt.preventDefault();
+      if (uuid && index) {
+        onShowAlertDetails(uuid, index);
+      }
+    },
+    [index, onShowAlertDetails, uuid]
+  );
 
   const handleClick = useCallback(() => {
     if (alert.kibana?.alert) {


### PR DESCRIPTION
## Summary

This PR implements a very small fix for an issue we've had for a while in the Session View component. Since we moved Session View to the expandable flyout experience, we've had a weird behavior happening when users click on the expand button icon to show the alert details. Because that button is nested within a Session View row, the actual session view details flyout is shown at the same time as the alert details flyout. The UI ends up not showing the alert details flyout...

You can see in the video below the issue:

https://github.com/user-attachments/assets/8bf2c1ff-27ce-4351-b866-dc40bae63a6e

What we had done in our end, was to add a `setTimeout` to ensure that our alert details flyout would be opened after. While this hacky implementation worked, it was not ideal. You could sometimes see a brief flickering in the UI, because we were actually opening 2 preview flyouts back to back (the session view details, then the alert details).

The small change implemented in this PR consist of preventing the propagation of the event, when the expand button is being clicked. The other behaviors (like clicking on the row) are unaffected.

This video show the change:

https://github.com/user-attachments/assets/30c9cb0a-92c1-401f-b3c7-b8e7fb233100

> [!NOTE]
> While this change is basically imperceptible in the UI (because of the `setTimeout` we had in place), it will be absolutely necessary with the new flyout using the EUI session flyout.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
