### PR TITLE
[Agent Builder] Show correct attachment version in conversation history

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/conversation_rounds.tsx
@@ -55,6 +55,8 @@ export const ConversationRounds: React.FC<ConversationRoundsProps> = ({
             rawRound={round}
             conversationId={conversation?.id}
             conversationAttachments={conversation?.attachments}
+            allRounds={conversationRounds}
+            roundIndex={index}
           />
         );
       })}

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_layout.tsx
@@ -7,10 +7,13 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { ConversationRound } from '@kbn/agent-builder-common';
-import type { VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import type {
+  VersionedAttachment,
+  AttachmentVersionRef,
+} from '@kbn/agent-builder-common/attachments';
 import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
 import { ConversationRoundStatus } from '@kbn/agent-builder-common';
 import { isConfirmationPrompt } from '@kbn/agent-builder-common/agents';
@@ -28,6 +31,8 @@ interface RoundLayoutProps {
   rawRound: ConversationRound;
   conversationAttachments?: VersionedAttachment[];
   conversationId?: string;
+  allRounds: ConversationRound[];
+  roundIndex: number;
 }
 
 const labels = {
@@ -36,12 +41,40 @@ const labels = {
   }),
 };
 
+/**
+ * Computes cumulative attachment refs from all rounds up to and including the given index.
+ * Returns the highest version seen for each attachment.
+ */
+const computeCumulativeRefs = (
+  rounds: ConversationRound[],
+  upToIndex: number
+): AttachmentVersionRef[] | undefined => {
+  const highestVersionByAttachment = new Map<string, AttachmentVersionRef>();
+
+  for (let i = 0; i <= upToIndex; i++) {
+    const roundRefs = rounds[i]?.input.attachment_refs;
+    if (roundRefs) {
+      for (const ref of roundRefs) {
+        const existing = highestVersionByAttachment.get(ref.attachment_id);
+        if (!existing || ref.version > existing.version) {
+          highestVersionByAttachment.set(ref.attachment_id, ref);
+        }
+      }
+    }
+  }
+
+  const values = Array.from(highestVersionByAttachment.values());
+  return values.length > 0 ? values : undefined;
+};
+
 export const RoundLayout: React.FC<RoundLayoutProps> = ({
   isCurrentRound,
   scrollContainerHeight,
   rawRound,
   conversationAttachments,
   conversationId,
+  allRounds,
+  roundIndex,
 }) => {
   const [roundContainerMinHeight, setRoundContainerMinHeight] = useState(0);
   const [hasBeenLoading, setHasBeenLoading] = useState(false);
@@ -64,6 +97,11 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
     status === ConversationRoundStatus.awaitingPrompt &&
     pendingPrompt &&
     !isResuming;
+
+  const cumulativeAttachmentRefs = useMemo(() => {
+    if (!response?.message) return undefined;
+    return computeCumulativeRefs(allRounds, roundIndex);
+  }, [allRounds, roundIndex, response?.message]);
 
   const handleConfirm = useCallback(() => {
     resumeRound({ promptId: pendingPrompt!.id, confirm: true });
@@ -156,7 +194,7 @@ export const RoundLayout: React.FC<RoundLayoutProps> = ({
               isLoading={isLoadingCurrentRound}
               isLastRound={isCurrentRound}
               conversationAttachments={conversationAttachments}
-              attachmentRefs={input.attachment_refs}
+              attachmentRefs={cumulativeAttachmentRefs}
               conversationId={conversationId}
             />
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.test.ts
@@ -42,7 +42,6 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs: undefined,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBe(5);
@@ -55,7 +54,6 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs: undefined,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBe(3);
@@ -70,7 +68,6 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBe(2);
@@ -78,7 +75,7 @@ describe('resolveAttachmentVersion', () => {
   });
 
   describe('when explicitVersion is undefined', () => {
-    it('returns the ref version when there is a single matching ref', () => {
+    it('returns the ref version when there is a matching ref', () => {
       const attachment = createMockAttachment(attachmentId);
       const attachmentRefs: AttachmentVersionRef[] = [{ attachment_id: attachmentId, version: 5 }];
 
@@ -87,37 +84,16 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBe(5);
     });
 
-    it('returns the highest version when multiple refs match the attachmentId', () => {
-      const attachment = createMockAttachment(attachmentId);
-      const attachmentRefs: AttachmentVersionRef[] = [
-        { attachment_id: attachmentId, version: 2 },
-        { attachment_id: attachmentId, version: 8 },
-        { attachment_id: attachmentId, version: 5 },
-      ];
-
-      const result = resolveAttachmentVersion({
-        explicitVersion: undefined,
-        attachmentId,
-        attachmentRefs,
-        attachment,
-        conversationAttachments: [attachment],
-      });
-
-      expect(result).toBe(8);
-    });
-
-    it('only considers refs matching the attachmentId when finding the highest version', () => {
+    it('only considers refs matching the attachmentId', () => {
       const attachment = createMockAttachment(attachmentId);
       const attachmentRefs: AttachmentVersionRef[] = [
         { attachment_id: 'other-attachment', version: 100 },
         { attachment_id: attachmentId, version: 3 },
-        { attachment_id: attachmentId, version: 7 },
         { attachment_id: 'another-attachment', version: 50 },
       ];
 
@@ -126,55 +102,16 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs,
         attachment,
-        conversationAttachments: [attachment],
       });
 
-      expect(result).toBe(7);
-    });
-  });
-
-  describe('when no refs match but other refs exist (time boundary inference)', () => {
-    it('returns the highest version created before the latest ref time', () => {
-      // Attachment we're rendering has 3 versions
-      const attachment = createMockAttachment(attachmentId, [
-        { version: 1, created_at: '2024-01-01T10:00:00Z' },
-        { version: 2, created_at: '2024-01-02T10:00:00Z' },
-        { version: 3, created_at: '2024-01-04T10:00:00Z' }, // After the ref time
-      ]);
-
-      // Other attachment that IS in refs (created at 2024-01-03)
-      const otherAttachment = createMockAttachment('other-attachment', [
-        { version: 1, created_at: '2024-01-03T10:00:00Z' },
-      ]);
-
-      // Refs only contain the other attachment
-      const attachmentRefs: AttachmentVersionRef[] = [
-        { attachment_id: 'other-attachment', version: 1 },
-      ];
-
-      const result = resolveAttachmentVersion({
-        explicitVersion: undefined,
-        attachmentId,
-        attachmentRefs,
-        attachment,
-        conversationAttachments: [attachment, otherAttachment],
-      });
-
-      // Should return version 2, as it was created before the ref time (2024-01-03)
-      // Version 3 was created after, so it's excluded
-      expect(result).toBe(2);
+      expect(result).toBe(3);
     });
 
-    it('returns the highest version when all versions are before the latest ref time', () => {
+    it('returns latest version when no refs match', () => {
       const attachment = createMockAttachment(attachmentId, [
         { version: 1, created_at: '2024-01-01T10:00:00Z' },
         { version: 2, created_at: '2024-01-02T10:00:00Z' },
       ]);
-
-      const otherAttachment = createMockAttachment('other-attachment', [
-        { version: 1, created_at: '2024-01-05T10:00:00Z' },
-      ]);
-
       const attachmentRefs: AttachmentVersionRef[] = [
         { attachment_id: 'other-attachment', version: 1 },
       ];
@@ -184,35 +121,8 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs,
         attachment,
-        conversationAttachments: [attachment, otherAttachment],
       });
 
-      expect(result).toBe(2);
-    });
-
-    it('returns latest version when all versions are after the latest ref time', () => {
-      const attachment = createMockAttachment(attachmentId, [
-        { version: 1, created_at: '2024-01-10T10:00:00Z' },
-        { version: 2, created_at: '2024-01-11T10:00:00Z' },
-      ]);
-
-      const otherAttachment = createMockAttachment('other-attachment', [
-        { version: 1, created_at: '2024-01-05T10:00:00Z' },
-      ]);
-
-      const attachmentRefs: AttachmentVersionRef[] = [
-        { attachment_id: 'other-attachment', version: 1 },
-      ];
-
-      const result = resolveAttachmentVersion({
-        explicitVersion: undefined,
-        attachmentId,
-        attachmentRefs,
-        attachment,
-        conversationAttachments: [attachment, otherAttachment],
-      });
-
-      // Falls back to latest version
       expect(result).toBe(2);
     });
   });
@@ -229,7 +139,6 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs: undefined,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBe(2);
@@ -243,7 +152,6 @@ describe('resolveAttachmentVersion', () => {
         attachmentId,
         attachmentRefs: undefined,
         attachment,
-        conversationAttachments: [attachment],
       });
 
       expect(result).toBeUndefined();

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
@@ -25,53 +25,20 @@ interface ResolveAttachmentVersionParams {
   attachmentId: string;
   attachmentRefs: AttachmentVersionRef[] | undefined;
   attachment: VersionedAttachment;
-  conversationAttachments: VersionedAttachment[] | undefined;
 }
-
-/**
- * Gets the latest created_at timestamp from any version referenced in attachmentRefs.
- * This serves as a "time boundary" for the round - if other attachments in this round
- * have refs up to time T, then any attachment rendered should show the version
- * that was current at time T.
- */
-const getLatestRefTime = (
-  attachmentRefs: AttachmentVersionRef[] | undefined,
-  conversationAttachments: VersionedAttachment[] | undefined
-): number | undefined => {
-  if (!attachmentRefs?.length || !conversationAttachments?.length) {
-    return undefined;
-  }
-
-  let latestTime: number | undefined;
-
-  for (const ref of attachmentRefs) {
-    const refAttachment = conversationAttachments.find((a) => a.id === ref.attachment_id);
-    const version = refAttachment?.versions.find((v) => v.version === ref.version);
-    if (version) {
-      const time = new Date(version.created_at).getTime();
-      if (latestTime === undefined || time > latestTime) {
-        latestTime = time;
-      }
-    }
-  }
-
-  return latestTime;
-};
 
 /**
  * Resolves the version to use for an attachment.
  * Priority:
  * 1. Explicit version from tag attributes
- * 2. Highest version from this round's attachment refs
- * 3. Highest version created at or before the latest ref time (to avoid showing future versions)
- * 4. Latest available version as fallback
+ * 2. Version from cumulative attachment refs (highest version seen up to this round)
+ * 3. Latest available version as fallback
  */
 export const resolveAttachmentVersion = ({
   explicitVersion,
   attachmentId,
   attachmentRefs,
   attachment,
-  conversationAttachments,
 }: ResolveAttachmentVersionParams): number | undefined => {
   if (explicitVersion !== undefined) {
     const parsed =
@@ -81,26 +48,9 @@ export const resolveAttachmentVersion = ({
     }
   }
 
-  const highestRefVersion = attachmentRefs
-    ?.filter((r) => r.attachment_id === attachmentId)
-    .reduce<number | undefined>(
-      (max, r) => (max === undefined || r.version > max ? r.version : max),
-      undefined
-    );
-
-  if (highestRefVersion !== undefined) {
-    return highestRefVersion;
-  }
-
-  // No refs for this attachment - infer time boundary from other refs in this round
-  const latestRefTime = getLatestRefTime(attachmentRefs, conversationAttachments);
-  if (latestRefTime !== undefined) {
-    const eligibleVersions = attachment.versions.filter(
-      (v) => new Date(v.created_at).getTime() <= latestRefTime
-    );
-    if (eligibleVersions.length > 0) {
-      return Math.max(...eligibleVersions.map((v) => v.version));
-    }
+  const ref = attachmentRefs?.find((r) => r.attachment_id === attachmentId);
+  if (ref) {
+    return ref.version;
   }
 
   // Final fallback: use the latest version
@@ -181,7 +131,6 @@ export const createRenderAttachmentRenderer = ({
       attachmentId,
       attachmentRefs,
       attachment,
-      conversationAttachments,
     });
 
     if (versionToUse === undefined) {


### PR DESCRIPTION
## Summary
Another take on https://github.com/elastic/kibana/pull/258119

Fixes attachment pills (badges) in conversation history showing the **latest version** instead of the version that was current **at the time of that round**.

  ### The Problem

  **Example scenario:**
  1. **Round 1**: User asks to create a dashboard → Dashboard v1 is created (but not displayed)
  2. **Round 2**: User says "show it" → Agent renders `<render_attachment id="dashboard-id"/>` (should show v1)
  3. **Round 3**: User says "add one more vis" → Dashboard is updated to v2

  **The bug**: When looking back at Round 2, the attachment pill showed v2 instead of v1.

  ### Why the Previous Solution Didn't Work

  The original approach used **time boundary inference** - looking at `created_at` timestamps of other attachment refs in the round to determine which version was current.

  **This failed because:**

  1. **Round 2 had no `attachment_refs`** - When the user said "show it", there are no steps recorded in api call (another bug? not sure, I'll investigate separately)

  2. **With no refs, the time boundary couldn't be computed** - The fallback logic relied on having *some* refs to establish a time boundary. With zero refs, it fell through to "use latest version".

  ### The Solution

  Instead of relying on time-based inference, we now use **cumulative attachment refs**:

  1. **`conversation_rounds.tsx`** passes `allRounds` and `roundIndex` to each `RoundLayout`

  2. **`round_layout.tsx`** computes `cumulativeAttachmentRefs` lazily - the highest version seen for each attachment across all rounds **up to and including the current round**

  3. **`resolveAttachmentVersion`** is now simplified:
     - Use explicit version if provided in the tag
     - Look up the version from cumulative refs
     - Fall back to latest version

  **Why this works:**
  - Round 1 has refs for the dashboard v1 being created
  - Round 2 inherits those refs (cumulative), so even though Round 2 itself has no refs, it "knows" about v1 from Round 1
  - Round 3 adds refs for v2, but Round 2's cumulative refs only go up to Round 2, so it still sees v1