### PR TITLE
Fix `node scripts/backport.js`

### DIFF
--- a/scripts/backport.js
+++ b/scripts/backport.js
@@ -9,8 +9,14 @@
 
 require('@kbn/setup-node-env/node_version_validator');
 var process = require('process');
-var backport = require('backport');
 
-backport.backportRun({
-  processArgs: process.argv.slice(2), // forward command line args to backport
-});
+import('backport')
+  .then(function (backport) {
+    backport.backportRun({
+      processArgs: process.argv.slice(2), // forward command line args to backport
+    });
+  })
+  .catch(function (err) {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/258085 which updated `backport` tool to v11 which is a pure ESM module. This broke the backport script in Kibana so when running `node scripts/backport.js` it would throw an error.

This PR fixes that by importing using `import` instead of `require`