### PR TITLE
[scout-vrt] Add main baseline publisher

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -306,6 +306,24 @@ steps:
         - exit_status: '-1'
           limit: 3
 
+  - command: .buildkite/scripts/steps/scout_vrt/publish_main_baselines.sh
+    label: 'Publish Main VRT Baselines'
+    agents:
+      image: family/kibana-ubuntu-2404
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-8
+      preemptible: true
+      spotZones: us-central1-b,us-central1-c,us-central1-f
+    key: vrt_main_baselines
+    depends_on:
+      - build
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
   - command: .buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
     label: 'Publish OAS docs to bump.sh'
     agents:

--- a/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.test.ts
+++ b/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.test.ts
@@ -1,0 +1,405 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VisualRegressionManifest, VisualRegressionRunManifest } from '@kbn/scout-vrt';
+import {
+  buildMainBaselineRunPlan,
+  createVisualBaselineBundleArchivePath,
+  createVisualBaselineBundles,
+  createVisualBaselineCatalog,
+  parseServerRunFlags,
+  type ModuleDiscoveryInfo,
+} from './main_baseline_publisher';
+
+const createRunManifest = (): VisualRegressionRunManifest => ({
+  schemaVersion: 1,
+  runId: 'vrt-main-stateful-classic',
+  status: 'passed',
+  mode: 'update-baselines',
+  startedAt: '2026-03-21T12:00:00.000Z',
+  completedAt: '2026-03-21T12:01:00.000Z',
+  durationMs: 60000,
+  git: {
+    commitSha: 'abc123',
+    branch: 'main',
+  },
+  target: {
+    location: 'local',
+    arch: 'stateful',
+    domain: 'classic',
+  },
+  execution: {
+    packageCount: 2,
+    browsers: ['chromium', 'webkit'],
+    viewports: [
+      {
+        width: 1440,
+        height: 900,
+      },
+      {
+        width: 1280,
+        height: 720,
+      },
+    ],
+  },
+  summary: {
+    tests: 2,
+    checkpoints: 2,
+    captured: 0,
+    updated: 2,
+  },
+  packages: [
+    {
+      packageId: 'advancedSettings',
+      status: 'passed',
+      browser: 'chromium',
+      viewport: {
+        width: 1440,
+        height: 900,
+      },
+      manifestPath: 'advancedSettings/manifest.json',
+      artifactsPath: 'advancedSettings',
+      startedAt: '2026-03-21T12:00:00.000Z',
+      completedAt: '2026-03-21T12:00:30.000Z',
+      durationMs: 30000,
+      summary: {
+        tests: 1,
+        checkpoints: 1,
+        captured: 0,
+        updated: 1,
+      },
+    },
+    {
+      packageId: 'customBranding',
+      status: 'passed',
+      browser: 'webkit',
+      viewport: {
+        width: 1280,
+        height: 720,
+      },
+      manifestPath: 'customBranding/manifest.json',
+      artifactsPath: 'customBranding',
+      startedAt: '2026-03-21T12:00:30.000Z',
+      completedAt: '2026-03-21T12:01:00.000Z',
+      durationMs: 30000,
+      summary: {
+        tests: 1,
+        checkpoints: 1,
+        captured: 0,
+        updated: 1,
+      },
+    },
+  ],
+});
+
+const createPackageManifest = (
+  packageId: string,
+  browser: string,
+  viewport: { width: number; height: number },
+  imagePath: string
+): VisualRegressionManifest => ({
+  schemaVersion: 1,
+  runId: 'vrt-main-stateful-classic',
+  commitSha: 'abc123',
+  branch: 'main',
+  target: {
+    location: 'local',
+    arch: 'stateful',
+    domain: 'classic',
+  },
+  browser,
+  viewport,
+  packageId,
+  results: [
+    {
+      testFile: `${packageId}.spec.ts`,
+      testTitle: `${packageId} visual test`,
+      testKey: `${packageId}-visual-test`,
+      stepTitle: 'step 1',
+      stepIndex: 1,
+      snapshotName: '01_step_1.png',
+      status: 'updated',
+      imagePath,
+      source: {
+        file: `${packageId}.spec.ts`,
+        line: 10,
+        column: 2,
+      },
+    },
+  ],
+});
+
+describe('parseServerRunFlags', () => {
+  it('extracts the VRT target from Scout serverRunFlags', () => {
+    expect(parseServerRunFlags('--arch serverless --domain search')).toEqual({
+      location: 'local',
+      arch: 'serverless',
+      domain: 'search',
+    });
+  });
+});
+
+describe('buildMainBaselineRunPlan', () => {
+  it('groups visual selections by unique Scout serverRunFlags', () => {
+    const moduleDiscovery: ModuleDiscoveryInfo[] = [
+      {
+        configs: [
+          {
+            path: 'src/platform/plugins/private/advanced_settings/test/scout/ui/playwright.config.ts',
+            serverRunFlags: ['--arch stateful --domain classic'],
+          },
+        ],
+      },
+      {
+        configs: [
+          {
+            path: 'src/platform/plugins/private/navigation/test/scout/ui/playwright.config.ts',
+            serverRunFlags: [
+              '--arch stateful --domain classic',
+              '--arch serverless --domain search',
+            ],
+          },
+        ],
+      },
+      {
+        configs: [
+          {
+            path: 'src/platform/plugins/private/navigation/test/scout/ui/playwright.config.ts',
+            serverRunFlags: ['--arch stateful --domain classic'],
+          },
+        ],
+      },
+    ];
+
+    const plan = buildMainBaselineRunPlan(
+      [
+        {
+          configPath: 'src/platform/plugins/private/navigation/test/scout/ui/playwright.config.ts',
+          visualTestFiles: ['b.spec.ts', 'a.spec.ts'],
+        },
+        {
+          configPath:
+            'src/platform/plugins/private/advanced_settings/test/scout/ui/playwright.config.ts',
+          visualTestFiles: ['advanced.spec.ts'],
+        },
+      ],
+      moduleDiscovery
+    );
+
+    expect(plan).toEqual([
+      {
+        target: {
+          location: 'local',
+          arch: 'serverless',
+          domain: 'search',
+        },
+        serverRunFlags: '--arch serverless --domain search',
+        runIdSuffix: 'serverless-search',
+        selections: [
+          {
+            configPath:
+              'src/platform/plugins/private/navigation/test/scout/ui/playwright.config.ts',
+            visualTestFiles: ['a.spec.ts', 'b.spec.ts'],
+          },
+        ],
+      },
+      {
+        target: {
+          location: 'local',
+          arch: 'stateful',
+          domain: 'classic',
+        },
+        serverRunFlags: '--arch stateful --domain classic',
+        runIdSuffix: 'stateful-classic',
+        selections: [
+          {
+            configPath:
+              'src/platform/plugins/private/advanced_settings/test/scout/ui/playwright.config.ts',
+            visualTestFiles: ['advanced.spec.ts'],
+          },
+          {
+            configPath:
+              'src/platform/plugins/private/navigation/test/scout/ui/playwright.config.ts',
+            visualTestFiles: ['a.spec.ts', 'b.spec.ts'],
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('createVisualBaselineBundles', () => {
+  it('partitions package manifests by target/browser/viewport bundle', () => {
+    const bundles = createVisualBaselineBundles(createRunManifest(), [
+      createPackageManifest(
+        'advancedSettings',
+        'chromium',
+        { width: 1440, height: 900 },
+        'advancedSettings/advancedSettings-visual-test/01_step_1.png'
+      ),
+      createPackageManifest(
+        'customBranding',
+        'webkit',
+        { width: 1280, height: 720 },
+        'customBranding/customBranding-visual-test/01_step_1.png'
+      ),
+    ]);
+
+    expect(bundles).toEqual([
+      {
+        relativePath: 'local/stateful/classic/chromium/1440x900',
+        browser: 'chromium',
+        viewport: {
+          width: 1440,
+          height: 900,
+        },
+        runManifest: {
+          ...createRunManifest(),
+          execution: {
+            packageCount: 1,
+            browsers: ['chromium'],
+            viewports: [
+              {
+                width: 1440,
+                height: 900,
+              },
+            ],
+          },
+          summary: {
+            tests: 1,
+            checkpoints: 1,
+            passed: 0,
+            failed: 0,
+            updated: 1,
+            missingBaselines: 0,
+            diffs: 0,
+          },
+          packages: [createRunManifest().packages[0]],
+        },
+        packageManifests: [
+          createPackageManifest(
+            'advancedSettings',
+            'chromium',
+            { width: 1440, height: 900 },
+            'advancedSettings/advancedSettings-visual-test/01_step_1.png'
+          ),
+        ],
+        imagePaths: ['advancedSettings/advancedSettings-visual-test/01_step_1.png'],
+      },
+      {
+        relativePath: 'local/stateful/classic/webkit/1280x720',
+        browser: 'webkit',
+        viewport: {
+          width: 1280,
+          height: 720,
+        },
+        runManifest: {
+          ...createRunManifest(),
+          execution: {
+            packageCount: 1,
+            browsers: ['webkit'],
+            viewports: [
+              {
+                width: 1280,
+                height: 720,
+              },
+            ],
+          },
+          summary: {
+            tests: 1,
+            checkpoints: 1,
+            passed: 0,
+            failed: 0,
+            updated: 1,
+            missingBaselines: 0,
+            diffs: 0,
+          },
+          packages: [createRunManifest().packages[1]],
+        },
+        packageManifests: [
+          createPackageManifest(
+            'customBranding',
+            'webkit',
+            { width: 1280, height: 720 },
+            'customBranding/customBranding-visual-test/01_step_1.png'
+          ),
+        ],
+        imagePaths: ['customBranding/customBranding-visual-test/01_step_1.png'],
+      },
+    ]);
+  });
+
+  it('builds a consumer-facing main baseline catalog', () => {
+    const bundles = createVisualBaselineBundles(createRunManifest(), [
+      createPackageManifest(
+        'advancedSettings',
+        'chromium',
+        { width: 1440, height: 900 },
+        'advancedSettings/advancedSettings-visual-test/01_step_1.png'
+      ),
+      createPackageManifest(
+        'customBranding',
+        'webkit',
+        { width: 1280, height: 720 },
+        'customBranding/customBranding-visual-test/01_step_1.png'
+      ),
+    ]);
+
+    expect(createVisualBaselineCatalog('abc123', '2026-03-21T12:02:00.000Z', bundles)).toEqual({
+      schemaVersion: 1,
+      baselineKind: 'main',
+      branch: 'main',
+      commitSha: 'abc123',
+      runIds: ['vrt-main-stateful-classic'],
+      generatedAt: '2026-03-21T12:02:00.000Z',
+      bundles: [
+        {
+          target: {
+            location: 'local',
+            arch: 'stateful',
+            domain: 'classic',
+          },
+          browser: 'chromium',
+          viewport: {
+            width: 1440,
+            height: 900,
+          },
+          relativePath: 'local/stateful/classic/chromium/1440x900',
+          manifestPath: 'local/stateful/classic/chromium/1440x900/manifest.json',
+          archivePath: 'local/stateful/classic/chromium/1440x900.tar.gz',
+          packageCount: 1,
+          packageIds: ['advancedSettings'],
+        },
+        {
+          target: {
+            location: 'local',
+            arch: 'stateful',
+            domain: 'classic',
+          },
+          browser: 'webkit',
+          viewport: {
+            width: 1280,
+            height: 720,
+          },
+          relativePath: 'local/stateful/classic/webkit/1280x720',
+          manifestPath: 'local/stateful/classic/webkit/1280x720/manifest.json',
+          archivePath: 'local/stateful/classic/webkit/1280x720.tar.gz',
+          packageCount: 1,
+          packageIds: ['customBranding'],
+        },
+      ],
+    });
+  });
+
+  it('derives a sibling archive path for each baseline bundle', () => {
+    expect(createVisualBaselineBundleArchivePath('local/stateful/classic/chromium/1440x900')).toBe(
+      'local/stateful/classic/chromium/1440x900.tar.gz'
+    );
+  });
+});

--- a/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.ts
+++ b/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import path from 'node:path';
+import type {
+  VisualRegressionManifest,
+  VisualRegressionManifestSummary,
+  VisualRegressionRunManifest,
+  VisualRegressionTarget,
+} from '@kbn/scout-vrt';
+
+interface ModuleDiscoveryConfig {
+  path: string;
+  serverRunFlags: string[];
+}
+
+export interface ModuleDiscoveryInfo {
+  configs: ModuleDiscoveryConfig[];
+}
+
+export interface PlannedVisualBaselineRun {
+  configPath: string;
+  visualTestFiles: string[];
+}
+
+export interface PlannedVisualBaselineRunGroup {
+  target: VisualRegressionTarget;
+  serverRunFlags: string;
+  runIdSuffix: string;
+  selections: PlannedVisualBaselineRun[];
+}
+
+export interface VisualBaselineBundle {
+  relativePath: string;
+  browser: string;
+  viewport?: {
+    width: number;
+    height: number;
+  };
+  runManifest: VisualRegressionRunManifest;
+  packageManifests: VisualRegressionManifest[];
+  imagePaths: string[];
+}
+
+export interface VisualBaselineCatalogEntry {
+  target: VisualRegressionTarget;
+  browser: string;
+  viewport?: {
+    width: number;
+    height: number;
+  };
+  relativePath: string;
+  manifestPath: string;
+  archivePath?: string;
+  packageCount: number;
+  packageIds: string[];
+}
+
+export interface VisualBaselineCatalog {
+  schemaVersion: 1;
+  baselineKind: 'main';
+  branch: 'main';
+  commitSha: string;
+  runIds: string[];
+  generatedAt: string;
+  bundles: VisualBaselineCatalogEntry[];
+}
+
+interface VisualRunSelection {
+  configPath: string;
+  visualTestFiles: string[];
+}
+
+const normalizePath = (filePath: string): string => filePath.split(path.sep).join('/');
+
+const summaryFromPackages = (
+  packages: Array<Pick<VisualRegressionRunManifest['packages'][number], 'summary'>>
+): VisualRegressionManifestSummary =>
+  packages.reduce<VisualRegressionManifestSummary>(
+    (summary, currentPackage) => ({
+      tests: summary.tests + currentPackage.summary.tests,
+      checkpoints: summary.checkpoints + currentPackage.summary.checkpoints,
+      captured: summary.captured + currentPackage.summary.captured,
+      updated: summary.updated + currentPackage.summary.updated,
+    }),
+    {
+      tests: 0,
+      checkpoints: 0,
+      captured: 0,
+      updated: 0,
+    }
+  );
+
+const sortPackages = <T extends { packageId: string }>(packages: T[]): T[] =>
+  [...packages].sort((left, right) => left.packageId.localeCompare(right.packageId));
+
+export const parseServerRunFlags = (serverRunFlags: string): VisualRegressionTarget => {
+  const archMatch = serverRunFlags.match(/--arch\s+(\S+)/);
+  const domainMatch = serverRunFlags.match(/--domain\s+(\S+)/);
+
+  if (!archMatch || !domainMatch) {
+    throw new Error(
+      `Expected serverRunFlags to include '--arch' and '--domain': ${serverRunFlags}`
+    );
+  }
+
+  return {
+    location: 'local',
+    arch: archMatch[1],
+    domain: domainMatch[1],
+  };
+};
+
+const createRunIdSuffix = ({ arch, domain }: VisualRegressionTarget): string => `${arch}-${domain}`;
+
+export const buildMainBaselineRunPlan = (
+  selections: VisualRunSelection[],
+  moduleDiscovery: ModuleDiscoveryInfo[]
+): PlannedVisualBaselineRunGroup[] => {
+  const flagsByConfigPath = new Map<string, Set<string>>();
+
+  for (const module of moduleDiscovery) {
+    for (const config of module.configs) {
+      const configPath = normalizePath(config.path);
+      const configFlags = flagsByConfigPath.get(configPath) ?? new Set<string>();
+
+      for (const serverRunFlags of config.serverRunFlags) {
+        configFlags.add(serverRunFlags.trim());
+      }
+
+      flagsByConfigPath.set(configPath, configFlags);
+    }
+  }
+
+  const groups = new Map<string, PlannedVisualBaselineRunGroup>();
+
+  for (const selection of selections) {
+    const normalizedConfigPath = normalizePath(selection.configPath);
+    const configFlags = flagsByConfigPath.get(normalizedConfigPath);
+
+    if (!configFlags || configFlags.size === 0) {
+      continue;
+    }
+
+    for (const serverRunFlags of Array.from(configFlags).sort((left, right) =>
+      left.localeCompare(right)
+    )) {
+      const target = parseServerRunFlags(serverRunFlags);
+      const groupKey = `${target.location}:${target.arch}:${target.domain}`;
+      const existingGroup = groups.get(groupKey);
+      const plannedSelection = {
+        configPath: normalizedConfigPath,
+        visualTestFiles: [...selection.visualTestFiles].sort((left, right) =>
+          left.localeCompare(right)
+        ),
+      };
+
+      if (existingGroup) {
+        const existing = existingGroup.selections.find(
+          (s) => s.configPath === plannedSelection.configPath
+        );
+        if (existing) {
+          const merged = new Set([...existing.visualTestFiles, ...plannedSelection.visualTestFiles]);
+          existing.visualTestFiles = Array.from(merged).sort((a, b) => a.localeCompare(b));
+        } else {
+          existingGroup.selections.push(plannedSelection);
+        }
+        continue;
+      }
+
+      groups.set(groupKey, {
+        target,
+        serverRunFlags,
+        runIdSuffix: createRunIdSuffix(target),
+        selections: [plannedSelection],
+      });
+    }
+  }
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      selections: group.selections.sort((left, right) =>
+        left.configPath.localeCompare(right.configPath)
+      ),
+    }))
+    .sort(
+      (left, right) =>
+        left.target.location.localeCompare(right.target.location) ||
+        left.target.arch.localeCompare(right.target.arch) ||
+        left.target.domain.localeCompare(right.target.domain)
+    );
+};
+
+const toViewportKey = (viewport?: { width: number; height: number }): string =>
+  viewport ? `${viewport.width}x${viewport.height}` : 'default';
+
+const createBundleRelativePath = (
+  target: VisualRegressionTarget,
+  browser: string,
+  viewport?: { width: number; height: number }
+): string =>
+  path.posix.join(target.location, target.arch, target.domain, browser, toViewportKey(viewport));
+
+export const createVisualBaselineBundleArchivePath = (relativePath: string): string =>
+  `${relativePath}.tar.gz`;
+
+export const createVisualBaselineBundles = (
+  runManifest: VisualRegressionRunManifest,
+  packageManifests: VisualRegressionManifest[]
+): VisualBaselineBundle[] => {
+  const manifestsByPackageId = new Map(
+    packageManifests.map((manifest) => [manifest.packageId, manifest] as const)
+  );
+  const groups = new Map<string, VisualBaselineBundle>();
+
+  for (const pkg of sortPackages(runManifest.packages)) {
+    const packageManifest = manifestsByPackageId.get(pkg.packageId);
+
+    if (!packageManifest) {
+      throw new Error(
+        `Missing package manifest for package '${pkg.packageId}' in run '${runManifest.runId}'`
+      );
+    }
+
+    const bundlePath = createBundleRelativePath(runManifest.target, pkg.browser, pkg.viewport);
+    const existingBundle = groups.get(bundlePath);
+
+    if (existingBundle) {
+      existingBundle.packageManifests.push(packageManifest);
+      existingBundle.imagePaths.push(...packageManifest.results.map(({ imagePath }) => imagePath));
+      existingBundle.runManifest.packages.push(pkg);
+      continue;
+    }
+
+    groups.set(bundlePath, {
+      relativePath: bundlePath,
+      browser: pkg.browser,
+      viewport: pkg.viewport,
+      runManifest: {
+        ...runManifest,
+        execution: {
+          packageCount: 1,
+          browsers: [pkg.browser],
+          viewports: pkg.viewport ? [pkg.viewport] : [],
+        },
+        summary: pkg.summary,
+        packages: [pkg],
+      },
+      packageManifests: [packageManifest],
+      imagePaths: packageManifest.results.map(({ imagePath }) => imagePath),
+    });
+  }
+
+  return Array.from(groups.values())
+    .map((bundle) => {
+      const sortedPackageManifests = sortPackages(bundle.packageManifests);
+      const sortedRunPackages = sortPackages(bundle.runManifest.packages);
+      return {
+        ...bundle,
+        runManifest: {
+          ...bundle.runManifest,
+          execution: {
+            packageCount: sortedRunPackages.length,
+            browsers: [bundle.browser],
+            viewports: bundle.viewport ? [bundle.viewport] : [],
+          },
+          summary: summaryFromPackages(sortedRunPackages),
+          packages: sortedRunPackages,
+        },
+        packageManifests: sortedPackageManifests,
+        imagePaths: Array.from(new Set(bundle.imagePaths)).sort((left, right) =>
+          left.localeCompare(right)
+        ),
+      };
+    })
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+};
+
+export const createVisualBaselineCatalog = (
+  commitSha: string,
+  generatedAt: string,
+  bundles: VisualBaselineBundle[]
+): VisualBaselineCatalog => ({
+  schemaVersion: 1,
+  baselineKind: 'main',
+  branch: 'main',
+  commitSha,
+  runIds: Array.from(new Set(bundles.map(({ runManifest }) => runManifest.runId))).sort(
+    (left, right) => left.localeCompare(right)
+  ),
+  generatedAt,
+  bundles: bundles.map((bundle) => ({
+    target: bundle.runManifest.target,
+    browser: bundle.browser,
+    viewport: bundle.viewport,
+    relativePath: bundle.relativePath,
+    manifestPath: path.posix.join(bundle.relativePath, 'manifest.json'),
+    archivePath: createVisualBaselineBundleArchivePath(bundle.relativePath),
+    packageCount: bundle.runManifest.packages.length,
+    packageIds: bundle.runManifest.packages.map(({ packageId }) => packageId),
+  })),
+});

--- a/.buildkite/scripts/steps/scout_vrt/publish_main_baselines.sh
+++ b/.buildkite/scripts/steps/scout_vrt/publish_main_baselines.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+ts-node --transpile-only .buildkite/scripts/steps/scout_vrt/publish_main_baselines.ts

--- a/.buildkite/scripts/steps/scout_vrt/publish_main_baselines.ts
+++ b/.buildkite/scripts/steps/scout_vrt/publish_main_baselines.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import {
+  cli,
+  type VisualRegressionManifest,
+  type VisualRegressionRunManifest,
+} from '@kbn/scout-vrt';
+import {
+  buildMainBaselineRunPlan,
+  createVisualBaselineBundleArchivePath,
+  createVisualBaselineBundles,
+  createVisualBaselineCatalog,
+  type ModuleDiscoveryInfo,
+  type PlannedVisualBaselineRunGroup,
+} from './main_baseline_publisher';
+import { getKibanaDir } from '#pipeline-utils';
+
+const BASELINES_BUCKET = 'ci-artifacts.kibana.dev/vrt/baselines/main';
+const CONFIG_DISCOVERY_PATH = path.join(
+  REPO_ROOT,
+  '.scout',
+  'test_configs',
+  'scout_playwright_configs.json'
+);
+const LOCAL_BASELINES_ROOT = path.join(REPO_ROOT, '.scout', 'baselines', 'vrt');
+const LOCAL_VRT_RUNS_ROOT = path.join(REPO_ROOT, '.scout', 'test-artifacts', 'vrt');
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable '${name}'`);
+  }
+
+  return value;
+};
+
+const exec = (file: string, args: string[], env?: Record<string, string>) => {
+  execFileSync(file, args, {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdio: 'inherit',
+  });
+};
+
+const runNodeScript = (scriptPath: string, args: string[], env?: Record<string, string>) => {
+  exec(process.execPath, [scriptPath, ...args], env);
+};
+
+const ensureScoutConfigDiscovery = () => {
+  console.log('--- Updating Scout config manifests for VRT baseline publishing');
+  runNodeScript(path.join(REPO_ROOT, 'scripts', 'scout.js'), [
+    'update-test-config-manifests',
+    '--concurrencyLimit',
+    '3',
+  ]);
+
+  console.log('--- Discovering Scout Playwright configs for VRT baseline publishing');
+  runNodeScript(path.join(REPO_ROOT, 'scripts', 'scout.js'), [
+    'discover-playwright-configs',
+    '--include-custom-servers',
+    '--save',
+  ]);
+};
+
+const readModuleDiscoveryInfo = (): ModuleDiscoveryInfo[] => {
+  return JSON.parse(fs.readFileSync(CONFIG_DISCOVERY_PATH, 'utf8')) as ModuleDiscoveryInfo[];
+};
+
+const readJsonFile = <T>(filePath: string): T => JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+
+const getRunManifestPath = (runId: string): string =>
+  path.join(LOCAL_VRT_RUNS_ROOT, runId, 'manifest.json');
+const getPackageManifestPath = (runId: string, packageId: string): string =>
+  path.join(LOCAL_VRT_RUNS_ROOT, runId, 'test-artifacts', packageId, 'manifest.json');
+
+const createBundleArchive = (publishRoot: string, relativePath: string): string => {
+  const archivePath = path.join(publishRoot, createVisualBaselineBundleArchivePath(relativePath));
+  fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+  execFileSync('tar', ['-czf', archivePath, '-C', publishRoot, relativePath], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  return archivePath;
+};
+
+const stageBundles = (runManifests: VisualRegressionRunManifest[], commitSha: string): string => {
+  const publishRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kibana-vrt-main-baselines-'));
+  const generatedAt = new Date().toISOString();
+  const bundles = runManifests.flatMap((runManifest) => {
+    const packageManifests = runManifest.packages.map(({ packageId }) =>
+      readJsonFile<VisualRegressionManifest>(getPackageManifestPath(runManifest.runId, packageId))
+    );
+
+    return createVisualBaselineBundles(runManifest, packageManifests);
+  });
+
+  for (const bundle of bundles) {
+    const bundleRoot = path.join(publishRoot, bundle.relativePath);
+    fs.mkdirSync(bundleRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(bundleRoot, 'manifest.json'),
+      JSON.stringify(bundle.runManifest, null, 2)
+    );
+
+    for (const packageManifest of bundle.packageManifests) {
+      const packageManifestPath = path.join(bundleRoot, packageManifest.packageId, 'manifest.json');
+      fs.mkdirSync(path.dirname(packageManifestPath), { recursive: true });
+      fs.writeFileSync(packageManifestPath, JSON.stringify(packageManifest, null, 2));
+    }
+
+    for (const imagePath of bundle.imagePaths) {
+      const sourcePath = path.join(LOCAL_BASELINES_ROOT, imagePath);
+      const destinationPath = path.join(bundleRoot, imagePath);
+
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+
+    createBundleArchive(publishRoot, bundle.relativePath);
+  }
+
+  const catalog = createVisualBaselineCatalog(commitSha, generatedAt, bundles);
+  fs.writeFileSync(path.join(publishRoot, 'index.json'), JSON.stringify(catalog, null, 2));
+
+  return publishRoot;
+};
+
+const uploadPublishRoot = (publishRoot: string, commitSha: string) => {
+  const originalDirectory = process.cwd();
+  const activateScript = path.join(
+    getKibanaDir(),
+    '.buildkite',
+    'scripts',
+    'common',
+    'activate_service_account.sh'
+  );
+
+  try {
+    process.chdir(publishRoot);
+    execFileSync(
+      '/bin/bash',
+      [
+        '-lc',
+        [
+          `${activateScript} gs://ci-artifacts.kibana.dev`,
+          `gcloud storage rsync --recursive --cache-control="no-cache, max-age=0, no-transform" --gzip-in-flight=json . 'gs://${BASELINES_BUCKET}/commits/${commitSha}/'`,
+          `gcloud storage rsync --recursive --delete-unmatched-destination-objects --cache-control="no-cache, max-age=0, no-transform" --gzip-in-flight=json . 'gs://${BASELINES_BUCKET}/latest/'`,
+        ].join('\n'),
+      ],
+      {
+        stdio: 'inherit',
+      }
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+};
+
+const runTargetBaselineGroup = (
+  group: PlannedVisualBaselineRunGroup,
+  buildId: string,
+  kibanaInstallDir: string
+): VisualRegressionRunManifest => {
+  const runId = `vrt-main-${buildId}-${group.runIdSuffix}`;
+  console.log(
+    `--- Publishing VRT baselines for ${group.target.location}/${group.target.arch}/${group.target.domain}`
+  );
+
+  for (const selection of group.selections) {
+    runNodeScript(
+      path.join(REPO_ROOT, 'scripts', 'scout_vrt'),
+      [
+        'run-tests',
+        '--location',
+        group.target.location,
+        '--arch',
+        group.target.arch,
+        '--domain',
+        group.target.domain,
+        '--config',
+        selection.configPath,
+        '--kibanaInstallDir',
+        kibanaInstallDir,
+        '--update-baselines',
+      ],
+      {
+        TEST_RUN_ID: runId,
+      }
+    );
+  }
+
+  return readJsonFile<VisualRegressionRunManifest>(getRunManifestPath(runId));
+};
+
+const main = async () => {
+  const buildId = getRequiredEnv('BUILDKITE_BUILD_ID');
+  const commitSha = getRequiredEnv('BUILDKITE_COMMIT');
+  const kibanaInstallDir = getRequiredEnv('KIBANA_BUILD_LOCATION');
+
+  ensureScoutConfigDiscovery();
+
+  const selections = await cli.discoverAllVisualRunSelections();
+
+  if (selections.length === 0) {
+    console.log('--- No VRT-enabled Scout configs were discovered on main');
+    return;
+  }
+
+  const plan = buildMainBaselineRunPlan(selections, readModuleDiscoveryInfo());
+
+  if (plan.length === 0) {
+    console.log('--- No VRT baseline publish plan could be created from Scout config discovery');
+    return;
+  }
+
+  const esDataDir = path.join(REPO_ROOT, '.es');
+
+  const runManifests = plan.map((group) => {
+    const manifest = runTargetBaselineGroup(group, buildId, kibanaInstallDir);
+
+    // Clean ES data between groups to prevent disk exhaustion on CI agents
+    if (fs.existsSync(esDataDir)) {
+      console.log('--- Cleaning ES data directory between VRT baseline groups');
+      fs.rmSync(esDataDir, { recursive: true, force: true });
+    }
+
+    return manifest;
+  });
+  const publishRoot = stageBundles(runManifests, commitSha);
+  uploadPublishRoot(publishRoot, commitSha);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md
@@ -1,0 +1,109 @@
+# CI Integration for @kbn/scout-vrt
+
+This document covers the second rollout stage: generating and publishing canonical `main` baselines from CI.
+
+It does not yet cover PR comparison or review-site generation. Those are added in the next stage.
+
+## Reviewer Summary
+
+This stage introduces baseline production, not baseline consumption:
+
+- merged `main` builds generate canonical baselines
+- those baselines are published by commit and through a moving `latest` alias
+- consumers resolve them through a catalog and optional per-bundle archive
+
+## On-Merge Baseline Publisher
+
+The canonical `main` baseline job lives in Kibana's on-merge pipeline:
+
+- pipeline file:
+  - `.buildkite/pipelines/on_merge.yml`
+- step label:
+  - `Publish Main VRT Baselines`
+- entrypoint:
+  - `.buildkite/scripts/steps/scout_vrt/publish_main_baselines.sh`
+
+That step:
+
+1. discovers only VRT-enabled Scout configs
+2. groups them by Scout target identity
+3. runs `node scripts/scout_vrt run-tests --update-baselines`
+4. packages the local baseline cache plus the corresponding manifests
+5. publishes commit-addressable bundles and a moving `latest` alias
+
+## Published Storage Layout
+
+The publisher writes to:
+
+- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/commits/<commitSha>/index.json`
+- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/latest/index.json`
+
+Each bundle is partitioned by:
+
+- `location`
+- `arch`
+- `domain`
+- `browser`
+- `viewport`
+
+For a bundle rooted at:
+
+- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/latest/<relativePath>/`
+
+the publisher writes:
+
+- `manifest.json`
+- `<packageId>/manifest.json`
+- baseline PNGs referenced by those manifests
+
+The same bundle also gets a sibling archive:
+
+- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/latest/<relativePath>.tar.gz`
+
+That archive contains the same manifest and image payload as the expanded bundle directory and exists to make whole-bundle download and transfer much cheaper.
+
+## Baseline Catalog
+
+`index.json` is the catalog entrypoint for downstream consumers.
+
+Each catalog entry identifies one bundle and includes:
+
+- the bundle's target identity
+- the bundle `relativePath`
+- the bundle `manifestPath`
+- the sibling `archivePath`
+
+The catalog is the source of truth for consumers that need to resolve the latest published baseline without knowing the full directory layout ahead of time.
+
+## Manual Seeding for a Branch or Demo
+
+If you want to seed baselines without merging to `main`, you can run the same publisher against a branch build or from a bespoke environment.
+
+You need:
+
+- a built Kibana install directory
+- credentials that can write to `gs://ci-artifacts.kibana.dev`
+- the same environment variables the publisher expects
+
+Example:
+
+```bash
+export BUILDKITE_BUILD_ID=manual-$(date +%s)
+export BUILDKITE_COMMIT=$(git rev-parse HEAD)
+export KIBANA_BUILD_LOCATION=/absolute/path/to/kibana/build/install
+
+.buildkite/scripts/steps/scout_vrt/publish_main_baselines.sh
+```
+
+Expected result:
+
+- commit-addressable bundles under `.../commits/<commitSha>/...`
+- a synchronized `.../latest/...` view
+- a top-level `index.json`
+- one `tar.gz` archive per bundle
+
+## Operational Notes
+
+- `latest/` is synchronized with deletion, so it remains a snapshot of the newest canonical baseline set rather than accumulating stale bundles.
+- The archive path is an optimization for transfer and hydration. The expanded bundle layout remains the canonical browser-readable form.
+- Baseline selection by commit or branch remains a CI concern. The runtime only knows how to write local baselines and emit manifests.

--- a/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md
@@ -1,12 +1,13 @@
 # Getting Started with @kbn/scout-vrt
 
-This guide covers the foundation workflow:
+This guide covers the first two rollout stages:
 
 1. author a visual Scout suite
 2. run VRT capture locally
-3. inspect the resulting artifacts and manifests
+3. generate local baselines
+4. inspect the resulting artifacts and manifests
 
-This stage is intentionally capture-only. Baseline generation, publication, and PR comparison are introduced in later rollout stages.
+This guide is still intentionally local-first. PR comparison and review-site reporting are introduced in the next stage.
 
 ## 1. Opt a Scout Suite into VRT
 
@@ -83,7 +84,28 @@ If you run the command without `--config` or `--testFiles`, it will:
 - prompt for a VRT-enabled config in an interactive shell
 - or list the discovered VRT-enabled configs otherwise
 
-## 4. Inspect the Output
+## 4. Generate Local Baselines
+
+Use the same command with `--update-baselines` when you want to treat the current screenshots as the local baseline set for the selected suites.
+
+Example:
+
+```bash
+node scripts/scout_vrt run-tests \
+  --location local \
+  --arch stateful \
+  --domain classic \
+  --config src/platform/plugins/private/advanced_settings/test/scout/ui/playwright.config.ts \
+  --update-baselines
+```
+
+That writes baseline PNGs to:
+
+- `.scout/baselines/vrt/<packageId>/<testKey>/<stepKey>.png`
+
+The run manifest for that execution will record `mode: "update-baselines"`, and each checkpoint record will use `status: "updated"`.
+
+## 5. Inspect the Output
 
 After a run, inspect:
 
@@ -103,12 +125,22 @@ The run manifest tells you:
 
 The package manifest tells you:
 
-- which checkpoints were captured
+- which checkpoints were captured or updated
 - their stable `testKey`
 - their shared `imagePath`
 - the source file and line that created the checkpoint
 
-## 5. Recommended Validation
+## 6. Publish Canonical `main` Baselines
+
+Publishing to remote storage is intentionally handled by CI, not by the local runtime. The on-merge baseline publisher reruns the same baseline-update mode on merged `main`, then packages and uploads the resulting baselines plus manifests.
+
+See [CI_INTEGRATION.md](CI_INTEGRATION.md) for:
+
+- the Buildkite step that publishes canonical `main` baselines
+- the published GCS layout
+- manual seeding instructions for a branch or demo environment
+
+## 7. Recommended Validation
 
 Before handing work off or pushing a branch:
 
@@ -118,11 +150,9 @@ yarn test:type_check --project src/platform/packages/shared/kbn-scout-vrt/tsconf
 node scripts/check_changes.ts
 ```
 
-## 6. What Comes Next
+## 8. What Comes Next
 
 Later rollout stages add:
 
-- local baseline generation
-- CI baseline publication
 - PR comparison against published baselines
 - static review-site generation

--- a/src/platform/packages/shared/kbn-scout-vrt/README.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/README.md
@@ -4,17 +4,17 @@
 
 ## Reviewer Summary
 
-This foundation stage does three things:
+This stage extends the foundation with baseline production and publication:
 
-- lets Scout suites opt into visual checkpoints with `visualTest`
-- captures one screenshot per checkpoint into Scout's artifact tree
-- writes versioned run and package manifests for downstream tooling
+- local runs can write baselines with `--update-baselines`
+- CI can publish canonical `main` baselines keyed by commit
+- consumers can resolve the latest published baseline set through `index.json`
 
-This stage does not yet define:
+This stage still does not define:
 
-- baseline generation or publication
-- baseline hydration
 - PR compare/reporting workflows
+- PR-side baseline hydration
+- approval flows
 
 ## What You Use
 
@@ -23,23 +23,52 @@ This stage does not yet define:
 - `createPlaywrightConfig`
   - a Playwright config wrapper that enables VRT artifact/report generation
 - `node scripts/scout_vrt run-tests`
-  - a helper CLI that discovers only VRT-enabled Scout suites and runs them in capture mode
+  - a helper CLI that discovers only VRT-enabled Scout suites and runs them in capture or baseline-update mode
 
-## What Capture Mode Produces
+## What The Runtime Produces
 
 When you run `node scripts/scout_vrt run-tests`, the package captures one image per visual checkpoint and writes manifests that describe the run.
 
-Artifacts are written under:
+Run artifacts are written under:
 
 - `.scout/test-artifacts/vrt/<runId>/manifest.json`
 - `.scout/test-artifacts/vrt/<runId>/test-artifacts/<packageId>/manifest.json`
 - `.scout/test-artifacts/vrt/<runId>/test-artifacts/<packageId>/<testKey>/<stepKey>.png`
+
+Local baselines are written under:
+
+- `.scout/baselines/vrt/<packageId>/<testKey>/<stepKey>.png`
 
 The package keeps the contract stable by writing:
 
 - a run-level manifest
 - one package manifest per Kibana module
 - checkpoint records with stable identity and source metadata
+
+## Main Baseline Publishing
+
+The on-merge baseline publisher stores canonical `main` baselines under:
+
+- `ci-artifacts.kibana.dev/vrt/baselines/main/commits/<commitSha>/...`
+- `ci-artifacts.kibana.dev/vrt/baselines/main/latest/...`
+
+Each published bundle is partitioned by:
+
+- `location`
+- `arch`
+- `domain`
+- `browser`
+- `viewport`
+
+Each bundle contains:
+
+- a filtered run manifest at `manifest.json`
+- the corresponding package manifests at `<packageId>/manifest.json`
+- the baseline images referenced by those manifests
+
+A top-level `index.json` catalogs the published bundles for downstream consumers. Each catalog entry also advertises a sibling bundle archive at `<bundle>.tar.gz`, so CI and local tooling can download one file per baseline bundle instead of recursively transferring the full expanded directory.
+
+For the CI details, see [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md).
 
 ## Public Contract
 
@@ -55,7 +84,7 @@ Stable downstream fields in `VisualCheckpointRecord`:
 - `testFile`, `testTitle`, `testKey`
 - `stepTitle`, `stepIndex`, `snapshotName`
 - `status`
-  - in this stage: `captured`
+  - in this stage: `captured` or `updated`
 - `imagePath`
 - `source.file`, `source.line`, `source.column`
 
@@ -66,10 +95,11 @@ The package is intentionally limited to:
 - sequential UI suites
 - viewport screenshots
 - local artifact generation
-- no baseline lifecycle yet
-- no CI orchestration yet
+- main-baseline publication
+- no PR compare/reporting workflow yet
 - no approval workflow
 
-## Next Doc
+## Next Docs
 
-See [GETTING_STARTED.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md) for a local authoring and capture walkthrough.
+- See [GETTING_STARTED.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md) for local authoring, capture, and baseline generation.
+- See [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md) for on-merge baseline publication and manual seeding.

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/arg_parsing.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/arg_parsing.ts
@@ -16,6 +16,7 @@ export interface ParsedVisualRunTestsArgs {
   forwardedArgs: string[];
   helpRequested: boolean;
   testFilesList?: string;
+  updateBaselines: boolean;
 }
 
 const parseFlagValue = (rawValue: string | undefined, flagName: string): string => {
@@ -31,12 +32,29 @@ export const parseVisualRunTestsArgs = (rawArgs: string[]): ParsedVisualRunTests
   let configPath: string | undefined;
   let testFilesList: string | undefined;
   let helpRequested = false;
+  let updateBaselines = false;
 
   for (let index = 0; index < rawArgs.length; index++) {
     const arg = rawArgs[index];
 
     if (HELP_FLAGS.has(arg)) {
       helpRequested = true;
+      continue;
+    }
+
+    if (arg === '--update-baselines') {
+      updateBaselines = true;
+      continue;
+    }
+
+    if (arg.startsWith('--update-baselines=')) {
+      const rawValue = arg.slice('--update-baselines='.length).trim().toLowerCase();
+
+      if (!['1', 'true', 'yes'].includes(rawValue)) {
+        throw createFlagError(`'--update-baselines' does not take a value of '${rawValue}'`);
+      }
+
+      updateBaselines = true;
       continue;
     }
 
@@ -88,5 +106,6 @@ export const parseVisualRunTestsArgs = (rawArgs: string[]): ParsedVisualRunTests
     forwardedArgs,
     helpRequested,
     testFilesList,
+    updateBaselines,
   };
 };

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/index.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/index.ts
@@ -29,7 +29,8 @@ Commands:
 Usage:
   node scripts/scout_vrt run-tests
   node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path>
-  node scripts/scout_vrt run-tests --arch stateful --domain classic --testFiles <spec_path_or_directory>`;
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --testFiles <spec_path_or_directory>
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --update-baselines`;
 
 const shouldPrintHelp = (command: string | undefined, args: string[]): boolean =>
   command === undefined ||

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.test.ts
@@ -32,11 +32,14 @@ const promptMock = jest.mocked(inquirer.prompt);
 
 describe('parseVisualRunTestsArgs', () => {
   it('allows bare runs so the CLI can list VRT-enabled configs', () => {
-    expect(parseVisualRunTestsArgs(['--arch', 'stateful', '--domain=classic'])).toEqual({
+    expect(
+      parseVisualRunTestsArgs(['--arch', 'stateful', '--domain=classic', '--update-baselines'])
+    ).toEqual({
       configPath: undefined,
       forwardedArgs: ['--arch', 'stateful', '--domain=classic'],
       helpRequested: false,
       testFilesList: undefined,
+      updateBaselines: true,
     });
   });
 
@@ -54,6 +57,7 @@ describe('parseVisualRunTestsArgs', () => {
       forwardedArgs: ['--arch', 'stateful', '--domain=classic'],
       helpRequested: false,
       testFilesList: undefined,
+      updateBaselines: false,
     });
   });
 
@@ -73,6 +77,7 @@ describe('parseVisualRunTestsArgs', () => {
       forwardedArgs: ['--location', 'cloud', '--arch', 'stateful', '--domain', 'classic'],
       helpRequested: false,
       testFilesList: 'src/plugin/test/scout/ui/tests/example.spec.ts',
+      updateBaselines: false,
     });
   });
 

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.ts
@@ -62,11 +62,14 @@ Usage:
   node scripts/scout_vrt run-tests
   node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path>
   node scripts/scout_vrt run-tests --arch stateful --domain classic --testFiles <spec_path_or_directory>
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --update-baselines
+
+Options:
+  --update-baselines  Refresh the local baseline cache for the selected visual suites
 
 All other flags are forwarded to 'node scripts/scout run-tests'.
 Visual specs are discovered by following each spec's local imports until a dependency on '@kbn/scout-vrt' is found.
-Run without '--config' or '--testFiles' to select a VRT-enabled Scout config in interactive shells, or list them otherwise.
-This command captures visual artifacts and manifests for the selected suites; baseline generation and comparison are added in follow-on CI work.`;
+Run without '--config' or '--testFiles' to select a VRT-enabled Scout config in interactive shells, or list them otherwise.`;
 
 export const runVisualTestsCommand = async (rawArgs: string[]) => {
   const parsedArgs = parseVisualRunTestsArgs(rawArgs);

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/scout_runner.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/scout_runner.ts
@@ -12,7 +12,11 @@ import path from 'path';
 import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { generateTestRunId } from '@kbn/scout-reporting';
-import { ensureVisualRegressionRunId, SCOUT_VISUAL_REGRESSION_ENABLED_ENV } from '../playwright/runtime/environment';
+import {
+  ensureVisualRegressionRunId,
+  SCOUT_VISUAL_REGRESSION_ENABLED_ENV,
+  SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV,
+} from '../playwright/runtime/environment';
 import type { ParsedVisualRunTestsArgs } from './arg_parsing';
 import type { VisualRunSelection } from './visual_test_discovery';
 
@@ -29,6 +33,7 @@ const createVisualRunEnvironment = (
   return {
     TEST_RUN_ID: runId,
     [SCOUT_VISUAL_REGRESSION_ENABLED_ENV]: 'true',
+    [SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV]: String(parsedArgs.updateBaselines),
   };
 };
 

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.test.ts
@@ -100,7 +100,7 @@ describe('createVisualRegressionManifest', () => {
           stepTitle: 'step 1',
           stepIndex: 1,
           snapshotName: '01_step_1.png',
-          status: 'captured',
+          status: 'updated',
           imagePath: 'pkg/second-test-local/01_step_1.png',
           source: {
             file: 'b.spec.ts',
@@ -115,7 +115,7 @@ describe('createVisualRegressionManifest', () => {
           stepTitle: 'step 2',
           stepIndex: 2,
           snapshotName: '02_step_2.png',
-          status: 'captured',
+          status: 'updated',
           imagePath: 'pkg/second-test-local/02_step_2.png',
           source: {
             file: 'b.spec.ts',
@@ -129,7 +129,8 @@ describe('createVisualRegressionManifest', () => {
     expect(summarizeVisualRegressionManifest(manifest)).toEqual({
       tests: 2,
       checkpoints: 4,
-      captured: 4,
+      captured: 2,
+      updated: 2,
     });
   });
 
@@ -143,7 +144,7 @@ describe('createVisualRegressionManifest', () => {
           stepTitle: 'step 1',
           stepIndex: 1,
           snapshotName: '01_step_1.png',
-          status: 'captured',
+          status: 'updated',
           imagePath: 'advancedSettings/first-test-local/01_step_1.png',
           source: {
             file: 'a.spec.ts',
@@ -157,7 +158,7 @@ describe('createVisualRegressionManifest', () => {
     const initialRunManifest = upsertVisualRegressionRunManifest({
       manifest: initialManifest,
       packageStatus: 'passed',
-      mode: 'capture',
+      mode: 'update-baselines',
       startedAt: '2026-03-20T18:00:00.000Z',
       completedAt: '2026-03-20T18:00:10.000Z',
     });
@@ -229,7 +230,8 @@ describe('createVisualRegressionManifest', () => {
       summary: {
         tests: 2,
         checkpoints: 2,
-        captured: 2,
+        captured: 1,
+        updated: 1,
       },
       packages: [
         {
@@ -248,7 +250,8 @@ describe('createVisualRegressionManifest', () => {
           summary: {
             tests: 1,
             checkpoints: 1,
-            captured: 1,
+            captured: 0,
+            updated: 1,
           },
         },
         {
@@ -268,6 +271,7 @@ describe('createVisualRegressionManifest', () => {
             tests: 1,
             checkpoints: 1,
             captured: 1,
+            updated: 0,
           },
         },
       ],

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.ts
@@ -44,9 +44,10 @@ export interface VisualRegressionManifestSummary {
   tests: number;
   checkpoints: number;
   captured: number;
+  updated: number;
 }
 
-export type VisualRegressionRunMode = 'capture';
+export type VisualRegressionRunMode = 'capture' | 'update-baselines';
 export type VisualRegressionRunStatus = 'passed' | 'failed' | 'timedout' | 'interrupted';
 
 export interface VisualRegressionRunManifestPackage {
@@ -111,6 +112,7 @@ const createEmptySummary = (): VisualRegressionManifestSummary => ({
   tests: 0,
   checkpoints: 0,
   captured: 0,
+  updated: 0,
 });
 
 const getDurationMs = (startedAt: string, completedAt: string): number => {
@@ -155,6 +157,9 @@ export const summarizeVisualRegressionManifest = (
       case 'captured':
         summary.captured += 1;
         break;
+      case 'updated':
+        summary.updated += 1;
+        break;
     }
 
   }
@@ -192,6 +197,7 @@ const summarizeRunPackages = (
       tests: summary.tests + currentPackage.summary.tests,
       checkpoints: summary.checkpoints + currentPackage.summary.checkpoints,
       captured: summary.captured + currentPackage.summary.captured,
+      updated: summary.updated + currentPackage.summary.updated,
     }),
     createEmptySummary()
   );

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/visual_regression_reporter.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/visual_regression_reporter.ts
@@ -24,7 +24,10 @@ import {
   type VisualRegressionRunManifest,
   upsertVisualRegressionRunManifest,
 } from './manifest';
-import { SCOUT_VISUAL_REGRESSION_ATTACHMENT_NAME } from '../runtime/environment';
+import {
+  SCOUT_VISUAL_REGRESSION_ATTACHMENT_NAME,
+  isUpdateBaselinesEnabled,
+} from '../runtime/environment';
 import {
   getVisualRegressionManifestPath,
   getVisualRegressionRunManifestPath,
@@ -146,7 +149,7 @@ export class ScoutVisualRegressionReporter implements Reporter {
       existing: existingRunManifest,
       manifest: this.manifest,
       packageStatus: _result.status,
-      mode: 'capture',
+      mode: isUpdateBaselinesEnabled() ? 'update-baselines' : 'capture',
       startedAt: this.startedAt ?? completedAt,
       completedAt,
     });

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.test.ts
@@ -15,6 +15,11 @@ import { captureVisualCheckpoint } from './checkpoint_capture';
 import type { VisualRegressionContext } from './types';
 
 let mockTempRoot = '';
+let mockUpdateBaselinesEnabled = false;
+
+jest.mock('./environment', () => ({
+  isUpdateBaselinesEnabled: () => mockUpdateBaselinesEnabled,
+}));
 
 jest.mock('./paths', () => {
   const nodePath = jest.requireActual<typeof import('node:path')>('node:path');
@@ -35,6 +40,8 @@ jest.mock('./paths', () => {
         testKey,
         snapshotName
       ),
+    getVisualRegressionBaselinePath: (packageId: string, testKey: string, snapshotName: string) =>
+      nodePath.join(mockTempRoot, 'baselines', packageId, testKey, snapshotName),
     getVisualRegressionImagePath: (packageId: string, testKey: string, snapshotName: string) =>
       nodePath.join(packageId, testKey, snapshotName),
     toRepoRelativePath: (filePath: string) =>
@@ -49,6 +56,7 @@ describe('captureVisualCheckpoint', () => {
 
   beforeEach(() => {
     mockTempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-vrt-checkpoint-'));
+    mockUpdateBaselinesEnabled = false;
 
     page = {
       evaluate: jest.fn(async () => undefined),
@@ -76,6 +84,35 @@ describe('captureVisualCheckpoint', () => {
       packageId: 'advancedSettings',
       testKey: 'renders-useful-state-local',
     };
+  });
+
+  it('updates the local baseline cache in update mode', async () => {
+    mockUpdateBaselinesEnabled = true;
+
+    const result = await captureVisualCheckpoint(context, {
+      stepTitle: 'advanced settings page is visible',
+      stepIndex: 1,
+      mask: [],
+      source: {
+        file: 'src/plugin/test.scout.spec.ts',
+        line: 20,
+        column: 4,
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.record.status).toBe('updated');
+    expect(
+      fs.readFileSync(
+        path.join(
+          mockTempRoot,
+          'baselines',
+          'advancedSettings',
+          'renders-useful-state-local',
+          '01_advanced_settings_page_is_visible.png'
+        )
+      )
+    ).toEqual(screenshotBuffer);
   });
 
   it('captures the actual image into the run artifact tree', async () => {

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.ts
@@ -9,8 +9,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { isUpdateBaselinesEnabled } from './environment';
 import {
   getVisualRegressionActualPath,
+  getVisualRegressionBaselinePath,
   getVisualRegressionImagePath,
   toRepoRelativePath,
 } from './paths';
@@ -30,18 +32,38 @@ export const captureVisualCheckpoint = async (
   const snapshotName = createVisualSnapshotName(options.stepIndex, options.stepTitle);
   const actualOutputPath = getVisualRegressionActualPath(runId, packageId, testKey, snapshotName);
   const imagePath = getVisualRegressionImagePath(packageId, testKey, snapshotName);
+  const baselineOutputPath = getVisualRegressionBaselinePath(packageId, testKey, snapshotName);
 
   fs.mkdirSync(path.dirname(actualOutputPath), { recursive: true });
 
   await waitForVisualStability(page);
 
-  await page.screenshot({
+  const actualBuffer = await page.screenshot({
     path: actualOutputPath,
     animations: 'disabled',
     caret: 'hide',
     mask: options.mask,
     scale: 'css',
   });
+
+  if (isUpdateBaselinesEnabled()) {
+    fs.mkdirSync(path.dirname(baselineOutputPath), { recursive: true });
+    fs.writeFileSync(baselineOutputPath, actualBuffer);
+
+    return {
+      record: {
+        testFile: toRepoRelativePath(testInfo.file),
+        testTitle: testInfo.title,
+        testKey,
+        stepTitle: options.stepTitle,
+        stepIndex: options.stepIndex,
+        snapshotName,
+        status: 'updated',
+        imagePath,
+        source: options.source,
+      },
+    };
+  }
 
   return {
     record: {

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/environment.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/environment.ts
@@ -18,10 +18,15 @@ const booleanFromEnv = (varName: string, defaultValue: boolean = false): boolean
 };
 
 export const SCOUT_VISUAL_REGRESSION_ENABLED_ENV = 'SCOUT_VISUAL_REGRESSION_ENABLED';
+export const SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV =
+  'SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES';
 export const SCOUT_VISUAL_REGRESSION_ATTACHMENT_NAME = 'scout-vrt-checkpoints';
 
 export const isVisualRegressionEnabled = (): boolean =>
   booleanFromEnv(SCOUT_VISUAL_REGRESSION_ENABLED_ENV);
+
+export const isUpdateBaselinesEnabled = (): boolean =>
+  booleanFromEnv(SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV);
 
 export const ensureVisualRegressionRunId = (factory: () => string): string => {
   const existingRunId = process.env.TEST_RUN_ID;

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/types.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/types.ts
@@ -22,7 +22,7 @@ export interface VisualCheckpointRecord {
   stepTitle: string;
   stepIndex: number;
   snapshotName: string;
-  status: 'captured';
+  status: 'captured' | 'updated';
   imagePath: string;
   source: VisualSourceLocation;
 }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/history_snapshot.spec.ts
@@ -22,7 +22,8 @@ import {
   waitForScheduledHistorySnapshot,
 } from '../fixtures/helpers';
 
-apiTest.describe('Entity Store History Snapshot', { tag: ENTITY_STORE_TAGS }, () => {
+// Failing: See https://github.com/elastic/kibana/issues/256862
+apiTest.describe.skip('Entity Store History Snapshot', { tag: ENTITY_STORE_TAGS }, () => {
   let defaultHeaders: Record<string, string>;
   let internalHeaders: Record<string, string>;
 


### PR DESCRIPTION
## Summary

This PR introduces canonical `main` baseline generation and publication for visual regression testing (VRT) in Kibana.

> [!NOTE]
> This PR is built from the ON-Week PR, https://github.com/elastic/kibana/pull/234343.  The [feedback](https://github.com/elastic/kibana/pull/234343#issuecomment-3411089676) from @elastic/kibana-qa led me to engage AI, specifically `GPT-5.4`, to adapt the approach based on that guidance.

This PR builds directly on the local VRT foundation from [PR1](https://github.com/elastic/kibana/pull/258987) and adds the first CI-owned baseline workflow: local runs can now write baselines with `--update-baselines`, and merged `main` can publish those baselines to remote storage for later consumers.

Importantly, this PR is still about producing baselines, not consuming them. It does not yet add PR-side baseline hydration, PR compare/reporting, or a review UI.

> [!NOTE]
> This PR intentionally stops at baseline generation and publication. PR comparison, reporting, and review-site publishing are layered on in the next PR.

## What This PR Adds

- `--update-baselines` for VRT-enabled Scout runs
- local baseline cache under `.scout/baselines/vrt/...`
- on-merge Buildkite baseline publishing for merged `main`
- canonical published baselines under `vrt/baselines/main/...`
- commit-addressable baseline bundles plus a moving `latest` alias
- published `index.json` catalog for downstream consumers
- sibling `tar.gz` archives for each baseline bundle to support fast whole-bundle transfer
- CI and getting-started docs for baseline generation, publication, and manual seeding

## Baseline Ownership

This PR establishes that baseline lineage is owned by CI:

- the local runtime can write baselines
- CI decides which merged `main` commit becomes canonical
- CI publishes those baselines for later compare workflows
- PRs still do not mutate or bless baselines in this stage

## Published Layout

Canonical `main` baselines are published to:

- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/commits/<commitSha>/...`
- `gs://ci-artifacts.kibana.dev/vrt/baselines/main/latest/...`

Each bundle contains:

- a filtered `manifest.json`
- package manifests
- baseline PNGs referenced by those manifests
- a sibling `tar.gz` archive for fast hydration and transfer

## Scope

This PR is limited to:

- local baseline generation
- canonical `main` baseline publication
- remote storage layout and catalog definition
- bundle archive generation
- manual seeding support for demos and branch validation

This PR does not yet include:

- PR-side baseline hydration
- PR compare/reporting
- review-site publishing
- Driftik integration
- approvals or baseline promotion
