### PR TITLE
Fix translation

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/microsoft_teams/microsoft_teams.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/microsoft_teams/microsoft_teams.ts
@@ -91,7 +91,7 @@ export const MicrosoftTeams: ConnectorSpec = {
                 'core.kibanaConnectorSpecs.microsoftTeams.auth.oauth.tokenUrl.helpText',
                 {
                   defaultMessage:
-                    'Replace {tenant-id} with your Azure AD tenant ID. For example: https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token',
+                    "Replace '{tenant-id}' with your Azure AD tenant ID. For example: https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token",
                 }
               ),
             },

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_online/sharepoint_online.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/sharepoint_online/sharepoint_online.ts
@@ -65,7 +65,7 @@ export const SharepointOnline: ConnectorSpec = {
                 'core.kibanaConnectorSpecs.sharepointOnline.auth.oauth.tokenUrl.helpText',
                 {
                   defaultMessage:
-                    'Replace {tenant-id} with your Azure AD tenant ID. For example: https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token',
+                    "Replace '{tenant-id}' with your Azure AD tenant ID. For example: https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token",
                 }
               ),
             },


### PR DESCRIPTION
## Summary

Without this the console includes this error

```
Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting default message for: "core.kibanaConnectorSpecs.microsoftTeams.auth.oauth.tokenUrl.helpText", rendering default message verbatim
MessageID: core.kibanaConnectorSpecs.microsoftTeams.auth.oauth.tokenUrl.helpText
Default Message: Replace {tenant-id} with your Azure AD tenant ID. For example: https://login.microsoftonline.com/your-tenant-id/oauth2/v2.0/token
Description: undefined
Locale: en
```

> In `@formatjs/intl`, curly braces {...} in a defaultMessage are treated as ICU message format placeholders, so they require a corresponding value to be passed in. Our string contains {tenant-id}, which the formatter tries to interpolate as a variable named tenant-id, but no values object was provided. Since {tenant-id} is meant to be literal text (not a dynamic value), we need to escape the curly braces by wrapping them in '...' quotes per ICU syntax.