### PR TITLE
[ES|QL] Ignore trailing whitespace in overlap matching

### DIFF
--- a/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.ts
+++ b/src/platform/packages/shared/kbn-esql-language/src/language/autocomplete/utils/prefix_range.ts
@@ -106,7 +106,11 @@ export function attachReplacementRanges(
       return [resolvedSuggestion];
     }
 
-    const overlapRange = CONTAINS_WHITESPACE_REGEX.test(suggestion.text)
+    // getOverlapRange is only needed for suggestions whose internal whitespace is
+    // part of the typed sequence, such as "IS NOT NULL" after "IS NO|". Using
+    // trimEnd() keeps trailing formatting whitespace from routing otherwise-normal
+    // suggestions through the overlap path.
+    const overlapRange = CONTAINS_WHITESPACE_REGEX.test(suggestion.text.trimEnd())
       ? getOverlapRange(innerText, suggestion.text)
       : undefined;
     const effectiveRange = overlapRange ?? { start: range.start, end: range.end };


### PR DESCRIPTION
## Summary

This is the first of two fixes. I'm separating them because they're two different scopes (and perhaps the second is optional).

That's happens for example when you write event or event.dataset then press `space `and then `backspace` and/or continue typing `backespace`


Before .

<img width="933" height="215" alt="before (1)" src="https://github.com/user-attachments/assets/f3db3cb9-cbb6-4646-a224-5a1f90a55583" />

after

<img width="929" height="140" alt="after" src="https://github.com/user-attachments/assets/e4135f73-018e-4630-87d2-7399c2f888e7" />
