### PR TITLE
[One Workflow] Fix HTTP connector headers silently lost on save

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/http/form_serialization.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/http/form_serialization.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formDeserializer, formSerializer } from './form_serialization';
+
+describe('formSerializer', () => {
+  it('should correctly serialize form data with headers', () => {
+    const formData = {
+      actionTypeId: '.connector-test',
+      isDeprecated: false,
+      __internal__: {
+        headers: [
+          { key: 'header1', value: 'foo', type: 'config' },
+          { key: 'header2', value: 'bar', type: 'config' },
+          { key: 'header3', value: 'secret-value', type: 'secret' },
+        ],
+        hasProxy: false,
+      },
+      config: {},
+      secrets: {},
+      isMissingSecrets: false,
+    };
+
+    expect(formSerializer(formData)).toEqual({
+      __internal__: formData.__internal__,
+      actionTypeId: '.connector-test',
+      config: {
+        headers: {
+          header1: 'foo',
+          header2: 'bar',
+        },
+        proxyUrl: null,
+        proxyVerificationMode: undefined,
+        hasProxyAuth: false,
+      },
+      isDeprecated: false,
+      isMissingSecrets: false,
+      secrets: {
+        secretHeaders: {
+          header3: 'secret-value',
+        },
+        proxyUsername: null,
+        proxyPassword: null,
+      },
+    });
+  });
+
+  it('should set headers to null and secretHeaders to undefined when empty', () => {
+    const formData = {
+      actionTypeId: '.connector-test',
+      isDeprecated: false,
+      __internal__: {
+        headers: [],
+        hasProxy: false,
+      },
+      config: {},
+      secrets: {},
+      isMissingSecrets: false,
+    };
+
+    expect(formSerializer(formData)).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          headers: null,
+        }),
+        secrets: expect.objectContaining({
+          secretHeaders: undefined,
+        }),
+      })
+    );
+  });
+});
+
+describe('formDeserializer', () => {
+  it('should correctly deserialize data', () => {
+    const data = {
+      actionTypeId: '.connector-test',
+      isDeprecated: false,
+      config: {
+        headers: {
+          foo: 'bar',
+          an: 'tonio',
+        },
+      },
+      secrets: {},
+      isMissingSecrets: false,
+    };
+
+    expect(formDeserializer(data)).toEqual({
+      actionTypeId: '.connector-test',
+      config: {
+        headers: [
+          { key: 'foo', type: 'config', value: 'bar' },
+          { key: 'an', type: 'config', value: 'tonio' },
+        ],
+      },
+      __internal__: {
+        headers: [
+          { key: 'foo', type: 'config', value: 'bar' },
+          { key: 'an', type: 'config', value: 'tonio' },
+        ],
+        hasProxy: false,
+      },
+      isDeprecated: false,
+      isMissingSecrets: false,
+      secrets: {},
+    });
+  });
+
+  it('should return data unchanged when actionTypeId is not set', () => {
+    const data = {
+      isDeprecated: false,
+      config: { headers: { foo: 'bar' } },
+      secrets: {},
+      isMissingSecrets: false,
+    };
+
+    expect(formDeserializer(data as any)).toBe(data);
+  });
+});

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/http/form_serialization.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/http/form_serialization.ts
@@ -78,7 +78,7 @@ export const formSerializer = (formData: HttpConnectorForm): ConnectorFormSchema
     ...formData,
     config: {
       ...formData.config,
-      ...(isEmpty(configHeaders) && { headers: null }),
+      headers: isEmpty(configHeaders) ? null : configHeaders,
       ...(supportsProxy &&
         !hasProxy && {
           proxyUrl: null,
@@ -88,7 +88,7 @@ export const formSerializer = (formData: HttpConnectorForm): ConnectorFormSchema
     },
     secrets: {
       ...formData.secrets,
-      ...(isEmpty(secretHeaders) && { secretHeaders: undefined }),
+      secretHeaders: isEmpty(secretHeaders) ? undefined : secretHeaders,
       ...(supportsProxy &&
         (!hasProxy || !formData.config?.hasProxyAuth) && {
           proxyUsername: null,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/259041

## Summary

Fixes a bug where HTTP connector headers were silently lost when creating or editing a connector. The `formSerializer` used an inverted conditional that only set `headers: null` when the headers array was empty, but never assigned the actual header values when non-empty — causing them to remain in the UseArray `[{key, value, type}]` format and be silently dropped by the API.

The fix aligns the HTTP serializer with the working webhook serializer pattern by using explicit ternary assignment:

```ts
// Before (buggy): only spreads { headers: null } when empty, never assigns actual values
...(isEmpty(configHeaders) && { headers: null }),

// After (fixed): always assigns headers explicitly
headers: isEmpty(configHeaders) ? null : configHeaders,
```

Also adds a unit test file for the HTTP form serialization (matching the existing webhook test pattern).

## Test plan

- Create an HTTP connector, toggle "Add HTTP header" ON, add header key-value pairs, save — headers should persist when re-opening the connector in edit mode
- Create an HTTP connector without headers — should still work correctly (headers set to `null`)
- Jest tests pass: `yarn test:jest x-pack/platform/plugins/shared/stack_connectors/public/connector_types/lib/http/form_serialization.test.ts`


Made with [Cursor](https://cursor.com)