### PR TITLE
[Security Solution][Attacks] Align AssigneesBadge with TagsBadge (popover + stop propagation)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/popover_items/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/popover_items/index.tsx
@@ -89,7 +89,10 @@ const PopoverItemsComponent = <T extends unknown>({
             iconType={popoverButtonIcon}
             color="hollow"
             data-test-subj={`${dataTestPrefix}DisplayPopoverButton`}
-            onClick={() => setIsExceptionOverflowPopoverOpen(!isExceptionOverflowPopoverOpen)}
+            onClick={(e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+              e.stopPropagation();
+              setIsExceptionOverflowPopoverOpen(!isExceptionOverflowPopoverOpen);
+            }}
             onClickAriaLabel={popoverButtonTitle}
           >
             {popoverButtonTitle}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/popover_items/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/popover_items/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiPopover,
   EuiBadgeGroup,
@@ -24,10 +24,6 @@ export interface PopoverItemsProps<T> {
   popoverTitle?: string;
   numberOfItemsToDisplay?: number;
   dataTestPrefix?: string;
-}
-
-interface OverflowListProps<T> {
-  readonly items: T[];
 }
 
 const PopoverItemsWrapper = styled(EuiFlexGroup)`
@@ -60,46 +56,60 @@ const PopoverItemsComponent = <T extends unknown>({
   numberOfItemsToDisplay = 0,
   dataTestPrefix = 'items',
 }: PopoverItemsProps<T>) => {
-  const [isExceptionOverflowPopoverOpen, setIsExceptionOverflowPopoverOpen] = useState(false);
+  const [isOverflowPopoverOpen, setIsOverflowPopoverOpen] = useState(false);
+  const { visibleItems, overflowItems, hasOverflowItems, shouldShowVisibleItems } = useMemo(() => {
+    return {
+      visibleItems: items.slice(0, numberOfItemsToDisplay),
+      overflowItems: items.slice(numberOfItemsToDisplay),
+      hasOverflowItems: items.length > numberOfItemsToDisplay,
+      shouldShowVisibleItems: numberOfItemsToDisplay !== 0,
+    };
+  }, [items, numberOfItemsToDisplay]);
 
-  const OverflowList = ({ items: itemsToRender }: OverflowListProps<T>) => (
-    <>{itemsToRender.map(renderItem)}</>
+  const onPopoverButtonClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+      e.stopPropagation();
+      setIsOverflowPopoverOpen((isOpen) => !isOpen);
+    },
+    []
   );
 
-  if (items.length <= numberOfItemsToDisplay) {
+  const closePopover = useCallback(() => {
+    setIsOverflowPopoverOpen(false);
+  }, []);
+
+  if (!hasOverflowItems) {
     return (
       <PopoverItemsWrapper data-test-subj={dataTestPrefix} alignItems="center" gutterSize="s">
-        <OverflowList items={items} />
+        {items.map(renderItem)}
       </PopoverItemsWrapper>
     );
   }
 
   return (
     <PopoverItemsWrapper alignItems="center" gutterSize="s" data-test-subj={dataTestPrefix}>
-      {numberOfItemsToDisplay !== 0 && (
+      {shouldShowVisibleItems && (
         <EuiFlexItem grow={1} className="eui-textTruncate">
-          <OverflowList items={items.slice(0, numberOfItemsToDisplay)} />
+          {visibleItems.map(renderItem)}
         </EuiFlexItem>
       )}
       <EuiPopover
         ownFocus
+        aria-label={popoverTitle ?? popoverButtonTitle}
         data-test-subj={`${dataTestPrefix}DisplayPopover`}
         button={
           <EuiBadge
             iconType={popoverButtonIcon}
             color="hollow"
             data-test-subj={`${dataTestPrefix}DisplayPopoverButton`}
-            onClick={(e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
-              e.stopPropagation();
-              setIsExceptionOverflowPopoverOpen(!isExceptionOverflowPopoverOpen);
-            }}
+            onClick={onPopoverButtonClick}
             onClickAriaLabel={popoverButtonTitle}
           >
             {popoverButtonTitle}
           </EuiBadge>
         }
-        isOpen={isExceptionOverflowPopoverOpen}
-        closePopover={() => setIsExceptionOverflowPopoverOpen(!isExceptionOverflowPopoverOpen)}
+        isOpen={isOverflowPopoverOpen}
+        closePopover={closePopover}
         repositionOnScroll
       >
         {popoverTitle ? (
@@ -108,7 +118,7 @@ const PopoverItemsComponent = <T extends unknown>({
           </EuiPopoverTitle>
         ) : null}
         <PopoverWrapper data-test-subj={`${dataTestPrefix}DisplayPopoverWrapper`}>
-          <OverflowList items={items.slice(numberOfItemsToDisplay)} />
+          {overflowItems.map(renderItem)}
         </PopoverWrapper>
       </EuiPopover>
     </PopoverItemsWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.test.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { AssigneesBadge } from './assignees_badge';
 import { UNKNOWN_USER_PROFILE_NAME } from '../../../../../common/components/user_profiles/translations';
+import { TestProviders } from '../../../../../common/mock/test_providers';
 
 const mockUseBulkGetUserProfiles = jest.fn();
 
@@ -17,68 +18,87 @@ jest.mock('../../../../../common/components/user_profiles/use_bulk_get_user_prof
   useBulkGetUserProfiles: () => mockUseBulkGetUserProfiles(),
 }));
 
+jest.mock('@kbn/user-profile-components', () => ({
+  UserAvatar: () => <div data-test-subj="user-avatar" />,
+}));
+
 describe('AssigneesBadge', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseBulkGetUserProfiles.mockReturnValue({
       data: [
-        { uid: '1', user: { username: 'user1', email: 'user1@example.com' } },
-        { uid: '2', user: { username: 'user2', email: 'user2@example.com' } },
+        { uid: '1', user: { username: 'user1', email: 'user1@example.com' }, data: {} },
+        { uid: '2', user: { username: 'user2', email: 'user2@example.com' }, data: {} },
       ],
     });
   });
 
   it('renders correctly with given assignees count', () => {
     const assignees = ['1', '2'];
-    const { getByText } = render(<AssigneesBadge assignees={assignees} />);
+    const { getByTestId } = render(
+      <TestProviders>
+        <AssigneesBadge assignees={assignees} />
+      </TestProviders>
+    );
 
-    // Check if the badge with the correct number of assignees is rendered
-    expect(getByText('2')).toBeInTheDocument();
+    expect(getByTestId('attack-assignees-badgeDisplayPopoverButton')).toHaveTextContent('2');
   });
 
   it('renders nothing when assignees array is empty', () => {
-    const { container } = render(<AssigneesBadge assignees={[]} />);
+    const { container } = render(
+      <TestProviders>
+        <AssigneesBadge assignees={[]} />
+      </TestProviders>
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('displays tooltip with title and correct assignees list on hover', async () => {
+  it('displays popover with title and correct assignees list on click', async () => {
     const assignees = ['1', '2'];
-    const { getByText, findByText } = render(<AssigneesBadge assignees={assignees} />);
+    const { getByTestId, findByText } = render(
+      <TestProviders>
+        <AssigneesBadge assignees={assignees} />
+      </TestProviders>
+    );
 
-    const badge = getByText('2');
-    fireEvent.mouseOver(badge);
+    getByTestId('attack-assignees-badgeDisplayPopoverButton').click();
 
-    // Check tooltip title
+    // Check popover title
     expect(await findByText('Assignees')).toBeInTheDocument();
 
-    // Check tooltip items
-    // First user has an email, so we expect the email to be shown over username
+    // First user has an email, so email is shown over username
     expect(await findByText('user1@example.com')).toBeInTheDocument();
     expect(await findByText('user2@example.com')).toBeInTheDocument();
   });
 
   it('falls back to username if email is missing', async () => {
     mockUseBulkGetUserProfiles.mockReturnValue({
-      data: [{ uid: '3', user: { username: 'user3_no_email' } }],
+      data: [{ uid: '3', user: { username: 'user3_no_email' }, data: {} }],
     });
     const assignees = ['3'];
-    const { getByText, findByText } = render(<AssigneesBadge assignees={assignees} />);
+    const { getByTestId, findByText } = render(
+      <TestProviders>
+        <AssigneesBadge assignees={assignees} />
+      </TestProviders>
+    );
 
-    const badge = getByText('1');
-    fireEvent.mouseOver(badge);
+    getByTestId('attack-assignees-badgeDisplayPopoverButton').click();
 
     expect(await findByText('user3_no_email')).toBeInTheDocument();
   });
 
   it('falls back to UNKNOWN_USER_PROFILE_NAME if user info is unavailable', async () => {
     mockUseBulkGetUserProfiles.mockReturnValue({
-      data: [undefined],
+      data: undefined,
     });
     const assignees = ['unknown_id'];
-    const { getByText, findByText } = render(<AssigneesBadge assignees={assignees} />);
+    const { getByTestId, findByText } = render(
+      <TestProviders>
+        <AssigneesBadge assignees={assignees} />
+      </TestProviders>
+    );
 
-    const badge = getByText('1');
-    fireEvent.mouseOver(badge);
+    getByTestId('attack-assignees-badgeDisplayPopoverButton').click();
 
     expect(await findByText(UNKNOWN_USER_PROFILE_NAME)).toBeInTheDocument();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
@@ -20,38 +20,53 @@ type AssigneeItem = UserProfileWithAvatar | undefined;
 export const AssigneesBadge = ({ assignees }: { assignees: string[] }) => {
   const uids = useMemo(() => new Set(assignees), [assignees]);
   const { data: assignedUsers } = useBulkGetUserProfiles({ uids });
+  const items: AssigneeItem[] = useMemo(
+    () => assignedUsers ?? assignees.map(() => undefined),
+    [assignedUsers, assignees]
+  );
+  const popoverButtonTitle = useMemo(() => assignees.length.toString(), [assignees.length]);
+  const popoverTitle = useMemo(
+    () =>
+      i18n.translate(
+        'xpack.securitySolution.detectionEngine.attacks.tableSection.assigneesTooltipTitle',
+        {
+          defaultMessage: 'Assignees',
+        }
+      ),
+    []
+  );
+  const renderAssigneeItem = useCallback((user: AssigneeItem, index: number) => {
+    const displayName = user ? user.user.email ?? user.user.username : UNKNOWN_USER_PROFILE_NAME;
+    return (
+      <EuiFlexGroup
+        key={index}
+        alignItems="center"
+        gutterSize="s"
+        responsive={false}
+        style={{ width: '100%' }}
+      >
+        <EuiFlexItem grow={false}>
+          <UserAvatar user={user?.user} avatar={user?.data?.avatar} size="s" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText size="s">{displayName}</EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }, []);
 
   if (assignees.length === 0) {
     return null;
   }
 
-  const items: AssigneeItem[] = assignedUsers ?? assignees.map(() => undefined);
-
   return (
     <PopoverItems
       items={items}
-      popoverTitle={i18n.translate(
-        'xpack.securitySolution.detectionEngine.attacks.tableSection.assigneesTooltipTitle',
-        { defaultMessage: 'Assignees' }
-      )}
-      popoverButtonTitle={assignees.length.toString()}
+      popoverTitle={popoverTitle}
+      popoverButtonTitle={popoverButtonTitle}
       popoverButtonIcon="users"
       dataTestPrefix="attack-assignees-badge"
-      renderItem={(user: AssigneeItem, index: number) => {
-        const displayName = user
-          ? user.user.email ?? user.user.username
-          : UNKNOWN_USER_PROFILE_NAME;
-        return (
-          <EuiFlexGroup key={index} alignItems="center" gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <UserAvatar user={user?.user} avatar={user?.data?.avatar} size="s" />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiText size="s">{displayName}</EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        );
-      }}
+      renderItem={renderAssigneeItem}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/attacks/table/attack_group_content/assignees_badge.tsx
@@ -6,20 +6,16 @@
  */
 
 import React, { useMemo } from 'react';
-import {
-  EuiBadge,
-  EuiHorizontalRule,
-  EuiToolTip,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { UserAvatar } from '@kbn/user-profile-components';
 
 import { useBulkGetUserProfiles } from '../../../../../common/components/user_profiles/use_bulk_get_user_profiles';
 import { UNKNOWN_USER_PROFILE_NAME } from '../../../../../common/components/user_profiles/translations';
+import { PopoverItems } from '../../../../../common/components/popover_items';
 
-const ASSIGNEES_TOOLTIP_MAX_HEIGHT = '150px';
+type AssigneeItem = UserProfileWithAvatar | undefined;
 
 export const AssigneesBadge = ({ assignees }: { assignees: string[] }) => {
   const uids = useMemo(() => new Set(assignees), [assignees]);
@@ -29,45 +25,33 @@ export const AssigneesBadge = ({ assignees }: { assignees: string[] }) => {
     return null;
   }
 
+  const items: AssigneeItem[] = assignedUsers ?? assignees.map(() => undefined);
+
   return (
-    <EuiToolTip
-      content={
-        <EuiFlexGroup direction="column" gutterSize="none">
-          <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              {i18n.translate(
-                'xpack.securitySolution.detectionEngine.attacks.tableSection.assigneesTooltipTitle',
-                { defaultMessage: 'Assignees' }
-              )}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiHorizontalRule margin="xs" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              direction="column"
-              gutterSize="xs"
-              style={{
-                maxHeight: ASSIGNEES_TOOLTIP_MAX_HEIGHT,
-                overflowY: 'auto',
-              }}
-            >
-              {assignedUsers?.map((user, index) => (
-                <EuiFlexItem key={user?.uid ?? index}>
-                  <EuiText size="s">
-                    {user ? user.user.email ?? user.user.username : UNKNOWN_USER_PROFILE_NAME}
-                  </EuiText>
-                </EuiFlexItem>
-              )) ?? null}
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-    >
-      <EuiBadge tabIndex={0} color="hollow" iconType="users">
-        {assignees.length}
-      </EuiBadge>
-    </EuiToolTip>
+    <PopoverItems
+      items={items}
+      popoverTitle={i18n.translate(
+        'xpack.securitySolution.detectionEngine.attacks.tableSection.assigneesTooltipTitle',
+        { defaultMessage: 'Assignees' }
+      )}
+      popoverButtonTitle={assignees.length.toString()}
+      popoverButtonIcon="users"
+      dataTestPrefix="attack-assignees-badge"
+      renderItem={(user: AssigneeItem, index: number) => {
+        const displayName = user
+          ? user.user.email ?? user.user.username
+          : UNKNOWN_USER_PROFILE_NAME;
+        return (
+          <EuiFlexGroup key={index} alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <UserAvatar user={user?.user} avatar={user?.data?.avatar} size="s" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s">{displayName}</EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      }}
+    />
   );
 };


### PR DESCRIPTION
## Summary

Closes #258805

Aligns `AssigneesBadge` behaviour with `TagsBadge` on the Attacks page, and fixes a bug where clicking either badge expands the underlying attack group row.

## Screen-recording (before) 🎬 

https://github.com/user-attachments/assets/9d531016-fca2-4e81-aaa0-2c29df839517



## Screen-recording (after) 🎬 

https://github.com/user-attachments/assets/dde52636-4916-470f-b170-512ad5100b24

