### PR TITLE
[WIP][PoC][APM] Dynamic dashboards as code in the metrics tab

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/dashboard_catalog.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/dashboard_catalog.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LanguageDashboard } from '../types';
+import { getJavaPanels } from './panels/java';
+
+export const languageDashboards: Record<string, LanguageDashboard> = {
+  java: getJavaPanels,
+};

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/index.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/index.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getLanguageDashboard } from '.';
+
+describe('getLanguageDashboard', () => {
+  it('returns Java dashboard for java agent', () => {
+    expect(getLanguageDashboard('java')).toBeDefined();
+  });
+
+  it('returns Java dashboard for OTel java agent', () => {
+    expect(getLanguageDashboard('opentelemetry/java/elastic')).toBeDefined();
+  });
+
+  it('returns Java dashboard for vanilla OTel java', () => {
+    expect(getLanguageDashboard('opentelemetry/java')).toBeDefined();
+  });
+
+  it('returns undefined for unknown agent', () => {
+    expect(getLanguageDashboard('my-custom-agent')).toBeUndefined();
+  });
+
+  it('returns undefined when agentName is undefined', () => {
+    expect(getLanguageDashboard(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for nodejs (not yet implemented)', () => {
+    expect(getLanguageDashboard('nodejs')).toBeUndefined();
+  });
+
+  it('returns panel slots when called with an index pattern', () => {
+    const dashboardFn = getLanguageDashboard('java');
+    const slots = dashboardFn!('metrics-*');
+    expect(slots.length).toBeGreaterThan(0);
+    expect(slots[0]).toHaveProperty('id');
+    expect(slots[0]).toHaveProperty('title');
+    expect(slots[0]).toHaveProperty('gridConfig');
+    expect(slots[0]).toHaveProperty('variants');
+    expect(slots[0].variants.length).toBeGreaterThan(0);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getSdkNameAndLanguage } from '@kbn/elastic-agent-utils';
+import type { LanguageDashboard } from '../types';
+import { languageDashboards } from './dashboard_catalog';
+
+export const getLanguageDashboard = (agentName?: string): LanguageDashboard | undefined => {
+  if (!agentName) {
+    return undefined;
+  }
+
+  const { language } = getSdkNameAndLanguage(agentName);
+  if (!language) {
+    return undefined;
+  }
+
+  return languageDashboards[language.toLowerCase()];
+};

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/panels/java/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/dashboards/panels/java/index.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PanelSlot } from '../../../types';
+
+const ESQL_LAYER_DEFAULTS = {
+  ignore_global_filters: false,
+  sampling: 1,
+} as const;
+
+const cpuUsagePanel = (indexPattern: string): PanelSlot => ({
+  id: 'cpu-usage',
+  title: 'CPU Usage',
+  gridConfig: { x: 0, y: 0, w: 24, h: 15 },
+  variants: [
+    {
+      id: 'semconv',
+      requiredFields: ['jvm.cpu.recent_utilization'],
+      config: {
+        type: 'xy',
+        title: 'CPU Usage',
+        layers: [
+          {
+            ...ESQL_LAYER_DEFAULTS,
+            type: 'line',
+            dataset: {
+              type: 'esql' as const,
+              query: `FROM ${indexPattern}
+  | STATS process_cpu_avg = AVG(jvm.cpu.recent_utilization),
+          process_cpu_max = MAX(jvm.cpu.recent_utilization)
+          BY service.instance.id, @timestamp = BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+  | STATS process_cpu_avg = AVG(process_cpu_avg),
+          process_cpu_max = AVG(process_cpu_max)
+          BY @timestamp
+  | RENAME process_cpu_avg AS \`Process avg\`,
+           process_cpu_max AS \`Process max\``,
+            },
+            y: [
+              { operation: 'value' as const, column: 'Process avg' },
+              { operation: 'value' as const, column: 'Process max' },
+            ],
+            x: { operation: 'value' as const, column: '@timestamp' },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+const memoryUsagePanel = (indexPattern: string): PanelSlot => ({
+  id: 'memory-usage',
+  title: 'Memory Usage',
+  gridConfig: { x: 24, y: 0, w: 24, h: 15 },
+  variants: [
+    {
+      id: 'semconv',
+      requiredFields: ['jvm.memory.used', 'jvm.memory.type'],
+      config: {
+        type: 'xy',
+        title: 'Memory Usage',
+        layers: [
+          {
+            ...ESQL_LAYER_DEFAULTS,
+            type: 'area',
+            dataset: {
+              type: 'esql' as const,
+              query: `FROM ${indexPattern}
+  | WHERE jvm.memory.used::long IS NOT NULL OR jvm.memory.limit IS NOT NULL
+  | EVAL heap_used = CASE(jvm.memory.type == "heap", jvm.memory.used::long, NULL),
+         off_heap_used = CASE(jvm.memory.type == "non_heap", jvm.memory.used::long, NULL)
+  | STATS heap_used = AVG(heap_used),
+          off_heap_used = AVG(off_heap_used)
+          BY service.instance.id, jvm.memory.pool.name, @timestamp = BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+  | STATS off_heap_used = AVG(off_heap_used),
+          heap_used = AVG(heap_used)
+          BY jvm.memory.pool.name, @timestamp
+  | RENAME off_heap_used AS \`Non Heap\`, heap_used AS \`Heap\``,
+            },
+            y: [
+              { operation: 'value' as const, column: 'Heap' },
+              { operation: 'value' as const, column: 'Non Heap' },
+            ],
+            x: { operation: 'value' as const, column: '@timestamp' },
+            breakdown_by: { operation: 'value' as const, column: 'jvm.memory.pool.name' },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+const threadCountPanel = (indexPattern: string): PanelSlot => ({
+  id: 'thread-count',
+  title: 'Thread Count',
+  gridConfig: { x: 0, y: 15, w: 24, h: 15 },
+  variants: [
+    {
+      id: 'semconv',
+      requiredFields: ['jvm.thread.count'],
+      config: {
+        type: 'xy',
+        title: 'Thread Count',
+        layers: [
+          {
+            ...ESQL_LAYER_DEFAULTS,
+            type: 'area',
+            dataset: {
+              type: 'esql' as const,
+              query: `FROM ${indexPattern}
+  | WHERE jvm.thread.count IS NOT NULL
+  | STATS thread_count = AVG(jvm.thread.count)
+          BY service.instance.id, jvm.thread.state, jvm.thread.daemon, @timestamp = BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+  | STATS thread_count = SUM(thread_count) BY service.instance.id, jvm.thread.state, @timestamp
+  | STATS thread_count = AVG(thread_count) BY jvm.thread.state, @timestamp
+  | RENAME thread_count AS \`Thread Count\``,
+            },
+            y: [{ operation: 'value' as const, column: 'Thread Count' }],
+            x: { operation: 'value' as const, column: '@timestamp' },
+            breakdown_by: { operation: 'value' as const, column: 'jvm.thread.state' },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+const memoryUsageRelativePanel = (indexPattern: string): PanelSlot => ({
+  id: 'memory-usage-relative',
+  title: 'Memory Usage (% of limit)',
+  gridConfig: { x: 24, y: 15, w: 24, h: 15 },
+  variants: [
+    {
+      id: 'semconv',
+      requiredFields: ['jvm.memory.used', 'jvm.memory.limit', 'jvm.memory.type'],
+      config: {
+        type: 'xy',
+        title: 'Memory Usage (% of limit)',
+        layers: [
+          {
+            ...ESQL_LAYER_DEFAULTS,
+            type: 'area',
+            dataset: {
+              type: 'esql' as const,
+              query: `FROM ${indexPattern}
+  | WHERE jvm.memory.used::long IS NOT NULL OR jvm.memory.limit IS NOT NULL
+  | EVAL heap_used = CASE(jvm.memory.type == "heap", jvm.memory.used::long, NULL),
+         off_heap_used = CASE(jvm.memory.type == "non_heap", jvm.memory.used::long, NULL),
+         heap_limit = CASE(jvm.memory.type == "heap", jvm.memory.limit, NULL),
+         off_heap_limit = CASE(jvm.memory.type == "non_heap", jvm.memory.limit, NULL)
+  | STATS heap_used = AVG(heap_used),
+          off_heap_used = AVG(off_heap_used),
+          heap_limit = AVG(heap_limit),
+          off_heap_limit = AVG(off_heap_limit)
+          BY service.instance.id, jvm.memory.pool.name, @timestamp = BUCKET(@timestamp, 100, ?_tstart, ?_tend)
+  | STATS off_heap_used_rel = AVG(off_heap_used / off_heap_limit),
+          heap_used_rel = AVG(heap_used / heap_limit)
+          BY jvm.memory.pool.name, @timestamp
+  | RENAME off_heap_used_rel AS \`Non Heap\`, heap_used_rel AS \`Heap\``,
+            },
+            y: [
+              { operation: 'value' as const, column: 'Heap' },
+              { operation: 'value' as const, column: 'Non Heap' },
+            ],
+            x: { operation: 'value' as const, column: '@timestamp' },
+            breakdown_by: { operation: 'value' as const, column: 'jvm.memory.pool.name' },
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const getJavaPanels = (indexPattern: string): PanelSlot[] => [
+  cpuUsagePanel(indexPattern),
+  memoryUsagePanel(indexPattern),
+  threadCountPanel(indexPattern),
+  memoryUsageRelativePanel(indexPattern),
+];

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/index.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useEffect, useMemo } from 'react';
+import type { DashboardApi, DashboardCreationOptions } from '@kbn/dashboard-plugin/public';
+import { DashboardRenderer } from '@kbn/dashboard-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { Filter } from '@kbn/es-query';
+import { buildPhraseFilter, buildExistsFilter } from '@kbn/es-query';
+import { LensConfigBuilder } from '@kbn/lens-embeddable-utils/config_builder';
+import { lensApiStateSchema } from '@kbn/lens-embeddable-utils/config_builder/schema';
+import type { DataViewsContract } from '@kbn/data-views-plugin/public';
+import { OPTIONS_LIST_CONTROL } from '@kbn/controls-constants';
+import {
+  ENVIRONMENT_ALL,
+  ENVIRONMENT_NOT_DEFINED,
+} from '../../../../../common/environment_filter_values';
+import { useApmServiceContext } from '../../../../context/apm_service/use_apm_service_context';
+import { useApmParams } from '../../../../hooks/use_apm_params';
+import type { PanelDefinition } from './types';
+
+export function DynamicDashboard({
+  panels,
+  dataView,
+  dataViewsService,
+}: {
+  panels: PanelDefinition[];
+  dataView: DataView;
+  dataViewsService: DataViewsContract;
+}) {
+  const [dashboard, setDashboard] = useState<DashboardApi | undefined>(undefined);
+  const {
+    query: { environment, kuery, rangeFrom, rangeTo },
+  } = useApmParams('/services/{serviceName}/metrics');
+
+  const { serviceName } = useApmServiceContext();
+
+  useEffect(() => {
+    if (!dashboard) return;
+    dashboard.setTimeRange({ from: rangeFrom, to: rangeTo });
+    dashboard.setQuery({ query: kuery, language: 'kuery' });
+  }, [kuery, dashboard, rangeFrom, rangeTo]);
+
+  useEffect(() => {
+    if (!dashboard) return;
+    dashboard.setFilters(getFilters(serviceName, environment, dataView));
+  }, [dataView, serviceName, environment, dashboard]);
+
+  const dashboardPanels = useMemo(() => {
+    const builder = new LensConfigBuilder(dataViewsService);
+    return panels.map((panel) => {
+      const validatedConfig = lensApiStateSchema.validate(panel.config);
+      const attributes = builder.fromAPIFormat(validatedConfig);
+      return {
+        type: 'lens',
+        grid: {
+          ...panel.gridConfig,
+          i: panel.id,
+        },
+        uid: panel.id,
+        config: {
+          attributes,
+          title: panel.title,
+        },
+      };
+    });
+  }, [panels, dataViewsService]);
+
+  const getCreationOptions = useMemo((): (() => Promise<DashboardCreationOptions>) => {
+    return async () => ({
+      useControlsIntegration: true,
+      getInitialInput: () => ({
+        viewMode: 'view' as const,
+        panels: dashboardPanels,
+        pinned_panels: [
+          {
+            type: OPTIONS_LIST_CONTROL,
+            config: {
+              data_view_id: dataView.id ?? '',
+              title: 'Node name',
+              field_name: 'service.node.name',
+            },
+            width: 'medium',
+            grow: true,
+          },
+        ],
+      }),
+    });
+  }, [dashboardPanels, dataView.id]);
+
+  if (dashboardPanels.length === 0) {
+    return null;
+  }
+
+  return (
+    <DashboardRenderer getCreationOptions={getCreationOptions} onApiAvailable={setDashboard} />
+  );
+}
+
+function getFilters(serviceName: string, environment: string, dataView: DataView): Filter[] {
+  const filters: Filter[] = [];
+
+  const serviceNameField = dataView.getFieldByName('service.name');
+  if (serviceNameField) {
+    filters.push(buildPhraseFilter(serviceNameField, serviceName, dataView));
+  }
+
+  const environmentField = dataView.getFieldByName('service.environment');
+  if (environmentField && environment && environment !== ENVIRONMENT_ALL.value) {
+    if (environment === ENVIRONMENT_NOT_DEFINED.value) {
+      const envExistsFilter = buildExistsFilter(environmentField, dataView);
+      envExistsFilter.meta.negate = true;
+      filters.push(envExistsFilter);
+    } else {
+      filters.push(buildPhraseFilter(environmentField, environment, dataView));
+    }
+  }
+
+  return filters;
+}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/resolve_variants.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/resolve_variants.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { PanelSlot } from './types';
+import { checkFieldExistence, resolveVariants } from './use_resolved_panels';
+
+const makePanelSlot = (overrides: Partial<PanelSlot> = {}): PanelSlot => ({
+  id: 'test-panel',
+  title: 'Test Panel',
+  gridConfig: { x: 0, y: 0, w: 24, h: 15 },
+  variants: [],
+  ...overrides,
+});
+
+describe('variant resolution', () => {
+  describe('field existence filtering', () => {
+    it('keeps variants whose required fields exist in the data view', () => {
+      const dataView = {
+        getFieldByName: (name: string) => {
+          const fields: Record<string, object> = {
+            'jvm.cpu.recent_utilization': { name: 'jvm.cpu.recent_utilization' },
+          };
+          return fields[name];
+        },
+      } as unknown as DataView;
+
+      const slot = makePanelSlot({
+        variants: [
+          {
+            id: 'semconv',
+            requiredFields: ['jvm.cpu.recent_utilization'],
+            config: { type: 'xy' } as any,
+          },
+          {
+            id: 'ecs',
+            requiredFields: ['system.process.cpu.total.norm.pct'],
+            config: { type: 'xy' } as any,
+          },
+        ],
+      });
+
+      const result = checkFieldExistence([slot], dataView);
+      expect(result).toHaveLength(1);
+      expect(result[0].variants).toHaveLength(1);
+      expect(result[0].variants[0].id).toBe('semconv');
+    });
+
+    it('removes slots with no surviving variants', () => {
+      const dataView = {
+        getFieldByName: () => undefined,
+      } as unknown as DataView;
+
+      const slot = makePanelSlot({
+        variants: [
+          {
+            id: 'semconv',
+            requiredFields: ['nonexistent.field'],
+            config: { type: 'xy' } as any,
+          },
+        ],
+      });
+
+      const result = checkFieldExistence([slot], dataView);
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps variants that require multiple fields when all exist', () => {
+      const dataView = {
+        getFieldByName: (name: string) => {
+          const fields: Record<string, object> = {
+            'jvm.memory.used': { name: 'jvm.memory.used' },
+            'jvm.memory.type': { name: 'jvm.memory.type' },
+          };
+          return fields[name];
+        },
+      } as unknown as DataView;
+
+      const slot = makePanelSlot({
+        variants: [
+          {
+            id: 'semconv',
+            requiredFields: ['jvm.memory.used', 'jvm.memory.type'],
+            config: { type: 'xy' } as any,
+          },
+        ],
+      });
+
+      const result = checkFieldExistence([slot], dataView);
+      expect(result).toHaveLength(1);
+      expect(result[0].variants[0].id).toBe('semconv');
+    });
+  });
+
+  describe('variant selection', () => {
+    it('selects first variant whose fields all have data', () => {
+      const slots: PanelSlot[] = [
+        makePanelSlot({
+          id: 'cpu',
+          variants: [
+            {
+              id: 'semconv',
+              requiredFields: ['jvm.cpu.recent_utilization'],
+              config: { type: 'xy' } as any,
+            },
+            {
+              id: 'ecs',
+              requiredFields: ['system.process.cpu.total.norm.pct'],
+              config: { type: 'xy' } as any,
+            },
+          ],
+        }),
+      ];
+
+      const result = resolveVariants(slots, {
+        'jvm.cpu.recent_utilization': true,
+        'system.process.cpu.total.norm.pct': true,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].variantId).toBe('semconv');
+    });
+
+    it('falls back to second variant when first has no data', () => {
+      const slots: PanelSlot[] = [
+        makePanelSlot({
+          id: 'cpu',
+          variants: [
+            {
+              id: 'semconv',
+              requiredFields: ['jvm.cpu.recent_utilization'],
+              config: { type: 'xy' } as any,
+            },
+            {
+              id: 'ecs',
+              requiredFields: ['system.process.cpu.total.norm.pct'],
+              config: { type: 'xy' } as any,
+            },
+          ],
+        }),
+      ];
+
+      const result = resolveVariants(slots, {
+        'jvm.cpu.recent_utilization': false,
+        'system.process.cpu.total.norm.pct': true,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].variantId).toBe('ecs');
+    });
+
+    it('skips slot when no variant has data', () => {
+      const slots: PanelSlot[] = [
+        makePanelSlot({
+          id: 'cpu',
+          variants: [
+            {
+              id: 'semconv',
+              requiredFields: ['jvm.cpu.recent_utilization'],
+              config: { type: 'xy' } as any,
+            },
+          ],
+        }),
+      ];
+
+      const result = resolveVariants(slots, {
+        'jvm.cpu.recent_utilization': false,
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('resolves multiple slots independently', () => {
+      const slots: PanelSlot[] = [
+        makePanelSlot({
+          id: 'cpu',
+          variants: [
+            {
+              id: 'semconv',
+              requiredFields: ['jvm.cpu.recent_utilization'],
+              config: { type: 'xy' } as any,
+            },
+          ],
+        }),
+        makePanelSlot({
+          id: 'memory',
+          variants: [
+            {
+              id: 'semconv',
+              requiredFields: ['jvm.memory.used'],
+              config: { type: 'xy' } as any,
+            },
+          ],
+        }),
+      ];
+
+      const result = resolveVariants(slots, {
+        'jvm.cpu.recent_utilization': true,
+        'jvm.memory.used': false,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('cpu');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/types.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensApiState } from '@kbn/lens-embeddable-utils/config_builder/schema';
+
+export interface PanelVariant {
+  id: string;
+  requiredFields: string[];
+  config: LensApiState;
+}
+
+export interface PanelSlot {
+  id: string;
+  title: string;
+  gridConfig: { x: number; y: number; w: number; h: number };
+  variants: PanelVariant[];
+}
+
+export interface PanelDefinition {
+  id: string;
+  title: string;
+  gridConfig: { x: number; y: number; w: number; h: number };
+  variantId: string;
+  config: LensApiState;
+}
+
+export type LanguageDashboard = (indexPattern: string) => PanelSlot[];

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/use_resolved_panels.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/dynamic_dashboard/use_resolved_panels.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { FETCH_STATUS, useFetcher } from '../../../../hooks/use_fetcher';
+import type { PanelDefinition, PanelSlot } from './types';
+import { getLanguageDashboard } from './dashboards';
+
+export function checkFieldExistence(slots: PanelSlot[], dataView: DataView): PanelSlot[] {
+  return slots
+    .map((slot) => ({
+      ...slot,
+      variants: slot.variants.filter((variant) =>
+        variant.requiredFields.every((field) => dataView.getFieldByName(field) !== undefined)
+      ),
+    }))
+    .filter((slot) => slot.variants.length > 0);
+}
+
+function collectRequiredFields(slots: PanelSlot[]): string[] {
+  const fields = new Set<string>();
+  for (const slot of slots) {
+    for (const variant of slot.variants) {
+      for (const field of variant.requiredFields) {
+        fields.add(field);
+      }
+    }
+  }
+  return Array.from(fields);
+}
+
+export function resolveVariants(
+  slots: PanelSlot[],
+  fieldAvailability: Record<string, boolean>
+): PanelDefinition[] {
+  const resolved: PanelDefinition[] = [];
+
+  for (const slot of slots) {
+    for (const variant of slot.variants) {
+      const allFieldsAvailable = variant.requiredFields.every(
+        (field) => fieldAvailability[field] === true
+      );
+
+      if (allFieldsAvailable) {
+        resolved.push({
+          id: slot.id,
+          title: slot.title,
+          gridConfig: slot.gridConfig,
+          variantId: variant.id,
+          config: variant.config,
+        });
+        break;
+      }
+    }
+  }
+
+  return resolved;
+}
+
+export const useResolvedPanels = ({
+  agentName,
+  dataView,
+  serviceName,
+  indexPattern,
+}: {
+  agentName?: string;
+  dataView?: DataView;
+  serviceName: string;
+  indexPattern?: string;
+}) => {
+  const dashboardFn = getLanguageDashboard(agentName);
+
+  const slots = useMemo(() => {
+    if (!dashboardFn || !indexPattern) {
+      return [];
+    }
+    return dashboardFn(indexPattern);
+  }, [dashboardFn, indexPattern]);
+
+  const filteredSlots = useMemo(() => {
+    if (!dataView || slots.length === 0) {
+      return [];
+    }
+    return checkFieldExistence(slots, dataView);
+  }, [slots, dataView]);
+
+  const fieldsToProbe = useMemo(() => collectRequiredFields(filteredSlots), [filteredSlots]);
+
+  const { data, status } = useFetcher(
+    (callApmApi) => {
+      if (fieldsToProbe.length === 0 || !serviceName) {
+        return Promise.resolve({ fieldAvailability: {} });
+      }
+
+      return callApmApi('POST /internal/apm/services/{serviceName}/metrics/has_fields', {
+        params: {
+          path: { serviceName },
+          body: { fields: fieldsToProbe },
+        },
+      });
+    },
+    [fieldsToProbe, serviceName],
+    { preservePreviousData: false, skipTimeRangeRefreshUpdate: true }
+  );
+
+  const panels = useMemo(() => {
+    if (!data?.fieldAvailability || filteredSlots.length === 0) {
+      return [];
+    }
+    return resolveVariants(filteredSlots, data.fieldAvailability);
+  }, [data?.fieldAvailability, filteredSlots]);
+
+  return {
+    panels,
+    hasDashboard: !!dashboardFn,
+    status,
+    isLoading: status === FETCH_STATUS.LOADING || status === FETCH_STATUS.NOT_INITIATED,
+  };
+};

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { isElasticAgentName, isJRubyAgentName } from '@kbn/elastic-agent-utils/src/agent_guards';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiCallOut, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isAWSLambdaAgentName } from '../../../../common/agent_name';
+import type { ApmPluginStartDeps } from '../../../plugin';
 import { useApmServiceContext } from '../../../context/apm_service/use_apm_service_context';
 import { ServerlessMetrics } from './serverless_metrics';
 import { ServiceMetrics } from './service_metrics';
@@ -17,20 +19,56 @@ import { JsonMetricsDashboard } from './static_dashboard';
 import { hasDashboard } from './static_dashboard/helper';
 import { useAdHocApmDataView } from '../../../hooks/use_adhoc_apm_data_view';
 import { JvmMetricsOverview } from './jvm_metrics_overview';
+import { DynamicDashboard } from './dynamic_dashboard';
+import { useResolvedPanels } from './dynamic_dashboard/use_resolved_panels';
 
 export function Metrics() {
-  const { agentName, runtimeName, serverlessType, telemetrySdkName, telemetrySdkLanguage } =
-    useApmServiceContext();
+  const { services } = useKibana<ApmPluginStartDeps>();
+  const {
+    agentName,
+    runtimeName,
+    serverlessType,
+    serviceName,
+    telemetrySdkName,
+    telemetrySdkLanguage,
+  } = useApmServiceContext();
   const isAWSLambda = isAWSLambdaAgentName(serverlessType);
   const { dataView, apmIndices } = useAdHocApmDataView();
 
   const hasDashboardFile = hasDashboard({ agentName, telemetrySdkName, telemetrySdkLanguage });
 
+  const {
+    panels: dynamicPanels,
+    hasDashboard: hasDynamicDashboard,
+    isLoading: isDynamicLoading,
+  } = useResolvedPanels({
+    agentName,
+    dataView,
+    serviceName,
+    indexPattern: dataView?.getIndexPattern?.(),
+  });
+
   if (isAWSLambda) {
     return <ServerlessMetrics />;
   }
 
-  if (!hasDashboardFile && !isElasticAgentName(agentName ?? '')) {
+  if (hasDynamicDashboard && dataView && services.dataViews) {
+    if (isDynamicLoading) {
+      return <EuiLoadingSpinner size="l" />;
+    }
+
+    if (dynamicPanels.length > 0) {
+      return (
+        <DynamicDashboard
+          panels={dynamicPanels}
+          dataView={dataView}
+          dataViewsService={services.dataViews}
+        />
+      );
+    }
+  }
+
+  if (!hasDashboardFile && !hasDynamicDashboard && !isElasticAgentName(agentName ?? '')) {
     return (
       <EuiCallOut
         announceOnMount

--- a/x-pack/solutions/observability/plugins/apm/server/routes/metrics/has_fields.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/metrics/has_fields.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { SERVICE_NAME } from '../../../common/es_fields/apm';
+import type { APMEventClient } from '../../lib/helpers/create_es_client/create_apm_event_client';
+
+export async function hasFields({
+  apmEventClient,
+  serviceName,
+  fields,
+}: {
+  apmEventClient: APMEventClient;
+  serviceName: string;
+  fields: string[];
+}): Promise<Record<string, boolean>> {
+  if (fields.length === 0) {
+    return {};
+  }
+
+  const aggs = Object.fromEntries(
+    fields.map((field) => [field, { filter: { exists: { field } } }])
+  );
+
+  const params = {
+    apm: {
+      events: [ProcessorEvent.metric],
+    },
+    track_total_hits: false,
+    size: 0,
+    query: {
+      bool: {
+        filter: [{ term: { [SERVICE_NAME]: serviceName } }],
+      },
+    },
+    aggs,
+  };
+
+  const response = await apmEventClient.search('has_fields_probe', params);
+
+  return Object.fromEntries(
+    fields.map((field) => {
+      const agg = response.aggregations?.[field] as { doc_count: number } | undefined;
+      return [field, (agg?.doc_count ?? 0) > 0];
+    })
+  );
+}

--- a/x-pack/solutions/observability/plugins/apm/server/routes/metrics/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/metrics/route.ts
@@ -13,6 +13,7 @@ import type { FetchAndTransformMetrics } from './fetch_and_transform_metrics';
 import { getMetricsChartDataByAgent } from './get_metrics_chart_data_by_agent';
 import type { ServiceNodesResponse } from './get_service_nodes';
 import { getServiceNodes } from './get_service_nodes';
+import { hasFields } from './has_fields';
 import { metricsServerlessRouteRepository } from './serverless/route';
 
 const metricsChartsRoute = createApmServerRoute({
@@ -87,8 +88,35 @@ const serviceMetricsJvm = createApmServerRoute({
   },
 });
 
+const metricsHasFieldsRoute = createApmServerRoute({
+  endpoint: 'POST /internal/apm/services/{serviceName}/metrics/has_fields',
+  params: t.type({
+    path: t.type({
+      serviceName: t.string,
+    }),
+    body: t.type({
+      fields: t.array(t.string),
+    }),
+  }),
+  security: { authz: { requiredPrivileges: ['apm'] } },
+  handler: async (resources): Promise<{ fieldAvailability: Record<string, boolean> }> => {
+    const apmEventClient = await getApmEventClient(resources);
+    const { serviceName } = resources.params.path;
+    const { fields } = resources.params.body;
+
+    const fieldAvailability = await hasFields({
+      apmEventClient,
+      serviceName,
+      fields,
+    });
+
+    return { fieldAvailability };
+  },
+});
+
 export const metricsRouteRepository = {
   ...metricsChartsRoute,
   ...serviceMetricsJvm,
+  ...metricsHasFieldsRoute,
   ...metricsServerlessRouteRepository,
 };


### PR DESCRIPTION
## Summary

PoC for variant-based dynamic dashboards in the APM Metrics tab, replacing static JSON files with code-defined panel definitions that resolve at runtime based on actual data availability.

Relates to https://github.com/elastic/observability-dev/issues/4592

### Problem

The current APM Metrics tab renders dashboards from static JSON files selected via a rigid 3-dimensional catalog (data format, SDK name, language). This causes several issues raised in the linked issue and by EDOT SDK teams:

- **No version awareness**: .NET 9 introduced entirely new built-in metrics, but the catalog cannot distinguish between .NET 8 and .NET 9 runtimes, so one dashboard must fit all versions poorly.
- **Panels show errors for missing fields**: When a dashboard is loaded for an SDK variant that doesn't emit certain metrics, panels render with errors instead of gracefully hiding.
- **High duplication**: EDOT and vanilla OTel Java dashboards are ~90% identical but maintained as separate JSON files.
- **No field-based detection**: Dashboard selection is based on agent metadata, not on what metrics the service actually emits.

### Approach: Variant-based panel resolution

This PoC introduces a new `dynamic_dashboard/` system alongside the existing `static_dashboard/` (no changes to the static system). The core idea:

1. **One dashboard per language** (e.g., Java) instead of per SDK variant
2. **Each panel has ordered variants** (e.g., semconv, ECS) with declared `requiredFields`
3. **Two-step runtime resolution**:
   - **Sync check**: Filter variants whose `requiredFields` don't exist in the DataView index mapping
   - **Async probe**: Call a new server endpoint (`POST /internal/apm/services/{serviceName}/metrics/has_fields`) that uses ES `filter` aggregations with `exists` clauses (not ES|QL, which crashes on non-existent fields) to verify actual data availability, unbounded by time range
4. **First viable variant wins**: For each panel slot, the first variant whose fields all have data is rendered; slots with no viable variant are omitted entirely

### What's included

- **Type system**: `PanelSlot`, `PanelVariant`, `PanelDefinition`, `LanguageDashboard` types
- **Server endpoint**: `has_fields.ts` -- batched field availability probe using ES `filter` aggregations
- **Resolution hook**: `useResolvedPanels` -- orchestrates sync field check + async data probe + variant selection
- **Java panels**: 4 panel slots (CPU, Memory, Thread Count, Memory %) with semconv variants using ES|QL `LensApiState` configs
- **Dashboard component**: `DynamicDashboard` renders resolved panels via `DashboardRenderer` + `LensConfigBuilder`
- **Integration**: `metrics/index.tsx` prioritizes dynamic dashboard, falls back to static JSON
- **Tests**: Unit tests for variant resolution logic and language dashboard lookup

### Architecture

```
metrics/index.tsx
  |
  |-- useResolvedPanels(agentName, dataView, serviceName)
  |     |
  |     |-- getLanguageDashboard(agentName) --> PanelSlot[]
  |     |-- checkFieldExistence(slots, dataView) --> filtered PanelSlot[] (sync)
  |     |-- POST has_fields(serviceName, fields) --> fieldAvailability (async)
  |     |-- resolveVariants(slots, fieldAvailability) --> PanelDefinition[]
  |     |
  |     v
  |-- DynamicDashboard(panels, dataView)
  |     |-- LensConfigBuilder.fromAPIFormat(config)
  |     |-- DashboardRenderer
  |
  |-- (fallback) JsonMetricsDashboard (existing static system)
```

### Next steps

- Add ECS variants to Java panels (semconv + ECS fallback in same slot)
- Add more languages (Node.js, .NET, Python, Go)
- Migrate static JSON dashboards to dynamic panels incrementally
- Remove `static_dashboard/` once all languages are migrated