### PR TITLE
[Osquery] Fix flaky experimental osquery test

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
@@ -167,20 +167,16 @@ describe(
       // Filter to "uptime" queries
       cy.getBySel(HISTORY_SEARCH_INPUT).type('uptime{enter}');
       cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').should('have.length.above', 0);
-      cy.getBySel(UNIFIED_HISTORY_TABLE)
-        .find('tbody tr')
-        .each(($row) => {
-          cy.wrap($row).should('contain', 'uptime');
-        });
+      cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').each(($row) => {
+        expect($row.text()).to.include('uptime');
+      });
 
       // Filter to "processes" queries
       cy.getBySel(HISTORY_SEARCH_INPUT).clear().type('processes{enter}');
       cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').should('have.length.above', 0);
-      cy.getBySel(UNIFIED_HISTORY_TABLE)
-        .find('tbody tr')
-        .each(($row) => {
-          cy.wrap($row).should('contain', 'processes');
-        });
+      cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').each(($row) => {
+        expect($row.text()).to.include('processes');
+      });
 
       // Non-matching search shows empty state
       cy.getBySel(HISTORY_SEARCH_INPUT).clear().type('zzz_nonexistent_query_zzz{enter}');

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
@@ -167,16 +167,20 @@ describe(
       // Filter to "uptime" queries
       cy.getBySel(HISTORY_SEARCH_INPUT).type('uptime{enter}');
       cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').should('have.length.above', 0);
-      cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').each(($row) => {
-        expect($row.text()).to.include('uptime');
-      });
+      cy.getBySel(UNIFIED_HISTORY_TABLE)
+        .find('tbody tr')
+        .each(($row) => {
+          expect($row.text()).to.include('uptime');
+        });
 
       // Filter to "processes" queries
       cy.getBySel(HISTORY_SEARCH_INPUT).clear().type('processes{enter}');
       cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').should('have.length.above', 0);
-      cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').each(($row) => {
-        expect($row.text()).to.include('processes');
-      });
+      cy.getBySel(UNIFIED_HISTORY_TABLE)
+        .find('tbody tr')
+        .each(($row) => {
+          expect($row.text()).to.include('processes');
+        });
 
       // Non-matching search shows empty state
       cy.getBySel(HISTORY_SEARCH_INPUT).clear().type('zzz_nonexistent_query_zzz{enter}');


### PR DESCRIPTION
Fixing issue:
```
1) EXPERIMENTAL - History (queryHistoryRework)
       should filter history via search input:
     CypressError: Timed out retrying after 60000ms: `cy.should()` failed because the page updated as a result of this
command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot
requery the page after commands such as `cy.should()`.
Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element
You can typically solve this by breaking up a chain. For example, rewrite:
> `cy.get('button').click().should('have.class', 'active')`
to
> `cy.get('button').as('btn').click()`
> `cy.get('@btn').should('have.class', 'active')`
```