### PR TITLE
[Fleet] Make warning icon visible only when policy are available

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/components/installed_integrations_table.tsx
@@ -249,9 +249,8 @@ export const InstalledIntegrationsTable: React.FunctionComponent<{
               const status = item.ui.installation_status;
               const review = item.installationInfo?.pending_upgrade_review;
               const showPendingReview = status === 'pending_upgrade_review' && review;
-              const showDeclinedReview = status === 'declined_review' && review;
 
-              if (!policyCount && !showPendingReview && !showDeclinedReview) {
+              if (!policyCount && !showPendingReview) {
                 return null;
               }
 
@@ -282,7 +281,7 @@ export const InstalledIntegrationsTable: React.FunctionComponent<{
                   </EuiLink>
                 </DisabledWrapperTooltip>
               ) : null;
-              if (showPendingReview) {
+              if (policyCount && showPendingReview) {
                 return (
                   <EuiFlexGroup direction="row" gutterSize="xs" alignItems="center" wrap={true}>
                     {policiesLink && <EuiFlexItem grow={false}>{policiesLink}</EuiFlexItem>}


### PR DESCRIPTION
## Summary

Very small bug related to https://github.com/elastic/kibana/pull/257937. The warning icon signaling the auto-upgrade was visible when no integration policies were available. This PR fixes it.

<img width="1333" height="87" alt="Screenshot 2026-03-20 at 12 20 39" src="https://github.com/user-attachments/assets/8bf197f3-b10a-44f5-82fe-e0fec898124b" />






