### PR TITLE
[Entity Analytics] Removing unnecessary format function from entity attachment type

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.test.ts
@@ -5,15 +5,11 @@
  * 2.0.
  */
 
-import type { Attachment } from '@kbn/agent-builder-common/attachments';
-import { agentBuilderMocks } from '@kbn/agent-builder-plugin/server/mocks';
-import { SecurityAgentBuilderAttachments } from '../../../common/constants';
 import { SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from '../tools';
 import { createEntityAttachmentType } from './entity';
 
 describe('createEntityAttachmentType', () => {
   const attachmentType = createEntityAttachmentType();
-  const formatContext = agentBuilderMocks.attachments.createFormatContextMock();
 
   describe('validate', () => {
     it('returns valid when entity data is valid with host identifierType', async () => {
@@ -118,36 +114,6 @@ describe('createEntityAttachmentType', () => {
       if (!result.valid) {
         expect(result.error).toBeDefined();
       }
-    });
-  });
-
-  describe('format', () => {
-    it('returns correct string format', async () => {
-      const attachment: Attachment<string, unknown> = {
-        id: 'test-id',
-        type: SecurityAgentBuilderAttachments.entity,
-        data: 'identifier: hostname-1, identifierType: host',
-      };
-
-      const formatted = await attachmentType.format(attachment, formatContext);
-      const representation = formatted.getRepresentation
-        ? await formatted.getRepresentation()
-        : { type: 'text', value: attachment.data };
-
-      expect(representation.type).toBe('text');
-      expect(representation.value).toBe('identifier: hostname-1, identifierType: host');
-    });
-
-    it('throws error when attachment data is invalid', () => {
-      const attachment: Attachment<string, unknown> = {
-        id: 'test-id',
-        type: SecurityAgentBuilderAttachments.entity,
-        data: 'invalid data',
-      };
-
-      expect(() => attachmentType.format(attachment, formatContext)).toThrow(
-        'Invalid risk entity attachment data for attachment test-id'
-      );
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/attachments/entity.ts
@@ -6,7 +6,6 @@
  */
 import { z } from '@kbn/zod/v4';
 import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
-import type { Attachment } from '@kbn/agent-builder-common/attachments';
 import { SecurityAgentBuilderAttachments } from '../../../common/constants';
 import { SECURITY_ENTITY_RISK_SCORE_TOOL_ID } from '../tools';
 import { securityAttachmentDataSchema } from './security_attachment_data_schema';
@@ -15,15 +14,6 @@ const riskEntityAttachmentDataSchema = securityAttachmentDataSchema.extend({
   identifierType: z.enum(['host', 'user', 'service', 'generic']),
   identifier: z.string().min(1),
 });
-
-/**
- * Type guard to check if data is a formatted risk entity string
- */
-const isEntityRiskFormattedData = (data: unknown): data is string => {
-  return (
-    typeof data === 'string' && data.includes('identifier:') && data.includes('identifierType:')
-  );
-};
 
 /**
  * Creates the definition for the `entity` attachment type.
@@ -39,20 +29,7 @@ export const createEntityAttachmentType = (): AttachmentTypeDefinition => {
         return { valid: false, error: parseResult.error.message };
       }
     },
-    format: (attachment: Attachment<string, unknown>) => {
-      // Extract data to allow proper type narrowing
-      const data = attachment.data;
-      // Necessary because we cannot currently use the AttachmentType type as agent is not
-      // registered with enum AttachmentType in agentBuilder attachment_types.ts
-      if (!isEntityRiskFormattedData(data)) {
-        throw new Error(`Invalid risk entity attachment data for attachment ${attachment.id}`);
-      }
-      return {
-        getRepresentation: () => {
-          return { type: 'text', value: data };
-        },
-      };
-    },
+    format: () => ({}),
     getTools: () => [SECURITY_ENTITY_RISK_SCORE_TOOL_ID],
     getAgentDescription: () => {
       const description = `You have access to a risk entity that needs to be evaluated. The entity has an identifierType and identifier that you should use to query the risk score.


### PR DESCRIPTION
## Summary

It looks like the fix for this bug: https://github.com/elastic/kibana/pull/250233 broke the `format` function on the entity attachment type. The data passed into format is the object representation of the attachment type when the format function throws if the input is not a string. This was causing an error to be thrown for the attachment type (which doesn't show up anywhere in the agent reasoning).

Looking at the `getRepresentation` function, it looks like this function is deprecated and we should just return the raw attachment data, so I removed the function altogether.

https://github.com/elastic/kibana/blob/059e1e7fdf5b50def67677d87bd6de5230e2aa37/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/type_definition.ts#L120-L125