### PR TITLE
[ES|QL Editor] Clicking above the first line of the Monaco editor opens resource browser

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.test.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import { monaco } from '@kbn/monaco';
+import { useSourcesBadge } from './use_resource_browser_badge';
+import { IndicesBrowserOpenMode } from './types';
+
+jest.mock('@elastic/eui', () => ({
+  useEuiTheme: () => ({
+    euiTheme: {
+      colors: { primary: '#07C', backgroundBasePrimary: '#FFF', backgroundLightPrimary: '#E0F0FF' },
+      size: { xs: '4px', s: '8px', xl: '24px' },
+      font: { scale: { s: '0.875rem' }, weight: { medium: '500' } },
+      animation: { fast: '150ms' },
+    },
+  }),
+}));
+
+describe('useSourcesBadge', () => {
+  const mockOpenIndicesBrowser = jest.fn();
+  const suppressSuggestionsRef = { current: false };
+
+  // 'FROM myindex': FROM occupies columns 1–4 (endColumn = 5), space at offset 4
+  const QUERY = 'FROM myindex';
+  const FROM_WORD = { word: 'FROM', startColumn: 1, endColumn: 5 };
+  const INDEX_WORD = { word: 'myindex', startColumn: 6, endColumn: 13 };
+
+  const mockEditor = {
+    setPosition: jest.fn(),
+    getDomNode: jest.fn(() => null),
+    createDecorationsCollection: jest.fn(() => ({ clear: jest.fn() })),
+  } as unknown as monaco.editor.IStandaloneCodeEditor;
+
+  const mockModel = {
+    getValue: jest.fn(() => QUERY),
+    getWordAtPosition: jest.fn(() => FROM_WORD),
+    // offset 4 → the space character in 'FROM myindex', satisfying the trailing-whitespace check
+    getOffsetAt: jest.fn(() => 4),
+  } as unknown as monaco.editor.ITextModel;
+
+  const editorRef = { current: mockEditor };
+  const editorModel = { current: mockModel };
+
+  const renderBadge = () =>
+    renderHook(() =>
+      useSourcesBadge({
+        editorRef,
+        editorModel,
+        openIndicesBrowser: mockOpenIndicesBrowser,
+        suppressSuggestionsRef,
+      })
+    );
+
+  const makeEvent = (
+    type: monaco.editor.MouseTargetType,
+    lineNumber: number,
+    column: number
+  ): monaco.editor.IEditorMouseEvent =>
+    ({
+      target: { type, position: { lineNumber, column } },
+    } as unknown as monaco.editor.IEditorMouseEvent);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockModel.getValue as jest.Mock).mockReturnValue(QUERY);
+    (mockModel.getWordAtPosition as jest.Mock).mockReturnValue(FROM_WORD);
+    (mockModel.getOffsetAt as jest.Mock).mockReturnValue(4);
+  });
+
+  describe('sourcesLabelClickHandler', () => {
+    it('does not open the browser when target type is CONTENT_EMPTY when clicking above the first line', () => {
+      // Monaco clamps e.target.position to {lineNumber: 1, column: 1} when the user clicks
+      // above the first line, but reports type CONTENT_EMPTY - without the target type guard
+      // this would incorrectly match the FROM keyword and open the browser.
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.CONTENT_EMPTY, 1, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not open the browser when target type is CONTENT_EMPTY when clicking below the last line', () => {
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.CONTENT_EMPTY, 2, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not open the browser for gutter clicks (GUTTER_LINE_NUMBERS)', () => {
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.GUTTER_LINE_NUMBERS, 1, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not open the browser for UNKNOWN target type', () => {
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.UNKNOWN, 1, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('opens the browser when clicking on the FROM keyword with CONTENT_TEXT type', () => {
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.CONTENT_TEXT, 1, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).toHaveBeenCalledWith({
+        openedFrom: IndicesBrowserOpenMode.Badge,
+      });
+    });
+
+    it('does not open the browser when clicking on the index name (not a supported command)', () => {
+      (mockModel.getWordAtPosition as jest.Mock).mockReturnValue(INDEX_WORD);
+
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.CONTENT_TEXT, 1, 6)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not open the browser when target position is null', () => {
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler({
+        target: { type: monaco.editor.MouseTargetType.CONTENT_TEXT, position: null },
+      } as unknown as monaco.editor.IEditorMouseEvent);
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+
+    it('does not open the browser when FROM has no trailing whitespace', () => {
+      // query is just 'FROM' with no space - getOffsetAt returns 4 which is beyond the
+      // string, so queryText[4] is undefined, failing the whitespace guard
+      (mockModel.getValue as jest.Mock).mockReturnValue('FROM');
+      (mockModel.getOffsetAt as jest.Mock).mockReturnValue(4);
+
+      const { result } = renderBadge();
+
+      result.current.sourcesLabelClickHandler(
+        makeEvent(monaco.editor.MouseTargetType.CONTENT_TEXT, 1, 1)
+      );
+
+      expect(mockOpenIndicesBrowser).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/resource_browser/use_resource_browser_badge.tsx
@@ -115,6 +115,12 @@ export const useSourcesBadge = ({
 
   const sourcesLabelClickHandler = useCallback(
     (e: monaco.editor.IEditorMouseEvent) => {
+      // Only handle clicks on actual text content. When clicking above the first
+      // line or below the last line, Monaco clamps e.target.position to the
+      // nearest line (e.g. line 1, column 1), which would incorrectly match the
+      // command keyword and open the browser.
+      if (e.target.type !== monaco.editor.MouseTargetType.CONTENT_TEXT) return;
+
       const editor = editorRef.current;
       const model = editorModel.current;
       if (!editor || !model) return;


### PR DESCRIPTION
## Summary

This PR: 

- Fixes a bug in the ES|QL editor where clicking on the blank area above the editor content would unexpectedly open the Resource Browser. Monaco clamps `e.target.position` to the nearest line (e.g. line 1, column 1) for out-of-text clicks, which caused the click handler to incorrectly match the `FROM`/`TS` command keyword and trigger the browser.

### iPad

#### Before
https://github.com/user-attachments/assets/35794d2b-eb1a-4eed-a641-aea0daed6422

#### After
https://github.com/user-attachments/assets/6d9cc458-d836-474c-b14f-95de5bfda8f6


Laptop

#### Before
https://github.com/user-attachments/assets/0f53f9bc-1432-4b3f-946b-f35513d57c66

#### After
https://github.com/user-attachments/assets/41abacc0-982d-42ac-83f7-03e944973d66

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.