### PR TITLE
[Security Solution][Attacks/Alerts][EASE] Disable Attacks and Alerts alignment feature for EASE (#237372)

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -116,6 +116,21 @@ xpack.fleet.integrationsHomeOverride: '/app/security/configurations/integrations
 xpack.fleet.prereleaseEnabledByDefault: true
 xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
+# Experimental Security Solution features
+
+# Since this config will override values from the "serverless.security.yml" we need to duplicate experimental feature disabled there
+# and add features that specifically disabled in EASE
+xpack.securitySolution.enableExperimental:
+  [
+    riskScoreAssistantToolDisabled,
+    disable:enableRiskScorePrivmonModifier,
+    disable:kubernetesEnabled,
+    trialCompanionEnabled,
+
+    # Alerts and Attacks alignment feature is disabled in EASE
+    disable:enableAlertsAndAttacksAlignment,
+  ]
+
 # Elastic Managed LLMs
 xpack.actions.preconfigured:
   Anthropic-Claude-Sonnet-3-7:

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -118,8 +118,9 @@ xpack.fleet.internal.registry.searchAiLakePackageAllowlistEnabled: true
 
 # Experimental Security Solution features
 
-# Since this config will override values from the "serverless.security.yml" we need to duplicate experimental feature disabled there
-# and add features that specifically disabled in EASE
+# Since array configurations here completely override the values from "serverless.security.yml",
+# we must duplicate all disabled experimental features from the base config
+# in addition to any features specifically disabled in EASE.
 xpack.securitySolution.enableExperimental:
   [
     riskScoreAssistantToolDisabled,


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/kibana/issues/237372

This PR explicitly disables the "Attacks and Alerts alignment" feature for the EASE (Search AI Lake) product tier.

Because `serverless.security.search_ai_lake.yml` overrides configurations from `serverless.security.yml`, array values are completely replaced rather than merged. Therefore, we must duplicate all the existing experimental feature flags from the base config and add `disable:enableAlertsAndAttacksAlignment` to the `xpack.securitySolution.enableExperimental` array to ensure this feature remains disabled in the EASE environment.

### Verification Steps

To verify these changes locally, you need to run the EASE product tier setup:

1. Ensure that in your `config/serverless.security.dev.yml` file, the `xpack.securitySolutionServerless.productTypes` array looks like the following:

   ```yaml
   xpack.securitySolutionServerless.productTypes:
     [{ product_line: 'ai_soc', product_tier: 'search_ai_lake' }]
   ```

2. Start Elasticsearch serverless with the correct project type and product tier:

   ```bash
   yarn es serverless --projectType security --productTier search_ai_lake
   ```

3. Start Kibana in serverless security mode:

   ```bash
   yarn serverless-security
   ```

4. Open Kibana in your browser at http://localhost:5601/

5. Navigate to **Stack Management > Advanced Settings** and verify that the "Enable alerts and attacks alignment" setting is not available.

6. Navigate to the Security Solution and verify that the "Attacks and Alerts alignment" feature is not visible/active in the UI.
