### PR TITLE
[9.2] [Index Management] Announce bulk actions button when is availble or hidden (#257089)

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
@@ -317,8 +317,11 @@ export class IndexActionsContextMenu extends Component {
       isPopoverOpen: false,
       renderConfirmModal: false,
     });
-    func();
-    this.props.resetSelection && this.props.resetSelection();
+    Promise.resolve()
+      .then(() => func())
+      .finally(() => {
+        this.props.resetSelection && this.props.resetSelection();
+      });
   };
 
   closePopover = () => {
@@ -612,6 +615,9 @@ export class IndexActionsContextMenu extends Component {
           : null}
         <EuiPopover
           id="contextMenuIndices"
+          aria-label={i18n.translate('xpack.idxMgmt.indexActionsMenu.popoverAriaLabel', {
+            defaultMessage: 'Index actions menu',
+          })}
           button={button}
           isOpen={this.state.isPopoverOpen}
           closePopover={this.closePopover}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/index_table.js
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/index_table.js
@@ -18,6 +18,7 @@ import {
   EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLiveAnnouncer,
   EuiPageSection,
   EuiScreenReaderOnly,
   EuiSpacer,
@@ -198,6 +199,7 @@ export class IndexTable extends Component {
 
     this.state = {
       selectedIndicesMap: {},
+      selectionAnnouncement: '',
     };
   }
 
@@ -227,6 +229,35 @@ export class IndexTable extends Component {
     for (const toggleParam of toggleParams) {
       if (toggles.includes(toggleParam)) {
         toggleChanged(toggleParam, rest[toggleParam] === 'true');
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const hadSelectedItems = Object.keys(prevState.selectedIndicesMap).length > 0;
+    const hasSelectedItems = Object.keys(this.state.selectedIndicesMap).length > 0;
+
+    if (!hadSelectedItems && hasSelectedItems) {
+      const selectionAnnouncement = i18n.translate(
+        'xpack.idxMgmt.indexTable.bulkActionsAnnouncementVisible',
+        {
+          defaultMessage: 'Bulk actions menu is now available.',
+        }
+      );
+
+      if (this.state.selectionAnnouncement !== selectionAnnouncement) {
+        this.setState({ selectionAnnouncement });
+      }
+    } else if (hadSelectedItems && !hasSelectedItems) {
+      const selectionAnnouncement = i18n.translate(
+        'xpack.idxMgmt.indexTable.bulkActionsAnnouncementHidden',
+        {
+          defaultMessage: 'Bulk actions menu is now hidden.',
+        }
+      );
+
+      if (this.state.selectionAnnouncement !== selectionAnnouncement) {
+        this.setState({ selectionAnnouncement });
       }
     }
   }
@@ -563,7 +594,7 @@ export class IndexTable extends Component {
       }
     }
 
-    const { selectedIndicesMap } = this.state;
+    const { selectedIndicesMap, selectionAnnouncement } = this.state;
     const atLeastOneItemSelected = Object.keys(selectedIndicesMap).length > 0;
 
     return (
@@ -700,6 +731,8 @@ export class IndexTable extends Component {
               {this.renderFilterError()}
 
               <EuiSpacer size="m" />
+
+              <EuiLiveAnnouncer>{selectionAnnouncement}</EuiLiveAnnouncer>
 
               <div style={{ maxWidth: '100%', overflow: 'auto' }}>
                 <EuiTable data-test-subj="indexTable">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Index Management] Announce bulk actions button when is availble or hidden (#257089)](https://github.com/elastic/kibana/pull/257089)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-03-18T13:06:08Z","message":"[Index Management] Announce bulk actions button when is availble or hidden (#257089)\n\nPartially addresses https://github.com/elastic/kibana/issues/242849\n\n\n## Summary\nFixes screen-reader announcements for bulk-action button visibility in\nIndex Management. Now the button appearance is notified when clicking\nthe multi selection checkbox in the header of the table or a single row\ncheckbox.\nThis PR only addresses the button appearance announcement from the\nissue, the table notifications will be handle with this EUI change:\nhttps://github.com/elastic/eui/issues/9445\n\n\n### How to test\n\nUsing Safari + Voice over:\n  1. Open Index Management > Indices.\n  2. Keyboard to header checkbox, toggle select all / clear all.\n  3. Keyboard to row checkbox, select first row then deselect last row.\n4. Trigger a bulk action flow that clears selection (`resetSelection`\npath).\n- Expected announcements:\n  - “Bulk actions menu is now available.”\n  - “Bulk actions menu is now hidden.”\n- Keyboard-only checks:\n  - checkboxes remain keyboard operable\n  - focus remains sensible after toggles/actions\n<img width=\"919\" height=\"616\" alt=\"Screenshot 2026-03-11 at 12 03 35\"\nsrc=\"https://github.com/user-attachments/assets/720af1fe-5e1d-4666-bc20-f38b90e1fc36\"\n/>\n<img width=\"821\" height=\"628\" alt=\"Screenshot 2026-03-11 at 12 30 18\"\nsrc=\"https://github.com/user-attachments/assets/47528150-35ea-45d2-aa74-b22131d63afc\"\n/>\n\n<img width=\"862\" height=\"567\" alt=\"Screenshot 2026-03-11 at 12 03 50\"\nsrc=\"https://github.com/user-attachments/assets/d1e3051b-6684-48e5-8b92-778bafd6b85e\"\n/>\n\n\n\n\n## Summary by CodeRabbit\n\n## Release Notes\n\n* **Accessibility**\n* Enhanced screen reader notifications for bulk actions in index tables,\nproviding live announcements when the bulk actions menu becomes visible\nor hidden.\n\n","sha":"a6bff7f313cf632545ca0fa7ff81b3bf2595cfd3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Index Management","Team:Kibana Management","backport:all-open","v9.4.0","v9.3.2"],"title":"[Index Management] Announce bulk actions button when is availble or hidden","number":257089,"url":"https://github.com/elastic/kibana/pull/257089","mergeCommit":{"message":"[Index Management] Announce bulk actions button when is availble or hidden (#257089)\n\nPartially addresses https://github.com/elastic/kibana/issues/242849\n\n\n## Summary\nFixes screen-reader announcements for bulk-action button visibility in\nIndex Management. Now the button appearance is notified when clicking\nthe multi selection checkbox in the header of the table or a single row\ncheckbox.\nThis PR only addresses the button appearance announcement from the\nissue, the table notifications will be handle with this EUI change:\nhttps://github.com/elastic/eui/issues/9445\n\n\n### How to test\n\nUsing Safari + Voice over:\n  1. Open Index Management > Indices.\n  2. Keyboard to header checkbox, toggle select all / clear all.\n  3. Keyboard to row checkbox, select first row then deselect last row.\n4. Trigger a bulk action flow that clears selection (`resetSelection`\npath).\n- Expected announcements:\n  - “Bulk actions menu is now available.”\n  - “Bulk actions menu is now hidden.”\n- Keyboard-only checks:\n  - checkboxes remain keyboard operable\n  - focus remains sensible after toggles/actions\n<img width=\"919\" height=\"616\" alt=\"Screenshot 2026-03-11 at 12 03 35\"\nsrc=\"https://github.com/user-attachments/assets/720af1fe-5e1d-4666-bc20-f38b90e1fc36\"\n/>\n<img width=\"821\" height=\"628\" alt=\"Screenshot 2026-03-11 at 12 30 18\"\nsrc=\"https://github.com/user-attachments/assets/47528150-35ea-45d2-aa74-b22131d63afc\"\n/>\n\n<img width=\"862\" height=\"567\" alt=\"Screenshot 2026-03-11 at 12 03 50\"\nsrc=\"https://github.com/user-attachments/assets/d1e3051b-6684-48e5-8b92-778bafd6b85e\"\n/>\n\n\n\n\n## Summary by CodeRabbit\n\n## Release Notes\n\n* **Accessibility**\n* Enhanced screen reader notifications for bulk actions in index tables,\nproviding live announcements when the bulk actions menu becomes visible\nor hidden.\n\n","sha":"a6bff7f313cf632545ca0fa7ff81b3bf2595cfd3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257089","number":257089,"mergeCommit":{"message":"[Index Management] Announce bulk actions button when is availble or hidden (#257089)\n\nPartially addresses https://github.com/elastic/kibana/issues/242849\n\n\n## Summary\nFixes screen-reader announcements for bulk-action button visibility in\nIndex Management. Now the button appearance is notified when clicking\nthe multi selection checkbox in the header of the table or a single row\ncheckbox.\nThis PR only addresses the button appearance announcement from the\nissue, the table notifications will be handle with this EUI change:\nhttps://github.com/elastic/eui/issues/9445\n\n\n### How to test\n\nUsing Safari + Voice over:\n  1. Open Index Management > Indices.\n  2. Keyboard to header checkbox, toggle select all / clear all.\n  3. Keyboard to row checkbox, select first row then deselect last row.\n4. Trigger a bulk action flow that clears selection (`resetSelection`\npath).\n- Expected announcements:\n  - “Bulk actions menu is now available.”\n  - “Bulk actions menu is now hidden.”\n- Keyboard-only checks:\n  - checkboxes remain keyboard operable\n  - focus remains sensible after toggles/actions\n<img width=\"919\" height=\"616\" alt=\"Screenshot 2026-03-11 at 12 03 35\"\nsrc=\"https://github.com/user-attachments/assets/720af1fe-5e1d-4666-bc20-f38b90e1fc36\"\n/>\n<img width=\"821\" height=\"628\" alt=\"Screenshot 2026-03-11 at 12 30 18\"\nsrc=\"https://github.com/user-attachments/assets/47528150-35ea-45d2-aa74-b22131d63afc\"\n/>\n\n<img width=\"862\" height=\"567\" alt=\"Screenshot 2026-03-11 at 12 03 50\"\nsrc=\"https://github.com/user-attachments/assets/d1e3051b-6684-48e5-8b92-778bafd6b85e\"\n/>\n\n\n\n\n## Summary by CodeRabbit\n\n## Release Notes\n\n* **Accessibility**\n* Enhanced screen reader notifications for bulk actions in index tables,\nproviding live announcements when the bulk actions menu becomes visible\nor hidden.\n\n","sha":"a6bff7f313cf632545ca0fa7ff81b3bf2595cfd3"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258350","number":258350,"state":"MERGED","mergeCommit":{"sha":"2c9b22622838b1233426840352e9971f5398376f","message":"[9.3] [Index Management] Announce bulk actions button when is availble or hidden (#257089) (#258350)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Index Management] Announce bulk actions button when is availble or\nhidden (#257089)](https://github.com/elastic/kibana/pull/257089)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sonia Sanz Vivas <sonia.sanzvivas@elastic.co>"}}]}] BACKPORT-->