### PR TITLE
[Scout] Remove manifest generation command from `scout-create-scaffold` skill

### DIFF
--- a/.agents/skills/scout-create-scaffold/SKILL.md
+++ b/.agents/skills/scout-create-scaffold/SKILL.md
@@ -61,8 +61,6 @@ Notes:
 
 ## After Generating
 
-- Update `.meta` manifests when adding/moving configs or tests:
-  - `node scripts/scout.js update-test-config-manifests`
 - Custom server config sets:
   - If you create/use `test/scout_<configSet>`, you typically also need a matching server config under `src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/<configSet>`.
   - `start-server` requires `--serverConfigSet <configSet>` when using a custom server config set.


### PR DESCRIPTION
This PR removes removes the `node scripts/scout.js update-test-config-manifests` instruction from the `scout-create-scaffold` skill. The Kibana CI will already [take care](https://github.com/elastic/kibana/blob/main/.buildkite/scripts/steps/test/scout/test_run_builder.sh#L11) of updating the config manifest files for us, there's no need to do it locally.