### PR TITLE
Fix ScopedHistory instance has fell out of navigation scope

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -232,6 +232,15 @@ export class Plugin
     this.telemetry = new TelemetryService();
   }
 
+  private canUseHistory = (history: AppMountParameters<unknown>['history']) => {
+    try {
+      history.createHref(history.location, { prependBasePath: false });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   public setup(
     coreSetup: CoreSetup<ObservabilityPublicPluginsStart, ObservabilityPublicStart>,
     pluginsSetup: ObservabilityPublicPluginsSetup
@@ -300,6 +309,10 @@ export class Plugin
 
       const { renderApp } = await import('./application');
       const { ruleTypeRegistry, actionTypeRegistry } = pluginsStart.triggersActionsUi;
+
+      if (!this.canUseHistory(params.history)) {
+        return () => {};
+      }
 
       return renderApp({
         appMountParameters: params,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/256453

## Summary

When navigating from one page to another very fast causes trouble to our mounting/unmounting logic, these changes aims to prevent an error when navigating too fast between observability pages.

### Before & After
Note: to replicate this in an easier way, I added an artificial delay to the mount so this can more easily be replicated and viewed



#### Before


https://github.com/user-attachments/assets/6a39c049-6159-4c3d-96c7-7aac75c22c5e




#### After


https://github.com/user-attachments/assets/c2839145-90bf-4ed8-a541-1ffceef81ef1




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->