### PR TITLE
[Metrics] Cancel in-flight metrics requests on breakdown change

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/hooks/use_chart_layers_from_esql.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/chart/hooks/use_chart_layers_from_esql.ts
@@ -8,8 +8,8 @@
  */
 
 import type { LensBaseLayer, LensSeriesLayer } from '@kbn/lens-embeddable-utils';
-import useAsync from 'react-use/lib/useAsync';
-import { useMemo } from 'react';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { useEffect, useMemo } from 'react';
 import type { TimeRange } from '@kbn/data-plugin/common';
 import { getESQLQueryColumns } from '@kbn/esql-utils';
 import type { MetricUnit } from '../../../types';
@@ -44,21 +44,24 @@ export const useChartLayersFromEsql = ({
 }: ChartLayersFromEsqlProps): ChartLayersFromEsqlResult => {
   const queryInfo = useEsqlQueryInfo({ query });
 
-  const {
-    value: columns = [],
-    loading,
-    error,
-  } = useAsync(
-    () =>
+  const [{ value: columns = [], loading, error }, fetchColumns] = useAsyncFn(
+    (signal: AbortSignal) =>
       getESQLQueryColumns({
         esqlQuery: query,
         search: services.data.search.search,
-        signal: abortController?.signal,
+        signal,
         timeRange,
       }),
-
-    [query, services.data.search, abortController, timeRange]
+    [query, services.data.search, timeRange]
   );
+
+  useEffect(() => {
+    const localAbortController = new AbortController();
+    fetchColumns(localAbortController.signal);
+    return () => {
+      localAbortController.abort();
+    };
+  }, [fetchColumns, abortController]);
 
   const layers = useMemo<LensSeriesLayer[]>(() => {
     if (columns.length === 0) {

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_fetch_metrics_data.ts
@@ -53,12 +53,12 @@ export function useFetchMetricsData({
     [esql, selectedDimensions]
   );
 
-  const [{ value, error, loading }, executeFetch] =
-    useAsyncFn(async (): Promise<ParsedMetricsResult | null> => {
+  const [{ value, error, loading }, executeFetch] = useAsyncFn(
+    async (signal: AbortSignal): Promise<ParsedMetricsResult | null> => {
       const result = await executeEsqlQuery<MetricsESQLResponse>({
         esqlQuery: metricsInfoQuery,
         search: services.data.search.search,
-        signal: fetchParams.abortController?.signal,
+        signal,
         dataView: fetchParams.dataView,
         timeRange: fetchParams.timeRange,
         filters: fetchParams.filters ?? [],
@@ -76,22 +76,27 @@ export function useFetchMetricsData({
           a.name.localeCompare(b.name)
         ),
       };
-    }, [
+    },
+    [
       metricsInfoQuery,
       fetchParams.dataView,
       fetchParams.timeRange,
-      fetchParams.abortController,
       fetchParams.filters,
       fetchParams.esqlVariables,
       services.data.search.search,
       services.uiSettings,
-    ]);
+    ]
+  );
 
   useEffect(() => {
     if (!shouldFetch || !fetchParams.dataView) {
       return;
     }
-    executeFetch();
+    const abortController = new AbortController();
+    executeFetch(abortController.signal);
+    return () => {
+      abortController.abort();
+    };
   }, [
     shouldFetch,
     selectedDimensionNames,


### PR DESCRIPTION
## Summary

When changing or removing a breakdown dimension in the metrics experience, in-flight ES|QL requests were not being cancelled. The old requests would run to completion in the background even though their results were  no longer needed, wasting cluster resources and potentially causing stale data flashes.

Each hook now creates a local AbortController inside its useEffect, passes the signal to the search request, and aborts it in the cleanup function. 