### PR TITLE
[scout-vrt] Add PR compare and reporting flow

### DIFF
--- a/.buildkite/pipelines/pull_request/vrt.yml
+++ b/.buildkite/pipelines/pull_request/vrt.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: .buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.sh
+    label: 'Run VRT Compare'
+    agents:
+      machineType: n2-standard-8
+      preemptible: true
+      spotZones: us-central1-f,us-central1-c,us-central1-a
+    depends_on:
+      - build
+    key: vrt_compare
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -262,6 +262,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks.yml', cancelable));
     }
 
+    if (GITHUB_PR_LABELS.includes('ci:vrt')) {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/vrt.yml'));
+    }
+
     if (GITHUB_PR_LABELS.includes('ci:build-webpack-bundle-analyzer')) {
       pipeline.push(
         getPipeline('.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml', cancelable)

--- a/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.test.ts
+++ b/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.test.ts
@@ -51,8 +51,12 @@ const createRunManifest = (): VisualRegressionRunManifest => ({
   summary: {
     tests: 2,
     checkpoints: 2,
+    passed: 0,
+    failed: 0,
     captured: 0,
     updated: 2,
+    missingBaselines: 0,
+    diffs: 0,
   },
   packages: [
     {
@@ -71,8 +75,12 @@ const createRunManifest = (): VisualRegressionRunManifest => ({
       summary: {
         tests: 1,
         checkpoints: 1,
+        passed: 0,
+        failed: 0,
         captured: 0,
         updated: 1,
+        missingBaselines: 0,
+        diffs: 0,
       },
     },
     {
@@ -91,8 +99,12 @@ const createRunManifest = (): VisualRegressionRunManifest => ({
       summary: {
         tests: 1,
         checkpoints: 1,
+        passed: 0,
+        failed: 0,
         captured: 0,
         updated: 1,
+        missingBaselines: 0,
+        diffs: 0,
       },
     },
   ],

--- a/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.ts
+++ b/.buildkite/scripts/steps/scout_vrt/main_baseline_publisher.ts
@@ -86,14 +86,22 @@ const summaryFromPackages = (
     (summary, currentPackage) => ({
       tests: summary.tests + currentPackage.summary.tests,
       checkpoints: summary.checkpoints + currentPackage.summary.checkpoints,
+      passed: summary.passed + currentPackage.summary.passed,
+      failed: summary.failed + currentPackage.summary.failed,
       captured: summary.captured + currentPackage.summary.captured,
       updated: summary.updated + currentPackage.summary.updated,
+      missingBaselines: summary.missingBaselines + currentPackage.summary.missingBaselines,
+      diffs: summary.diffs + currentPackage.summary.diffs,
     }),
     {
       tests: 0,
       checkpoints: 0,
+      passed: 0,
+      failed: 0,
       captured: 0,
       updated: 0,
+      missingBaselines: 0,
+      diffs: 0,
     }
   );
 

--- a/.buildkite/scripts/steps/scout_vrt/pr_compare_reporting.ts
+++ b/.buildkite/scripts/steps/scout_vrt/pr_compare_reporting.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  VisualRegressionManifestSummary,
+  VisualRegressionRunManifest,
+  VisualRegressionRunStatus,
+} from '@kbn/scout-vrt';
+
+export interface PrVrtRunReport {
+  status: VisualRegressionRunStatus;
+  summary: VisualRegressionManifestSummary;
+  runManifest: VisualRegressionRunManifest;
+}
+
+export interface PrVrtSummary {
+  runs: number;
+  packages: number;
+  tests: number;
+  checkpoints: number;
+  passed: number;
+  failed: number;
+  updated: number;
+  missingBaselines: number;
+  diffs: number;
+}
+
+const statusSeverity: Record<VisualRegressionRunStatus, number> = {
+  passed: 0,
+  failed: 1,
+  timedout: 2,
+  interrupted: 3,
+};
+
+export const summarizePrVrtRuns = (runReports: PrVrtRunReport[]): PrVrtSummary =>
+  runReports.reduce<PrVrtSummary>(
+    (summary, currentRun) => ({
+      runs: summary.runs + 1,
+      packages: summary.packages + currentRun.runManifest.packages.length,
+      tests: summary.tests + currentRun.summary.tests,
+      checkpoints: summary.checkpoints + currentRun.summary.checkpoints,
+      passed: summary.passed + currentRun.summary.passed,
+      failed: summary.failed + currentRun.summary.failed,
+      updated: summary.updated + currentRun.summary.updated,
+      missingBaselines: summary.missingBaselines + currentRun.summary.missingBaselines,
+      diffs: summary.diffs + currentRun.summary.diffs,
+    }),
+    {
+      runs: 0,
+      packages: 0,
+      tests: 0,
+      checkpoints: 0,
+      passed: 0,
+      failed: 0,
+      updated: 0,
+      missingBaselines: 0,
+      diffs: 0,
+    }
+  );
+
+export const pickPrVrtStyle = (runReports: PrVrtRunReport[]): 'success' | 'warning' | 'error' => {
+  const highestSeverity = runReports.reduce<number>(
+    (severity, currentRun) => Math.max(severity, statusSeverity[currentRun.status]),
+    0
+  );
+
+  if (highestSeverity >= statusSeverity.timedout) {
+    return 'error';
+  }
+
+  const summary = summarizePrVrtRuns(runReports);
+
+  if (summary.failed > 0 || summary.missingBaselines > 0) {
+    return 'error';
+  }
+
+  if (summary.diffs > 0) {
+    return 'warning';
+  }
+
+  return 'success';
+};
+
+const pluralize = (count: number, singular: string, plural: string = `${singular}s`): string =>
+  `${count} ${count === 1 ? singular : plural}`;
+
+export const createPrVrtAnnotation = (runReports: PrVrtRunReport[], reportUrl: string): string => {
+  const summary = summarizePrVrtRuns(runReports);
+
+  return [
+    '**Visual Regression Tests**<br />',
+    `Runs: ${summary.runs}<br />`,
+    `Packages: ${summary.packages}<br />`,
+    `Tests: ${summary.tests}<br />`,
+    `Checkpoints: ${summary.checkpoints}<br />`,
+    `Failed checkpoints: ${summary.failed}<br />`,
+    `Missing baselines: ${summary.missingBaselines}<br />`,
+    `Diff images: ${summary.diffs}<br />`,
+    `<a href="${reportUrl}">Open VRT review site</a>`,
+  ].join('\n');
+};
+
+export const createPrVrtCommentHead = (runReports: PrVrtRunReport[], reportUrl: string): string => {
+  const summary = summarizePrVrtRuns(runReports);
+  const details = [
+    pluralize(summary.failed, 'failed checkpoint'),
+    pluralize(summary.missingBaselines, 'missing baseline'),
+    pluralize(summary.diffs, 'diff image'),
+  ].join(', ');
+
+  return `* [VRT Report](${reportUrl}) - ${details}`;
+};
+
+export const createPrVrtCommentBody = (runReports: PrVrtRunReport[], reportUrl: string): string => {
+  const summary = summarizePrVrtRuns(runReports);
+
+  return [
+    '### Visual Regression Tests',
+    '',
+    `* [Open VRT review site](${reportUrl})`,
+    `* ${pluralize(summary.runs, 'run')}`,
+    `* ${pluralize(summary.packages, 'package')}`,
+    `* ${pluralize(summary.tests, 'test')}`,
+    `* ${pluralize(summary.checkpoints, 'checkpoint')}`,
+    `* ${pluralize(summary.failed, 'failed checkpoint')}`,
+    `* ${pluralize(summary.missingBaselines, 'missing baseline')}`,
+    `* ${pluralize(summary.diffs, 'diff image')}`,
+  ].join('\n');
+};

--- a/.buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.sh
+++ b/.buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+ts-node --transpile-only .buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.ts

--- a/.buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.ts
+++ b/.buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.ts
@@ -1,0 +1,619 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import {
+  cli,
+  type VisualRegressionManifest,
+  type VisualRegressionRunManifest,
+} from '@kbn/scout-vrt';
+import {
+  buildMainBaselineRunPlan,
+  type ModuleDiscoveryInfo,
+  type PlannedVisualBaselineRunGroup,
+  type VisualBaselineCatalog,
+  type VisualBaselineCatalogEntry,
+} from './main_baseline_publisher';
+import {
+  createPrVrtAnnotation,
+  createPrVrtCommentBody,
+  createPrVrtCommentHead,
+  pickPrVrtStyle,
+  summarizePrVrtRuns,
+  type PrVrtRunReport,
+} from './pr_compare_reporting';
+import { getKibanaDir } from '#pipeline-utils';
+
+const MAIN_BASELINES_BUCKET = 'ci-artifacts.kibana.dev/vrt/baselines/main';
+const PR_REPORTS_BUCKET = 'ci-artifacts.kibana.dev/vrt/pr';
+const CONFIG_DISCOVERY_PATH = path.join(
+  REPO_ROOT,
+  '.scout',
+  'test_configs',
+  'scout_playwright_configs.json'
+);
+const LOCAL_BASELINES_ROOT = path.join(REPO_ROOT, '.scout', 'baselines', 'vrt');
+const LOCAL_VRT_RUNS_ROOT = path.join(REPO_ROOT, '.scout', 'test-artifacts', 'vrt');
+
+interface CompletedCompareRun {
+  exitCode: number;
+  runId: string;
+  runManifest?: VisualRegressionRunManifest;
+}
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable '${name}'`);
+  }
+
+  return value;
+};
+
+const exec = (file: string, args: string[], env?: Record<string, string>) => {
+  execFileSync(file, args, {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdio: 'inherit',
+  });
+};
+
+const runNodeScript = (scriptPath: string, args: string[], env?: Record<string, string>) => {
+  exec(process.execPath, [scriptPath, ...args], env);
+};
+
+const runNodeScriptWithExitCode = (
+  scriptPath: string,
+  args: string[],
+  env?: Record<string, string>
+): number =>
+  spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdio: 'inherit',
+  }).status ?? 1;
+
+const ensureScoutConfigDiscovery = () => {
+  console.log('--- Updating Scout config manifests for VRT PR compare');
+  runNodeScript(path.join(REPO_ROOT, 'scripts', 'scout.js'), [
+    'update-test-config-manifests',
+    '--concurrencyLimit',
+    '3',
+  ]);
+
+  console.log('--- Discovering Scout Playwright configs for VRT PR compare');
+  runNodeScript(path.join(REPO_ROOT, 'scripts', 'scout.js'), [
+    'discover-playwright-configs',
+    '--include-custom-servers',
+    '--save',
+  ]);
+};
+
+const readModuleDiscoveryInfo = (): ModuleDiscoveryInfo[] => {
+  return JSON.parse(fs.readFileSync(CONFIG_DISCOVERY_PATH, 'utf8')) as ModuleDiscoveryInfo[];
+};
+
+const readJsonFile = <T>(filePath: string): T => JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+
+const getRunManifestPath = (runId: string): string =>
+  path.join(LOCAL_VRT_RUNS_ROOT, runId, 'manifest.json');
+
+const getPackageManifestPath = (runId: string, packageId: string): string =>
+  path.join(LOCAL_VRT_RUNS_ROOT, runId, 'test-artifacts', packageId, 'manifest.json');
+
+const readRunManifestIfPresent = (runId: string): VisualRegressionRunManifest | undefined => {
+  const manifestPath = getRunManifestPath(runId);
+  return fs.existsSync(manifestPath)
+    ? readJsonFile<VisualRegressionRunManifest>(manifestPath)
+    : undefined;
+};
+
+const activateServiceAccountScript = (): string =>
+  path.join(getKibanaDir(), '.buildkite', 'scripts', 'common', 'activate_service_account.sh');
+
+const runGcloudCommands = (commands: string[]) => {
+  execFileSync(
+    '/bin/bash',
+    [
+      '-lc',
+      [`${activateServiceAccountScript()} gs://ci-artifacts.kibana.dev`, ...commands].join('\n'),
+    ],
+    {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    }
+  );
+};
+
+const extractBundleArchive = (archivePath: string, destinationRoot: string) => {
+  execFileSync('tar', ['-xzf', archivePath, '-C', destinationRoot], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+};
+
+const downloadLatestCatalog = (downloadRoot: string): VisualBaselineCatalog => {
+  const catalogPath = path.join(downloadRoot, 'latest-index.json');
+
+  runGcloudCommands([
+    `gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" 'gs://${MAIN_BASELINES_BUCKET}/latest/index.json' '${catalogPath}'`,
+  ]);
+
+  return readJsonFile<VisualBaselineCatalog>(catalogPath);
+};
+
+const matchesTarget = (
+  bundle: VisualBaselineCatalogEntry,
+  group: PlannedVisualBaselineRunGroup
+): boolean =>
+  bundle.target.location === group.target.location &&
+  bundle.target.arch === group.target.arch &&
+  bundle.target.domain === group.target.domain;
+
+const hydrateBundleBaselines = (bundleRoot: string) => {
+  const runManifest = readJsonFile<VisualRegressionRunManifest>(
+    path.join(bundleRoot, 'manifest.json')
+  );
+
+  for (const { packageId } of runManifest.packages) {
+    const packageManifest = readJsonFile<VisualRegressionManifest>(
+      path.join(bundleRoot, packageId, 'manifest.json')
+    );
+
+    for (const { imagePath } of packageManifest.results) {
+      const sourcePath = path.join(bundleRoot, imagePath);
+      const destinationPath = path.join(LOCAL_BASELINES_ROOT, imagePath);
+
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+  }
+};
+
+const hydrateLatestBaselinesForPlan = (
+  plan: PlannedVisualBaselineRunGroup[],
+  catalog: VisualBaselineCatalog,
+  downloadRoot: string
+) => {
+  fs.rmSync(LOCAL_BASELINES_ROOT, { recursive: true, force: true });
+  fs.mkdirSync(LOCAL_BASELINES_ROOT, { recursive: true });
+
+  const matchedBundlePaths = new Set<string>();
+
+  for (const group of plan) {
+    const matchingBundles = catalog.bundles.filter((bundle) => matchesTarget(bundle, group));
+
+    if (matchingBundles.length === 0) {
+      throw new Error(
+        `No latest main baseline bundle found for ${group.target.location}/${group.target.arch}/${group.target.domain}`
+      );
+    }
+
+    for (const bundle of matchingBundles) {
+      if (matchedBundlePaths.has(bundle.relativePath)) {
+        continue;
+      }
+
+      const bundleRoot = path.join(downloadRoot, bundle.relativePath);
+      fs.mkdirSync(path.dirname(bundleRoot), { recursive: true });
+
+      if (bundle.archivePath) {
+        const archivePath = path.join(downloadRoot, bundle.archivePath);
+        fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+        runGcloudCommands([
+          `gcloud storage cp --cache-control="no-cache, max-age=0, no-transform" 'gs://${MAIN_BASELINES_BUCKET}/latest/${bundle.archivePath}' '${archivePath}'`,
+        ]);
+        extractBundleArchive(archivePath, downloadRoot);
+      } else {
+        fs.mkdirSync(bundleRoot, { recursive: true });
+        runGcloudCommands([
+          `gcloud storage rsync --recursive 'gs://${MAIN_BASELINES_BUCKET}/latest/${bundle.relativePath}/' '${bundleRoot}'`,
+        ]);
+      }
+
+      hydrateBundleBaselines(bundleRoot);
+      matchedBundlePaths.add(bundle.relativePath);
+    }
+  }
+};
+
+const runTargetCompareGroup = (
+  group: PlannedVisualBaselineRunGroup,
+  buildId: string,
+  kibanaInstallDir: string
+): CompletedCompareRun => {
+  const runId = `vrt-pr-${buildId}-${group.runIdSuffix}`;
+  let exitCode = 0;
+
+  console.log(
+    `--- Running VRT compare for ${group.target.location}/${group.target.arch}/${group.target.domain}`
+  );
+
+  for (const selection of group.selections) {
+    const nextExitCode = runNodeScriptWithExitCode(
+      path.join(REPO_ROOT, 'scripts', 'scout_vrt'),
+      [
+        'run-tests',
+        '--compare-baselines',
+        '--location',
+        group.target.location,
+        '--arch',
+        group.target.arch,
+        '--domain',
+        group.target.domain,
+        '--config',
+        selection.configPath,
+        '--kibanaInstallDir',
+        kibanaInstallDir,
+      ],
+      {
+        TEST_RUN_ID: runId,
+      }
+    );
+
+    if (nextExitCode !== 0 && exitCode === 0) {
+      exitCode = nextExitCode;
+    }
+  }
+
+  return {
+    exitCode,
+    runId,
+    runManifest: readRunManifestIfPresent(runId),
+  };
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+
+const copyFileIfPresent = (sourcePath: string, destinationPath: string): string | undefined => {
+  if (!fs.existsSync(sourcePath)) {
+    return undefined;
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(sourcePath, destinationPath);
+  return destinationPath;
+};
+
+const writeReviewSite = (runReports: PrVrtRunReport[], reportUrl: string): string => {
+  const siteRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kibana-vrt-pr-site-'));
+  const sections: string[] = [];
+  const summary = summarizePrVrtRuns(runReports);
+
+  for (const runReport of runReports) {
+    const runManifest = runReport.runManifest;
+    const runJsonDir = path.join(siteRoot, 'json', runManifest.runId);
+    fs.mkdirSync(runJsonDir, { recursive: true });
+    fs.writeFileSync(path.join(runJsonDir, 'manifest.json'), JSON.stringify(runManifest, null, 2));
+
+    const packageSections = runManifest.packages.map((pkg) => {
+      const packageManifest = readJsonFile<VisualRegressionManifest>(
+        getPackageManifestPath(runManifest.runId, pkg.packageId)
+      );
+      const packageJsonDir = path.join(runJsonDir, pkg.packageId);
+      fs.mkdirSync(packageJsonDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageJsonDir, 'manifest.json'),
+        JSON.stringify(packageManifest, null, 2)
+      );
+
+      const checkpointRows = packageManifest.results
+        .map((result) => {
+          const baselineRelativePath = path.join('assets', 'baseline', result.imagePath);
+          const actualRelativePath = path.join(
+            'assets',
+            'actual',
+            runManifest.runId,
+            result.imagePath
+          );
+          const diffRelativePath = result.diffPath
+            ? path.join('assets', 'diff', runManifest.runId, result.diffPath)
+            : undefined;
+
+          copyFileIfPresent(
+            path.join(LOCAL_BASELINES_ROOT, result.imagePath),
+            path.join(siteRoot, baselineRelativePath)
+          );
+          copyFileIfPresent(
+            path.join(LOCAL_VRT_RUNS_ROOT, runManifest.runId, 'test-artifacts', result.imagePath),
+            path.join(siteRoot, actualRelativePath)
+          );
+          const copiedDiffPath = diffRelativePath
+            ? copyFileIfPresent(
+                path.join(
+                  LOCAL_VRT_RUNS_ROOT,
+                  runManifest.runId,
+                  'test-artifacts',
+                  result.diffPath!
+                ),
+                path.join(siteRoot, diffRelativePath)
+              )
+            : undefined;
+
+          const mismatchText =
+            result.mismatchPercent === undefined ? '' : `${result.mismatchPercent.toFixed(2)}%`;
+
+          return `
+            <tr>
+              <td><code>${escapeHtml(result.testTitle)}</code><br /><small>${escapeHtml(
+            result.stepTitle
+          )}</small></td>
+              <td><strong>${escapeHtml(result.status)}</strong><br /><small>${escapeHtml(
+            mismatchText
+          )}</small></td>
+              <td>${
+                fs.existsSync(path.join(siteRoot, baselineRelativePath))
+                  ? `<img src="${baselineRelativePath}" alt="baseline" loading="lazy" />`
+                  : '<span>missing</span>'
+              }</td>
+              <td><img src="${actualRelativePath}" alt="actual" loading="lazy" /></td>
+              <td>${
+                copiedDiffPath
+                  ? `<img src="${diffRelativePath}" alt="diff" loading="lazy" />`
+                  : '<span>-</span>'
+              }</td>
+            </tr>
+          `;
+        })
+        .join('\n');
+
+      return `
+        <section class="package">
+          <h3>${escapeHtml(pkg.packageId)}</h3>
+          <p>
+            Status: <strong>${escapeHtml(pkg.status)}</strong> · Browser: <code>${escapeHtml(
+        pkg.browser
+      )}</code> ·
+            <a href="./json/${runManifest.runId}/${
+        pkg.packageId
+      }/manifest.json">package manifest</a>
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Checkpoint</th>
+                <th>Status</th>
+                <th>Baseline</th>
+                <th>Actual</th>
+                <th>Diff</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${checkpointRows}
+            </tbody>
+          </table>
+        </section>
+      `;
+    });
+
+    sections.push(`
+      <section class="run">
+        <h2>${escapeHtml(
+          `${runManifest.target.location}/${runManifest.target.arch}/${runManifest.target.domain}`
+        )}</h2>
+        <p>
+          Status: <strong>${escapeHtml(runReport.status)}</strong> ·
+          <a href="./json/${runManifest.runId}/manifest.json">run manifest</a>
+        </p>
+        ${packageSections.join('\n')}
+      </section>
+    `);
+  }
+
+  fs.writeFileSync(
+    path.join(siteRoot, 'index.json'),
+    JSON.stringify(
+      {
+        summary,
+        reportUrl,
+        runs: runReports.map(({ runManifest, status }) => ({
+          runId: runManifest.runId,
+          status,
+          target: runManifest.target,
+          summary: runManifest.summary,
+          packages: runManifest.packages.map(({ packageId, status: packageStatus }) => ({
+            packageId,
+            status: packageStatus,
+          })),
+        })),
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(siteRoot, 'index.html'),
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kibana VRT Review</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f6f2e8;
+        --panel: #fffdfa;
+        --ink: #1e1b16;
+        --muted: #5c5448;
+        --accent: #005f73;
+        --border: #d8cfc0;
+      }
+      body {
+        margin: 0;
+        padding: 32px;
+        font: 16px/1.5 Georgia, 'Times New Roman', serif;
+        color: var(--ink);
+        background: radial-gradient(circle at top left, #fff8ea, var(--bg));
+      }
+      a { color: var(--accent); }
+      .shell {
+        max-width: 1440px;
+        margin: 0 auto;
+        padding: 24px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        box-shadow: 0 12px 40px rgba(30, 27, 22, 0.08);
+      }
+      .run, .package {
+        margin-top: 32px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 16px;
+      }
+      th, td {
+        padding: 12px;
+        vertical-align: top;
+        border-top: 1px solid var(--border);
+      }
+      img {
+        max-width: 320px;
+        width: 100%;
+        border: 1px solid var(--border);
+        background: white;
+      }
+      code, small {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+    <body>
+    <main class="shell">
+      <h1>Kibana Visual Regression Review</h1>
+      <p><a href="${reportUrl}">${reportUrl}</a></p>
+      <p>
+        Runs: <strong>${summary.runs}</strong> ·
+        Packages: <strong>${summary.packages}</strong> ·
+        Tests: <strong>${summary.tests}</strong> ·
+        Checkpoints: <strong>${summary.checkpoints}</strong> ·
+        Failed: <strong>${summary.failed}</strong> ·
+        Missing baselines: <strong>${summary.missingBaselines}</strong>
+      </p>
+      ${sections.join('\n')}
+    </main>
+  </body>
+</html>`
+  );
+
+  return siteRoot;
+};
+
+const uploadReviewSite = (siteRoot: string, prNumber: string, buildId: string): string => {
+  const reportUrl = `https://${PR_REPORTS_BUCKET}/${prNumber}/${buildId}/index.html`;
+
+  runGcloudCommands([
+    `cd '${siteRoot}'`,
+    `gcloud storage rsync --recursive --delete-unmatched-destination-objects --cache-control="no-cache, max-age=0, no-transform" --gzip-in-flight=html,json . 'gs://${PR_REPORTS_BUCKET}/${prNumber}/${buildId}/'`,
+  ]);
+
+  return reportUrl;
+};
+
+const annotateAndComment = (runReports: PrVrtRunReport[], reportUrl: string) => {
+  const style = pickPrVrtStyle(runReports);
+  const annotation = createPrVrtAnnotation(runReports, reportUrl);
+
+  execFileSync('buildkite-agent', ['annotate', '--context', 'vrt', '--style', style, annotation], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+
+  execFileSync(
+    'buildkite-agent',
+    ['meta-data', 'set', 'pr_comment:vrt:head', createPrVrtCommentHead(runReports, reportUrl)],
+    { cwd: REPO_ROOT, stdio: 'inherit' }
+  );
+
+  execFileSync(
+    'buildkite-agent',
+    ['meta-data', 'set', 'pr_comment:vrt:body', createPrVrtCommentBody(runReports, reportUrl)],
+    { cwd: REPO_ROOT, stdio: 'inherit' }
+  );
+};
+
+const main = async () => {
+  const buildId = getRequiredEnv('BUILDKITE_BUILD_ID');
+  const kibanaInstallDir = getRequiredEnv('KIBANA_BUILD_LOCATION');
+  const prNumber = getRequiredEnv('GITHUB_PR_NUMBER');
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kibana-vrt-pr-'));
+
+  ensureScoutConfigDiscovery();
+
+  const selections = await cli.discoverAllVisualRunSelections();
+
+  if (selections.length === 0) {
+    console.log('--- No VRT-enabled Scout configs were discovered for this PR');
+    return;
+  }
+
+  const plan = buildMainBaselineRunPlan(selections, readModuleDiscoveryInfo());
+
+  if (plan.length === 0) {
+    console.log('--- No VRT compare plan could be created from Scout config discovery');
+    return;
+  }
+
+  hydrateLatestBaselinesForPlan(plan, downloadLatestCatalog(tempRoot), tempRoot);
+
+  const completedRuns = plan.map((group) =>
+    runTargetCompareGroup(group, buildId, kibanaInstallDir)
+  );
+  const runReports = completedRuns
+    .filter(
+      (
+        completedRun
+      ): completedRun is CompletedCompareRun & { runManifest: VisualRegressionRunManifest } =>
+        completedRun.runManifest !== undefined
+    )
+    .map<PrVrtRunReport>(({ runManifest }) => ({
+      status: runManifest.status,
+      summary: runManifest.summary,
+      runManifest,
+    }));
+
+  if (runReports.length === 0) {
+    throw new Error('VRT compare completed without producing any run manifests');
+  }
+
+  const siteRoot = writeReviewSite(
+    runReports,
+    `https://${PR_REPORTS_BUCKET}/${prNumber}/${buildId}/index.html`
+  );
+  const reportUrl = uploadReviewSite(siteRoot, prNumber, buildId);
+  annotateAndComment(runReports, reportUrl);
+
+  const failedRun = completedRuns.find(({ exitCode }) => exitCode !== 0);
+
+  if (failedRun) {
+    process.exitCode = failedRun.exitCode;
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md
@@ -1,16 +1,17 @@
 # CI Integration for @kbn/scout-vrt
 
-This document covers the second rollout stage: generating and publishing canonical `main` baselines from CI.
+This document covers the second and third rollout stages:
 
-It does not yet cover PR comparison or review-site generation. Those are added in the next stage.
+- generating and publishing canonical `main` baselines from CI
+- hydrating those baselines in PR CI, running compare mode, and publishing review output
 
 ## Reviewer Summary
 
-This stage introduces baseline production, not baseline consumption:
+This stage closes the loop from baseline publication to PR review:
 
 - merged `main` builds generate canonical baselines
-- those baselines are published by commit and through a moving `latest` alias
-- consumers resolve them through a catalog and optional per-bundle archive
+- labeled PRs hydrate those baselines and run compare mode
+- PR output is published as manifests, diff images, and a static review site
 
 ## On-Merge Baseline Publisher
 
@@ -102,8 +103,54 @@ Expected result:
 - a top-level `index.json`
 - one `tar.gz` archive per bundle
 
+## PR Compare Flow
+
+The PR compare job lives in Kibana's pull-request pipeline and is opt-in by label:
+
+- PR label:
+  - `ci:vrt`
+- pipeline file:
+  - `.buildkite/pipelines/pull_request/vrt.yml`
+- label gate:
+  - `.buildkite/scripts/pipelines/pull_request/pipeline.ts`
+- compare entrypoint:
+  - `.buildkite/scripts/steps/scout_vrt/run_pr_vrt_compare.sh`
+
+That step:
+
+1. reads `gs://ci-artifacts.kibana.dev/vrt/baselines/main/latest/index.json`
+2. resolves the matching bundle for the PR target
+3. downloads the bundle archive when `archivePath` is available
+4. falls back to syncing the expanded bundle directory when it is not
+5. hydrates `.scout/baselines/vrt/...`
+6. runs `node scripts/scout_vrt run-tests --compare-baselines`
+7. publishes a static review site and CI summary output
+
+## PR Outputs
+
+A successful labeled PR run produces:
+
+- raw run artifacts under the normal Scout artifact upload paths
+- compare-mode manifests with `passed`, `failed`, and `missing-baseline` checkpoint states
+- diff PNGs for mismatched checkpoints
+- a static review site rooted at:
+  - `https://ci-artifacts.kibana.dev/vrt/pr/<pr-number>/<build-id>/index.html`
+
+The PR compare job is read-only with respect to baselines. It never blesses or mutates the published `main` baseline store.
+
+## Demo And Validation Notes
+
+To demo the full flow without merging to `main`:
+
+1. seed the remote baseline catalog and bundles with the publisher
+2. open a PR from the compare/reporting branch
+3. add the `ci:vrt` label
+4. confirm hydration, compare output, and review-site publication
+5. rerun once without code changes to validate idempotence
+
 ## Operational Notes
 
 - `latest/` is synchronized with deletion, so it remains a snapshot of the newest canonical baseline set rather than accumulating stale bundles.
 - The archive path is an optimization for transfer and hydration. The expanded bundle layout remains the canonical browser-readable form.
 - Baseline selection by commit or branch remains a CI concern. The runtime only knows how to write local baselines and emit manifests.
+- PR compare hydration prefers the archive path so one bundle can be downloaded quickly without listing or transferring every object individually.

--- a/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md
@@ -1,13 +1,14 @@
 # Getting Started with @kbn/scout-vrt
 
-This guide covers the first two rollout stages:
+This guide covers the first three rollout stages:
 
 1. author a visual Scout suite
 2. run VRT capture locally
 3. generate local baselines
-4. inspect the resulting artifacts and manifests
+4. compare against hydrated baselines
+5. inspect the resulting artifacts and manifests
 
-This guide is still intentionally local-first. PR comparison and review-site reporting are introduced in the next stage.
+This guide focuses on the local runtime loop. CI publishing and PR reporting are documented separately.
 
 ## 1. Opt a Scout Suite into VRT
 
@@ -105,7 +106,35 @@ That writes baseline PNGs to:
 
 The run manifest for that execution will record `mode: "update-baselines"`, and each checkpoint record will use `status: "updated"`.
 
-## 5. Inspect the Output
+## 5. Compare Against Baselines
+
+Use `--compare-baselines` when the local baseline cache has already been seeded and you want to compare the current screenshots against it.
+
+Example:
+
+```bash
+node scripts/scout_vrt run-tests \
+  --location local \
+  --arch stateful \
+  --domain classic \
+  --config src/platform/plugins/private/advanced_settings/test/scout/ui/playwright.config.ts \
+  --compare-baselines
+```
+
+Expected checkpoint outcomes:
+
+- no change:
+  - `status: "passed"`
+- visual diff:
+  - `status: "failed"`
+  - `diffPath`
+  - `mismatchPercent`
+- missing local baseline:
+  - `status: "missing-baseline"`
+
+Compare mode never updates the local baseline cache. It only reads from `.scout/baselines/vrt/...` and writes actual and diff artifacts under the run output tree.
+
+## 6. Inspect the Output
 
 After a run, inspect:
 
@@ -125,12 +154,13 @@ The run manifest tells you:
 
 The package manifest tells you:
 
-- which checkpoints were captured or updated
+- which checkpoints were captured, updated, passed, failed, or missing a baseline
 - their stable `testKey`
 - their shared `imagePath`
+- any `diffPath` and `mismatchPercent` values from compare mode
 - the source file and line that created the checkpoint
 
-## 6. Publish Canonical `main` Baselines
+## 7. Publish Canonical `main` Baselines
 
 Publishing to remote storage is intentionally handled by CI, not by the local runtime. The on-merge baseline publisher reruns the same baseline-update mode on merged `main`, then packages and uploads the resulting baselines plus manifests.
 
@@ -140,7 +170,18 @@ See [CI_INTEGRATION.md](CI_INTEGRATION.md) for:
 - the published GCS layout
 - manual seeding instructions for a branch or demo environment
 
-## 7. Recommended Validation
+## 8. Run PR Compare In CI
+
+PR comparison is also handled by CI. A labeled PR run hydrates the latest published `main` baseline bundle, runs compare mode, and publishes a static review site.
+
+See [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md) for:
+
+- the `ci:vrt` PR trigger
+- archive-first baseline hydration
+- review-site publishing
+- expected PR outputs
+
+## 9. Recommended Validation
 
 Before handing work off or pushing a branch:
 
@@ -150,9 +191,8 @@ yarn test:type_check --project src/platform/packages/shared/kbn-scout-vrt/tsconf
 node scripts/check_changes.ts
 ```
 
-## 8. What Comes Next
+## 10. What Comes Next
 
 Later rollout stages add:
 
-- PR comparison against published baselines
-- static review-site generation
+- release-drift reporting against the last serverless release baseline

--- a/src/platform/packages/shared/kbn-scout-vrt/README.md
+++ b/src/platform/packages/shared/kbn-scout-vrt/README.md
@@ -4,17 +4,17 @@
 
 ## Reviewer Summary
 
-This stage extends the foundation with baseline production and publication:
+This stage extends baseline publication into a full PR review loop:
 
-- local runs can write baselines with `--update-baselines`
-- CI can publish canonical `main` baselines keyed by commit
-- consumers can resolve the latest published baseline set through `index.json`
+- local runs can compare against a seeded baseline cache with `--compare-baselines`
+- PR CI hydrates baselines from the published `main` catalog
+- labeled PRs publish a static review site with baseline, actual, and diff assets
 
-This stage still does not define:
+This stage does not add:
 
-- PR compare/reporting workflows
-- PR-side baseline hydration
-- approval flows
+- baseline mutation from PRs
+- approvals or write-back flows
+- release-drift reporting
 
 ## What You Use
 
@@ -23,7 +23,7 @@ This stage still does not define:
 - `createPlaywrightConfig`
   - a Playwright config wrapper that enables VRT artifact/report generation
 - `node scripts/scout_vrt run-tests`
-  - a helper CLI that discovers only VRT-enabled Scout suites and runs them in capture or baseline-update mode
+  - a helper CLI that discovers only VRT-enabled Scout suites and runs them in capture, baseline-update, or compare mode
 
 ## What The Runtime Produces
 
@@ -38,6 +38,10 @@ Run artifacts are written under:
 Local baselines are written under:
 
 - `.scout/baselines/vrt/<packageId>/<testKey>/<stepKey>.png`
+
+Compare-mode diff images are written alongside actuals as:
+
+- `.scout/test-artifacts/vrt/<runId>/test-artifacts/<packageId>/<testKey>/<stepKey>-diff.png`
 
 The package keeps the contract stable by writing:
 
@@ -68,6 +72,17 @@ Each bundle contains:
 
 A top-level `index.json` catalogs the published bundles for downstream consumers. Each catalog entry also advertises a sibling bundle archive at `<bundle>.tar.gz`, so CI and local tooling can download one file per baseline bundle instead of recursively transferring the full expanded directory.
 
+## PR Compare And Reporting
+
+PR compare runs hydrate the local baseline cache from the published `main` baseline catalog, then execute compare mode without mutating the baseline store.
+
+The compare/reporting flow is opt-in in PR CI and is responsible for:
+
+- hydrating `.scout/baselines/vrt/...` from the latest published bundle for the requested target
+- preferring the published bundle archive for hydration, with expanded-directory fallback
+- running compare mode and producing `passed`, `failed`, and `missing-baseline` checkpoint states
+- publishing a static review site for baseline, actual, and diff inspection
+
 For the CI details, see [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md).
 
 ## Public Contract
@@ -84,8 +99,10 @@ Stable downstream fields in `VisualCheckpointRecord`:
 - `testFile`, `testTitle`, `testKey`
 - `stepTitle`, `stepIndex`, `snapshotName`
 - `status`
-  - in this stage: `captured` or `updated`
+  - in this stage: `captured`, `updated`, `passed`, `failed`, or `missing-baseline`
 - `imagePath`
+- optional `diffPath`
+- optional `mismatchPercent`
 - `source.file`, `source.line`, `source.column`
 
 ## Scope
@@ -96,10 +113,10 @@ The package is intentionally limited to:
 - viewport screenshots
 - local artifact generation
 - main-baseline publication
-- no PR compare/reporting workflow yet
+- PR compare/reporting against hydrated baselines
 - no approval workflow
 
-## Next Docs
+## Docs
 
-- See [GETTING_STARTED.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md) for local authoring, capture, and baseline generation.
-- See [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md) for on-merge baseline publication and manual seeding.
+- See [GETTING_STARTED.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/GETTING_STARTED.md) for local authoring, capture, baseline generation, and compare mode.
+- See [CI_INTEGRATION.md](/Users/clint/Projects/kibana.worktrees/scout-vrt/src/platform/packages/shared/kbn-scout-vrt/CI_INTEGRATION.md) for baseline publication, PR hydration, and reporting.

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/arg_parsing.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/arg_parsing.ts
@@ -16,6 +16,7 @@ export interface ParsedVisualRunTestsArgs {
   forwardedArgs: string[];
   helpRequested: boolean;
   testFilesList?: string;
+  compareBaselines: boolean;
   updateBaselines: boolean;
 }
 
@@ -31,6 +32,7 @@ export const parseVisualRunTestsArgs = (rawArgs: string[]): ParsedVisualRunTests
   const forwardedArgs: string[] = [];
   let configPath: string | undefined;
   let testFilesList: string | undefined;
+  let compareBaselines = false;
   let helpRequested = false;
   let updateBaselines = false;
 
@@ -55,6 +57,22 @@ export const parseVisualRunTestsArgs = (rawArgs: string[]): ParsedVisualRunTests
       }
 
       updateBaselines = true;
+      continue;
+    }
+
+    if (arg === '--compare-baselines') {
+      compareBaselines = true;
+      continue;
+    }
+
+    if (arg.startsWith('--compare-baselines=')) {
+      const rawValue = arg.slice('--compare-baselines='.length).trim().toLowerCase();
+
+      if (!['1', 'true', 'yes'].includes(rawValue)) {
+        throw createFlagError(`'--compare-baselines' does not take a value of '${rawValue}'`);
+      }
+
+      compareBaselines = true;
       continue;
     }
 
@@ -101,7 +119,14 @@ export const parseVisualRunTestsArgs = (rawArgs: string[]): ParsedVisualRunTests
     throw createFlagError(`Cannot use both '--config' and '--testFiles' at the same time`);
   }
 
+  if (!helpRequested && compareBaselines && updateBaselines) {
+    throw createFlagError(
+      `Cannot use both '--compare-baselines' and '--update-baselines' at the same time`
+    );
+  }
+
   return {
+    compareBaselines,
     configPath,
     forwardedArgs,
     helpRequested,

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/index.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/index.ts
@@ -30,7 +30,8 @@ Usage:
   node scripts/scout_vrt run-tests
   node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path>
   node scripts/scout_vrt run-tests --arch stateful --domain classic --testFiles <spec_path_or_directory>
-  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --update-baselines`;
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --update-baselines
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --compare-baselines`;
 
 const shouldPrintHelp = (command: string | undefined, args: string[]): boolean =>
   command === undefined ||

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.test.ts
@@ -35,6 +35,7 @@ describe('parseVisualRunTestsArgs', () => {
     expect(
       parseVisualRunTestsArgs(['--arch', 'stateful', '--domain=classic', '--update-baselines'])
     ).toEqual({
+      compareBaselines: false,
       configPath: undefined,
       forwardedArgs: ['--arch', 'stateful', '--domain=classic'],
       helpRequested: false,
@@ -53,6 +54,7 @@ describe('parseVisualRunTestsArgs', () => {
         'src/plugin/test/scout/ui/playwright.config.ts',
       ])
     ).toEqual({
+      compareBaselines: false,
       configPath: 'src/plugin/test/scout/ui/playwright.config.ts',
       forwardedArgs: ['--arch', 'stateful', '--domain=classic'],
       helpRequested: false,
@@ -73,10 +75,32 @@ describe('parseVisualRunTestsArgs', () => {
         '--testFiles=src/plugin/test/scout/ui/tests/example.spec.ts',
       ])
     ).toEqual({
+      compareBaselines: false,
       configPath: undefined,
       forwardedArgs: ['--location', 'cloud', '--arch', 'stateful', '--domain', 'classic'],
       helpRequested: false,
       testFilesList: 'src/plugin/test/scout/ui/tests/example.spec.ts',
+      updateBaselines: false,
+    });
+  });
+
+  it('parses compare-based runs', () => {
+    expect(
+      parseVisualRunTestsArgs([
+        '--arch',
+        'stateful',
+        '--domain',
+        'classic',
+        '--compare-baselines',
+        '--config',
+        'src/plugin/test/scout/ui/playwright.config.ts',
+      ])
+    ).toEqual({
+      compareBaselines: true,
+      configPath: 'src/plugin/test/scout/ui/playwright.config.ts',
+      forwardedArgs: ['--arch', 'stateful', '--domain', 'classic'],
+      helpRequested: false,
+      testFilesList: undefined,
       updateBaselines: false,
     });
   });
@@ -90,6 +114,17 @@ describe('parseVisualRunTestsArgs', () => {
         'src/plugin/test/scout/ui/tests/example.spec.ts',
       ])
     ).toThrow(`Cannot use both '--config' and '--testFiles' at the same time`);
+  });
+
+  it('rejects combining compare and update mode', () => {
+    expect(() =>
+      parseVisualRunTestsArgs([
+        '--compare-baselines',
+        '--update-baselines',
+        '--config',
+        'src/plugin/test/scout/ui/playwright.config.ts',
+      ])
+    ).toThrow(`Cannot use both '--compare-baselines' and '--update-baselines' at the same time`);
   });
 });
 

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/run_tests.ts
@@ -63,9 +63,11 @@ Usage:
   node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path>
   node scripts/scout_vrt run-tests --arch stateful --domain classic --testFiles <spec_path_or_directory>
   node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --update-baselines
+  node scripts/scout_vrt run-tests --arch stateful --domain classic --config <playwright_config_path> --compare-baselines
 
 Options:
   --update-baselines  Refresh the local baseline cache for the selected visual suites
+  --compare-baselines Compare against the local baseline cache and fail on missing or mismatched baselines
 
 All other flags are forwarded to 'node scripts/scout run-tests'.
 Visual specs are discovered by following each spec's local imports until a dependency on '@kbn/scout-vrt' is found.

--- a/src/platform/packages/shared/kbn-scout-vrt/src/cli/scout_runner.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/cli/scout_runner.ts
@@ -13,6 +13,7 @@ import { createFailError } from '@kbn/dev-cli-errors';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { generateTestRunId } from '@kbn/scout-reporting';
 import {
+  SCOUT_VISUAL_REGRESSION_COMPARE_BASELINES_ENV,
   ensureVisualRegressionRunId,
   SCOUT_VISUAL_REGRESSION_ENABLED_ENV,
   SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV,
@@ -33,6 +34,7 @@ const createVisualRunEnvironment = (
   return {
     TEST_RUN_ID: runId,
     [SCOUT_VISUAL_REGRESSION_ENABLED_ENV]: 'true',
+    [SCOUT_VISUAL_REGRESSION_COMPARE_BASELINES_ENV]: String(parsedArgs.compareBaselines),
     [SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV]: String(parsedArgs.updateBaselines),
   };
 };

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.test.ts
@@ -70,7 +70,7 @@ describe('createVisualRegressionManifest', () => {
           stepTitle: 'step 1',
           stepIndex: 1,
           snapshotName: '01_step_1.png',
-          status: 'captured',
+          status: 'passed',
           imagePath: 'pkg/first-test-local/01_step_1.png',
           source: {
             file: 'a.spec.ts',
@@ -85,8 +85,9 @@ describe('createVisualRegressionManifest', () => {
           stepTitle: 'step 2',
           stepIndex: 2,
           snapshotName: '02_step_2.png',
-          status: 'captured',
+          status: 'failed',
           imagePath: 'pkg/first-test-local/02_step_2.png',
+          diffPath: 'pkg/first-test-local/02_step_2-diff.png',
           source: {
             file: 'a.spec.ts',
             line: 20,
@@ -129,8 +130,12 @@ describe('createVisualRegressionManifest', () => {
     expect(summarizeVisualRegressionManifest(manifest)).toEqual({
       tests: 2,
       checkpoints: 4,
-      captured: 2,
+      passed: 1,
+      failed: 1,
+      captured: 0,
       updated: 2,
+      missingBaselines: 0,
+      diffs: 1,
     });
   });
 
@@ -180,8 +185,9 @@ describe('createVisualRegressionManifest', () => {
             stepTitle: 'step 1',
             stepIndex: 1,
             snapshotName: '01_step_1.png',
-            status: 'captured',
+            status: 'failed',
             imagePath: 'customBranding/branding-test-local/01_step_1.png',
+            diffPath: 'customBranding/branding-test-local/01_step_1-diff.png',
             source: {
               file: 'c.spec.ts',
               line: 40,
@@ -191,7 +197,7 @@ describe('createVisualRegressionManifest', () => {
         ],
       }),
       packageStatus: 'failed',
-      mode: 'capture',
+      mode: 'compare',
       startedAt: '2026-03-20T18:01:00.000Z',
       completedAt: '2026-03-20T18:01:15.000Z',
     });
@@ -200,7 +206,7 @@ describe('createVisualRegressionManifest', () => {
       schemaVersion: 1,
       runId: 'run-id',
       status: 'failed',
-      mode: 'capture',
+      mode: 'compare',
       startedAt: '2026-03-20T18:00:00.000Z',
       completedAt: '2026-03-20T18:01:15.000Z',
       durationMs: 75000,
@@ -230,8 +236,12 @@ describe('createVisualRegressionManifest', () => {
       summary: {
         tests: 2,
         checkpoints: 2,
-        captured: 1,
+        passed: 0,
+        failed: 1,
+        captured: 0,
         updated: 1,
+        missingBaselines: 0,
+        diffs: 1,
       },
       packages: [
         {
@@ -250,8 +260,12 @@ describe('createVisualRegressionManifest', () => {
           summary: {
             tests: 1,
             checkpoints: 1,
+            passed: 0,
+            failed: 0,
             captured: 0,
             updated: 1,
+            missingBaselines: 0,
+            diffs: 0,
           },
         },
         {
@@ -270,8 +284,12 @@ describe('createVisualRegressionManifest', () => {
           summary: {
             tests: 1,
             checkpoints: 1,
-            captured: 1,
+            passed: 0,
+            failed: 1,
+            captured: 0,
             updated: 0,
+            missingBaselines: 0,
+            diffs: 1,
           },
         },
       ],

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/manifest.ts
@@ -43,11 +43,15 @@ export type VisualRegressionManifestSeed = Omit<
 export interface VisualRegressionManifestSummary {
   tests: number;
   checkpoints: number;
+  passed: number;
+  failed: number;
   captured: number;
   updated: number;
+  missingBaselines: number;
+  diffs: number;
 }
 
-export type VisualRegressionRunMode = 'capture' | 'update-baselines';
+export type VisualRegressionRunMode = 'capture' | 'compare' | 'update-baselines';
 export type VisualRegressionRunStatus = 'passed' | 'failed' | 'timedout' | 'interrupted';
 
 export interface VisualRegressionRunManifestPackage {
@@ -111,8 +115,12 @@ export const createVisualRegressionManifest = (
 const createEmptySummary = (): VisualRegressionManifestSummary => ({
   tests: 0,
   checkpoints: 0,
+  passed: 0,
+  failed: 0,
   captured: 0,
   updated: 0,
+  missingBaselines: 0,
+  diffs: 0,
 });
 
 const getDurationMs = (startedAt: string, completedAt: string): number => {
@@ -154,14 +162,26 @@ export const summarizeVisualRegressionManifest = (
     summary.checkpoints += 1;
 
     switch (result.status) {
+      case 'passed':
+        summary.passed += 1;
+        break;
+      case 'failed':
+        summary.failed += 1;
+        break;
       case 'captured':
         summary.captured += 1;
         break;
       case 'updated':
         summary.updated += 1;
         break;
+      case 'missing-baseline':
+        summary.missingBaselines += 1;
+        break;
     }
 
+    if (result.diffPath) {
+      summary.diffs += 1;
+    }
   }
 
   summary.tests = tests.size;
@@ -196,8 +216,12 @@ const summarizeRunPackages = (
     (summary, currentPackage) => ({
       tests: summary.tests + currentPackage.summary.tests,
       checkpoints: summary.checkpoints + currentPackage.summary.checkpoints,
+      passed: summary.passed + currentPackage.summary.passed,
+      failed: summary.failed + currentPackage.summary.failed,
       captured: summary.captured + currentPackage.summary.captured,
       updated: summary.updated + currentPackage.summary.updated,
+      missingBaselines: summary.missingBaselines + currentPackage.summary.missingBaselines,
+      diffs: summary.diffs + currentPackage.summary.diffs,
     }),
     createEmptySummary()
   );

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/visual_regression_reporter.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/reporting/visual_regression_reporter.ts
@@ -25,6 +25,7 @@ import {
   upsertVisualRegressionRunManifest,
 } from './manifest';
 import {
+  isCompareBaselinesEnabled,
   SCOUT_VISUAL_REGRESSION_ATTACHMENT_NAME,
   isUpdateBaselinesEnabled,
 } from '../runtime/environment';
@@ -149,7 +150,11 @@ export class ScoutVisualRegressionReporter implements Reporter {
       existing: existingRunManifest,
       manifest: this.manifest,
       packageStatus: _result.status,
-      mode: isUpdateBaselinesEnabled() ? 'update-baselines' : 'capture',
+      mode: isUpdateBaselinesEnabled()
+        ? 'update-baselines'
+        : isCompareBaselinesEnabled()
+        ? 'compare'
+        : 'capture',
       startedAt: this.startedAt ?? completedAt,
       completedAt,
     });

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.test.ts
@@ -11,14 +11,21 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { Page, TestInfo } from 'playwright/test';
+import { compareImages } from './compare_images';
 import { captureVisualCheckpoint } from './checkpoint_capture';
 import type { VisualRegressionContext } from './types';
 
 let mockTempRoot = '';
+let mockCompareBaselinesEnabled = false;
 let mockUpdateBaselinesEnabled = false;
 
 jest.mock('./environment', () => ({
+  isCompareBaselinesEnabled: () => mockCompareBaselinesEnabled,
   isUpdateBaselinesEnabled: () => mockUpdateBaselinesEnabled,
+}));
+
+jest.mock('./compare_images', () => ({
+  compareImages: jest.fn(),
 }));
 
 jest.mock('./paths', () => {
@@ -42,6 +49,17 @@ jest.mock('./paths', () => {
       ),
     getVisualRegressionBaselinePath: (packageId: string, testKey: string, snapshotName: string) =>
       nodePath.join(mockTempRoot, 'baselines', packageId, testKey, snapshotName),
+    getVisualRegressionDiffPath: (
+      runId: string,
+      packageId: string,
+      testKey: string,
+      snapshotName: string
+    ) =>
+      nodePath
+        .join(mockTempRoot, 'runs', runId, 'test-artifacts', packageId, testKey, snapshotName)
+        .replace(/\.png$/, '-diff.png'),
+    getVisualRegressionDiffImagePath: (packageId: string, testKey: string, snapshotName: string) =>
+      nodePath.join(packageId, testKey, snapshotName.replace(/\.png$/, '-diff.png')),
     getVisualRegressionImagePath: (packageId: string, testKey: string, snapshotName: string) =>
       nodePath.join(packageId, testKey, snapshotName),
     toRepoRelativePath: (filePath: string) =>
@@ -50,12 +68,15 @@ jest.mock('./paths', () => {
 });
 
 describe('captureVisualCheckpoint', () => {
+  const mockedCompareImages = jest.mocked(compareImages);
   const screenshotBuffer = Buffer.from('fake-image-buffer');
   let page: jest.Mocked<Page>;
   let context: VisualRegressionContext;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockTempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scout-vrt-checkpoint-'));
+    mockCompareBaselinesEnabled = false;
     mockUpdateBaselinesEnabled = false;
 
     page = {
@@ -115,6 +136,30 @@ describe('captureVisualCheckpoint', () => {
     ).toEqual(screenshotBuffer);
   });
 
+  it('warns and fails when a baseline is missing in compare mode', async () => {
+    mockCompareBaselinesEnabled = true;
+    const warnSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const result = await captureVisualCheckpoint(context, {
+      stepTitle: 'advanced settings page is visible',
+      stepIndex: 1,
+      mask: [],
+      source: {
+        file: 'src/plugin/test.scout.spec.ts',
+        line: 20,
+        column: 4,
+      },
+    });
+
+    expect(result.record.status).toBe('missing-baseline');
+    expect(result.error?.message).toContain('Missing visual baseline');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing visual baseline for 'advancedSettings")
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('captures the actual image into the run artifact tree', async () => {
     const result = await captureVisualCheckpoint(context, {
       stepTitle: 'advanced settings page is visible',
@@ -149,5 +194,82 @@ describe('captureVisualCheckpoint', () => {
         )
       )
     ).toBe(true);
+  });
+
+  it('compares the captured image against the cached baseline', async () => {
+    mockCompareBaselinesEnabled = true;
+    const baselinePath = path.join(
+      mockTempRoot,
+      'baselines',
+      'advancedSettings',
+      'renders-useful-state-local',
+      '01_advanced_settings_page_is_visible.png'
+    );
+
+    fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+    fs.writeFileSync(baselinePath, Buffer.from('baseline-image-buffer'));
+    mockedCompareImages.mockResolvedValue({
+      dimensionMismatch: false,
+      mismatchRatio: 0,
+    });
+
+    const result = await captureVisualCheckpoint(context, {
+      stepTitle: 'advanced settings page is visible',
+      stepIndex: 1,
+      mask: [],
+      source: {
+        file: 'src/plugin/test.scout.spec.ts',
+        line: 20,
+        column: 4,
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.record.status).toBe('passed');
+    expect(mockedCompareImages).toHaveBeenCalledWith({
+      actualBuffer: screenshotBuffer,
+      baselineBuffer: Buffer.from('baseline-image-buffer'),
+      diffPath: path.join(
+        mockTempRoot,
+        'runs',
+        'run-id',
+        'test-artifacts',
+        'advancedSettings',
+        'renders-useful-state-local',
+        '01_advanced_settings_page_is_visible-diff.png'
+      ),
+    });
+  });
+
+  it('stores mismatchPercent as a percent value', async () => {
+    mockCompareBaselinesEnabled = true;
+    const baselinePath = path.join(
+      mockTempRoot,
+      'baselines',
+      'advancedSettings',
+      'renders-useful-state-local',
+      '01_advanced_settings_page_is_visible.png'
+    );
+
+    fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+    fs.writeFileSync(baselinePath, Buffer.from('baseline-image-buffer'));
+    mockedCompareImages.mockResolvedValue({
+      dimensionMismatch: false,
+      mismatchRatio: 0.01234,
+    });
+
+    const result = await captureVisualCheckpoint(context, {
+      stepTitle: 'advanced settings page is visible',
+      stepIndex: 1,
+      mask: [],
+      source: {
+        file: 'src/plugin/test.scout.spec.ts',
+        line: 20,
+        column: 4,
+      },
+    });
+
+    expect(result.record.status).toBe('failed');
+    expect(result.record.mismatchPercent).toBe(1.23);
   });
 });

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/checkpoint_capture.ts
@@ -9,10 +9,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { isUpdateBaselinesEnabled } from './environment';
+import { isCompareBaselinesEnabled, isUpdateBaselinesEnabled } from './environment';
+import { compareImages } from './compare_images';
 import {
   getVisualRegressionActualPath,
   getVisualRegressionBaselinePath,
+  getVisualRegressionDiffImagePath,
+  getVisualRegressionDiffPath,
   getVisualRegressionImagePath,
   toRepoRelativePath,
 } from './paths';
@@ -24,6 +27,14 @@ import type {
 } from './types';
 import { waitForVisualStability } from './wait_for_visual_stability';
 
+const createMissingBaselineError = (imagePath: string): Error =>
+  new Error(
+    `Missing visual baseline for '${imagePath}'. Run 'node scripts/scout_vrt run-tests ... --update-baselines' to create it.`
+  );
+
+const toMismatchPercent = (mismatchRatio: number): number =>
+  Math.round(mismatchRatio * 10000) / 100;
+
 export const captureVisualCheckpoint = async (
   context: VisualRegressionContext,
   options: VisualCheckpointCaptureOptions
@@ -33,6 +44,7 @@ export const captureVisualCheckpoint = async (
   const actualOutputPath = getVisualRegressionActualPath(runId, packageId, testKey, snapshotName);
   const imagePath = getVisualRegressionImagePath(packageId, testKey, snapshotName);
   const baselineOutputPath = getVisualRegressionBaselinePath(packageId, testKey, snapshotName);
+  const diffOutputPath = getVisualRegressionDiffPath(runId, packageId, testKey, snapshotName);
 
   fs.mkdirSync(path.dirname(actualOutputPath), { recursive: true });
 
@@ -62,6 +74,75 @@ export const captureVisualCheckpoint = async (
         imagePath,
         source: options.source,
       },
+    };
+  }
+
+  if (isCompareBaselinesEnabled()) {
+    if (!fs.existsSync(baselineOutputPath)) {
+      const error = createMissingBaselineError(imagePath);
+      process.stderr.write(`[scout-vrt] ${error.message}\n`);
+
+      return {
+        record: {
+          testFile: toRepoRelativePath(testInfo.file),
+          testTitle: testInfo.title,
+          testKey,
+          stepTitle: options.stepTitle,
+          stepIndex: options.stepIndex,
+          snapshotName,
+          status: 'missing-baseline',
+          imagePath,
+          source: options.source,
+        },
+        error,
+      };
+    }
+
+    const comparison = await compareImages({
+      actualBuffer,
+      baselineBuffer: fs.readFileSync(baselineOutputPath),
+      diffPath: diffOutputPath,
+    });
+
+    if (!comparison.dimensionMismatch && comparison.mismatchRatio === 0) {
+      return {
+        record: {
+          testFile: toRepoRelativePath(testInfo.file),
+          testTitle: testInfo.title,
+          testKey,
+          stepTitle: options.stepTitle,
+          stepIndex: options.stepIndex,
+          snapshotName,
+          status: 'passed',
+          imagePath,
+          source: options.source,
+        },
+      };
+    }
+
+    const dimensionSuffix = comparison.dimensionMismatch
+      ? ' Screenshot dimensions changed between baseline and actual.'
+      : '';
+    const error = new Error(
+      `Visual regression mismatch for '${imagePath}' (ratio ${comparison.mismatchRatio}).${dimensionSuffix}`
+    );
+
+    return {
+      record: {
+        testFile: toRepoRelativePath(testInfo.file),
+        testTitle: testInfo.title,
+        testKey,
+        stepTitle: options.stepTitle,
+        stepIndex: options.stepIndex,
+        snapshotName,
+        status: 'failed',
+        imagePath,
+        diffPath: getVisualRegressionDiffImagePath(packageId, testKey, snapshotName),
+        mismatchPercent:
+          comparison.mismatchRatio > 0 ? toMismatchPercent(comparison.mismatchRatio) : undefined,
+        source: options.source,
+      },
+      error,
     };
   }
 

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/environment.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/environment.ts
@@ -18,12 +18,17 @@ const booleanFromEnv = (varName: string, defaultValue: boolean = false): boolean
 };
 
 export const SCOUT_VISUAL_REGRESSION_ENABLED_ENV = 'SCOUT_VISUAL_REGRESSION_ENABLED';
+export const SCOUT_VISUAL_REGRESSION_COMPARE_BASELINES_ENV =
+  'SCOUT_VISUAL_REGRESSION_COMPARE_BASELINES';
 export const SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV =
   'SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES';
 export const SCOUT_VISUAL_REGRESSION_ATTACHMENT_NAME = 'scout-vrt-checkpoints';
 
 export const isVisualRegressionEnabled = (): boolean =>
   booleanFromEnv(SCOUT_VISUAL_REGRESSION_ENABLED_ENV);
+
+export const isCompareBaselinesEnabled = (): boolean =>
+  booleanFromEnv(SCOUT_VISUAL_REGRESSION_COMPARE_BASELINES_ENV);
 
 export const isUpdateBaselinesEnabled = (): boolean =>
   booleanFromEnv(SCOUT_VISUAL_REGRESSION_UPDATE_BASELINES_ENV);

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/types.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/runtime/types.ts
@@ -22,8 +22,10 @@ export interface VisualCheckpointRecord {
   stepTitle: string;
   stepIndex: number;
   snapshotName: string;
-  status: 'captured' | 'updated';
+  status: 'captured' | 'updated' | 'passed' | 'failed' | 'missing-baseline';
   imagePath: string;
+  diffPath?: string;
+  mismatchPercent?: number;
   source: VisualSourceLocation;
 }
 

--- a/src/platform/packages/shared/kbn-scout-vrt/src/playwright/test/visual_test.ts
+++ b/src/platform/packages/shared/kbn-scout-vrt/src/playwright/test/visual_test.ts
@@ -154,10 +154,6 @@ const createVisualTest = <T extends typeof visualTestBase>(baseTest: T) => {
             });
 
             context.checkpoints.push(result.record);
-
-            if (result.error) {
-              throw result.error;
-            }
           },
         }),
       stepOptions


### PR DESCRIPTION
## Summary

This PR introduces PR-side comparison and reporting for visual regression testing (VRT) in Kibana.


> [!NOTE]
> This PR is built from the ON-Week PR, https://github.com/elastic/kibana/pull/234343.  The [feedback](https://github.com/elastic/kibana/pull/234343#issuecomment-3411089676) from @elastic/kibana-qa led me to engage AI, specifically `GPT-5.4`, to adapt the approach based on that guidance.

This PR builds directly on the baseline publication work from https://github.com/elastic/kibana/pull/258991 and adds the first review workflow: a labeled PR can now hydrate the latest published `main` baseline for the relevant target, run compare mode, emit compare-aware manifests and diff artifacts, and publish a static review site.

Importantly, this PR keeps PR runs read-only with respect to baselines. A PR can compare against published baselines, but it does not bless, mutate, or promote them.

> [!NOTE]
> This PR intentionally focuses on comparison and reporting. It does not yet replace the temporary Kibana-owned review site with Driftik, and it does not yet add release-drift reporting against the last serverless release baseline.

## What This PR Adds

- `--compare-baselines` for VRT-enabled Scout runs
- PR-side hydration of `.scout/baselines/vrt/...` from the published `main` baseline catalog
- opt-in PR trigger via the `ci:vrt` label
- archive-first baseline hydration with expanded-directory fallback
- compare-mode checkpoint statuses such as `passed`, `failed`, and `missing-baseline`
- diff image generation for mismatched checkpoints
- Buildkite annotations and PR comment metadata for VRT runs
- publication of a temporary Kibana-owned static review site
- docs for PR hydration, comparison, reporting, and the planned Driftik follow-up

## PR Compare Flow

When a PR includes the `ci:vrt` label, CI now:

- downloads the latest published `main` baseline catalog
- resolves the matching bundle for the requested target
- hydrates the local baseline cache
- runs `node scripts/scout_vrt run-tests --compare-baselines`
- preserves compare artifacts and manifests
- publishes a static review site for baseline / actual / diff inspection
- emits Buildkite annotation and PR comment metadata

This keeps the comparison attributable to current `main`, rather than making it cumulative against the last release.

## Baseline Safety

This PR keeps baselines read-only from the PR side:

- PR runs compare against published baselines
- PR runs do not update or bless baselines
- canonical baseline publication remains a merged-`main` responsibility from PR2

## Scope

This PR is limited to:

- PR-side baseline hydration
- compare-mode execution
- CI reporting and review-site publication
- archive-first bundle download for hydration

This PR does not yet include:

- baseline mutation from PRs
- approvals or baseline promotion
- Driftik integration
- release-drift reporting
