### PR TITLE
[Osquery] Fix `profile_uid` dropped in `getUserInfo` authc fallback

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/lib/get_user_info.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/get_user_info.test.ts
@@ -69,4 +69,29 @@ describe('getUserInfo', () => {
       profile_uid: null,
     });
   });
+
+  it('uses profile_uid from authc fallback when available', async () => {
+    const security = {
+      userProfiles: {
+        getCurrent: jest.fn().mockResolvedValue(null),
+      },
+      authc: {
+        getCurrentUser: jest.fn().mockReturnValue({
+          username: 'cloud-user',
+          full_name: null,
+          email: 'cloud-user@example.com',
+          profile_uid: 'u_cloud_profile_123',
+        }),
+      },
+    } as unknown as SecurityPluginStart;
+
+    const result = await getUserInfo({ request, security, logger });
+
+    expect(result).toEqual({
+      username: 'cloud-user@example.com',
+      full_name: null,
+      email: 'cloud-user@example.com',
+      profile_uid: 'u_cloud_profile_123',
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/osquery/server/lib/get_user_info.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/lib/get_user_info.ts
@@ -58,7 +58,7 @@ export const getUserInfo = async ({
         username: displayName,
         full_name: user.full_name ?? null,
         email: user.email ?? null,
-        profile_uid: null,
+        profile_uid: user.profile_uid ?? null,
       };
     }
   } catch (error) {


### PR DESCRIPTION
I'm working on adding Scout API tests (https://github.com/elastic/kibana/pull/258534) and noticed that `created_by_profile_uid` and `updated_by_profile_uid` fields are absent from all Osquery API responses on ECH (Elastic Cloud Hosted), even though the authenticated user clearly has a `profile_uid` available.

## Test it yourself on ECH (dev console)

Confirm the user has a `profile_uid`:

```bash
GET kbn:/internal/security/me
```

This returns `{ "profile_uid": "u_..." }`.

Now create a saved query and check the response keys:

```bash
POST kbn:/api/osquery/saved_queries
{"id":"profile-uid-test","query":"select 1;","interval":"3600"}
```

The `created_by_profile_uid` and `updated_by_profile_uid` fields are missing from the response on ECH. On local stateful they appear just fine.

## Hypothesis (LLM-assisted)

`getUserInfo()` has two code paths for resolving user identity:

1. **Primary**: `userProfiles.getCurrent()` — returns `profile_uid` from the user profile service
2. **Fallback**: `authc.getCurrentUser()` — used when the primary fails or returns `null`

The fallback hardcodes `profile_uid: null` instead of reading `user.profile_uid` from the `AuthenticatedUser` object (available since 2022, PR #141092).

On ECH (Elastic Cloud Hosted), `userProfiles.getCurrent()` returns `null`, so the fallback is always used. The hardcoded `null` then cascades through route handlers:
- Converted to `undefined` via `?? undefined`
- Stripped by `JSON.stringify` (packs) or `pickBy` (saved queries)

## Why didn't we spot this sooner and why Scout comes to the rescue

The existing FTR API tests [[1](https://github.com/elastic/kibana/blob/main/x-pack/platform/test/api_integration/apis/osquery/saved_queries.ts#L90-L126)] [[2](https://github.com/elastic/kibana/blob/main/x-pack/platform/test/api_integration/apis/osquery/packs.ts#L191-L251)] covering this ground aren't run on ECH. Scout is designed to be [deployment-agnostic](https://www.elastic.co/docs/extend/kibana/scout/best-practices#design-tests-with-a-cloud-first-mindset), and we have pipelines in place to run Scout tests on ECH, so we're easily able to run the same set of tests on different testing surfaces.

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->