### PR TITLE
Add tool registry filtering for efficiency

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
@@ -12,11 +12,15 @@ import type { InternalToolDefinition } from './internal';
 /**
  * Parameters for listing tools.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ToolListParams {
-  // blank for now
-  // type?: ToolType[];
-  // tags?: string[];
+  /**
+   * Filter tools by type. Only tools matching one of the specified types will be returned.
+   */
+  type?: ToolType[];
+  /**
+   * Filter tools by tags. Only tools that have at least one of the specified tags will be returned.
+   */
+  tags?: string[];
 }
 
 /**

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/tools/registry.ts
@@ -16,7 +16,7 @@ export interface ToolListParams {
   /**
    * Filter tools by type. Only tools matching one of the specified types will be returned.
    */
-  type?: ToolType[];
+  types?: ToolType[];
   /**
    * Filter tools by tags. Only tools that have at least one of the specified tags will be returned.
    */

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -574,7 +574,7 @@ export function registerInternalToolsRoutes({
       const registry = await toolService.getRegistry({ request });
       const healthClient = toolService.getHealthClient({ request });
 
-      const mcpTools = (await registry.list({ types: [ToolType.mcp] })) as McpToolDefinition[];
+      const mcpTools = (await registry.list({ types: [ToolType.mcp] })).filter(isMcpTool);
 
       if (mcpTools.length === 0) {
         return response.ok<ListMcpToolsHealthResponse>({

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -197,7 +197,7 @@ export function registerInternalToolsRoutes({
       const { tools: toolService } = getInternalServices();
       const registry = await toolService.getRegistry({ request });
 
-      const allTools = await registry.list({});
+      const allTools = await registry.list({ types: [ToolType.mcp] });
 
       const toolsInNamespace = allTools.filter((tool) => {
         const lastDotIndex = tool.id.lastIndexOf('.');
@@ -574,7 +574,7 @@ export function registerInternalToolsRoutes({
       const registry = await toolService.getRegistry({ request });
       const healthClient = toolService.getHealthClient({ request });
 
-      const mcpTools = (await registry.list({ type: [ToolType.mcp] })) as McpToolDefinition[];
+      const mcpTools = (await registry.list({ types: [ToolType.mcp] })) as McpToolDefinition[];
 
       if (mcpTools.length === 0) {
         return response.ok<ListMcpToolsHealthResponse>({

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -574,7 +574,9 @@ export function registerInternalToolsRoutes({
       const registry = await toolService.getRegistry({ request });
       const healthClient = toolService.getHealthClient({ request });
 
-      const mcpTools = (await registry.list({ types: [ToolType.mcp] })).filter(isMcpTool);
+      const mcpTools: McpToolDefinition[] = (await registry.list({ types: [ToolType.mcp] })).filter(
+        (tool) => isMcpTool(tool)
+      );
 
       if (mcpTools.length === 0) {
         return response.ok<ListMcpToolsHealthResponse>({

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/tools.ts
@@ -13,7 +13,7 @@ import {
   type ActionTypeExecutorResult,
   AgentBuilderConnectorFeatureId,
 } from '@kbn/actions-plugin/common';
-import { isMcpTool, type McpToolDefinition } from '@kbn/agent-builder-common/tools';
+import { ToolType, isMcpTool, type McpToolDefinition } from '@kbn/agent-builder-common/tools';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
 import type {
@@ -574,8 +574,7 @@ export function registerInternalToolsRoutes({
       const registry = await toolService.getRegistry({ request });
       const healthClient = toolService.getHealthClient({ request });
 
-      const allTools = await registry.list({});
-      const mcpTools: McpToolDefinition[] = allTools.filter((tool) => isMcpTool(tool));
+      const mcpTools = (await registry.list({ type: [ToolType.mcp] })) as McpToolDefinition[];
 
       if (mcpTools.length === 0) {
         return response.ok<ListMcpToolsHealthResponse>({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/builtin_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/builtin_provider.ts
@@ -8,7 +8,11 @@
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ToolType } from '@kbn/agent-builder-common';
 import { createToolNotFoundError, createBadRequestError } from '@kbn/agent-builder-common';
-import type { ToolProviderFn, ReadonlyToolProvider } from '../tool_provider';
+import type {
+  ToolProviderFn,
+  ReadonlyToolProvider,
+  ToolProviderListFilters,
+} from '../tool_provider';
 import type { BuiltinToolRegistry } from './builtin_registry';
 import type {
   AnyToolTypeDefinition,
@@ -74,12 +78,26 @@ export const createBuiltinToolProvider = ({
       }
       return convertTool({ tool, definition, context, cache: availabilityCache });
     },
-    list() {
+    list(filters?: ToolProviderListFilters) {
+      const typeFilter =
+        filters?.types && filters.types.length > 0 ? new Set(filters.types) : undefined;
+      const tagFilter =
+        filters?.tags && filters.tags.length > 0 ? new Set(filters.tags) : undefined;
+
       const tools = registry.list();
       return tools
         .filter((tool) => {
           // evict unknown tools - atm it's used for workflow tools if the plugin is disabled.
-          return definitionMap[tool.type];
+          if (!definitionMap[tool.type]) {
+            return false;
+          }
+          if (typeFilter && !typeFilter.has(tool.type)) {
+            return false;
+          }
+          if (tagFilter && !tool.tags.some((tag) => tagFilter.has(tag))) {
+            return false;
+          }
+          return true;
         })
         .map((tool) => {
           const definition = definitionMap[tool.type]!;

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
@@ -8,26 +8,21 @@
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import { createToolNotFoundError, createBadRequestError, type ToolType } from '@kbn/agent-builder-common';
+import { createToolNotFoundError, createBadRequestError } from '@kbn/agent-builder-common';
 import type { ToolCreateParams } from '@kbn/agent-builder-server';
 import { createSpaceDslFilter } from '../../../../utils/spaces';
-import type { ToolTypeUpdateParams } from '../../tool_provider';
+import type { ToolTypeUpdateParams, ToolProviderListFilters } from '../../tool_provider';
 import type { ToolStorage } from './storage';
 import { createStorage } from './storage';
 import { fromEs, createAttributes, updateDocument } from './converters';
 import type { ToolDocument, ToolPersistedDefinition } from './types';
-
-export interface ToolClientListFilters {
-  types?: ToolType[];
-  tags?: string[];
-}
 
 /**
  * Client for persisted tool definitions.
  */
 export interface ToolClient {
   get(toolId: string): Promise<ToolPersistedDefinition>;
-  list(filters?: ToolClientListFilters): Promise<ToolPersistedDefinition[]>;
+  list(filters?: ToolProviderListFilters): Promise<ToolPersistedDefinition[]>;
   create(esqlTool: ToolCreateParams): Promise<ToolPersistedDefinition>;
   update(toolId: string, updates: ToolTypeUpdateParams): Promise<ToolPersistedDefinition>;
   delete(toolId: string): Promise<boolean>;
@@ -65,7 +60,7 @@ class ToolClientImpl {
     return fromEs(document);
   }
 
-  async list(filters?: ToolClientListFilters): Promise<ToolPersistedDefinition[]> {
+  async list(filters?: ToolProviderListFilters): Promise<ToolPersistedDefinition[]> {
     const filterClauses: QueryDslQueryContainer[] = [createSpaceDslFilter(this.space)];
 
     if (filters?.types && filters.types.length > 0) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { createToolNotFoundError, createBadRequestError } from '@kbn/agent-builder-common';
@@ -16,12 +17,17 @@ import { createStorage } from './storage';
 import { fromEs, createAttributes, updateDocument } from './converters';
 import type { ToolDocument, ToolPersistedDefinition } from './types';
 
+export interface ToolClientListFilters {
+  types?: string[];
+  tags?: string[];
+}
+
 /**
  * Client for persisted tool definitions.
  */
 export interface ToolClient {
   get(toolId: string): Promise<ToolPersistedDefinition>;
-  list(): Promise<ToolPersistedDefinition[]>;
+  list(filters?: ToolClientListFilters): Promise<ToolPersistedDefinition[]>;
   create(esqlTool: ToolCreateParams): Promise<ToolPersistedDefinition>;
   update(toolId: string, updates: ToolTypeUpdateParams): Promise<ToolPersistedDefinition>;
   delete(toolId: string): Promise<boolean>;
@@ -59,11 +65,20 @@ class ToolClientImpl {
     return fromEs(document);
   }
 
-  async list(): Promise<ToolPersistedDefinition[]> {
+  async list(filters?: ToolClientListFilters): Promise<ToolPersistedDefinition[]> {
+    const filterClauses: QueryDslQueryContainer[] = [createSpaceDslFilter(this.space)];
+
+    if (filters?.types && filters.types.length > 0) {
+      filterClauses.push({ terms: { type: filters.types } });
+    }
+    if (filters?.tags && filters.tags.length > 0) {
+      filterClauses.push({ terms: { tags: filters.tags } });
+    }
+
     const document = await this.storage.getClient().search({
       query: {
         bool: {
-          filter: [createSpaceDslFilter(this.space)],
+          filter: filterClauses,
         },
       },
       size: 1000,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/client.ts
@@ -8,7 +8,7 @@
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import { createToolNotFoundError, createBadRequestError } from '@kbn/agent-builder-common';
+import { createToolNotFoundError, createBadRequestError, type ToolType } from '@kbn/agent-builder-common';
 import type { ToolCreateParams } from '@kbn/agent-builder-server';
 import { createSpaceDslFilter } from '../../../../utils/spaces';
 import type { ToolTypeUpdateParams } from '../../tool_provider';
@@ -18,7 +18,7 @@ import { fromEs, createAttributes, updateDocument } from './converters';
 import type { ToolDocument, ToolPersistedDefinition } from './types';
 
 export interface ToolClientListFilters {
-  types?: string[];
+  types?: ToolType[];
   tags?: string[];
 }
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/index.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { createClient, type ToolClient } from './client';
+export { createClient, type ToolClient, type ToolClientListFilters } from './client';
 export type { ToolPersistedDefinition } from './types';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/client/index.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { createClient, type ToolClient, type ToolClientListFilters } from './client';
+export { createClient, type ToolClient } from './client';
 export type { ToolPersistedDefinition } from './types';

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/persisted/provider.ts
@@ -10,7 +10,11 @@ import type { ToolType } from '@kbn/agent-builder-common';
 import { createBadRequestError, isToolNotFoundError } from '@kbn/agent-builder-common';
 import type { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import type { WritableToolProvider, ToolProviderFn } from '../tool_provider';
+import type {
+  WritableToolProvider,
+  ToolProviderFn,
+  ToolProviderListFilters,
+} from '../tool_provider';
 import type { AnyToolTypeDefinition, ToolTypeDefinition } from '../tool_types/definitions';
 import { isEnabledDefinition } from '../tool_types/definitions';
 import { createClient } from './client';
@@ -94,8 +98,11 @@ export const createPersistedToolClient = ({
       return convertPersistedDefinition({ tool, definition, context: conversionContext() });
     },
 
-    async list() {
-      const tools = await toolClient.list();
+    async list(filters?: ToolProviderListFilters) {
+      const tools = await toolClient.list({
+        types: filters?.types,
+        tags: filters?.tags,
+      });
       const context = conversionContext();
       return tools
         .filter((tool) => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_provider.ts
@@ -7,6 +7,7 @@
 
 import type { MaybePromise } from '@kbn/utility-types';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ToolType } from '@kbn/agent-builder-common';
 import type {
   InternalToolDefinition,
   ToolCreateParams,
@@ -16,12 +17,17 @@ import type {
 export type ToolTypeCreateParams<TConfig extends object = {}> = ToolCreateParams<TConfig>;
 export type ToolTypeUpdateParams<TConfig extends object = {}> = ToolUpdateParams<TConfig>;
 
+export interface ToolProviderListFilters {
+  types?: ToolType[];
+  tags?: string[];
+}
+
 export interface ReadonlyToolProvider {
   id: string;
   readonly: true;
   has(toolId: string): MaybePromise<boolean>;
   get(toolId: string): MaybePromise<InternalToolDefinition>;
-  list(): MaybePromise<Array<InternalToolDefinition>>;
+  list(filters?: ToolProviderListFilters): MaybePromise<Array<InternalToolDefinition>>;
 }
 
 export interface WritableToolProvider extends Omit<ReadonlyToolProvider, 'readonly'> {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
@@ -166,7 +166,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool, mcpTool],
         });
 
-        await registry.list({ type: [ToolType.mcp] });
+        await registry.list({ types: [ToolType.mcp] });
 
         expect(builtinProvider.list).toHaveBeenCalledWith({
           types: [ToolType.mcp],
@@ -202,7 +202,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool, mcpTool],
         });
 
-        await registry.list({ type: [ToolType.mcp], tags: ['search'] });
+        await registry.list({ types: [ToolType.mcp], tags: ['search'] });
 
         expect(builtinProvider.list).toHaveBeenCalledWith({
           types: [ToolType.mcp],
@@ -220,7 +220,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool],
         });
 
-        await registry.list({ type: [], tags: [] });
+        await registry.list({ types: [], tags: [] });
 
         expect(builtinProvider.list).toHaveBeenCalledWith({
           types: undefined,
@@ -240,7 +240,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool, mcpTool, workflowTool],
         });
 
-        const tools = await registry.list({ type: [ToolType.mcp] });
+        const tools = await registry.list({ types: [ToolType.mcp] });
 
         expect(tools).toHaveLength(1);
         expect(tools[0].id).toBe('mcp.tavily.search');
@@ -252,7 +252,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool, mcpTool, workflowTool],
         });
 
-        const tools = await registry.list({ type: [ToolType.mcp, ToolType.esql] });
+        const tools = await registry.list({ types: [ToolType.mcp, ToolType.esql] });
 
         expect(tools).toHaveLength(2);
         expect(tools.map((t) => t.id)).toEqual(['my-esql-query', 'mcp.tavily.search']);
@@ -264,7 +264,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool],
         });
 
-        const tools = await registry.list({ type: [ToolType.index_search] });
+        const tools = await registry.list({ types: [ToolType.index_search] });
 
         expect(tools).toHaveLength(0);
       });
@@ -275,7 +275,7 @@ describe('ToolRegistryImpl', () => {
           persistedTools: [esqlTool],
         });
 
-        const tools = await registry.list({ type: [] });
+        const tools = await registry.list({ types: [] });
 
         expect(tools).toHaveLength(2);
       });
@@ -347,7 +347,7 @@ describe('ToolRegistryImpl', () => {
         });
 
         const tools = await registry.list({
-          type: [ToolType.mcp, ToolType.builtin],
+          types: [ToolType.mcp, ToolType.builtin],
           tags: ['search'],
         });
 
@@ -362,7 +362,7 @@ describe('ToolRegistryImpl', () => {
         });
 
         const tools = await registry.list({
-          type: [ToolType.mcp],
+          types: [ToolType.mcp],
           tags: ['search'],
         });
 
@@ -377,7 +377,7 @@ describe('ToolRegistryImpl', () => {
         });
 
         const tools = await registry.list({
-          type: [ToolType.esql],
+          types: [ToolType.esql],
           tags: ['search'],
         });
 
@@ -397,7 +397,7 @@ describe('ToolRegistryImpl', () => {
         persistedTools: [mcpTool, unavailableTool],
       });
 
-      const tools = await registry.list({ type: [ToolType.mcp] });
+      const tools = await registry.list({ types: [ToolType.mcp] });
 
       expect(tools).toHaveLength(1);
       expect(tools[0].id).toBe('mcp.tavily.search');

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
@@ -1,0 +1,406 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolType } from '@kbn/agent-builder-common';
+import type { InternalToolDefinition } from '@kbn/agent-builder-server';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
+import { createMockedTool } from '../../test_utils/tools';
+import { createToolRegistry } from './tool_registry';
+import type {
+  ReadonlyToolProvider,
+  WritableToolProvider,
+  ToolProviderListFilters,
+} from './tool_provider';
+import type { ToolHealthClient } from './health';
+
+const applyFilters = (
+  tools: InternalToolDefinition[],
+  filters?: ToolProviderListFilters
+): InternalToolDefinition[] => {
+  let result = tools;
+  if (filters?.types && filters.types.length > 0) {
+    const typeSet = new Set(filters.types);
+    result = result.filter((t) => typeSet.has(t.type));
+  }
+  if (filters?.tags && filters.tags.length > 0) {
+    const tagSet = new Set(filters.tags);
+    result = result.filter((t) => t.tags.some((tag) => tagSet.has(tag)));
+  }
+  return result;
+};
+
+const createMockBuiltinProvider = (tools: InternalToolDefinition[]): ReadonlyToolProvider => ({
+  id: 'builtin',
+  readonly: true,
+  has: jest.fn((toolId) => tools.some((t) => t.id === toolId)),
+  get: jest.fn((toolId) => {
+    const tool = tools.find((t) => t.id === toolId);
+    if (!tool) throw new Error(`Tool ${toolId} not found`);
+    return tool;
+  }),
+  list: jest.fn((filters?: ToolProviderListFilters) => applyFilters(tools, filters)),
+});
+
+const createMockPersistedProvider = (tools: InternalToolDefinition[]): WritableToolProvider => ({
+  id: 'persisted',
+  readonly: false,
+  has: jest.fn(async (toolId) => tools.some((t) => t.id === toolId)),
+  get: jest.fn(async (toolId) => {
+    const tool = tools.find((t) => t.id === toolId);
+    if (!tool) throw new Error(`Tool ${toolId} not found`);
+    return tool;
+  }),
+  list: jest.fn(async (filters?: ToolProviderListFilters) => applyFilters(tools, filters)),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+});
+
+const createMockHealthClient = (): jest.Mocked<ToolHealthClient> => ({
+  get: jest.fn(),
+  recordSuccess: jest.fn(),
+  recordFailure: jest.fn(),
+  delete: jest.fn(),
+  listBySpace: jest.fn(),
+});
+
+const availableTool = (overrides: Partial<InternalToolDefinition> = {}) =>
+  createMockedTool({
+    isAvailable: jest.fn(async () => ({ status: 'available' as const })),
+    ...overrides,
+  }) as unknown as InternalToolDefinition;
+
+describe('ToolRegistryImpl', () => {
+  const request = httpServerMock.createKibanaRequest();
+  const uiSettings = uiSettingsServiceMock.createStartContract();
+  const savedObjects = savedObjectsServiceMock.createStartContract();
+
+  const setup = ({
+    builtinTools = [],
+    persistedTools = [],
+  }: {
+    builtinTools?: InternalToolDefinition[];
+    persistedTools?: InternalToolDefinition[];
+  } = {}) => {
+    const builtinProvider = createMockBuiltinProvider(builtinTools);
+    const persistedProvider = createMockPersistedProvider(persistedTools);
+    const healthClient = createMockHealthClient();
+
+    const registry = createToolRegistry({
+      getRunner: jest.fn() as any,
+      builtinProvider,
+      persistedProvider,
+      request,
+      space: 'default',
+      uiSettings,
+      savedObjects,
+      healthClient,
+      healthTrackedToolTypes: new Set(),
+    });
+
+    return { registry, builtinProvider, persistedProvider };
+  };
+
+  describe('list', () => {
+    const builtinTool = availableTool({
+      id: 'builtin-search',
+      type: ToolType.builtin,
+      tags: ['search', 'sml'],
+    });
+
+    const esqlTool = availableTool({
+      id: 'my-esql-query',
+      type: ToolType.esql,
+      tags: ['custom', 'analytics'],
+    });
+
+    const mcpTool = availableTool({
+      id: 'mcp.tavily.search',
+      type: ToolType.mcp,
+      tags: ['search', 'external'],
+    });
+
+    const workflowTool = availableTool({
+      id: 'my-workflow',
+      type: ToolType.workflow,
+      tags: [],
+    });
+
+    it('returns all tools when no filters are provided', async () => {
+      const { registry } = setup({
+        builtinTools: [builtinTool],
+        persistedTools: [esqlTool, mcpTool],
+      });
+
+      const tools = await registry.list();
+
+      expect(tools).toHaveLength(3);
+      expect(tools.map((t) => t.id)).toEqual([
+        'builtin-search',
+        'my-esql-query',
+        'mcp.tavily.search',
+      ]);
+    });
+
+    it('returns all tools when empty opts are provided', async () => {
+      const { registry } = setup({
+        builtinTools: [builtinTool],
+        persistedTools: [esqlTool],
+      });
+
+      const tools = await registry.list({});
+
+      expect(tools).toHaveLength(2);
+    });
+
+    describe('filter delegation to providers', () => {
+      it('passes type filters to providers', async () => {
+        const { registry, builtinProvider, persistedProvider } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool],
+        });
+
+        await registry.list({ type: [ToolType.mcp] });
+
+        expect(builtinProvider.list).toHaveBeenCalledWith({
+          types: [ToolType.mcp],
+          tags: undefined,
+        });
+        expect(persistedProvider.list).toHaveBeenCalledWith({
+          types: [ToolType.mcp],
+          tags: undefined,
+        });
+      });
+
+      it('passes tag filters to providers', async () => {
+        const { registry, builtinProvider, persistedProvider } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool],
+        });
+
+        await registry.list({ tags: ['search'] });
+
+        expect(builtinProvider.list).toHaveBeenCalledWith({
+          types: undefined,
+          tags: ['search'],
+        });
+        expect(persistedProvider.list).toHaveBeenCalledWith({
+          types: undefined,
+          tags: ['search'],
+        });
+      });
+
+      it('passes combined filters to providers', async () => {
+        const { registry, builtinProvider, persistedProvider } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool],
+        });
+
+        await registry.list({ type: [ToolType.mcp], tags: ['search'] });
+
+        expect(builtinProvider.list).toHaveBeenCalledWith({
+          types: [ToolType.mcp],
+          tags: ['search'],
+        });
+        expect(persistedProvider.list).toHaveBeenCalledWith({
+          types: [ToolType.mcp],
+          tags: ['search'],
+        });
+      });
+
+      it('normalizes empty arrays to undefined', async () => {
+        const { registry, builtinProvider, persistedProvider } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool],
+        });
+
+        await registry.list({ type: [], tags: [] });
+
+        expect(builtinProvider.list).toHaveBeenCalledWith({
+          types: undefined,
+          tags: undefined,
+        });
+        expect(persistedProvider.list).toHaveBeenCalledWith({
+          types: undefined,
+          tags: undefined,
+        });
+      });
+    });
+
+    describe('type filter', () => {
+      it('filters tools by a single type', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({ type: [ToolType.mcp] });
+
+        expect(tools).toHaveLength(1);
+        expect(tools[0].id).toBe('mcp.tavily.search');
+      });
+
+      it('filters tools by multiple types', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({ type: [ToolType.mcp, ToolType.esql] });
+
+        expect(tools).toHaveLength(2);
+        expect(tools.map((t) => t.id)).toEqual(['my-esql-query', 'mcp.tavily.search']);
+      });
+
+      it('returns nothing when type matches no tools', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool],
+        });
+
+        const tools = await registry.list({ type: [ToolType.index_search] });
+
+        expect(tools).toHaveLength(0);
+      });
+
+      it('ignores empty type array', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool],
+        });
+
+        const tools = await registry.list({ type: [] });
+
+        expect(tools).toHaveLength(2);
+      });
+    });
+
+    describe('tags filter', () => {
+      it('filters tools by a single tag', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({ tags: ['search'] });
+
+        expect(tools).toHaveLength(2);
+        expect(tools.map((t) => t.id)).toEqual(['builtin-search', 'mcp.tavily.search']);
+      });
+
+      it('filters tools by multiple tags (OR logic)', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({ tags: ['sml', 'external'] });
+
+        expect(tools).toHaveLength(2);
+        expect(tools.map((t) => t.id)).toEqual(['builtin-search', 'mcp.tavily.search']);
+      });
+
+      it('returns nothing when tag matches no tools', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool],
+        });
+
+        const tools = await registry.list({ tags: ['nonexistent'] });
+
+        expect(tools).toHaveLength(0);
+      });
+
+      it('excludes tools with empty tags', async () => {
+        const { registry } = setup({
+          persistedTools: [workflowTool],
+        });
+
+        const tools = await registry.list({ tags: ['search'] });
+
+        expect(tools).toHaveLength(0);
+      });
+
+      it('ignores empty tags array', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool],
+        });
+
+        const tools = await registry.list({ tags: [] });
+
+        expect(tools).toHaveLength(2);
+      });
+    });
+
+    describe('combined filters', () => {
+      it('applies both type and tags filters (AND logic)', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({
+          type: [ToolType.mcp, ToolType.builtin],
+          tags: ['search'],
+        });
+
+        expect(tools).toHaveLength(2);
+        expect(tools.map((t) => t.id)).toEqual(['builtin-search', 'mcp.tavily.search']);
+      });
+
+      it('narrows results when both filters apply', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool, workflowTool],
+        });
+
+        const tools = await registry.list({
+          type: [ToolType.mcp],
+          tags: ['search'],
+        });
+
+        expect(tools).toHaveLength(1);
+        expect(tools[0].id).toBe('mcp.tavily.search');
+      });
+
+      it('returns nothing when filters are mutually exclusive', async () => {
+        const { registry } = setup({
+          builtinTools: [builtinTool],
+          persistedTools: [esqlTool, mcpTool],
+        });
+
+        const tools = await registry.list({
+          type: [ToolType.esql],
+          tags: ['search'],
+        });
+
+        expect(tools).toHaveLength(0);
+      });
+    });
+
+    it('still applies availability check when filtering', async () => {
+      const unavailableTool = createMockedTool({
+        id: 'unavailable-mcp',
+        type: ToolType.mcp,
+        tags: ['search'],
+        isAvailable: jest.fn(async () => ({ status: 'unavailable' as const })),
+      }) as unknown as InternalToolDefinition;
+
+      const { registry } = setup({
+        persistedTools: [mcpTool, unavailableTool],
+      });
+
+      const tools = await registry.list({ type: [ToolType.mcp] });
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].id).toBe('mcp.tavily.search');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.test.ts
@@ -10,7 +10,7 @@ import type { InternalToolDefinition } from '@kbn/agent-builder-server';
 import { httpServerMock } from '@kbn/core-http-server-mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
-import { createMockedTool } from '../../test_utils/tools';
+import { createMockedTool, type MockedTool } from '../../test_utils/tools';
 import { createToolRegistry } from './tool_registry';
 import type {
   ReadonlyToolProvider,
@@ -64,13 +64,14 @@ const createMockPersistedProvider = (tools: InternalToolDefinition[]): WritableT
 
 const createMockHealthClient = (): jest.Mocked<ToolHealthClient> => ({
   get: jest.fn(),
+  upsert: jest.fn(),
   recordSuccess: jest.fn(),
   recordFailure: jest.fn(),
   delete: jest.fn(),
   listBySpace: jest.fn(),
 });
 
-const availableTool = (overrides: Partial<InternalToolDefinition> = {}) =>
+const availableTool = (overrides: Partial<MockedTool> = {}) =>
   createMockedTool({
     isAvailable: jest.fn(async () => ({ status: 'available' as const })),
     ...overrides,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.ts
@@ -129,9 +129,14 @@ class ToolRegistryImpl implements ToolRegistry {
   }
 
   async list(opts?: ToolListParams | undefined) {
+    const providerFilters = {
+      types: opts?.type && opts.type.length > 0 ? opts.type : undefined,
+      tags: opts?.tags && opts.tags.length > 0 ? opts.tags : undefined,
+    };
+
     const allTools: InternalToolDefinition[] = [];
     for (const provider of this.orderedProviders) {
-      const toolsFromType = await provider.list();
+      const toolsFromType = await provider.list(providerFilters);
       for (const tool of toolsFromType) {
         if (await this.isAvailable(tool)) {
           allTools.push(tool);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_registry.ts
@@ -130,7 +130,7 @@ class ToolRegistryImpl implements ToolRegistry {
 
   async list(opts?: ToolListParams | undefined) {
     const providerFilters = {
-      types: opts?.type && opts.type.length > 0 ? opts.type : undefined,
+      types: opts?.types && opts.types.length > 0 ? opts.types : undefined,
       tags: opts?.tags && opts.tags.length > 0 ? opts.tags : undefined,
     };
 


### PR DESCRIPTION
## Summary

While working on https://github.com/elastic/kibana/pull/258244, I found that there wasn't an efficient way to find relevant tools, and I was having to scan through _all_ tools for a linear filter. As connectors introduce significantly more tools to the catalog, I'm concerned this will start causing latency. 

This PR aims to push any provided filters on type/tags to Elasticsearch, where possible, and even for the builtin (in-memory) provider, allows callers to specify filters rather than having to redundantly implement filtering.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


