### PR TITLE
[9.2] [Discover] Fix StaticLookupFormat behavior for empty values (#258287)

### DIFF
--- a/src/platform/plugins/shared/field_formats/common/converters/static_lookup.test.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/static_lookup.test.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { NULL_LABEL, EMPTY_LABEL } from '@kbn/field-formats-common';
+import { StaticLookupFormat } from './static_lookup';
+
+describe('StaticLookupFormat', () => {
+  let formatter: StaticLookupFormat;
+
+  beforeEach(() => {
+    formatter = new StaticLookupFormat({
+      lookupEntries: [
+        { key: '', value: 'Empty String Mapped' },
+        { key: 'test', value: 'Test Value' },
+        { key: 'html', value: '<script>alert("test")</script>' },
+      ],
+      unknownKeyValue: 'Custom Unknown',
+    });
+  });
+
+  describe('textConvert', () => {
+    test('maps empty string to configured value', () => {
+      expect(formatter.convert('', 'text')).toBe('Empty String Mapped');
+    });
+
+    test('null stays null and shows null label', () => {
+      expect(formatter.convert(null, 'text')).toBe(NULL_LABEL);
+    });
+
+    test('undefined stays undefined and shows null label', () => {
+      expect(formatter.convert(undefined, 'text')).toBe(NULL_LABEL);
+    });
+
+    test('maps known key to configured value', () => {
+      expect(formatter.convert('test', 'text')).toBe('Test Value');
+    });
+
+    test('maps unknown key to unknownKeyValue', () => {
+      expect(formatter.convert('unknown', 'text')).toBe('Custom Unknown');
+    });
+
+    test('falls back to original value when no unknownKeyValue is set', () => {
+      const formatterWithoutUnknown = new StaticLookupFormat({
+        lookupEntries: [{ key: 'test', value: 'Test Value' }],
+        unknownKeyValue: null,
+      });
+      expect(formatterWithoutUnknown.convert('unknown', 'text')).toBe('unknown');
+    });
+
+    test('falls back to null label for null/undefined when no unknownKeyValue is set', () => {
+      const formatterWithoutUnknown = new StaticLookupFormat({
+        lookupEntries: [{ key: 'test', value: 'Test Value' }],
+        unknownKeyValue: null,
+      });
+      expect(formatterWithoutUnknown.convert(null, 'text')).toBe(NULL_LABEL);
+      expect(formatterWithoutUnknown.convert(undefined, 'text')).toBe(NULL_LABEL);
+    });
+
+    test('falls back to unknownKeyValue for an empty string when no mapping exists', () => {
+      const formatterWithUnknown = new StaticLookupFormat({
+        lookupEntries: [{ key: 'test', value: 'Test Value' }],
+        unknownKeyValue: 'Unknown',
+      });
+      expect(formatterWithUnknown.convert('', 'text')).toBe('Unknown');
+    });
+
+    test('falls back to empty label for an empty string when no unknownKeyValue is set', () => {
+      const formatterWithoutUnknown = new StaticLookupFormat({
+        lookupEntries: [{ key: 'test', value: 'Test Value' }],
+        unknownKeyValue: null,
+      });
+      expect(formatterWithoutUnknown.convert('', 'text')).toBe(EMPTY_LABEL);
+    });
+  });
+
+  describe('falsy mapped values', () => {
+    test('correctly maps to empty string value (does not fall back to unknownKeyValue)', () => {
+      const formatterWithEmptyStringValue = new StaticLookupFormat({
+        lookupEntries: [{ key: 'empty', value: '' }],
+        unknownKeyValue: 'Should Not Use',
+      });
+      expect(formatterWithEmptyStringValue.convert('empty', 'text')).toBe('');
+      expect(formatterWithEmptyStringValue.convert('empty', 'html')).toBe('');
+    });
+
+    test('skips entry with empty key and empty value, falls back to unknownKeyValue', () => {
+      const formatterWithEmptyKeyAndValue = new StaticLookupFormat({
+        lookupEntries: [{ key: '', value: '' }],
+        unknownKeyValue: 'Unknown',
+      });
+      expect(formatterWithEmptyKeyAndValue.convert('', 'text')).toBe('Unknown');
+      expect(formatterWithEmptyKeyAndValue.convert('', 'html')).toBe('Unknown');
+    });
+
+    test('skips entry with undefined key and empty value, falls back to missing value label', () => {
+      const formatterWithUndefinedKeyEmptyValue = new StaticLookupFormat({
+        lookupEntries: [{ key: undefined, value: '' }],
+        unknownKeyValue: null,
+      });
+      expect(formatterWithUndefinedKeyEmptyValue.convert('', 'text')).toBe(EMPTY_LABEL);
+      expect(formatterWithUndefinedKeyEmptyValue.convert('', 'html')).toBe(
+        '<span class="ffString__emptyValue">(blank)</span>'
+      );
+    });
+
+    test('correctly maps to 0 value (does not fall back to unknownKeyValue)', () => {
+      const formatterWithZeroValue = new StaticLookupFormat({
+        lookupEntries: [{ key: 'zero', value: 0 }],
+        unknownKeyValue: 'Should Not Use',
+      });
+      expect(formatterWithZeroValue.convert('zero', 'text')).toBe('0');
+      expect(formatterWithZeroValue.convert('zero', 'html')).toBe('0');
+    });
+
+    test('correctly maps to false value (does not fall back to unknownKeyValue)', () => {
+      const formatterWithFalseValue = new StaticLookupFormat({
+        lookupEntries: [{ key: 'falsy', value: false }],
+        unknownKeyValue: 'Should Not Use',
+      });
+      expect(formatterWithFalseValue.convert('falsy', 'text')).toBe('false');
+      expect(formatterWithFalseValue.convert('falsy', 'html')).toBe('false');
+    });
+  });
+
+  describe('htmlConvert', () => {
+    test('maps empty string to configured value and escapes HTML', () => {
+      expect(formatter.convert('', 'html')).toBe('Empty String Mapped');
+    });
+
+    test('null stays null and shows null label HTML', () => {
+      expect(formatter.convert(null, 'html')).toBe(
+        '<span class="ffString__emptyValue">(null)</span>'
+      );
+    });
+
+    test('undefined stays undefined and shows null label HTML', () => {
+      expect(formatter.convert(undefined, 'html')).toBe(
+        '<span class="ffString__emptyValue">(null)</span>'
+      );
+    });
+
+    test('maps known key to configured value and escapes HTML', () => {
+      expect(formatter.convert('test', 'html')).toBe('Test Value');
+    });
+
+    test('maps unknown key to unknownKeyValue and escapes HTML', () => {
+      expect(formatter.convert('unknown', 'html')).toBe('Custom Unknown');
+    });
+
+    test('escapes HTML in mapped values', () => {
+      expect(formatter.convert('html', 'html')).toBe(
+        '&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;'
+      );
+    });
+
+    test('preserves highlight functionality', () => {
+      const options = {
+        field: { name: 'test_field' },
+        hit: {
+          highlight: {
+            test_field: ['@kibana-highlighted-field@Test@/kibana-highlighted-field@ Value'],
+          },
+        },
+      };
+      // The highlight should replace the formatted text with the highlighted version
+      expect(formatter.convert('test', 'html', options)).toBe(
+        '<mark class="ffSearch__highlight">Test</mark> Value'
+      );
+    });
+
+    test('falls back to missing value handling when textConvert returns original null/empty values', () => {
+      const formatterWithoutCustomMapping = new StaticLookupFormat({
+        lookupEntries: [{ key: 'test', value: 'Test Value' }],
+        unknownKeyValue: null, // No custom unknown value
+      });
+
+      // Empty string should show (blank) since textConvert returns the original empty string
+      expect(formatterWithoutCustomMapping.convert('', 'html')).toBe(
+        '<span class="ffString__emptyValue">(blank)</span>'
+      );
+
+      // Null should show (null) since textConvert returns the original null
+      expect(formatterWithoutCustomMapping.convert(null, 'html')).toBe(
+        '<span class="ffString__emptyValue">(null)</span>'
+      );
+
+      // Undefined should show (null) since textConvert returns the original undefined
+      expect(formatterWithoutCustomMapping.convert(undefined, 'html')).toBe(
+        '<span class="ffString__emptyValue">(null)</span>'
+      );
+
+      // Unknown value should fall back to original value since unknownKeyValue is null
+      expect(formatterWithoutCustomMapping.convert('unknown', 'html')).toBe('unknown');
+    });
+  });
+
+  describe('boolean key translations', () => {
+    beforeEach(() => {
+      formatter = new StaticLookupFormat({
+        lookupEntries: [
+          { key: 'true', value: 'Yes' },
+          { key: 'false', value: 'No' },
+        ],
+        unknownKeyValue: 'Unknown',
+      });
+    });
+
+    test('maps boolean true (1) to "true" key value', () => {
+      expect(formatter.convert(1, 'text')).toBe('Yes');
+      expect(formatter.convert(1, 'html')).toBe('Yes');
+    });
+
+    test('maps boolean false (0) to "false" key value', () => {
+      expect(formatter.convert(0, 'text')).toBe('No');
+      expect(formatter.convert(0, 'html')).toBe('No');
+    });
+
+    test('maps string "true" to configured value', () => {
+      expect(formatter.convert('true', 'text')).toBe('Yes');
+      expect(formatter.convert('true', 'html')).toBe('Yes');
+    });
+
+    test('maps string "false" to configured value', () => {
+      expect(formatter.convert('false', 'text')).toBe('No');
+      expect(formatter.convert('false', 'html')).toBe('No');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles empty lookupEntries array', () => {
+      const emptyFormatter = new StaticLookupFormat({
+        lookupEntries: [],
+        unknownKeyValue: 'Default',
+      });
+      expect(emptyFormatter.convert('anything', 'text')).toBe('Default');
+      expect(emptyFormatter.convert('anything', 'html')).toBe('Default');
+    });
+
+    test('handles lookupEntries with empty objects', () => {
+      const formatterWithEmptyEntries = new StaticLookupFormat({
+        lookupEntries: [{}],
+        unknownKeyValue: 'Default',
+      });
+      expect(formatterWithEmptyEntries.convert('test', 'text')).toBe('Default');
+      expect(formatterWithEmptyEntries.convert('test', 'html')).toBe('Default');
+    });
+
+    test('treats undefined key as empty string key when value is provided', () => {
+      // This simulates the case where the user adds a lookup entry
+      // but doesn't explicitly set the key (leaving it undefined)
+      const formatterWithUndefinedKey = new StaticLookupFormat({
+        lookupEntries: [{ key: undefined, value: 'Empty String Mapped' }],
+        unknownKeyValue: null,
+      });
+      // Empty string should map to the value with undefined key
+      expect(formatterWithUndefinedKey.convert('', 'text')).toBe('Empty String Mapped');
+      expect(formatterWithUndefinedKey.convert('', 'html')).toBe('Empty String Mapped');
+    });
+
+    test('treats null key as empty string key when value is provided', () => {
+      const formatterWithNullKey = new StaticLookupFormat({
+        lookupEntries: [{ key: null, value: 'Empty String Mapped' }],
+        unknownKeyValue: null,
+      });
+      expect(formatterWithNullKey.convert('', 'text')).toBe('Empty String Mapped');
+      expect(formatterWithNullKey.convert('', 'html')).toBe('Empty String Mapped');
+    });
+
+    test('does not treat undefined key as empty string key when value is not provided', () => {
+      const formatterWithEmptyEntry = new StaticLookupFormat({
+        lookupEntries: [{ key: undefined, value: undefined }],
+        unknownKeyValue: 'Unknown',
+      });
+      // Empty string should not be mapped, should fall back to unknownKeyValue
+      expect(formatterWithEmptyEntry.convert('', 'text')).toBe('Unknown');
+      expect(formatterWithEmptyEntry.convert('', 'html')).toBe('Unknown');
+    });
+  });
+});

--- a/src/platform/plugins/shared/field_formats/common/converters/static_lookup.ts
+++ b/src/platform/plugins/shared/field_formats/common/converters/static_lookup.ts
@@ -8,17 +8,42 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import escape from 'lodash/escape';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { FieldFormat } from '../field_format';
-import type { TextContextTypeConvert } from '../types';
+import type { TextContextTypeConvert, HtmlContextTypeConvert } from '../types';
 import { FIELD_FORMAT_IDS } from '../types';
+import { getHighlightHtml, checkForMissingValueHtml } from '../utils';
 
 function convertLookupEntriesToMap(
-  lookupEntries: Array<{ key: string; value: unknown }>
+  lookupEntries: Array<{ key?: string | null; value: unknown }>
 ): Record<string, unknown> {
   return lookupEntries.reduce(
-    (lookupMap: Record<string, unknown>, lookupEntry: { key: string; value: unknown }) => {
-      lookupMap[lookupEntry.key] = lookupEntry.value;
+    (lookupMap: Record<string, unknown>, lookupEntry: { key?: string | null; value: unknown }) => {
+      const { key, value } = lookupEntry;
+      // Skip entries where both key and value are not defined
+      const hasKey = key != null && key !== '';
+      const hasValue = value != null && value !== '';
+      if (!hasKey && !hasValue) {
+        return lookupMap;
+      }
+
+      // Normalize undefined/null keys to empty string when value is defined
+      const normalizedKey = key ?? '';
+      lookupMap[normalizedKey] = value;
+
+      /**
+       * Do some key translations because Elasticsearch returns
+       * boolean-type aggregation results as 0 and 1
+       */
+      if (normalizedKey === 'true') {
+        lookupMap[1] = value;
+      }
+
+      if (normalizedKey === 'false') {
+        lookupMap[0] = value;
+      }
+
       return lookupMap;
     },
     {} as Record<string, unknown>
@@ -45,11 +70,59 @@ export class StaticLookupFormat extends FieldFormat {
     };
   }
 
-  textConvert: TextContextTypeConvert = (val: string) => {
+  private lookup(val: unknown): { result: unknown; isMissingValue: boolean } {
     const lookupEntries = this.param('lookupEntries');
     const unknownKeyValue = this.param('unknownKeyValue');
-
     const lookupMap = convertLookupEntriesToMap(lookupEntries);
-    return lookupMap[val] || unknownKeyValue || val;
+
+    // Guard against null/undefined - these should not be mapped, stay as missing values
+    if (val == null) {
+      return { result: val, isMissingValue: true };
+    }
+
+    const key = String(val);
+    // Use Object.hasOwn to check key existence (handles falsy mapped values like '' and avoids prototype chain)
+    if (Object.hasOwn(lookupMap, key)) {
+      return { result: lookupMap[key], isMissingValue: false };
+    }
+
+    // Use unknownKeyValue for unmatched keys (including empty string)
+    if (unknownKeyValue != null) {
+      return { result: unknownKeyValue, isMissingValue: false };
+    }
+
+    return { result: val, isMissingValue: true };
+  }
+
+  textConvert: TextContextTypeConvert = (val: string) => {
+    const { result, isMissingValue } = this.lookup(val);
+
+    if (isMissingValue) {
+      const missingText = this.checkForMissingValueText(result);
+      if (missingText) {
+        return missingText;
+      }
+    }
+
+    return String(result ?? '');
+  };
+
+  htmlConvert: HtmlContextTypeConvert = (value, options = {}) => {
+    const { result, isMissingValue } = this.lookup(value);
+
+    if (isMissingValue) {
+      const missingHtml = checkForMissingValueHtml(result);
+      if (missingHtml) {
+        return missingHtml;
+      }
+    }
+
+    // Escape the result and handle highlights
+    const { field, hit } = options;
+    const formatted = escape(String(result ?? ''));
+
+    return !field || !hit || !hit.highlight || !hit.highlight[field.name]
+      ? formatted
+      : getHighlightHtml(formatted, hit.highlight[field.name]);
   };
 }

--- a/src/platform/test/functional/apps/management/data_views/_field_formatter.ts
+++ b/src/platform/test/functional/apps/management/data_views/_field_formatter.ts
@@ -566,6 +566,58 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               await testSubjects.setValue('~staticLookupEditorValue', 'yes');
             },
           },
+          {
+            fieldType: ES_FIELD_TYPES.KEYWORD,
+            fieldValue: '',
+            applyFormatterType: FIELD_FORMAT_IDS.STATIC_LOOKUP,
+            expectFormattedValue: 'Empty Value Mapped',
+            beforeSave: async () => {
+              await testSubjects.click('staticLookupEditorAddEntry');
+              await testSubjects.setValue('~staticLookupEditorKey', '');
+              await testSubjects.setValue('~staticLookupEditorValue', 'Empty Value Mapped');
+            },
+          },
+          {
+            fieldType: ES_FIELD_TYPES.KEYWORD,
+            fieldValue: null,
+            applyFormatterType: FIELD_FORMAT_IDS.STATIC_LOOKUP,
+            expectFormattedValue: '(null)',
+            beforeSave: async () => {
+              await testSubjects.click('staticLookupEditorAddEntry');
+              await testSubjects.setValue('~staticLookupEditorKey', 'some key');
+              await testSubjects.setValue('~staticLookupEditorValue', 'some value');
+              await testSubjects.setValue('staticLookupEditorUnknownValue', 'Custom Unknown');
+            },
+          },
+          {
+            fieldType: ES_FIELD_TYPES.KEYWORD,
+            fieldValue: '',
+            applyFormatterType: FIELD_FORMAT_IDS.STATIC_LOOKUP,
+            expectFormattedValue: 'Custom Unknown',
+            beforeSave: async () => {
+              await testSubjects.click('staticLookupEditorAddEntry');
+              await testSubjects.setValue('staticLookupEditorUnknownValue', 'Custom Unknown');
+            },
+          },
+          {
+            fieldType: ES_FIELD_TYPES.KEYWORD,
+            fieldValue: 'html_test',
+            applyFormatterType: FIELD_FORMAT_IDS.STATIC_LOOKUP,
+            expectFormattedValue: '<script>alert("test")</script>',
+            beforeSave: async () => {
+              await testSubjects.click('staticLookupEditorAddEntry');
+              await testSubjects.setValue('~staticLookupEditorKey', 'html_test');
+              await testSubjects.setValue(
+                '~staticLookupEditorValue',
+                '<script>alert("test")</script>'
+              );
+            },
+            expect: async (renderedValueContainer) => {
+              // Verify no script element exists (XSS safety)
+              const scripts = await renderedValueContainer.findAllByTagName('script');
+              expect(scripts).to.have.length(0);
+            },
+          },
         ]);
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Discover] Fix StaticLookupFormat behavior for empty values (#258287)](https://github.com/elastic/kibana/pull/258287)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2026-03-20T13:59:16Z","message":"[Discover] Fix StaticLookupFormat behavior for empty values (#258287)\n\n- Follow up for https://github.com/elastic/kibana/pull/257998\n\n## Summary\n\nRealized that https://github.com/elastic/kibana/pull/257998\nunintentionally affected the previous behavior of Static Lookup\nformatter which should have a different to other formatters handling of\nempty values. Addressing it here.\n\nChanges:\n- Added custom htmlConvert method to StaticLookupFormat that preserves\ncustom lookup logic while maintaining HTML escaping\n- Uses custom mappings when configured, falls back to standard missing\nvalue handling when no custom mapping exists\n- Added unit tests and functional tests for custom empty/null mappings\nand HTML escaping\n\nBefore (broken):\n- User configures \"\" → \"N/A\" but sees \"(blank)\"\n\nAfter (fixed):\n- Custom mappings are respected: \"\" → \"N/A\"\n- Fallback preserved: When no custom mapping exists, shows \"(blank)\" and\n\"(null)\" as expected\n\nWhen testing, consider comparing with v9.0.\n\n```\nPUT sample\nPUT sample/_mapping\n{\n  \"properties\": {\n    \"message\": {\n      \"type\": \"keyword\"\n    },\n    \"date\": {\n      \"type\": \"date\"\n    }\n  }\n}\nPUT sample/_doc/1\n{\n    \"message\": \"doc 1\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/2\n{\n    \"message\": \"\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/3\n{\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/4\n{\n    \"message\": \"hi there\",\n    \"date\": \"2023-05-10T11:01:10Z\"\n }\n```\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"bb344c4e9aa645b58fdf05355cf5300627ba4f25","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:FieldFormatters","Team:DataDiscovery","backport:version","v9.4.0","reviewer:coderabbit","v9.3.3","v9.2.8"],"title":"[Discover] Fix StaticLookupFormat behavior for empty values","number":258287,"url":"https://github.com/elastic/kibana/pull/258287","mergeCommit":{"message":"[Discover] Fix StaticLookupFormat behavior for empty values (#258287)\n\n- Follow up for https://github.com/elastic/kibana/pull/257998\n\n## Summary\n\nRealized that https://github.com/elastic/kibana/pull/257998\nunintentionally affected the previous behavior of Static Lookup\nformatter which should have a different to other formatters handling of\nempty values. Addressing it here.\n\nChanges:\n- Added custom htmlConvert method to StaticLookupFormat that preserves\ncustom lookup logic while maintaining HTML escaping\n- Uses custom mappings when configured, falls back to standard missing\nvalue handling when no custom mapping exists\n- Added unit tests and functional tests for custom empty/null mappings\nand HTML escaping\n\nBefore (broken):\n- User configures \"\" → \"N/A\" but sees \"(blank)\"\n\nAfter (fixed):\n- Custom mappings are respected: \"\" → \"N/A\"\n- Fallback preserved: When no custom mapping exists, shows \"(blank)\" and\n\"(null)\" as expected\n\nWhen testing, consider comparing with v9.0.\n\n```\nPUT sample\nPUT sample/_mapping\n{\n  \"properties\": {\n    \"message\": {\n      \"type\": \"keyword\"\n    },\n    \"date\": {\n      \"type\": \"date\"\n    }\n  }\n}\nPUT sample/_doc/1\n{\n    \"message\": \"doc 1\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/2\n{\n    \"message\": \"\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/3\n{\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/4\n{\n    \"message\": \"hi there\",\n    \"date\": \"2023-05-10T11:01:10Z\"\n }\n```\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"bb344c4e9aa645b58fdf05355cf5300627ba4f25"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258287","number":258287,"mergeCommit":{"message":"[Discover] Fix StaticLookupFormat behavior for empty values (#258287)\n\n- Follow up for https://github.com/elastic/kibana/pull/257998\n\n## Summary\n\nRealized that https://github.com/elastic/kibana/pull/257998\nunintentionally affected the previous behavior of Static Lookup\nformatter which should have a different to other formatters handling of\nempty values. Addressing it here.\n\nChanges:\n- Added custom htmlConvert method to StaticLookupFormat that preserves\ncustom lookup logic while maintaining HTML escaping\n- Uses custom mappings when configured, falls back to standard missing\nvalue handling when no custom mapping exists\n- Added unit tests and functional tests for custom empty/null mappings\nand HTML escaping\n\nBefore (broken):\n- User configures \"\" → \"N/A\" but sees \"(blank)\"\n\nAfter (fixed):\n- Custom mappings are respected: \"\" → \"N/A\"\n- Fallback preserved: When no custom mapping exists, shows \"(blank)\" and\n\"(null)\" as expected\n\nWhen testing, consider comparing with v9.0.\n\n```\nPUT sample\nPUT sample/_mapping\n{\n  \"properties\": {\n    \"message\": {\n      \"type\": \"keyword\"\n    },\n    \"date\": {\n      \"type\": \"date\"\n    }\n  }\n}\nPUT sample/_doc/1\n{\n    \"message\": \"doc 1\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/2\n{\n    \"message\": \"\",\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/3\n{\n    \"date\": \"2023-05-11T11:01:10Z\"\n }\nPUT sample/_doc/4\n{\n    \"message\": \"hi there\",\n    \"date\": \"2023-05-10T11:01:10Z\"\n }\n```\n\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"bb344c4e9aa645b58fdf05355cf5300627ba4f25"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258849","number":258849,"state":"OPEN"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->