### PR TITLE
[Discover] [ES|QL] Displays an extra chart if the transformational command returns a timefield

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/__mocks__/lens_vis.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/__mocks__/lens_vis.ts
@@ -33,7 +33,6 @@ export const getLensVisMock = async ({
   breakdownField,
   dataView,
   allSuggestions,
-  isTransformationalESQL,
   table,
   externalVisContext,
   getModifiedVisAttributes,
@@ -48,7 +47,6 @@ export const getLensVisMock = async ({
   timeRange?: TimeRange | null;
   breakdownField: DataViewField | undefined;
   allSuggestions?: Suggestion[];
-  isTransformationalESQL?: boolean;
   table?: Datatable;
   externalVisContext?: UnifiedHistogramVisContext;
   getModifiedVisAttributes?: Parameters<LensVisService['update']>[0]['getModifiedVisAttributes'];
@@ -66,12 +64,13 @@ export const getLensVisMock = async ({
           const context = params[0];
           const preferredChartType = params[3];
           onLensSuggestionsApiCall?.(preferredChartType);
+          // Same query object as the test's Discover query → simulate Lens suggestions for the table result.
           if ('query' in context && context.query === query) {
             return allSuggestions;
           }
-          return !isTransformationalESQL && dataView.isTimeBased()
-            ? [histogramESQLSuggestionMock]
-            : [];
+          // Histogram path passes a new `{ esql }` with appended STATS/BUCKET; it never matches `query` above.
+          // Any other time-based follow-up call should return the histogram suggestion mock.
+          return dataView.isTimeBased() ? [histogramESQLSuggestionMock] : [];
         }
       : lensApi.suggestions,
   });

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.test.tsx
@@ -119,7 +119,6 @@ const mountComponent = async (mountProps: MountComponentProps = {}) => {
       breakdownField: fetchParams.breakdown?.field,
       columns: [],
       allSuggestions,
-      isTransformationalESQL,
     })
   ).lensService;
 

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
@@ -10,7 +10,7 @@
 import type { ReactElement } from 'react';
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { IconButtonGroup, type IconButtonGroupProps } from '@kbn/shared-ux-button-toolbar';
-import { EuiDelayRender, EuiProgress, EuiSpacer } from '@elastic/eui';
+import { EuiButtonGroup, EuiDelayRender, EuiProgress, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type {
   EmbeddableComponentProps,
@@ -35,7 +35,11 @@ import type {
   UnifiedHistogramSuggestionContext,
   LensVisServiceState,
 } from '../../types';
-import { UnifiedHistogramFetchStatus, UnifiedHistogramSuggestionType } from '../../types';
+import {
+  EsqlTransformationalChartToggleMode,
+  UnifiedHistogramFetchStatus,
+  UnifiedHistogramSuggestionType,
+} from '../../types';
 import { BreakdownFieldSelector } from './breakdown_field_selector';
 import { TimeIntervalSelector } from './time_interval_selector';
 import { useTotalHits } from './hooks/use_total_hits';
@@ -69,6 +73,7 @@ export interface UnifiedHistogramChartProps {
   onChartHiddenChange?: (chartHidden: boolean) => void;
   onTimeIntervalChange?: (timeInterval: string) => void;
   onBreakdownFieldChange?: (breakdownField: DataViewField | undefined) => void;
+  onEsqlTransformationalChartModeChange?: (mode: EsqlTransformationalChartToggleMode) => void;
   onTotalHitsChange?: (status: UnifiedHistogramFetchStatus, result?: number | Error) => void;
   onChartLoad?: (event: UnifiedHistogramChartLoadEvent) => void;
   onFilter?: LensEmbeddableInput['onFilter'];
@@ -95,6 +100,7 @@ export function UnifiedHistogramChart({
   onChartHiddenChange,
   onTimeIntervalChange,
   onBreakdownFieldChange,
+  onEsqlTransformationalChartModeChange,
   onTotalHitsChange,
   onChartLoad,
   ...histogramProps
@@ -247,9 +253,38 @@ export function UnifiedHistogramChart({
     [chartVisible, toggleHideChart, renderCustomChartToggleActions]
   );
 
+  const esqlTransformationalChartToggle = lensVisServiceState.esqlTransformationalChartToggle;
+
   const toolbarSelectors = useMemo(
     () => [
-      ,
+      chartVisible && esqlTransformationalChartToggle && onEsqlTransformationalChartModeChange ? (
+        <EuiButtonGroup
+          key="esqlChartMode"
+          buttonSize="compressed"
+          data-test-subj="unifiedHistogramEsqlChartMode"
+          legend={i18n.translate('unifiedHistogram.esqlChartModeLegend', {
+            defaultMessage: 'Chart type',
+          })}
+          options={[
+            {
+              id: EsqlTransformationalChartToggleMode.result,
+              label: i18n.translate('unifiedHistogram.esqlResultChart', {
+                defaultMessage: 'Result chart',
+              }),
+            },
+            {
+              id: EsqlTransformationalChartToggleMode.timeDistribution,
+              label: i18n.translate('unifiedHistogram.esqlTimeDistribution', {
+                defaultMessage: 'Time distribution',
+              }),
+            },
+          ]}
+          idSelected={esqlTransformationalChartToggle.activeMode}
+          onChange={(id) =>
+            onEsqlTransformationalChartModeChange(id as EsqlTransformationalChartToggleMode)
+          }
+        />
+      ) : null,
       chartVisible && !isPlainRecord && !!onTimeIntervalChange ? (
         <TimeIntervalSelector chart={chart} onTimeIntervalChange={onTimeIntervalChange} />
       ) : null,
@@ -266,7 +301,9 @@ export function UnifiedHistogramChart({
     ],
     [
       chartVisible,
+      esqlTransformationalChartToggle,
       isPlainRecord,
+      onEsqlTransformationalChartModeChange,
       onTimeIntervalChange,
       chart,
       breakdown,

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_services_bootstrap.ts
@@ -120,6 +120,7 @@ export const useServicesBootstrap = (
             isPlainRecord: nextFetchParams.isESQLQuery,
             columns: nextFetchParams.columns,
             columnsMap: nextFetchParams.columnsMap,
+            esqlTransformationalChartMode: nextFetchParams.esqlTransformationalChartMode,
           },
           timeInterval:
             !nextFetchParams.isTimeBased && !nextFetchParams.isESQLQuery

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
@@ -15,6 +15,7 @@ import type {
   UnifiedHistogramServices,
   UnifiedHistogramVisContext,
   UnifiedHistogramFetchParamsExternal,
+  EsqlTransformationalChartToggleMode,
 } from '../types';
 import { UnifiedHistogramSuggestionType } from '../types';
 import type {
@@ -65,6 +66,10 @@ export type UseUnifiedHistogramProps = Omit<UnifiedHistogramStateOptions, 'servi
     nextVisContext: UnifiedHistogramVisContext | undefined,
     externalVisContextStatus: UnifiedHistogramExternalVisContextStatus
   ) => void;
+  /**
+   * ES|QL transformational chart: switch between Lens result chart and time histogram.
+   */
+  onEsqlTransformationalChartModeChange?: (mode: EsqlTransformationalChartToggleMode) => void;
 };
 
 export type UnifiedHistogramApi = {

--- a/src/platform/packages/shared/kbn-unified-histogram/index.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/index.ts
@@ -13,8 +13,13 @@ export type {
   UnifiedHistogramAdapters,
   UnifiedHistogramVisContext,
   UnifiedHistogramFetchParamsExternal,
+  EsqlTransformationalChartToggleState,
 } from './types';
-export { UnifiedHistogramFetchStatus, UnifiedHistogramExternalVisContextStatus } from './types';
+export {
+  UnifiedHistogramFetchStatus,
+  UnifiedHistogramExternalVisContextStatus,
+  EsqlTransformationalChartToggleMode,
+} from './types';
 
 export {
   UnifiedBreakdownFieldSelector,

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.attributes.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.attributes.test.ts
@@ -832,7 +832,6 @@ describe('LensVisService attributes', () => {
       columns: [],
       isPlainRecord: true,
       allSuggestions: [], // none available
-      isTransformationalESQL: false,
     });
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
   });

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.suggestions.test.ts
@@ -86,7 +86,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: true,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
@@ -115,7 +114,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(
@@ -153,7 +151,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(
@@ -191,7 +188,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(
@@ -229,7 +225,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: true,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
@@ -258,7 +253,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
@@ -287,7 +281,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(UnifiedHistogramSuggestionType.unsupported);
@@ -321,7 +314,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(
@@ -372,7 +364,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: allSuggestionsMock,
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(
@@ -403,7 +394,6 @@ describe('LensVisService suggestions', () => {
       ],
       isPlainRecord: true,
       allSuggestions: [],
-      isTransformationalESQL: false,
     });
 
     expect(lensVis.currentSuggestionContext?.type).toBe(

--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -44,10 +44,12 @@ import type { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common'
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { fieldSupportsBreakdown } from '@kbn/field-utils';
 import type {
+  EsqlTransformationalChartToggleState,
   UnifiedHistogramSuggestionContext,
   UnifiedHistogramVisContext,
   LensVisServiceState,
 } from '../types';
+import { EsqlTransformationalChartToggleMode } from '../types';
 import {
   UnifiedHistogramExternalVisContextStatus,
   UnifiedHistogramSuggestionType,
@@ -104,6 +106,7 @@ export class LensVisService {
         type: UnifiedHistogramSuggestionType.unsupported,
       },
       visContext: undefined,
+      esqlTransformationalChartToggle: undefined,
     };
     this.state$ = new BehaviorSubject<LensVisServiceState>(initialState);
 
@@ -163,6 +166,7 @@ export class LensVisService {
       status: LensVisServiceStatus.completed,
       currentSuggestionContext: suggestionState.currentSuggestionContext,
       visContext: lensAttributesState.visContext,
+      esqlTransformationalChartToggle: suggestionState.esqlTransformationalChartToggle,
     };
 
     this.state$.next(nextState);
@@ -218,9 +222,13 @@ export class LensVisService {
     breakdownField: DataViewField | undefined;
   }): {
     currentSuggestionContext: UnifiedHistogramSuggestionContext;
+    esqlTransformationalChartToggle?: EsqlTransformationalChartToggleState;
   } => {
     let type = UnifiedHistogramSuggestionType.unsupported;
     let currentSuggestion: Suggestion | undefined;
+    let transformationalChartToggleAvailability:
+      | { timeDistributionAvailable: boolean; resultChartAvailable: boolean }
+      | undefined;
 
     const availableSuggestionsWithType: Array<{
       suggestion: UnifiedHistogramSuggestionContext['suggestion'];
@@ -249,17 +257,30 @@ export class LensVisService {
             });
           }
         } else if (hasTransformationalCommand(queryParams.query.esql)) {
-          // appends the first lens suggestion if available
           const allSuggestions = this.getAllSuggestions({
             queryParams,
             preferredVisAttributes: externalVisContext?.attributes,
           });
-
-          if (allSuggestions.length) {
-            availableSuggestionsWithType.push({
-              suggestion: allSuggestions[0],
-              type: UnifiedHistogramSuggestionType.lensSuggestion,
-            });
+          const histogramSuggestionForESQL = this.getTransformationalHistogramSuggestion(
+            queryParams,
+            breakdownField,
+            externalVisContext?.attributes
+          );
+          const effectiveMode = this.resolveEffectiveTransformationalChartMode(
+            queryParams.esqlTransformationalChartMode,
+            allSuggestions.length > 0,
+            Boolean(histogramSuggestionForESQL)
+          );
+          const toggleAvailability = this.appendTransformationalChartSuggestionEntries(
+            availableSuggestionsWithType,
+            {
+              allSuggestions,
+              histogramSuggestion: histogramSuggestionForESQL,
+              effectiveMode,
+            }
+          );
+          if (toggleAvailability) {
+            transformationalChartToggleAvailability = toggleAvailability;
           }
         } else if (hasTimeseriesInfoCommand(queryParams.query.esql)) {
           // skip chart suggestions for info commands
@@ -268,6 +289,7 @@ export class LensVisService {
               type: UnifiedHistogramSuggestionType.unsupported,
               suggestion: undefined,
             },
+            esqlTransformationalChartToggle: undefined,
           };
         } else {
           // appends an ES|QL histogram if available
@@ -333,12 +355,137 @@ export class LensVisService {
       type = availableSuggestionsWithType[0].type;
     }
 
+    const resolvedType = currentSuggestion ? type : UnifiedHistogramSuggestionType.unsupported;
+
+    let esqlTransformationalChartToggle: EsqlTransformationalChartToggleState | undefined;
+    if (
+      transformationalChartToggleAvailability?.timeDistributionAvailable &&
+      transformationalChartToggleAvailability?.resultChartAvailable
+    ) {
+      esqlTransformationalChartToggle = {
+        activeMode:
+          resolvedType === UnifiedHistogramSuggestionType.histogramForESQL
+            ? EsqlTransformationalChartToggleMode.timeDistribution
+            : EsqlTransformationalChartToggleMode.result,
+      };
+    }
+
     return {
       currentSuggestionContext: {
-        type: Boolean(currentSuggestion) ? type : UnifiedHistogramSuggestionType.unsupported,
+        type: resolvedType,
         suggestion: currentSuggestion,
       },
+      esqlTransformationalChartToggle,
     };
+  };
+
+  /**
+   * Time-distribution histogram for transformational ES|QL when the data view time field is still
+   * present in the query result (KEEP/STATS output) as a date column.
+   */
+  private getTransformationalHistogramSuggestion = (
+    queryParams: QueryParams,
+    breakdownField: DataViewField | undefined,
+    preferredVisAttributes: UnifiedHistogramVisContext['attributes'] | undefined
+  ): Suggestion | undefined => {
+    const { dataView, query, timeRange, columns } = queryParams;
+    if (!isOfAggregateQueryType(query) || !query.esql || !timeRange) {
+      return undefined;
+    }
+    const timeFieldName = dataView.timeFieldName;
+    if (!timeFieldName || !columns?.some((column) => column.name === timeFieldName)) {
+      return undefined;
+    }
+    return this.getHistogramSuggestionForESQL({
+      queryParams,
+      breakdownField,
+      preferredVisAttributes,
+      allowTransformationalHistogram: true,
+    });
+  };
+
+  /**
+   * Chooses result vs time-distribution: uses stored app preference when set, otherwise defaults.
+   * The corrections below handle stale `storedMode` (e.g. saved search / URL) when availability
+   * no longer matches — the toggle may be hidden, but `esqlTransformationalChartMode` can still be set.
+   */
+  private resolveEffectiveTransformationalChartMode = (
+    storedMode: EsqlTransformationalChartToggleMode | undefined,
+    hasResultChart: boolean,
+    hasTimeDistributionChart: boolean
+  ): EsqlTransformationalChartToggleMode => {
+    let mode =
+      storedMode ??
+      (hasResultChart
+        ? EsqlTransformationalChartToggleMode.result
+        : EsqlTransformationalChartToggleMode.timeDistribution);
+
+    // Align impossible stored preference with what we can build (toggle not shown in single-chart cases).
+    if (
+      mode === EsqlTransformationalChartToggleMode.result &&
+      !hasResultChart &&
+      hasTimeDistributionChart
+    ) {
+      mode = EsqlTransformationalChartToggleMode.timeDistribution;
+    }
+    if (
+      mode === EsqlTransformationalChartToggleMode.timeDistribution &&
+      !hasTimeDistributionChart &&
+      hasResultChart
+    ) {
+      mode = EsqlTransformationalChartToggleMode.result;
+    }
+    return mode;
+  };
+
+  /**
+   * Pushes transformational chart suggestions; returns toggle availability only when both modes exist.
+   */
+  private appendTransformationalChartSuggestionEntries = (
+    availableSuggestionsWithType: Array<{
+      suggestion: UnifiedHistogramSuggestionContext['suggestion'];
+      type: UnifiedHistogramSuggestionType;
+    }>,
+    params: {
+      allSuggestions: Suggestion[];
+      histogramSuggestion: Suggestion | undefined;
+      effectiveMode: EsqlTransformationalChartToggleMode;
+    }
+  ): { timeDistributionAvailable: boolean; resultChartAvailable: boolean } | undefined => {
+    const { allSuggestions, histogramSuggestion, effectiveMode } = params;
+    const resultChartAvailable = allSuggestions.length > 0;
+    const timeDistributionAvailable = Boolean(histogramSuggestion);
+
+    if (timeDistributionAvailable && resultChartAvailable) {
+      if (effectiveMode === EsqlTransformationalChartToggleMode.timeDistribution) {
+        availableSuggestionsWithType.push({
+          suggestion: histogramSuggestion!,
+          type: UnifiedHistogramSuggestionType.histogramForESQL,
+        });
+      } else {
+        availableSuggestionsWithType.push({
+          suggestion: allSuggestions[0],
+          type: UnifiedHistogramSuggestionType.lensSuggestion,
+        });
+      }
+      return {
+        timeDistributionAvailable: true,
+        resultChartAvailable: true,
+      };
+    }
+
+    if (timeDistributionAvailable) {
+      availableSuggestionsWithType.push({
+        suggestion: histogramSuggestion!,
+        type: UnifiedHistogramSuggestionType.histogramForESQL,
+      });
+    } else if (resultChartAvailable) {
+      availableSuggestionsWithType.push({
+        suggestion: allSuggestions[0],
+        type: UnifiedHistogramSuggestionType.lensSuggestion,
+      });
+    }
+    return undefined;
   };
 
   private getDefaultHistogramSuggestion = ({
@@ -493,10 +640,12 @@ export class LensVisService {
     queryParams,
     breakdownField,
     preferredVisAttributes: originalPreferredVisAttributes,
+    allowTransformationalHistogram = false,
   }: {
     queryParams: QueryParams;
     breakdownField?: DataViewField;
     preferredVisAttributes?: UnifiedHistogramVisContext['attributes'];
+    allowTransformationalHistogram?: boolean;
   }): Suggestion | undefined => {
     const { dataView, query, timeRange, columns } = queryParams;
     const breakdownColumn = breakdownField?.name
@@ -527,96 +676,99 @@ export class LensVisService {
       }
     }
 
-    if (
-      dataView.timeFieldName &&
-      timeRange &&
+    const canBuildHistogram =
+      Boolean(dataView.timeFieldName) &&
+      timeRange != null &&
       isOfAggregateQueryType(query) &&
-      !hasTransformationalCommand(query.esql)
-    ) {
-      const interval = computeInterval(timeRange, this.services.data);
-      const esqlQuery = this.getESQLHistogramQuery({
-        dataView,
-        query,
-        timeRange,
-        interval,
-        breakdownColumn,
-      });
-      const dateFieldLabel = `${dataView.timeFieldName} every ${interval}`;
-      const context = {
-        dataViewSpec: dataView?.toSpec(),
-        fieldName: '',
-        textBasedColumns: [
-          {
-            id: TIMESTAMP_COLUMN,
-            name: dateFieldLabel,
-            meta: {
-              type: 'date',
-            },
+      (!hasTransformationalCommand(query.esql) || allowTransformationalHistogram);
+
+    if (!canBuildHistogram) {
+      return undefined;
+    }
+
+    const interval = computeInterval(timeRange, this.services.data);
+    const esqlQuery = this.getESQLHistogramQuery({
+      dataView,
+      query,
+      timeRange,
+      interval,
+      breakdownColumn,
+    });
+    const dateFieldLabel = `${dataView.timeFieldName} every ${interval}`;
+    const context = {
+      dataViewSpec: dataView?.toSpec(),
+      fieldName: '',
+      textBasedColumns: [
+        {
+          id: TIMESTAMP_COLUMN,
+          name: dateFieldLabel,
+          meta: {
+            type: 'date',
           },
-          {
-            id: 'results',
-            name: 'results',
-            meta: {
-              type: 'number',
-            },
-          },
-        ] as DatatableColumn[],
-        query: {
-          esql: esqlQuery,
         },
-      };
+        {
+          id: 'results',
+          name: 'results',
+          meta: {
+            type: 'number',
+          },
+        },
+      ] as DatatableColumn[],
+      query: {
+        esql: esqlQuery,
+      },
+    };
 
-      if (breakdownColumn) {
-        context.textBasedColumns.push(breakdownColumn);
+    if (breakdownColumn) {
+      context.textBasedColumns.push(breakdownColumn);
+    }
+
+    // here the attributes contain the main query and not the histogram one
+    const updatedAttributesWithQuery = preferredVisAttributes
+      ? injectESQLQueryIntoLensLayers(
+          preferredVisAttributes,
+          {
+            esql: esqlQuery,
+          },
+          dateFieldLabel
+        )
+      : undefined;
+
+    const suggestions =
+      this.lensSuggestionsApi(
+        context,
+        dataView,
+        ['lnsDatatable'],
+        ChartType.XY,
+        updatedAttributesWithQuery
+      ) ?? [];
+    if (suggestions.length) {
+      const suggestion = suggestions[0];
+      const suggestionVisualizationState = Object.assign({}, suggestion?.visualizationState);
+      // the suggestions api will suggest a numeric column as a metric and not as a breakdown,
+      // so we need to adjust it here
+      if (
+        breakdownColumn &&
+        breakdownColumn.meta?.type === 'number' &&
+        suggestion &&
+        'layers' in suggestionVisualizationState &&
+        Array.isArray(suggestionVisualizationState.layers)
+      ) {
+        return {
+          ...suggestion,
+          visualizationState: {
+            ...(suggestionVisualizationState ?? {}),
+            layers: suggestionVisualizationState.layers.map((layer) => {
+              return {
+                ...layer,
+                accessors: ['results'],
+                splitAccessors: [breakdownColumn.name],
+              };
+            }),
+          },
+        };
       }
-
-      // here the attributes contain the main query and not the histogram one
-      const updatedAttributesWithQuery = preferredVisAttributes
-        ? injectESQLQueryIntoLensLayers(
-            preferredVisAttributes,
-            {
-              esql: esqlQuery,
-            },
-            dateFieldLabel
-          )
-        : undefined;
-
-      const suggestions =
-        this.lensSuggestionsApi(
-          context,
-          dataView,
-          ['lnsDatatable'],
-          ChartType.XY,
-          updatedAttributesWithQuery
-        ) ?? [];
-      if (suggestions.length) {
-        const suggestion = suggestions[0];
-        const suggestionVisualizationState = Object.assign({}, suggestion?.visualizationState);
-        // the suggestions api will suggest a numeric column as a metric and not as a breakdown,
-        // so we need to adjust it here
-        if (
-          breakdownColumn &&
-          breakdownColumn.meta?.type === 'number' &&
-          suggestion &&
-          'layers' in suggestionVisualizationState &&
-          Array.isArray(suggestionVisualizationState.layers)
-        ) {
-          return {
-            ...suggestion,
-            visualizationState: {
-              ...(suggestionVisualizationState ?? {}),
-              layers: suggestionVisualizationState.layers.map((layer) => {
-                return {
-                  ...layer,
-                  accessors: ['results'],
-                  splitAccessors: [breakdownColumn.name],
-                };
-              }),
-            },
-          };
-        }
-        return suggestion;
-      }
+      return suggestion;
     }
 
     return undefined;

--- a/src/platform/packages/shared/kbn-unified-histogram/types.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/types.ts
@@ -165,10 +165,23 @@ export enum LensVisServiceStatus {
   'completed' = 'completed',
 }
 
+export enum EsqlTransformationalChartToggleMode {
+  result = 'result',
+  timeDistribution = 'timeDistribution',
+}
+
+export interface EsqlTransformationalChartToggleState {
+  activeMode: EsqlTransformationalChartToggleMode;
+}
+
 export interface LensVisServiceState {
   status: LensVisServiceStatus;
   currentSuggestionContext: UnifiedHistogramSuggestionContext;
   visContext: UnifiedHistogramVisContext | undefined;
+  /**
+   * When both Lens and time histogram are available for a transformational ES|QL query.
+   */
+  esqlTransformationalChartToggle?: EsqlTransformationalChartToggleState;
 }
 /**
  * Unified Histogram type for recreating a stored Lens vis
@@ -246,6 +259,10 @@ export interface UnifiedHistogramFetchParamsExternal {
   getModifiedVisAttributes?: (
     attributes: TypedLensByValueInput['attributes']
   ) => TypedLensByValueInput['attributes'];
+  /**
+   * For ES|QL transformational queries: switch between result chart and time histogram.
+   */
+  esqlTransformationalChartMode?: EsqlTransformationalChartToggleMode;
 }
 
 export type UnifiedHistogramFetchParams = Omit<
@@ -269,6 +286,10 @@ export type UnifiedHistogramFetchParams = Omit<
       }
     | undefined;
   timeInterval: string;
+  /**
+   * Passed from Discover when the user toggles chart mode for transformational ES|QL.
+   */
+  esqlTransformationalChartMode?: EsqlTransformationalChartToggleMode;
 };
 
 export interface UnifiedHistogramFetch$Arguments {

--- a/src/platform/packages/shared/kbn-unified-histogram/utils/external_vis_context.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/utils/external_vis_context.ts
@@ -18,7 +18,7 @@ import type {
 } from '@kbn/lens-common';
 import { getDatasourceId } from '@kbn/visualization-utils';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
-import type { UnifiedHistogramVisContext } from '../types';
+import type { EsqlTransformationalChartToggleMode, UnifiedHistogramVisContext } from '../types';
 import { UnifiedHistogramSuggestionType } from '../types';
 import { removeTablesFromLensAttributes } from './lens_vis_from_table';
 
@@ -32,6 +32,10 @@ export interface QueryParams {
   columns?: DatatableColumn[];
   columnsMap?: Record<string, DatatableColumn>;
   timeRange?: TimeRange;
+  /**
+   * User preference for transformational ES|QL chart: Categorical vs time histogram.
+   */
+  esqlTransformationalChartMode?: EsqlTransformationalChartToggleMode;
 }
 
 export const exportVisContext = (

--- a/src/platform/packages/shared/kbn-unified-histogram/utils/process_fetch_params.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/utils/process_fetch_params.ts
@@ -66,6 +66,7 @@ export const processFetchParams = ({
       breakdownField,
     }),
     timeInterval: params.timeInterval ?? DEFAULT_TIME_INTERVAL,
+    esqlTransformationalChartMode: params.esqlTransformationalChartMode,
   };
 };
 

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -409,14 +409,30 @@ export const useDiscoverHistogram = (
           },
         })
       );
+      dispatch(
+        updateAttributes({
+          attributes: { secondaryVisContext: undefined },
+        })
+      );
     }
     previousQueryEsqlRef.current = nextEsql;
-  }, [dispatch, query, updateAppState]);
+  }, [dispatch, query, updateAppState, updateAttributes]);
+
+  const secondaryVisContext = useCurrentTabSelector((tab) => tab.attributes.secondaryVisContext);
 
   const onEsqlTransformationalChartModeChange = useCallback<
     NonNullable<UseUnifiedHistogramProps['onEsqlTransformationalChartModeChange']>
   >(
     (mode) => {
+      // Swap visContext and secondaryVisContext so each mode preserves its chart config
+      dispatch(
+        updateAttributes({
+          attributes: {
+            visContext: secondaryVisContext,
+            secondaryVisContext: visContext,
+          },
+        })
+      );
       dispatch(
         updateAppState({
           appState: {
@@ -425,7 +441,7 @@ export const useDiscoverHistogram = (
         })
       );
     },
-    [dispatch, updateAppState]
+    [dispatch, updateAppState, updateAttributes, visContext, secondaryVisContext]
   );
 
   return useMemo(

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -27,6 +27,7 @@ import useLatest from 'react-use/lib/useLatest';
 import type { RequestAdapter } from '@kbn/inspector-plugin/common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { ESQL_TABLE_TYPE } from '@kbn/data-plugin/common';
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import { useProfileAccessor } from '../../../../context_awareness';
 import { useDiscoverCustomization } from '../../../../customizations';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
@@ -59,6 +60,7 @@ const TAB_ATTRIBUTE_TO_TRIGGER_CHART_FETCH: Array<keyof UnifiedHistogramFetchPar
   'externalVisContext',
   'breakdownField',
   'timeInterval',
+  'esqlTransformationalChartMode',
 ];
 
 export interface UseUnifiedHistogramOptions {
@@ -206,6 +208,9 @@ export const useDiscoverHistogram = (
   const filters = useCurrentTabSelector(selectTabCombinedFilters);
   const timeInterval = useAppStateSelector((state) => state.interval);
   const breakdownField = useAppStateSelector((state) => state.breakdownField);
+  const esqlTransformationalChartMode = useAppStateSelector(
+    (state) => state.esqlTransformationalChartMode
+  );
   const esqlVariables = useCurrentTabSelector((tab) => tab.esqlVariables);
   const visContext = useCurrentTabSelector((tab) => tab.attributes.visContext);
 
@@ -233,9 +238,11 @@ export const useDiscoverHistogram = (
       // visContext should be in sync with current query
       externalVisContext: isEsqlMode && canImportVisContext(visContext) ? visContext : undefined,
       getModifiedVisAttributes,
+      esqlTransformationalChartMode: isEsqlMode ? esqlTransformationalChartMode : undefined,
     };
   }, [
     breakdownField,
+    esqlTransformationalChartMode,
     timeInterval,
     currentTabControlState,
     dataView,
@@ -391,6 +398,36 @@ export const useDiscoverHistogram = (
     [timeInterval, dispatch, updateAppState]
   );
 
+  const previousQueryEsqlRef = useRef<string | undefined>();
+  useEffect(() => {
+    const nextEsql = query && isOfAggregateQueryType(query) ? query.esql : undefined;
+    if (previousQueryEsqlRef.current !== undefined && previousQueryEsqlRef.current !== nextEsql) {
+      dispatch(
+        updateAppState({
+          appState: {
+            esqlTransformationalChartMode: undefined,
+          },
+        })
+      );
+    }
+    previousQueryEsqlRef.current = nextEsql;
+  }, [dispatch, query, updateAppState]);
+
+  const onEsqlTransformationalChartModeChange = useCallback<
+    NonNullable<UseUnifiedHistogramProps['onEsqlTransformationalChartModeChange']>
+  >(
+    (mode) => {
+      dispatch(
+        updateAppState({
+          appState: {
+            esqlTransformationalChartMode: mode,
+          },
+        })
+      );
+    },
+    [dispatch, updateAppState]
+  );
+
   return useMemo(
     () => ({
       setUnifiedHistogramApi,
@@ -411,6 +448,9 @@ export const useDiscoverHistogram = (
       onVisContextChanged: isEsqlMode ? onVisContextChanged : undefined,
       onBreakdownFieldChange,
       onTimeIntervalChange,
+      onEsqlTransformationalChartModeChange: isEsqlMode
+        ? onEsqlTransformationalChartModeChange
+        : undefined,
     }),
     [
       chartHidden,
@@ -421,6 +461,7 @@ export const useDiscoverHistogram = (
       isEsqlMode,
       isChartLoading,
       onBreakdownFieldChange,
+      onEsqlTransformationalChartModeChange,
       onTimeIntervalChange,
       onVisContextChanged,
       options?.initialLayoutProps?.topPanelHeight,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/constants.ts
@@ -25,6 +25,7 @@ export const DEFAULT_TAB_STATE: Omit<TabState, keyof TabItem> = {
   },
   attributes: {
     visContext: undefined,
+    secondaryVisContext: undefined,
     controlGroupState: undefined,
     timeRestore: false,
   },

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/tab_mapping_utils.ts
@@ -50,6 +50,8 @@ export const fromSavedObjectTabToTabState = ({
     breakdownField: tab.breakdownField,
     interval: tab.chartInterval,
     density: tab.density,
+    esqlTransformationalChartMode:
+      tab.esqlTransformationalChartMode as DiscoverAppState['esqlTransformationalChartMode'],
   };
 
   const globalState = {
@@ -74,6 +76,7 @@ export const fromSavedObjectTabToTabState = ({
       ...DEFAULT_TAB_STATE.attributes,
       timeRestore: tab.timeRestore ?? false,
       visContext: tab.visContext,
+      secondaryVisContext: tab.secondaryVisContext,
       controlGroupState: tab.controlGroupJson
         ? parseControlGroupJson(tab.controlGroupJson)
         : undefined,
@@ -188,6 +191,8 @@ export const fromTabStateToSavedObjectTab = ({
     chartInterval: tab.appState.interval,
     density: tab.appState.density,
     visContext: tab.attributes.visContext,
+    secondaryVisContext: tab.attributes.secondaryVisContext,
+    esqlTransformationalChartMode: tab.appState.esqlTransformationalChartMode,
     controlGroupJson: tab.attributes.controlGroupState
       ? JSON.stringify(tab.attributes.controlGroupState)
       : undefined,

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -24,8 +24,10 @@ import type {
   UnifiedFieldListRestorableState,
   UnifiedFieldListSidebarContainerProps,
 } from '@kbn/unified-field-list';
-import type { UnifiedHistogramVisContext } from '@kbn/unified-histogram';
-import type { EsqlTransformationalChartToggleMode } from '@kbn/unified-histogram';
+import type {
+  EsqlTransformationalChartToggleMode,
+  UnifiedHistogramVisContext,
+} from '@kbn/unified-histogram';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-chart-section-viewer';
 import type { UnifiedSearchDraft } from '@kbn/unified-search-plugin/public';
 import type { TabItem } from '@kbn/unified-tabs';
@@ -152,6 +154,7 @@ export interface TabState extends TabItem {
   // Persistable attributes of the tab (stored in Discover Session and in local storage).
   attributes: {
     visContext: UnifiedHistogramVisContext | {} | undefined;
+    secondaryVisContext: UnifiedHistogramVisContext | {} | undefined;
     controlGroupState: ControlPanelsState<OptionsListESQLControlState> | undefined;
     timeRestore: boolean;
   };

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/types.ts
@@ -25,6 +25,7 @@ import type {
   UnifiedFieldListSidebarContainerProps,
 } from '@kbn/unified-field-list';
 import type { UnifiedHistogramVisContext } from '@kbn/unified-histogram';
+import type { EsqlTransformationalChartToggleMode } from '@kbn/unified-histogram';
 import type { UnifiedMetricsGridRestorableState } from '@kbn/unified-chart-section-viewer';
 import type { UnifiedSearchDraft } from '@kbn/unified-search-plugin/public';
 import type { TabItem } from '@kbn/unified-tabs';
@@ -113,6 +114,10 @@ export interface DiscoverAppState {
    * Breakdown field of chart
    */
   breakdownField?: string;
+  /**
+   * ES|QL transformational queries: user-selected chart (result vs time histogram).
+   */
+  esqlTransformationalChartMode?: EsqlTransformationalChartToggleMode;
   /**
    * Density of table
    */

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_initial_app_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/utils/get_initial_app_state.ts
@@ -226,6 +226,10 @@ function getDefaultAppState({
   if (persistedTab?.density) {
     defaultState.density = persistedTab.density;
   }
+  if (persistedTab?.esqlTransformationalChartMode) {
+    defaultState.esqlTransformationalChartMode =
+      persistedTab.esqlTransformationalChartMode as DiscoverAppState['esqlTransformationalChartMode'];
+  }
 
   return defaultState;
 }

--- a/src/platform/plugins/shared/saved_search/common/service/get_discover_session.ts
+++ b/src/platform/plugins/shared/saved_search/common/service/get_discover_session.ts
@@ -49,6 +49,8 @@ export const getDiscoverSession = async (
       chartInterval: tab.attributes.chartInterval,
       density: tab.attributes.density as DataGridDensity,
       visContext: tab.attributes.visContext,
+      secondaryVisContext: tab.attributes.secondaryVisContext,
+      esqlTransformationalChartMode: tab.attributes.esqlTransformationalChartMode,
       controlGroupJson: tab.attributes.controlGroupJson,
     })),
     managed: Boolean(so.item.managed),

--- a/src/platform/plugins/shared/saved_search/common/types.ts
+++ b/src/platform/plugins/shared/saved_search/common/types.ts
@@ -129,6 +129,8 @@ export interface DiscoverSessionTab {
   chartInterval?: string;
   density?: DataGridDensity;
   visContext?: VisContextUnmapped;
+  secondaryVisContext?: VisContextUnmapped;
+  esqlTransformationalChartMode?: string;
   controlGroupJson?: string; // JSON string of ControlPanelsState<OptionsListESQLControlState>
 }
 

--- a/src/platform/plugins/shared/saved_search/public/service/save_discover_session.ts
+++ b/src/platform/plugins/shared/saved_search/public/service/save_discover_session.ts
@@ -121,12 +121,19 @@ export const saveDiscoverSession = async (
         chartInterval: tab.chartInterval,
         density: tab.density,
         visContext: tab.visContext,
+        secondaryVisContext: tab.secondaryVisContext,
+        esqlTransformationalChartMode: tab.esqlTransformationalChartMode,
         controlGroupJson: tab.controlGroupJson,
       },
     };
   });
 
-  const { chartInterval, ...firstTabAttributes } = tabs[0].attributes;
+  const {
+    chartInterval,
+    secondaryVisContext: _secondaryVisContext,
+    esqlTransformationalChartMode: _esqlTransformationalChartMode,
+    ...firstTabAttributes
+  } = tabs[0].attributes;
 
   const attributes: SavedSearchAttributes = {
     title: discoverSession.title,

--- a/src/platform/plugins/shared/saved_search/server/content_management/schema/v1/cm_services.ts
+++ b/src/platform/plugins/shared/saved_search/server/content_management/schema/v1/cm_services.ts
@@ -16,9 +16,9 @@ import {
   updateOptionsSchema,
   createResultSchema,
 } from '@kbn/content-management-utils';
-import { SCHEMA_SEARCH_MODEL_VERSION_11 } from '../../../saved_objects/schema';
+import { SCHEMA_SEARCH_MODEL_VERSION_12 } from '../../../saved_objects/schema';
 
-const savedSearchSavedObjectSchema = savedObjectSchema(SCHEMA_SEARCH_MODEL_VERSION_11);
+const savedSearchSavedObjectSchema = savedObjectSchema(SCHEMA_SEARCH_MODEL_VERSION_12);
 
 const savedSearchCreateOptionsSchema = schema.maybe(
   schema.object({
@@ -56,7 +56,7 @@ export const serviceDefinition: ServicesDefinition = {
         schema: savedSearchCreateOptionsSchema,
       },
       data: {
-        schema: SCHEMA_SEARCH_MODEL_VERSION_11,
+        schema: SCHEMA_SEARCH_MODEL_VERSION_12,
       },
     },
     out: {
@@ -71,7 +71,7 @@ export const serviceDefinition: ServicesDefinition = {
         schema: savedSearchUpdateOptionsSchema,
       },
       data: {
-        schema: SCHEMA_SEARCH_MODEL_VERSION_11,
+        schema: SCHEMA_SEARCH_MODEL_VERSION_12,
       },
     },
   },

--- a/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
+++ b/src/platform/plugins/shared/saved_search/server/saved_objects/schema.ts
@@ -100,26 +100,28 @@ export const SCHEMA_SEARCH_MODEL_VERSION_2 = SCHEMA_SEARCH_MODEL_VERSION_1.exten
   headerRowHeight: schema.maybe(schema.number()),
 });
 
-export const SCHEMA_SEARCH_MODEL_VERSION_3 = SCHEMA_SEARCH_MODEL_VERSION_2.extends({
-  visContext: schema.maybe(
-    schema.oneOf([
-      // existing value
-      schema.object({
-        // unified histogram state
-        suggestionType: schema.string(),
-        requestData: schema.object({
-          dataViewId: schema.maybe(schema.string()),
-          timeField: schema.maybe(schema.string()),
-          timeInterval: schema.maybe(schema.string()),
-          breakdownField: schema.maybe(schema.string()),
-        }),
-        // lens attributes
-        attributes: schema.recordOf(schema.string(), schema.any()),
+const visContextSchema = schema.maybe(
+  schema.oneOf([
+    // existing value
+    schema.object({
+      // unified histogram state
+      suggestionType: schema.string(),
+      requestData: schema.object({
+        dataViewId: schema.maybe(schema.string()),
+        timeField: schema.maybe(schema.string()),
+        timeInterval: schema.maybe(schema.string()),
+        breakdownField: schema.maybe(schema.string()),
       }),
-      // cleared previous value
-      schema.object({}),
-    ])
-  ),
+      // lens attributes
+      attributes: schema.recordOf(schema.string(), schema.any()),
+    }),
+    // cleared previous value
+    schema.object({}),
+  ])
+);
+
+export const SCHEMA_SEARCH_MODEL_VERSION_3 = SCHEMA_SEARCH_MODEL_VERSION_2.extends({
+  visContext: visContextSchema,
 });
 
 export const SCHEMA_SEARCH_MODEL_VERSION_4 = SCHEMA_SEARCH_MODEL_VERSION_3.extends({
@@ -233,7 +235,28 @@ export const SCHEMA_SEARCH_MODEL_VERSION_11_SO_API_WORKAROUND = schema.object({
   tabs: schema.maybe(tabsV11),
 });
 
+const DISCOVER_SESSION_TAB_ATTRIBUTES_VERSION_12 =
+  DISCOVER_SESSION_TAB_ATTRIBUTES_VERSION_10.extends({
+    secondaryVisContext: visContextSchema,
+    esqlTransformationalChartMode: schema.maybe(schema.string()),
+  });
+
+const SCHEMA_DISCOVER_SESSION_TAB_VERSION_12 = SCHEMA_DISCOVER_SESSION_TAB_VERSION_10.extends({
+  attributes: DISCOVER_SESSION_TAB_ATTRIBUTES_VERSION_12,
+});
+
+export const SCHEMA_SEARCH_MODEL_VERSION_12 = SCHEMA_SEARCH_MODEL_VERSION_11.extends({
+  tabs: schema.arrayOf(SCHEMA_DISCOVER_SESSION_TAB_VERSION_12, { minSize: 1 }),
+});
+
+const { tabs: tabsV12, ...restV12Props } = SCHEMA_SEARCH_MODEL_VERSION_12.getPropSchemas();
+
+export const SCHEMA_SEARCH_MODEL_VERSION_12_SO_API_WORKAROUND = schema.object({
+  ...restV12Props,
+  tabs: schema.maybe(tabsV12),
+});
+
 export type DiscoverSessionTabAttributes = TypeOf<
-  typeof DISCOVER_SESSION_TAB_ATTRIBUTES_VERSION_10
+  typeof DISCOVER_SESSION_TAB_ATTRIBUTES_VERSION_12
 >;
-export type DiscoverSessionTab = TypeOf<typeof SCHEMA_DISCOVER_SESSION_TAB_VERSION_10>;
+export type DiscoverSessionTab = TypeOf<typeof SCHEMA_DISCOVER_SESSION_TAB_VERSION_12>;

--- a/src/platform/plugins/shared/saved_search/server/saved_objects/search.ts
+++ b/src/platform/plugins/shared/saved_search/server/saved_objects/search.ts
@@ -26,6 +26,7 @@ import {
   SCHEMA_SEARCH_MODEL_VERSION_9_SO_API_WORKAROUND,
   SCHEMA_SEARCH_MODEL_VERSION_10_SO_API_WORKAROUND,
   SCHEMA_SEARCH_MODEL_VERSION_11_SO_API_WORKAROUND,
+  SCHEMA_SEARCH_MODEL_VERSION_12_SO_API_WORKAROUND,
 } from './schema';
 
 export function getSavedSearchObjectType(
@@ -142,6 +143,16 @@ export function getSavedSearchObjectType(
             { unknowns: 'ignore' }
           ),
           create: SCHEMA_SEARCH_MODEL_VERSION_11_SO_API_WORKAROUND,
+        },
+      },
+      12: {
+        changes: [],
+        schemas: {
+          forwardCompatibility: SCHEMA_SEARCH_MODEL_VERSION_12_SO_API_WORKAROUND.extends(
+            {},
+            { unknowns: 'ignore' }
+          ),
+          create: SCHEMA_SEARCH_MODEL_VERSION_12_SO_API_WORKAROUND,
         },
       },
     },


### PR DESCRIPTION
## Summary

Gives the users the ability to also see the Time distribution if the transformational commands returns the timefield

<img width="2492" height="978" alt="image" src="https://github.com/user-attachments/assets/6218a05b-9cea-4866-a198-e6fcf978e281" />

<img width="2491" height="907" alt="image" src="https://github.com/user-attachments/assets/44059a7d-f8c5-46da-b237-ba1f34da39a2" />


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




