### PR TITLE
[Security Solution][Attacks] Align context menu terminology from "alert" to "attack"

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_closing_reason.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_closing_reason.tsx
@@ -41,6 +41,8 @@ interface BulkAlertClosingReasonComponentProps {
    * @param reason
    */
   onSubmit(reason?: AlertClosingReason): void;
+  /** Optional label override for the confirm button */
+  buttonLabel?: string;
 }
 
 /**
@@ -49,6 +51,7 @@ interface BulkAlertClosingReasonComponentProps {
  */
 const BulkAlertClosingReasonComponent: React.FC<BulkAlertClosingReasonComponentProps> = ({
   onSubmit,
+  buttonLabel,
 }) => {
   const {
     services: { uiSettings },
@@ -87,7 +90,7 @@ const BulkAlertClosingReasonComponent: React.FC<BulkAlertClosingReasonComponentP
         {(list) => list}
       </EuiSelectable>
       <EuiButton fullWidth size="s" disabled={!selectedOption} onClick={onSubmitHandler}>
-        {i18n.ALERT_CLOSING_REASON_BUTTON_MESSAGE}
+        {buttonLabel ?? i18n.ALERT_CLOSING_REASON_BUTTON_MESSAGE}
       </EuiButton>
     </>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_tags.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_tags.tsx
@@ -26,6 +26,8 @@ export interface BulkAlertTagsPanelComponentProps {
   clearSelection?: () => void;
   closePopoverMenu: () => void;
   onSubmit: SetAlertTagsFunc;
+  /** Optional empty message override for the selectable list */
+  emptyMessage?: string;
 }
 
 const BulkAlertTagsPanelComponent: React.FC<BulkAlertTagsPanelComponentProps> = ({
@@ -36,6 +38,7 @@ const BulkAlertTagsPanelComponent: React.FC<BulkAlertTagsPanelComponentProps> = 
   clearSelection,
   closePopoverMenu,
   onSubmit,
+  emptyMessage,
 }) => {
   const [defaultAlertTagOptions] = useUiSetting$<string[]>(DEFAULT_ALERT_TAGS_KEY);
 
@@ -135,7 +138,7 @@ const BulkAlertTagsPanelComponent: React.FC<BulkAlertTagsPanelComponentProps> = 
         aria-label={i18n.ALERT_TAGS_MENU_SEARCH_PLACEHOLDER}
         options={selectableAlertTags}
         onChange={handleTagsOnChange}
-        emptyMessage={i18n.ALERT_TAGS_MENU_EMPTY}
+        emptyMessage={emptyMessage ?? i18n.ALERT_TAGS_MENU_EMPTY}
         noMatchesMessage={i18n.ALERT_TAGS_MENU_SEARCH_NO_TAGS_FOUND}
         data-test-subj="alert-tags-selectable-menu"
       >

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_closing_reason_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_closing_reason_items.tsx
@@ -30,6 +30,8 @@ export interface UseBulkAlertClosingReasonItemsProps {
    * Called once the user confirms the closing reason
    */
   onSubmitCloseReason?: (params: OnSubmitCloseReasonParams) => void;
+  /** Optional label override for the confirm button */
+  buttonLabel?: string;
 }
 
 /**
@@ -37,6 +39,7 @@ export interface UseBulkAlertClosingReasonItemsProps {
  */
 export const useBulkAlertClosingReasonItems = ({
   onSubmitCloseReason,
+  buttonLabel,
 }: UseBulkAlertClosingReasonItemsProps = {}) => {
   const { hasIndexWrite } = useAlertsPrivileges();
   const item = useMemo(
@@ -55,8 +58,10 @@ export const useBulkAlertClosingReasonItems = ({
   const getRenderContent = useCallback(
     ({
       onSubmitCloseReason: onSubmitCloseReasonCb,
+      buttonLabel: buttonLabelOverride,
     }: {
       onSubmitCloseReason?: UseBulkAlertClosingReasonItemsProps['onSubmitCloseReason'];
+      buttonLabel?: string;
     }) => {
       function renderContent(renderProps: RenderContentPanelProps) {
         const handleSubmit = (reason: AlertClosingReason) => {
@@ -66,7 +71,7 @@ export const useBulkAlertClosingReasonItems = ({
           });
         };
 
-        return <BulkAlertClosingReason onSubmit={handleSubmit} />;
+        return <BulkAlertClosingReason onSubmit={handleSubmit} buttonLabel={buttonLabelOverride} />;
       }
 
       return renderContent;
@@ -81,11 +86,11 @@ export const useBulkAlertClosingReasonItems = ({
             {
               id: ALERT_CLOSING_REASON_PANEL_ID,
               title: i18n.ALERT_CLOSING_REASON_MENU_TITLE,
-              renderContent: getRenderContent({ onSubmitCloseReason }),
+              renderContent: getRenderContent({ onSubmitCloseReason, buttonLabel }),
             },
           ] as ContentPanelConfig[])
         : [],
-    [hasIndexWrite, getRenderContent, onSubmitCloseReason]
+    [hasIndexWrite, getRenderContent, onSubmitCloseReason, buttonLabel]
   );
 
   /**
@@ -103,11 +108,14 @@ export const useBulkAlertClosingReasonItems = ({
             {
               id: ALERT_CLOSING_REASON_PANEL_ID,
               title: i18n.ALERT_CLOSING_REASON_MENU_TITLE,
-              renderContent: getRenderContent({ onSubmitCloseReason: onSubmitCloseReasonCb }),
+              renderContent: getRenderContent({
+                onSubmitCloseReason: onSubmitCloseReasonCb,
+                buttonLabel,
+              }),
             },
           ] as ContentPanelConfig[])
         : [],
-    [getRenderContent, hasIndexWrite]
+    [getRenderContent, hasIndexWrite, buttonLabel]
   );
 
   return useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_assignees_items.tsx
@@ -91,17 +91,17 @@ export const useBulkAttackAssigneesItems = ({
       {
         key: 'manage-attack-assignees',
         'data-test-subj': 'attack-assignees-context-menu-item',
-        name: i18n.ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
+        name: i18n.ATTACK_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
         panel: 2,
-        label: i18n.ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
+        label: i18n.ATTACK_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE,
         disableOnQuery: true,
         disable: false,
       },
       {
         key: 'remove-all-attack-assignees',
         'data-test-subj': 'remove-attack-assignees-menu-item',
-        name: i18n.REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE,
-        label: i18n.REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE,
+        name: i18n.REMOVE_ATTACK_ASSIGNEES_CONTEXT_MENU_TITLE,
+        label: i18n.REMOVE_ATTACK_ASSIGNEES_CONTEXT_MENU_TITLE,
         disableOnQuery: true,
         onClick: onRemoveAllAssignees,
         disable: alertAssignments ? isEmpty(alertAssignments) : false,
@@ -119,7 +119,7 @@ export const useBulkAttackAssigneesItems = ({
   const TitleContent = useMemo(
     () => (
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-        <EuiFlexItem grow={false}>{i18n.ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{i18n.ATTACK_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE}</EuiFlexItem>
       </EuiFlexGroup>
     ),
     []

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
@@ -49,9 +49,9 @@ export const useBulkAttackTagsItems = ({
       {
         key: 'manage-attack-tags',
         'data-test-subj': 'attack-tags-context-menu-item',
-        name: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
+        name: i18n.ATTACK_TAGS_CONTEXT_MENU_ITEM_TITLE,
         panel: 1,
-        label: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
+        label: i18n.ATTACK_TAGS_CONTEXT_MENU_ITEM_TITLE,
         disableOnQuery: true,
       },
     ];
@@ -60,9 +60,9 @@ export const useBulkAttackTagsItems = ({
   const TitleContent = useMemo(
     () => (
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-        <EuiFlexItem grow={false}>{i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{i18n.ATTACK_TAGS_CONTEXT_MENU_ITEM_TITLE}</EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiIconTip content={i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO} position="right" />
+          <EuiIconTip content={i18n.ATTACK_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO} position="right" />
         </EuiFlexItem>
       </EuiFlexGroup>
     ),

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_tags_items.tsx
@@ -87,6 +87,7 @@ export const useBulkAttackTagsItems = ({
           setIsLoading={setIsBulkActionsLoading}
           clearSelection={clearSelection}
           closePopoverMenu={closePopoverMenu}
+          emptyMessage={i18n.ATTACK_TAGS_MENU_EMPTY}
           onSubmit={async (tags, _, onSuccess, setIsLoading) => {
             closePopoverMenu();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_workflow_status_items.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/bulk_action_items/use_bulk_attack_workflow_status_items.tsx
@@ -79,7 +79,10 @@ export const useBulkAttackWorkflowStatusItems = ({
   );
 
   const { item: alertClosingReasonItem, panels: alertClosingReasonPanels } =
-    useBulkAlertClosingReasonItems({ onSubmitCloseReason });
+    useBulkAlertClosingReasonItems({
+      onSubmitCloseReason,
+      buttonLabel: i18n.CLOSE_ATTACK_BUTTON_MESSAGE,
+    });
 
   const workflowStatusItems: BulkActionsConfig[] = useMemo(() => {
     // Return empty array if user doesn't have required permissions or data is still loading

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/confirmation_modal/update_attacks_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/confirmation_modal/update_attacks_modal.test.tsx
@@ -43,7 +43,7 @@ describe('UpdateAttacksModal', () => {
   it('should render modal with correct title', () => {
     render(<UpdateAttacksModal {...defaultProps} />);
 
-    expect(screen.getByText(/update alerts\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/update attacks\?/i)).toBeInTheDocument();
   });
 
   it('should render modal body with alert counts', () => {
@@ -112,13 +112,13 @@ describe('UpdateAttacksModal', () => {
   it('should render correct title for assignees action type', () => {
     render(<UpdateAttacksModal {...defaultProps} />);
 
-    expect(screen.getByText(/update alerts\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/update attacks\?/i)).toBeInTheDocument();
   });
 
   it('should render correct title for tags action type', () => {
     render(<UpdateAttacksModal {...defaultProps} />);
 
-    expect(screen.getByText(/update alerts\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/update attacks\?/i)).toBeInTheDocument();
   });
 
   it('should handle singular attack discovery count', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
@@ -55,7 +55,7 @@ export const UPDATE_ATTACKS_TITLE = () => {
   return i18n.translate(
     'xpack.securitySolution.detections.hooks.attacks.bulkActions.updateAttacksModal.updateAttacksTitle',
     {
-      defaultMessage: 'Update alerts?',
+      defaultMessage: 'Update attacks?',
     }
   );
 };
@@ -118,27 +118,41 @@ export const ADD_TO_EXISTING_CASE = i18n.translate(
 export const ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertTagsContextMenuItemTitle',
   {
-    defaultMessage: 'Apply alert tags',
+    defaultMessage: 'Apply attack tags',
   }
 );
 
 export const ALERT_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertTagsContextMenuItemTooltip',
   {
-    defaultMessage: 'Change alert tag options in Kibana Advanced Settings.',
+    defaultMessage: 'Change attack tag options in Kibana Advanced Settings.',
   }
 );
 
 export const ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertAssigneesContextMenuItemTitle',
   {
-    defaultMessage: 'Assign alert',
+    defaultMessage: 'Assign attack',
   }
 );
 
 export const REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.removeAlertAssigneesContextMenuTitle',
   {
-    defaultMessage: 'Unassign alert',
+    defaultMessage: 'Unassign attack',
+  }
+);
+
+export const CLOSE_ATTACK_BUTTON_MESSAGE = i18n.translate(
+  'xpack.securitySolution.detections.hooks.attacks.bulkActions.closeAttackButtonMessage',
+  {
+    defaultMessage: 'Close attack',
+  }
+);
+
+export const ATTACK_TAGS_MENU_EMPTY = i18n.translate(
+  'xpack.securitySolution.detections.hooks.attacks.bulkActions.attackTagsMenuEmpty',
+  {
+    defaultMessage: 'No attack tag options exist, add tag options in Kibana Advanced Settings.',
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/attacks/bulk_actions/translations.ts
@@ -115,28 +115,28 @@ export const ADD_TO_EXISTING_CASE = i18n.translate(
   }
 );
 
-export const ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
+export const ATTACK_TAGS_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertTagsContextMenuItemTitle',
   {
     defaultMessage: 'Apply attack tags',
   }
 );
 
-export const ALERT_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO = i18n.translate(
+export const ATTACK_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertTagsContextMenuItemTooltip',
   {
     defaultMessage: 'Change attack tag options in Kibana Advanced Settings.',
   }
 );
 
-export const ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
+export const ATTACK_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.alertAssigneesContextMenuItemTitle',
   {
     defaultMessage: 'Assign attack',
   }
 );
 
-export const REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE = i18n.translate(
+export const REMOVE_ATTACK_ASSIGNEES_CONTEXT_MENU_TITLE = i18n.translate(
   'xpack.securitySolution.detections.hooks.attacks.bulkActions.removeAlertAssigneesContextMenuTitle',
   {
     defaultMessage: 'Unassign attack',


### PR DESCRIPTION
## Summary

Closes #258815

Aligns the "Take actions" context menu on the Attacks page so all labels use "attack" terminology instead of "alert" (e.g. "Assign attack" instead of "Assign alert", "Apply attack tags" instead of "Apply alert tags").

Shared bulk-action components accept new optional override props so the Attacks page can inject attack-specific copy without affecting existing alert usage elsewhere.

## Changes

- **`translations.ts`** — Updated 5 existing strings (`UPDATE_ATTACKS_TITLE`, `ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE`, `ALERT_TAGS_CONTEXT_MENU_ITEM_TOOLTIP_INFO`, `ALERT_ASSIGNEES_CONTEXT_MENU_ITEM_TITLE`, `REMOVE_ALERT_ASSIGNEES_CONTEXT_MENU_TITLE`) and added 2 new ones (`CLOSE_ATTACK_BUTTON_MESSAGE`, `ATTACK_TAGS_MENU_EMPTY`)
- **`alert_bulk_closing_reason.tsx`** — Added optional `buttonLabel` prop; confirm button uses `buttonLabel ?? i18n.ALERT_CLOSING_REASON_BUTTON_MESSAGE`
- **`use_bulk_alert_closing_reason_items.tsx`** — Added optional `buttonLabel` prop, threaded through `getRenderContent` → `BulkAlertClosingReason`
- **`use_bulk_attack_workflow_status_items.tsx`** — Passes `buttonLabel: i18n.CLOSE_ATTACK_BUTTON_MESSAGE` to `useBulkAlertClosingReasonItems`
- **`alert_bulk_tags.tsx`** — Added optional `emptyMessage` prop; `EuiSelectable` uses `emptyMessage ?? i18n.ALERT_TAGS_MENU_EMPTY`
- **`use_bulk_attack_tags_items.tsx`** — Passes `emptyMessage={i18n.ATTACK_TAGS_MENU_EMPTY}` to `BulkAlertTagsPanel`

## Test plan

- [x] Unit tests for all modified files pass (28 tests across 5 suites)
- [ ] Visually verify the Attacks page "Take actions" menu shows attack-specific labels for tags, assignees, and close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)