### PR TITLE
[Security Solution] Add related attacks to correlations overview and fix preview banner

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/related_attacks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/related_attacks.test.tsx
@@ -101,6 +101,11 @@ describe('<RelatedAttacks />', () => {
       params: {
         attackId: 'attack-id-1',
         indexName: 'index',
+        banner: {
+          backgroundColor: 'warning',
+          textColor: 'warning',
+          title: 'Preview attack details',
+        },
       },
     });
     expect(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/related_attacks.tsx
@@ -18,6 +18,7 @@ import {
 } from './correlations_details_alerts_table';
 import { CORRELATIONS_DETAILS_RELATED_ATTACKS_SECTION_TEST_ID } from './test_ids';
 import { AttackDetailsPreviewPanelKey } from '../../../attack_details/constants/panel_keys';
+import { ATTACK_PREVIEW_BANNER } from '../../../attack_details/context';
 
 export interface RelatedAttacksProps {
   /**
@@ -48,6 +49,7 @@ export const RelatedAttacks: React.FC<RelatedAttacksProps> = ({ attackIds, scope
         params: {
           attackId,
           indexName,
+          banner: ATTACK_PREVIEW_BANNER,
         },
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
@@ -23,6 +23,8 @@ import { SuppressedAlerts } from './suppressed_alerts';
 import { useShowSuppressedAlerts } from '../../shared/hooks/use_show_suppressed_alerts';
 import { RelatedCases } from './related_cases';
 import { useShowRelatedCases } from '../../shared/hooks/use_show_related_cases';
+import { RelatedAttacks } from './related_attacks';
+import { useShowRelatedAttacks } from '../../shared/hooks/use_show_related_attacks';
 import { CORRELATIONS_TEST_ID } from './test_ids';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { LeftPanelInsightsTab } from '../../left';
@@ -76,13 +78,15 @@ export const CorrelationsOverview: React.FC = () => {
   const { show: showSuppressedAlerts, alertSuppressionCount } = useShowSuppressedAlerts({
     getFieldsData,
   });
+  const { show: showRelatedAttacks, attackIds } = useShowRelatedAttacks({ getFieldsData });
 
   const canShowAtLeastOneInsight =
     showAlertsByAncestry ||
     showSameSourceAlerts ||
     showAlertsBySession ||
     showCases ||
-    showSuppressedAlerts;
+    showSuppressedAlerts ||
+    showRelatedAttacks;
 
   const ruleType = get(dataAsNestedObject, ALERT_RULE_TYPE)?.[0] as Type | undefined;
 
@@ -128,6 +132,7 @@ export const CorrelationsOverview: React.FC = () => {
           {showAlertsByAncestry && (
             <RelatedAlertsByAncestry documentId={documentId} indices={securityDefaultPatterns} />
           )}
+          {showRelatedAttacks && <RelatedAttacks attackIds={attackIds} />}
         </EuiFlexGroup>
       ) : (
         <FormattedMessage

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import {
+  CORRELATIONS_RELATED_ATTACKS_TEST_ID,
+  SUMMARY_ROW_BUTTON_TEST_ID,
+  SUMMARY_ROW_TEXT_TEST_ID,
+} from './test_ids';
+import { RelatedAttacks } from './related_attacks';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
+
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
+
+const TEXT_TEST_ID = SUMMARY_ROW_TEXT_TEST_ID(CORRELATIONS_RELATED_ATTACKS_TEST_ID);
+const BUTTON_TEST_ID = SUMMARY_ROW_BUTTON_TEST_ID(CORRELATIONS_RELATED_ATTACKS_TEST_ID);
+
+const renderRelatedAttacks = (attackIds: string[]) =>
+  render(
+    <IntlProvider locale="en">
+      <RelatedAttacks attackIds={attackIds} />
+    </IntlProvider>
+  );
+
+describe('<RelatedAttacks />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue(mockNavigateToLeftPanel);
+  });
+
+  it('should render singular label for one attack', () => {
+    const { getByTestId } = renderRelatedAttacks(['attack-1']);
+    expect(getByTestId(TEXT_TEST_ID)).toHaveTextContent('Attack related to this alert');
+    expect(getByTestId(BUTTON_TEST_ID)).toHaveTextContent('1');
+  });
+
+  it('should render plural label for multiple attacks', () => {
+    const { getByTestId } = renderRelatedAttacks(['attack-1', 'attack-2', 'attack-3']);
+    expect(getByTestId(TEXT_TEST_ID)).toHaveTextContent('Attacks related to this alert');
+    expect(getByTestId(BUTTON_TEST_ID)).toHaveTextContent('3');
+  });
+
+  it('should render zero attacks', () => {
+    const { getByTestId } = renderRelatedAttacks([]);
+    expect(getByTestId(TEXT_TEST_ID)).toHaveTextContent('Attacks related to this alert');
+    expect(getByTestId(BUTTON_TEST_ID)).toHaveTextContent('0');
+  });
+
+  it('should navigate to left panel correlations tab when the count is clicked', () => {
+    const { getByTestId } = renderRelatedAttacks(['attack-1']);
+    getByTestId(BUTTON_TEST_ID).click();
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
+import { InsightsSummaryRow } from './insights_summary_row';
+import { CORRELATIONS_RELATED_ATTACKS_TEST_ID } from './test_ids';
+
+export interface RelatedAttacksProps {
+  /**
+   * Values of the kibana.alert.attack_ids field
+   */
+  attackIds: string[];
+}
+
+/**
+ * Show related attacks count in summary row
+ */
+export const RelatedAttacks: React.VFC<RelatedAttacksProps> = ({ attackIds }) => {
+  const count = attackIds.length;
+
+  const text = useMemo(
+    () => (
+      <FormattedMessage
+        id="xpack.securitySolution.flyout.right.insights.correlations.relatedAttacksLabel"
+        defaultMessage="{count, plural, one {Attack} other {Attacks}} related to this alert"
+        values={{ count }}
+      />
+    ),
+    [count]
+  );
+
+  return (
+    <InsightsSummaryRow
+      text={text}
+      value={count}
+      expandedSubTab={CORRELATIONS_TAB_ID}
+      data-test-subj={CORRELATIONS_RELATED_ATTACKS_TEST_ID}
+      key={`correlation-row-${CORRELATIONS_RELATED_ATTACKS_TEST_ID}`}
+    />
+  );
+};
+
+RelatedAttacks.displayName = 'RelatedAttacks';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
@@ -8,7 +8,7 @@
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { InsightsSummaryRow } from './insights_summary_row';
+import { InsightsSummaryRow } from '../../../../flyout_v2/document/components/insights_summary_row';
 import { CORRELATIONS_RELATED_ATTACKS_TEST_ID } from './test_ids';
 
 export interface RelatedAttacksProps {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_attacks.tsx
@@ -7,7 +7,9 @@
 
 import React, { useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { LeftPanelInsightsTab } from '../../left';
 import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 import { InsightsSummaryRow } from '../../../../flyout_v2/document/components/insights_summary_row';
 import { CORRELATIONS_RELATED_ATTACKS_TEST_ID } from './test_ids';
 
@@ -23,6 +25,10 @@ export interface RelatedAttacksProps {
  */
 export const RelatedAttacks: React.VFC<RelatedAttacksProps> = ({ attackIds }) => {
   const count = attackIds.length;
+  const goToCorrelationsTab = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: CORRELATIONS_TAB_ID,
+  });
 
   const text = useMemo(
     () => (
@@ -39,7 +45,7 @@ export const RelatedAttacks: React.VFC<RelatedAttacksProps> = ({ attackIds }) =>
     <InsightsSummaryRow
       text={text}
       value={count}
-      expandedSubTab={CORRELATIONS_TAB_ID}
+      onShowDetails={goToCorrelationsTab}
       data-test-subj={CORRELATIONS_RELATED_ATTACKS_TEST_ID}
       key={`correlation-row-${CORRELATIONS_RELATED_ATTACKS_TEST_ID}`}
     />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
@@ -178,6 +178,8 @@ export const CORRELATIONS_RELATED_ALERTS_BY_SAME_SOURCE_EVENT_TEST_ID =
   `${CORRELATIONS_TEST_ID}RelatedAlertsBySameSourceEvent` as const;
 export const CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID =
   `${CORRELATIONS_TEST_ID}RelatedAlertsByAncestry` as const;
+export const CORRELATIONS_RELATED_ATTACKS_TEST_ID =
+  `${CORRELATIONS_TEST_ID}RelatedAttacks` as const;
 
 /* Visualizations section */
 


### PR DESCRIPTION
## Summary

- Adds a **Related Attacks** summary row to the Correlations section of the alert flyout overview (right panel), showing the count of attacks linked to the alert via `kibana.alert.attack_ids`. Uses the existing `useShowRelatedAttacks` hook — only shown when the `enableAlertsAndAttacksAlignment` feature flag is enabled and the field has values.
- Fixes a bug where the **attack details preview panel opened without a banner**. The initial `openPreviewPanel` call in the left panel's `RelatedAttacks` component was missing `banner: ATTACK_PREVIEW_BANNER`, which the expandable flyout framework needs to render the preview banner. Tab switches already passed the banner correctly, so the banner appeared only after switching tabs.

## Screen-recording 🎬 

https://github.com/user-attachments/assets/6b1d2da9-b9f7-4994-9152-5b4029ab22cb
