### PR TITLE
[Fleet] Add namespace for dynamic routing of metrics collected by elasticapm processor

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -625,6 +625,8 @@ describe('generateOtelcolConfig', () => {
               ],
             },
           ],
+        },
+        'transform/apmtest-apm-namespace-routing': {
           metric_statements: [
             {
               context: 'datapoint',
@@ -632,10 +634,10 @@ describe('generateOtelcolConfig', () => {
             },
           ],
         },
-        'elasticapm/test-traces-stream-id-1': {},
+        'elasticapm/apmtest': {},
       },
       connectors: {
-        'elasticapm/test-traces-stream-id-1': {},
+        'elasticapm/apmtest': {},
         forward: {},
       },
       exporters: {
@@ -647,15 +649,12 @@ describe('generateOtelcolConfig', () => {
         pipelines: {
           'traces/test-traces-stream-id-1': {
             receivers: ['zipkin/test-traces-stream-id-1'],
-            exporters: ['elasticapm/test-traces-stream-id-1', 'forward'],
-            processors: [
-              'elasticapm/test-traces-stream-id-1',
-              'transform/test-traces-stream-id-1-routing',
-            ],
+            exporters: ['elasticapm/apmtest', 'forward'],
+            processors: ['elasticapm/apmtest', 'transform/test-traces-stream-id-1-routing'],
           },
-          'metrics/test-traces-stream-id-1-aggregated-apm-metrics': {
-            receivers: ['elasticapm/test-traces-stream-id-1'],
-            processors: ['transform/test-traces-stream-id-1-routing'],
+          'metrics/apmtest-aggregated-apm-metrics': {
+            receivers: ['elasticapm/apmtest'],
+            processors: ['transform/apmtest-apm-namespace-routing'],
             exporters: ['forward'],
           },
           traces: {
@@ -707,30 +706,103 @@ describe('generateOtelcolConfig', () => {
 
     const result = generateOtelcolConfig([inputA, inputB], defaultOutput);
 
+    expect(result.connectors?.['elasticapm/ns-a']).toEqual({});
+    expect(result.connectors?.['elasticapm/ns-b']).toEqual({});
+    expect(result.connectors?.['elasticapm/policy-a-stream-id-1']).toBeUndefined();
+    expect(result.connectors?.['elasticapm/policy-b-stream-id-1']).toBeUndefined();
+
+    expect(result.service?.pipelines?.['metrics/ns-a-aggregated-apm-metrics']).toEqual({
+      receivers: ['elasticapm/ns-a'],
+      processors: ['transform/ns-a-apm-namespace-routing'],
+      exporters: ['forward'],
+    });
+    expect(result.service?.pipelines?.['metrics/ns-b-aggregated-apm-metrics']).toEqual({
+      receivers: ['elasticapm/ns-b'],
+      processors: ['transform/ns-b-apm-namespace-routing'],
+      exporters: ['forward'],
+    });
     expect(
       result.service?.pipelines?.['metrics/policy-a-stream-id-1-aggregated-apm-metrics']
-    ).toEqual({
-      receivers: ['elasticapm/policy-a-stream-id-1'],
-      processors: ['transform/policy-a-stream-id-1-routing'],
-      exporters: ['forward'],
-    });
+    ).toBeUndefined();
     expect(
       result.service?.pipelines?.['metrics/policy-b-stream-id-1-aggregated-apm-metrics']
-    ).toEqual({
-      receivers: ['elasticapm/policy-b-stream-id-1'],
-      processors: ['transform/policy-b-stream-id-1-routing'],
+    ).toBeUndefined();
+
+    expect(result.processors?.['transform/ns-a-apm-namespace-routing']).toEqual({
+      metric_statements: [
+        { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-a")'] },
+      ],
+    });
+    expect(result.processors?.['transform/ns-b-apm-namespace-routing']).toEqual({
+      metric_statements: [
+        { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-b")'] },
+      ],
+    });
+
+    expect(result.service?.pipelines?.['traces/policy-a-stream-id-1']?.exporters).toContain(
+      'elasticapm/ns-a'
+    );
+    expect(result.service?.pipelines?.['traces/policy-b-stream-id-1']?.exporters).toContain(
+      'elasticapm/ns-b'
+    );
+  });
+
+  it('should produce a single aggregated-apm-metrics pipeline for two APM package policies with the same namespace', () => {
+    const inputA: FullAgentPolicyInput = {
+      ...otelTracesInputWithAPM,
+      id: 'policy-a',
+      name: 'policy-a',
+      package_policy_id: 'policy-a',
+      data_stream: { namespace: 'ns-shared' },
+      streams: [
+        {
+          id: 'stream-id-1',
+          data_stream: { dataset: 'apm', type: 'traces' },
+          use_apm: true,
+          receivers: { otlp: { protocols: { grpc: { endpoint: '0.0.0.0:4317' } } } },
+          service: { pipelines: { traces: { receivers: ['otlp'] } } },
+        },
+      ],
+    };
+    const inputB: FullAgentPolicyInput = {
+      ...otelTracesInputWithAPM,
+      id: 'policy-b',
+      name: 'policy-b',
+      package_policy_id: 'policy-b',
+      data_stream: { namespace: 'ns-shared' },
+      streams: [
+        {
+          id: 'stream-id-1',
+          data_stream: { dataset: 'apm', type: 'traces' },
+          use_apm: true,
+          receivers: { otlp: { protocols: { grpc: { endpoint: '0.0.0.0:4318' } } } },
+          service: { pipelines: { traces: { receivers: ['otlp'] } } },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig([inputA, inputB], defaultOutput);
+
+    expect(result.connectors?.['elasticapm/ns-shared']).toEqual({});
+    expect(result.connectors?.['elasticapm/policy-a-stream-id-1']).toBeUndefined();
+    expect(result.connectors?.['elasticapm/policy-b-stream-id-1']).toBeUndefined();
+
+    const aggregatedPipelineKeys = Object.keys(result.service?.pipelines ?? {}).filter((k) =>
+      k.includes('aggregated-apm-metrics')
+    );
+    expect(aggregatedPipelineKeys).toHaveLength(1);
+    expect(result.service?.pipelines?.['metrics/ns-shared-aggregated-apm-metrics']).toEqual({
+      receivers: ['elasticapm/ns-shared'],
+      processors: ['transform/ns-shared-apm-namespace-routing'],
       exporters: ['forward'],
     });
-    expect(
-      result.processors?.['transform/policy-a-stream-id-1-routing']?.metric_statements
-    ).toEqual([
-      { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-a")'] },
-    ]);
-    expect(
-      result.processors?.['transform/policy-b-stream-id-1-routing']?.metric_statements
-    ).toEqual([
-      { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-b")'] },
-    ]);
+
+    expect(result.service?.pipelines?.['traces/policy-a-stream-id-1']?.exporters).toContain(
+      'elasticapm/ns-shared'
+    );
+    expect(result.service?.pipelines?.['traces/policy-b-stream-id-1']?.exporters).toContain(
+      'elasticapm/ns-shared'
+    );
   });
 
   describe('with dynamic_signal_types (multiple signal types)', () => {
@@ -871,25 +943,23 @@ describe('generateOtelcolConfig', () => {
       const inputs: FullAgentPolicyInput[] = [inputWithUseApm];
       const result = generateOtelcolConfig(inputs, defaultOutput, packageInfoCache);
 
-      expect(result.connectors?.['elasticapm/test-multi-signal-stream-id-1']).toEqual({});
-      expect(result.processors?.['elasticapm/test-multi-signal-stream-id-1']).toEqual({});
-      expect(
-        result.service?.pipelines?.['metrics/test-multi-signal-stream-id-1-aggregated-apm-metrics']
-      ).toEqual({
-        receivers: ['elasticapm/test-multi-signal-stream-id-1'],
-        processors: ['transform/test-multi-signal-stream-id-1-routing'],
+      expect(result.connectors?.['elasticapm/default']).toEqual({});
+      expect(result.processors?.['elasticapm/default']).toEqual({});
+      expect(result.service?.pipelines?.['metrics/default-aggregated-apm-metrics']).toEqual({
+        receivers: ['elasticapm/default'],
+        processors: ['transform/default-apm-namespace-routing'],
         exporters: ['forward'],
       });
       const tracesPipelineKey = 'traces/otlp/test-multi-signal-stream-id-1';
       const tracesPipeline = result.service?.pipelines?.[tracesPipelineKey];
       expect(tracesPipeline).toBeDefined();
-      expect(tracesPipeline?.exporters).toContain('elasticapm/test-multi-signal-stream-id-1');
-      expect(tracesPipeline?.processors).toContain('elasticapm/test-multi-signal-stream-id-1');
+      expect(tracesPipeline?.exporters).toContain('elasticapm/default');
+      expect(tracesPipeline?.processors).toContain('elasticapm/default');
       const metricsPipelineKey = 'metrics/otlp/test-multi-signal-stream-id-1';
       const metricsPipeline = result.service?.pipelines?.[metricsPipelineKey];
       expect(metricsPipeline).toBeDefined();
-      expect(metricsPipeline?.exporters).not.toContain('elasticapm');
-      expect(metricsPipeline?.processors).not.toContain('elasticapm');
+      expect(metricsPipeline?.exporters).not.toContain('elasticapm/default');
+      expect(metricsPipeline?.processors).not.toContain('elasticapm/default');
     });
 
     it('should generate transform with multiple signal type statements when dynamic_signal_types is true', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.test.ts
@@ -214,7 +214,7 @@ describe('generateOtelcolConfig', () => {
     name: 'test-traces',
     revision: 0,
     data_stream: {
-      namespace: 'default',
+      namespace: 'apmtest',
     },
     use_output: 'default',
     package_policy_id: 'tracespolicy',
@@ -614,22 +614,28 @@ describe('generateOtelcolConfig', () => {
               statements: [
                 'set(attributes["data_stream.type"], "traces")',
                 'set(attributes["data_stream.dataset"], "zipkinreceiver")',
-                'set(attributes["data_stream.namespace"], "default")',
+                'set(attributes["data_stream.namespace"], "apmtest")',
               ],
             },
             {
               context: 'spanevent',
               statements: [
                 'set(attributes["data_stream.type"], "logs")',
-                'set(attributes["data_stream.namespace"], "default")',
+                'set(attributes["data_stream.namespace"], "apmtest")',
               ],
             },
           ],
+          metric_statements: [
+            {
+              context: 'datapoint',
+              statements: ['set(attributes["data_stream.namespace"], "apmtest")'],
+            },
+          ],
         },
-        elasticapm: {},
+        'elasticapm/test-traces-stream-id-1': {},
       },
       connectors: {
-        elasticapm: {},
+        'elasticapm/test-traces-stream-id-1': {},
         forward: {},
       },
       exporters: {
@@ -641,11 +647,15 @@ describe('generateOtelcolConfig', () => {
         pipelines: {
           'traces/test-traces-stream-id-1': {
             receivers: ['zipkin/test-traces-stream-id-1'],
-            exporters: ['elasticapm', 'forward'],
-            processors: ['elasticapm', 'transform/test-traces-stream-id-1-routing'],
+            exporters: ['elasticapm/test-traces-stream-id-1', 'forward'],
+            processors: [
+              'elasticapm/test-traces-stream-id-1',
+              'transform/test-traces-stream-id-1-routing',
+            ],
           },
-          'metrics/aggregated-otel-metrics': {
-            receivers: ['elasticapm'],
+          'metrics/test-traces-stream-id-1-aggregated-apm-metrics': {
+            receivers: ['elasticapm/test-traces-stream-id-1'],
+            processors: ['transform/test-traces-stream-id-1-routing'],
             exporters: ['forward'],
           },
           traces: {
@@ -659,6 +669,68 @@ describe('generateOtelcolConfig', () => {
         },
       },
     });
+  });
+
+  it('should produce separate aggregated-apm-metrics pipelines for two APM package policies with different namespaces', () => {
+    const inputA: FullAgentPolicyInput = {
+      ...otelTracesInputWithAPM,
+      id: 'policy-a',
+      name: 'policy-a',
+      package_policy_id: 'policy-a',
+      data_stream: { namespace: 'ns-a' },
+      streams: [
+        {
+          id: 'stream-id-1',
+          data_stream: { dataset: 'apm', type: 'traces' },
+          use_apm: true,
+          receivers: { otlp: { protocols: { grpc: { endpoint: '0.0.0.0:4317' } } } },
+          service: { pipelines: { traces: { receivers: ['otlp'] } } },
+        },
+      ],
+    };
+    const inputB: FullAgentPolicyInput = {
+      ...otelTracesInputWithAPM,
+      id: 'policy-b',
+      name: 'policy-b',
+      package_policy_id: 'policy-b',
+      data_stream: { namespace: 'ns-b' },
+      streams: [
+        {
+          id: 'stream-id-1',
+          data_stream: { dataset: 'apm', type: 'traces' },
+          use_apm: true,
+          receivers: { otlp: { protocols: { grpc: { endpoint: '0.0.0.0:4318' } } } },
+          service: { pipelines: { traces: { receivers: ['otlp'] } } },
+        },
+      ],
+    };
+
+    const result = generateOtelcolConfig([inputA, inputB], defaultOutput);
+
+    expect(
+      result.service?.pipelines?.['metrics/policy-a-stream-id-1-aggregated-apm-metrics']
+    ).toEqual({
+      receivers: ['elasticapm/policy-a-stream-id-1'],
+      processors: ['transform/policy-a-stream-id-1-routing'],
+      exporters: ['forward'],
+    });
+    expect(
+      result.service?.pipelines?.['metrics/policy-b-stream-id-1-aggregated-apm-metrics']
+    ).toEqual({
+      receivers: ['elasticapm/policy-b-stream-id-1'],
+      processors: ['transform/policy-b-stream-id-1-routing'],
+      exporters: ['forward'],
+    });
+    expect(
+      result.processors?.['transform/policy-a-stream-id-1-routing']?.metric_statements
+    ).toEqual([
+      { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-a")'] },
+    ]);
+    expect(
+      result.processors?.['transform/policy-b-stream-id-1-routing']?.metric_statements
+    ).toEqual([
+      { context: 'datapoint', statements: ['set(attributes["data_stream.namespace"], "ns-b")'] },
+    ]);
   });
 
   describe('with dynamic_signal_types (multiple signal types)', () => {
@@ -799,17 +871,20 @@ describe('generateOtelcolConfig', () => {
       const inputs: FullAgentPolicyInput[] = [inputWithUseApm];
       const result = generateOtelcolConfig(inputs, defaultOutput, packageInfoCache);
 
-      expect(result.connectors?.elasticapm).toEqual({});
-      expect(result.processors?.elasticapm).toEqual({});
-      expect(result.service?.pipelines?.['metrics/aggregated-otel-metrics']).toEqual({
-        receivers: ['elasticapm'],
+      expect(result.connectors?.['elasticapm/test-multi-signal-stream-id-1']).toEqual({});
+      expect(result.processors?.['elasticapm/test-multi-signal-stream-id-1']).toEqual({});
+      expect(
+        result.service?.pipelines?.['metrics/test-multi-signal-stream-id-1-aggregated-apm-metrics']
+      ).toEqual({
+        receivers: ['elasticapm/test-multi-signal-stream-id-1'],
+        processors: ['transform/test-multi-signal-stream-id-1-routing'],
         exporters: ['forward'],
       });
       const tracesPipelineKey = 'traces/otlp/test-multi-signal-stream-id-1';
       const tracesPipeline = result.service?.pipelines?.[tracesPipelineKey];
       expect(tracesPipeline).toBeDefined();
-      expect(tracesPipeline?.exporters).toContain('elasticapm');
-      expect(tracesPipeline?.processors).toContain('elasticapm');
+      expect(tracesPipeline?.exporters).toContain('elasticapm/test-multi-signal-stream-id-1');
+      expect(tracesPipeline?.processors).toContain('elasticapm/test-multi-signal-stream-id-1');
       const metricsPipelineKey = 'metrics/otlp/test-multi-signal-stream-id-1';
       const metricsPipeline = result.service?.pipelines?.[metricsPipelineKey];
       expect(metricsPipeline).toBeDefined();

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -25,8 +25,6 @@ import { getOutputIdForAgentPolicy } from '../../../common/services/output_helpe
 import { pkgToPkgKey } from '../epm/registry';
 import { hasDynamicSignalTypes } from '../epm/packages/input_type_packages';
 
-const AGGREGATED_OTEL_METRICS_PIPELINE = 'metrics/aggregated-otel-metrics';
-
 // Generate OTel Collector policy
 export function generateOtelcolConfig(
   inputs: FullAgentPolicyInput[] | TemplateAgentPolicyInput[],
@@ -50,25 +48,38 @@ export function generateOtelcolConfig(
       const otelInputs: OTelCollectorConfig[] = (input?.streams ?? []).map((stream) => {
         // Avoid dots in keys, as they can create subobjects in agent config.
         const suffix = (input.id + '-' + stream.id).replaceAll('.', '-');
+        const namespace =
+          'data_stream' in input
+            ? (input as FullAgentPolicyInput).data_stream.namespace
+            : 'default';
         // Extract signal types from pipeline IDs
         const signalTypes = stream.service?.pipelines
           ? extractSignalTypesFromPipelines(stream.service?.pipelines)
           : [];
-        const attributesTransform = generateOTelAttributesTransform(
-          stream.data_stream.type ? stream.data_stream.type : 'logs',
-          stream.data_stream.dataset,
-          'data_stream' in input
-            ? (input as FullAgentPolicyInput).data_stream.namespace
-            : 'default',
-          suffix,
-          packageInfo,
-          signalTypes
-        );
         const hasTracesPipeline = signalTypes.includes('traces');
 
         const shouldAddAPMConfig =
           (stream.data_stream.type === dataTypes.Traces || hasTracesPipeline) &&
           stream[USE_APM_VAR_NAME] === true;
+
+        const attributesTransform = generateOTelAttributesTransform(
+          stream.data_stream.type ? stream.data_stream.type : 'logs',
+          stream.data_stream.dataset,
+          namespace,
+          suffix,
+          packageInfo,
+          signalTypes
+        );
+
+        if (shouldAddAPMConfig) {
+          const [, routingTransformConfig] = Object.entries(attributesTransform)[0];
+          routingTransformConfig.metric_statements = [
+            {
+              context: 'datapoint',
+              statements: [`set(attributes["data_stream.namespace"], "${namespace}")`],
+            },
+          ];
+        }
 
         let otelConfig: OTelCollectorConfig = {
           ...addSuffixToOtelcolComponentsConfig('extensions', suffix, stream?.extensions),
@@ -86,7 +97,8 @@ export function generateOtelcolConfig(
                       suffix,
                       addSuffixToOtelcolPipelinesComponents(stream.service.pipelines, suffix)
                     ).pipelines ?? {},
-                    shouldAddAPMConfig
+                    shouldAddAPMConfig,
+                    suffix
                   ),
                 },
               }
@@ -103,11 +115,12 @@ export function generateOtelcolConfig(
             otelConfig.processors = {};
           }
 
-          otelConfig.connectors.elasticapm = {};
-          otelConfig.processors.elasticapm = {};
+          otelConfig.connectors[`elasticapm/${suffix}`] = {};
+          otelConfig.processors[`elasticapm/${suffix}`] = {};
 
-          otelConfig.service!.pipelines![AGGREGATED_OTEL_METRICS_PIPELINE] = {
-            receivers: ['elasticapm'],
+          otelConfig.service!.pipelines![`metrics/${suffix}-aggregated-apm-metrics`] = {
+            receivers: [`elasticapm/${suffix}`],
+            processors: [`transform/${suffix}-routing`],
           };
         }
 
@@ -280,7 +293,8 @@ function addSuffixToOtelcolComponentsConfig(
 
 function conditionallyAddApmToPipelines(
   pipelines: Record<OTelCollectorPipelineID, any>,
-  shouldAddAPMConfig: boolean
+  shouldAddAPMConfig: boolean,
+  suffix: string
 ): Record<OTelCollectorPipelineID, any> {
   if (!shouldAddAPMConfig) {
     return pipelines;
@@ -290,8 +304,8 @@ function conditionallyAddApmToPipelines(
     ([pipelineID, pipeline]) => {
       const signalType = getSignalType(pipelineID);
       if (signalType === 'traces') {
-        pipeline.exporters = [...(pipeline.exporters || []), 'elasticapm'];
-        pipeline.processors = [...(pipeline.processors || []), 'elasticapm'];
+        pipeline.exporters = [...(pipeline.exporters || []), `elasticapm/${suffix}`];
+        pipeline.processors = [...(pipeline.processors || []), `elasticapm/${suffix}`];
       }
       result[pipelineID] = pipeline;
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -71,16 +71,6 @@ export function generateOtelcolConfig(
           signalTypes
         );
 
-        if (shouldAddAPMConfig) {
-          const [, routingTransformConfig] = Object.entries(attributesTransform)[0];
-          routingTransformConfig.metric_statements = [
-            {
-              context: 'datapoint',
-              statements: [`set(attributes["data_stream.namespace"], "${namespace}")`],
-            },
-          ];
-        }
-
         let otelConfig: OTelCollectorConfig = {
           ...addSuffixToOtelcolComponentsConfig('extensions', suffix, stream?.extensions),
           ...addSuffixToOtelcolComponentsConfig('receivers', suffix, stream?.receivers),
@@ -98,29 +88,33 @@ export function generateOtelcolConfig(
                       addSuffixToOtelcolPipelinesComponents(stream.service.pipelines, suffix)
                     ).pipelines ?? {},
                     shouldAddAPMConfig,
-                    suffix
+                    namespace
                   ),
                 },
               }
             : {}),
         };
 
+        // Must run before the APM block below so the aggregated metrics pipeline
+        // does not receive the per-stream routing transform.
         otelConfig = appendOtelComponents(otelConfig, 'processors', [attributesTransform]);
 
         if (shouldAddAPMConfig) {
-          if (!otelConfig?.connectors) {
-            otelConfig.connectors = {};
-          }
-          if (!otelConfig?.processors) {
-            otelConfig.processors = {};
-          }
-
-          otelConfig.connectors[`elasticapm/${suffix}`] = {};
-          otelConfig.processors[`elasticapm/${suffix}`] = {};
-
-          otelConfig.service!.pipelines![`metrics/${suffix}-aggregated-apm-metrics`] = {
-            receivers: [`elasticapm/${suffix}`],
-            processors: [`transform/${suffix}-routing`],
+          otelConfig.connectors ??= {};
+          otelConfig.processors ??= {};
+          otelConfig.connectors[`elasticapm/${namespace}`] = {};
+          otelConfig.processors[`elasticapm/${namespace}`] = {};
+          otelConfig.processors[`transform/${namespace}-apm-namespace-routing`] = {
+            metric_statements: [
+              {
+                context: 'datapoint',
+                statements: [`set(attributes["data_stream.namespace"], "${namespace}")`],
+              },
+            ],
+          };
+          otelConfig.service.pipelines![`metrics/${namespace}-aggregated-apm-metrics`] = {
+            receivers: [`elasticapm/${namespace}`],
+            processors: [`transform/${namespace}-apm-namespace-routing`],
           };
         }
 
@@ -294,7 +288,7 @@ function addSuffixToOtelcolComponentsConfig(
 function conditionallyAddApmToPipelines(
   pipelines: Record<OTelCollectorPipelineID, any>,
   shouldAddAPMConfig: boolean,
-  suffix: string
+  namespace: string
 ): Record<OTelCollectorPipelineID, any> {
   if (!shouldAddAPMConfig) {
     return pipelines;
@@ -304,8 +298,8 @@ function conditionallyAddApmToPipelines(
     ([pipelineID, pipeline]) => {
       const signalType = getSignalType(pipelineID);
       if (signalType === 'traces') {
-        pipeline.exporters = [...(pipeline.exporters || []), `elasticapm/${suffix}`];
-        pipeline.processors = [...(pipeline.processors || []), `elasticapm/${suffix}`];
+        pipeline.exporters = [...(pipeline.exporters || []), `elasticapm/${namespace}`];
+        pipeline.processors = [...(pipeline.processors || []), `elasticapm/${namespace}`];
       }
       result[pipelineID] = pipeline;
     }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/otel_collector.ts
@@ -102,6 +102,7 @@ export function generateOtelcolConfig(
         if (shouldAddAPMConfig) {
           otelConfig.connectors ??= {};
           otelConfig.processors ??= {};
+          otelConfig.service ??= { pipelines: {} };
           otelConfig.connectors[`elasticapm/${namespace}`] = {};
           otelConfig.processors[`elasticapm/${namespace}`] = {};
           otelConfig.processors[`transform/${namespace}-apm-namespace-routing`] = {


### PR DESCRIPTION
## Summary

Namespace metrics collected by `elasticapm` processor introduced when `use_apm` is enabled, so the documents for these metrics go to namespaced data streams instead of to the `default` ones:
```
metrics-service_summary.1m.otel-default
metrics-transaction.1m.otel-default
metrics-service_transaction.1m.otel-default
```

For that, these changes are done to the aggregated metrics pipeline:
* A pipeline is created per namespace, instead of a global one.
* Each namespaced pipeline includes now a transform to add the namespace for dynamic routing.
* Additional tests are added for cases with multiple traces pipelines.

This change is done to keep consistency with any other Fleet-managed configuration, that allows to namespace data. This helps on data stream housekeeping.

For users keeping everything on the single `default` namespace nothing changes.

_Change assisted by Cursor_.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

With this change APM metrics are going to be aggregated by namespace instead of being aggregated per collector. This is probably fine. If global aggregations are wanted, this needs to be taken into account in any case.

### Related issues

* APM processing added in https://github.com/elastic/kibana/pull/252428.
* Testing support in elastic-package added in https://github.com/elastic/elastic-package/pull/3373.