### PR TITLE
[9.3] [Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources (#256470)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.test.ts
@@ -380,7 +380,7 @@ describe('lens suggestions api helpers', () => {
         ...mockAllSuggestions[0],
         datasourceState: {
           indexPatternRefs: [
-            { id: 'new-index-id', title: 'index2' },
+            { id: 'new-index-id', title: 'index2', timeField: '@timestamp' },
             { id: 'other-index-id', title: 'index3' },
           ],
         },
@@ -398,6 +398,7 @@ describe('lens suggestions api helpers', () => {
                 layer1: {
                   query: { esql: 'from index2 | limit 15' },
                   index: 'new-index-id',
+                  timeField: '@timestamp',
                 },
               },
             },
@@ -411,6 +412,55 @@ describe('lens suggestions api helpers', () => {
         suggestionWithIndexRefs
       );
       expect(newAttributes).toStrictEqual(expectedLensAttributes);
+    });
+
+    it('should clear timeField when switching to an index without a time field', async () => {
+      const newQuery = {
+        esql: 'from ecommerce_index | limit 15',
+      };
+
+      const lensAttributes = {
+        title: 'test',
+        visualizationType: 'testVis',
+        state: {
+          datasourceStates: {
+            textBased: {
+              layers: {
+                layer1: {
+                  query: { esql: 'from logs_index | limit 10' },
+                  index: 'old-index-id',
+                  timeField: '@timestamp',
+                },
+              },
+            },
+          },
+          visualization: { preferredSeriesType: 'line' },
+        },
+        filters: [],
+        query: {
+          esql: 'from logs_index | limit 10',
+        },
+        references: [],
+      } as unknown as TypedLensSerializedState['attributes'];
+
+      const suggestionWithNoTimeField = {
+        ...mockAllSuggestions[0],
+        datasourceState: {
+          indexPatternRefs: [{ id: 'ecommerce-id', title: 'ecommerce_index' }],
+        },
+      };
+
+      const newAttributes = injectESQLQueryIntoLensLayers(
+        lensAttributes,
+        newQuery,
+        suggestionWithNoTimeField
+      );
+      const layer = (
+        newAttributes.state.datasourceStates.textBased as {
+          layers: Record<string, { timeField?: string }>;
+        }
+      ).layers.layer1;
+      expect(layer.timeField).toBeUndefined();
     });
 
     it('should keep original index when no matching indexPatternRef is found', async () => {

--- a/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/lens_suggestions_api/helpers.ts
@@ -61,7 +61,7 @@ export const injectESQLQueryIntoLensLayers = (
 
   const datasourceState = structuredClone(attributes.state.datasourceStates[datasourceId]);
 
-  // Update each layer with the new query and index pattern if needed
+  // Update each layer with the new query, index pattern, and timeField
   if (datasourceState?.layers) {
     Object.values(datasourceState.layers).forEach((layer) => {
       if (!isEqual(layer.query, query)) {
@@ -70,8 +70,15 @@ export const injectESQLQueryIntoLensLayers = (
         if (index) {
           layer.index = index;
         }
+        if (indexPatternRef) {
+          layer.timeField = indexPatternRef.timeField;
+        }
       }
     });
+  }
+
+  if (indexPatternRef && datasourceHasIndexPatternRefs(datasourceState)) {
+    datasourceState.indexPatternRefs = [indexPatternRef];
   }
   return {
     ...attributes,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources (#256470)](https://github.com/elastic/kibana/pull/256470)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"andreana.malama@elastic.co"},"sourceCommit":{"committedDate":"2026-03-18T10:31:22Z","message":"[Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources (#256470)\n\n## Summary\n\nFix #256469\n\nThis PR fixes the dashboard time range not being correctly applied when\nswitching an ES|QL chart between data sources with different time\nfields. Previously, the `timeField` and `indexPatternRefs` in the Lens\ndatasource state were not updated during source switches, causing the\nstale time field from the previous source to persist.\n\nThis meant switching from a source without `@timestamp` to one with it\nwould never apply time filtering, and switching the other way would\nfilter on a non-existent field returning zero results.\n\n### Before: \n\n\n\nhttps://github.com/user-attachments/assets/19e257ae-f23b-48c6-b49a-1eaaaa41a408\n\n\n### After:\n\n\n\nhttps://github.com/user-attachments/assets/eac74abe-842d-4e4a-8318-78edd5781b8f\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"868bf2c5fe9cde0e5c34ca1f15219e2bf032b3e1","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.4.0","v9.3.3","v9.2.8"],"title":"[Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources","number":256470,"url":"https://github.com/elastic/kibana/pull/256470","mergeCommit":{"message":"[Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources (#256470)\n\n## Summary\n\nFix #256469\n\nThis PR fixes the dashboard time range not being correctly applied when\nswitching an ES|QL chart between data sources with different time\nfields. Previously, the `timeField` and `indexPatternRefs` in the Lens\ndatasource state were not updated during source switches, causing the\nstale time field from the previous source to persist.\n\nThis meant switching from a source without `@timestamp` to one with it\nwould never apply time filtering, and switching the other way would\nfilter on a non-existent field returning zero results.\n\n### Before: \n\n\n\nhttps://github.com/user-attachments/assets/19e257ae-f23b-48c6-b49a-1eaaaa41a408\n\n\n### After:\n\n\n\nhttps://github.com/user-attachments/assets/eac74abe-842d-4e4a-8318-78edd5781b8f\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"868bf2c5fe9cde0e5c34ca1f15219e2bf032b3e1"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256470","number":256470,"mergeCommit":{"message":"[Lens][ESQL] Fix ES|QL chart time field not updating when switching between data sources (#256470)\n\n## Summary\n\nFix #256469\n\nThis PR fixes the dashboard time range not being correctly applied when\nswitching an ES|QL chart between data sources with different time\nfields. Previously, the `timeField` and `indexPatternRefs` in the Lens\ndatasource state were not updated during source switches, causing the\nstale time field from the previous source to persist.\n\nThis meant switching from a source without `@timestamp` to one with it\nwould never apply time filtering, and switching the other way would\nfilter on a non-existent field returning zero results.\n\n### Before: \n\n\n\nhttps://github.com/user-attachments/assets/19e257ae-f23b-48c6-b49a-1eaaaa41a408\n\n\n### After:\n\n\n\nhttps://github.com/user-attachments/assets/eac74abe-842d-4e4a-8318-78edd5781b8f\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"868bf2c5fe9cde0e5c34ca1f15219e2bf032b3e1"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->