### PR TITLE
[Security Solution] fix bug clicking on the notes icon opens the alert flyout instead of attack flyout

### DIFF
--- a/packages/kbn-babel-preset/styled_components_files.js
+++ b/packages/kbn-babel-preset/styled_components_files.js
@@ -413,7 +413,6 @@ module.exports = {
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]data_providers[\/\\]providers.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]index.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]notes[\/\\]notes_button.test.tsx/,
-    /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]notes[\/\\]notes_button.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]search_or_filter[\/\\]helpers.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]search_or_filter[\/\\]search_or_filter.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]timelines[\/\\]components[\/\\]timeline[\/\\]selectable_timeline[\/\\]index.tsx/,

--- a/x-pack/solutions/security/plugins/security_solution/common/types/header_actions/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/types/header_actions/index.ts
@@ -17,6 +17,7 @@ import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { SortColumnTable } from '@kbn/securitysolution-data-table';
 import type { SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import type { OnRowSelected, SetEventsDeleted, SetEventsLoading } from '..';
 import type { BrowserFields } from '../../search_strategy';
 
@@ -90,6 +91,7 @@ export interface ActionProps {
   disablePinAction?: boolean;
   disableTimelineAction?: boolean;
   ecsData: Ecs;
+  eventData?: DataTableRecord & TimelineItem;
   eventId: string;
   eventIdToNoteIds?: Readonly<Record<string, string[]>>;
   hit: DataTableRecord | undefined;
@@ -106,7 +108,7 @@ export interface ActionProps {
   showNotes?: boolean;
   tabType?: string;
   timelineId: string;
-  toggleShowNotes?: () => void;
+  toggleShowNotes?: (eventId?: string, eventData?: DataTableRecord & TimelineItem) => void;
   width?: number;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -36,6 +36,7 @@ const defaultProps: ActionsComponentProps = {
   disablePinAction: false,
   disableTimelineAction: false,
   ecsData: mockTimelineData[0].ecs,
+  eventData: undefined,
   eventId: 'abc',
   eventIdToNoteIds: {},
   hit: { id: 'id', raw: {}, flattened: {} },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -48,6 +48,7 @@ export type ActionsComponentProps = Pick<
   | 'disablePinAction'
   | 'disableTimelineAction'
   | 'ecsData'
+  | 'eventData'
   | 'eventId'
   | 'eventIdToNoteIds'
   | 'hit'
@@ -67,6 +68,7 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
   disablePinAction = true,
   disableTimelineAction = false,
   ecsData,
+  eventData,
   eventId,
   eventIdToNoteIds,
   hit,
@@ -204,6 +206,7 @@ const ActionsComponent: React.FC<ActionsComponentProps> = ({
             key="add-event-note"
             timelineType={timelineType}
             notesCount={documentBasedNotes.length}
+            eventData={eventData}
             eventId={eventId}
             toggleShowNotes={toggleShowNotes}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/add_note_icon_item.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/header_actions/add_note_icon_item.tsx
@@ -7,6 +7,8 @@
 
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { NotesButton } from '../../../timelines/components/timeline/notes/notes_button';
 import { type TimelineType, TimelineTypeEnum } from '../../../../common/api/timeline';
 import { useUserPrivileges } from '../user_privileges';
@@ -53,7 +55,8 @@ const VIEW_NOTES_COUNT_TOOLTIP = ({ notesCount }: { notesCount: number }) =>
 interface AddEventNoteActionProps {
   ariaLabel?: string;
   timelineType: TimelineType;
-  toggleShowNotes?: () => void | ((eventId: string) => void);
+  toggleShowNotes?: (eventId?: string, eventData?: DataTableRecord & TimelineItem) => void;
+  eventData?: DataTableRecord & TimelineItem;
   eventId?: string;
   /*
    * Number of notes associated with the event
@@ -65,6 +68,7 @@ const AddEventNoteActionComponent: React.FC<AddEventNoteActionProps> = ({
   ariaLabel,
   timelineType,
   toggleShowNotes,
+  eventData,
   eventId,
   notesCount,
 }) => {
@@ -98,6 +102,7 @@ const AddEventNoteActionComponent: React.FC<AddEventNoteActionProps> = ({
         timelineType={timelineType}
         toggleShowNotes={toggleShowNotes}
         toolTip={tooltip}
+        eventData={eventData}
         eventId={eventId}
         notesCount={notesCount}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/notes/notes_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/notes/notes_button.test.tsx
@@ -11,13 +11,25 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { NotesButton } from './notes_button';
 import { TimelineTypeEnum } from '../../../../../common/api/timeline';
 import { ThemeProvider } from 'styled-components';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 
 const toggleShowNotesMock = jest.fn();
+
+const mockEventData: DataTableRecord & TimelineItem = {
+  id: 'event-id',
+  raw: { _id: 'event-id', _index: 'test-index' },
+  flattened: {},
+  _id: 'event-id',
+  data: [],
+  ecs: { _id: 'event-id', _index: 'test-index' },
+} as unknown as DataTableRecord & TimelineItem;
 
 const defaultProps: ComponentProps<typeof NotesButton> = {
   ariaLabel: 'Sample Notes',
   isDisabled: false,
   toggleShowNotes: toggleShowNotesMock,
+  eventData: mockEventData,
   eventId: 'event-id',
   notesCount: 1,
   timelineType: TimelineTypeEnum.default,
@@ -71,7 +83,7 @@ describe('helpers', () => {
     fireEvent.click(button);
 
     expect(toggleShowNotesMock).toHaveBeenCalledTimes(1);
-    expect(toggleShowNotesMock).toHaveBeenCalledWith('event-id');
+    expect(toggleShowNotesMock).toHaveBeenCalledWith('event-id', mockEventData);
   });
 
   test('should call the toggleShowNotes correctly when the button is clicked and eventId is not available', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/notes/notes_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/notes/notes_button.tsx
@@ -5,89 +5,27 @@
  * 2.0.
  */
 
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
-import styled from 'styled-components';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { type TimelineType, TimelineTypeEnum } from '../../../../../common/api/timeline';
 
 const NOTES = i18n.translate('xpack.securitySolution.timeline.notes.notesButtonLabel', {
   defaultMessage: 'Notes',
 });
 
-export const NotificationDot = styled.span`
-  position: absolute;
-  display: block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: ${({ theme }) => theme.eui.euiColorDanger};
-  top: 17%;
-  left: 52%;
-`;
-
-interface SmallNotesButtonProps {
-  ariaLabel?: string;
-  isDisabled?: boolean;
-  toggleShowNotes?: (eventId?: string) => void;
-  timelineType: TimelineType;
-  eventId?: string;
-  /**
-   * Number of notes. If > 0, then a red dot is shown in the top right corner of the icon.
-   */
-  notesCount: number;
-}
-
 export const NOTES_BUTTON_CLASS_NAME = 'notes-button';
-
-const NotesButtonContainer = styled(EuiFlexGroup)`
-  position: relative;
-`;
-
-const SmallNotesButton = React.memo<SmallNotesButtonProps>(
-  ({ ariaLabel = NOTES, isDisabled, toggleShowNotes, timelineType, eventId, notesCount }) => {
-    const isTemplate = timelineType === TimelineTypeEnum.template;
-    const onClick = useCallback(() => {
-      if (eventId != null) {
-        toggleShowNotes?.(eventId);
-      } else {
-        toggleShowNotes?.();
-      }
-    }, [toggleShowNotes, eventId]);
-
-    return (
-      <NotesButtonContainer>
-        <EuiFlexItem grow={false}>
-          {notesCount > 0 ? (
-            <NotificationDot
-              className="timeline-notes-notification-dot"
-              data-test-subj="timeline-notes-notification-dot"
-            />
-          ) : null}
-          <EuiButtonIcon
-            aria-label={ariaLabel}
-            className={NOTES_BUTTON_CLASS_NAME}
-            data-test-subj="timeline-notes-button-small"
-            disabled={isDisabled}
-            iconType="editorComment"
-            onClick={onClick}
-            size="s"
-            isDisabled={isTemplate}
-            color="text"
-          />
-        </EuiFlexItem>
-      </NotesButtonContainer>
-    );
-  }
-);
-SmallNotesButton.displayName = 'SmallNotesButton';
 
 interface NotesButtonProps {
   ariaLabel?: string;
   isDisabled?: boolean;
-  toggleShowNotes?: () => void | ((eventId: string) => void);
+  toggleShowNotes?: (eventId?: string, eventData?: DataTableRecord & TimelineItem) => void;
   toolTip: string;
   timelineType: TimelineType;
+  eventData?: DataTableRecord & TimelineItem;
   eventId?: string;
   /**
    * Number of notes. If > 0, then a red dot is shown in the top right corner of the icon.
@@ -96,18 +34,66 @@ interface NotesButtonProps {
 }
 
 export const NotesButton = React.memo<NotesButtonProps>(
-  ({ ariaLabel, isDisabled, timelineType, toggleShowNotes, toolTip, eventId, notesCount }) => (
-    <EuiToolTip content={toolTip} data-test-subj="timeline-notes-tool-tip">
-      <SmallNotesButton
-        ariaLabel={ariaLabel}
-        isDisabled={isDisabled}
-        toggleShowNotes={toggleShowNotes}
-        timelineType={timelineType}
-        eventId={eventId}
-        notesCount={notesCount ?? 0}
-      />
-    </EuiToolTip>
-  )
+  ({
+    ariaLabel = NOTES,
+    isDisabled,
+    timelineType,
+    toggleShowNotes,
+    toolTip,
+    eventData,
+    eventId,
+    notesCount = 0,
+  }) => {
+    const { euiTheme } = useEuiTheme();
+    const isTemplate = timelineType === TimelineTypeEnum.template;
+    const onClick = useCallback(() => {
+      if (eventId != null) {
+        toggleShowNotes?.(eventId, eventData);
+      } else {
+        toggleShowNotes?.();
+      }
+    }, [toggleShowNotes, eventId, eventData]);
+
+    return (
+      <EuiToolTip content={toolTip} data-test-subj="timeline-notes-tool-tip">
+        <EuiFlexGroup
+          css={css`
+            position: relative;
+          `}
+        >
+          <EuiFlexItem grow={false}>
+            {notesCount > 0 ? (
+              <span
+                className="timeline-notes-notification-dot"
+                data-test-subj="timeline-notes-notification-dot"
+                css={css`
+                  position: absolute;
+                  display: block;
+                  width: 6px;
+                  height: 6px;
+                  border-radius: 50%;
+                  background-color: ${euiTheme.colors.danger};
+                  top: 17%;
+                  left: 52%;
+                `}
+              />
+            ) : null}
+            <EuiButtonIcon
+              aria-label={ariaLabel}
+              className={NOTES_BUTTON_CLASS_NAME}
+              data-test-subj="timeline-notes-button-small"
+              disabled={isDisabled}
+              iconType="editorComment"
+              onClick={onClick}
+              size="s"
+              isDisabled={isTemplate}
+              color="text"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiToolTip>
+    );
+  }
 );
 
 NotesButton.displayName = 'NotesButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -15,7 +15,8 @@ import deepEqual from 'fast-deep-equal';
 import { InPortal } from 'react-reverse-portal';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { RunTimeMappings, TimelineItem } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import { PageScope } from '../../../../../data_view_manager/constants';
 import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
@@ -48,6 +49,12 @@ import { DocumentEventTypes, NotesEventTypes } from '../../../../../common/lib/t
 import { TimelineRefetch } from '../../refetch_timeline';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
+import { isAttackDiscoveryRow } from '../../unified_components/data_table/is_attack_discovery_row';
+import {
+  AttackDetailsLeftPanelKey,
+  AttackDetailsRightPanelKey,
+} from '../../../../../flyout/attack_details/constants/panel_keys';
+import { NOTES_TAB_ID } from '../../../../../flyout/attack_details/constants/left_panel_paths';
 
 export type Props = TimelineTabCommonProps & PropsFromRedux;
 
@@ -174,33 +181,57 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   const { openFlyout } = useExpandableFlyoutApi();
 
   const onToggleShowNotes = useCallback(
-    (eventId?: string) => {
+    (eventId?: string, eventData?: DataTableRecord & TimelineItem) => {
       if (!eventId) {
         return;
       }
 
+      const isAttackRow = eventData != null && isAttackDiscoveryRow(eventData);
       const indexName = selectedPatterns.join(',');
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+
+      if (isAttackRow) {
+        openFlyout({
+          right: {
+            id: AttackDetailsRightPanelKey,
+            params: {
+              attackId: eventId,
+              indexName,
+            },
           },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: LeftPanelNotesTab,
+          left: {
+            id: AttackDetailsLeftPanelKey,
+            path: {
+              tab: NOTES_TAB_ID,
+            },
+            params: {
+              attackId: eventId,
+              indexName,
+            },
           },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+        });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-        },
-      });
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+        });
+      }
       telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
         location: timelineId,
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -13,6 +13,9 @@ import { TimelineId } from '../../../../../../common/types/timeline';
 import { useTimelineEventsDetails } from '../../../../containers/details';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
+import { ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/elastic-assistant-common';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { DataLoadingState } from '@kbn/unified-data-table';
 import {
   createMockStore,
   createSecuritySolutionStorageMock,
@@ -1053,6 +1056,87 @@ describe.skip('query tab with unified timeline', () => {
 
         await waitFor(() => {
           expect(mockOpenFlyout).toHaveBeenCalled();
+        });
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the document details flyout with notes tab for a regular event',
+      async () => {
+        renderTestComponents();
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(mockOpenFlyout).toHaveBeenCalledWith(
+            expect.objectContaining({
+              right: expect.objectContaining({ id: 'document-details-right' }),
+              left: expect.objectContaining({ id: 'document-details-left' }),
+            })
+          );
+        });
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should open the attack details flyout with notes tab for an attack discovery event',
+      async () => {
+        const attackDiscoveryEvent = {
+          ...mockTimelineData[0],
+          data: [
+            ...mockTimelineData[0].data,
+            {
+              field: ALERT_RULE_TYPE_ID,
+              value: [ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID],
+            },
+          ],
+          ecs: {
+            ...mockTimelineData[0].ecs,
+            _index: '.alerts-security.attack.discovery.alerts-default-000001',
+          },
+        };
+
+        useTimelineEventsSpy.mockReturnValue([
+          DataLoadingState.loaded,
+          {
+            id: 'id',
+            pageInfo: {
+              activePage: 0,
+              querySize: 0,
+            },
+            events: [attackDiscoveryEvent],
+            rawEvents: [{ _id: attackDiscoveryEvent._id, _index: attackDiscoveryEvent.ecs._index }],
+            inspect: { dsl: [], response: [] },
+            totalCount: 1,
+            loadNextBatch: jest.fn(),
+            refreshedAt: 0,
+            refetch: jest.fn(),
+          },
+        ]);
+
+        renderTestComponents();
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        await waitFor(() => {
+          expect(screen.getByTestId('timeline-notes-button-small')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('timeline-notes-button-small'));
+
+        await waitFor(() => {
+          expect(mockOpenFlyout).toHaveBeenCalledWith(
+            expect.objectContaining({
+              right: expect.objectContaining({ id: 'attack-details-right' }),
+              left: expect.objectContaining({ id: 'attack-details-left' }),
+            })
+          );
         });
       },
       SPECIAL_TEST_TIMEOUT

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -15,6 +15,8 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { PageScope } from '../../../../../data_view_manager/constants';
 import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
@@ -25,6 +27,12 @@ import {
   DocumentDetailsRightPanelKey,
 } from '../../../../../flyout/document_details/shared/constants/panel_keys';
 import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
+import {
+  AttackDetailsLeftPanelKey,
+  AttackDetailsRightPanelKey,
+} from '../../../../../flyout/attack_details/constants/panel_keys';
+import { NOTES_TAB_ID } from '../../../../../flyout/attack_details/constants/left_panel_paths';
+import { isAttackDiscoveryRow } from '../../unified_components/data_table/is_attack_discovery_row';
 import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useTimelineDataFilters } from '../../../../containers/use_timeline_data_filters';
@@ -256,33 +264,58 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const { openFlyout } = useExpandableFlyoutApi();
 
   const onToggleShowNotes = useCallback(
-    (eventId?: string) => {
+    (eventId?: string, eventData?: DataTableRecord & TimelineItem) => {
       if (!eventId) {
         return;
       }
 
-      const indexName = selectedPatterns.join(',');
-      openFlyout({
-        right: {
-          id: DocumentDetailsRightPanelKey,
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+      const isAttackRow = eventData != null && isAttackDiscoveryRow(eventData);
+      const indexName =
+        (isAttackRow ? eventData.ecs._index : undefined) ?? selectedPatterns.join(',');
+
+      if (isAttackRow) {
+        openFlyout({
+          right: {
+            id: AttackDetailsRightPanelKey,
+            params: {
+              attackId: eventId,
+              indexName,
+            },
           },
-        },
-        left: {
-          id: DocumentDetailsLeftPanelKey,
-          path: {
-            tab: LeftPanelNotesTab,
+          left: {
+            id: AttackDetailsLeftPanelKey,
+            path: {
+              tab: NOTES_TAB_ID,
+            },
+            params: {
+              attackId: eventId,
+              indexName,
+            },
           },
-          params: {
-            id: eventId,
-            indexName,
-            scopeId: timelineId,
+        });
+      } else {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
           },
-        },
-      });
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+        });
+      }
       telemetry.reportEvent(NotesEventTypes.OpenNoteInExpandableFlyoutClicked, {
         location: timelineId,
       });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
@@ -24,7 +24,7 @@ interface UseTimelineControlColumnArgs {
   events: TimelineItem[];
   rawEvents: EsHitRecord[];
   eventIdToNoteIds: Record<string, string[]>;
-  onToggleShowNotes: (eventId?: string) => void;
+  onToggleShowNotes: (eventId?: string, eventData?: DataTableRecord & TimelineItem) => void;
 }
 
 export const useTimelineControlColumn = ({
@@ -74,6 +74,10 @@ export const useTimelineControlColumn = ({
         // We are creating this object here so we can pass it to the cell action, which will then pass it to the flyout.
         // This way we can use the same flyout content code between Security Solution and Discover.
         const esHitRecord: DataTableRecord = buildDataTableRecord(rawEvents[props.rowIndex]);
+        const eventData: DataTableRecord & TimelineItem = {
+          ...esHitRecord,
+          ...events[props.rowIndex],
+        };
 
         return (
           <TimelineControlColumnCellRender
@@ -81,6 +85,7 @@ export const useTimelineControlColumn = ({
             columnValues=""
             disablePinAction={!canWriteTimelines}
             ecsData={events[props.rowIndex].ecs}
+            eventData={eventData}
             eventId={events[props.rowIndex]?._id}
             eventIdToNoteIds={eventIdToNoteIds}
             hit={esHitRecord}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/control_column_cell_render.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/control_column_cell_render.tsx
@@ -17,6 +17,7 @@ type TimelineControlColumnCellRenderProps = Pick<
   | 'columnValues'
   | 'disablePinAction'
   | 'ecsData'
+  | 'eventData'
   | 'eventId'
   | 'eventIdToNoteIds'
   | 'hit'
@@ -37,6 +38,7 @@ export const TimelineControlColumnCellRender = memo(function TimelineControlColu
       disablePinAction={props.disablePinAction}
       disableTimelineAction={false}
       ecsData={props.ecsData}
+      eventData={props.eventData}
       eventId={props.eventId}
       eventIdToNoteIds={props.eventIdToNoteIds}
       hit={props.hit}


### PR DESCRIPTION
## Summary

This PR makes a small fix: when clicking on the notes button in Timeline, the alert flyout was opened instead of the attack one.

### Code changes:

- pass `eventData` alongside the current `eventId` in the `onToggleNotes` callback, to allow using the `isAttackDiscoveryRow` that differentiates an alert document from an attack one.
- make a small code simplification within the `NotesButton` code to merge that component with its child `SmallNotesButton` (which was completely unnecessary
- also make a small change to the `NotesButton` component to use `@emotion` instead of `styled-components`

### Visual changes

Before (broken)

https://github.com/user-attachments/assets/05924026-fb87-4a6e-920a-f0c00767494c

Now (fixed)

https://github.com/user-attachments/assets/05b22544-f729-4ae7-9973-a025c8bf9c9b

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
