### PR TITLE
Fix  Differential flamegraph tooltip causes recursion issues that lead to page crash

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.test.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.test.ts
@@ -16,9 +16,11 @@ describe('asNumber', () => {
     expect(asNumber(0.001)).toBe('~0.00');
 
     expect(asNumber(0)).toBe('0');
+
+    expect(asNumber(12.34)).toBe('12.34');
   });
 
-  it('adds k/m/b where needed', () => {
+  it('adds k/m/b/t/q where needed', () => {
     expect(asNumber(999.999)).toBe('1k');
 
     expect(asNumber(4.5e5)).toBe('450k');
@@ -28,11 +30,40 @@ describe('asNumber', () => {
     expect(asNumber(2.4991e7)).toBe('24.99m');
 
     expect(asNumber(9e9)).toBe('9b');
+
+    expect(asNumber(1e12)).toBe('1t');
+
+    expect(asNumber(3.668e15)).toBe('3.67q');
+
+    expect(asNumber(9.9958e17)).toBe('999.58q');
   });
 
   it('handles non-finite values', () => {
     expect(asNumber(Infinity)).toBe(NOT_AVAILABLE_LABEL);
     expect(asNumber(-Infinity)).toBe(NOT_AVAILABLE_LABEL);
     expect(asNumber(NaN)).toBe(NOT_AVAILABLE_LABEL);
+  });
+
+  it('handles very large numbers without causing recursion errors', () => {
+    expect(() => asNumber(Number.MAX_VALUE)).not.toThrow();
+    expect(asNumber(1e18)).toBe(NOT_AVAILABLE_LABEL);
+    expect(asNumber(1e300)).toBe(NOT_AVAILABLE_LABEL);
+
+    expect(asNumber(Number.MAX_VALUE)).toBe(NOT_AVAILABLE_LABEL);
+  });
+
+  it('handles very small numbers', () => {
+    expect(asNumber(1e-10)).toBe('~0.00');
+    expect(asNumber(Number.MIN_VALUE)).toBe('~0.00');
+  });
+
+  it('handles negative numbers', () => {
+    expect(asNumber(-999)).toBe('-999');
+    expect(asNumber(-4.5e5)).toBe('-450k');
+    expect(asNumber(-2.4991e7)).toBe('-24.99m');
+    expect(asNumber(-9e9)).toBe('-9b');
+    expect(asNumber(-1e12)).toBe('-1t');
+    expect(asNumber(-3.668e15)).toBe('-3.67q');
+    expect(asNumber(-9.9958e17)).toBe('-999.58q');
   });
 });

--- a/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/utils/formatters/as_number.ts
@@ -6,6 +6,7 @@
  */
 
 import { NOT_AVAILABLE_LABEL } from '../../../common';
+const units = ['', 'k', 'm', 'b', 't', 'q'];
 
 export function asNumber(value: number): string {
   if (isNaN(value) || !Number.isFinite(value)) {
@@ -16,21 +17,25 @@ export function asNumber(value: number): string {
     return '0';
   }
 
+  // Round the value once to get the base precision
   value = Math.round(value * 100) / 100;
   if (Math.abs(value) < 0.01) {
     return '~0.00';
   }
-  if (Math.abs(value) < 1e3) {
-    return value.toString();
+
+  let unitIndex = 0;
+
+  while (unitIndex < units.length - 1 && Math.abs(value) >= 1e3) {
+    value = value / 1e3;
+    unitIndex += 1;
   }
 
-  if (Math.abs(value) < 1e6) {
-    return `${asNumber(value / 1e3)}k`;
+  if (unitIndex === units.length - 1 && Math.abs(value) >= 1e3) {
+    return NOT_AVAILABLE_LABEL;
   }
 
-  if (Math.abs(value) < 1e9) {
-    return `${asNumber(value / 1e6)}m`;
-  }
+  // Round after scaling to match the original recursive behavior
+  value = Math.round(value * 100) / 100;
 
-  return `${asNumber(value / 1e9)}b`;
+  return `${value.toString()}${units[unitIndex]}`;
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/256003

## Summary

- Partially fixed in this PR https://github.com/elastic/kibana/pull/249218
- Changed `asNumber` function to handle any number
- `asNumber` now support trillions and quadrillions without breaking format 
- Any number larger than `999.999q` will show as `N/A` instead of compounding letters (examples bellow)
- New unit tests for these scenarios


Note: The before and after doesn't show the page crashing because I wasn't able to do so even with a 10 year date range filter, not even hardcoding very large numbers like `4e300` and nothing broke.

### Before and After (failed tests are new, check only the outputs)


#### Before

<img width="708" height="226" alt="Before" src="https://github.com/user-attachments/assets/993214da-98df-481d-be61-40ac478bc8a6" />


#### After

<img width="697" height="201" alt="After" src="https://github.com/user-attachments/assets/38a619dc-f8b3-4270-a7c6-4468732359c0" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
