### PR TITLE
[Scout Docs] Add Scout Training page

### DIFF
--- a/docs/extend/scout/getting-started.md
+++ b/docs/extend/scout/getting-started.md
@@ -10,3 +10,4 @@ Start here to set up Scout in a plugin/package, run tests, and debug failures.
 - [Run Scout tests](./run-tests.md)
 - [Debug Scout test runs](./debugging.md)
 - [Best practices for Scout tests](./best-practices.md)
+- [Training](./training.md)

--- a/docs/extend/scout/training.md
+++ b/docs/extend/scout/training.md
@@ -1,0 +1,47 @@
+---
+navigation_title: Training
+---
+
+# Scout training [scout-training]
+
+Get the most out of Scout with dedicated training sessions recorded by the AppEx QA team.
+
+:::::{important}
+These videos are currently available for Elasticians only.
+:::::
+
+## Scout Essentials [training-scout-essentials]
+
+Learn more about what makes Scout powerful: parallel testing, its modular architecture, and its extensible building blocks (fixtures, API service, and page objects).
+
+- {icon}`playFilled` [Video](https://drive.google.com/file/d/1mRgm2_ea78mzS9WHsXZZPQIIwAJka3nc/view?usp=sharing)
+- {icon}`document` [Slides](https://docs.google.com/presentation/d/1AjgZVqNFoFAVlLDSm35tLgBJ1pex1csedOiltAGpgsg/edit?usp=sharing)
+
+## Scout Agentic Skills [training-scout-agentic-skills]
+
+Improve your Scout PRs and streamline FTR-to-Scout test migrations by mastering two of Scout's most powerful agentic skills.
+
+- {icon}`playFilled` [Video](https://drive.google.com/file/d/1fG4jPwZm-dF7CNEhJD_4FMCDAH-oNlnF/view?usp=sharing)
+- {icon}`document` [Slides](https://docs.google.com/presentation/d/1cehd4RxgnjWbdDpRDlyHKpRxagwLqn_o6OlkbTd-mrw/edit?usp=sharing)
+
+:::::{tip}
+The code reviewer skill is based on our [Scout best practices](./best-practices.md) article.
+:::::
+
+## Team-level QA insights [training-scout-qa-insights]
+
+Improve your team's QA metrics by leveraging the rich test event data collected during every CI run.
+
+- {icon}`playFilled` [Video](https://drive.google.com/file/d/1eWmY6Dqzh37p2E-WL0ve5u39pbaK_kB8/view?usp=sharing)
+- {icon}`document` [Slides](https://docs.google.com/presentation/d/1bXqiMZgZ6F0qzTJ_QFHDvkiq594KihoOx-C75qk0B1U/edit?usp=sharing)
+
+## Break the Flake: test design anti-patterns [training-scout-break-the-flake]
+
+Identify common test design anti-patterns that cause flakiness and learn proven strategies to combat them.
+
+- {icon}`playFilled` [Video](https://drive.google.com/file/d/1s7lj2uYnl5BTOVo14vWYnVklU2cwwuwO/view?usp=sharing)
+- {icon}`document` [Slides](https://docs.google.com/presentation/d/1QqSSrxehjvgAhinU9IFGLgLbr_H2C53dy5DloL3dGws/edit?usp=sharing)
+
+:::::{note}
+This talk is testing framework-agnostic. The talk showcases FTR code examples but the same concepts are also valid with Scout.
+:::::

--- a/docs/extend/scout/training.md
+++ b/docs/extend/scout/training.md
@@ -47,5 +47,5 @@ Identify common test design anti-patterns that cause flakiness and learn proven 
 - {icon}`document` [Slides](https://docs.google.com/presentation/d/1QqSSrxehjvgAhinU9IFGLgLbr_H2C53dy5DloL3dGws/edit?usp=sharing)
 
 :::::{note}
-This talk is testing framework-agnostic. The talk showcases FTR code examples but the same concepts are also valid with Scout.
+This talk is testing framework-agnostic. It showcases FTR code examples, but the same concepts apply to Scout as well.
 :::::

--- a/docs/extend/scout/training.md
+++ b/docs/extend/scout/training.md
@@ -10,14 +10,18 @@ Get the most out of [Scout](../scout.md) with dedicated training sessions record
 These videos are currently available for Elasticians only.
 :::::
 
-## Scout Essentials [training-scout-essentials]
+## Sessions
 
-Learn more about what makes Scout powerful: parallel testing, its modular architecture, and its extensible building blocks (fixtures, API service, and page objects).
+You can watch these sessions in any order.
+
+### Scout Essentials [training-scout-essentials]
+
+Learn more about what makes Scout powerful: parallel testing, its modular architecture, and its extensible building blocks (fixtures, API services, and page objects).
 
 - {icon}`playFilled` [Video](https://drive.google.com/file/d/1mRgm2_ea78mzS9WHsXZZPQIIwAJka3nc/view?usp=sharing)
 - {icon}`document` [Slides](https://docs.google.com/presentation/d/1AjgZVqNFoFAVlLDSm35tLgBJ1pex1csedOiltAGpgsg/edit?usp=sharing)
 
-## Scout Agentic Skills [training-scout-agentic-skills]
+### Scout Agentic Skills [training-scout-agentic-skills]
 
 Improve your Scout PRs and streamline FTR-to-Scout test migrations by mastering two of Scout's most powerful agentic skills.
 
@@ -28,14 +32,14 @@ Improve your Scout PRs and streamline FTR-to-Scout test migrations by mastering 
 The code reviewer skill is based on our [Scout best practices](./best-practices.md) article.
 :::::
 
-## Team-level QA insights [training-scout-qa-insights]
+### Team-level QA insights [training-scout-qa-insights]
 
 Improve your team's QA metrics by leveraging the rich test event data collected during every CI run.
 
 - {icon}`playFilled` [Video](https://drive.google.com/file/d/1eWmY6Dqzh37p2E-WL0ve5u39pbaK_kB8/view?usp=sharing)
 - {icon}`document` [Slides](https://docs.google.com/presentation/d/1bXqiMZgZ6F0qzTJ_QFHDvkiq594KihoOx-C75qk0B1U/edit?usp=sharing)
 
-## Break the Flake: test design anti-patterns [training-scout-break-the-flake]
+### Break the Flake: test design anti-patterns [training-scout-break-the-flake]
 
 Identify common test design anti-patterns that cause flakiness and learn proven strategies to combat them.
 

--- a/docs/extend/scout/training.md
+++ b/docs/extend/scout/training.md
@@ -4,7 +4,7 @@ navigation_title: Training
 
 # Scout training [scout-training]
 
-Get the most out of Scout with dedicated training sessions recorded by the AppEx QA team.
+Get the most out of [Scout](../scout.md) with dedicated training sessions recorded by the AppEx QA team.
 
 :::::{important}
 These videos are currently available for Elasticians only.

--- a/docs/extend/toc.yml
+++ b/docs/extend/toc.yml
@@ -61,6 +61,7 @@ toc:
           - file: scout/run-tests.md
           - file: scout/debugging.md
           - file: scout/best-practices.md
+          - file: scout/training.md
       - file: scout/core-concepts.md
         children:
           - file: scout/fixtures.md


### PR DESCRIPTION
This PR introduces a new Training page under [Scout](https://www.elastic.co/docs/extend/kibana/scout) > [Getting Started](https://www.elastic.co/docs/extend/kibana/scout/getting-started) to advertise our Scout training material (videos, slides). This includes, but isn't limited to, videos in the Scout Learning Series.