### PR TITLE
[SLO] temp skip failing health scan api tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/health_scan.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/health_scan.ts
@@ -95,7 +95,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
   let transformHelper: TransformHelper;
 
-  describe('Health Scan', function () {
+  // Failing see https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/8735
+  describe.skip('Health Scan', function () {
     before(async () => {
       adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
       transformHelper = createTransformHelper(getService);

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/health_scan.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/slo/health_scan.ts
@@ -95,8 +95,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   let adminRoleAuthc: RoleCredentials;
   let transformHelper: TransformHelper;
 
-  // Failing see https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/8735
-  describe.skip('Health Scan', function () {
+  describe('Health Scan', function () {
+    // Failing see https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/8735
+    this.tags(['skipMKI']);
     before(async () => {
       adminRoleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('admin');
       transformHelper = createTransformHelper(getService);


### PR DESCRIPTION
Temporarily skip failing SLO health scan tests on MKI https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/8735

