### PR TITLE
Change v2 package owners to rna team

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/kibana.jsonc
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/alerting-v2-rule-form",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/rna-project-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/kibana.jsonc
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/alerting-v2-schemas",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/rna-project-team",
   "group": "platform",
   "visibility": "shared"
 }


### PR DESCRIPTION
## Summary

We changed the main v2 alerting plugin previously but the packages we use in v2, which are fully v2 only, are still owned by response ops. This creates review bottlenecks for the rna project that we can alleviate by using the rna-project-team owner while we are in active development. 



