### PR TITLE
Fix page reset

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_notification_policies.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_notification_policies.ts
@@ -51,6 +51,7 @@ export const useFetchNotificationPolicies = ({
         sortOrder,
       }),
     refetchOnWindowFocus: false,
+    keepPreviousData: true,
     onError: (error: Error) => {
       toasts.addError(error, {
         title: i18n.translate('xpack.alertingV2.notificationPolicies.fetchError', {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
@@ -123,15 +123,15 @@ export const ListNotificationPoliciesPage = () => {
     sortOrder: sortDirection,
   });
 
-  const handleSearchChange = (value: string) => {
+  const handleSearchChange = useCallback((value: string) => {
     setSearch(value);
     setPage(0);
-  };
+  }, []);
 
-  const handleEnabledChange = (value: string) => {
+  const handleEnabledChange = useCallback((value: string) => {
     setEnabled(value);
     setPage(0);
-  };
+  }, []);
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
@@ -140,9 +140,11 @@ export const ListNotificationPoliciesPage = () => {
     page: tablePage,
     sort,
   }: CriteriaWithPagination<NotificationPolicyResponse>) => {
-    setPage(tablePage.index);
-    setPerPage(tablePage.size);
-    clearSelection();
+    if (tablePage) {
+      setPage(tablePage.index);
+      setPerPage(tablePage.size);
+    }
+
     if (sort) {
       setSortField(sort.field as 'name' | 'updatedAt' | 'updatedByUsername');
       setSortDirection(sort.direction);
@@ -187,10 +189,10 @@ export const ListNotificationPoliciesPage = () => {
 
   const selection: EuiTableSelectionType<NotificationPolicyResponse> = {
     onSelectionChange,
-    selected: selectedPolicies,
     selectable: () => {
       return !isBulkActionInProgress;
     },
+    selected: selectedPolicies,
   };
 
   const columns: Array<EuiBasicTableColumn<NotificationPolicyResponse>> = [

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/list_notification_policies_page/list_notification_policies_page.tsx
@@ -114,7 +114,7 @@ export const ListNotificationPoliciesPage = () => {
     createNotificationPolicy(data);
   };
 
-  const { data, isLoading, isError, error } = useFetchNotificationPolicies({
+  const { data, isError, error, isFetching } = useFetchNotificationPolicies({
     page: page + 1,
     perPage,
     search: search || undefined,
@@ -405,7 +405,7 @@ export const ListNotificationPoliciesPage = () => {
             columns={columns}
             itemId="id"
             selection={selection}
-            loading={isLoading}
+            loading={isFetching}
             pagination={pagination}
             responsiveBreakpoint={false}
             css={css`


### PR DESCRIPTION
## Summary

Upon clicking on the next page on the notification policy table, we were instantly redirected to the first page. Using useCallback on the search and filter functions to prevent this from happening.

## testing

- Create at least 11 notification policies (1 then 10 clone)
- Select 10 per page
- Click on page 2