### PR TITLE
[Scout Docs] Clarify serverless project type in Run Scout tests guide

### DIFF
--- a/docs/extend/scout/run-tests.md
+++ b/docs/extend/scout/run-tests.md
@@ -232,11 +232,12 @@ To retrieve its password, call the `_reset-internal-credentials` Elastic Cloud A
 ```bash
 curl -XPOST \
   -H "Authorization: ApiKey $API_KEY" \
-  "${CLOUD_ENV_URL}/api/v1/serverless/projects/elasticsearch/${PROJECT_ID}/_reset-internal-credentials"
+  "${CLOUD_ENV_URL}/api/v1/serverless/projects/${PROJECT_TYPE}/${PROJECT_ID}/_reset-internal-credentials"
 ```
 
 - `API_KEY`: create in the Elastic Cloud UI (Organization → API keys)
 - `CLOUD_ENV_URL`: base URL of your Cloud environment (for example `https://console.qa.cld.elstc.co`)
+- `PROJECT_TYPE`: must match your serverless project type — one of `elasticsearch`, `security`, or `observability`
 - `PROJECT_ID`: serverless project ID from the Cloud UI
 
 :::::::

--- a/docs/extend/scout/run-tests.md
+++ b/docs/extend/scout/run-tests.md
@@ -237,7 +237,7 @@ curl -XPOST \
 
 - `API_KEY`: create in the Elastic Cloud UI (Organization → API keys)
 - `CLOUD_ENV_URL`: base URL of your Cloud environment (for example `https://console.qa.cld.elstc.co`)
-- `PROJECT_TYPE`: must match your serverless project type — one of `elasticsearch`, `security`, or `observability`
+- `PROJECT_TYPE`: serverless project type (`elasticsearch`, `security`, or `observability`)
 - `PROJECT_ID`: serverless project ID from the Cloud UI
 
 :::::::


### PR DESCRIPTION
This PR updates the existing [Run Scout tests](https://www.elastic.co/docs/extend/kibana/scout/run-tests) guide to remove the hardcoded `elasticsearch` value from the URL, and **provide a list of possible project types** that can be passed to the Elasticians-only `_reset-internal-credentials` endpoint. This endpoint is used to retrieve the credentials for the `testing-internal` operator user.