### PR TITLE
[Obs Agent] fix get_traces maxTraces flaky test

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_traces.spec.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/observability_agent_builder/tools/get_traces.spec.ts
@@ -48,7 +48,6 @@ async function indexCorrelatedLogs({
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
   const synthtrace = getService('synthtrace');
-  const range = timerange(START, END);
 
   describe(`tool: ${OBSERVABILITY_GET_TRACES_TOOL_ID}`, function () {
     let agentBuilderApiClient: ReturnType<typeof createAgentBuilderApiClient>;
@@ -66,7 +65,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       await logsSynthtraceEsClient.clean();
 
       const apmData = generateGetTracesApmDataset({
-        range,
+        range: timerange(START, END),
         apmEsClient: apmSynthtraceEsClient,
         traces: DEFAULT_TRACE_CONFIGS,
       });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/254316

## Summary
Fixes a flaky test in `get_traces` related to `maxTraces`.

### Root Cause
The problem happens because the time range is calculated when the file is loaded, not during the test setup.
- The time range is created once when the test file loads.
- The tests use a sliding time window (`now-10m` → `now`).

### Why this caused flakiness
- APM data is indexed with timestamps that are already old, timestamps are outside the query window used in the tests.



<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->