### PR TITLE
[Osquery] Add eslint and type check commands to package json

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -6,6 +6,8 @@
   "license": "Elastic License 2.0",
   "scripts": {
     "test:jest": "node ../../../../../scripts/jest --config jest.config.js",
+    "test:eslint": "node ../../../../../scripts/eslint --fix x-pack/platform/plugins/shared/osquery",
+    "test:type_check": "node ../../../../../scripts/type_check --project x-pack/platform/plugins/shared/osquery/tsconfig.type_check.json",
     "cypress:burn": "yarn cypress:run --env burn=2 --headed",
     "cypress:changed-specs-only": "yarn cypress:run --changed-specs-only --env burn=2",
     "cypress": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/cli_config",

--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -6,8 +6,8 @@
   "license": "Elastic License 2.0",
   "scripts": {
     "test:jest": "node ../../../../../scripts/jest --config jest.config.js",
-    "test:eslint": "node ../../../../../scripts/eslint --fix x-pack/platform/plugins/shared/osquery",
-    "test:type_check": "node ../../../../../scripts/type_check --project x-pack/platform/plugins/shared/osquery/tsconfig.type_check.json",
+    "test:eslint": "node ../../../../../scripts/eslint --fix .",
+    "test:type_check": "node ../../../../../scripts/type_check --project tsconfig.type_check.json",
     "cypress:burn": "yarn cypress:run --env burn=2 --headed",
     "cypress:changed-specs-only": "yarn cypress:run --changed-specs-only --env burn=2",
     "cypress": "node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel --config-file ../../../x-pack/platform/plugins/shared/osquery/cypress/cypress.config.ts --ftr-config-file ../../../../../x-pack/solutions/security/test/osquery_cypress/cli_config",


### PR DESCRIPTION
## Summary

Add defined commands that run only in Osquery plugin scope