### PR TITLE
[Agent Builder] Reduce token usage for mapping representation

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/generate_esql/prompts.ts
@@ -62,7 +62,7 @@ ${prompts.examples}`,
 ${nlQuery}
 </user_query>
 
-${formatResourceWithSampledValues({ resource, indentLevel: 0 })}
+${formatResourceWithSampledValues({ resource })}
 
 Now, based on that information, request documentation from the ES|QL handbook
 to help you get the right information needed to generate a query.`,
@@ -133,7 +133,7 @@ ${nlQuery}
 
 ${additionalContext ? `<additional_context>\n${additionalContext}\n</<additional_context>` : ''}
 
-${formatResourceWithSampledValues({ resource, indentLevel: 0 })}
+${formatResourceWithSampledValues({ resource })}
 
 Now, based on that information, please generate the ES|QL query.`,
     ],

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/resources/format_resource_with_sampling.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/utils/resources/format_resource_with_sampling.ts
@@ -8,60 +8,52 @@
 import { take } from 'lodash';
 import type { ResolvedResourceWithSampling } from './resolve_resource_with_sampling_stats';
 import type { MappingFieldWithStats } from '../sampling';
-import type { XmlNode } from '../formatting';
-import { generateXmlTree } from '../formatting';
 
 /**
- * Represents a resource as a xml tree,
- * useful for including them into a prompt
+ * Field types where sample values are meaningful for ES|QL query generation.
+ * Numeric, date, boolean, and ip fields are excluded — their sampled values
+ * do not constrain the query vocabulary and would only add token cost.
+ */
+const SAMPLE_VALUE_TYPES = new Set([
+  'keyword',
+  'constant_keyword',
+  'wildcard',
+  'text',
+  'semantic_text',
+  'match_only_text',
+  'pattern_text',
+]);
+
+/**
+ * Formats a resource with sampled field values as a compact plain-text block,
+ * suitable for inclusion in a prompt.
+ *
+ * Each field is rendered as a single line:
+ *   path (type) [description][: val1, val2]
  */
 export const formatResourceWithSampledValues = ({
   resource,
-  indentLevel,
 }: {
   resource: ResolvedResourceWithSampling;
-  indentLevel?: number;
 }) => {
-  return generateXmlTree(
-    {
-      tagName: 'target_resource',
-      attributes: {
-        name: resource.name,
-        type: resource.type,
-      },
-      children: [
-        {
-          tagName: 'fields',
-          children: resource.fields.map((field) => mapFieldWithStats(field, 3)),
-        },
-      ],
-    },
-    { initialIndentLevel: indentLevel }
-  );
+  const samplingCount = resource.fields.length > 1000 ? 0 : resource.fields.length > 200 ? 1 : 2;
+  const lines = resource.fields.map((field) => renderFieldLine(field, samplingCount));
+  return [
+    `<target_resource name="${resource.name}" type="${resource.type}">`,
+    ...lines,
+    `</target_resource>`,
+  ].join('\n');
 };
 
-const mapFieldWithStats = (field: MappingFieldWithStats, maxValues: number = 3): XmlNode => {
-  return {
-    tagName: 'field',
-    attributes: {
-      path: field.path,
-      type: field.type,
-      description: field.meta.description,
-    },
-    children: field.stats.values.length
-      ? [
-          {
-            tagName: 'sample_values',
-            children: take(field.stats.values, maxValues).map<XmlNode>((value) => {
-              return {
-                tagName: 'value',
-                children: [truncate(normalizeSpaces(`${value.value}`), 100)],
-              };
-            }),
-          },
-        ]
-      : undefined,
-  };
+const renderFieldLine = (field: MappingFieldWithStats, samplingCount: number): string => {
+  const description = field.meta.description ? ` ${field.meta.description}` : '';
+  const samples =
+    SAMPLE_VALUE_TYPES.has(field.type) && field.stats.values.length && samplingCount > 0
+      ? ` (${take(field.stats.values, samplingCount)
+          .map((v) => truncate(normalizeSpaces(`${v.value}`), 80))
+          .join(', ')}...)`
+      : '';
+  return `- ${field.path} [${field.type}]${description}${samples}`;
 };
 
 const truncate = (text: unknown, maxLength: number): string => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/get_index_mapping.ts
@@ -7,13 +7,23 @@
 
 import { z } from '@kbn/zod/v4';
 import { platformCoreTools, ToolType } from '@kbn/agent-builder-common';
+import type { MappingField } from '@kbn/agent-builder-genai-utils';
+import { otherResult } from '@kbn/agent-builder-genai-utils/tools/utils/results';
 import { getIndexFields } from '@kbn/agent-builder-genai-utils';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
-import { ToolResultType } from '@kbn/agent-builder-common/tools/tool_result';
 
 const getIndexMappingsSchema = z.object({
   indices: z.array(z.string()).min(1).describe('List of indices to retrieve mappings for.'),
+  raw: z
+    .boolean()
+    .default(false)
+    .describe('Whether to return the raw mapping tree instead of the summarized fields.'),
 });
+
+const formatField = (field: MappingField): string => {
+  const description = field.meta.description ? ` ${field.meta.description}` : '';
+  return `- ${field.path} [${field.type}]${description}`;
+};
 
 export const getIndexMappingsTool = (): BuiltinToolDefinition<typeof getIndexMappingsSchema> => {
   return {
@@ -21,7 +31,7 @@ export const getIndexMappingsTool = (): BuiltinToolDefinition<typeof getIndexMap
     type: ToolType.builtin,
     description: 'Retrieve mappings for the specified index or indices.',
     schema: getIndexMappingsSchema,
-    handler: async ({ indices }, { esClient }) => {
+    handler: async ({ indices, raw }, { esClient }) => {
       // getIndexFields transparently handles the local-vs-CCS split:
       //  - local indices use _mapping API (full mapping tree in rawMapping)
       //  - CCS indices use batched _field_caps API (flat field list)
@@ -32,35 +42,46 @@ export const getIndexMappingsTool = (): BuiltinToolDefinition<typeof getIndexMap
 
       const results = [];
 
-      // Local indices: return full mapping tree for richer LLM context
-      const localEntries = Object.entries(indexFields).filter(([, v]) => v.rawMapping);
-      if (localEntries.length > 0) {
-        results.push({
-          type: ToolResultType.other,
-          data: {
-            mappings: Object.fromEntries(
-              localEntries.map(([idx, v]) => [idx, { mappings: v.rawMapping }])
-            ),
-            indices: localEntries.map(([idx]) => idx),
-          },
-        });
-      }
-
-      // Remote (CCS) indices: return flattened field lists
-      const remoteEntries = Object.entries(indexFields).filter(([, v]) => !v.rawMapping);
-      if (remoteEntries.length > 0) {
-        results.push({
-          type: ToolResultType.other,
-          data: {
-            fieldsByIndex: Object.fromEntries(
-              remoteEntries.map(([idx, v]) => [
+      if (raw) {
+        // Local indices: return full mapping tree for richer LLM context
+        const localEntries = Object.entries(indexFields).filter(([, v]) => v.rawMapping);
+        if (localEntries.length > 0) {
+          results.push(
+            otherResult({
+              mappings: Object.fromEntries(
+                localEntries.map(([idx, v]) => [idx, { mappings: v.rawMapping }])
+              ),
+              indices: localEntries.map(([idx]) => idx),
+            })
+          );
+        }
+        // Remote (CCS) indices: return flattened field lists
+        const remoteEntries = Object.entries(indexFields).filter(([, v]) => !v.rawMapping);
+        if (remoteEntries.length > 0) {
+          results.push(
+            otherResult({
+              indices: remoteEntries.map(([idx]) => idx),
+              fields_by_index: Object.fromEntries(
+                remoteEntries.map(([idx, v]) => [
+                  idx,
+                  { fields: v.fields.map(({ path, type }) => ({ path, type })) },
+                ])
+              ),
+            })
+          );
+        }
+      } else {
+        results.push(
+          otherResult({
+            indices: Object.entries(indexFields).map(([idx]) => idx),
+            fields_by_index: Object.fromEntries(
+              Object.entries(indexFields).map(([idx, v]) => [
                 idx,
-                { fields: v.fields.map(({ path, type }) => ({ path, type })) },
+                v.fields.map(formatField).join('\n'),
               ])
             ),
-            indices: remoteEntries.map(([idx]) => idx),
-          },
-        });
+          })
+        );
       }
 
       return { results };


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/13410

Change the format and perform other optimizations to reduce the overall token usage for mappings representation.

- Use a text format instead of XML which is **very** token consuming (this is the most impactful change)
- Only use sampling for field types it make sense to (text fields basically. Examples of date, boolean, vector fields aren't really useful)
- Add dynamic sampling count ( 3 samples when < 200 fields, 2 when < 1000 fields and disable sampling for > 1000) *this is a opinionated tradeoff*
- Reduce max length of sampling value from 100 to 80

Also update the `get_index_mappings` tool to change the default mapping representation to string too (and add a "raw" tool option to show the "full" mappings instead)

### Tests

**"Users" index** (10 fields index from our eval dataset with descriptions on each field)
Before: 822 tokens
After 261 tokens 
Reduction: **68%**

**Sample 1000 indices index** (with many empty fields -> less sampling data token)
Before: 14,271 tokens
After: 6,465 tokens
Reduction: **55%** (this is the "worse case" scenario)

### Example

Initial format


```
<target_resource name="users" type="index">
  <fields>
    <field path="created_at" type="date">
      <sample_values>
        <value>2023-05-20 05:18:33</value>
        <value>2024-03-16 05:55:33</value>
        <value>2024-10-04 04:10:16</value>
      </sample_values>
    </field>
    <field path="customer_id" type="keyword" description="Unique customer identifier from billing system.">
      <sample_values>
        <value>cus_5211e964cffe4212</value>
        <value>cus_858d0d15e7544bc4</value>
        <value>cus_9e4299401cf043f6</value>
      </sample_values>
    </field>
    <field path="email" type="keyword" description="User&apos;s unique email address.">
      <sample_values>
        <value>gabriella.ray@williams.com</value>
        <value>amanda.perry@clark.com</value>
        <value>brian.evans@williams.com</value>
      </sample_values>
    </field>
    <field path="first_name" type="text" description="User&apos;s first name.">
      <sample_values>
        <value>Daniel</value>
        <value>Elizabeth</value>
        <value>Mary</value>
      </sample_values>
    </field>
    <field path="id" type="keyword" description="Unique user identifier (UUID).">
      <sample_values>
        <value>69c6cd30-515f-40ee-ae04-8214ad3d3dea</value>
        <value>bd6b8584-4f90-4d9f-b4e7-af62a18aff1d</value>
        <value>bdcdccb0-ea35-4913-99f7-73f86123f8e1</value>
      </sample_values>
    </field>
    <field path="last_name" type="text" description="User&apos;s last name.">
      <sample_values>
        <value>Smith</value>
        <value>Wilson</value>
        <value>Jackson</value>
      </sample_values>
    </field>
    <field path="max_project_limit" type="integer" description="Maximum number of projects allowed for the user.">
      <sample_values>
        <value>100</value>
        <value>932</value>
        <value>569</value>
      </sample_values>
    </field>
    <field path="organization_id" type="keyword" description="Identifier for the user&apos;s organization.">
      <sample_values>
        <value>org_7640e850b00748dd</value>
        <value>org_4aa1b8785cef4d2e</value>
        <value>org_edabdbc4d17a453a</value>
      </sample_values>
    </field>
    <field path="updated_at" type="date">
      <sample_values>
        <value>2024-09-18 06:30:38</value>
        <value>2024-09-20 04:46:29</value>
        <value>2024-10-20 23:01:06</value>
      </sample_values>
    </field>
    <field path="zendesk_user_id" type="keyword" description="User&apos;s corresponding ID in Zendesk for support.">
      <sample_values>
        <value>61</value>
        <value>73</value>
        <value>90</value>
      </sample_values>
    </field>
  </fields>
</target_resource>
```


Final format

```
<target_resource name="users" type="index">
- created_at [date]
- customer_id [keyword] Unique customer identifier from billing system. (cus_650a9cc1548e4e4e, cus_2ccdb527d1744198...)
- email [keyword] User's unique email address. (lisa.wilson@williams.com, barbara.hoover@walker.com...)
- first_name [text] User's first name. (Daniel, Elizabeth...)
- id [keyword] Unique user identifier (UUID). (c62980df-7628-406c-be09-036134a06326, a30a353a-42fa-4251-9f45-d58f4211e61c...)
- last_name [text] User's last name. (Smith, Wilson...)
- max_project_limit [integer] Maximum number of projects allowed for the user.
- organization_id [keyword] Identifier for the user's organization. (org_9f502c09fbf24add, org_57cf9dfb28384fb0...)
- updated_at [date]
- zendesk_user_id [keyword] User's corresponding ID in Zendesk for support. (79, 75...)
</target_resource>
```