### PR TITLE
[DOCS] Adds security advisory to the 8.19.13 Kibana release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -125,6 +125,8 @@ include::upgrade-notes.asciidoc[]
 
 The 8.19.13 release includes the following fixes.
 
+IMPORTANT: This release contains fixes for potential security vulnerabilities. Check our link:https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+
 [float]
 [[fixes-v8.19.13]]
 === Fixes


### PR DESCRIPTION
## Summary

This PR adds a security advisory to the 8.19.13 Kibana release notes.


