### PR TITLE
dash : move access control owner from data to meta in dashboard API responses

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/access_control_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/access_control_manager.ts
@@ -19,7 +19,7 @@ export function initializeAccessControlManager(
   savedObjectId$?: BehaviorSubject<string | undefined>
 ) {
   const accessControl$ = new BehaviorSubject<Partial<SavedObjectAccessControl>>({
-    owner: savedObjectResult?.data?.access_control?.owner,
+    owner: savedObjectResult?.meta?.owner,
     accessMode: savedObjectResult?.data?.access_control?.access_mode,
   });
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -73,7 +73,7 @@ export function getDashboardApi({
     savedObjectId,
     accessControl: {
       accessMode: readResult?.data?.access_control?.access_mode,
-      owner: readResult?.data?.access_control?.owner,
+      owner: readResult?.meta?.owner,
     },
     createdBy: readResult?.meta?.created_by,
     user,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -234,7 +234,7 @@ export const useDashboardListingTable = ({
                 isGloballyAuthorized ||
                 accessControlClient.checkUserAccessControl({
                   accessControl: {
-                    owner: data?.access_control?.owner,
+                    owner: meta.owner,
                     accessMode: data?.access_control?.access_mode,
                   },
                   createdBy: meta.created_at,

--- a/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/dashboard_state_schemas.ts
@@ -155,7 +155,6 @@ export const optionsSchema = schema.object({
 
 export const accessControlSchema = schema.maybe(
   schema.object({
-    owner: schema.maybe(schema.string()),
     access_mode: schema.maybe(
       schema.oneOf([schema.literal('write_restricted'), schema.literal('default')])
     ),

--- a/src/platform/plugins/shared/dashboard/server/api/meta_schemas.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/meta_schemas.ts
@@ -11,6 +11,7 @@ import { schema } from '@kbn/config-schema';
 
 export const baseMetaSchema = schema.object({
   managed: schema.maybe(schema.boolean()),
+  owner: schema.maybe(schema.string()),
   error: schema.maybe(
     schema.object({
       error: schema.string(),

--- a/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/saved_object_utils.ts
@@ -25,6 +25,7 @@ export function getDashboardMeta(
     updated_at: savedObject.updated_at,
     updated_by: savedObject.updated_by,
     version: savedObject.version ?? '',
+    ...(savedObject?.accessControl?.owner && { owner: savedObject.accessControl.owner }),
     ...(['create', 'read', 'search'].includes(operation) && {
       created_at: savedObject.created_at,
       created_by: savedObject.created_by,
@@ -56,7 +57,6 @@ export function getDashboardCRUResponseBody(
       ...(savedObject?.accessControl && {
         access_control: {
           access_mode: savedObject.accessControl.accessMode,
-          owner: savedObject.accessControl.owner,
         },
       }),
     },

--- a/src/platform/plugins/shared/dashboard/server/api/search/search.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/search/search.ts
@@ -53,7 +53,6 @@ export async function search(
           ...(time_range && { time_range }),
           ...(so?.accessControl && {
             access_control: {
-              owner: so.accessControl.owner,
               access_mode: so.accessControl.accessMode,
             },
           }),


### PR DESCRIPTION
### summary

- Move dashboard owner from data.access_control to meta.owner.
 -Keep data.access_control limited to user-definable access_mode.
- Update dashboard API consumers to read owner from meta.

### Checklist
[x] EUI writing/i18n check
[x] Plugin config key check (not applicable)
[x] Breaking API change check completed

### Identify risks

- API clients using data.access_control.owner may break (Medium).
- Mitigation: use meta.owner instead; in-repo consumers updated.


fix : #258838