### PR TITLE
Change product offering to Elasticsearch from Elastic Search

### DIFF
--- a/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
+++ b/x-pack/platform/plugins/private/product_intercept/public/plugin.ts
@@ -44,7 +44,9 @@ export class ProductInterceptPublicPlugin implements Plugin {
       analytics: core.analytics,
     });
 
-    const productOffering = `Elastic ${capitalize(cloud.serverless.projectType || '')}`.trim();
+    const projectType = cloud.serverless.projectType || '';
+    const productOffering =
+      projectType === 'search' ? 'Elasticsearch' : `Elastic ${capitalize(projectType)}`.trim();
 
     void (async () => {
       const currentUser = await core.security.authc.getCurrentUser();


### PR DESCRIPTION
## Summary

This PR changes the displayed product offering for Elasticsearch to `Elasticsearch` from `Elastic Search` to be consistent with brand guidelines.

Closes: https://github.com/elastic/kibana/issues/255991



<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->