### PR TITLE
[Dashboards as Code] Strip unknown keys in transforms using panel schema if provided

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_panels_out.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/transforms/out/transform_panels_out.ts
@@ -88,6 +88,11 @@ function transformPanelProperties(
     transformedPanelConfig =
       transforms?.transformOut?.(embeddableConfig, panelReferences, containerReferences) ??
       defaultTransform(embeddableConfig);
+
+    transformedPanelConfig =
+      transforms?.schema?.validate(transformedPanelConfig, undefined, undefined, {
+        stripUnknownKeys: true,
+      }) ?? transformedPanelConfig;
   } catch (transformOutError) {
     // do not prevent read on transformOutError
     logger.warn(


### PR DESCRIPTION
Fixes #258635

## Summary

Currently, unsupported properties in the saved object are being passed through to the API result. These cause the dashboard response validation to fail on read requests. If provided, we can use the panel schema to strip unknown keys from the transformOut. This ensures that the response matches the provided schema.


## Testing this PR
1. Install the sample data logs
2. From Kibana Dev Tools console 
`GET kbn:/api/dashboards/edf84fe0-e1a0-11e7-b6d5-4dc382ef7f5b?apiVersion=1`
3. The response should return successfully.
4. The first panel in the response, `title: "Metrics"` is should not contain the unsupported `disabledActions` key that is currently stored `embeddableConfig` in the panel in the dashboard saved object.