### PR TITLE
[Lens API] improve xScale schema description for ES|QL time axis rendering

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.ts
@@ -232,8 +232,9 @@ const decorationsSchema = schema.object(
 const xScaleSchema = schema.maybe(
   schema.oneOf([schema.literal('ordinal'), schema.literal('temporal'), schema.literal('linear')], {
     meta: {
+      // IMPORTANT: This description guides LLM agents - modify with caution and test agent behavior after changes
       description:
-        'X-axis scale type. Only used in ES|QL charts. Data view based charts fall back to the X operation type.',
+        "X-axis scale type for ES|QL charts. Use 'temporal' for timestamp/date fields (e.g., @timestamp, DATE_TRUNC results). Use 'ordinal' for categorical/text fields. Use 'linear' for numeric fields.",
     },
   })
 );


### PR DESCRIPTION
## Summary

Fixes ES|QL visualizations not displaying time with a proper time axis in the dashboard agent builder.

The `xScale` schema property was already available but the LLM wasn't using it correctly because the  description didn't explain when to use each scale type. Updated the schema description to explicitly  guide usage:

  - `'temporal'` for timestamp/date fields (e.g., @timestamp, DATE_TRUNC results)
  - `'ordinal'` for categorical/text fields  
  - `'linear'` for numeric fields

This guidance flows automatically through the JSON schema to the LLM prompt without requiring special handling in the agent code.

Before:
<img width="909" height="558" alt="Screenshot 2026-03-19 at 22 17 42" src="https://github.com/user-attachments/assets/9fc6001e-131c-4d65-be81-977e77651c54" />

After:
<img width="904" height="626" alt="Screenshot 2026-03-19 at 22 17 26" src="https://github.com/user-attachments/assets/232424be-6e91-4fe9-9feb-3ff71420e3ce" />
