### PR TITLE
[8.19] [scout] selective testing for "configs" test distribution strategy (#257660)

### DIFF
--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -17,6 +17,7 @@ export interface ModuleDiscoveryInfo {
   name: string;
   group: string;
   type: 'plugin' | 'package';
+  isAffected?: boolean;
   configs: {
     path: string;
     hasTests: boolean;
@@ -58,9 +59,10 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const scoutCiRunGroups = modulesWithTests.map((module) => {
     // Check if any config in this module uses parallel workers
     const usesParallelWorkers = module.configs.some((config) => config.usesParallelWorkers);
+    const affectedPrefix = module.isAffected ? 'affected ' : '';
 
     return {
-      label: `Scout: [ ${module.group} / ${module.name} ] ${module.type}`,
+      label: `${affectedPrefix}Scout: [ ${module.group} / ${module.name} ] ${module.type}`,
       key: module.name,
       agents: expandAgentQueue(usesParallelWorkers ? 'n2-8-spot' : 'n2-4-spot'),
       group: module.group,

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -125,6 +125,7 @@ steps:
       SCOUT_TEST_DISTRIBUTION_STRATEGY: 'configs'
       SCOUT_CONFIGS_DEPS: 'build_scout_tests'
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout/configs.sh'
+      SELECTIVE_TESTING_ENABLED: 'true'
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/scripts/steps/test/scout/test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout/test_run_builder.sh
@@ -8,6 +8,8 @@ echo '--- Verify Playwright CLI is functional'
 node scripts/scout run-playwright-test-check
 
 echo '--- Update Scout Test Config Manifests'
+# Updates **/test/scout/.meta (manifest) files. Those paths are excluded from affected-packages
+# so they do not cause extra modules to be considered "changed" in the next step.
 node scripts/scout.js update-test-config-manifests --concurrencyLimit 3
 
 SCOUT_TEST_DISTRIBUTION_STRATEGY="${SCOUT_TEST_DISTRIBUTION_STRATEGY:-configs}"
@@ -46,16 +48,30 @@ if [[ "$SCOUT_TEST_DISTRIBUTION_STRATEGY" == "lanes" ]]; then
     --showMultiTrackSummary
 
 else
-  echo '--- Discover Playwright Configs and upload to Buildkite artifacts'
-# Look for both stateful and serverless tests when run on "main" / PRs to "main", otherwise only stateful tests to be discovered and run
   if [[ "${BUILDKITE_BRANCH:-}" == "main" || "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" == "main" ]]; then
     SCOUT_DISCOVERY_TARGET="local"
   else
     SCOUT_DISCOVERY_TARGET="local-stateful-only"
   fi
+
+  AFFECTED_MODULES_FILE=""
+  if [[ -n "${GITHUB_PR_MERGE_BASE:-}" ]] && [[ "${SELECTIVE_TESTING_ENABLED:-}" == "true" ]]; then
+    mkdir -p .scout
+    AFFECTED_MODULES_FILE=".scout/affected_modules.json"
+    .buildkite/pipeline-utils/affected-packages/list_affected \
+      --strategy git --deep --merge-base "$GITHUB_PR_MERGE_BASE" --json \
+      > "$AFFECTED_MODULES_FILE"
+  fi
+
+  echo "--- Discover Playwright Configs and upload to Buildkite artifacts${AFFECTED_MODULES_FILE:+ (selective testing)}"
+  AFFECTED_FLAG=()
+  if [[ -n "$AFFECTED_MODULES_FILE" ]]; then
+    AFFECTED_FLAG=(--affected-modules "$AFFECTED_MODULES_FILE")
+  fi
   node scripts/scout discover-playwright-configs \
     --include-custom-servers \
     --target "$SCOUT_DISCOVERY_TARGET" \
+    "${AFFECTED_FLAG[@]}" \
     --save
   cp .scout/test_configs/scout_playwright_configs.json scout_playwright_configs.json
   buildkite-agent artifact upload "scout_playwright_configs.json"

--- a/src/platform/packages/shared/kbn-scout/moon.yml
+++ b/src/platform/packages/shared/kbn-scout/moon.yml
@@ -23,6 +23,7 @@ dependsOn:
   - '@kbn/dev-cli-errors'
   - '@kbn/ci-stats-reporter'
   - '@kbn/repo-info'
+  - '@kbn/repo-packages'
   - '@kbn/es'
   - '@kbn/dev-proc-runner'
   - '@kbn/test'

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.test.ts
@@ -108,6 +108,7 @@ describe('runDiscoverPlaywrightConfigs', () => {
       enum: jest.fn(),
       arrayOfStrings: jest.fn(),
       boolean: jest.fn(),
+      string: jest.fn(),
     } as any;
 
     log = {

--- a/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
+++ b/src/platform/packages/shared/kbn-scout/src/cli/config_discovery.ts
@@ -12,6 +12,7 @@ import { SCOUT_PLAYWRIGHT_CONFIGS_PATH } from '@kbn/scout-info';
 import { testableModules } from '@kbn/scout-reporting/src/registry';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { saveFlattenedConfigGroups, saveModuleDiscoveryInfo } from '../tests_discovery/file_utils';
+import { markModulesAffectedStatus } from '../tests_discovery/affected_modules';
 import {
   filterModulesByScoutCiConfig,
   getScoutCiExcludedConfigs,
@@ -206,11 +207,18 @@ export const runDiscoverPlaywrightConfigs = (flagsReader: FlagsReader, log: Tool
   const targetTags = getTestTagsForTarget(target);
   const flatten = flagsReader.boolean('flatten');
   const includeCustomServers = flagsReader.boolean('include-custom-servers');
+  const affectedModulesPath = flagsReader.string('affected-modules');
 
   // Build initial module discovery info
   const modulesWithTests = buildModuleDiscoveryInfo();
+
+  // Mark affected status when selective testing is enabled (all modules kept, isAffected set)
+  const modulesAfterAffectedMark = affectedModulesPath
+    ? markModulesAffectedStatus(modulesWithTests, affectedModulesPath, log)
+    : modulesWithTests;
+
   // Filter modules by target tags and compute server run flags
-  const filteredModulesByTags = filterModulesByTargetTags(modulesWithTests, targetTags);
+  const filteredModulesByTags = filterModulesByTargetTags(modulesAfterAffectedMark, targetTags);
   const filteredModules = filterModulesByCustomServerPaths(
     filteredModulesByTags,
     includeCustomServers
@@ -260,6 +268,9 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
                               - 'local-stateful-only': @local-stateful-* tags only
                               - 'mki': @cloud-serverless-* tags
                               - 'ech': @cloud-stateful-* tags
+    --affected-modules <file>  Path to a JSON file containing affected @kbn/ module IDs
+                              (produced by list_affected). All modules run; affected ones
+                              get "affected" prefix in Buildkite step (selective testing).
     --include-custom-servers  Include configs under 'test/scout_*' paths for custom server setups
     --validate                Validate that all discovered modules are registered in Scout CI config
     --save                    Validate and save enabled modules to '${SCOUT_PLAYWRIGHT_CONFIGS_PATH}'
@@ -293,9 +304,12 @@ export const discoverPlaywrightConfigsCmd: Command<void> = {
 
     # Save flattened configs for Cloud test execution
     node scripts/scout discover-playwright-configs --flatten --save
+
+    # Selective testing: only configs for affected modules
+    node scripts/scout discover-playwright-configs --affected-modules .scout/affected_modules.json --save
   `,
   flags: {
-    string: ['target'],
+    string: ['target', 'affected-modules'],
     boolean: ['save', 'validate', 'flatten', 'include-custom-servers'],
     default: {
       target: 'all',

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.test.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ToolingLog } from '@kbn/tooling-log';
+import fs from 'fs';
+import path from 'path';
+import type { ModuleDiscoveryInfo } from './types';
+
+jest.mock('@kbn/repo-info', () => ({
+  REPO_ROOT: '/mock/repo/root',
+}));
+
+jest.mock('fs');
+
+const mockFindPackageForPath = jest.fn();
+jest.mock('@kbn/repo-packages', () => ({
+  findPackageForPath: (...args: unknown[]) => mockFindPackageForPath(...args),
+}));
+
+import { markModulesAffectedStatus, readAffectedModules } from './affected_modules';
+
+/** Path -> @kbn/ module ID mapping used by the findPackageForPath mock */
+const CONFIG_PATH_TO_MODULE_ID: Record<string, string> = {
+  'x-pack/solutions/security/plugins/security_solution/test/scout/ui/playwright.config.ts':
+    '@kbn/security-solution-plugin',
+  'src/platform/plugins/shared/discover/test/scout/ui/playwright.config.ts': '@kbn/discover-plugin',
+  'src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts': '@kbn/scout',
+};
+
+const createModule = (
+  name: string,
+  type: 'plugin' | 'package',
+  configPath: string
+): ModuleDiscoveryInfo => ({
+  name,
+  group: 'test-group',
+  type,
+  configs: [
+    {
+      path: configPath,
+      hasTests: true,
+      tags: ['@local-stateful-classic'],
+      serverRunFlags: ['--arch stateful --domain classic'],
+      usesParallelWorkers: false,
+    },
+  ],
+});
+
+const setupFindPackageMock = () => {
+  mockFindPackageForPath.mockImplementation((repoRoot: string, filePath: string) => {
+    const rel = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+    const id = CONFIG_PATH_TO_MODULE_ID[rel];
+    return id ? { id } : undefined;
+  });
+};
+
+describe('affected_modules', () => {
+  let mockLog: ToolingLog;
+
+  beforeEach(() => {
+    mockLog = new ToolingLog({ level: 'verbose', writeTo: process.stdout });
+    jest.spyOn(mockLog, 'info').mockImplementation(jest.fn());
+    jest.spyOn(mockLog, 'warning').mockImplementation(jest.fn());
+    setupFindPackageMock();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('readAffectedModules', () => {
+    it('should read and parse a valid JSON array file', () => {
+      const modules = ['@kbn/scout', '@kbn/discover-plugin'];
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(modules));
+
+      const result = readAffectedModules('/some/path.json', mockLog);
+
+      expect(result).toEqual(new Set(modules));
+    });
+
+    it('should return null for non-array JSON', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ not: 'an array' }));
+
+      const result = readAffectedModules('/some/path.json', mockLog);
+
+      expect(result).toBeNull();
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('does not contain a JSON array')
+      );
+    });
+
+    it('should return null when file does not exist', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+
+      const result = readAffectedModules('/missing/file.json', mockLog);
+
+      expect(result).toBeNull();
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to read affected modules file')
+      );
+    });
+
+    it('should return null for invalid JSON', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('not valid json');
+
+      const result = readAffectedModules('/some/path.json', mockLog);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('markModulesAffectedStatus', () => {
+    const modules: ModuleDiscoveryInfo[] = [
+      createModule(
+        'security_solution',
+        'plugin',
+        'x-pack/solutions/security/plugins/security_solution/test/scout/ui/playwright.config.ts'
+      ),
+      createModule(
+        'discover',
+        'plugin',
+        'src/platform/plugins/shared/discover/test/scout/ui/playwright.config.ts'
+      ),
+      createModule(
+        'kbn-scout',
+        'package',
+        'src/platform/packages/shared/kbn-scout/test/scout/api/playwright.config.ts'
+      ),
+    ];
+
+    it('should mark affected modules with isAffected: true', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify(['@kbn/security-solution-plugin', '@kbn/scout'])
+      );
+
+      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
+
+      expect(result).toHaveLength(3);
+      expect(result.find((m) => m.name === 'security_solution')?.isAffected).toBe(true);
+      expect(result.find((m) => m.name === 'discover')?.isAffected).toBe(false);
+      expect(result.find((m) => m.name === 'kbn-scout')?.isAffected).toBe(true);
+    });
+
+    it('should mark non-affected modules with isAffected: false', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(['@kbn/scout']));
+
+      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
+
+      expect(result).toHaveLength(3);
+      expect(result.find((m) => m.name === 'security_solution')?.isAffected).toBe(false);
+      expect(result.find((m) => m.name === 'discover')?.isAffected).toBe(false);
+      expect(result.find((m) => m.name === 'kbn-scout')?.isAffected).toBe(true);
+    });
+
+    it('should mark unmapped modules with isAffected: false and warn', () => {
+      const modulesWithUnmapped: ModuleDiscoveryInfo[] = [
+        ...modules,
+        createModule(
+          'unknown_module',
+          'plugin',
+          'some/unknown/path/test/scout/ui/playwright.config.ts'
+        ),
+      ];
+
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(['@kbn/scout']));
+
+      const result = markModulesAffectedStatus(modulesWithUnmapped, '/affected.json', mockLog);
+
+      expect(result).toHaveLength(4);
+      expect(result.find((m) => m.name === 'unknown_module')?.isAffected).toBe(false);
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining("module 'unknown_module'")
+      );
+      expect(mockLog.warning).toHaveBeenCalledWith(
+        expect.stringContaining('could not resolve @kbn/ ID')
+      );
+    });
+
+    it('should throw when the affected modules file cannot be read', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(() => markModulesAffectedStatus(modules, '/missing.json', mockLog)).toThrow(
+        'Selective testing: could not load affected modules file'
+      );
+    });
+
+    it('should mark all as isAffected: false when affected set is empty', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify([]));
+
+      const result = markModulesAffectedStatus(modules, '/affected.json', mockLog);
+
+      expect(result).toHaveLength(3);
+      expect(result.every((m) => m.isAffected === false)).toBe(true);
+    });
+
+    it('should log affected and rest counts', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify(['@kbn/security-solution-plugin'])
+      );
+
+      markModulesAffectedStatus(modules, '/affected.json', mockLog);
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        expect.stringContaining('1 affected module(s), 2 rest')
+      );
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/affected_modules.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createFailError } from '@kbn/dev-cli-errors';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { findPackageForPath } from '@kbn/repo-packages';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { ModuleDiscoveryInfo } from './types';
+
+/**
+ * Resolve the @kbn/ module ID for a Scout config path using the kibana.jsonc-based package map.
+ */
+const getModuleIdForConfigPath = (configPath: string): string | undefined => {
+  const absolutePath = path.isAbsolute(configPath) ? configPath : path.join(REPO_ROOT, configPath);
+  const pkg = findPackageForPath(REPO_ROOT, absolutePath);
+  return pkg?.id;
+};
+
+/**
+ * Read the affected modules JSON file produced by the `list_affected` CLI.
+ * Returns null on any error (missing file, invalid JSON) to allow graceful fallback.
+ */
+export const readAffectedModules = (filePath: string, log: ToolingLog): Set<string> | null => {
+  try {
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(REPO_ROOT, filePath);
+    const content = fs.readFileSync(absolutePath, 'utf-8');
+    const parsed = JSON.parse(content);
+
+    if (!Array.isArray(parsed)) {
+      log.warning(`Affected modules file does not contain a JSON array: ${filePath}`);
+      return null;
+    }
+
+    return new Set<string>(parsed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warning(`Failed to read affected modules file '${filePath}': ${message}`);
+    return null;
+  }
+};
+
+/**
+ * Mark modules with isAffected based on the affected modules set.
+ * All modules are returned; none are filtered out.
+ *
+ * Behavior:
+ * - Module maps to an affected @kbn/ ID -> isAffected: true
+ * - Module does not map to any @kbn/ ID -> isAffected: false (warn)
+ * - Module maps to a @kbn/ ID NOT in affected set -> isAffected: false
+ * - If the file cannot be read or is invalid -> throw (fail fast)
+ */
+export const markModulesAffectedStatus = (
+  modules: ModuleDiscoveryInfo[],
+  affectedModulesPath: string,
+  log: ToolingLog
+): ModuleDiscoveryInfo[] => {
+  const affectedModules = readAffectedModules(affectedModulesPath, log);
+
+  if (affectedModules === null) {
+    throw createFailError(
+      'Selective testing: could not load affected modules file. Check that list_affected produced a valid JSON array.'
+    );
+  }
+
+  let affectedCount = 0;
+  let unmappedCount = 0;
+
+  const marked = modules.map((module) => {
+    const configPath = module.configs[0]?.path ?? '';
+    const moduleId = configPath ? getModuleIdForConfigPath(configPath) : undefined;
+
+    if (!moduleId) {
+      log.warning(
+        `Selective testing: module '${module.name}' could not resolve @kbn/ ID (check kibana.jsonc or run 'yarn kbn bootstrap')`
+      );
+      unmappedCount += 1;
+      return { ...module, isAffected: false };
+    }
+
+    const isAffected = affectedModules.has(moduleId);
+    if (isAffected) affectedCount += 1;
+    return { ...module, isAffected };
+  });
+
+  log.info(
+    `Selective testing: ${affectedCount} affected module(s), ${
+      marked.length - affectedCount
+    } rest, ${unmappedCount} unmapped`
+  );
+
+  return marked;
+};

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/index.ts
@@ -12,3 +12,4 @@ export * from './tag_utils';
 export * from './transform_utils';
 export * from './file_utils';
 export * from './search_configs';
+export * from './affected_modules';

--- a/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
+++ b/src/platform/packages/shared/kbn-scout/src/tests_discovery/types.ts
@@ -20,6 +20,8 @@ export interface ModuleDiscoveryInfo {
   name: string;
   group: string;
   type: 'plugin' | 'package';
+  /** When selective testing is enabled, true if this module's @kbn/ ID is in the affected set */
+  isAffected?: boolean;
   configs: {
     path: string;
     hasTests: boolean;

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -19,6 +19,7 @@
     "@kbn/dev-cli-errors",
     "@kbn/ci-stats-reporter",
     "@kbn/repo-info",
+    "@kbn/repo-packages",
     "@kbn/es",
     "@kbn/dev-proc-runner",
     "@kbn/test",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] selective testing for "configs" test distribution strategy (#257660)](https://github.com/elastic/kibana/pull/257660)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-03-20T12:14:29Z","message":"[scout] selective testing for \"configs\" test distribution strategy (#257660)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/254275\n\nAdds selective testing for Scout tests on PR builds: all Scout configs\nstill run, but modules touched by the PR are clearly marked in the\nBuildkite UI.\n\n### How it works:\n1. When it runs\nFor every PR (`SELECTIVE_TESTING_ENABLED` variable is set for pipeline)\nbuild where `GITHUB_PR_MERGE_BASE` is set (no label required).\n\n2. Affected modules\n`list_affected` computes affected `@kbn/ IDs` from the git diff vs the\nmerge base (ignoring Scout .meta files).\n\n3. Marking, not filtering\n**All Scout configs run.** Each module is marked with `isAffected`:\n- Affected → isAffected: true → Buildkite step label: \"affected Scout: [\ngroup / name ] type\"\n- Rest → isAffected: false → Buildkite step label: \"Scout: [ group /\nname ] type\"\n\n4. Module resolution\nUses `findPackageForPath` from `@kbn/repo-packages` to map Scout config\npaths to `@kbn/ IDs` via `kibana.jsonc`.\n\n5. Error handling\nIf the affected-modules file cannot be loaded, the pipeline fails (no\nfallback). Unmapped modules are warned and kept with isAffected: false.\n\nCI logs:\n\n```\n\nDiscover Playwright Configs and upload to Buildkite artifacts (selective testing)\n--\n.peggy require hook already registered, skipping\ninfo Selective testing: 45 affected module(s), 0 rest, 0 unmapped\nwarn The following plugin(s)/package(s) are disabled in '.buildkite/scout_ci_config.yml' and will be excluded from CI:\n- kbn-scout-release-testing (package)\n- kbn-scout (package)\ninfo Scout configs were filtered for CI. Saved 42 plugin(s) and 1 package(s) to '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1773919930868822194/elastic/kibana-pull-request/kibana/.scout/test_configs/scout_playwright_configs.json'\n```\n\n<img width=\"1067\" height=\"783\" alt=\"Screenshot 2026-03-19 at 12 47 27\"\nsrc=\"https://github.com/user-attachments/assets/c035657a-fd9e-42b5-b610-e6ec7681e3d6\"\n/>\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>","sha":"46e281ca118279c2706ab63066bbe584dd0ded5a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","v9.3.3","v9.2.8"],"title":"[scout] selective testing for \"configs\" test distribution strategy","number":257660,"url":"https://github.com/elastic/kibana/pull/257660","mergeCommit":{"message":"[scout] selective testing for \"configs\" test distribution strategy (#257660)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/254275\n\nAdds selective testing for Scout tests on PR builds: all Scout configs\nstill run, but modules touched by the PR are clearly marked in the\nBuildkite UI.\n\n### How it works:\n1. When it runs\nFor every PR (`SELECTIVE_TESTING_ENABLED` variable is set for pipeline)\nbuild where `GITHUB_PR_MERGE_BASE` is set (no label required).\n\n2. Affected modules\n`list_affected` computes affected `@kbn/ IDs` from the git diff vs the\nmerge base (ignoring Scout .meta files).\n\n3. Marking, not filtering\n**All Scout configs run.** Each module is marked with `isAffected`:\n- Affected → isAffected: true → Buildkite step label: \"affected Scout: [\ngroup / name ] type\"\n- Rest → isAffected: false → Buildkite step label: \"Scout: [ group /\nname ] type\"\n\n4. Module resolution\nUses `findPackageForPath` from `@kbn/repo-packages` to map Scout config\npaths to `@kbn/ IDs` via `kibana.jsonc`.\n\n5. Error handling\nIf the affected-modules file cannot be loaded, the pipeline fails (no\nfallback). Unmapped modules are warned and kept with isAffected: false.\n\nCI logs:\n\n```\n\nDiscover Playwright Configs and upload to Buildkite artifacts (selective testing)\n--\n.peggy require hook already registered, skipping\ninfo Selective testing: 45 affected module(s), 0 rest, 0 unmapped\nwarn The following plugin(s)/package(s) are disabled in '.buildkite/scout_ci_config.yml' and will be excluded from CI:\n- kbn-scout-release-testing (package)\n- kbn-scout (package)\ninfo Scout configs were filtered for CI. Saved 42 plugin(s) and 1 package(s) to '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1773919930868822194/elastic/kibana-pull-request/kibana/.scout/test_configs/scout_playwright_configs.json'\n```\n\n<img width=\"1067\" height=\"783\" alt=\"Screenshot 2026-03-19 at 12 47 27\"\nsrc=\"https://github.com/user-attachments/assets/c035657a-fd9e-42b5-b610-e6ec7681e3d6\"\n/>\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>","sha":"46e281ca118279c2706ab63066bbe584dd0ded5a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257660","number":257660,"mergeCommit":{"message":"[scout] selective testing for \"configs\" test distribution strategy (#257660)\n\n## Summary\n\nFollow-up to https://github.com/elastic/kibana/pull/254275\n\nAdds selective testing for Scout tests on PR builds: all Scout configs\nstill run, but modules touched by the PR are clearly marked in the\nBuildkite UI.\n\n### How it works:\n1. When it runs\nFor every PR (`SELECTIVE_TESTING_ENABLED` variable is set for pipeline)\nbuild where `GITHUB_PR_MERGE_BASE` is set (no label required).\n\n2. Affected modules\n`list_affected` computes affected `@kbn/ IDs` from the git diff vs the\nmerge base (ignoring Scout .meta files).\n\n3. Marking, not filtering\n**All Scout configs run.** Each module is marked with `isAffected`:\n- Affected → isAffected: true → Buildkite step label: \"affected Scout: [\ngroup / name ] type\"\n- Rest → isAffected: false → Buildkite step label: \"Scout: [ group /\nname ] type\"\n\n4. Module resolution\nUses `findPackageForPath` from `@kbn/repo-packages` to map Scout config\npaths to `@kbn/ IDs` via `kibana.jsonc`.\n\n5. Error handling\nIf the affected-modules file cannot be loaded, the pipeline fails (no\nfallback). Unmapped modules are warned and kept with isAffected: false.\n\nCI logs:\n\n```\n\nDiscover Playwright Configs and upload to Buildkite artifacts (selective testing)\n--\n.peggy require hook already registered, skipping\ninfo Selective testing: 45 affected module(s), 0 rest, 0 unmapped\nwarn The following plugin(s)/package(s) are disabled in '.buildkite/scout_ci_config.yml' and will be excluded from CI:\n- kbn-scout-release-testing (package)\n- kbn-scout (package)\ninfo Scout configs were filtered for CI. Saved 42 plugin(s) and 1 package(s) to '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1773919930868822194/elastic/kibana-pull-request/kibana/.scout/test_configs/scout_playwright_configs.json'\n```\n\n<img width=\"1067\" height=\"783\" alt=\"Screenshot 2026-03-19 at 12 47 27\"\nsrc=\"https://github.com/user-attachments/assets/c035657a-fd9e-42b5-b610-e6ec7681e3d6\"\n/>\n\n---------\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>","sha":"46e281ca118279c2706ab63066bbe584dd0ded5a"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258836","number":258836,"state":"MERGED","mergeCommit":{"sha":"540776a90ba43b1483c3590b75a480ea0f6420d1","message":"[9.3] [scout] selective testing for \"configs\" test distribution strategy (#257660) (#258836)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[scout] selective testing for \"configs\" test distribution strategy\n(#257660)](https://github.com/elastic/kibana/pull/257660)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/258835","number":258835,"state":"MERGED","mergeCommit":{"sha":"30d82bed88aeb3206cf388eba70fa33c1848d58d","message":"[9.2] [scout] selective testing for \"configs\" test distribution strategy (#257660) (#258835)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[scout] selective testing for \"configs\" test distribution strategy\n(#257660)](https://github.com/elastic/kibana/pull/257660)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->