### PR TITLE
[SigEvents] Fix KI feature details flyout

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_features/feature_details_flyout.tsx
@@ -137,6 +137,11 @@ export function FeatureDetailsFlyout({
       ownFocus={false}
       size="40%"
       hideCloseButton
+      css={css`
+        // Temporary workaround for #253800 removing global push-flyout positioning.
+        // Remove once the platform team restores these rules.
+        top: var(--kbn-layout--application-top, 0px);
+      `}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>


### PR DESCRIPTION
## Summary

Temporary workaround for a regression introduced in #253800 ("[Flyout System] Support EuiFlyout container prop"), which removed global CSS positioning rules for right-positioned push flyouts.

After that change, `type="push"` flyouts no longer respect the Kibana header offset, causing them to render behind/over the top navigation bar.

This adds the `top` positioning back as a scoped CSS override on the Streams feature details flyout.

Before:
<img width="1512" height="829" alt="Screenshot 2026-03-19 at 12 39 43" src="https://github.com/user-attachments/assets/dc7de56b-5f2c-4be6-a933-06931af32ffd" />

After:
<img width="1510" height="828" alt="Screenshot 2026-03-19 at 12 39 31" src="https://github.com/user-attachments/assets/e97cfe5b-ce4b-436a-aa2c-eae256b6b8ba" />

