### PR TITLE
chore(NA): update versions after v9.2.8 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -12,7 +12,7 @@
       "branchType": "release"
     },
     {
-      "version": "9.2.7",
+      "version": "9.2.8",
       "branch": "9.2",
       "branchType": "release"
     },


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.