### PR TITLE
feat(agent-builder): tool listing page for agent centric UX

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/constants.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const FLYOUT_WIDTH = '960px';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_library_panel.tsx
@@ -23,6 +23,7 @@ import { labels } from '../../../utils/i18n';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { appPaths } from '../../../utils/app_paths';
 import { LibraryToggleRow } from '../common/library_toggle_row';
+import { FLYOUT_WIDTH } from '../common/constants';
 
 interface PluginLibraryPanelProps {
   onClose: () => void;
@@ -56,7 +57,7 @@ export const PluginLibraryPanel: React.FC<PluginLibraryPanelProps> = ({
   return (
     <EuiFlyout
       side="right"
-      size="960px"
+      size={FLYOUT_WIDTH}
       onClose={onClose}
       aria-labelledby="pluginLibraryFlyoutTitle"
       pushMinBreakpoint="xs"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_library_panel.tsx
@@ -24,6 +24,7 @@ import { labels } from '../../../utils/i18n';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { appPaths } from '../../../utils/app_paths';
 import { LibraryToggleRow } from '../common/library_toggle_row';
+import { FLYOUT_WIDTH } from '../common/constants';
 
 interface SkillLibraryPanelProps {
   onClose: () => void;
@@ -59,7 +60,7 @@ export const SkillLibraryPanel: React.FC<SkillLibraryPanelProps> = ({
   return (
     <EuiFlyout
       side="right"
-      size="960px"
+      size={FLYOUT_WIDTH}
       onClose={onClose}
       aria-labelledby="skillLibraryFlyoutTitle"
       pushMinBreakpoint="xs"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -83,8 +83,6 @@ export const AgentTools: React.FC = () => {
 
   const builtinToolIdSet = useMemo(() => new Set(builtinTools.map((t) => t.id)), [builtinTools]);
 
-  // When elastic capabilities is on, builtin (readonly) tools are auto-included
-  // even if they aren't in the explicit tool selections.
   const activeTools = useMemo(() => {
     if (!agent) return [];
     const explicitTools = allTools.filter((t) => isToolSelected(t, agentToolSelections));
@@ -98,7 +96,6 @@ export const AgentTools: React.FC = () => {
 
   const activeToolIdSet = useMemo(() => new Set(activeTools.map((t) => t.id)), [activeTools]);
 
-  // For the library flyout: union of explicit selections and builtin IDs when elastic capabilities is on
   const libraryActiveToolIdSet = useMemo(() => {
     if (enableElasticCapabilities) return new Set([...activeToolIdSet, ...builtinToolIdSet]);
     return activeToolIdSet;
@@ -125,7 +122,6 @@ export const AgentTools: React.FC = () => {
     );
   }, [activeTools, searchQuery]);
 
-  // Mutation to update the agent's tool selections
   const updateToolsMutation = useMutation({
     mutationFn: (newToolSelections: ToolSelection[]) => {
       return agentService.update(agentId!, { configuration: { tools: newToolSelections } });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ToolDefinition, ToolSelection } from '@kbn/agent-builder-common';
+import { defaultAgentToolIds } from '@kbn/agent-builder-common';
 import { useMutation, useQueryClient } from '@kbn/react-query';
 import { labels } from '../../../utils/i18n';
 import { useToolsService } from '../../../hooks/tools/use_tools';
@@ -62,27 +63,29 @@ export const AgentTools: React.FC = () => {
 
   const enableElasticCapabilities = agent?.configuration?.enable_elastic_capabilities ?? false;
 
-  const builtinTools = useMemo(() => allTools.filter((t) => t.readonly), [allTools]);
-
-  const builtinToolIdSet = useMemo(() => new Set(builtinTools.map((t) => t.id)), [builtinTools]);
+  // The static set of tool IDs managed by the elastic capabilities flag,
+  // matching the exact server-side defaultAgentToolIds list for backward compatibility.
+  const defaultToolIdSet = useMemo(() => new Set<string>(defaultAgentToolIds), []);
 
   const activeTools = useMemo(() => {
     if (!agent) return [];
     const explicitTools = allTools.filter((t) => isToolSelected(t, agentToolSelections));
     if (enableElasticCapabilities) {
       const explicitIdSet = new Set(explicitTools.map((t) => t.id));
-      const builtinNotExplicit = builtinTools.filter((t) => !explicitIdSet.has(t.id));
-      return [...explicitTools, ...builtinNotExplicit];
+      const defaultToolsNotExplicit = allTools.filter(
+        (t) => defaultToolIdSet.has(t.id) && !explicitIdSet.has(t.id)
+      );
+      return [...explicitTools, ...defaultToolsNotExplicit];
     }
     return explicitTools;
-  }, [allTools, agentToolSelections, agent, enableElasticCapabilities, builtinTools]);
+  }, [allTools, agentToolSelections, agent, enableElasticCapabilities, defaultToolIdSet]);
 
   const activeToolIdSet = useMemo(() => new Set(activeTools.map((t) => t.id)), [activeTools]);
 
   const libraryActiveToolIdSet = useMemo(() => {
-    if (enableElasticCapabilities) return new Set([...activeToolIdSet, ...builtinToolIdSet]);
+    if (enableElasticCapabilities) return new Set([...activeToolIdSet, ...defaultToolIdSet]);
     return activeToolIdSet;
-  }, [activeToolIdSet, enableElasticCapabilities, builtinToolIdSet]);
+  }, [activeToolIdSet, enableElasticCapabilities, defaultToolIdSet]);
 
   useEffect(() => {
     if (!selectedToolId) {
@@ -149,24 +152,24 @@ export const AgentTools: React.FC = () => {
 
   const handleToggleTool = useCallback(
     (tool: ToolDefinition, isActive: boolean) => {
-      if (enableElasticCapabilities && tool.readonly) return;
+      if (enableElasticCapabilities && defaultToolIdSet.has(tool.id)) return;
       if (isActive) {
         handleAddTool(tool);
       } else {
         handleRemoveTool(tool);
       }
     },
-    [handleAddTool, handleRemoveTool, enableElasticCapabilities]
+    [handleAddTool, handleRemoveTool, enableElasticCapabilities, defaultToolIdSet]
   );
 
   const handleRemoveSelectedTool = useCallback(() => {
     if (!selectedToolId) return;
     const tool = activeTools.find((t) => t.id === selectedToolId);
     if (tool) {
-      if (enableElasticCapabilities && tool.readonly) return;
+      if (enableElasticCapabilities && defaultToolIdSet.has(tool.id)) return;
       handleRemoveTool(tool);
     }
-  }, [selectedToolId, activeTools, handleRemoveTool, enableElasticCapabilities]);
+  }, [selectedToolId, activeTools, handleRemoveTool, enableElasticCapabilities, defaultToolIdSet]);
 
   const isLoading = agentLoading || toolsLoading;
 
@@ -268,7 +271,7 @@ export const AgentTools: React.FC = () => {
               </EuiText>
             ) : (
               filteredActiveTools.map((tool) => {
-                const isBuiltinManaged = enableElasticCapabilities && tool.readonly;
+                const isBuiltinManaged = enableElasticCapabilities && defaultToolIdSet.has(tool.id);
                 return (
                   <ActiveItemRow
                     key={tool.id}
@@ -302,10 +305,7 @@ export const AgentTools: React.FC = () => {
             <ToolDetailPanel
               toolId={selectedToolId}
               onRemove={handleRemoveSelectedTool}
-              isReadOnly={
-                enableElasticCapabilities &&
-                (activeTools.find((t) => t.id === selectedToolId)?.readonly ?? false)
-              }
+              isReadOnly={enableElasticCapabilities && defaultToolIdSet.has(selectedToolId)}
             />
           ) : (
             <EuiFlexGroup
@@ -331,7 +331,7 @@ export const AgentTools: React.FC = () => {
           onToggleTool={handleToggleTool}
           mutatingToolId={mutatingToolId}
           enableElasticCapabilities={enableElasticCapabilities}
-          builtinToolIdSet={builtinToolIdSet}
+          builtinToolIdSet={defaultToolIdSet}
         />
       )}
     </div>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -63,8 +63,6 @@ export const AgentTools: React.FC = () => {
 
   const enableElasticCapabilities = agent?.configuration?.enable_elastic_capabilities ?? false;
 
-  // The static set of tool IDs managed by the elastic capabilities flag,
-  // matching the exact server-side defaultAgentToolIds list for backward compatibility.
   const defaultToolIdSet = useMemo(() => new Set<string>(defaultAgentToolIds), []);
 
   const activeTools = useMemo(() => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -1,0 +1,393 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPopover,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { ToolDefinition, ToolSelection } from '@kbn/agent-builder-common';
+import { useMutation, useQueryClient } from '@kbn/react-query';
+import { labels } from '../../../utils/i18n';
+import { useToolsService } from '../../../hooks/tools/use_tools';
+import { useAgentBuilderAgentById } from '../../../hooks/agents/use_agent_by_id';
+import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_service';
+import { useToasts } from '../../../hooks/use_toasts';
+import { queryKeys } from '../../../query_keys';
+import { useFlyoutState } from '../../../hooks/use_flyout_state';
+import { useNavigation } from '../../../hooks/use_navigation';
+import { appPaths } from '../../../utils/app_paths';
+import { isToolSelected, toggleToolSelection } from '../../../utils/tool_selection_utils';
+import { ActiveItemRow } from '../common/active_item_row';
+import { ToolLibraryPanel } from './tool_library_panel';
+import { ToolDetailPanel } from './tool_detail_panel';
+
+const FLEX_ITEM_WIDTH = '280px';
+
+export const AgentTools: React.FC = () => {
+  const { agentId } = useParams<{ agentId: string }>();
+  const { euiTheme } = useEuiTheme();
+  const { agentService } = useAgentBuilderServices();
+  const { addSuccessToast, addErrorToast } = useToasts();
+  const { navigateToAgentBuilderUrl } = useNavigation();
+  const queryClient = useQueryClient();
+
+  const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
+  const { tools: allTools, isLoading: toolsLoading } = useToolsService();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
+  const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
+  const [mutatingToolId, setMutatingToolId] = useState<string | null>(null);
+  const {
+    isOpen: isLibraryOpen,
+    openFlyout: openLibrary,
+    closeFlyout: closeLibrary,
+  } = useFlyoutState();
+
+  const handleOpenLibrary = useCallback(() => {
+    setIsAddMenuOpen(false);
+    openLibrary();
+  }, [openLibrary]);
+
+  const handleCreateNewTool = useCallback(() => {
+    setIsAddMenuOpen(false);
+    navigateToAgentBuilderUrl(appPaths.manage.toolsNew);
+  }, [navigateToAgentBuilderUrl]);
+
+  const agentToolSelections = useMemo(
+    () => agent?.configuration?.tools ?? [],
+    [agent?.configuration?.tools]
+  );
+
+  const enableElasticCapabilities = agent?.configuration?.enable_elastic_capabilities ?? false;
+
+  const builtinTools = useMemo(() => allTools.filter((t) => t.readonly), [allTools]);
+
+  const builtinToolIdSet = useMemo(() => new Set(builtinTools.map((t) => t.id)), [builtinTools]);
+
+  // When elastic capabilities is on, builtin (readonly) tools are auto-included
+  // even if they aren't in the explicit tool selections.
+  const activeTools = useMemo(() => {
+    if (!agent) return [];
+    const explicitTools = allTools.filter((t) => isToolSelected(t, agentToolSelections));
+    if (enableElasticCapabilities) {
+      const explicitIdSet = new Set(explicitTools.map((t) => t.id));
+      const builtinNotExplicit = builtinTools.filter((t) => !explicitIdSet.has(t.id));
+      return [...explicitTools, ...builtinNotExplicit];
+    }
+    return explicitTools;
+  }, [allTools, agentToolSelections, agent, enableElasticCapabilities, builtinTools]);
+
+  const activeToolIdSet = useMemo(() => new Set(activeTools.map((t) => t.id)), [activeTools]);
+
+  // For the library flyout: union of explicit selections and builtin IDs when elastic capabilities is on
+  const libraryActiveToolIdSet = useMemo(() => {
+    if (enableElasticCapabilities) return new Set([...activeToolIdSet, ...builtinToolIdSet]);
+    return activeToolIdSet;
+  }, [activeToolIdSet, enableElasticCapabilities, builtinToolIdSet]);
+
+  useEffect(() => {
+    if (!selectedToolId) {
+      if (activeTools.length > 0) {
+        setSelectedToolId(activeTools[0].id);
+      }
+    } else {
+      const stillActive = activeTools.some((t) => t.id === selectedToolId);
+      if (!stillActive) {
+        setSelectedToolId(activeTools[0]?.id ?? null);
+      }
+    }
+  }, [activeTools, selectedToolId]);
+
+  const filteredActiveTools = useMemo(() => {
+    if (!searchQuery.trim()) return activeTools;
+    const lower = searchQuery.toLowerCase();
+    return activeTools.filter(
+      (t) => t.id.toLowerCase().includes(lower) || t.description.toLowerCase().includes(lower)
+    );
+  }, [activeTools, searchQuery]);
+
+  // Mutation to update the agent's tool selections
+  const updateToolsMutation = useMutation({
+    mutationFn: (newToolSelections: ToolSelection[]) => {
+      return agentService.update(agentId!, { configuration: { tools: newToolSelections } });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.agentProfiles.byId(agentId) });
+    },
+    onError: () => {
+      addErrorToast({ title: labels.agentTools.updateToolsErrorToast });
+    },
+  });
+
+  const handleAddTool = useCallback(
+    async (tool: ToolDefinition) => {
+      if (isToolSelected(tool, agentToolSelections)) return;
+      const newSelections = toggleToolSelection(tool.id, allTools, agentToolSelections);
+      setMutatingToolId(tool.id);
+      try {
+        await updateToolsMutation.mutateAsync(newSelections);
+        addSuccessToast({ title: labels.agentTools.addToolSuccessToast(tool.id) });
+      } finally {
+        setMutatingToolId(null);
+      }
+    },
+    [agentToolSelections, allTools, updateToolsMutation, addSuccessToast]
+  );
+
+  const handleRemoveTool = useCallback(
+    (tool: ToolDefinition) => {
+      const newSelections = toggleToolSelection(tool.id, allTools, agentToolSelections);
+      setMutatingToolId(tool.id);
+      updateToolsMutation.mutate(newSelections, {
+        onSuccess: () => {
+          setSelectedToolId(null);
+          addSuccessToast({ title: labels.agentTools.removeToolSuccessToast(tool.id) });
+        },
+        onSettled: () => setMutatingToolId(null),
+      });
+    },
+    [agentToolSelections, allTools, updateToolsMutation, addSuccessToast]
+  );
+
+  const handleToggleTool = useCallback(
+    (tool: ToolDefinition, isActive: boolean) => {
+      if (enableElasticCapabilities && tool.readonly) return;
+      if (isActive) {
+        handleAddTool(tool);
+      } else {
+        handleRemoveTool(tool);
+      }
+    },
+    [handleAddTool, handleRemoveTool, enableElasticCapabilities]
+  );
+
+  const handleRemoveSelectedTool = useCallback(() => {
+    if (!selectedToolId) return;
+    const tool = activeTools.find((t) => t.id === selectedToolId);
+    if (tool) {
+      if (enableElasticCapabilities && tool.readonly) return;
+      handleRemoveTool(tool);
+    }
+  }, [selectedToolId, activeTools, handleRemoveTool, enableElasticCapabilities]);
+
+  const isLoading = agentLoading || toolsLoading;
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup
+        alignItems="center"
+        justifyContent="center"
+        css={css`
+          padding: ${euiTheme.size.xxl};
+        `}
+      >
+        <EuiLoadingSpinner size="xl" />
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <div
+      css={css`
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      `}
+    >
+      <div
+        css={css`
+          padding: ${euiTheme.size.l};
+          flex-shrink: 0;
+        `}
+      >
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="l">
+              <h1>{labels.tools.title}</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiPopover
+              aria-label={labels.agentTools.addToolButton}
+              button={
+                <EuiButton
+                  fill
+                  iconType="plusInCircle"
+                  iconSide="left"
+                  onClick={() => setIsAddMenuOpen((prev) => !prev)}
+                >
+                  {labels.agentTools.addToolButton}
+                </EuiButton>
+              }
+              isOpen={isAddMenuOpen}
+              closePopover={() => setIsAddMenuOpen(false)}
+              anchorPosition="downLeft"
+              panelPaddingSize="none"
+            >
+              <EuiContextMenuPanel
+                items={[
+                  <EuiContextMenuItem
+                    key="fromLibrary"
+                    icon="importAction"
+                    onClick={handleOpenLibrary}
+                  >
+                    {labels.agentTools.fromLibraryMenuItem}
+                  </EuiContextMenuItem>,
+                  <EuiContextMenuItem
+                    key="createNew"
+                    icon="plusInCircle"
+                    onClick={handleCreateNewTool}
+                  >
+                    {labels.agentTools.createNewToolMenuItem}
+                  </EuiContextMenuItem>,
+                ]}
+              />
+            </EuiPopover>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size="s" />
+        <EuiText size="s" color="subdued">
+          {labels.agentTools.pageDescription}
+        </EuiText>
+      </div>
+
+      <EuiFlexGroup
+        gutterSize="none"
+        responsive={false}
+        css={css`
+          flex: 1;
+          overflow: hidden;
+          padding: 0px ${euiTheme.size.l};
+        `}
+      >
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            width: ${FLEX_ITEM_WIDTH};
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+          `}
+        >
+          <div
+            css={css`
+              padding: 0px ${euiTheme.size.m} ${euiTheme.size.s} 0px;
+              flex-shrink: 0;
+            `}
+          >
+            <EuiFieldSearch
+              placeholder={labels.agentTools.searchActiveToolsPlaceholder}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              incremental
+              fullWidth
+            />
+          </div>
+
+          <div
+            css={css`
+              flex: 1;
+              overflow-y: auto;
+              padding: 0px ${euiTheme.size.m} ${euiTheme.size.s} 0px;
+            `}
+          >
+            {filteredActiveTools.length === 0 ? (
+              <EuiText size="s" color="subdued" textAlign="center">
+                <p>
+                  {searchQuery.trim()
+                    ? labels.agentTools.noActiveToolsMatchMessage
+                    : labels.agentTools.noActiveToolsMessage}
+                </p>
+              </EuiText>
+            ) : (
+              filteredActiveTools.map((tool) => {
+                const isBuiltinManaged = enableElasticCapabilities && tool.readonly;
+                return (
+                  <ActiveItemRow
+                    key={tool.id}
+                    id={tool.id}
+                    name={tool.id}
+                    isSelected={selectedToolId === tool.id}
+                    onSelect={() => setSelectedToolId(tool.id)}
+                    onRemove={() => handleRemoveTool(tool)}
+                    isRemoving={updateToolsMutation.isLoading}
+                    removeAriaLabel={labels.agentTools.removeToolAriaLabel}
+                    readOnlyContent={
+                      isBuiltinManaged ? (
+                        <EuiBadge color="hollow">
+                          {labels.agentTools.elasticCapabilitiesReadOnlyBadge}
+                        </EuiBadge>
+                      ) : undefined
+                    }
+                  />
+                );
+              })
+            )}
+          </div>
+        </EuiFlexItem>
+
+        <EuiFlexItem
+          css={css`
+            overflow: hidden;
+          `}
+        >
+          {selectedToolId ? (
+            <ToolDetailPanel
+              toolId={selectedToolId}
+              onRemove={handleRemoveSelectedTool}
+              isReadOnly={
+                enableElasticCapabilities &&
+                (activeTools.find((t) => t.id === selectedToolId)?.readonly ?? false)
+              }
+            />
+          ) : (
+            <EuiFlexGroup
+              justifyContent="center"
+              alignItems="center"
+              css={css`
+                height: 100%;
+              `}
+            >
+              <EuiText size="s" color="subdued">
+                {labels.agentTools.noToolSelectedMessage}
+              </EuiText>
+            </EuiFlexGroup>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {isLibraryOpen && (
+        <ToolLibraryPanel
+          onClose={closeLibrary}
+          allTools={allTools}
+          activeToolIdSet={libraryActiveToolIdSet}
+          onToggleTool={handleToggleTool}
+          mutatingToolId={mutatingToolId}
+          enableElasticCapabilities={enableElasticCapabilities}
+          builtinToolIdSet={builtinToolIdSet}
+        />
+      )}
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -30,12 +30,75 @@ import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_servic
 import { useToasts } from '../../../hooks/use_toasts';
 import { queryKeys } from '../../../query_keys';
 import { useFlyoutState } from '../../../hooks/use_flyout_state';
-import { isToolSelected, toggleToolSelection } from '../../../utils/tool_selection_utils';
+import {
+  getActiveTools,
+  isToolSelected,
+  toggleToolSelection,
+} from '../../../utils/tool_selection_utils';
 import { ActiveItemRow } from '../common/active_item_row';
 import { ToolLibraryPanel } from './tool_library_panel';
 import { ToolDetailPanel } from './tool_detail_panel';
 
 const FLEX_ITEM_WIDTH = '280px';
+
+const ActiveToolsList: React.FC<{
+  filteredActiveTools: ToolDefinition[];
+  searchQuery: string;
+  selectedToolId: string | null;
+  enableElasticCapabilities: boolean;
+  defaultToolIdSet: Set<string>;
+  isRemoving: boolean;
+  onSelect: (id: string) => void;
+  onRemove: (tool: ToolDefinition) => void;
+}> = ({
+  filteredActiveTools,
+  searchQuery,
+  selectedToolId,
+  enableElasticCapabilities,
+  defaultToolIdSet,
+  isRemoving,
+  onSelect,
+  onRemove,
+}) => {
+  if (filteredActiveTools.length === 0) {
+    return (
+      <EuiText size="s" color="subdued" textAlign="center">
+        <p>
+          {searchQuery.trim()
+            ? labels.agentTools.noActiveToolsMatchMessage
+            : labels.agentTools.noActiveToolsMessage}
+        </p>
+      </EuiText>
+    );
+  }
+
+  return (
+    <>
+      {filteredActiveTools.map((tool) => {
+        const isBuiltinManaged = enableElasticCapabilities && defaultToolIdSet.has(tool.id);
+        return (
+          <ActiveItemRow
+            key={tool.id}
+            id={tool.id}
+            name={tool.id}
+            isSelected={selectedToolId === tool.id}
+            onSelect={() => onSelect(tool.id)}
+            onRemove={() => onRemove(tool)}
+            isRemoving={isRemoving}
+            removeAriaLabel={labels.agentTools.removeToolAriaLabel}
+            readOnlyContent={
+              isBuiltinManaged ? (
+                <EuiBadge color="hollow">
+                  {labels.agentTools.elasticCapabilitiesReadOnlyBadge}
+                </EuiBadge>
+              ) : undefined
+            }
+          />
+        );
+      })}
+    </>
+  );
+};
 
 export const AgentTools: React.FC = () => {
   const { agentId } = useParams<{ agentId: string }>();
@@ -65,18 +128,13 @@ export const AgentTools: React.FC = () => {
 
   const defaultToolIdSet = useMemo(() => new Set<string>(defaultAgentToolIds), []);
 
-  const activeTools = useMemo(() => {
-    if (!agent) return [];
-    const explicitTools = allTools.filter((t) => isToolSelected(t, agentToolSelections));
-    if (enableElasticCapabilities) {
-      const explicitIdSet = new Set(explicitTools.map((t) => t.id));
-      const defaultToolsNotExplicit = allTools.filter(
-        (t) => defaultToolIdSet.has(t.id) && !explicitIdSet.has(t.id)
-      );
-      return [...explicitTools, ...defaultToolsNotExplicit];
-    }
-    return explicitTools;
-  }, [allTools, agentToolSelections, agent, enableElasticCapabilities, defaultToolIdSet]);
+  const activeTools = useMemo(
+    () =>
+      agent
+        ? getActiveTools(allTools, agentToolSelections, enableElasticCapabilities, defaultToolIdSet)
+        : [],
+    [allTools, agentToolSelections, agent, enableElasticCapabilities, defaultToolIdSet]
+  );
 
   const activeToolIdSet = useMemo(() => new Set(activeTools.map((t) => t.id)), [activeTools]);
 
@@ -259,38 +317,16 @@ export const AgentTools: React.FC = () => {
               padding: 0px ${euiTheme.size.m} ${euiTheme.size.s} 0px;
             `}
           >
-            {filteredActiveTools.length === 0 ? (
-              <EuiText size="s" color="subdued" textAlign="center">
-                <p>
-                  {searchQuery.trim()
-                    ? labels.agentTools.noActiveToolsMatchMessage
-                    : labels.agentTools.noActiveToolsMessage}
-                </p>
-              </EuiText>
-            ) : (
-              filteredActiveTools.map((tool) => {
-                const isBuiltinManaged = enableElasticCapabilities && defaultToolIdSet.has(tool.id);
-                return (
-                  <ActiveItemRow
-                    key={tool.id}
-                    id={tool.id}
-                    name={tool.id}
-                    isSelected={selectedToolId === tool.id}
-                    onSelect={() => setSelectedToolId(tool.id)}
-                    onRemove={() => handleRemoveTool(tool)}
-                    isRemoving={updateToolsMutation.isLoading}
-                    removeAriaLabel={labels.agentTools.removeToolAriaLabel}
-                    readOnlyContent={
-                      isBuiltinManaged ? (
-                        <EuiBadge color="hollow">
-                          {labels.agentTools.elasticCapabilitiesReadOnlyBadge}
-                        </EuiBadge>
-                      ) : undefined
-                    }
-                  />
-                );
-              })
-            )}
+            <ActiveToolsList
+              filteredActiveTools={filteredActiveTools}
+              searchQuery={searchQuery}
+              selectedToolId={selectedToolId}
+              enableElasticCapabilities={enableElasticCapabilities}
+              defaultToolIdSet={defaultToolIdSet}
+              isRemoving={updateToolsMutation.isLoading}
+              onSelect={setSelectedToolId}
+              onRemove={handleRemoveTool}
+            />
           </div>
         </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -10,13 +10,10 @@ import { useParams } from 'react-router-dom';
 import {
   EuiBadge,
   EuiButton,
-  EuiContextMenuItem,
-  EuiContextMenuPanel,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
-  EuiPopover,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -32,8 +29,6 @@ import { useAgentBuilderServices } from '../../../hooks/use_agent_builder_servic
 import { useToasts } from '../../../hooks/use_toasts';
 import { queryKeys } from '../../../query_keys';
 import { useFlyoutState } from '../../../hooks/use_flyout_state';
-import { useNavigation } from '../../../hooks/use_navigation';
-import { appPaths } from '../../../utils/app_paths';
 import { isToolSelected, toggleToolSelection } from '../../../utils/tool_selection_utils';
 import { ActiveItemRow } from '../common/active_item_row';
 import { ToolLibraryPanel } from './tool_library_panel';
@@ -46,7 +41,6 @@ export const AgentTools: React.FC = () => {
   const { euiTheme } = useEuiTheme();
   const { agentService } = useAgentBuilderServices();
   const { addSuccessToast, addErrorToast } = useToasts();
-  const { navigateToAgentBuilderUrl } = useNavigation();
   const queryClient = useQueryClient();
 
   const { agent, isLoading: agentLoading } = useAgentBuilderAgentById(agentId);
@@ -54,23 +48,12 @@ export const AgentTools: React.FC = () => {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
-  const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
   const [mutatingToolId, setMutatingToolId] = useState<string | null>(null);
   const {
     isOpen: isLibraryOpen,
     openFlyout: openLibrary,
     closeFlyout: closeLibrary,
   } = useFlyoutState();
-
-  const handleOpenLibrary = useCallback(() => {
-    setIsAddMenuOpen(false);
-    openLibrary();
-  }, [openLibrary]);
-
-  const handleCreateNewTool = useCallback(() => {
-    setIsAddMenuOpen(false);
-    navigateToAgentBuilderUrl(appPaths.manage.toolsNew);
-  }, [navigateToAgentBuilderUrl]);
 
   const agentToolSelections = useMemo(
     () => agent?.configuration?.tools ?? [],
@@ -223,42 +206,9 @@ export const AgentTools: React.FC = () => {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiPopover
-              aria-label={labels.agentTools.addToolButton}
-              button={
-                <EuiButton
-                  fill
-                  iconType="plusInCircle"
-                  iconSide="left"
-                  onClick={() => setIsAddMenuOpen((prev) => !prev)}
-                >
-                  {labels.agentTools.addToolButton}
-                </EuiButton>
-              }
-              isOpen={isAddMenuOpen}
-              closePopover={() => setIsAddMenuOpen(false)}
-              anchorPosition="downLeft"
-              panelPaddingSize="none"
-            >
-              <EuiContextMenuPanel
-                items={[
-                  <EuiContextMenuItem
-                    key="fromLibrary"
-                    icon="importAction"
-                    onClick={handleOpenLibrary}
-                  >
-                    {labels.agentTools.fromLibraryMenuItem}
-                  </EuiContextMenuItem>,
-                  <EuiContextMenuItem
-                    key="createNew"
-                    icon="plusInCircle"
-                    onClick={handleCreateNewTool}
-                  >
-                    {labels.agentTools.createNewToolMenuItem}
-                  </EuiContextMenuItem>,
-                ]}
-              />
-            </EuiPopover>
+            <EuiButton fill iconType="plusInCircle" iconSide="left" onClick={openLibrary}>
+              {labels.agentTools.addToolButton}
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_detail_panel.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiConfirmModal,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiTitle,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { labels } from '../../../utils/i18n';
+import { useToolService } from '../../../hooks/tools/use_tools';
+import { DetailRow } from '../common/detail_row';
+
+interface ToolDetailPanelProps {
+  toolId: string;
+  onRemove: () => void;
+  /** When true the tool is auto-included and cannot be removed. */
+  isReadOnly?: boolean;
+}
+
+/**
+ * Right-side detail panel for the selected tool in the agent tools page.
+ * Displays tool metadata (ID, type, description, tags) and a remove action
+ * with confirmation modal.
+ */
+export const ToolDetailPanel: React.FC<ToolDetailPanelProps> = ({
+  toolId,
+  onRemove,
+  isReadOnly = false,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const { tool, isLoading } = useToolService(toolId);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup
+        justifyContent="center"
+        alignItems="center"
+        css={css`
+          padding: ${euiTheme.size.xxl};
+        `}
+      >
+        <EuiLoadingSpinner size="l" />
+      </EuiFlexGroup>
+    );
+  }
+
+  if (!tool) return null;
+
+  return (
+    <div
+      css={css`
+        height: 100%;
+        overflow-y: auto;
+        padding: 0;
+      `}
+    >
+      <div
+        css={css`
+          border: ${euiTheme.border.thin};
+          overflow: hidden;
+        `}
+      >
+        {/* Header with tool name, badges, and remove button */}
+        <div
+          css={css`
+            padding: ${euiTheme.size.m};
+            border-bottom: ${euiTheme.border.thin};
+            background-color: ${euiTheme.colors.backgroundBaseSubdued};
+          `}
+        >
+          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiTitle size="s">
+                    <h2>{tool.id}</h2>
+                  </EuiTitle>
+                </EuiFlexItem>
+                {tool.readonly && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">{labels.agentTools.readOnlyBadge}</EuiBadge>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            {!isReadOnly && (
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="cross"
+                  size="xs"
+                  color="danger"
+                  onClick={() => setIsConfirmOpen(true)}
+                >
+                  {labels.agentTools.removeToolButtonLabel}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </div>
+
+        {/* Detail rows: tags, description, type, ID */}
+        <div
+          css={css`
+            padding: ${euiTheme.size.m};
+          `}
+        >
+          {tool.tags.length > 0 && (
+            <DetailRow label={labels.agentTools.toolDetailTagsLabel}>
+              <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+                {tool.tags.map((tag) => (
+                  <EuiFlexItem key={tag} grow={false}>
+                    <EuiBadge color="hollow">{tag}</EuiBadge>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </DetailRow>
+          )}
+          <DetailRow label={labels.agentTools.toolDetailDescriptionLabel}>
+            <EuiText size="s">{tool.description || '\u2014'}</EuiText>
+          </DetailRow>
+          <DetailRow label={labels.agentTools.toolDetailTypeLabel}>
+            <EuiText size="s">{tool.type}</EuiText>
+          </DetailRow>
+          <DetailRow label={labels.agentTools.toolDetailIdLabel} isLast>
+            <EuiText size="s">{tool.id}</EuiText>
+          </DetailRow>
+        </div>
+      </div>
+
+      {isConfirmOpen && (
+        <EuiConfirmModal
+          title={labels.agentTools.removeToolConfirmTitle(tool.id)}
+          aria-label={labels.agentTools.removeToolConfirmTitle(tool.id)}
+          onCancel={() => setIsConfirmOpen(false)}
+          onConfirm={() => {
+            setIsConfirmOpen(false);
+            onRemove();
+          }}
+          cancelButtonText={labels.agentTools.removeToolCancelButton}
+          confirmButtonText={labels.agentTools.removeToolConfirmButton}
+          buttonColor="danger"
+        >
+          <p>{labels.agentTools.removeToolConfirmBody}</p>
+        </EuiConfirmModal>
+      )}
+    </div>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  EuiCallOut,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import type { ToolDefinition } from '@kbn/agent-builder-common';
+import { labels } from '../../../utils/i18n';
+import { useNavigation } from '../../../hooks/use_navigation';
+import { appPaths } from '../../../utils/app_paths';
+import { LibraryToggleRow } from '../common/library_toggle_row';
+
+interface ToolLibraryPanelProps {
+  onClose: () => void;
+  allTools: ToolDefinition[];
+  activeToolIdSet: Set<string>;
+  onToggleTool: (tool: ToolDefinition, isActive: boolean) => void;
+  mutatingToolId: string | null;
+  enableElasticCapabilities?: boolean;
+  builtinToolIdSet?: Set<string>;
+}
+
+/**
+ * Flyout that lists all available tools from the library with toggle switches
+ * to add/remove tools from the current agent. Mirrors the skill library panel pattern.
+ * When elastic capabilities is enabled, builtin tools are locked on with a tooltip.
+ */
+export const ToolLibraryPanel: React.FC<ToolLibraryPanelProps> = ({
+  onClose,
+  allTools,
+  activeToolIdSet,
+  onToggleTool,
+  mutatingToolId,
+  enableElasticCapabilities = false,
+  builtinToolIdSet,
+}) => {
+  const { createAgentBuilderUrl } = useNavigation();
+  const manageLibraryUrl = createAgentBuilderUrl(appPaths.tools.list);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredTools = useMemo(() => {
+    if (!searchQuery.trim()) return allTools;
+    const lower = searchQuery.toLowerCase();
+    return allTools.filter(
+      (t) => t.id.toLowerCase().includes(lower) || t.description.toLowerCase().includes(lower)
+    );
+  }, [allTools, searchQuery]);
+
+  return (
+    <EuiFlyout
+      side="right"
+      size="960px"
+      onClose={onClose}
+      aria-labelledby="toolLibraryFlyoutTitle"
+      pushMinBreakpoint="xs"
+      hideCloseButton={false}
+    >
+      <EuiFlyoutHeader hasBorder>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="xs">
+              <h2 id="toolLibraryFlyoutTitle">{labels.agentTools.addToolFromLibraryTitle}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiLink href={manageLibraryUrl} external>
+              {labels.agentTools.manageToolLibraryLink}
+            </EuiLink>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFieldSearch
+          placeholder={labels.agentTools.searchAvailableToolsPlaceholder}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          incremental
+          fullWidth
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiText size="xs" color="subdued">
+          {labels.agentTools.availableToolsSummary(filteredTools.length, allTools.length)}
+        </EuiText>
+
+        <EuiSpacer size="m" />
+
+        {enableElasticCapabilities && (
+          <>
+            <EuiCallOut
+              size="s"
+              iconType="iInCircle"
+              title={labels.agentTools.elasticCapabilitiesCallout}
+              announceOnMount={false}
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        {filteredTools.length === 0 ? (
+          <EuiText size="s" color="subdued" textAlign="center">
+            {searchQuery.trim()
+              ? labels.agentTools.noAvailableToolsMatchMessage
+              : labels.agentTools.noAvailableToolsMessage}
+          </EuiText>
+        ) : (
+          <EuiFlexGroup direction="column" gutterSize="m">
+            {filteredTools.map((tool) => {
+              const isBuiltinManaged =
+                enableElasticCapabilities && (builtinToolIdSet?.has(tool.id) ?? false);
+
+              return (
+                <EuiFlexItem key={tool.id} grow={false}>
+                  <LibraryToggleRow
+                    id={tool.id}
+                    name={tool.id}
+                    description={tool.description}
+                    isActive={activeToolIdSet.has(tool.id)}
+                    onToggle={(checked) => onToggleTool(tool, checked)}
+                    isMutating={mutatingToolId === tool.id}
+                    isDisabled={isBuiltinManaged}
+                    disabledTooltip={
+                      isBuiltinManaged
+                        ? labels.agentTools.elasticCapabilitiesManagedTooltip
+                        : undefined
+                    }
+                  />
+                </EuiFlexItem>
+              );
+            })}
+          </EuiFlexGroup>
+        )}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
@@ -24,6 +24,7 @@ import { labels } from '../../../utils/i18n';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { appPaths } from '../../../utils/app_paths';
 import { LibraryToggleRow } from '../common/library_toggle_row';
+import { FLYOUT_WIDTH } from '../common/constants';
 
 interface ToolLibraryPanelProps {
   onClose: () => void;
@@ -59,7 +60,7 @@ export const ToolLibraryPanel: React.FC<ToolLibraryPanelProps> = ({
   return (
     <EuiFlyout
       side="right"
-      size="960px"
+      size={FLYOUT_WIDTH}
       onClose={onClose}
       aria-labelledby="toolLibraryFlyoutTitle"
       pushMinBreakpoint="xs"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_library_panel.tsx
@@ -35,11 +35,6 @@ interface ToolLibraryPanelProps {
   builtinToolIdSet?: Set<string>;
 }
 
-/**
- * Flyout that lists all available tools from the library with toggle switches
- * to add/remove tools from the current agent. Mirrors the skill library panel pattern.
- * When elastic capabilities is enabled, builtin tools are locked on with a tooltip.
- */
 export const ToolLibraryPanel: React.FC<ToolLibraryPanelProps> = ({
   onClose,
   allTools,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_header/conversation_actions_right.tsx
@@ -37,10 +37,10 @@ export const ConversationRightActions: React.FC<ConversationRightActionsProps> =
       aria-label={labels.container}
       responsive={false}
     >
-        <MoreActionsButton
-          onRenameConversation={onRenameConversation}
-          onCloseSidebar={isEmbeddedContext ? onClose : undefined}
-        />
+      <MoreActionsButton
+        onRenameConversation={onRenameConversation}
+        onCloseSidebar={isEmbeddedContext ? onClose : undefined}
+      />
       {isEmbeddedContext ? <CloseDockedViewButton onClose={onClose} /> : null}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -119,7 +119,7 @@ export const agentRoutes: RouteDefinition[] = [
     sidebarView: 'agentSettings',
     navLabel: navLabels.tools,
     navIcon: 'wrench',
-    navSection: 'Advanced',
+    navSection: navSections.advanced,
     element: <AgentTools />,
   },
   // Catch-all for agent root - must be last

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/route_config.tsx
@@ -26,6 +26,7 @@ import { AgentBuilderPluginsPage } from './pages/plugins';
 import { AgentBuilderPluginDetailsPage } from './pages/plugin_details';
 import { AgentBuilderConnectorsPage } from './pages/connectors';
 import { AgentPlugins } from './components/agents/plugins/agent_plugins';
+import { AgentTools } from './components/agents/tools/agent_tools';
 
 export type SidebarView = 'conversation' | 'agentSettings' | 'manage';
 
@@ -98,6 +99,14 @@ export const agentRoutes: RouteDefinition[] = [
     navIcon: 'plugs',
     navSection: 'Capabilities',
     element: <RouteDisplay />,
+  },
+  {
+    path: '/agents/:agentId/tools',
+    sidebarView: 'agentSettings',
+    navLabel: navLabels.tools,
+    navIcon: 'wrench',
+    navSection: 'Advanced',
+    element: <AgentTools />,
   },
   // Catch-all for agent root - must be last
   {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/app_paths.ts
@@ -21,6 +21,7 @@ export const appPaths = {
     },
     skills: ({ agentId }: { agentId: string }) => `/agents/${agentId}/skills`,
     plugins: ({ agentId }: { agentId: string }) => `/agents/${agentId}/plugins`,
+    tools: ({ agentId }: { agentId: string }) => `/agents/${agentId}/tools`,
     connectors: ({ agentId }: { agentId: string }) => `/agents/${agentId}/connectors`,
     overview: ({ agentId }: { agentId: string }) => `/agents/${agentId}/overview`,
   },

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -995,6 +995,152 @@ export const labels = {
       }
     ),
   },
+  agentTools: {
+    pageDescription: i18n.translate('xpack.agentBuilder.agentTools.pageDescription', {
+      defaultMessage:
+        'Modular, reusable Elasticsearch operations. Agents use them to search, retrieve, and analyze your data.',
+    }),
+    addToolButton: i18n.translate('xpack.agentBuilder.agentTools.addToolButton', {
+      defaultMessage: 'Add tool',
+    }),
+    fromLibraryMenuItem: i18n.translate('xpack.agentBuilder.agentTools.fromLibraryMenuItem', {
+      defaultMessage: 'From library',
+    }),
+    createNewToolMenuItem: i18n.translate('xpack.agentBuilder.agentTools.createNewToolMenuItem', {
+      defaultMessage: 'Create new tool',
+    }),
+    searchActiveToolsPlaceholder: i18n.translate(
+      'xpack.agentBuilder.agentTools.searchActiveToolsPlaceholder',
+      {
+        defaultMessage: 'Search active tools',
+      }
+    ),
+    noActiveToolsMessage: i18n.translate('xpack.agentBuilder.agentTools.noActiveToolsMessage', {
+      defaultMessage:
+        'No tools assigned to this agent yet. Add tools from the library or create a new one.',
+    }),
+    noActiveToolsMatchMessage: i18n.translate(
+      'xpack.agentBuilder.agentTools.noActiveToolsMatchMessage',
+      {
+        defaultMessage: 'No active tools match your search.',
+      }
+    ),
+    removeToolButtonLabel: i18n.translate('xpack.agentBuilder.agentTools.removeToolButtonLabel', {
+      defaultMessage: 'Remove',
+    }),
+    removeToolAriaLabel: i18n.translate('xpack.agentBuilder.agentTools.removeToolAriaLabel', {
+      defaultMessage: 'Remove tool from agent',
+    }),
+    removeToolConfirmTitle: (toolId: string) =>
+      i18n.translate('xpack.agentBuilder.agentTools.removeToolConfirmTitle', {
+        defaultMessage: 'Remove "{toolId}" from agent?',
+        values: { toolId },
+      }),
+    removeToolConfirmBody: i18n.translate('xpack.agentBuilder.agentTools.removeToolConfirmBody', {
+      defaultMessage: 'The tool will no longer be available to this agent.',
+    }),
+    removeToolConfirmButton: i18n.translate(
+      'xpack.agentBuilder.agentTools.removeToolConfirmButton',
+      {
+        defaultMessage: 'Remove',
+      }
+    ),
+    removeToolCancelButton: i18n.translate('xpack.agentBuilder.agentTools.removeToolCancelButton', {
+      defaultMessage: 'Cancel',
+    }),
+    addToolSuccessToast: (toolId: string) =>
+      i18n.translate('xpack.agentBuilder.agentTools.addToolSuccessToast', {
+        defaultMessage: 'Tool "{toolId}" added to agent',
+        values: { toolId },
+      }),
+    removeToolSuccessToast: (toolId: string) =>
+      i18n.translate('xpack.agentBuilder.agentTools.removeToolSuccessToast', {
+        defaultMessage: 'Tool "{toolId}" removed from agent',
+        values: { toolId },
+      }),
+    updateToolsErrorToast: i18n.translate('xpack.agentBuilder.agentTools.updateToolsErrorToast', {
+      defaultMessage: 'Unable to update agent tools',
+    }),
+    noToolSelectedMessage: i18n.translate('xpack.agentBuilder.agentTools.noToolSelectedMessage', {
+      defaultMessage: 'Select a tool to view details.',
+    }),
+    readOnlyBadge: i18n.translate('xpack.agentBuilder.agentTools.readOnlyBadge', {
+      defaultMessage: 'Read only',
+    }),
+    addToolFromLibraryTitle: i18n.translate(
+      'xpack.agentBuilder.agentTools.addToolFromLibraryTitle',
+      {
+        defaultMessage: 'Add tool from library',
+      }
+    ),
+    manageToolLibraryLink: i18n.translate('xpack.agentBuilder.agentTools.manageToolLibraryLink', {
+      defaultMessage: 'Manage tool library',
+    }),
+    searchAvailableToolsPlaceholder: i18n.translate(
+      'xpack.agentBuilder.agentTools.searchAvailableToolsPlaceholder',
+      {
+        defaultMessage: 'Search available tools',
+      }
+    ),
+    availableToolsSummary: (showing: number, total: number) =>
+      i18n.translate('xpack.agentBuilder.agentTools.availableToolsSummary', {
+        defaultMessage: 'Showing {showing} of {total} {total, plural, one {Tool} other {Tools}}',
+        values: { showing, total },
+      }),
+    noAvailableToolsMatchMessage: i18n.translate(
+      'xpack.agentBuilder.agentTools.noAvailableToolsMatchMessage',
+      {
+        defaultMessage: 'No available tools match your search.',
+      }
+    ),
+    noAvailableToolsMessage: i18n.translate(
+      'xpack.agentBuilder.agentTools.noAvailableToolsMessage',
+      {
+        defaultMessage: 'All tools have been added to this agent.',
+      }
+    ),
+    toolDetailIdLabel: i18n.translate('xpack.agentBuilder.agentTools.toolDetailIdLabel', {
+      defaultMessage: 'ID',
+    }),
+    toolDetailTypeLabel: i18n.translate('xpack.agentBuilder.agentTools.toolDetailTypeLabel', {
+      defaultMessage: 'Type',
+    }),
+    toolDetailDescriptionLabel: i18n.translate(
+      'xpack.agentBuilder.agentTools.toolDetailDescriptionLabel',
+      {
+        defaultMessage: 'Description',
+      }
+    ),
+    toolDetailTagsLabel: i18n.translate('xpack.agentBuilder.agentTools.toolDetailTagsLabel', {
+      defaultMessage: 'Tags',
+    }),
+    noTagsLabel: i18n.translate('xpack.agentBuilder.agentTools.noTagsLabel', {
+      defaultMessage: 'No tags',
+    }),
+    autoIncludedTooltip: i18n.translate('xpack.agentBuilder.agentTools.autoIncludedTooltip', {
+      defaultMessage: 'This tool is automatically included and cannot be removed.',
+    }),
+    elasticCapabilitiesManagedTooltip: i18n.translate(
+      'xpack.agentBuilder.agentTools.elasticCapabilitiesManagedTooltip',
+      {
+        defaultMessage:
+          'This built-in tool is automatically included because Elastic Capabilities is enabled for this agent.',
+      }
+    ),
+    elasticCapabilitiesReadOnlyBadge: i18n.translate(
+      'xpack.agentBuilder.agentTools.elasticCapabilitiesReadOnlyBadge',
+      {
+        defaultMessage: 'Managed',
+      }
+    ),
+    elasticCapabilitiesCallout: i18n.translate(
+      'xpack.agentBuilder.agentTools.elasticCapabilitiesCallout',
+      {
+        defaultMessage:
+          'Built-in tools are automatically included while Elastic Capabilities is enabled.',
+      }
+    ),
+  },
   plugins: {
     title: i18n.translate('xpack.agentBuilder.plugins.title', { defaultMessage: 'Plugins' }),
     pluginsTableCaption: (pluginsCount: number) =>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/tool_selection_utils.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/tool_selection_utils.test.ts
@@ -14,6 +14,7 @@ import { ToolType, allToolsSelectionWildcard } from '@kbn/agent-builder-common';
 import {
   toggleToolSelection,
   isToolSelected,
+  getActiveTools,
   cleanInvalidToolReferences,
 } from './tool_selection_utils';
 import type { AgentEditState } from '../hooks/agents/use_agent_edit';
@@ -76,6 +77,53 @@ describe('tool_selection_utils', () => {
       expect(result[0].tool_ids).toContain('tool2');
       expect(result[0].tool_ids).toContain('tool3');
       expect(result[0].tool_ids).not.toContain(allToolsSelectionWildcard);
+    });
+  });
+
+  describe('getActiveTools', () => {
+    const defaultToolIds = new Set(['tool1', 'tool3']);
+
+    it('should return only explicitly selected tools when elastic capabilities are disabled', () => {
+      const selections: ToolSelection[] = [{ tool_ids: ['tool2'] }];
+      const result = getActiveTools(mockTools, selections, false, defaultToolIds);
+
+      expect(result.map((t) => t.id)).toEqual(['tool2']);
+    });
+
+    it('should include default tools when elastic capabilities are enabled', () => {
+      const selections: ToolSelection[] = [{ tool_ids: ['tool2'] }];
+      const result = getActiveTools(mockTools, selections, true, defaultToolIds);
+
+      expect(result.map((t) => t.id)).toEqual(['tool2', 'tool1', 'tool3']);
+    });
+
+    it('should not duplicate tools that are both explicit and default', () => {
+      const selections: ToolSelection[] = [{ tool_ids: ['tool1', 'tool2'] }];
+      const result = getActiveTools(mockTools, selections, true, defaultToolIds);
+
+      expect(result.map((t) => t.id)).toEqual(['tool1', 'tool2', 'tool3']);
+    });
+
+    it('should return empty array when no tools match selections', () => {
+      const selections: ToolSelection[] = [{ tool_ids: [] }];
+      const result = getActiveTools(mockTools, selections, false, defaultToolIds);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return only default tools when no explicit selections and elastic capabilities are enabled', () => {
+      const selections: ToolSelection[] = [{ tool_ids: [] }];
+      const result = getActiveTools(mockTools, selections, true, defaultToolIds);
+
+      expect(result.map((t) => t.id)).toEqual(['tool1', 'tool3']);
+    });
+
+    it('should handle wildcard selections with elastic capabilities', () => {
+      const selections: ToolSelection[] = [{ tool_ids: [allToolsSelectionWildcard] }];
+      const result = getActiveTools(mockTools, selections, true, defaultToolIds);
+
+      // All tools already selected via wildcard, no defaults to append
+      expect(result.map((t) => t.id)).toEqual(['tool1', 'tool2', 'tool3']);
     });
   });
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/tool_selection_utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/tool_selection_utils.ts
@@ -94,6 +94,28 @@ export const toggleToolSelection = (
 };
 
 /**
+ * Returns the list of active tools for an agent, combining explicitly selected tools
+ * with default tools when elastic capabilities are enabled. Default tools that are
+ * already explicitly selected are not duplicated.
+ */
+export const getActiveTools = <T extends ToolSelectionRelevantFields>(
+  allTools: T[],
+  agentToolSelections: ToolSelection[],
+  enableElasticCapabilities: boolean,
+  defaultToolIds: Set<string>
+): T[] => {
+  const explicitTools = allTools.filter((t) => isToolSelected(t, agentToolSelections));
+  if (enableElasticCapabilities) {
+    const explicitIdSet = new Set(explicitTools.map((t) => t.id));
+    const defaultToolsNotExplicit = allTools.filter(
+      (t) => defaultToolIds.has(t.id) && !explicitIdSet.has(t.id)
+    );
+    return [...explicitTools, ...defaultToolsNotExplicit];
+  }
+  return explicitTools;
+};
+
+/**
  * Removes invalid tool references from the agent configuration.
  * Filters out tool IDs that don't exist in the available tools list,
  * while preserving wildcard selections and removing empty selections.


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/13479

## Summary

This PR adds a new Tool page for the chosen agent.  Agent > Customize > Advanced > Tool



https://github.com/user-attachments/assets/51fc947b-2a90-4334-9274-54739c2e1ce7









