### PR TITLE
[8.19] [Lens] Fix saving lens by-ref dashboard panels (#256984)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.test.tsx
@@ -210,7 +210,7 @@ describe('LensEditConfigurationFlyout', () => {
     expect(updatePanelStateSpy).toHaveBeenCalled();
   });
 
-  it('should call the updateByRefInput callback if cancel button is clicked and savedObjectId exists', async () => {
+  it('should call the updateByRefInput callback with savedObjectId and previous attributes if cancel button is clicked and savedObjectId exists', async () => {
     const updateByRefInputSpy = jest.fn();
 
     await renderConfigFlyout({
@@ -219,10 +219,10 @@ describe('LensEditConfigurationFlyout', () => {
       savedObjectId: 'id',
     });
     await userEvent.click(screen.getByTestId('cancelFlyoutButton'));
-    expect(updateByRefInputSpy).toHaveBeenCalled();
+    expect(updateByRefInputSpy).toHaveBeenCalledWith('id', lensAttributes);
   });
 
-  it('should call the saveByRef callback if apply button is clicked and savedObjectId exists', async () => {
+  it('should call the saveByRef and updateByRefInput with the current attributes when apply button is clicked and savedObjectId exists', async () => {
     const updateByRefInputSpy = jest.fn();
     const saveByRefSpy = jest.fn();
 
@@ -233,8 +233,14 @@ describe('LensEditConfigurationFlyout', () => {
       saveByRef: saveByRefSpy,
     });
     await userEvent.click(screen.getByTestId('applyFlyoutButton'));
-    expect(updateByRefInputSpy).toHaveBeenCalled();
     expect(saveByRefSpy).toHaveBeenCalled();
+    expect(updateByRefInputSpy).toHaveBeenCalledWith(
+      'id',
+      expect.objectContaining({
+        title: 'test',
+        visualizationType: 'testVis',
+      })
+    );
   });
 
   it('should call the onApplyCb callback if apply button is clicked', async () => {

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -146,7 +146,7 @@ export function LensEditConfigurationFlyout({
         updateSuggestion?.(previousAttrs);
       }
       if (savedObjectId) {
-        updateByRefInput?.(savedObjectId);
+        updateByRefInput?.(savedObjectId, previousAttrs);
       }
     }
     onCancelCallback?.();
@@ -179,7 +179,7 @@ export function LensEditConfigurationFlyout({
     }
     if (savedObjectId) {
       saveByRef?.(currentAttributes);
-      updateByRefInput?.(savedObjectId);
+      updateByRefInput?.(savedObjectId, currentAttributes);
     }
 
     // check if visualization type changed, if it did, don't pass the previous visualization state

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
@@ -53,7 +53,7 @@ export interface EditConfigPanelProps {
   /** Contains the active data, necessary for some panel configuration such as coloring */
   lensAdapters?: ReturnType<LensInspector['getInspectorAdapters']>;
   /** Optional callback called when updating the by reference embeddable */
-  updateByRefInput?: (soId: string) => void;
+  updateByRefInput?: (soId: string, attrs: TypedLensSerializedState['attributes']) => void;
   /** Callback for closing the edit flyout */
   closeFlyout?: () => void;
   /** Boolean used for adding a flyout wrapper */

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
@@ -77,8 +77,11 @@ export function prepareInlineEditPanel(
       startDependencies.data.query.filterManager.extract
     );
 
-    const updateByRefInput = (savedObjectId: LensRuntimeState['savedObjectId']) => {
-      updateState({ attributes, savedObjectId });
+    const updateByRefInput = (
+      savedObjectId: LensRuntimeState['savedObjectId'],
+      attrs: TypedLensSerializedState['attributes']
+    ) => {
+      updateState({ attributes: attrs, savedObjectId });
     };
 
     if (attributes?.visualizationType == null) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens] Fix saving lens by-ref dashboard panels (#256984)](https://github.com/elastic/kibana/pull/256984)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-03-20T19:42:46Z","message":"[Lens] Fix saving lens by-ref dashboard panels (#256984)\n\n## Summary\n\nFixes a bug where editing a by-reference Lens panel inline from a\ndashboard would persist the changes to the saved object, but the panel\nwould visually revert to its original state until the page was\nrefreshed.","sha":"13079bc39e8b63bafa4cb0867f1ab5d1a777c588","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","backport:all-open","v9.4.0"],"title":"[Lens] Fix saving lens by-ref dashboard panels","number":256984,"url":"https://github.com/elastic/kibana/pull/256984","mergeCommit":{"message":"[Lens] Fix saving lens by-ref dashboard panels (#256984)\n\n## Summary\n\nFixes a bug where editing a by-reference Lens panel inline from a\ndashboard would persist the changes to the saved object, but the panel\nwould visually revert to its original state until the page was\nrefreshed.","sha":"13079bc39e8b63bafa4cb0867f1ab5d1a777c588"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256984","number":256984,"mergeCommit":{"message":"[Lens] Fix saving lens by-ref dashboard panels (#256984)\n\n## Summary\n\nFixes a bug where editing a by-reference Lens panel inline from a\ndashboard would persist the changes to the saved object, but the panel\nwould visually revert to its original state until the page was\nrefreshed.","sha":"13079bc39e8b63bafa4cb0867f1ab5d1a777c588"}},{"url":"https://github.com/elastic/kibana/pull/258918","number":258918,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->