### PR TITLE
[Synthetics] Only delete legacy policies that exist upon monitor delete

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
@@ -353,6 +353,7 @@ describe('SyntheticsPrivateLocation', () => {
         ...serverMock.fleet,
         packagePolicyService: {
           ...serverMock.fleet.packagePolicyService,
+          getByIDs: jest.fn().mockResolvedValue([{ id: 'testId-policyId' }]),
           delete(
             soClient: SavedObjectsClientContract,
             esClient: any,
@@ -417,6 +418,47 @@ describe('SyntheticsPrivateLocation', () => {
     const deletedIds = deleteMock.mock.calls[0][2] as string[];
     expect(deletedIds).toContain('testId-policyId');
     expect(deletedIds).toContain('testId-policyId-test-space');
+  });
+
+  it('deleteMonitors only deletes new-format id when that policy exists', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const getByIDsMock = jest.fn().mockResolvedValue([{ id: 'testId-policyId-test-space' }]);
+    const syntheticsPrivateLocation = new SyntheticsPrivateLocation({
+      ...serverMock,
+      fleet: {
+        ...serverMock.fleet,
+        packagePolicyService: {
+          ...serverMock.fleet.packagePolicyService,
+          getByIDs: getByIDsMock,
+          delete: deleteMock,
+        },
+      },
+    });
+
+    await syntheticsPrivateLocation.deleteMonitors([testConfig], 'test-space');
+
+    const deletedIds = deleteMock.mock.calls[0][2] as string[];
+    expect(deletedIds).toEqual(['testId-policyId-test-space']);
+    expect(deletedIds).not.toContain('testId-policyId');
+  });
+
+  it('deleteMonitors does not call delete when no matching policies exist', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const syntheticsPrivateLocation = new SyntheticsPrivateLocation({
+      ...serverMock,
+      fleet: {
+        ...serverMock.fleet,
+        packagePolicyService: {
+          ...serverMock.fleet.packagePolicyService,
+          getByIDs: jest.fn().mockResolvedValue([]),
+          delete: deleteMock,
+        },
+      },
+    });
+
+    await syntheticsPrivateLocation.deleteMonitors([testConfig], 'test-space');
+
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('formats monitors stream properly', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
@@ -87,6 +87,7 @@ describe('SyntheticsPrivateLocation', () => {
   } as unknown as SyntheticsServerSetup;
   beforeEach(() => {
     mockBuildPackagePolicy.mockReturnValue(undefined);
+    (serverMock.fleet.packagePolicyService.getByIDs as jest.Mock).mockResolvedValue([]);
   });
 
   describe('getPolicyNamespace', () => {
@@ -368,6 +369,54 @@ describe('SyntheticsPrivateLocation', () => {
     } catch (e) {
       expect(e).toEqual(new Error(error));
     }
+  });
+
+  it('deleteMonitors only deletes legacy package policy ids that exist', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const getByIDsMock = jest.fn().mockResolvedValue([{ id: 'testId-policyId' }]);
+    const syntheticsPrivateLocation = new SyntheticsPrivateLocation({
+      ...serverMock,
+      fleet: {
+        ...serverMock.fleet,
+        packagePolicyService: {
+          ...serverMock.fleet.packagePolicyService,
+          getByIDs: getByIDsMock,
+          delete: deleteMock,
+        },
+      },
+    });
+
+    await syntheticsPrivateLocation.deleteMonitors([testConfig], 'test-space');
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    const deletedIds = deleteMock.mock.calls[0][2] as string[];
+    expect(deletedIds).toContain('testId-policyId');
+    expect(deletedIds).not.toContain('testId-policyId-test-space');
+    expect(deletedIds.length).toBe(1);
+  });
+
+  it('deleteMonitors deletes legacy package policy ids when they exist', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+    const getByIDsMock = jest
+      .fn()
+      .mockResolvedValue([{ id: 'testId-policyId' }, { id: 'testId-policyId-test-space' }]);
+    const syntheticsPrivateLocation = new SyntheticsPrivateLocation({
+      ...serverMock,
+      fleet: {
+        ...serverMock.fleet,
+        packagePolicyService: {
+          ...serverMock.fleet.packagePolicyService,
+          getByIDs: getByIDsMock,
+          delete: deleteMock,
+        },
+      },
+    });
+
+    await syntheticsPrivateLocation.deleteMonitors([testConfig], 'test-space');
+
+    const deletedIds = deleteMock.mock.calls[0][2] as string[];
+    expect(deletedIds).toContain('testId-policyId');
+    expect(deletedIds).toContain('testId-policyId-test-space');
   });
 
   it('formats monitors stream properly', () => {

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -568,17 +568,35 @@ export class SyntheticsPrivateLocation {
     const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
     const allSpacesWithMonitors = await this.getAllSpacesWithMonitors();
     const allSpaces = new Set([spaceId, ...allSpacesWithMonitors]);
-    const policyIdsToDelete = new Set<string>();
 
+    const policyIdsToFetch = new Set<string>();
     for (const config of configs) {
-      const { locations } = config;
-      const monitorPrivateLocations = locations.filter((loc) => !loc.isServiceManaged);
-
+      const monitorPrivateLocations = config.locations.filter((loc) => !loc.isServiceManaged);
       for (const privateLocation of monitorPrivateLocations) {
-        policyIdsToDelete.add(this.getPolicyId(config, privateLocation.id));
+        policyIdsToFetch.add(this.getPolicyId(config, privateLocation.id));
         this.getLegacyPolicyIdsForAllSpaces(config.id, privateLocation.id, allSpaces).forEach(
-          (id) => policyIdsToDelete.add(id)
+          (id) => policyIdsToFetch.add(id)
         );
+      }
+    }
+
+    const existingPolicies =
+      (await this.server.fleet.packagePolicyService.getByIDs(soClient, [...policyIdsToFetch], {
+        ignoreMissing: true,
+      })) ?? [];
+
+    const policyIdsToDelete = new Set<string>();
+    for (const config of configs) {
+      const monitorPrivateLocations = config.locations.filter((loc) => !loc.isServiceManaged);
+      for (const privateLocation of monitorPrivateLocations) {
+        const { legacyPolicyIds } = this.getPolicyIdFormatInfo(
+          config,
+          privateLocation.id,
+          existingPolicies,
+          allSpaces
+        );
+        policyIdsToDelete.add(this.getPolicyId(config, privateLocation.id));
+        legacyPolicyIds.forEach((id) => policyIdsToDelete.add(id));
       }
     }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -589,13 +589,15 @@ export class SyntheticsPrivateLocation {
     for (const config of configs) {
       const monitorPrivateLocations = config.locations.filter((loc) => !loc.isServiceManaged);
       for (const privateLocation of monitorPrivateLocations) {
-        const { legacyPolicyIds } = this.getPolicyIdFormatInfo(
+        const { hasNewFormatPolicyId, legacyPolicyIds } = this.getPolicyIdFormatInfo(
           config,
           privateLocation.id,
           existingPolicies,
           allSpaces
         );
-        policyIdsToDelete.add(this.getPolicyId(config, privateLocation.id));
+        if (hasNewFormatPolicyId) {
+          policyIdsToDelete.add(this.getPolicyId(config, privateLocation.id));
+        }
         legacyPolicyIds.forEach((id) => policyIdsToDelete.add(id));
       }
     }


### PR DESCRIPTION
### Problem

When deleting monitor(s), it tried to delete every possible legacy package policy id ({configId}-{locationId}-{spaceId} for all spaces with monitors), even when those saved objects never existed - e.g. fresh cluster using only the new id format. That produced noisy Fleet 404 errors.

### Solution

Align delete with the edit path - only add legacy ids to the delete batch when they exist.