### PR TITLE
[Index Management ]Fix text field announcement in "Create Index" modal

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
@@ -94,12 +94,7 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
   };
 
   return (
-    <EuiModal
-      aria-labelledby={modalTitleId}
-      onClose={closeModal}
-      initialFocus="[name=indexName]"
-      css={{ width: 450 }}
-    >
+    <EuiModal aria-labelledby={modalTitleId} onClose={closeModal} css={{ width: 450 }}>
       <EuiModalHeader>
         <EuiModalHeaderTitle id={modalTitleId}>
           <FormattedMessage
@@ -143,6 +138,7 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
             <EuiFieldText
               isInvalid={indexNameError !== undefined}
               fullWidth
+              autoFocus
               name="indexName"
               value={indexName}
               onChange={(e) => onNameChange(e.target.value)}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242850

## Summary
Fix initial focus handling for the Index Management “Create index” modal so the “Index name” field receives focus in a way that VoiceOver/Safari can announce correctly on modal open.

### Test plan
- Manual (issue env): macOS Sequoia + Safari 18.5 + VoiceOver
  - Navigate to Index Management → Indices
  - Activate “Create index”
  - Verify VO announces the focused “Index name” field immediately on open
  - Verify Tab/Shift+Tab cycle and Escape close behavior remain correct
 
### Screenshot
<img width="1045" height="527" alt="Screenshot 2026-03-19 at 10 36 14" src="https://github.com/user-attachments/assets/5fbbdc73-6890-422f-bfcf-d30c15122bc5" />

**Before / After**
- Before: modal opens; DOM focus appears on “Index name”, but VoiceOver remains on the “Create index” button until the user moves focus away and back.
- After: modal opens and “Index name” field is focused via `autoFocus` (intended to align VO announcement with the focused input on initial open).
