### PR TITLE
Move inheritance: true to top level in .coderabbit.yml

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+inheritance: true
 reviews:
-  inheritance: true
   review_status: false
   poem: false
   auto_review:


### PR DESCRIPTION
## Summary
- Move `inheritance: true` from nested under `reviews:` to the top level in `.coderabbit.yml`, which is the correct location per the CodeRabbit schema

## Test plan
- Verified the updated YAML is valid against the CodeRabbit v2 schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)