### PR TITLE
fix(dashboard): reject meta/warnings in write requests

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/create/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/create/schemas.ts
@@ -25,7 +25,10 @@ export const createRequestParamsSchema = schema.maybe(
 );
 
 export function getCreateRequestBodySchema(isDashboardAppRequest: boolean) {
-  return getDashboardStateSchema(isDashboardAppRequest);
+  return getDashboardStateSchema(isDashboardAppRequest).extends({
+    meta: schema.maybe(schema.never()),
+    warnings: schema.maybe(schema.never()),
+  });
 }
 
 export function getCreateResponseBodySchema(isDashboardAppRequest: boolean) {

--- a/src/platform/plugins/shared/dashboard/server/api/update/schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/update/schemas.ts
@@ -12,7 +12,10 @@ import { getDashboardStateSchema } from '../dashboard_state_schemas';
 import { baseMetaSchema, updatedMetaSchema } from '../meta_schemas';
 
 export function getUpdateRequestBodySchema(isDashboardAppRequest: boolean) {
-  return getDashboardStateSchema(isDashboardAppRequest);
+  return getDashboardStateSchema(isDashboardAppRequest).extends({
+    meta: schema.maybe(schema.never()),
+    warnings: schema.maybe(schema.never()),
+  });
 }
 
 export function getUpdateResponseBodySchema(isDashboardAppRequest: boolean) {

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/create_dashboard.spec.ts
@@ -140,4 +140,23 @@ apiTest.describe('dashboards - create', { tag: tags.deploymentAgnostic }, () => 
       '[request body.panels]: expected value of type [array] but got [Object]'
     );
   });
+
+  apiTest('validation - returns error when meta is provided', async ({ apiClient }) => {
+    const response = await apiClient.post(DASHBOARD_API_PATH, {
+      headers: {
+        ...COMMON_HEADERS,
+        ...editorCredentials.apiKeyHeader,
+      },
+      body: {
+        title: 'foo',
+        meta: {},
+      },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(400);
+    expect(response.body.message).toBe(
+      "[request body.meta]: a value wasn't expected to be present"
+    );
+  });
 });

--- a/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
+++ b/src/platform/plugins/shared/dashboard/test/scout/api/tests/update_dashboard.spec.ts
@@ -102,4 +102,23 @@ apiTest.describe('dashboards - update', { tag: tags.deploymentAgnostic }, () => 
       '[request body.panels]: expected value of type [array] but got [Object]'
     );
   });
+
+  apiTest('validation - returns error when warnings is provided', async ({ apiClient }) => {
+    const response = await apiClient.put(`${DASHBOARD_API_PATH}/${TEST_DASHBOARD_ID}`, {
+      headers: {
+        ...COMMON_HEADERS,
+        ...editorCredentials.apiKeyHeader,
+      },
+      body: {
+        title: 'foo',
+        warnings: ['copied-from-get'],
+      },
+      responseType: 'json',
+    });
+
+    expect(response).toHaveStatusCode(400);
+    expect(response.body.message).toBe(
+      "[request body.warnings]: a value wasn't expected to be present"
+    );
+  });
 });


### PR DESCRIPTION
Closes elastic/kibana#249196

## Summary
Improve Dashboards-as-Code write request validation by explicitly rejecting response-only `meta` and `warnings` fields, so copy/pasting GET responses into POST/PUT yields a targeted error.

## Problem
Dashboards-as-code GET responses include response-only fields like `meta` and sometimes `warnings`. Users commonly copy the GET JSON into POST/PUT requests, which currently fails validation with an unclear unknown-key error (e.g. `[request body.meta]: definition for this key is missing`).

## Solution
- Explicitly forbid `meta` and `warnings` in the dashboards REST create/update request-body schemas so validation fails with a targeted message when these response-only fields are provided.
- Add Scout API tests covering POST with `meta` and PUT with `warnings`.


