### PR TITLE
[Discover] Unified doc viewer viewed event

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -185,7 +185,7 @@ pageLoadAssetSize:
   transform: 16515
   triggersActionsUi: 114000
   uiActions: 35278
-  unifiedDocViewer: 14513
+  unifiedDocViewer: 15000
   unifiedSearch: 19500
   upgradeAssistant: 6898
   uptime: 48171

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/moon.yml
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/moon.yml
@@ -28,6 +28,7 @@ dependsOn:
   - '@kbn/core-analytics-browser-mocks'
   - '@kbn/shared-ux-error-boundary'
   - '@kbn/restorable-state'
+  - '@kbn/core'
 tags:
   - shared-browser
   - package

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/constants.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/constants.ts
@@ -7,17 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  DocViewer,
-  type DocViewerProps,
-  type DocViewerApi,
-  type DocViewerRestorableState,
-  DocViewsRegistry,
-  ElasticRequestState,
-  FieldName,
-  registerDocViewerAnalyticsEvents,
-  type UseDocViewerTabViewedEventParams,
-  type UseDocViewerViewedEventParams,
-  useDocViewerTabViewedEvent,
-  useDocViewerViewedEvent,
-} from './src';
+export const DOC_VIEWER_VIEWED_EVENT_TYPE = 'unified_doc_viewer_viewed';
+export const DOC_VIEWER_VIEWED_ROOT_CONTENT_ID = 'doc_detail';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/doc_viewer_viewed_event.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/doc_viewer_viewed_event.test.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { DOC_VIEWER_VIEWED_EVENT_TYPE, DOC_VIEWER_VIEWED_ROOT_CONTENT_ID } from './constants';
+import { useDocViewerTabViewedEvent, useDocViewerViewedEvent } from './doc_viewer_viewed_event';
+
+const createReportEvent = () => analyticsServiceMock.createAnalyticsServiceStart().reportEvent;
+
+const createHit = (id: string) =>
+  buildDataTableRecord(
+    {
+      _id: id,
+      _index: 'test-index',
+    },
+    dataViewMock
+  );
+
+describe('useDocViewerViewedEvent', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('reports an event on mount and when the event key changes', () => {
+    const reportEvent = createReportEvent();
+    const onEventKeyChange = jest.fn();
+
+    const { rerender } = renderHook(useDocViewerViewedEvent, {
+      initialProps: {
+        reportEvent,
+        contentId: 'content-1',
+        tabId: 'tab-1',
+        keys: ['doc-1'],
+        onEventKeyChange,
+      },
+    });
+
+    expect(onEventKeyChange).toHaveBeenCalledWith('content-1|tab-1|doc-1');
+    expect(reportEvent).toHaveBeenCalledWith(DOC_VIEWER_VIEWED_EVENT_TYPE, {
+      contentId: 'content-1',
+      tabId: 'tab-1',
+    });
+
+    rerender({
+      reportEvent,
+      contentId: 'content-1',
+      tabId: 'tab-1',
+      keys: ['doc-1'],
+      onEventKeyChange,
+    });
+
+    expect(reportEvent).toHaveBeenCalledTimes(1);
+
+    rerender({
+      reportEvent,
+      contentId: 'content-1',
+      tabId: 'tab-2',
+      keys: ['doc-1'],
+      onEventKeyChange,
+    });
+
+    expect(onEventKeyChange).toHaveBeenNthCalledWith(2, 'content-1|tab-2|doc-1');
+    expect(reportEvent).toHaveBeenNthCalledWith(2, DOC_VIEWER_VIEWED_EVENT_TYPE, {
+      contentId: 'content-1',
+      tabId: 'tab-2',
+    });
+  });
+
+  test('does not report when disabled', () => {
+    const reportEvent = createReportEvent();
+
+    const { rerender } = renderHook(useDocViewerViewedEvent, {
+      initialProps: {
+        reportEvent,
+        contentId: 'content-1',
+        tabId: 'tab-1',
+        enabled: false,
+      },
+    });
+
+    expect(reportEvent).not.toHaveBeenCalled();
+
+    rerender({
+      reportEvent,
+      contentId: 'content-1',
+      tabId: 'tab-1',
+      enabled: true,
+    });
+
+    expect(reportEvent).toHaveBeenCalledWith(DOC_VIEWER_VIEWED_EVENT_TYPE, {
+      contentId: 'content-1',
+      tabId: 'tab-1',
+    });
+    expect(reportEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not report when the initial event key matches the current one', () => {
+    const reportEvent = createReportEvent();
+
+    renderHook(useDocViewerViewedEvent, {
+      initialProps: {
+        reportEvent,
+        contentId: 'content-1',
+        tabId: 'tab-1',
+        keys: ['doc-1'],
+        initialEventKey: 'content-1|tab-1|doc-1',
+      },
+    });
+
+    expect(reportEvent).not.toHaveBeenCalled();
+  });
+
+  test('logs and swallows report errors', () => {
+    const reportEvent = createReportEvent();
+    const reportError = new Error('boom');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    reportEvent.mockImplementation(() => {
+      throw reportError;
+    });
+
+    renderHook(useDocViewerViewedEvent, {
+      initialProps: {
+        reportEvent,
+        contentId: 'content-1',
+        tabId: 'tab-1',
+      },
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Error reporting event ${DOC_VIEWER_VIEWED_EVENT_TYPE}:`,
+      reportError
+    );
+  });
+});
+
+describe('useDocViewerTabViewedEvent', () => {
+  test('reports the active tab for the root doc viewer content', () => {
+    const reportEvent = createReportEvent();
+
+    renderHook(useDocViewerTabViewedEvent, {
+      initialProps: {
+        reportEvent,
+        hit: createHit('doc-1'),
+        tabId: 'table',
+      },
+    });
+
+    expect(reportEvent).toHaveBeenCalledWith(DOC_VIEWER_VIEWED_EVENT_TYPE, {
+      contentId: DOC_VIEWER_VIEWED_ROOT_CONTENT_ID,
+      tabId: 'table',
+    });
+  });
+
+  test('does not report when there is no active tab', () => {
+    const reportEvent = createReportEvent();
+
+    renderHook(useDocViewerTabViewedEvent, {
+      initialProps: {
+        reportEvent,
+        hit: createHit('doc-1'),
+      },
+    });
+
+    expect(reportEvent).not.toHaveBeenCalled();
+  });
+
+  test('reports again when the hit id changes', () => {
+    const reportEvent = createReportEvent();
+
+    const { rerender } = renderHook(useDocViewerTabViewedEvent, {
+      initialProps: {
+        reportEvent,
+        hit: createHit('doc-1'),
+        tabId: 'table',
+      },
+    });
+
+    rerender({
+      reportEvent,
+      hit: createHit('doc-2'),
+      tabId: 'table',
+    });
+
+    expect(reportEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/doc_viewer_viewed_event.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/doc_viewer_viewed_event.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AnalyticsServiceStart } from '@kbn/core/public';
+import { useEffect, useMemo, useRef } from 'react';
+import { DOC_VIEWER_VIEWED_EVENT_TYPE, DOC_VIEWER_VIEWED_ROOT_CONTENT_ID } from './constants';
+import type { DocViewRenderProps } from '../types';
+
+/**
+ * Payload for the `unified_doc_viewer_viewed` event.
+ */
+export interface DocViewerViewedEvent {
+  /**
+   * Identifies which doc viewer content is being viewed.
+   */
+  contentId: string;
+  /**
+   * Active tab identifier within the main content.
+   */
+  tabId?: string;
+}
+
+/**
+ * Parameters for reporting a doc viewer viewed event.
+ */
+export interface UseDocViewerViewedEventParams
+  extends Pick<AnalyticsServiceStart, 'reportEvent'>,
+    DocViewerViewedEvent {
+  /**
+   * Additional values that participate in the deduplication key for the event.
+   */
+  keys?: string[];
+  /**
+   * Enables or disables event reporting.
+   */
+  enabled?: boolean;
+  /**
+   * Initial deduplication key to seed the last reported event state.
+   */
+  initialEventKey?: string;
+  /**
+   * Called after the deduplication key changes.
+   */
+  onEventKeyChange?: (eventKey: string) => void;
+}
+
+/**
+ * Reports a viewed event for a doc viewer content area when its calculated event key changes.
+ */
+export const useDocViewerViewedEvent = ({
+  reportEvent,
+  contentId,
+  tabId,
+  keys,
+  enabled = true,
+  initialEventKey,
+  onEventKeyChange,
+}: UseDocViewerViewedEventParams) => {
+  const lastReportedEventRef = useRef(initialEventKey);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const eventKey = [contentId, tabId, ...(keys ?? [])].filter(Boolean).join('|');
+
+    if (lastReportedEventRef.current === eventKey) {
+      return;
+    }
+
+    lastReportedEventRef.current = eventKey;
+
+    try {
+      onEventKeyChange?.(eventKey);
+      reportEvent(DOC_VIEWER_VIEWED_EVENT_TYPE, {
+        contentId,
+        tabId,
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Error reporting event ${DOC_VIEWER_VIEWED_EVENT_TYPE}:`, error);
+    }
+  }, [contentId, enabled, keys, onEventKeyChange, reportEvent, tabId]);
+};
+
+/**
+ * Parameters for reporting a viewed event tied to the currently rendered doc viewer tab.
+ */
+export type UseDocViewerTabViewedEventParams = Omit<
+  UseDocViewerViewedEventParams,
+  'contentId' | 'keys' | 'enabled'
+> &
+  Pick<DocViewRenderProps, 'hit'>;
+
+/**
+ * Reports a viewed event for the active doc viewer tab.
+ */
+export const useDocViewerTabViewedEvent = ({
+  hit,
+  ...params
+}: UseDocViewerTabViewedEventParams) => {
+  const keys = useMemo(() => [hit.id], [hit.id]);
+
+  useDocViewerViewedEvent({
+    ...params,
+    contentId: DOC_VIEWER_VIEWED_ROOT_CONTENT_ID,
+    keys,
+    enabled: Boolean(params.tabId),
+  });
+};

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/index.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/index.ts
@@ -7,17 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export * from './constants';
+export { registerDocViewerAnalyticsEvents } from './register_analytics_events';
 export {
-  DocViewer,
-  type DocViewerProps,
-  type DocViewerApi,
-  type DocViewerRestorableState,
-  DocViewsRegistry,
-  ElasticRequestState,
-  FieldName,
-  registerDocViewerAnalyticsEvents,
-  type UseDocViewerTabViewedEventParams,
   type UseDocViewerViewedEventParams,
-  useDocViewerTabViewedEvent,
+  type UseDocViewerTabViewedEventParams,
   useDocViewerViewedEvent,
-} from './src';
+  useDocViewerTabViewedEvent,
+} from './doc_viewer_viewed_event';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/register_analytics_events.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/analytics/register_analytics_events.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AnalyticsServiceSetup } from '@kbn/core/public';
+import { DOC_VIEWER_VIEWED_EVENT_TYPE, DOC_VIEWER_VIEWED_ROOT_CONTENT_ID } from './constants';
+
+export const registerDocViewerAnalyticsEvents = (analytics: AnalyticsServiceSetup) => {
+  analytics.registerEventType({
+    eventType: DOC_VIEWER_VIEWED_EVENT_TYPE,
+    schema: {
+      contentId: {
+        type: 'keyword',
+        _meta: {
+          description: `Doc viewer content viewed (root content ID is '${DOC_VIEWER_VIEWED_ROOT_CONTENT_ID}').`,
+          optional: false,
+        },
+      },
+      tabId: {
+        type: 'keyword',
+        _meta: {
+          description: 'Active tab identifier within the main content.',
+          optional: true,
+        },
+      },
+    },
+  });
+};

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { DocViewerProps } from './doc_viewer';
@@ -35,14 +35,30 @@ jest.mock('react-use/lib/useLocalStorage', () => {
   });
 });
 
-const WrappedDocViewer = (props: DocViewerProps) => (
+const WrappedDocViewer = (props: Omit<DocViewerProps, 'reportEvent'>) => (
   <KibanaErrorBoundaryProvider analytics={analytics}>
-    <DocViewer {...props} />
+    <DocViewer reportEvent={analytics.reportEvent} {...props} />
   </KibanaErrorBoundaryProvider>
 );
 
 const ThrowingComponent = ({ message }: { message?: string }) => {
   throw new Error(message ?? 'Invalid');
+};
+
+const InitialStateReportingTab = ({
+  content,
+  onInitialStateChange,
+  state,
+}: {
+  content: string;
+  onInitialStateChange: (state: object) => void;
+  state: object;
+}) => {
+  useEffect(() => {
+    onInitialStateChange(state);
+  }, [onInitialStateChange, state]);
+
+  return <div>{content}</div>;
 };
 
 describe('<DocViewer />', () => {
@@ -283,9 +299,15 @@ describe('<DocViewer />', () => {
 
   test('should call onInitialDocViewerStateChange when tab state changes', () => {
     const onInitialDocViewerStateChange = jest.fn();
+    const initialState = { someState: 'value1' };
     const renderFn = jest.fn(({ onInitialStateChange }) => {
-      onInitialStateChange({ someState: 'value1' });
-      return <div>Tab 1 Content</div>;
+      return (
+        <InitialStateReportingTab
+          content="Tab 1 Content"
+          onInitialStateChange={onInitialStateChange}
+          state={initialState}
+        />
+      );
     });
 
     const registry = new DocViewsRegistry();
@@ -301,28 +323,40 @@ describe('<DocViewer />', () => {
         docViews={registry.getAll()}
         hit={records[0]}
         dataView={dataViewMock}
-        onInitialDocViewerStateChange={onInitialDocViewerStateChange}
+        onInitialStateChange={onInitialDocViewerStateChange}
       />
     );
 
     expect(onInitialDocViewerStateChange).toHaveBeenCalledWith({
       docViewerTabsState: {
-        test1: { someState: 'value1' },
+        test1: initialState,
       },
     });
   });
 
   test('should handle state for multiple tabs independently', async () => {
     const onInitialDocViewerStateChange = jest.fn();
+    const tab1State = { tab1State: 'value1' };
+    const tab2State = { tab2State: 'value2' };
 
     const renderTab1 = jest.fn(({ onInitialStateChange }) => {
-      onInitialStateChange({ tab1State: 'value1' });
-      return <div>Tab 1 Content</div>;
+      return (
+        <InitialStateReportingTab
+          content="Tab 1 Content"
+          onInitialStateChange={onInitialStateChange}
+          state={tab1State}
+        />
+      );
     });
 
     const renderTab2 = jest.fn(({ onInitialStateChange }) => {
-      onInitialStateChange({ tab2State: 'value2' });
-      return <div>Tab 2 Content</div>;
+      return (
+        <InitialStateReportingTab
+          content="Tab 2 Content"
+          onInitialStateChange={onInitialStateChange}
+          state={tab2State}
+        />
+      );
     });
 
     const registry = new DocViewsRegistry();
@@ -344,22 +378,24 @@ describe('<DocViewer />', () => {
         docViews={registry.getAll()}
         hit={records[0]}
         dataView={dataViewMock}
-        onInitialDocViewerStateChange={onInitialDocViewerStateChange}
+        onInitialStateChange={onInitialDocViewerStateChange}
       />
     );
 
     expect(onInitialDocViewerStateChange).toHaveBeenCalledWith({
       docViewerTabsState: {
-        test1: { tab1State: 'value1' },
+        test1: tab1State,
       },
     });
 
     await userEvent.click(screen.getByTestId('docViewerTab-test2'));
 
-    expect(onInitialDocViewerStateChange).toHaveBeenCalledWith({
+    expect(onInitialDocViewerStateChange).toHaveBeenLastCalledWith({
       docViewerTabsState: {
-        test2: { tab2State: 'value2' },
+        test1: tab1State,
+        test2: tab2State,
       },
+      initialDocViewerViewedEventKey: 'doc_detail|test2|i::1::',
     });
   });
 
@@ -390,7 +426,7 @@ describe('<DocViewer />', () => {
         hit={records[0]}
         dataView={dataViewMock}
         initialTabId="testTab"
-        initialDocViewerState={initialDocViewerState}
+        initialState={initialDocViewerState}
       />
     );
 

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -7,49 +7,37 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { RefAttributes } from 'react';
+import type { ComponentProps, ComponentRef, RefAttributes } from 'react';
 import React, { forwardRef, useCallback, useImperativeHandle, useState, useEffect } from 'react';
 import type { EuiTabbedContentTab } from '@elastic/eui';
 import { EuiTabbedContent } from '@elastic/eui';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
+import type { AnalyticsServiceStart } from '@kbn/core/public';
 import { DocViewerTab } from './doc_viewer_tab';
-import type { DocView, DocViewRenderProps, DocViewerRestorableState } from '../../types';
+import type { DocView, DocViewRenderProps } from '../../types';
+import { useDocViewerTabViewedEvent } from '../../analytics';
+import { useRestorableState, withRestorableState } from './restorable_state';
 
 export const INITIAL_TAB = 'unifiedDocViewer:initialTab';
 
-export interface DocViewerApi {
+export interface InternalDocViewerApi {
   setSelectedTabId: (tabId: string) => void;
 }
 
-export interface DocViewerProps extends DocViewRenderProps, RefAttributes<DocViewerApi> {
+export interface InternalDocViewerProps
+  extends DocViewRenderProps,
+    RefAttributes<InternalDocViewerApi>,
+    Pick<AnalyticsServiceStart, 'reportEvent'> {
   docViews: DocView[];
   initialTabId?: DocView['id'];
-  initialDocViewerState?: DocViewerRestorableState;
-  onInitialDocViewerStateChange?: (state: DocViewerRestorableState) => void;
   onUpdateSelectedTabId?: (tabId: string | undefined) => void;
 }
 
 const getFullTabId = (tabId: string) => `kbn_doc_viewer_tab_${tabId}`;
 const getOriginalTabId = (fullTabId: string) => fullTabId.replace('kbn_doc_viewer_tab_', '');
 
-/**
- * Rendering tabs with different views of 1 Elasticsearch hit in Discover.
- * The tabs are provided by the `docs_views` registry.
- * A view can contain a React `component`, or any JS framework by using
- * a `render` function.
- */
-export const DocViewer = forwardRef<DocViewerApi, DocViewerProps>(
-  (
-    {
-      docViews,
-      initialTabId,
-      initialDocViewerState,
-      onInitialDocViewerStateChange,
-      onUpdateSelectedTabId,
-      ...renderProps
-    },
-    ref
-  ) => {
+const InternalDocViewer = forwardRef<InternalDocViewerApi, InternalDocViewerProps>(
+  ({ docViews, initialTabId, onUpdateSelectedTabId, reportEvent, ...renderProps }, ref) => {
     const tabs = docViews
       .filter(({ enabled }) => enabled) // Filter out disabled doc views
       .map((docView: DocView) => ({
@@ -60,8 +48,6 @@ export const DocViewer = forwardRef<DocViewerApi, DocViewerProps>(
             key={`${renderProps.hit.id}_${docView.id}`}
             docView={docView}
             renderProps={renderProps}
-            initialDocViewerState={initialDocViewerState}
-            onInitialDocViewerStateChange={onInitialDocViewerStateChange}
           />
         ),
         ['data-test-subj']: `docViewerTab-${docView.id}`,
@@ -71,7 +57,8 @@ export const DocViewer = forwardRef<DocViewerApi, DocViewerProps>(
     const [selectedTabId, setSelectedTabId] = useState<string | undefined>(
       initialTabId ? getFullTabId(initialTabId) : storedInitialTabId
     );
-    const selectedTab = selectedTabId ? tabs.find(({ id }) => id === selectedTabId) : undefined;
+    const selectedTab =
+      (selectedTabId ? tabs.find(({ id }) => id === selectedTabId) : undefined) ?? tabs.at(0);
 
     useEffect(() => {
       onUpdateSelectedTabId?.(selectedTabId ? getOriginalTabId(selectedTabId) : undefined);
@@ -87,6 +74,19 @@ export const DocViewer = forwardRef<DocViewerApi, DocViewerProps>(
       }),
       [setInitialTabId]
     );
+
+    const [initialDocViewerViewedEventKey, setInitialDocViewerViewedEventKey] = useRestorableState(
+      'initialDocViewerViewedEventKey',
+      undefined
+    );
+
+    useDocViewerTabViewedEvent({
+      reportEvent,
+      tabId: selectedTab ? getOriginalTabId(selectedTab.id) : undefined,
+      hit: renderProps.hit,
+      initialEventKey: initialDocViewerViewedEventKey,
+      onEventKeyChange: setInitialDocViewerViewedEventKey,
+    });
 
     const onTabClick = useCallback(
       (tab: EuiTabbedContentTab) => {
@@ -109,3 +109,8 @@ export const DocViewer = forwardRef<DocViewerApi, DocViewerProps>(
     );
   }
 );
+
+export const DocViewer = withRestorableState(InternalDocViewer);
+
+export type DocViewerProps = ComponentProps<typeof DocViewer>;
+export type DocViewerApi = ComponentRef<typeof DocViewer>;

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer_tab.tsx
@@ -10,13 +10,11 @@
 import React, { useCallback } from 'react';
 import { KibanaSectionErrorBoundary } from '@kbn/shared-ux-error-boundary';
 import type { DocView, DocViewRenderProps } from '../../types';
-import type { DocViewerProps } from './doc_viewer';
+import { useRestorableState } from './restorable_state';
 
 interface Props {
   docView: DocView;
   renderProps: DocViewRenderProps;
-  initialDocViewerState?: DocViewerProps['initialDocViewerState'];
-  onInitialDocViewerStateChange?: DocViewerProps['onInitialDocViewerStateChange'];
 }
 
 type ExtractState<T> = T extends DocView<infer TState> ? TState | undefined : never;
@@ -26,27 +24,21 @@ type ExtractState<T> = T extends DocView<infer TState> ? TState | undefined : ne
  * Displays an error message when it encounters exceptions, thanks to
  * Error Boundaries.
  */
-export const DocViewerTab = ({
-  docView,
-  renderProps,
-  initialDocViewerState,
-  onInitialDocViewerStateChange,
-}: Props) => {
-  const initialState = initialDocViewerState?.docViewerTabsState?.[docView.id] as ExtractState<
-    typeof docView
-  >;
+export const DocViewerTab = ({ docView, renderProps }: Props) => {
+  const [docViewerTabsState, setDocViewerTabsState] = useRestorableState(
+    'docViewerTabsState',
+    undefined
+  );
+  const initialState = docViewerTabsState?.[docView.id] as ExtractState<typeof docView>;
 
   const onInitialStateChange = useCallback(
     (state: object) => {
-      onInitialDocViewerStateChange?.({
-        ...initialDocViewerState,
-        docViewerTabsState: {
-          ...initialDocViewerState?.docViewerTabsState,
-          [docView.id]: state,
-        },
-      });
+      setDocViewerTabsState((prevState) => ({
+        ...prevState,
+        [docView.id]: state,
+      }));
     },
-    [docView.id, initialDocViewerState, onInitialDocViewerStateChange]
+    [docView.id, setDocViewerTabsState]
   );
 
   return (

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/restorable_state.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/restorable_state.ts
@@ -7,17 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  DocViewer,
-  type DocViewerProps,
-  type DocViewerApi,
-  type DocViewerRestorableState,
-  DocViewsRegistry,
-  ElasticRequestState,
-  FieldName,
-  registerDocViewerAnalyticsEvents,
-  type UseDocViewerTabViewedEventParams,
-  type UseDocViewerViewedEventParams,
-  useDocViewerTabViewedEvent,
-  useDocViewerViewedEvent,
-} from './src';
+import { createRestorableStateProvider } from '@kbn/restorable-state';
+import type { DocViewerRestorableState } from '../../types';
+
+export const { withRestorableState, useRestorableState } =
+  createRestorableStateProvider<DocViewerRestorableState>();

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/index.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/index.ts
@@ -9,3 +9,4 @@
 
 export * from './components';
 export * from './services';
+export * from './analytics';

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/services/types.ts
@@ -26,6 +26,10 @@ export interface DocViewerRestorableState {
    * Each tab can store its own state as needed.
    */
   docViewerTabsState?: DocViewerTabsState;
+  /**
+   * Used to dedupe initial `unified_doc_viewer_viewed` event when restoring state.
+   */
+  initialDocViewerViewedEventKey?: string;
 }
 
 export interface FieldMapping {

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/tsconfig.json
@@ -22,5 +22,6 @@
     "@kbn/core-analytics-browser-mocks",
     "@kbn/shared-ux-error-boundary",
     "@kbn/restorable-state",
+    "@kbn/core",
   ]
 }

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -16,6 +16,7 @@ import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DataTableColumnsMeta } from '@kbn/unified-data-table';
 import type { DocViewerProps, DocViewsRegistry } from '@kbn/unified-doc-viewer';
 import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
+import type { UnifiedDocViewerFlyoutProps } from '@kbn/unified-doc-viewer-plugin/public';
 import { UnifiedDocViewerFlyout } from '@kbn/unified-doc-viewer-plugin/public';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
 import { useFlyoutActions } from './use_flyout_actions';
@@ -27,7 +28,7 @@ export const FLYOUT_WIDTH_KEY = 'discover:flyoutWidth';
 
 export interface DiscoverGridFlyoutProps
   extends Pick<
-    DocViewerProps,
+    UnifiedDocViewerFlyoutProps,
     'initialDocViewerState' | 'onInitialDocViewerStateChange' | 'onUpdateSelectedTabId'
   > {
   savedSearchId?: string;

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer/doc_viewer.tsx
@@ -13,19 +13,27 @@ import { DocViewer } from '@kbn/unified-doc-viewer';
 
 import { getUnifiedDocViewerServices } from '../../plugin';
 
-export const UnifiedDocViewer = forwardRef<DocViewerApi, Omit<DocViewerProps, 'docViews'>>(
-  ({ docViewsRegistry, ...props }, ref) => {
-    const { unifiedDocViewer } = getUnifiedDocViewerServices();
+export const UnifiedDocViewer = forwardRef<
+  DocViewerApi,
+  Omit<DocViewerProps, 'docViews' | 'reportEvent'>
+>(({ docViewsRegistry, ...props }, ref) => {
+  const { unifiedDocViewer, analytics } = getUnifiedDocViewerServices();
 
-    const registry = useMemo(() => {
-      if (docViewsRegistry) {
-        return typeof docViewsRegistry === 'function'
-          ? docViewsRegistry(unifiedDocViewer.registry.clone())
-          : docViewsRegistry;
-      }
-      return unifiedDocViewer.registry;
-    }, [docViewsRegistry, unifiedDocViewer.registry]);
+  const registry = useMemo(() => {
+    if (docViewsRegistry) {
+      return typeof docViewsRegistry === 'function'
+        ? docViewsRegistry(unifiedDocViewer.registry.clone())
+        : docViewsRegistry;
+    }
+    return unifiedDocViewer.registry;
+  }, [docViewsRegistry, unifiedDocViewer.registry]);
 
-    return <DocViewer ref={ref} docViews={registry.getAll()} {...props} />;
-  }
-);
+  return (
+    <DocViewer
+      ref={ref}
+      docViews={registry.getAll()}
+      reportEvent={analytics.reportEvent}
+      {...props}
+    />
+  );
+});

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -36,13 +36,7 @@ import { UnifiedDocViewer } from '../lazy_doc_viewer';
 import { useFlyoutA11y } from './use_flyout_a11y';
 
 export interface UnifiedDocViewerFlyoutProps
-  extends Pick<
-    DocViewerProps,
-    | 'initialTabId'
-    | 'initialDocViewerState'
-    | 'onInitialDocViewerStateChange'
-    | 'onUpdateSelectedTabId'
-  > {
+  extends Pick<DocViewerProps, 'initialTabId' | 'onUpdateSelectedTabId'> {
   docViewerRef?: DocViewerProps['ref'];
   'data-test-subj'?: string;
   flyoutTitle?: string;
@@ -62,6 +56,8 @@ export interface UnifiedDocViewerFlyoutProps
   hits?: DataTableRecord[];
   dataView: DataView;
   hideFilteringOnComputedColumns?: boolean;
+  initialDocViewerState?: DocViewerProps['initialState'];
+  onInitialDocViewerStateChange?: DocViewerProps['onInitialStateChange'];
   renderCustomHeader?: (props: DocViewRenderProps) => React.ReactElement;
   setExpandedDoc: (doc?: DataTableRecord) => void;
   onClose: () => void;
@@ -328,8 +324,8 @@ export function UnifiedDocViewerFlyout({
           <UnifiedDocViewer
             ref={docViewerRef}
             initialTabId={initialTabId}
-            initialDocViewerState={initialDocViewerState}
-            onInitialDocViewerStateChange={onInitialDocViewerStateChange}
+            initialState={initialDocViewerState}
+            onInitialStateChange={onInitialDocViewerStateChange}
             onUpdateSelectedTabId={onUpdateSelectedTabId}
             {...docViewRenderProps}
           />

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/common/constants.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/common/constants.ts
@@ -24,3 +24,9 @@ export const OPEN_IN_DISCOVER_ARIA_LABEL = i18n.translate(
 export const NOT_AVAILABLE_LABEL = i18n.translate('unifiedDocViewer.observability.traces.na', {
   defaultMessage: 'N/A',
 });
+
+export enum FlyoutContentId {
+  TRACE_TIMELINE = 'trace_timeline',
+  SPAN_DETAIL = 'span_detail',
+  LOG_DETAIL = 'log_detail',
+}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '.';
 import { setUnifiedDocViewerServices } from '../../../../../plugin';
 import type { UnifiedDocViewerServices } from '../../../../../types';
+import { mockUnifiedDocViewerServices } from '../../../../../__mocks__';
 
 jest.mock('./waterfall_flyout/span_flyout', () => ({
   spanFlyoutId: 'spanDetailFlyout',
@@ -58,6 +59,7 @@ describe('FullScreenWaterfall', () => {
 
   beforeAll(() => {
     setUnifiedDocViewerServices({
+      ...mockUnifiedDocViewerServices,
       discoverShared: {
         features: {
           registry: {

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/index.tsx
@@ -20,9 +20,11 @@ import { i18n } from '@kbn/i18n';
 import type { FullTraceWaterfallOnErrorClick } from '@kbn/apm-types';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useDocViewerViewedEvent } from '@kbn/unified-doc-viewer';
 import { getUnifiedDocViewerServices } from '../../../../../plugin';
 import type { TraceOverviewSections } from '../../doc_viewer_overview/overview';
 import { DocumentDetailFlyout, type DocumentType } from './waterfall_flyout/document_detail_flyout';
+import { FlyoutContentId } from '../../common/constants';
 
 export const FULL_TRACE_WATERFALL_RENDER_DELAY_MS = 150;
 
@@ -59,11 +61,16 @@ export const FullScreenWaterfall = ({
   onCloseFlyout,
   onExitFullScreen,
 }: FullScreenWaterfallProps) => {
-  const { discoverShared } = getUnifiedDocViewerServices();
+  const { analytics, discoverShared } = getUnifiedDocViewerServices();
   const FullTraceWaterfall = discoverShared.features.registry.getById(
     'observability-full-trace-waterfall'
   )?.render;
   const { euiTheme } = useEuiTheme();
+
+  useDocViewerViewedEvent({
+    reportEvent: analytics.reportEvent,
+    contentId: FlyoutContentId.TRACE_TIMELINE,
+  });
 
   /*
    * Temporary workaround: add a native <style> tag to fix the z-index of EuiDataGrid cell popovers

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/document_detail_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/document_detail_flyout.tsx
@@ -13,12 +13,13 @@ import React from 'react';
 import { WaterfallFlyout } from '.';
 import type { TraceOverviewSections } from '../../../doc_viewer_overview/overview';
 import { spanFlyoutId, SpanFlyoutContent } from './span_flyout';
-import { logsFlyoutId, LogFlyoutContent } from './logs_flyout';
+import { LogFlyoutContent } from './logs_flyout';
 import {
   useDocumentFlyoutData,
   type DocumentType,
   type DocumentFlyoutData,
 } from './use_document_flyout_data';
+import { FlyoutContentId } from '../../../common/constants';
 
 export type { DocumentType } from './use_document_flyout_data';
 
@@ -28,23 +29,35 @@ interface FlyoutContentProps {
   activeSection?: TraceOverviewSections;
 }
 
-function FlyoutContent({ data, dataView, activeSection }: FlyoutContentProps) {
-  if (!data.hit) {
-    return null;
-  }
-
-  const isSpanType = data.type === spanFlyoutId;
-  if (isSpanType) {
-    return <SpanFlyoutContent hit={data.hit} dataView={dataView} activeSection={activeSection} />;
-  }
-
-  const isLogType = data.type === logsFlyoutId;
-  if (isLogType && data.logDataView) {
-    return <LogFlyoutContent hit={data.hit} logDataView={data.logDataView} />;
-  }
-
-  return null;
+interface FlyoutConfig {
+  contentId: FlyoutContentId;
+  render: (params: FlyoutContentProps) => React.ReactNode;
 }
+
+const getFlyoutConfig = (type: DocumentType): FlyoutConfig => {
+  if (type === spanFlyoutId) {
+    return {
+      contentId: FlyoutContentId.SPAN_DETAIL,
+      render: ({ data, dataView, activeSection }) => {
+        if (!data.hit) return null;
+
+        return (
+          <SpanFlyoutContent hit={data.hit} dataView={dataView} activeSection={activeSection} />
+        );
+      },
+    };
+  }
+
+  // if it's not a span flyout, it's a logs flyout
+  return {
+    contentId: FlyoutContentId.LOG_DETAIL,
+    render: ({ data }) => {
+      if (!data.hit || !data.logDataView) return null;
+
+      return <LogFlyoutContent hit={data.hit} logDataView={data.logDataView} />;
+    },
+  };
+};
 
 export interface DocumentDetailFlyoutProps {
   type: DocumentType;
@@ -69,6 +82,8 @@ export function DocumentDetailFlyout({
 }: DocumentDetailFlyoutProps) {
   const data = useDocumentFlyoutData({ type, docId, traceId, docIndex });
 
+  const flyoutConfig = getFlyoutConfig(type);
+
   return (
     <WaterfallFlyout
       onCloseFlyout={onCloseFlyout}
@@ -77,11 +92,10 @@ export function DocumentDetailFlyout({
       loading={data.loading}
       title={data.title}
       dataTestSubj={dataTestSubj}
+      flyoutContentId={flyoutConfig.contentId}
     >
       {data.error && <EuiCallOut announceOnMount title={data.error} color="danger" />}
-      {data.hit ? (
-        <FlyoutContent data={data} dataView={dataView} activeSection={activeSection} />
-      ) : null}
+      {flyoutConfig.render({ data, dataView, activeSection })}
     </WaterfallFlyout>
   );
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.test.tsx
@@ -12,6 +12,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { WaterfallFlyout, type Props } from '.';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { buildDataTableRecord } from '@kbn/discover-utils';
+import { FlyoutContentId } from '../../../common/constants';
+import { setUnifiedDocViewerServices } from '../../../../../../plugin';
+import { mockUnifiedDocViewerServices } from '../../../../../../__mocks__';
+
+setUnifiedDocViewerServices(mockUnifiedDocViewerServices);
 
 jest.mock('../../../../../doc_viewer_table', () => ({
   __esModule: true,
@@ -50,6 +55,7 @@ describe('WaterfallFlyout', () => {
     hit: mockHit,
     loading: false,
     dataView: dataViewMock,
+    flyoutContentId: FlyoutContentId.SPAN_DETAIL,
     children: <div data-test-subj="customChildren">Custom Children Content</div>,
   };
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/full_screen_waterfall/waterfall_flyout/index.tsx
@@ -24,8 +24,11 @@ import type { DataTableRecord } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import React, { useState } from 'react';
+import { useDocViewerViewedEvent } from '@kbn/unified-doc-viewer';
 import DocViewerSource from '../../../../../doc_viewer_source';
 import DocViewerTable from '../../../../../doc_viewer_table';
+import { getUnifiedDocViewerServices } from '../../../../../../plugin';
+import type { FlyoutContentId } from '../../../common/constants';
 
 const tabIds = {
   OVERVIEW: 'unifiedDocViewerTracesSpanFlyoutOverview',
@@ -76,6 +79,7 @@ export interface Props {
   loading: boolean;
   dataView: DocViewRenderProps['dataView'];
   dataTestSubj?: string;
+  flyoutContentId: FlyoutContentId;
   children: React.ReactNode;
 }
 
@@ -87,10 +91,18 @@ export function WaterfallFlyout({
   children,
   title,
   dataTestSubj,
+  flyoutContentId,
 }: Props) {
+  const { analytics } = getUnifiedDocViewerServices();
   const [selectedTabId, setSelectedTabId] = useState(tabIds.OVERVIEW);
   const flyoutTitleId = useGeneratedHtmlId();
   const flyoutId = useGeneratedHtmlId({ prefix: 'documentDetailFlyout' });
+
+  useDocViewerViewedEvent({
+    reportEvent: analytics.reportEvent,
+    contentId: flyoutContentId,
+    tabId: selectedTabId,
+  });
 
   return (
     <EuiFlyout

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import type { CoreSetup, Plugin } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import { DocViewsRegistry, registerDocViewerAnalyticsEvents } from '@kbn/unified-doc-viewer';
 import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
 import { createGetterSetter, Storage } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
@@ -56,6 +56,8 @@ export class UnifiedDocViewerPublicPlugin
   private docViewsRegistry = new DocViewsRegistry();
 
   public setup(core: CoreSetup<UnifiedDocViewerStartDeps, UnifiedDocViewerStart>) {
+    registerDocViewerAnalyticsEvents(core.analytics);
+
     this.docViewsRegistry.add({
       id: 'doc_view_table',
       title: i18n.translate('unifiedDocViewer.docViews.table.tableTitle', {


### PR DESCRIPTION
## Summary

Test.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.