### PR TITLE
Update gutter size for cloud resources block

### DIFF
--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
@@ -189,7 +189,7 @@ export const CloudResources = () => {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFlexGroup>
+        <EuiFlexGroup gutterSize='l'>
           {cards.map((card, index) => (
             <EuiFlexItem key={`resource-${index}`}>
               <ResourceCard

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
@@ -189,7 +189,7 @@ export const CloudResources = () => {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFlexGroup gutterSize='l'>
+        <EuiFlexGroup gutterSize="l">
           {cards.map((card, index) => (
             <EuiFlexItem key={`resource-${index}`}>
               <ResourceCard

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage/cloud_resources.tsx
@@ -159,7 +159,7 @@ export const CloudResources = () => {
     {
       icon: (assetBasePath: string) => `${assetBasePath}/search_serverless.svg`,
       title: i18n.translate('xpack.searchHomepage.cloudResources.elasticCloud.title', {
-        defaultMessage: 'Try manage Elastic',
+        defaultMessage: 'Try managed Elastic',
       }),
       description: i18n.translate('xpack.searchHomepage.cloudResources.elasticCloud.description', {
         defaultMessage:


### PR DESCRIPTION
## Summary

This PR fixes a small type and updates the guttersize for the size for cloud resources block so it matches the panels above it.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~




<!--ONMERGE {"backportTargets":["9.5"]} ONMERGE-->