### PR TITLE
[kbn-es] Harden ES snapshot cache integrity

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/artifact.test.js
+++ b/src/platform/packages/shared/kbn-es/src/artifact.test.js
@@ -7,10 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+
 import { ToolingLog } from '@kbn/tooling-log';
+jest.mock('timers/promises', () => ({
+  setTimeout: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('node-fetch');
 import fetch from 'node-fetch';
-const { Response } = jest.requireActual('node-fetch');
+const { Headers, Response } = jest.requireActual('node-fetch');
 
 import { Artifact } from './artifact';
 
@@ -26,6 +35,7 @@ const MOCK_FILENAME = 'test-filename';
 const DAILY_SNAPSHOT_BASE_URL = 'https://storage.googleapis.com/kibana-ci-es-snapshots-daily';
 const PERMANENT_SNAPSHOT_BASE_URL =
   'https://storage.googleapis.com/kibana-ci-es-snapshots-permanent';
+const TEMP_DIRS = [];
 
 const createArchive = (params = {}) => {
   const license = params.license || 'default';
@@ -44,6 +54,40 @@ const createArchive = (params = {}) => {
 
 const mockFetch = (mock) =>
   fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(mock))));
+
+const getChecksum = (contents) => crypto.createHash('sha512').update(contents).digest('hex');
+
+const createArtifactResponse = ({ contents, headers = {}, status = 200 }) => ({
+  status,
+  ok: status >= 200 && status < 300,
+  body: Readable.from([contents]),
+  headers: new Headers(headers),
+});
+
+const createArtifactDest = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-test-'));
+  TEMP_DIRS.push(dir);
+
+  return path.join(dir, MOCK_FILENAME);
+};
+
+const createCachedArtifact = ({ contents, etag = 'etag' }) => {
+  const dest = createArtifactDest();
+  fs.writeFileSync(dest, contents);
+  fs.writeFileSync(
+    `${dest}.meta`,
+    JSON.stringify(
+      {
+        ts: new Date().toISOString(),
+        etag,
+      },
+      null,
+      2
+    )
+  );
+
+  return dest;
+};
 
 const previousEnvVars = {};
 const ENV_VARS_TO_RESET = ['ES_SNAPSHOT_MANIFEST', 'KBN_ES_SNAPSHOT_USE_UNVERIFIED'];
@@ -85,6 +129,12 @@ beforeEach(() => {
   };
 });
 
+afterEach(() => {
+  TEMP_DIRS.splice(0).forEach((dir) => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 const artifactTest = (requestedLicense, expectedLicense, fetchTimesCalled = 1) => {
   return async () => {
     const artifact = await Artifact.getSnapshot(requestedLicense, MOCK_VERSION, log);
@@ -105,6 +155,102 @@ const artifactTest = (requestedLicense, expectedLicense, fetchTimesCalled = 1) =
 };
 
 describe('Artifact', () => {
+  describe('download()', () => {
+    it('redownloads a corrupt cached artifact after a 304 response', async () => {
+      const artifact = new Artifact(log, {
+        url: MOCK_URL,
+        filename: MOCK_FILENAME,
+        checksumUrl: `${MOCK_URL}.sha512`,
+        checksumType: 'sha512',
+      });
+      const validContents = Buffer.from('valid artifact');
+      const dest = createCachedArtifact({
+        contents: Buffer.from('corrupt artifact'),
+      });
+
+      fetch
+        .mockReturnValueOnce(Promise.resolve(new Response('', { status: 304 })))
+        .mockReturnValueOnce(
+          Promise.resolve(new Response(`${getChecksum(validContents)}  ${MOCK_FILENAME}`))
+        )
+        .mockReturnValueOnce(
+          Promise.resolve(
+            createArtifactResponse({
+              contents: validContents,
+              headers: { etag: 'fresh-etag' },
+            })
+          )
+        )
+        .mockReturnValueOnce(
+          Promise.resolve(new Response(`${getChecksum(validContents)}  ${MOCK_FILENAME}`))
+        );
+
+      await artifact.download(dest);
+
+      expect(fs.readFileSync(dest)).toEqual(validContents);
+      expect(JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8')).etag).toBe('fresh-etag');
+      expect(fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('reuses a cached artifact when the checksum endpoint is unavailable', async () => {
+      const artifact = new Artifact(log, {
+        url: MOCK_URL,
+        filename: MOCK_FILENAME,
+        checksumUrl: `${MOCK_URL}.sha512`,
+        checksumType: 'sha512',
+      });
+      const cachedContents = Buffer.from('cached artifact');
+      const dest = createCachedArtifact({
+        contents: cachedContents,
+      });
+
+      fetch
+        .mockReturnValueOnce(Promise.resolve(new Response('', { status: 304 })))
+        .mockReturnValueOnce(
+          Promise.resolve(new Response('', { status: 503, statusText: 'Service Unavailable' }))
+        );
+
+      await artifact.download(dest);
+
+      expect(fs.readFileSync(dest)).toEqual(cachedContents);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips the truncation guard for content-encoded responses', async () => {
+      const artifact = new Artifact(log, {
+        url: MOCK_URL,
+        filename: MOCK_FILENAME,
+        checksumUrl: `${MOCK_URL}.sha512`,
+        checksumType: 'sha512',
+      });
+      const validContents = Buffer.from('valid artifact');
+      const dest = createArtifactDest();
+
+      fetch
+        .mockReturnValueOnce(
+          Promise.resolve(
+            createArtifactResponse({
+              contents: validContents,
+              headers: {
+                etag: 'fresh-etag',
+                'content-encoding': 'gzip',
+                'content-length': '1',
+              },
+            })
+          )
+        )
+        .mockReturnValueOnce(
+          Promise.resolve(new Response(`${getChecksum(validContents)}  ${MOCK_FILENAME}`))
+        );
+
+      await artifact.download(dest);
+
+      expect(fs.readFileSync(dest)).toEqual(validContents);
+      expect(JSON.parse(fs.readFileSync(`${dest}.meta`, 'utf8')).etag).toBe('fresh-etag');
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getSnapshot()', () => {
     describe('with default snapshot', () => {
       beforeEach(() => {

--- a/src/platform/packages/shared/kbn-es/src/artifact.ts
+++ b/src/platform/packages/shared/kbn-es/src/artifact.ts
@@ -69,6 +69,9 @@ interface ArtifactCached {
   cached: true;
 }
 
+const CHECKSUM_MISMATCH_ERROR = 'ARTIFACT_CHECKSUM_MISMATCH';
+const CHECKSUM_UNAVAILABLE_ERROR = 'ARTIFACT_CHECKSUM_UNAVAILABLE';
+
 function getChecksumType(checksumUrl: string): ChecksumType {
   if (checksumUrl.endsWith('.sha512')) {
     return 'sha512';
@@ -82,6 +85,14 @@ function headersToString(headers: Headers, indent = '') {
     (acc, [key, value]) => `${acc}\n${indent}${key}: ${value}`,
     ''
   );
+}
+
+function createTaggedError(message: string, code: string) {
+  return Object.assign(new Error(message), { code });
+}
+
+function isTaggedError(error: unknown, code: string) {
+  return error instanceof Error && 'code' in error && error.code === code;
 }
 
 async function retry<T>(log: ToolingLog, fn: () => Promise<T>): Promise<T> {
@@ -235,10 +246,50 @@ export class Artifact {
 
       const artifactResp = await this.fetchArtifact(tmpPath, cacheMeta.etag, cacheMeta.ts);
       if (artifactResp.cached) {
+        // A 304 means the remote etag matches, but the file on disk may still be
+        // corrupt, e.g. if an ES snapshot was promoted while a CI VM image was
+        // being built, the cached file could have been overwritten mid-download.
+        // Verify the checksum before trusting the cache.
+        try {
+          await this.verifyExistingFileChecksum(dest);
+          return;
+        } catch (error) {
+          if (
+            isTaggedError(error, CHECKSUM_MISMATCH_ERROR) ||
+            (error as NodeJS.ErrnoException).code === 'ENOENT'
+          ) {
+            this.log.warning(
+              'cached artifact is invalid, redownloading:',
+              error instanceof Error ? error.message : error
+            );
+          } else if (isTaggedError(error, CHECKSUM_UNAVAILABLE_ERROR)) {
+            this.log.warning(
+              'unable to verify cached artifact checksum, reusing cached artifact:',
+              error.message
+            );
+            return;
+          } else {
+            throw error;
+          }
+        }
+
+        const redownloadedArtifact = await this.downloadAndVerify(tmpPath, cacheMeta.ts);
+
+        // cache the etag for future downloads
+        cache.writeMeta(dest, { etag: redownloadedArtifact.etag });
+
+        // rename temp download to the destination location
+        fs.renameSync(tmpPath, dest);
         return;
       }
 
-      await this.verifyChecksum(artifactResp);
+      try {
+        await this.verifyChecksum(artifactResp);
+      } catch (error) {
+        // clean up the temp file so a partial download doesn't linger
+        this.safeUnlink(tmpPath);
+        throw error;
+      }
 
       // cache the etag for future downloads
       cache.writeMeta(dest, { etag: artifactResp.etag });
@@ -249,11 +300,38 @@ export class Artifact {
   }
 
   /**
+   * Download (bypassing etag cache) and verify checksum, cleaning up on failure
+   */
+  private async downloadAndVerify(tmpPath: string, ts: string): Promise<ArtifactDownloaded> {
+    const artifactResp = await this.fetchArtifact(tmpPath, undefined, ts);
+    if (artifactResp.cached) {
+      throw new Error('expected cache bypass to download the artifact');
+    }
+
+    try {
+      await this.verifyChecksum(artifactResp);
+    } catch (error) {
+      this.safeUnlink(tmpPath);
+      throw error;
+    }
+
+    return artifactResp;
+  }
+
+  private safeUnlink(filePath: string) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch (e) {
+      // ignore if already gone
+    }
+  }
+
+  /**
    * Fetch the artifact with an etag
    */
   private async fetchArtifact(
     tmpPath: string,
-    etag: string,
+    etag: string | undefined,
     ts: string
   ): Promise<ArtifactDownloaded | ArtifactCached> {
     const url = this.spec.url;
@@ -267,9 +345,7 @@ export class Artifact {
     const abc = new AbortController();
     const resp = await fetch(url, {
       signal: abc.signal,
-      headers: {
-        'If-None-Match': etag,
-      },
+      headers: etag ? { 'If-None-Match': etag } : {},
     });
 
     if (resp.status === 304) {
@@ -321,6 +397,22 @@ export class Artifact {
       fs.createWriteStream(tmpPath)
     );
 
+    // Detect truncated downloads that closed cleanly (e.g. the server reset
+    // the connection after sending partial data). The checksum would also catch
+    // this, but failing here gives a clearer error message.
+    const expectedContentLength = resp.headers.get('content-length');
+    const contentEncoding = resp.headers.get('content-encoding');
+    if (
+      !contentEncoding &&
+      expectedContentLength &&
+      contentLength !== parseInt(expectedContentLength, 10)
+    ) {
+      this.safeUnlink(tmpPath);
+      throw new Error(
+        `download from ${url} was truncated, received ${contentLength} of ${expectedContentLength} bytes`
+      );
+    }
+
     return {
       cached: false,
       checksum: hash.digest('hex'),
@@ -335,6 +427,29 @@ export class Artifact {
    * Verify the checksum of the downloaded artifact with the checksum at checksumUrl
    */
   private async verifyChecksum(artifactResp: ArtifactDownloaded) {
+    const expectedChecksum = await this.fetchExpectedChecksum();
+
+    if (artifactResp.checksum !== expectedChecksum) {
+      const len = Buffer.byteLength(artifactResp.first500Bytes);
+      const lenString = `${len} / ${artifactResp.contentLength}`;
+
+      // Not a CliError so that retry() will re-attempt the download.
+      // The checksum mismatch may be transient if the artifact was being
+      // replaced on the server mid-download.
+      throw createTaggedError(
+        `artifact downloaded from ${this.spec.url} does not match expected checksum\n` +
+          `  expected: ${expectedChecksum}\n` +
+          `  received: ${artifactResp.checksum}\n` +
+          `  headers: ${headersToString(artifactResp.headers, '    ')}\n` +
+          `  content[${lenString} base64]: ${artifactResp.first500Bytes.toString('base64')}`,
+        CHECKSUM_MISMATCH_ERROR
+      );
+    }
+
+    this.log.info('checksum verified');
+  }
+
+  private async fetchExpectedChecksum() {
     this.log.info('downloading artifact checksum from %s', chalk.bold(this.spec.checksumUrl));
 
     const abc = new AbortController();
@@ -344,26 +459,32 @@ export class Artifact {
 
     if (!resp.ok) {
       abc.abort();
-      throw new Error(
+      throw createTaggedError(
         `Unable to download elasticsearch checksum: ${resp.statusText}${headersToString(
           resp.headers,
           '  '
-        )}`
+        )}`,
+        CHECKSUM_UNAVAILABLE_ERROR
       );
     }
 
     // in format of stdout from `shasum` cmd, which is `<checksum>   <filename>`
     const [expectedChecksum] = (await resp.text()).split(' ');
-    if (artifactResp.checksum !== expectedChecksum) {
-      const len = Buffer.byteLength(artifactResp.first500Bytes);
-      const lenString = `${len} / ${artifactResp.contentLength}`;
+    return expectedChecksum;
+  }
 
-      throw createCliError(
-        `artifact downloaded from ${this.spec.url} does not match expected checksum\n` +
-          `  expected: ${expectedChecksum}\n` +
-          `  received: ${artifactResp.checksum}\n` +
-          `  headers: ${headersToString(artifactResp.headers, '    ')}\n` +
-          `  content[${lenString} base64]: ${artifactResp.first500Bytes.toString('base64')}`
+  private async verifyExistingFileChecksum(dest: string) {
+    const hash = createHash(this.spec.checksumType);
+    for await (const chunk of fs.createReadStream(dest)) {
+      hash.update(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    const expectedChecksum = await this.fetchExpectedChecksum();
+    const actualChecksum = hash.digest('hex');
+    if (actualChecksum !== expectedChecksum) {
+      throw createTaggedError(
+        `cached artifact at ${dest} checksum mismatch: expected ${expectedChecksum}, got ${actualChecksum}`,
+        CHECKSUM_MISMATCH_ERROR
       );
     }
 


### PR DESCRIPTION
A 304 (etag match) was trusted blindly, so a corrupted cached tarball caused ZlibError during extraction on CI.

- Hash cached files against the remote .sha512 on cache hit; re-download on mismatch
- Make checksum mismatches retryable (was CliError, which retry() skipped)
- Detect truncated downloads via Content-Length comparison
- Clean up .tmp files on download failure

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->