### PR TITLE
[8.19] [Custom Threshold Rule] add noDataBehavior field [backend] (#254612)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/custom_threshold/v1.ts
@@ -81,6 +81,13 @@ export const customThresholdParamsSchema = schema.object(
     groupBy: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),
     alertOnNoData: schema.maybe(schema.boolean()),
     alertOnGroupDisappear: schema.maybe(schema.boolean()),
+    noDataBehavior: schema.maybe(
+      schema.oneOf([
+        schema.literal('recover'),
+        schema.literal('remainActive'),
+        schema.literal('alertOnNoData'),
+      ])
+    ),
     searchConfiguration: searchConfigSchema,
   },
   { unknowns: 'allow' }

--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
@@ -3345,6 +3345,57 @@ Object {
       ],
       "type": "alternatives",
     },
+    "noDataBehavior": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "recover",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "remainActive",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "alertOnNoData",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
     "searchConfiguration": Object {
       "flags": Object {
         "default": Object {

--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
@@ -1831,6 +1831,7 @@ describe('The custom threshold alert type', () => {
               },
             ],
             alertOnNoData,
+            ...(alertOnNoData === false ? { alertOnGroupDisappear: false } : {}),
           },
         });
       test('sends a No Data alert when configured to do so', async () => {
@@ -2373,6 +2374,742 @@ describe('The custom threshold alert type', () => {
           expect(getLastReportedAlert(instanceID)).toBe(undefined);
           expect(getLastReportedAlert(instanceIdA)).toHaveNoDataAction();
           expect(getLastReportedAlert(instanceIdB)).toHaveNoDataAction();
+        });
+      });
+    });
+
+    describe('noDataBehavior parameter', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        clearInstances();
+      });
+      afterAll(() => clearInstances());
+      const instanceID = '*';
+
+      describe("noDataBehavior: 'recover' (default)", () => {
+        const execute = (sourceId: string = 'default') =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              sourceId,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'recover',
+            },
+          });
+
+        test('should not report any alerts when there is no data', async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+          await execute();
+          expect(getLastReportedAlert(instanceID)).toBe(undefined);
+        });
+
+        test('should report alert when condition is met', async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: 2,
+                timestamp: new Date().toISOString(),
+                shouldFire: true,
+                isNoData: false,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+          await execute();
+          const reportedAlert = getLastReportedAlert(instanceID);
+          expect(reportedAlert?.context?.reason).toEqual(
+            'Average test.metric.1 is 2, above the threshold of 1. (duration: 1 min, data view: mockedDataViewName)'
+          );
+          expect(reportedAlert).toHaveAlertAction();
+        });
+      });
+
+      describe("noDataBehavior: 'recover' with groupBy", () => {
+        const instanceIdA = 'a';
+        const instanceIdB = 'b';
+        const execute = () =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              groupBy: ['groupByField'],
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'recover',
+            },
+          });
+
+        test('should not report alerts for groups with no data (all groups recover)', async () => {
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // No alerts should be reported - all groups recover
+          expect(getLastReportedAlert(instanceIdA)).toBe(undefined);
+          expect(getLastReportedAlert(instanceIdB)).toBe(undefined);
+        });
+
+        test('should report alert only for groups that meet condition, not for no-data groups', async () => {
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: 2,
+                timestamp: new Date().toISOString(),
+                shouldFire: true,
+                isNoData: false,
+                bucketKey: { groupBy0: 'a' },
+                flattenGrouping: { groupByField: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // Only group 'a' should be reported (has data and meets condition)
+          // Group 'b' should recover (no alert)
+          expect(getLastReportedAlert(instanceIdA)).toHaveAlertAction();
+          expect(getLastReportedAlert(instanceIdB)).toBe(undefined);
+        });
+      });
+
+      describe("noDataBehavior: 'alertOnNoData'", () => {
+        const execute = (sourceId: string = 'default') =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              sourceId,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'alertOnNoData',
+            },
+          });
+
+        test('should report NO_DATA alert when there is no data', async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+          await execute();
+          const reportedAlert = getLastReportedAlert(instanceID);
+          expect(reportedAlert?.context?.reason).toEqual(
+            'Average test.metric.1 reported no data in the last 1m'
+          );
+          expect(reportedAlert).toHaveNoDataAction();
+        });
+      });
+
+      describe("noDataBehavior: 'remainActive'", () => {
+        const execute = (state?: any) =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'remainActive',
+            },
+            state: state ?? mockOptions.state.wrapped,
+          });
+
+        test('should keep alert in ALERT state when there is no data and alert was previously active', async () => {
+          services.alertsClient.isTrackedAlert.mockReturnValue(true);
+
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await execute();
+          const reportedAlert = getLastReportedAlert(instanceID);
+          expect(reportedAlert?.context?.reason).toEqual(
+            'Average test.metric.1 reported no data in the last 1m'
+          );
+          expect(reportedAlert?.actionGroup).toEqual(FIRED_ACTION.id);
+          expect(reportedAlert?.context?.reason).toContain('no data');
+
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+        });
+
+        test('should not create new alert when there is no data and alert was not previously active', async () => {
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await execute();
+          expect(getLastReportedAlert(instanceID)).toBe(undefined);
+        });
+      });
+
+      describe('noDataBehavior takes precedence over alertOnNoData', () => {
+        test("noDataBehavior: 'recover' should override alertOnNoData: true", async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              alertOnNoData: true,
+              noDataBehavior: 'recover',
+            },
+          });
+
+          expect(getLastReportedAlert(instanceID)).toBe(undefined);
+        });
+
+        test("noDataBehavior: 'alertOnNoData' should override alertOnNoData: false", async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              alertOnNoData: false,
+              noDataBehavior: 'alertOnNoData',
+            },
+          });
+
+          const reportedAlert = getLastReportedAlert(instanceID);
+          expect(reportedAlert?.context?.reason).toEqual(
+            'Average test.metric.1 reported no data in the last 1m'
+          );
+          expect(reportedAlert).toHaveNoDataAction();
+        });
+      });
+
+      describe('backward compatibility - when noDataBehavior is not set', () => {
+        test('should use alertOnNoData: true behavior (trigger NO_DATA alert)', async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              alertOnNoData: true,
+            },
+          });
+
+          const reportedAlert = getLastReportedAlert(instanceID);
+          expect(reportedAlert?.context?.reason).toEqual(
+            'Average test.metric.1 reported no data in the last 1m'
+          );
+          expect(reportedAlert).toHaveNoDataAction();
+        });
+
+        test('should use alertOnNoData: false behavior (recover/no alert)', async () => {
+          setEvaluationResults([
+            {
+              '*': {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: '*' },
+              },
+            },
+          ]);
+
+          await executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              alertOnNoData: false,
+              alertOnGroupDisappear: false,
+            },
+          });
+
+          expect(getLastReportedAlert(instanceID)).toBe(undefined);
+        });
+      });
+
+      describe("noDataBehavior: 'remainActive' with groupBy", () => {
+        const instanceIdA = 'a';
+        const instanceIdB = 'b';
+        const execute = () =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              groupBy: ['groupByField'],
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'remainActive',
+            },
+          });
+
+        test('should keep only tracked group alerts active when there is no data', async () => {
+          // Mock: group 'a' is tracked, group 'b' is not tracked
+          services.alertsClient.isTrackedAlert.mockImplementation(
+            (id: string) => id === instanceIdA
+          );
+
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // Only group 'a' should be reported (it was tracked)
+          const reportedAlertA = getLastReportedAlert(instanceIdA);
+          expect(reportedAlertA?.context?.reason).toContain('no data');
+          expect(reportedAlertA?.actionGroup).toEqual(FIRED_ACTION.id);
+          expect(getLastReportedAlert(instanceIdB)).toBe(undefined);
+
+          // Reset mock
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+        });
+      });
+
+      describe("noDataBehavior: 'alertOnNoData' with groupBy", () => {
+        const instanceIdA = 'a';
+        const instanceIdB = 'b';
+        const execute = () =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              groupBy: ['groupByField'],
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'alertOnNoData',
+            },
+          });
+
+        test('should report NO_DATA alerts for all groups with no data', async () => {
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // Both groups should get NO_DATA alerts
+          expect(getLastReportedAlert(instanceIdA)).toHaveNoDataAction();
+          expect(getLastReportedAlert(instanceIdB)).toHaveNoDataAction();
+        });
+
+        test('should report FIRED alert for firing group and NO_DATA for no-data group', async () => {
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: 2,
+                timestamp: new Date().toISOString(),
+                shouldFire: true,
+                isNoData: false,
+                bucketKey: { groupBy0: 'a' },
+                flattenGrouping: { groupByField: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          expect(getLastReportedAlert(instanceIdA)).toHaveAlertAction();
+          expect(getLastReportedAlert(instanceIdB)).toHaveNoDataAction();
+        });
+      });
+
+      describe("noDataBehavior: 'remainActive' with groupBy - mixed scenarios", () => {
+        const instanceIdA = 'a';
+        const instanceIdB = 'b';
+        const instanceIdC = 'c';
+        const execute = () =>
+          executor({
+            ...mockOptions,
+            services,
+            params: {
+              ...mockOptions.params,
+              groupBy: ['groupByField'],
+              criteria: [
+                {
+                  ...customThresholdNonCountCriterion,
+                  comparator: COMPARATORS.GREATER_THAN,
+                  threshold: [1],
+                },
+              ],
+              noDataBehavior: 'remainActive',
+            },
+          });
+
+        test('should handle mixed scenario: firing, no-data tracked, and no-data untracked groups', async () => {
+          // Mock: group 'a' is tracked (was previously active), group 'b' is not tracked, group 'c' has data
+          services.alertsClient.isTrackedAlert.mockImplementation(
+            (id: string) => id === instanceIdA || id === instanceIdC
+          );
+
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+              c: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: 2,
+                timestamp: new Date().toISOString(),
+                shouldFire: true,
+                isNoData: false,
+                bucketKey: { groupBy0: 'c' },
+                flattenGrouping: { groupByField: 'c' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // Group 'a': tracked + no data → should remain active (FIRED)
+          // Group 'b': not tracked + no data → should NOT create new alert
+          // Group 'c': has data + firing → should report FIRED alert
+          expect(getLastReportedAlert(instanceIdA)?.actionGroup).toEqual(FIRED_ACTION.id);
+          expect(getLastReportedAlert(instanceIdB)).toBe(undefined);
+          expect(getLastReportedAlert(instanceIdC)).toHaveAlertAction();
+
+          // Reset mock
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+        });
+
+        test('should keep all tracked groups active when all have no data', async () => {
+          // All groups are tracked
+          services.alertsClient.isTrackedAlert.mockReturnValue(true);
+
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // Both groups are tracked, both should remain active
+          expect(getLastReportedAlert(instanceIdA)?.actionGroup).toEqual(FIRED_ACTION.id);
+          expect(getLastReportedAlert(instanceIdB)?.actionGroup).toEqual(FIRED_ACTION.id);
+
+          // Reset mock
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+        });
+
+        test('should not create any alerts when no groups are tracked and all have no data', async () => {
+          // No groups are tracked
+          services.alertsClient.isTrackedAlert.mockReturnValue(false);
+
+          setEvaluationResults([
+            {
+              a: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'a' },
+              },
+              b: {
+                ...customThresholdNonCountCriterion,
+                comparator: COMPARATORS.GREATER_THAN,
+                threshold: [1],
+                currentValue: null,
+                timestamp: new Date().toISOString(),
+                shouldFire: false,
+                isNoData: true,
+                bucketKey: { groupBy0: 'b' },
+              },
+            },
+          ]);
+
+          await execute();
+
+          // No groups are tracked, no alerts should be created
+          expect(getLastReportedAlert(instanceIdA)).toBe(undefined);
+          expect(getLastReportedAlert(instanceIdB)).toBe(undefined);
         });
       });
     });
@@ -3581,6 +4318,7 @@ describe('The custom threshold alert type', () => {
               },
             ],
             alertOnNoData,
+            ...(alertOnNoData === false ? { alertOnGroupDisappear: false } : {}),
           },
         });
       test('sends a No Data alert when configured to do so', async () => {

--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -109,7 +109,8 @@ export const createCustomThresholdExecutor = ({
     };
 
     // For backwards-compatibility, interpret undefined alertOnGroupDisappear as true
-    const alertOnGroupDisappear = _alertOnGroupDisappear !== false;
+    const alertOnGroupDisappear =
+      _alertOnGroupDisappear !== false && params.noDataBehavior !== 'recover';
     const compositeSize = config.customThresholdRule.groupByPageSize;
     const queryIsSame = isEqual(
       state.searchConfiguration?.query.query,
@@ -191,20 +192,32 @@ export const createCustomThresholdExecutor = ({
       const shouldAlertFire = alertResults.every((result) => result[group]?.shouldFire);
       // AND logic; because we need to evaluate all criteria, if one of them reports no data then the
       // whole alert is in a No Data/Error state
-      const isNoData = alertResults.some((result) => result[group]?.isNoData);
+      const isNoDataFound = alertResults.some((result) => result[group]?.isNoData);
 
-      if (isNoData && group !== UNGROUPED_FACTORY_KEY) {
+      if (isNoDataFound && group !== UNGROUPED_FACTORY_KEY) {
         nextMissingGroups.add({ key: group, bucketKey: alertResults[0][group].bucketKey });
       }
 
-      const nextState = isNoData
-        ? AlertStates.NO_DATA
-        : shouldAlertFire
-        ? AlertStates.ALERT
-        : AlertStates.OK;
+      const isIndeterminateState =
+        isNoDataFound &&
+        params.noDataBehavior === 'remainActive' &&
+        alertsClient.isTrackedAlert(group);
+
+      const isAlertOnNoDataEnabled = params.noDataBehavior
+        ? params.noDataBehavior === 'alertOnNoData'
+        : alertOnNoData || alertOnGroupDisappear;
+
+      const nextState =
+        isNoDataFound && isAlertOnNoDataEnabled
+          ? AlertStates.NO_DATA
+          : isIndeterminateState
+          ? AlertStates.ALERT
+          : shouldAlertFire
+          ? AlertStates.ALERT
+          : AlertStates.OK;
 
       let reason;
-      if (nextState === AlertStates.ALERT) {
+      if (nextState === AlertStates.ALERT && !isIndeterminateState) {
         reason = buildFiredAlertReason(alertResults, group, dataViewName);
       }
 
@@ -224,17 +237,16 @@ export const createCustomThresholdExecutor = ({
        * If `alertOnNoData` is true but `alertOnGroupDisappear` is false, we don't need to worry about the {a, b, c} possibility.
        * At this point in the function, a false `alertOnGroupDisappear` would already have prevented group 'a' from being evaluated at all.
        */
-      if (alertOnNoData || (alertOnGroupDisappear && hasGroups)) {
-        // In the previous line we've determined if the user is interested in No Data states, so only now do we actually
-        // check to see if a No Data state has occurred
-        if (nextState === AlertStates.NO_DATA) {
-          reason = alertResults
-            .filter((result) => result[group]?.isNoData)
-            .map((result) =>
-              buildNoDataAlertReason({ ...result[group], label: getLabel(result[group]), group })
-            )
-            .join('\n');
-        }
+      const shouldBuildNoDataReason = params.noDataBehavior
+        ? params.noDataBehavior !== 'recover'
+        : alertOnNoData || (alertOnGroupDisappear && hasGroups);
+      if (shouldBuildNoDataReason && (nextState === AlertStates.NO_DATA || isIndeterminateState)) {
+        reason = alertResults
+          .filter((result) => result[group]?.isNoData)
+          .map((result) =>
+            buildNoDataAlertReason({ ...result[group], label: getLabel(result[group]), group })
+          )
+          .join('\n');
       }
 
       if (reason) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)](https://github.com/elastic/kibana/pull/254612)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2026-02-24T14:36:22Z","message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Team:actionable-obs","v9.4.0","author:actionable-obs","Team:obs-ux-management"],"title":"[Custom Threshold Rule] add noDataBehavior field [backend]","number":254612,"url":"https://github.com/elastic/kibana/pull/254612","mergeCommit":{"message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/254612","number":254612,"mergeCommit":{"message":"[Custom Threshold Rule] add noDataBehavior field [backend] (#254612)\n\n## Summary\n\nPartially implements #249850\nIntermediate merge with [this\nPR](https://github.com/elastic/kibana/pull/251976)\n\nAlert on no data options for metric threshold rule have now been\nextended to custom threshold rule.","sha":"f0d8c32fc39e5e0f0a11d9da7cdf96033f6a8690"}},{"url":"https://github.com/elastic/kibana/pull/258564","number":258564,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/258565","number":258565,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->