### PR TITLE
[Security Solution] fix bug where attack flyout doesn't show Timeline interaction when saving a note

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.test.tsx
@@ -45,6 +45,10 @@ jest.mock('../../../shared/components/notes_details_content', () => ({
   )),
 }));
 
+jest.mock('../../../document_details/shared/hooks/use_timeline_config', () => ({
+  useTimelineConfig: jest.fn().mockReturnValue(undefined),
+}));
+
 const renderNotesTab = () =>
   render(
     <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/attack_details/left/tabs/notes_tab.tsx
@@ -7,19 +7,25 @@
 
 import React, { memo } from 'react';
 import { EuiPanel } from '@elastic/eui';
-import { NotesDetailsContent } from '../../../shared/components/notes_details_content';
-import { useAttackDetailsContext } from '../../context';
 import { NOTES_TAB_CONTENT_TEST_ID } from '../../constants/test_ids';
+import { useAttackDetailsContext } from '../../context';
+import { NotesDetailsContent } from '../../../shared/components/notes_details_content';
+import { useTimelineConfig } from '../../../document_details/shared/hooks/use_timeline_config';
 
 /**
  * Notes tab content for the Attack Details flyout left panel.
  */
 export const NotesTab = memo(() => {
   const { attackId, searchHit } = useAttackDetailsContext();
+  const timelineConfig = useTimelineConfig(attackId);
 
   return (
     <EuiPanel data-test-subj={NOTES_TAB_CONTENT_TEST_ID} hasShadow={false}>
-      <NotesDetailsContent documentId={attackId} searchHit={searchHit} />
+      <NotesDetailsContent
+        documentId={attackId}
+        searchHit={searchHit}
+        timelineConfig={timelineConfig}
+      />
     </EuiPanel>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/notes_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/notes_details.test.tsx
@@ -19,15 +19,11 @@ import {
   ATTACH_TO_TIMELINE_CALLOUT_TEST_ID,
   ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID,
 } from './test_ids';
-import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
-import { Flyouts } from '../../shared/constants/flyouts';
-import { TimelineId } from '../../../../../common/types';
 import { ReqStatus } from '../../../../notes';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
-import { TimelineStatusEnum } from '../../../../../common/api/timeline';
-import type { State } from '../../../../common/store';
+import { useTimelineConfig } from '../../shared/hooks/use_timeline_config';
 
-jest.mock('../../shared/hooks/use_which_flyout');
+jest.mock('../../shared/hooks/use_timeline_config');
 jest.mock('../../shared/hooks/use_basic_data_from_details_data');
 
 jest.mock('../../../../common/components/user_privileges');
@@ -55,23 +51,20 @@ const panelContextValue = {
   searchHit: { _index: 'test', _id: 'test-id' },
 } as unknown as DocumentDetailsContext;
 
-const mockGlobalStateWithSavedTimeline: State = {
-  ...mockGlobalState,
-  timeline: {
-    ...mockGlobalState.timeline,
-    timelineById: {
-      ...mockGlobalState.timeline.timelineById,
-      [TimelineId.active]: {
-        ...mockGlobalState.timeline.timelineById[TimelineId.test],
-        savedObjectId: 'savedObjectId',
-        status: TimelineStatusEnum.active,
-        pinnedEventIds: {},
-      },
-    },
-  },
+const mockTimelineConfig = {
+  timelineSavedObjectId: 'savedObjectId',
+  isTimelineSaved: true,
+  onNoteAddInTimeline: jest.fn(),
+  attachToTimeline: true,
+  setAttachToTimeline: jest.fn(),
+  attachToTimelineElement: (
+    <div data-test-subj="attach-to-timeline-callout">
+      <input data-test-subj="attach-to-timeline-checkbox" type="checkbox" />
+    </div>
+  ),
 };
 
-const mockStore = createMockStore(mockGlobalStateWithSavedTimeline);
+const mockStore = createMockStore(mockGlobalState);
 const renderNotesDetails = () =>
   render(
     <TestProviders store={mockStore}>
@@ -88,7 +81,7 @@ describe('NotesDetails', () => {
       notesPrivileges: { crud: true },
       timelinePrivileges: { crud: true },
     });
-    (useWhichFlyout as jest.Mock).mockReturnValue(Flyouts.timeline);
+    (useTimelineConfig as jest.Mock).mockReturnValue(mockTimelineConfig);
     (useBasicDataFromDetailsData as jest.Mock).mockReturnValue({ isAlert: true });
   });
 
@@ -99,11 +92,11 @@ describe('NotesDetails', () => {
 
   it('should render loading spinner if notes are being fetched', () => {
     const store = createMockStore({
-      ...mockGlobalStateWithSavedTimeline,
+      ...mockGlobalState,
       notes: {
-        ...mockGlobalStateWithSavedTimeline.notes,
+        ...mockGlobalState.notes,
         status: {
-          ...mockGlobalStateWithSavedTimeline.notes.status,
+          ...mockGlobalState.notes.status,
           fetchNotesByDocumentIds: ReqStatus.Loading,
         },
       },
@@ -122,11 +115,11 @@ describe('NotesDetails', () => {
 
   it('should render no data message for alerts if no notes are present', () => {
     const store = createMockStore({
-      ...mockGlobalStateWithSavedTimeline,
+      ...mockGlobalState,
       notes: {
-        ...mockGlobalStateWithSavedTimeline.notes,
+        ...mockGlobalState.notes,
         status: {
-          ...mockGlobalStateWithSavedTimeline.notes.status,
+          ...mockGlobalState.notes.status,
           fetchNotesByDocumentIds: ReqStatus.Succeeded,
         },
       },
@@ -156,11 +149,11 @@ describe('NotesDetails', () => {
 
   it('should render no data message for events if no notes are present', () => {
     const store = createMockStore({
-      ...mockGlobalStateWithSavedTimeline,
+      ...mockGlobalState,
       notes: {
-        ...mockGlobalStateWithSavedTimeline.notes,
+        ...mockGlobalState.notes,
         status: {
-          ...mockGlobalStateWithSavedTimeline.notes.status,
+          ...mockGlobalState.notes.status,
           fetchNotesByDocumentIds: ReqStatus.Succeeded,
         },
       },
@@ -180,15 +173,15 @@ describe('NotesDetails', () => {
 
   it('should render error toast if fetching notes fails', () => {
     const store = createMockStore({
-      ...mockGlobalStateWithSavedTimeline,
+      ...mockGlobalState,
       notes: {
-        ...mockGlobalStateWithSavedTimeline.notes,
+        ...mockGlobalState.notes,
         status: {
-          ...mockGlobalStateWithSavedTimeline.notes.status,
+          ...mockGlobalState.notes.status,
           fetchNotesByDocumentIds: ReqStatus.Failed,
         },
         error: {
-          ...mockGlobalStateWithSavedTimeline.notes.error,
+          ...mockGlobalState.notes.error,
           fetchNotesByDocumentIds: { type: 'http', status: 500 },
         },
       },
@@ -221,7 +214,7 @@ describe('NotesDetails', () => {
   });
 
   it('should not render the callout and attach to timeline checkbox if not timeline flyout', () => {
-    (useWhichFlyout as jest.Mock).mockReturnValue(Flyouts.securitySolution);
+    (useTimelineConfig as jest.Mock).mockReturnValue(undefined);
 
     const { getByTestId, queryByTestId } = renderNotesDetails();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
@@ -5,18 +5,9 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import type { TimelineModel } from '../../../..';
-import { Flyouts } from '../../shared/constants/flyouts';
-import { timelineSelectors } from '../../../../timelines/store';
-import { TimelineId } from '../../../../../common/types';
-import { AttachToActiveTimeline } from './attach_to_active_timeline';
-import { pinEvent } from '../../../../timelines/store/actions';
-import type { State } from '../../../../common/store';
-import { TimelineStatusEnum } from '../../../../../common/api/timeline';
+import React, { memo } from 'react';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
+import { useTimelineConfig } from '../../shared/hooks/use_timeline_config';
 import {
   NotesDetailsContent,
   FETCH_NOTES_ERROR,
@@ -30,52 +21,8 @@ export { FETCH_NOTES_ERROR, NO_NOTES };
  * Displayed in the document details expandable flyout left section.
  */
 export const NotesDetails = memo(() => {
-  const dispatch = useDispatch();
   const { eventId, searchHit } = useDocumentDetailsContext();
-
-  const [attachToTimeline, setAttachToTimeline] = useState<boolean>(true);
-
-  const isTimelineFlyout = useWhichFlyout() === Flyouts.timeline;
-
-  const timeline: TimelineModel = useSelector((state: State) =>
-    timelineSelectors.selectTimelineById(state, TimelineId.active)
-  );
-  const timelineSavedObjectId = useMemo(
-    () => timeline.savedObjectId ?? '',
-    [timeline.savedObjectId]
-  );
-  const isTimelineSaved: boolean = useMemo(
-    () => timeline.status === TimelineStatusEnum.active,
-    [timeline.status]
-  );
-
-  const onNoteAddInTimeline = useCallback(() => {
-    const isEventPinned = eventId ? timeline?.pinnedEventIds[eventId] === true : false;
-    if (!isEventPinned && eventId && timelineSavedObjectId) {
-      dispatch(
-        pinEvent({
-          id: TimelineId.active,
-          eventId,
-        })
-      );
-    }
-  }, [dispatch, eventId, timelineSavedObjectId, timeline.pinnedEventIds]);
-
-  const timelineConfig = isTimelineFlyout
-    ? {
-        timelineSavedObjectId,
-        isTimelineSaved,
-        onNoteAddInTimeline,
-        attachToTimeline,
-        setAttachToTimeline,
-        attachToTimelineElement: (
-          <AttachToActiveTimeline
-            setAttachToTimeline={setAttachToTimeline}
-            isCheckboxDisabled={!isTimelineSaved}
-          />
-        ),
-      }
-    : undefined;
+  const timelineConfig = useTimelineConfig(eventId);
 
   return (
     <NotesDetailsContent

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_timeline_config.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_timeline_config.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
+import { useTimelineConfig } from './use_timeline_config';
+import { useWhichFlyout } from './use_which_flyout';
+import { Flyouts } from '../constants/flyouts';
+import { TimelineId } from '../../../../../common/types';
+import { TimelineStatusEnum } from '../../../../../common/api/timeline';
+import { pinEvent } from '../../../../timelines/store/actions';
+import type { State } from '../../../../common/store';
+
+jest.mock('./use_which_flyout');
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+  return {
+    ...original,
+    useDispatch: () => mockDispatch,
+  };
+});
+
+const EVENT_ID = 'test-event-id';
+const SAVED_OBJECT_ID = 'timeline-saved-object-id';
+
+const mockGlobalStateWithSavedTimeline: State = {
+  ...mockGlobalState,
+  timeline: {
+    ...mockGlobalState.timeline,
+    timelineById: {
+      ...mockGlobalState.timeline.timelineById,
+      [TimelineId.active]: {
+        ...mockGlobalState.timeline.timelineById[TimelineId.test],
+        savedObjectId: SAVED_OBJECT_ID,
+        status: TimelineStatusEnum.active,
+        pinnedEventIds: {},
+      },
+    },
+  },
+};
+
+const mockGlobalStateWithUnsavedTimeline: State = {
+  ...mockGlobalState,
+  timeline: {
+    ...mockGlobalState.timeline,
+    timelineById: {
+      ...mockGlobalState.timeline.timelineById,
+      [TimelineId.active]: {
+        ...mockGlobalState.timeline.timelineById[TimelineId.test],
+        savedObjectId: null,
+        status: TimelineStatusEnum.draft,
+        pinnedEventIds: {},
+      },
+    },
+  },
+};
+
+const renderUseTimelineConfig = (
+  eventId = EVENT_ID,
+  store = createMockStore(mockGlobalStateWithSavedTimeline)
+) =>
+  renderHook(() => useTimelineConfig(eventId), {
+    wrapper: ({ children }) => <TestProviders store={store}>{children}</TestProviders>,
+  });
+
+describe('useTimelineConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useWhichFlyout as jest.Mock).mockReturnValue(Flyouts.timeline);
+  });
+
+  describe('when not in the timeline flyout', () => {
+    it('returns undefined when flyout is securitySolution', () => {
+      (useWhichFlyout as jest.Mock).mockReturnValue(Flyouts.securitySolution);
+      const { result } = renderUseTimelineConfig();
+      expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when no flyout is open', () => {
+      (useWhichFlyout as jest.Mock).mockReturnValue(null);
+      const { result } = renderUseTimelineConfig();
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe('when in the timeline flyout', () => {
+    it('returns a config object', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(result.current).not.toBeUndefined();
+    });
+
+    it('returns the correct timelineSavedObjectId from the store', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(result.current?.timelineSavedObjectId).toBe(SAVED_OBJECT_ID);
+    });
+
+    it('returns isTimelineSaved true when timeline status is active', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(result.current?.isTimelineSaved).toBe(true);
+    });
+
+    it('returns isTimelineSaved false when timeline is not saved', () => {
+      const store = createMockStore(mockGlobalStateWithUnsavedTimeline);
+      const { result } = renderUseTimelineConfig(EVENT_ID, store);
+      expect(result.current?.isTimelineSaved).toBe(false);
+    });
+
+    it('returns attachToTimeline as true by default', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(result.current?.attachToTimeline).toBe(true);
+    });
+
+    it('returns a setAttachToTimeline function', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(typeof result.current?.setAttachToTimeline).toBe('function');
+    });
+
+    it('returns an attachToTimelineElement React element', () => {
+      const { result } = renderUseTimelineConfig();
+      expect(React.isValidElement(result.current?.attachToTimelineElement)).toBe(true);
+    });
+
+    describe('onNoteAddInTimeline', () => {
+      it('dispatches pinEvent when the event is not pinned and timeline is saved', () => {
+        const { result } = renderUseTimelineConfig();
+        result.current?.onNoteAddInTimeline();
+        expect(mockDispatch).toHaveBeenCalledWith(
+          pinEvent({ id: TimelineId.active, eventId: EVENT_ID })
+        );
+      });
+
+      it('does not dispatch pinEvent when the event is already pinned', () => {
+        const storeWithPinnedEvent = createMockStore({
+          ...mockGlobalStateWithSavedTimeline,
+          timeline: {
+            ...mockGlobalStateWithSavedTimeline.timeline,
+            timelineById: {
+              ...mockGlobalStateWithSavedTimeline.timeline.timelineById,
+              [TimelineId.active]: {
+                ...mockGlobalStateWithSavedTimeline.timeline.timelineById[TimelineId.active],
+                pinnedEventIds: { [EVENT_ID]: true },
+              },
+            },
+          },
+        });
+        const { result } = renderUseTimelineConfig(EVENT_ID, storeWithPinnedEvent);
+        result.current?.onNoteAddInTimeline();
+        expect(mockDispatch).not.toHaveBeenCalled();
+      });
+
+      it('does not dispatch pinEvent when timelineSavedObjectId is empty', () => {
+        const store = createMockStore(mockGlobalStateWithUnsavedTimeline);
+        const { result } = renderUseTimelineConfig(EVENT_ID, store);
+        result.current?.onNoteAddInTimeline();
+        expect(mockDispatch).not.toHaveBeenCalled();
+      });
+
+      it('does not dispatch pinEvent when eventId is empty', () => {
+        const { result } = renderUseTimelineConfig('');
+        result.current?.onNoteAddInTimeline();
+        expect(mockDispatch).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_timeline_config.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_timeline_config.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { TimelineModel } from '../../../..';
+import type { State } from '../../../../common/store';
+import { timelineSelectors } from '../../../../timelines/store';
+import { TimelineId } from '../../../../../common/types';
+import { TimelineStatusEnum } from '../../../../../common/api/timeline';
+import { pinEvent } from '../../../../timelines/store/actions';
+import { Flyouts } from '../constants/flyouts';
+import { useWhichFlyout } from './use_which_flyout';
+import { AttachToActiveTimeline } from '../../left/components/attach_to_active_timeline';
+import type { NotesDetailsContentTimelineConfig } from '../../../shared/components/notes_details_content';
+
+/**
+ * Builds the `timelineConfig` object required by `NotesDetailsContent` when the document is
+ * opened inside the Timeline flyout. Returns `undefined` when the active flyout is not the
+ * Timeline flyout, which disables "attach to timeline" behavior in the notes panel.
+ */
+export const useTimelineConfig = (
+  documentId: string
+): NotesDetailsContentTimelineConfig | undefined => {
+  const dispatch = useDispatch();
+  const [attachToTimeline, setAttachToTimeline] = useState<boolean>(true);
+
+  const isTimelineFlyout = useWhichFlyout() === Flyouts.timeline;
+
+  const timeline: TimelineModel = useSelector((state: State) =>
+    timelineSelectors.selectTimelineById(state, TimelineId.active)
+  );
+
+  const timelineSavedObjectId = useMemo(
+    () => timeline.savedObjectId ?? '',
+    [timeline.savedObjectId]
+  );
+
+  const isTimelineSaved: boolean = useMemo(
+    () => timeline.status === TimelineStatusEnum.active,
+    [timeline.status]
+  );
+
+  const onNoteAddInTimeline = useCallback(() => {
+    const isEventPinned = documentId ? timeline?.pinnedEventIds[documentId] === true : false;
+    if (!isEventPinned && documentId && timelineSavedObjectId) {
+      dispatch(
+        pinEvent({
+          id: TimelineId.active,
+          eventId: documentId,
+        })
+      );
+    }
+  }, [dispatch, documentId, timelineSavedObjectId, timeline.pinnedEventIds]);
+
+  return useMemo(
+    () =>
+      isTimelineFlyout
+        ? {
+            timelineSavedObjectId,
+            isTimelineSaved,
+            onNoteAddInTimeline,
+            attachToTimeline,
+            setAttachToTimeline,
+            attachToTimelineElement: (
+              <AttachToActiveTimeline
+                setAttachToTimeline={setAttachToTimeline}
+                isCheckboxDisabled={!isTimelineSaved}
+              />
+            ),
+          }
+        : undefined,
+
+    [
+      isTimelineFlyout,
+      timelineSavedObjectId,
+      isTimelineSaved,
+      onNoteAddInTimeline,
+      attachToTimeline,
+    ]
+  );
+};


### PR DESCRIPTION
## Summary

This PR fixes a small bug in the attack flyout Notes details tab: when the flyout is opened from Timeline, we need to show the correct callout to allow users to save the notes to the Timeline.

### Visual changes

Before (broken)

https://github.com/user-attachments/assets/1636effe-1206-4ebe-9f26-1c96f87f1b9a

After (fixed)

https://github.com/user-attachments/assets/f8e62536-c645-4eb9-95b4-15a4667f2549

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
