### PR TITLE
[9.2] [Custom Threshold Rule] add noDataBehavior field [backend] (#254612)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
@@ -81,6 +81,13 @@ export const customThresholdParamsSchema = schema.object(
     groupBy: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
     alertOnNoData: schema.maybe(schema.boolean()),
     alertOnGroupDisappear: schema.maybe(schema.boolean()),
+    noDataBehavior: schema.maybe(
+      schema.oneOf([
+        schema.literal('recover'),
+        schema.literal('remainActive'),
+        schema.literal('alertOnNoData'),
+      ])
+    ),
     searchConfiguration: searchConfigSchema,
   },
   { unknowns: 'allow' }

--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
@@ -3398,6 +3398,57 @@ Object {
       ],
       "type": "alternatives",
     },
+    "noDataBehavior": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "recover",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "remainActive",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "alertOnNoData",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
     "searchConfiguration": Object {
       "flags": Object {
         "default": Object {

--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -113,7 +113,8 @@ export const createCustomThresholdExecutor = ({
     };
 
     // For backwards-compatibility, interpret undefined alertOnGroupDisappear as true
-    const alertOnGroupDisappear = _alertOnGroupDisappear !== false;
+    const alertOnGroupDisappear =
+      _alertOnGroupDisappear !== false && params.noDataBehavior !== 'recover';
     const compositeSize = config.customThresholdRule.groupByPageSize;
     const queryIsSame = isEqual(
       state.searchConfiguration?.query.query,
@@ -195,20 +196,32 @@ export const createCustomThresholdExecutor = ({
       const shouldAlertFire = alertResults.every((result) => result[group]?.shouldFire);
       // AND logic; because we need to evaluate all criteria, if one of them reports no data then the
       // whole alert is in a No Data/Error state
-      const isNoData = alertResults.some((result) => result[group]?.isNoData);
+      const isNoDataFound = alertResults.some((result) => result[group]?.isNoData);
 
-      if (isNoData && group !== UNGROUPED_FACTORY_KEY) {
+      if (isNoDataFound && group !== UNGROUPED_FACTORY_KEY) {
         nextMissingGroups.add({ key: group, bucketKey: alertResults[0][group].bucketKey });
       }
 
-      const nextState = isNoData
-        ? AlertStates.NO_DATA
-        : shouldAlertFire
-        ? AlertStates.ALERT
-        : AlertStates.OK;
+      const isIndeterminateState =
+        isNoDataFound &&
+        params.noDataBehavior === 'remainActive' &&
+        alertsClient.isTrackedAlert(group);
+
+      const isAlertOnNoDataEnabled = params.noDataBehavior
+        ? params.noDataBehavior === 'alertOnNoData'
+        : alertOnNoData || alertOnGroupDisappear;
+
+      const nextState =
+        isNoDataFound && isAlertOnNoDataEnabled
+          ? AlertStates.NO_DATA
+          : isIndeterminateState
+          ? AlertStates.ALERT
+          : shouldAlertFire
+          ? AlertStates.ALERT
+          : AlertStates.OK;
 
       let reason;
-      if (nextState === AlertStates.ALERT) {
+      if (nextState === AlertStates.ALERT && !isIndeterminateState) {
         reason = buildFiredAlertReason(alertResults, group, dataViewName);
       }
 
@@ -228,17 +241,16 @@ export const createCustomThresholdExecutor = ({
        * If `alertOnNoData` is true but `alertOnGroupDisappear` is false, we don't need to worry about the {a, b, c} possibility.
        * At this point in the function, a false `alertOnGroupDisappear` would already have prevented group 'a' from being evaluated at all.
        */
-      if (alertOnNoData || (alertOnGroupDisappear && hasGroups)) {
-        // In the previous line we've determined if the user is interested in No Data states, so only now do we actually
-        // check to see if a No Data state has occurred
-        if (nextState === AlertStates.NO_DATA) {
-          reason = alertResults
-            .filter((result) => result[group]?.isNoData)
-            .map((result) =>
-              buildNoDataAlertReason({ ...result[group], label: getLabel(result[group]), group })
-            )
-            .join('\n');
-        }
+      const shouldBuildNoDataReason = params.noDataBehavior
+        ? params.noDataBehavior !== 'recover'
+        : alertOnNoData || (alertOnGroupDisappear && hasGroups);
+      if (shouldBuildNoDataReason && (nextState === AlertStates.NO_DATA || isIndeterminateState)) {
+        reason = alertResults
+          .filter((result) => result[group]?.isNoData)
+          .map((result) =>
+            buildNoDataAlertReason({ ...result[group], label: getLabel(result[group]), group })
+          )
+          .join('\n');
       }
 
       if (reason) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)](https://github.com/elastic/kibana/pull/254612)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2026-02-24T14:36:22Z","message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Team:actionable-obs","v9.4.0","author:actionable-obs","Team:obs-ux-management"],"title":"[Custom Threshold Rule] add noDataBehavior field [backend]","number":254612,"url":"https://github.com/elastic/kibana/pull/254612","mergeCommit":{"message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254612","number":254612,"mergeCommit":{"message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690"}},{"url":"https://github.com/elastic/kibana/pull/258564","number":258564,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->