### PR TITLE
[Agent Builder] Add attachment origin to Converse API

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -2835,7 +2835,7 @@ paths:
                     properties:
                       data:
                         additionalProperties: {}
-                        description: Payload of the attachment.
+                        description: Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).
                         type: object
                       hidden:
                         description: When true, the attachment will not be displayed in the UI.
@@ -2843,12 +2843,14 @@ paths:
                       id:
                         description: Optional id for the attachment.
                         type: string
+                      origin:
+                        description: Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.
+                        type: string
                       type:
                         description: Type of the attachment.
                         type: string
                     required:
                       - type
-                      - data
                   type: array
                 browser_api_tools:
                   description: Optional browser API tools to be registered as LLM tools with browser.* namespace. These tools execute on the client side.
@@ -3202,7 +3204,7 @@ paths:
                     properties:
                       data:
                         additionalProperties: {}
-                        description: Payload of the attachment.
+                        description: Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).
                         type: object
                       hidden:
                         description: When true, the attachment will not be displayed in the UI.
@@ -3210,12 +3212,14 @@ paths:
                       id:
                         description: Optional id for the attachment.
                         type: string
+                      origin:
+                        description: Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.
+                        type: string
                       type:
                         description: Type of the attachment.
                         type: string
                     required:
                       - type
-                      - data
                   type: array
                 browser_api_tools:
                   description: Optional browser API tools to be registered as LLM tools with browser.* namespace. These tools execute on the client side.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -2902,7 +2902,7 @@ paths:
                     properties:
                       data:
                         additionalProperties: {}
-                        description: Payload of the attachment.
+                        description: Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).
                         type: object
                       hidden:
                         description: When true, the attachment will not be displayed in the UI.
@@ -2910,12 +2910,14 @@ paths:
                       id:
                         description: Optional id for the attachment.
                         type: string
+                      origin:
+                        description: Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.
+                        type: string
                       type:
                         description: Type of the attachment.
                         type: string
                     required:
                       - type
-                      - data
                   type: array
                 browser_api_tools:
                   description: Optional browser API tools to be registered as LLM tools with browser.* namespace. These tools execute on the client side.
@@ -3269,7 +3271,7 @@ paths:
                     properties:
                       data:
                         additionalProperties: {}
-                        description: Payload of the attachment.
+                        description: Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).
                         type: object
                       hidden:
                         description: When true, the attachment will not be displayed in the UI.
@@ -3277,12 +3279,14 @@ paths:
                       id:
                         description: Optional id for the attachment.
                         type: string
+                      origin:
+                        description: Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.
+                        type: string
                       type:
                         description: Type of the attachment.
                         type: string
                     required:
                       - type
-                      - data
                   type: array
                 browser_api_tools:
                   description: Optional browser API tools to be registered as LLM tools with browser.* namespace. These tools execute on the client side.

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/attachments.ts
@@ -42,11 +42,3 @@ export type ScreenContextAttachment = Attachment<AttachmentType.screenContext>;
 export type EsqlAttachment = Attachment<AttachmentType.esql>;
 export type VisualizationAttachment = Attachment<AttachmentType.visualization>;
 export type ConnectorAttachment = Attachment<AttachmentType.connector>;
-
-/**
- * Input version of an attachment, where the id is optional
- */
-export type AttachmentInput<
-  Type extends string = string,
-  DataType = Type extends AttachmentType ? AttachmentDataOf<Type> : Record<string, unknown>
-> = Omit<Attachment<Type, DataType>, 'id'> & Partial<Pick<Attachment<Type, DataType>, 'id'>>;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/index.ts
@@ -8,7 +8,6 @@
 export type {
   Attachment,
   UnknownAttachment,
-  AttachmentInput,
   TextAttachment,
   ScreenContextAttachment,
   EsqlAttachment,
@@ -49,7 +48,7 @@ export type {
   AttachmentRefOperation,
   AttachmentRefActor,
   AttachmentDiff,
-  VersionedAttachmentInput,
+  AttachmentInput,
   UpdateOriginResponse,
 } from './versioned_attachment';
 export {
@@ -60,7 +59,7 @@ export {
   attachmentVersionRefSchema,
   attachmentRefOperationSchema,
   attachmentRefActorSchema,
-  versionedAttachmentInputSchema,
+  attachmentInputSchema,
   attachmentDiffSchema,
   getLatestVersion,
   getVersion,
@@ -71,4 +70,5 @@ export {
   isVersionedAttachmentWithOrigin,
   hashContent,
   estimateTokens,
+  getContentKey,
 } from './versioned_attachment';

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.test.ts
@@ -18,10 +18,10 @@ import {
   attachmentVersionSchema,
   versionedAttachmentSchema,
   attachmentVersionRefSchema,
-  versionedAttachmentInputSchema,
   attachmentDiffSchema,
   type VersionedAttachment,
   type AttachmentVersion,
+  attachmentInputSchema,
 } from './versioned_attachment';
 
 describe('versioned_attachment', () => {
@@ -464,7 +464,7 @@ describe('versioned_attachment', () => {
           type: 'text',
           data: { content: 'test' },
         };
-        const result = versionedAttachmentInputSchema.safeParse(valid);
+        const result = attachmentInputSchema.safeParse(valid);
         expect(result.success).toBe(true);
       });
 
@@ -476,7 +476,7 @@ describe('versioned_attachment', () => {
           description: 'My attachment',
           hidden: false,
         };
-        const result = versionedAttachmentInputSchema.safeParse(valid);
+        const result = attachmentInputSchema.safeParse(valid);
         expect(result.success).toBe(true);
       });
 
@@ -484,7 +484,7 @@ describe('versioned_attachment', () => {
         const invalid = {
           data: { content: 'test' },
         };
-        const result = versionedAttachmentInputSchema.safeParse(invalid);
+        const result = attachmentInputSchema.safeParse(invalid);
         expect(result.success).toBe(false);
       });
     });

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.ts
@@ -135,7 +135,7 @@ export interface AttachmentDiff {
 /**
  * Input for creating a new versioned attachment.
  */
-export interface VersionedAttachmentInput<
+export interface AttachmentInput<
   Type extends string = string,
   DataType = Type extends AttachmentType ? AttachmentDataOf<Type> : unknown
 > {
@@ -200,7 +200,7 @@ export const versionedAttachmentSchema = z.object({
   origin_snapshot_at: z.string().optional(),
 });
 
-export const versionedAttachmentInputSchema = z.object({
+export const attachmentInputSchema = z.object({
   id: z.string().optional(),
   type: z.string(),
   data: z.unknown().optional(),
@@ -311,3 +311,13 @@ export interface UpdateOriginResponse {
   success: boolean;
   attachment: VersionedAttachment;
 }
+
+export const getContentKey = (input: AttachmentInput, fallback: string): string => {
+  if (input.data !== undefined) {
+    return `${input.type}:${hashContent(input.data)}`;
+  }
+  if (input.origin !== undefined) {
+    return `${input.type}:origin:${input.origin}`;
+  }
+  return `${input.type}:${fallback}`;
+};

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/attachments/versioned_attachment.ts
@@ -312,6 +312,9 @@ export interface UpdateOriginResponse {
   attachment: VersionedAttachment;
 }
 
+/**
+ * Builds a stable key for deduplicating or grouping attachment inputs (e.g. pending rows).
+ */
 export const getContentKey = (input: AttachmentInput, fallback: string): string => {
   if (input.data !== undefined) {
     return `${input.type}:${hashContent(input.data)}`;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/chat/conversation.ts
@@ -9,8 +9,8 @@ import type { UserIdAndName } from '../base/users';
 import type { ToolResult } from '../tools/tool_result';
 import type {
   Attachment,
-  AttachmentInput,
   VersionedAttachment,
+  AttachmentInput,
   AttachmentVersionRef,
 } from '../attachments';
 import type { PromptRequest, PromptResponse, PromptStorageState } from '../agents/prompts';
@@ -46,6 +46,7 @@ export interface ConverseInput {
   message?: string;
   /**
    * Optional attachments to provide to the agent.
+   * Use `origin` without `data` for by-reference types that implement `resolve`.
    * @deprecated Use attachment_refs with conversation-level attachments instead
    */
   attachments?: AttachmentInput[];

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/attachment_state_manager.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/attachments/attachment_state_manager.ts
@@ -11,7 +11,7 @@ import type {
   AttachmentVersion,
   AttachmentVersionRef,
   AttachmentDiff,
-  VersionedAttachmentInput,
+  AttachmentInput,
   AttachmentType,
   AttachmentRefActor,
   AttachmentRefOperation,
@@ -105,7 +105,7 @@ export interface AttachmentStateManager {
 
   /** Add a new attachment. If only `origin` is provided (no `data`), resolves content via the type's resolve(). */
   add<TType extends string>(
-    input: VersionedAttachmentInput<TType>,
+    input: AttachmentInput<TType>,
     actor?: AttachmentRefActor,
     resolveContext?: AttachmentResolveContext
   ): Promise<VersionedAttachment<TType>>;
@@ -290,7 +290,7 @@ class AttachmentStateManagerImpl implements AttachmentStateManager {
   }
 
   async add<TType extends string>(
-    input: VersionedAttachmentInput<TType>,
+    input: AttachmentInput<TType>,
     actor?: AttachmentRefActor,
     resolveContext?: AttachmentResolveContext
   ): Promise<VersionedAttachment<TType>> {

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
@@ -17,7 +17,10 @@ import type { BrowserApiToolMetadata } from '@kbn/agent-builder-common';
 import type { PromptRequest, PromptResponse } from '@kbn/agent-builder-common/agents';
 
 /**
- * body payload for request to the /internal/agent_builder/chat endpoint
+ * Body payload for the public agent_builder converse endpoints (`/api/agent_builder/converse`, `/converse/async`).
+ *
+ * Attachments may be by-value (`data`), by-reference (`origin` without `data`, resolved once via the type’s
+ * `resolve` hook), or both (same shape as conversation attachment APIs).
  */
 export interface ChatRequestBodyPayload {
   agent_id?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/chat.ts
@@ -18,9 +18,6 @@ import type { PromptRequest, PromptResponse } from '@kbn/agent-builder-common/ag
 
 /**
  * Body payload for the public agent_builder converse endpoints (`/api/agent_builder/converse`, `/converse/async`).
- *
- * Attachments may be by-value (`data`), by-reference (`origin` without `data`, resolved once via the type’s
- * `resolve` hook), or both (same shape as conversation attachment APIs).
  */
 export interface ChatRequestBodyPayload {
   agent_id?: string;

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -34,24 +34,33 @@ export const InputSchema = z.object({
    */
   attachments: z
     .array(
-      z.object({
-        /**
-         * Optional unique identifier for the attachment.
-         */
-        id: z.string().optional(),
-        /**
-         * Type of the attachment (e.g., "security.alert").
-         */
-        type: z.string(),
-        /**
-         * Data payload of the attachment, specific to the attachment type.
-         */
-        data: z.record(z.string(), z.any()),
-        /**
-         * When true, the attachment will not be displayed in the UI.
-         */
-        hidden: z.boolean().optional(),
-      })
+      z
+        .object({
+          /**
+           * Optional unique identifier for the attachment.
+           */
+          id: z.string().optional(),
+          /**
+           * Type of the attachment (e.g., "security.alert").
+           */
+          type: z.string(),
+          /**
+           * Data payload of the attachment, specific to the attachment type.
+           * Required unless `origin` is provided.
+           */
+          data: z.record(z.string(), z.any()).optional(),
+          /**
+           * Origin string (e.g. saved object ID) for by-reference attachments; resolved at send time when `data` is omitted.
+           */
+          origin: z.string().optional(),
+          /**
+           * When true, the attachment will not be displayed in the UI.
+           */
+          hidden: z.boolean().optional(),
+        })
+        .refine((a) => a.data !== undefined || a.origin !== undefined, {
+          message: 'Each attachment must include either data or origin',
+        })
     )
     .optional()
     .describe('Optional attachments to provide to the agent.'),

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/attachment_pills_row.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/attachment_pills_row.tsx
@@ -45,14 +45,24 @@ export const AttachmentPillsRow: React.FC<AttachmentPillsRowProps> = ({
       aria-label={labels.attachments}
       data-test-subj="agentBuilderAttachmentPillsRow"
     >
-      {attachments.map((attachment, index) => (
-        <EuiFlexItem key={attachment.id ?? `${attachment.type}-${index}`} grow={false}>
-          <AttachmentPill
-            attachment={attachment as Attachment}
-            onRemoveAttachment={removable ? () => removeAttachment?.(index) : undefined}
-          />
-        </EuiFlexItem>
-      ))}
+      {attachments.map((attachment, index) => {
+        const attachmentId = attachment.id ?? `${attachment.type}-${index}`;
+
+        return (
+          <EuiFlexItem key={attachmentId} grow={false}>
+            <AttachmentPill
+              attachment={{
+                id: attachmentId,
+                type: attachment.type,
+                data: (attachment.data ?? {}) as Record<string, unknown>,
+                hidden: attachment.hidden,
+                origin: attachment.origin,
+              }}
+              onRemoveAttachment={removable ? () => removeAttachment?.(index) : undefined}
+            />
+          </EuiFlexItem>
+        );
+      })}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/upsert_attachments_into_list.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/upsert_attachments_into_list.test.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { VersionedAttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
 import { upsertAttachmentsIntoList } from './upsert_attachments_into_list';
 
 const attachment = (
   id: string | undefined,
-  overrides: Partial<VersionedAttachmentInput> = {}
-): VersionedAttachmentInput => ({
+  overrides: Partial<AttachmentInput> = {}
+): AttachmentInput => ({
   id,
   type: 'visualization',
   data: {},

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/upsert_attachments_into_list.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/conversation/upsert_attachments_into_list.test.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { VersionedAttachmentInput } from '@kbn/agent-builder-common/attachments';
 import { upsertAttachmentsIntoList } from './upsert_attachments_into_list';
 
 const attachment = (
   id: string | undefined,
-  overrides: Partial<AttachmentInput> = {}
-): AttachmentInput => ({
+  overrides: Partial<VersionedAttachmentInput> = {}
+): VersionedAttachmentInput => ({
   id,
   type: 'visualization',
   data: {},

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.test.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { AttachmentInput, VersionedAttachment } from '@kbn/agent-builder-common/attachments';
+import type {
+  VersionedAttachment,
+  VersionedAttachmentInput,
+} from '@kbn/agent-builder-common/attachments';
 import {
   ATTACHMENT_REF_ACTOR,
   ATTACHMENT_REF_OPERATION,
@@ -51,7 +54,7 @@ describe('buildOptimisticAttachments', () => {
     const conversationAttachments = [
       createVersionedAttachment({ id: 'attachment-1', type: 'text', data: { value: 'before' } }),
     ];
-    const attachments: AttachmentInput[] = [
+    const attachments: VersionedAttachmentInput[] = [
       { id: 'attachment-1', type: 'text', data: { value: 'after' } },
     ];
 
@@ -73,7 +76,7 @@ describe('buildOptimisticAttachments', () => {
     const conversationAttachments = [
       createVersionedAttachment({ id: 'attachment-1', type: 'text', data }),
     ];
-    const attachments: AttachmentInput[] = [{ type: 'text', data }];
+    const attachments: VersionedAttachmentInput[] = [{ type: 'text', data }];
 
     const result = buildOptimisticAttachments({ attachments, conversationAttachments });
 
@@ -81,7 +84,9 @@ describe('buildOptimisticAttachments', () => {
   });
 
   it('creates a fallback attachment and ref for new inputs', () => {
-    const attachments: AttachmentInput[] = [{ type: 'text', data: { value: 'new' }, hidden: true }];
+    const attachments: VersionedAttachmentInput[] = [
+      { type: 'text', data: { value: 'new' }, hidden: true },
+    ];
 
     const result = buildOptimisticAttachments({ attachments, conversationAttachments: [] });
 
@@ -99,7 +104,7 @@ describe('buildOptimisticAttachments', () => {
   });
 
   it('deduplicates new attachments with matching content', () => {
-    const attachments: AttachmentInput[] = [
+    const attachments: VersionedAttachmentInput[] = [
       { type: 'text', data: { value: 'dup' } },
       { type: 'text', data: { value: 'dup' } },
     ];
@@ -107,6 +112,24 @@ describe('buildOptimisticAttachments', () => {
     const result = buildOptimisticAttachments({ attachments, conversationAttachments: [] });
 
     expect(result.fallbackAttachments).toHaveLength(1);
+    expect(result.attachmentRefs).toHaveLength(1);
+  });
+
+  it('creates fallback for origin-only attachment (by-reference)', () => {
+    const attachments: VersionedAttachmentInput[] = [
+      { type: 'visualization', origin: 'dashboard-so-id' },
+    ];
+
+    const result = buildOptimisticAttachments({ attachments, conversationAttachments: [] });
+
+    expect(result.fallbackAttachments).toEqual([
+      {
+        id: 'pending-attachment-0',
+        type: 'visualization',
+        data: {},
+        origin: 'dashboard-so-id',
+      },
+    ]);
     expect(result.attachmentRefs).toHaveLength(1);
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.test.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  VersionedAttachment,
-  VersionedAttachmentInput,
-} from '@kbn/agent-builder-common/attachments';
+import type { VersionedAttachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
 import {
   ATTACHMENT_REF_ACTOR,
   ATTACHMENT_REF_OPERATION,
@@ -54,7 +51,7 @@ describe('buildOptimisticAttachments', () => {
     const conversationAttachments = [
       createVersionedAttachment({ id: 'attachment-1', type: 'text', data: { value: 'before' } }),
     ];
-    const attachments: VersionedAttachmentInput[] = [
+    const attachments: AttachmentInput[] = [
       { id: 'attachment-1', type: 'text', data: { value: 'after' } },
     ];
 
@@ -76,7 +73,7 @@ describe('buildOptimisticAttachments', () => {
     const conversationAttachments = [
       createVersionedAttachment({ id: 'attachment-1', type: 'text', data }),
     ];
-    const attachments: VersionedAttachmentInput[] = [{ type: 'text', data }];
+    const attachments: AttachmentInput[] = [{ type: 'text', data }];
 
     const result = buildOptimisticAttachments({ attachments, conversationAttachments });
 
@@ -84,9 +81,7 @@ describe('buildOptimisticAttachments', () => {
   });
 
   it('creates a fallback attachment and ref for new inputs', () => {
-    const attachments: VersionedAttachmentInput[] = [
-      { type: 'text', data: { value: 'new' }, hidden: true },
-    ];
+    const attachments: AttachmentInput[] = [{ type: 'text', data: { value: 'new' }, hidden: true }];
 
     const result = buildOptimisticAttachments({ attachments, conversationAttachments: [] });
 
@@ -104,7 +99,7 @@ describe('buildOptimisticAttachments', () => {
   });
 
   it('deduplicates new attachments with matching content', () => {
-    const attachments: VersionedAttachmentInput[] = [
+    const attachments: AttachmentInput[] = [
       { type: 'text', data: { value: 'dup' } },
       { type: 'text', data: { value: 'dup' } },
     ];
@@ -116,9 +111,7 @@ describe('buildOptimisticAttachments', () => {
   });
 
   it('creates fallback for origin-only attachment (by-reference)', () => {
-    const attachments: VersionedAttachmentInput[] = [
-      { type: 'visualization', origin: 'dashboard-so-id' },
-    ];
+    const attachments: AttachmentInput[] = [{ type: 'visualization', origin: 'dashboard-so-id' }];
 
     const result = buildOptimisticAttachments({ attachments, conversationAttachments: [] });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/build_optimistic_attachments.ts
@@ -6,16 +6,16 @@
  */
 
 import type {
-  AttachmentInput,
   Attachment,
   VersionedAttachment,
+  AttachmentInput,
   AttachmentVersionRef,
 } from '@kbn/agent-builder-common/attachments';
 import {
   ATTACHMENT_REF_ACTOR,
   ATTACHMENT_REF_OPERATION,
   getLatestVersion,
-  hashContent,
+  getContentKey,
 } from '@kbn/agent-builder-common/attachments';
 
 export const buildOptimisticAttachments = ({
@@ -55,18 +55,18 @@ export const buildOptimisticAttachments = ({
       return;
     }
 
-    const contentHash = hashContent(input.data);
-    const contentKey = `${input.type}:${contentHash}`;
+    const createdId = inputId ?? `pending-attachment-${index}`;
+    const contentKey = getContentKey(input, createdId);
     if (existingByContentKey.has(contentKey)) {
       return;
     }
 
-    const createdId = inputId ?? `pending-attachment-${index}`;
     fallbackAttachments.push({
       id: createdId,
       type: input.type,
-      data: input.data,
-      ...(input.hidden !== undefined ? { hidden: input.hidden } : {}),
+      data: (input.data ?? {}) as Record<string, unknown>,
+      origin: input.origin,
+      hidden: input.hidden,
     });
     attachmentRefs.push({
       attachment_id: createdId,

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
@@ -72,37 +72,46 @@ export function registerChatRoutes({
     ),
     attachments: schema.maybe(
       schema.arrayOf(
-        schema.object({
-          id: schema.maybe(
-            schema.string({
-              meta: { description: 'Optional id for the attachment.' },
-            })
-          ),
-          type: schema.string({
-            meta: { description: 'Type of the attachment.' },
-          }),
-          data: schema.maybe(
-            schema.recordOf(schema.string(), schema.any(), {
-              meta: {
-                description:
-                  'Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).',
-              },
-            })
-          ),
-          origin: schema.maybe(
-            schema.string({
-              meta: {
-                description:
-                  'Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.',
-              },
-            })
-          ),
-          hidden: schema.maybe(
-            schema.boolean({
-              meta: { description: 'When true, the attachment will not be displayed in the UI.' },
-            })
-          ),
-        }),
+        schema.object(
+          {
+            id: schema.maybe(
+              schema.string({
+                meta: { description: 'Optional id for the attachment.' },
+              })
+            ),
+            type: schema.string({
+              meta: { description: 'Type of the attachment.' },
+            }),
+            data: schema.maybe(
+              schema.recordOf(schema.string(), schema.any(), {
+                meta: {
+                  description:
+                    'Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).',
+                },
+              })
+            ),
+            origin: schema.maybe(
+              schema.string({
+                meta: {
+                  description:
+                    'Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.',
+                },
+              })
+            ),
+            hidden: schema.maybe(
+              schema.boolean({
+                meta: { description: 'When true, the attachment will not be displayed in the UI.' },
+              })
+            ),
+          },
+          {
+            validate: (attachment) => {
+              if (attachment.data === undefined && attachment.origin === undefined) {
+                return 'Each attachment must include either data or origin (by-reference attachments require origin)';
+              }
+            },
+          }
+        ),
         {
           meta: {
             description:
@@ -201,18 +210,6 @@ export function registerChatRoutes({
     }
   };
 
-  const validateConverseAttachments = (payload: ChatRequestBodyPayload) => {
-    if (!payload.attachments?.length) {
-      return;
-    }
-    for (const attachment of payload.attachments) {
-      if (attachment.data === undefined && attachment.origin === undefined) {
-        throw createBadRequestError(
-          'Each attachment must include either data or origin (by-reference attachments require origin)'
-        );
-      }
-    }
-  };
   const validateConfigurationOverrides = async ({
     payload,
     request,
@@ -321,7 +318,6 @@ export function registerChatRoutes({
 
         await validateConfigurationOverrides({ payload, request });
         validateAction(payload);
-        validateConverseAttachments(payload);
 
         const abortController = new AbortController();
         request.events.aborted$.subscribe(() => {
@@ -395,7 +391,6 @@ export function registerChatRoutes({
 
         await validateConfigurationOverrides({ payload, request });
         validateAction(payload);
-        validateConverseAttachments(payload);
 
         const abortController = new AbortController();
         request.events.aborted$.subscribe(() => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/chat.ts
@@ -81,9 +81,22 @@ export function registerChatRoutes({
           type: schema.string({
             meta: { description: 'Type of the attachment.' },
           }),
-          data: schema.recordOf(schema.string(), schema.any(), {
-            meta: { description: 'Payload of the attachment.' },
-          }),
+          data: schema.maybe(
+            schema.recordOf(schema.string(), schema.any(), {
+              meta: {
+                description:
+                  'Payload of the attachment. Required unless `origin` is provided (content is resolved once at send time).',
+              },
+            })
+          ),
+          origin: schema.maybe(
+            schema.string({
+              meta: {
+                description:
+                  'Origin string (for example, saved object ID) for by-reference attachments. When provided without `data`, the content is resolved once using the attachment type’s `resolve` hook.',
+              },
+            })
+          ),
           hidden: schema.maybe(
             schema.boolean({
               meta: { description: 'When true, the attachment will not be displayed in the UI.' },
@@ -185,6 +198,19 @@ export function registerChatRoutes({
   const validateAction = (payload: ChatRequestBodyPayload) => {
     if (payload.action === 'regenerate' && !payload.conversation_id) {
       throw createBadRequestError('conversation_id is required when action is regenerate');
+    }
+  };
+
+  const validateConverseAttachments = (payload: ChatRequestBodyPayload) => {
+    if (!payload.attachments?.length) {
+      return;
+    }
+    for (const attachment of payload.attachments) {
+      if (attachment.data === undefined && attachment.origin === undefined) {
+        throw createBadRequestError(
+          'Each attachment must include either data or origin (by-reference attachments require origin)'
+        );
+      }
     }
   };
   const validateConfigurationOverrides = async ({
@@ -295,6 +321,7 @@ export function registerChatRoutes({
 
         await validateConfigurationOverrides({ payload, request });
         validateAction(payload);
+        validateConverseAttachments(payload);
 
         const abortController = new AbortController();
         request.events.aborted$.subscribe(() => {
@@ -368,6 +395,7 @@ export function registerChatRoutes({
 
         await validateConfigurationOverrides({ payload, request });
         validateAction(payload);
+        validateConverseAttachments(payload);
 
         const abortController = new AbortController();
         request.events.aborted$.subscribe(() => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/prepare_conversation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/agents/modes/utils/prepare_conversation.ts
@@ -17,16 +17,18 @@ import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/atta
 import {
   ATTACHMENT_REF_ACTOR,
   getLatestVersion,
-  hashContent,
+  getContentKey,
 } from '@kbn/agent-builder-common/attachments';
 import type { ProcessedAttachment, ProcessedRoundInput } from '@kbn/agent-builder-server';
 import type {
   AttachmentFormatContext,
+  AttachmentResolveContext,
   AttachmentStateManager,
 } from '@kbn/agent-builder-server/attachments';
 import type { AttachmentsService } from '@kbn/agent-builder-server/runner';
 import type { AgentHandlerContext } from '@kbn/agent-builder-server/agents';
 import { getToolResultId } from '@kbn/agent-builder-server/tools';
+
 import {
   prepareAttachmentPresentation,
   type AttachmentPresentation,
@@ -66,7 +68,7 @@ const createFormatContext = (agentContext: AgentHandlerContext): AttachmentForma
 const mergeInputAttachmentsIntoAttachmentState = async (
   attachmentStateManager: AttachmentStateManager,
   inputs: AttachmentInput[],
-  options?: { updateOriginSnapshot?: boolean }
+  options?: { updateOriginSnapshot?: boolean; resolveContext?: AttachmentResolveContext }
 ) => {
   if (inputs.length === 0) return;
 
@@ -102,8 +104,7 @@ const mergeInputAttachmentsIntoAttachmentState = async (
       }
     }
 
-    const contentHash = hashContent(input.data);
-    const contentKey = `${input.type}:${contentHash}`;
+    const contentKey = getContentKey(input, 'unknown');
     if (existingByContentKey.has(contentKey)) {
       // already present (same content), nothing to do
       continue;
@@ -114,9 +115,11 @@ const mergeInputAttachmentsIntoAttachmentState = async (
         ...(input.id ? { id: input.id } : {}),
         type: input.type,
         data: input.data,
+        ...(input.origin !== undefined ? { origin: input.origin } : {}),
         ...(input.hidden !== undefined ? { hidden: input.hidden } : {}),
       },
-      ATTACHMENT_REF_ACTOR.user
+      ATTACHMENT_REF_ACTOR.user,
+      options?.resolveContext
     );
 
     const latest = getLatestVersion(created);
@@ -172,6 +175,14 @@ export const prepareConversation = async ({
 }): Promise<ProcessedConversation> => {
   const { attachments: attachmentsService, attachmentStateManager } = context;
   const formatContext = createFormatContext(context);
+  const resolveContext: AttachmentResolveContext | undefined =
+    context.savedObjectsClient !== undefined
+      ? {
+          request: context.request,
+          spaceId: context.spaceId,
+          savedObjectsClient: context.savedObjectsClient,
+        }
+      : undefined;
 
   // Handle regenerate action: use last round's input and strip it from previous rounds
   const { effectiveRounds, effectiveNextInput } = prepareForAction({
@@ -188,10 +199,13 @@ export const prepareConversation = async ({
   ) as AttachmentInput[];
   const nextInputAttachments = (effectiveNextInput.attachments ?? []) as AttachmentInput[];
 
-  await mergeInputAttachmentsIntoAttachmentState(attachmentStateManager, previousAttachments);
+  await mergeInputAttachmentsIntoAttachmentState(attachmentStateManager, previousAttachments, {
+    resolveContext,
+  });
   attachmentStateManager.clearAccessTracking();
   await mergeInputAttachmentsIntoAttachmentState(attachmentStateManager, nextInputAttachments, {
     updateOriginSnapshot: true,
+    resolveContext,
   });
 
   const strippedNextInput: ConverseInput = { ...effectiveNextInput, attachments: [] };
@@ -360,8 +374,16 @@ const prepareAttachment = async ({
 };
 
 const inputToFinal = (input: AttachmentInput): Attachment => {
+  if (input.data === undefined) {
+    throw createInternalError(
+      'Attachment is missing data; by-reference attachments must be resolved before formatting'
+    );
+  }
   return {
-    ...input,
     id: input.id ?? getToolResultId(),
-  };
+    type: input.type,
+    data: input.data,
+    hidden: input.hidden,
+    origin: input.origin,
+  } as Attachment;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import type { SavedObjectsServiceStart } from '@kbn/core/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import { getCurrentSpaceId } from '../../utils/spaces';
 import {
   createAttachmentTypeRegistry,
   type AttachmentTypeRegistry,
@@ -12,9 +15,14 @@ import {
 import type { AttachmentServiceSetup, AttachmentServiceStart } from './types';
 import { validateAttachment } from './validate_attachment';
 
+export interface AttachmentServiceStartDeps {
+  spaces?: SpacesPluginStart;
+  savedObjects: SavedObjectsServiceStart;
+}
+
 export interface AttachmentService {
   setup: () => AttachmentServiceSetup;
-  start: () => AttachmentServiceStart;
+  start: (deps: AttachmentServiceStartDeps) => AttachmentServiceStart;
 }
 
 export const createAttachmentService = (): AttachmentService => {
@@ -34,9 +42,14 @@ export class AttachmentServiceImpl implements AttachmentService {
     };
   }
 
-  start(): AttachmentServiceStart {
+  start(deps: AttachmentServiceStartDeps): AttachmentServiceStart {
     return {
-      validate: (attachment, resolveContext) => {
+      validate: (attachment, request) => {
+        const resolveContext = {
+          request,
+          spaceId: getCurrentSpaceId({ request, spaces: deps.spaces }),
+          savedObjectsClient: deps.savedObjects.getScopedClient(request),
+        };
         return validateAttachment({
           attachment,
           registry: this.attachmentTypeRegistry,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/attachment_service.ts
@@ -36,8 +36,12 @@ export class AttachmentServiceImpl implements AttachmentService {
 
   start(): AttachmentServiceStart {
     return {
-      validate: (attachment) => {
-        return validateAttachment({ attachment, registry: this.attachmentTypeRegistry });
+      validate: (attachment, resolveContext) => {
+        return validateAttachment({
+          attachment,
+          registry: this.attachmentTypeRegistry,
+          resolveContext,
+        });
       },
       getTypeDefinition: (attachment) => {
         return this.attachmentTypeRegistry.get(attachment);

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
@@ -6,7 +6,10 @@
  */
 
 import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
-import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type {
+  AttachmentResolveContext,
+  AttachmentTypeDefinition,
+} from '@kbn/agent-builder-server/attachments';
 import type { ValidateAttachmentResult } from './validate_attachment';
 
 export interface AttachmentServiceSetup {
@@ -15,7 +18,8 @@ export interface AttachmentServiceSetup {
 
 export interface AttachmentServiceStart {
   validate<Type extends string, Data>(
-    attachment: AttachmentInput<Type, Data>
+    attachment: AttachmentInput<Type, Data>,
+    resolveContext: AttachmentResolveContext
   ): Promise<ValidateAttachmentResult<Type, Data>>;
   getTypeDefinition(type: string): AttachmentTypeDefinition | undefined;
   getRegisteredTypeIds(): string[];

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/types.ts
@@ -6,10 +6,8 @@
  */
 
 import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
-import type {
-  AttachmentResolveContext,
-  AttachmentTypeDefinition,
-} from '@kbn/agent-builder-server/attachments';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ValidateAttachmentResult } from './validate_attachment';
 
 export interface AttachmentServiceSetup {
@@ -19,7 +17,7 @@ export interface AttachmentServiceSetup {
 export interface AttachmentServiceStart {
   validate<Type extends string, Data>(
     attachment: AttachmentInput<Type, Data>,
-    resolveContext: AttachmentResolveContext
+    request: KibanaRequest
   ): Promise<ValidateAttachmentResult<Type, Data>>;
   getTypeDefinition(type: string): AttachmentTypeDefinition | undefined;
   getRegisteredTypeIds(): string[];

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock } from '@kbn/core-http-server-mocks';
+import type { AttachmentResolveContext } from '@kbn/agent-builder-server/attachments';
+import { validateAttachment } from './validate_attachment';
+import type { AttachmentTypeRegistry } from './attachment_type_registry';
+
+const createRegistry = (definition: {
+  validate: (
+    input: unknown
+  ) => Promise<{ valid: true; data: unknown } | { valid: false; error: string }>;
+  resolve?: (origin: string, context: AttachmentResolveContext) => Promise<unknown>;
+}): AttachmentTypeRegistry =>
+  ({
+    has: () => true,
+    get: () => definition,
+  } as unknown as AttachmentTypeRegistry);
+
+describe('validateAttachment', () => {
+  const request = httpServerMock.createKibanaRequest();
+  const resolveContext: AttachmentResolveContext = {
+    request,
+    spaceId: 'default',
+    savedObjectsClient: {} as AttachmentResolveContext['savedObjectsClient'],
+  };
+
+  it('validates by-value attachments and preserves optional origin', async () => {
+    const registry = createRegistry({
+      validate: async (input) => ({ valid: true, data: input }),
+    });
+
+    const result = await validateAttachment({
+      attachment: { type: 'text', data: { body: 'hi' }, origin: 'so-1' },
+      registry,
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      attachment: expect.objectContaining({
+        type: 'text',
+        data: { body: 'hi' },
+        origin: 'so-1',
+      }),
+    });
+  });
+
+  it('resolves origin-only attachments when resolve context and resolve() are available', async () => {
+    const resolved = { body: 'from-origin' };
+    const registry = createRegistry({
+      validate: async (input) => ({ valid: true, data: input }),
+      resolve: async () => resolved,
+    });
+
+    const result = await validateAttachment({
+      attachment: { type: 'text', origin: 'dashboard-id' },
+      registry,
+      resolveContext,
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      attachment: expect.objectContaining({
+        type: 'text',
+        data: resolved,
+        origin: 'dashboard-id',
+      }),
+    });
+  });
+
+  it('fails origin-only attachments without resolve context', async () => {
+    const registry = createRegistry({
+      validate: async (input) => ({ valid: true, data: input }),
+      resolve: async () => ({}),
+    });
+
+    const result = await validateAttachment({
+      attachment: { type: 'text', origin: 'x' },
+      registry,
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: 'Resolve context is required for attachments that only specify origin',
+    });
+  });
+
+  it('fails when neither data nor origin is provided', async () => {
+    const registry = createRegistry({
+      validate: async (input) => ({ valid: true, data: input }),
+    });
+
+    const result = await validateAttachment({
+      attachment: { type: 'text' },
+      registry,
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: 'Either data or origin must be provided for an attachment',
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.test.ts
@@ -29,79 +29,90 @@ describe('validateAttachment', () => {
     savedObjectsClient: {} as AttachmentResolveContext['savedObjectsClient'],
   };
 
-  it('validates by-value attachments and preserves optional origin', async () => {
-    const registry = createRegistry({
-      validate: async (input) => ({ valid: true, data: input }),
+  describe('Converse attachment input scenarios (structural + resolution)', () => {
+    it('only data: validates using inline data', async () => {
+      const registry = createRegistry({
+        validate: async (input) => ({ valid: true, data: input }),
+      });
+
+      const result = await validateAttachment({
+        attachment: { type: 'text', data: { body: 'only-data' } },
+        registry,
+        resolveContext,
+      });
+
+      expect(result).toEqual({
+        valid: true,
+        attachment: expect.objectContaining({
+          type: 'text',
+          data: { body: 'only-data' },
+        }),
+      });
     });
 
-    const result = await validateAttachment({
-      attachment: { type: 'text', data: { body: 'hi' }, origin: 'so-1' },
-      registry,
+    it('only origin: resolves when resolve() and context are available', async () => {
+      const resolved = { body: 'from-origin' };
+      const registry = createRegistry({
+        validate: async (input) => ({ valid: true, data: input }),
+        resolve: async () => resolved,
+      });
+
+      const result = await validateAttachment({
+        attachment: { type: 'text', origin: 'dashboard-id' },
+        registry,
+        resolveContext,
+      });
+
+      expect(result).toEqual({
+        valid: true,
+        attachment: expect.objectContaining({
+          type: 'text',
+          data: resolved,
+          origin: 'dashboard-id',
+        }),
+      });
     });
 
-    expect(result).toEqual({
-      valid: true,
-      attachment: expect.objectContaining({
-        type: 'text',
-        data: { body: 'hi' },
-        origin: 'so-1',
-      }),
-    });
-  });
+    it('data and origin: uses inline data and does not call resolve', async () => {
+      const resolve = jest.fn().mockRejectedValue(new Error('resolve should not run'));
+      const registry = createRegistry({
+        validate: async (input) => ({ valid: true, data: input }),
+        resolve,
+      });
 
-  it('resolves origin-only attachments when resolve context and resolve() are available', async () => {
-    const resolved = { body: 'from-origin' };
-    const registry = createRegistry({
-      validate: async (input) => ({ valid: true, data: input }),
-      resolve: async () => resolved,
-    });
+      const result = await validateAttachment({
+        attachment: { type: 'text', data: { body: 'inline' }, origin: 'so-1' },
+        registry,
+        resolveContext,
+      });
 
-    const result = await validateAttachment({
-      attachment: { type: 'text', origin: 'dashboard-id' },
-      registry,
-      resolveContext,
-    });
-
-    expect(result).toEqual({
-      valid: true,
-      attachment: expect.objectContaining({
-        type: 'text',
-        data: resolved,
-        origin: 'dashboard-id',
-      }),
-    });
-  });
-
-  it('fails origin-only attachments without resolve context', async () => {
-    const registry = createRegistry({
-      validate: async (input) => ({ valid: true, data: input }),
-      resolve: async () => ({}),
+      expect(resolve).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        valid: true,
+        attachment: expect.objectContaining({
+          type: 'text',
+          data: { body: 'inline' },
+          origin: 'so-1',
+        }),
+      });
     });
 
-    const result = await validateAttachment({
-      attachment: { type: 'text', origin: 'x' },
-      registry,
-    });
+    it('neither data nor origin: fails before type validation', async () => {
+      const registry = createRegistry({
+        validate: async (input) => ({ valid: true, data: input }),
+      });
 
-    expect(result).toEqual({
-      valid: false,
-      error: 'Resolve context is required for attachments that only specify origin',
-    });
-  });
+      const result = await validateAttachment({
+        attachment: { type: 'text' },
+        registry,
+        resolveContext,
+      });
 
-  it('fails when neither data nor origin is provided', async () => {
-    const registry = createRegistry({
-      validate: async (input) => ({ valid: true, data: input }),
-    });
-
-    const result = await validateAttachment({
-      attachment: { type: 'text' },
-      registry,
-    });
-
-    expect(result).toEqual({
-      valid: false,
-      error: 'Either data or origin must be provided for an attachment',
+      expect(result).toEqual({
+        valid: false,
+        error:
+          'Error during attachment validation: Either data or origin must be provided for an attachment',
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.ts
@@ -30,7 +30,7 @@ export const validateAttachment = async <Type extends string, Data>({
     return { valid: false, error: `Unknown attachment type: ${attachment.type}` };
   }
 
-  const typeDefinition = registry.get(attachment.type)! as AttachmentTypeDefinition<any>;
+  const typeDefinition = registry.get(attachment.type)!;
 
   try {
     const resolvedData = await resolveAttachment({ attachment, resolveContext, typeDefinition });
@@ -50,7 +50,8 @@ export const validateAttachment = async <Type extends string, Data>({
       },
     };
   } catch (e) {
-    return { valid: false, error: `Error during attachment validation: ${e.message}` };
+    const message = e instanceof Error ? e.message : String(e);
+    return { valid: false, error: `Error during attachment validation: ${message}` };
   }
 };
 
@@ -61,10 +62,10 @@ const resolveAttachment = async <Type extends string, Data>({
 }: {
   attachment: AttachmentInput<Type, Data>;
   resolveContext: AttachmentResolveContext;
-  typeDefinition: AttachmentTypeDefinition<Type, Data>;
+  typeDefinition: AttachmentTypeDefinition;
 }): Promise<Data> => {
   if (attachment.data !== undefined) {
-    return attachment.data as Data;
+    return attachment.data;
   }
 
   if (attachment.origin === undefined) {
@@ -75,10 +76,10 @@ const resolveAttachment = async <Type extends string, Data>({
     throw new Error(`Attachment type "${attachment.type}" does not support resolving from origin`);
   }
   const resolved = await typeDefinition.resolve(attachment.origin, resolveContext);
-  if (resolved === undefined) {
+  if (resolved == null) {
     throw new Error(
       `Failed to resolve content from origin for attachment type "${attachment.type}"`
     );
   }
-  return resolved;
+  return resolved as Data;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/attachments/validate_attachment.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
-import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import type {
+  AttachmentResolveContext,
+  AttachmentTypeDefinition,
+} from '@kbn/agent-builder-server/attachments';
 import { getToolResultId } from '@kbn/agent-builder-server/tools';
 import type { AttachmentTypeRegistry } from './attachment_type_registry';
 
@@ -17,31 +20,65 @@ export type ValidateAttachmentResult<Type extends string, Data> =
 export const validateAttachment = async <Type extends string, Data>({
   attachment,
   registry,
+  resolveContext,
 }: {
   attachment: AttachmentInput<Type, Data>;
   registry: AttachmentTypeRegistry;
+  resolveContext: AttachmentResolveContext;
 }): Promise<ValidateAttachmentResult<Type, Data>> => {
   if (!registry.has(attachment.type)) {
     return { valid: false, error: `Unknown attachment type: ${attachment.type}` };
   }
+
   const typeDefinition = registry.get(attachment.type)! as AttachmentTypeDefinition<any>;
 
   try {
-    const typeValidation = await typeDefinition.validate(attachment.data);
-    if (typeValidation.valid) {
-      return {
-        valid: true,
-        attachment: {
-          id: attachment.id ?? getToolResultId(),
-          type: attachment.type,
-          data: typeValidation.data as Data,
-          hidden: attachment.hidden,
-        },
-      };
-    } else {
+    const resolvedData = await resolveAttachment({ attachment, resolveContext, typeDefinition });
+    const typeValidation = await typeDefinition.validate(resolvedData);
+    if (!typeValidation.valid) {
       return { valid: false, error: typeValidation.error };
     }
+
+    return {
+      valid: true,
+      attachment: {
+        id: attachment.id ?? getToolResultId(),
+        type: attachment.type,
+        data: typeValidation.data as Data,
+        hidden: attachment.hidden,
+        ...(attachment.origin !== undefined ? { origin: attachment.origin } : {}),
+      },
+    };
   } catch (e) {
     return { valid: false, error: `Error during attachment validation: ${e.message}` };
   }
+};
+
+const resolveAttachment = async <Type extends string, Data>({
+  attachment,
+  resolveContext,
+  typeDefinition,
+}: {
+  attachment: AttachmentInput<Type, Data>;
+  resolveContext: AttachmentResolveContext;
+  typeDefinition: AttachmentTypeDefinition<Type, Data>;
+}): Promise<Data> => {
+  if (attachment.data !== undefined) {
+    return attachment.data as Data;
+  }
+
+  if (attachment.origin === undefined) {
+    throw new Error('Either data or origin must be provided for an attachment');
+  }
+
+  if (!typeDefinition.resolve) {
+    throw new Error(`Attachment type "${attachment.type}" does not support resolving from origin`);
+  }
+  const resolved = await typeDefinition.resolve(attachment.origin, resolveContext);
+  if (resolved === undefined) {
+    throw new Error(
+      `Failed to resolve content from origin for attachment type "${attachment.type}"`
+    );
+  }
+  return resolved;
 };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -115,7 +115,10 @@ export class ServiceManager {
       return runner;
     };
 
-    const attachments = this.services.attachments.start();
+    const attachments = this.services.attachments.start({
+      spaces,
+      savedObjects,
+    });
     const sml = this.services.sml.start({
       logger: logger.get('sml'),
       securityAuthz: securityPlugin?.authz,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -16,7 +16,8 @@ import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ChatEvent } from '@kbn/agent-builder-common';
 import { agentBuilderDefaultAgentId, createBadRequestError } from '@kbn/agent-builder-common';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
-import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { AttachmentResolveContext } from '@kbn/agent-builder-server/attachments';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { AttachmentServiceStart } from '../attachments';
 import type {
@@ -63,20 +64,28 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     this.logger = deps.logger;
   }
 
+  private getAttachmentResolveContext(request: KibanaRequest): AttachmentResolveContext {
+    const spaceId = getCurrentSpaceId({ request, spaces: this.deps.spaces });
+    const savedObjectsClient = this.deps.savedObjects.getScopedClient(request);
+    return { request, spaceId, savedObjectsClient };
+  }
+
   private async validateAttachmentsIfProvided(
-    attachments: AttachmentInput[] | undefined
-  ): Promise<AttachmentInput[] | undefined> {
+    attachments: AttachmentInput[] | undefined,
+    request: KibanaRequest
+  ): Promise<Attachment[] | undefined> {
     if (!attachments || attachments.length === 0) {
       return undefined;
     }
 
-    const validated: AttachmentInput[] = [];
+    const resolveContext = this.getAttachmentResolveContext(request);
+    const validated: Attachment[] = [];
     for (const attachment of attachments) {
-      const result = await this.deps.attachmentsService.validate(attachment);
+      const result = await this.deps.attachmentsService.validate(attachment, resolveContext);
       if (!result.valid) {
         throw createBadRequestError(`Attachment validation failed: ${result.error}`);
       }
-      validated.push(result.attachment);
+      validated.push(result.attachment as Attachment);
     }
 
     return validated;
@@ -104,7 +113,8 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     }
 
     const validatedAttachments = await this.validateAttachmentsIfProvided(
-      params.nextInput.attachments
+      params.nextInput.attachments,
+      request
     );
     const validatedParams = validatedAttachments
       ? { ...params, nextInput: { ...params.nextInput, attachments: validatedAttachments } }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/execution/execution_service.ts
@@ -17,7 +17,6 @@ import type { ChatEvent } from '@kbn/agent-builder-common';
 import { agentBuilderDefaultAgentId, createBadRequestError } from '@kbn/agent-builder-common';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import type { Attachment, AttachmentInput } from '@kbn/agent-builder-common/attachments';
-import type { AttachmentResolveContext } from '@kbn/agent-builder-server/attachments';
 import { getCurrentSpaceId } from '../../utils/spaces';
 import type { AttachmentServiceStart } from '../attachments';
 import type {
@@ -64,12 +63,6 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
     this.logger = deps.logger;
   }
 
-  private getAttachmentResolveContext(request: KibanaRequest): AttachmentResolveContext {
-    const spaceId = getCurrentSpaceId({ request, spaces: this.deps.spaces });
-    const savedObjectsClient = this.deps.savedObjects.getScopedClient(request);
-    return { request, spaceId, savedObjectsClient };
-  }
-
   private async validateAttachmentsIfProvided(
     attachments: AttachmentInput[] | undefined,
     request: KibanaRequest
@@ -78,10 +71,9 @@ class AgentExecutionServiceImpl implements AgentExecutionService {
       return undefined;
     }
 
-    const resolveContext = this.getAttachmentResolveContext(request);
     const validated: Attachment[] = [];
     for (const attachment of attachments) {
-      const result = await this.deps.attachmentsService.validate(attachment, resolveContext);
+      const result = await this.deps.attachmentsService.validate(attachment, request);
       if (!result.valid) {
         throw createBadRequestError(`Attachment validation failed: ${result.error}`);
       }

--- a/x-pack/platform/test/agent_builder_api_integration/apis/converse/attachments.ts
+++ b/x-pack/platform/test/agent_builder_api_integration/apis/converse/attachments.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import type { AgentBuilderApiFtrProviderContext } from '../../../agent_builder/services/api';
 import { createLlmProxy, type LlmProxy } from '../../utils/llm_proxy';
 import { setupAgentDirectAnswer } from '../../utils/proxy_scenario';
@@ -73,6 +73,37 @@ export function createAttachmentsTests(executionMode: ExecutionMode) {
 
         expect(body.statusCode).to.eql(400);
         expect(body.message).to.contain('Attachment validation failed');
+      });
+
+      it('returns an error when attachment has neither data nor origin', async () => {
+        const body: any = await agentBuilderApiClient.converse({
+          input: 'Hello AgentBuilder',
+          attachments: [
+            {
+              type: 'text',
+            },
+          ],
+          connector_id: connectorId,
+        });
+
+        expect(body.statusCode).to.eql(400);
+        expect(body.message).to.contain('either data or origin');
+      });
+
+      it('returns an error when origin-only attachment type does not support resolve', async () => {
+        const body: any = await agentBuilderApiClient.converse({
+          input: 'Hello AgentBuilder',
+          attachments: [
+            {
+              type: 'text',
+              origin: 'some-origin-id',
+            },
+          ],
+          connector_id: connectorId,
+        });
+
+        expect(body.statusCode).to.eql(400);
+        expect(body.message).to.contain('does not support resolving from origin');
       });
 
       it('calls the LLM with the attachment', async () => {

--- a/x-pack/platform/test/agent_builder_api_integration/apis/converse/attachments.ts
+++ b/x-pack/platform/test/agent_builder_api_integration/apis/converse/attachments.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import type { AgentBuilderApiFtrProviderContext } from '../../../agent_builder/services/api';
 import { createLlmProxy, type LlmProxy } from '../../utils/llm_proxy';
 import { setupAgentDirectAnswer } from '../../utils/proxy_scenario';
@@ -75,69 +75,103 @@ export function createAttachmentsTests(executionMode: ExecutionMode) {
         expect(body.message).to.contain('Attachment validation failed');
       });
 
-      it('returns an error when attachment has neither data nor origin', async () => {
-        const body: any = await agentBuilderApiClient.converse({
-          input: 'Hello AgentBuilder',
-          attachments: [
-            {
-              type: 'text',
-            },
-          ],
-          connector_id: connectorId,
-        });
+      describe('Converse attachment payload: data vs origin', () => {
+        it('accepts data-only: forwards attachment content to the LLM', async () => {
+          await setupAgentDirectAnswer({
+            proxy: llmProxy,
+            title: MOCKED_LLM_TITLE,
+            response: MOCKED_LLM_RESPONSE,
+          });
 
-        expect(body.statusCode).to.eql(400);
-        expect(body.message).to.contain('either data or origin');
-      });
-
-      it('returns an error when origin-only attachment type does not support resolve', async () => {
-        const body: any = await agentBuilderApiClient.converse({
-          input: 'Hello AgentBuilder',
-          attachments: [
-            {
-              type: 'text',
-              origin: 'some-origin-id',
-            },
-          ],
-          connector_id: connectorId,
-        });
-
-        expect(body.statusCode).to.eql(400);
-        expect(body.message).to.contain('does not support resolving from origin');
-      });
-
-      it('calls the LLM with the attachment', async () => {
-        await setupAgentDirectAnswer({
-          proxy: llmProxy,
-          title: MOCKED_LLM_TITLE,
-          response: MOCKED_LLM_RESPONSE,
-        });
-
-        await agentBuilderApiClient.converse({
-          input: 'Hello AgentBuilder',
-          attachments: [
-            {
-              type: 'text',
-              data: {
-                content: 'some text content',
+          await agentBuilderApiClient.converse({
+            input: 'Hello AgentBuilder',
+            attachments: [
+              {
+                type: 'text',
+                data: {
+                  content: 'some text content',
+                },
               },
-            },
-          ],
-          connector_id: connectorId,
+            ],
+            connector_id: connectorId,
+          });
+
+          await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+          const firstAgentRequest = llmProxy.interceptedRequests.find(
+            (request) => request.matchingInterceptorName === 'handover-to-answer'
+          )!.requestBody;
+
+          // Attachments are injected via conversation-level presentation, not legacy per-round fields.
+          const allMessageContent = firstAgentRequest.messages
+            .map((m: any) => String(m.content ?? ''))
+            .join('\n');
+          expect(allMessageContent).to.contain('some text content');
         });
 
-        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+        it('rejects attachment with neither data nor origin', async () => {
+          const body: any = await agentBuilderApiClient.converse({
+            input: 'Hello AgentBuilder',
+            attachments: [
+              {
+                type: 'text',
+              },
+            ],
+            connector_id: connectorId,
+          });
 
-        const firstAgentRequest = llmProxy.interceptedRequests.find(
-          (request) => request.matchingInterceptorName === 'handover-to-answer'
-        )!.requestBody;
+          expect(body.statusCode).to.eql(400);
+          expect(body.message).to.contain('either data or origin');
+        });
 
-        // Attachments are now injected into the LLM context via conversation-level attachments presentation,
-        // not as legacy per-round user message attachments.
-        const allMessageContent = firstAgentRequest.messages
-          .map((m: any) => String(m.content ?? ''))
-          .join('\n');
-        expect(allMessageContent).to.contain('some text content');
+        it('rejects origin-only when the type does not implement resolve (e.g. text)', async () => {
+          const body: any = await agentBuilderApiClient.converse({
+            input: 'Hello AgentBuilder',
+            attachments: [
+              {
+                type: 'text',
+                origin: 'some-origin-id',
+              },
+            ],
+            connector_id: connectorId,
+          });
+
+          expect(body.statusCode).to.eql(400);
+          expect(body.message).to.contain('does not support resolving from origin');
+        });
+
+        it('accepts data and origin together and uses inline data for the model', async () => {
+          await setupAgentDirectAnswer({
+            proxy: llmProxy,
+            title: MOCKED_LLM_TITLE,
+            response: MOCKED_LLM_RESPONSE,
+          });
+
+          await agentBuilderApiClient.converse({
+            input: 'Hello AgentBuilder',
+            attachments: [
+              {
+                type: 'text',
+                origin: 'ignored-origin-id',
+                data: {
+                  content: 'inline-payload-for-model',
+                },
+              },
+            ],
+            connector_id: connectorId,
+          });
+
+          await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+          const firstAgentRequest = llmProxy.interceptedRequests.find(
+            (request) => request.matchingInterceptorName === 'handover-to-answer'
+          )!.requestBody;
+
+          const allMessageContent = firstAgentRequest.messages
+            .map((m: any) => String(m.content ?? ''))
+            .join('\n');
+          expect(allMessageContent).to.contain('inline-payload-for-model');
+        });
       });
 
       it('persists the attachment in the conversation', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/13477

## Summary

Agent Builder **Converse** (and related client surfaces) now accept attachments with optional **`data`**, optional **`origin`**, or **both**—so by-reference payloads match conversation APIs and are no longer rejected when the UI sends only `origin`.

**Types:** **`AttachInput` and `VersionedAttachmentInput` are merged** into a single attachment-input shape used consistently across HTTP, plugin APIs, and the browser.

## Architecture

- **Contract:** one versioned attachment input type end-to-end; each attachment must include **at least one** of `data` or `origin`.
- **Server:** converse (and step) validation resolves **`origin`** when `data` is omitted, using request-scoped context where types implement `resolve`; validated payloads become full **`Attachment`** objects before execution and conversation merge.
- **Client:** optimistic UI and display paths tolerate **`origin`-only** pending rows using stable keys.

**Breaking changes:** none—this extends accepted shapes.

### How to test

Exercise Converse (sync/async) and in-product attachment flows with by-value, by-reference, and combined payloads; confirm errors when neither `data` nor `origin` is present.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Release notes

Converse accepts optional **`origin`** on attachments for by-reference flows; rejects attachments with neither **`data`** nor **`origin`**. Attachment input types are unified so HTTP and UI use the same shape.