### PR TITLE
[Overlays Flyouts] Auto-close flyouts after navigating to another app

### DIFF
--- a/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.test.tsx
@@ -34,21 +34,23 @@ const mountText = (text: string) => (container: HTMLElement) => {
   return () => {};
 };
 
-const getServiceStart = () => {
+const getService = () => {
   const service = new FlyoutService();
-  return service.start({
+  const flyouts = service.start({
     analytics: analyticsMock,
     i18n: i18nMock,
     theme: themeMock,
     userProfile: userProfileMock,
     targetDomElement: document.createElement('div'),
   });
+  return { service, flyouts };
 };
 
 describe('FlyoutService', () => {
   let flyouts: OverlayFlyoutStart;
+  let service: FlyoutService;
   beforeEach(() => {
-    flyouts = getServiceStart();
+    ({ service, flyouts } = getService());
   });
 
   describe('openFlyout()', () => {
@@ -82,6 +84,24 @@ describe('FlyoutService', () => {
       });
     });
   });
+  describe('closeAllFlyouts()', () => {
+    it('closes the active flyout and resolves onClose', async () => {
+      const ref = flyouts.open(mountText('Flyout content'));
+      const onCloseComplete = jest.fn();
+      ref.onClose.then(onCloseComplete);
+
+      service.closeAllFlyouts();
+
+      await ref.onClose;
+      expect(onCloseComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when no flyout is open', () => {
+      expect(() => service.closeAllFlyouts()).not.toThrow();
+      expect(mockReactDomUnmount).not.toHaveBeenCalled();
+    });
+  });
+
   describe('FlyoutRef#close()', () => {
     it('resolves the onClose Promise', async () => {
       const ref = flyouts.open(mountText('Flyout content'));

--- a/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.tsx
@@ -143,6 +143,12 @@ export class FlyoutService {
     };
   }
 
+  public closeAllFlyouts(): void {
+    if (this.activeFlyout) {
+      this.activeFlyout.close();
+    }
+  }
+
   /**
    * Using React.Render to re-render into a target DOM element will replace
    * the content of the target but won't call unmountComponent on any

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.test.tsx
@@ -278,6 +278,34 @@ describe('SystemFlyoutService', () => {
     });
   });
 
+  describe('closeAllFlyouts()', () => {
+    it('closes all active flyouts', () => {
+      systemFlyouts.open(<div>Flyout 1</div>);
+      systemFlyouts.open(<div>Flyout 2</div>);
+
+      expect(targetDomElement.children.length).toBe(2);
+      mockReactDomUnmount.mockClear();
+
+      service.closeAllFlyouts();
+
+      expect(mockReactDomUnmount).toHaveBeenCalledTimes(2);
+      expect(targetDomElement.children.length).toBe(0);
+    });
+
+    it('is a no-op when no flyouts are open', () => {
+      expect(() => service.closeAllFlyouts()).not.toThrow();
+      expect(mockReactDomUnmount).not.toHaveBeenCalled();
+    });
+
+    it('allows new flyouts to be opened after closing all', () => {
+      systemFlyouts.open(<div>Flyout 1</div>);
+      service.closeAllFlyouts();
+
+      expect(() => systemFlyouts.open(<div>Flyout 2</div>)).not.toThrow();
+      expect(targetDomElement.children.length).toBe(1);
+    });
+  });
+
   describe('stop()', () => {
     it('closes all active flyouts', () => {
       skipCleanup = true;

--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
@@ -143,13 +143,13 @@ export class SystemFlyoutService {
   /**
    * Cleanup method for when the service is stopped
    */
-  public stop(): void {
-    this.closeAllSystemFlyouts();
-    this.targetDomElement = null;
-  }
-
-  private closeAllSystemFlyouts(): void {
+  public closeAllFlyouts(): void {
     this.activeFlyouts.forEach((flyout) => flyout.close());
     this.activeFlyouts.clear();
+  }
+
+  public stop(): void {
+    this.closeAllFlyouts();
+    this.targetDomElement = null;
   }
 }

--- a/src/core/packages/overlays/browser-internal/src/overlay_service.test.ts
+++ b/src/core/packages/overlays/browser-internal/src/overlay_service.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import './overlay.test.mocks';
+import React from 'react';
+import { Subject } from 'rxjs';
+import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
+import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
+import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
+import { OverlayService } from './overlay_service';
+
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  return {
+    ...actual,
+    getFlyoutManagerStore: jest.fn(() => ({
+      subscribeToEvents: jest.fn(() => () => {}),
+    })),
+  };
+});
+
+const mountText = (text: string) => (container: HTMLElement) => {
+  const content = document.createElement('span');
+  content.textContent = text;
+  container.append(content);
+  return () => {};
+};
+
+const getService = () => {
+  const service = new OverlayService();
+  const overlays = service.start({
+    analytics: analyticsServiceMock.createAnalyticsServiceStart(),
+    i18n: i18nServiceMock.createStartContract(),
+    theme: themeServiceMock.createStartContract(),
+    userProfile: userProfileServiceMock.createStart(),
+    uiSettings: uiSettingsServiceMock.createStartContract(),
+    targetDomElement: document.createElement('div'),
+  });
+  return { service, overlays };
+};
+
+describe('OverlayService', () => {
+  describe('closeAllFlyouts()', () => {
+    it('closes an open legacy flyout', async () => {
+      const { service, overlays } = getService();
+      const ref = overlays.openFlyout(mountText('Flyout content'));
+      const onCloseComplete = jest.fn();
+      ref.onClose.then(onCloseComplete);
+
+      service.closeAllFlyouts();
+
+      await ref.onClose;
+      expect(onCloseComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes an open system flyout', async () => {
+      const { service, overlays } = getService();
+      const ref = overlays.openSystemFlyout(React.createElement('div', null, 'System flyout'));
+      const onCloseComplete = jest.fn();
+      ref.onClose.then(onCloseComplete);
+
+      service.closeAllFlyouts();
+
+      await ref.onClose;
+      expect(onCloseComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when no flyouts are open', () => {
+      const { service } = getService();
+      expect(() => service.closeAllFlyouts()).not.toThrow();
+    });
+  });
+});

--- a/src/core/packages/overlays/browser-internal/src/overlay_service.test.ts
+++ b/src/core/packages/overlays/browser-internal/src/overlay_service.test.ts
@@ -9,7 +9,6 @@
 
 import './overlay.test.mocks';
 import React from 'react';
-import { Subject } from 'rxjs';
 import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
 import { themeServiceMock } from '@kbn/core-theme-browser-mocks';

--- a/src/core/packages/overlays/browser-internal/src/overlay_service.ts
+++ b/src/core/packages/overlays/browser-internal/src/overlay_service.ts
@@ -34,6 +34,11 @@ export class OverlayService {
   private flyoutService = new FlyoutService();
   private systemFlyoutService = new SystemFlyoutService();
 
+  public closeAllFlyouts(): void {
+    this.flyoutService.closeAllFlyouts();
+    this.systemFlyoutService.closeAllFlyouts();
+  }
+
   public start({ targetDomElement, ...startDeps }: StartDeps): OverlayStart {
     const flyoutElement = document.createElement('div');
     targetDomElement.appendChild(flyoutElement);

--- a/src/core/packages/overlays/browser-mocks/src/flyout_service.mock.ts
+++ b/src/core/packages/overlays/browser-mocks/src/flyout_service.mock.ts
@@ -25,6 +25,7 @@ const createStartContractMock = () => {
 const createMock = () => {
   const mocked: jest.Mocked<PublicMethodsOf<FlyoutService>> = lazyObject({
     start: jest.fn().mockReturnValue(createStartContractMock()),
+    closeAllFlyouts: jest.fn(),
   });
   return mocked;
 };

--- a/src/core/packages/overlays/browser-mocks/src/overlay_service.mock.ts
+++ b/src/core/packages/overlays/browser-mocks/src/overlay_service.mock.ts
@@ -32,6 +32,7 @@ const createStartContractMock = () => {
 const createMock = () => {
   const mocked: jest.Mocked<PublicMethodsOf<OverlayService>> = lazyObject({
     start: jest.fn().mockReturnValue(createStartContractMock()),
+    closeAllFlyouts: jest.fn(),
   });
   return mocked;
 };

--- a/src/core/packages/root/browser-internal/src/core_system.ts
+++ b/src/core/packages/root/browser-internal/src/core_system.ts
@@ -8,7 +8,7 @@
  */
 
 import { css } from '@emotion/css';
-import { filter, firstValueFrom } from 'rxjs';
+import { type Subscription, filter, firstValueFrom, pairwise } from 'rxjs';
 import type { CoreContext } from '@kbn/core-base-browser-internal';
 import {
   InjectedMetadataService,
@@ -117,6 +117,7 @@ export class CoreSystem {
   private readonly userProfile: UserProfileService;
   private readonly pricing: PricingService;
   private fatalErrorsSetup: FatalErrorsSetup | null = null;
+  private overlayNavigationSubscription: Subscription | undefined;
 
   constructor(params: CoreSystemParams) {
     const { rootDomElement, browserSupportsCsp, injectedMetadata } = params;
@@ -357,6 +358,12 @@ export class CoreSystem {
         curApp$: application.currentAppId$,
       });
 
+      this.overlayNavigationSubscription = application.currentAppId$
+        .pipe(pairwise())
+        .subscribe(() => {
+          this.overlay.closeAllFlyouts();
+        });
+
       const featureFlags = await this.featureFlags.start();
 
       // Temp hack: https://github.com/elastic/kibana/issues/247820
@@ -494,6 +501,7 @@ export class CoreSystem {
   }
 
   public stop() {
+    this.overlayNavigationSubscription?.unsubscribe();
     this.plugins.stop();
     this.coreApp.stop();
     this.notifications.stop();

--- a/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
@@ -12,7 +12,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { FC } from 'react';
 import React, { Suspense, lazy } from 'react';
-import { combineLatest, distinctUntilChanged, first, from, skip, takeUntil } from 'rxjs';
+import { combineLatest, first, skip } from 'rxjs';
 import type { EditLookupIndexContentContext, FlyoutDeps } from '../types';
 import { isPlaceholderColumn } from '../utils';
 
@@ -20,7 +20,6 @@ export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentCont
   const {
     http,
     overlays,
-    application: { currentAppId$ },
     ...startServices
   } = deps.coreStart;
 
@@ -86,12 +85,6 @@ export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentCont
     flyoutSession.close();
   });
 
-  // Close the flyout when user navigates out of the current plugin
-  currentAppId$
-    .pipe(skip(1), takeUntil(from(flyoutSession.onClose)), distinctUntilChanged())
-    .subscribe(() => {
-      flyoutSession.close();
-    });
 }
 
 const LoadingContents: FC = () => (

--- a/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
+++ b/src/platform/packages/private/kbn-index-editor/src/components/create_flyout.tsx
@@ -17,11 +17,7 @@ import type { EditLookupIndexContentContext, FlyoutDeps } from '../types';
 import { isPlaceholderColumn } from '../utils';
 
 export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentContext) {
-  const {
-    http,
-    overlays,
-    ...startServices
-  } = deps.coreStart;
+  const { http, overlays, ...startServices } = deps.coreStart;
 
   const indexUpdateService = deps.indexUpdateService;
 
@@ -84,7 +80,6 @@ export function createFlyout(deps: FlyoutDeps, props: EditLookupIndexContentCont
     });
     flyoutSession.close();
   });
-
 }
 
 const LoadingContents: FC = () => (

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -12,7 +12,6 @@ import { htmlIdGenerator } from '@elastic/eui';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import useAsync from 'react-use/lib/useAsync';
 import { i18n } from '@kbn/i18n';
-import { skip, take } from 'rxjs';
 import { focusFirstFocusable } from './focus_helpers';
 import { LoadingFlyout } from './loading_flyout';
 import { tracksOverlays } from './tracks_overlays';
@@ -37,12 +36,11 @@ interface OpenLazyFlyoutParams {
  * This helper handles:
  * - Mounting a flyout panel with async content.
  * - Automatically focusing the flyout when content is ready.
- * - Closing the flyout when the user navigates to a different app.
  * - Tracking the flyout if `parentApi` supports overlay tracking.
  * - Returning focus to a trigger element when the flyout closes.
  *
  * @param params - Configuration object.
- * @param params.core - The `CoreStart` contract, used for overlays, app lifecycle, and notifications.
+ * @param params.core - The `CoreStart` contract, used for overlays and notifications.
  * @param params.loadContent - Async function that loads the flyout content. Must return a valid React element.
  *                             If it resolves to `null` or `undefined`, the flyout will close automatically.
  * @param params.flyoutProps - Optional props passed to `openFlyout` (e.g. size, className, etc).
@@ -65,14 +63,6 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
       focusFirstFocusable(document.getElementById(triggerId));
     }
   };
-
-  /**
-   * Close the flyout whenever the app changes - this handles cases for when the flyout is open outside of the
-   * Dashboard app (`overlayTracker` is not available)
-   */
-  core.application.currentAppId$.pipe(skip(1), take(1)).subscribe(() => {
-    onClose();
-  });
 
   const flyoutRef = core.overlays.openFlyout(
     toMountPoint(

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/flyout/create_flyout.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/flyout/create_flyout.tsx
@@ -19,11 +19,7 @@ export function createFlyout(
   plugins: FileUploadStartDependencies,
   props: OpenFileUploadLiteContext
 ) {
-  const {
-    http,
-    overlays,
-    ...startServices
-  } = coreStart;
+  const { http, overlays, ...startServices } = coreStart;
 
   const LazyFlyoutContents = lazy(async () => {
     const { FileDataVisualizerLite } = await import('../file_upload_lite');
@@ -66,7 +62,6 @@ export function createFlyout(
       size: '500px',
     }
   );
-
 }
 
 const LoadingContents: FC = () => (

--- a/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/flyout/create_flyout.tsx
+++ b/x-pack/platform/packages/shared/file-upload/src/file_upload_component/new/flyout/create_flyout.tsx
@@ -7,8 +7,6 @@
 
 import type { FC } from 'react';
 import React, { Suspense, lazy } from 'react';
-import { takeUntil, distinctUntilChanged, skip } from 'rxjs';
-import { from } from 'rxjs';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { CoreStart } from '@kbn/core/public';
 import type { FileUploadResults, OpenFileUploadLiteContext } from '@kbn/file-upload-common';
@@ -24,7 +22,6 @@ export function createFlyout(
   const {
     http,
     overlays,
-    application: { currentAppId$ },
     ...startServices
   } = coreStart;
 
@@ -70,12 +67,6 @@ export function createFlyout(
     }
   );
 
-  // Close the flyout when user navigates out of the current plugin
-  currentAppId$
-    .pipe(skip(1), takeUntil(from(flyoutSession.onClose)), distinctUntilChanged())
-    .subscribe(() => {
-      flyoutSession.close();
-    });
 }
 
 const LoadingContents: FC = () => (

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/show_flyout.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/show_flyout.tsx
@@ -94,7 +94,6 @@ export async function showCategorizeFlyout(
           focusTrapProps,
         }
       );
-
     } catch (error) {
       reject(error);
     }

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/show_flyout.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/show_flyout.tsx
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import { takeUntil, distinctUntilChanged, skip } from 'rxjs';
-import { from } from 'rxjs';
 import { pick } from 'lodash';
 import type { CoreStart } from '@kbn/core/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
@@ -36,7 +34,7 @@ export async function showCategorizeFlyout(
   additionalFilter?: CategorizationAdditionalFilter,
   focusTrapProps?: EuiFlyoutProps['focusTrapProps']
 ): Promise<void> {
-  const { overlays, application, i18n } = coreStart;
+  const { overlays, i18n } = coreStart;
 
   return new Promise((resolve, reject) => {
     try {
@@ -97,12 +95,6 @@ export async function showCategorizeFlyout(
         }
       );
 
-      // Close the flyout when user navigates out of the current plugin
-      application.currentAppId$
-        .pipe(skip(1), takeUntil(from(flyoutSession.onClose)), distinctUntilChanged())
-        .subscribe(() => {
-          flyoutSession.close();
-        });
     } catch (error) {
       reject(error);
     }

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/create_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/create_flyout.tsx
@@ -27,11 +27,7 @@ export function createFlyout(
   dashboardService: DashboardStart,
   lens?: LensPublicStart
 ): Promise<void> {
-  const {
-    http,
-    overlays,
-    ...startServices
-  } = coreStart;
+  const { http, overlays, ...startServices } = coreStart;
 
   return new Promise(async (resolve, reject) => {
     try {
@@ -69,7 +65,6 @@ export function createFlyout(
           size: '35vw',
         }
       );
-
     } catch (error) {
       reject(error);
     }

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/create_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/job_creation/common/create_flyout.tsx
@@ -6,8 +6,6 @@
  */
 
 import React from 'react';
-import { takeUntil, distinctUntilChanged, skip } from 'rxjs';
-import { from } from 'rxjs';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
@@ -32,7 +30,6 @@ export function createFlyout(
   const {
     http,
     overlays,
-    application: { currentAppId$ },
     ...startServices
   } = coreStart;
 
@@ -73,12 +70,6 @@ export function createFlyout(
         }
       );
 
-      // Close the flyout when user navigates out of the current plugin
-      currentAppId$
-        .pipe(skip(1), takeUntil(from(flyoutSession.onClose)), distinctUntilChanged())
-        .subscribe(() => {
-          flyoutSession.close();
-        });
     } catch (error) {
       reject(error);
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/251693

1. Creates listeners internal to `flyout_service.tsx` and `system_flyout_service.tsx` that are responsible for closing flyouts when the user navigates to another app.
2. Cleans up custom listeners in various app code for closing flyouts when the user navigates to another app.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
- ~~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
- ~~[ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
