### PR TITLE
[Fleet] Fixes for package idle data streams alerting

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.test.tsx
@@ -321,7 +321,7 @@ describe('AlertingPage', () => {
       expect(screen.queryByText('Idle data streams alerting available')).not.toBeInTheDocument();
     });
 
-    it('should not show callout when inactivity template exists', async () => {
+    it('should not show callout when inactivity template exists in default space', async () => {
       mockExperimentalFeaturesGet.mockReturnValue({
         enableIntegrationInactivityAlerting: true,
       });
@@ -347,6 +347,58 @@ describe('AlertingPage', () => {
             },
             'fleet-system-inactivity-monitoring': {
               id: 'fleet-system-inactivity-monitoring',
+              type: 'alerting_rule_template',
+              attributes: { title: '[System] Idle data streams' },
+            },
+          },
+        },
+        userCreatedRules: [],
+        isLoading: false,
+        fetchError: undefined,
+        refetch: jest.fn(),
+      });
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('[System] Template')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Idle data streams alerting available')).not.toBeInTheDocument();
+    });
+
+    it('should not show callout when space-specific inactivity template exists', async () => {
+      mockExperimentalFeaturesGet.mockReturnValue({
+        enableIntegrationInactivityAlerting: true,
+      });
+
+      mockUseAlertingAssets.mockReturnValue({
+        alertingAssets: [
+          { id: 'template-1', type: 'alerting_rule_template' },
+          {
+            id: 'fleet-system-inactivity-monitoring-my-space',
+            type: 'alerting_rule_template',
+          },
+        ],
+        alertingAssetsByType: {
+          alerting_rule_template: [
+            { id: 'template-1', type: 'alerting_rule_template' },
+            {
+              id: 'fleet-system-inactivity-monitoring-my-space',
+              type: 'alerting_rule_template',
+            },
+          ],
+        },
+        deferredAlerts: [],
+        assetSavedObjectsByType: {
+          alerting_rule_template: {
+            'template-1': {
+              id: 'template-1',
+              type: 'alerting_rule_template',
+              attributes: { title: '[System] Template' },
+            },
+            'fleet-system-inactivity-monitoring-my-space': {
+              id: 'fleet-system-inactivity-monitoring-my-space',
               type: 'alerting_rule_template',
               attributes: { title: '[System] Idle data streams' },
             },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/alerting/alerting_page.tsx
@@ -43,7 +43,7 @@ import { DeferredAssetsAccordion } from '../assets/deferred_assets_accordion';
 
 import { ALERTING_ASSET_TYPES } from '.';
 
-const getInactivityMonitoringTemplateId = (pkgName: string): string =>
+const getInactivityMonitoringTemplatePrefix = (pkgName: string): string =>
   `fleet-${pkgName}-inactivity-monitoring`;
 
 interface AlertingPageProps {
@@ -86,10 +86,15 @@ export const AlertingPage = ({ packageInfo, refetchPackageInfo }: AlertingPagePr
   const { enableIntegrationInactivityAlerting } = ExperimentalFeaturesService.get();
   const hasDataStreams = (packageInfo.data_streams?.length ?? 0) > 0;
   const isIntegrationPackage = packageInfo.type === 'integration';
-  const inactivityTemplateId = getInactivityMonitoringTemplateId(name);
+  const inactivityTemplatePrefix = getInactivityMonitoringTemplatePrefix(name);
   const hasInactivityTemplate = useMemo(
-    () => alertingAssets.some((asset) => asset.id === inactivityTemplateId),
-    [alertingAssets, inactivityTemplateId]
+    () =>
+      alertingAssets.some(
+        (asset) =>
+          asset.id === inactivityTemplatePrefix ||
+          asset.id.startsWith(inactivityTemplatePrefix + '-')
+      ),
+    [alertingAssets, inactivityTemplatePrefix]
   );
   const showInactivityCallout =
     enableIntegrationInactivityAlerting &&

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -32,6 +32,7 @@ import type { MockedFleetStartServices, TestRenderer } from '../../../../../../m
 import { createIntegrationsTestRendererMock } from '../../../../../../mock';
 
 import { ExperimentalFeaturesService } from '../../../../services';
+import { allowedExperimentalValues } from '../../../../../../../common/experimental_features';
 
 import type { DetailViewPanelName } from '.';
 import { Detail } from '.';
@@ -118,7 +119,12 @@ describe('When on integration detail', () => {
       expect(await renderResult.findByTestId('tab-alerting')).not.toBeNull();
     });
 
-    it('should not show Alerting tab when package has no alerting type assets', async () => {
+    it('should not show Alerting tab when package has no alerting type assets and inactivity alerting is off', async () => {
+      ExperimentalFeaturesService.init({
+        ...allowedExperimentalValues,
+        enableIntegrationInactivityAlerting: false,
+      });
+
       const baseResponse = mockedApi.responseProvider.epmGetInfo('nginx');
       const kibanaAssets = baseResponse.item.assets?.kibana as Record<string, unknown> | undefined;
       const itemWithoutAlertingAssets = {
@@ -143,6 +149,45 @@ describe('When on integration detail', () => {
       await act(() => mockedApi.waitForApi());
 
       expect(renderResult.queryByTestId('tab-alerting')).toBeNull();
+
+      // Reset to default
+      ExperimentalFeaturesService.init(allowedExperimentalValues);
+    });
+
+    it('should show Alerting tab for installed integration packages when inactivity alerting is enabled', async () => {
+      ExperimentalFeaturesService.init({
+        ...allowedExperimentalValues,
+        enableIntegrationInactivityAlerting: true,
+      });
+
+      const baseResponse = mockedApi.responseProvider.epmGetInfo('nginx');
+      const kibanaAssets = baseResponse.item.assets?.kibana as Record<string, unknown> | undefined;
+      const itemWithoutAlertingAssets = {
+        ...baseResponse.item,
+        type: 'integration' as const,
+        assets: {
+          ...baseResponse.item.assets,
+          kibana: {
+            dashboard: kibanaAssets?.dashboard ?? [],
+            search: kibanaAssets?.search ?? [],
+            visualization: kibanaAssets?.visualization ?? [],
+          },
+        },
+      };
+      mockedApi.responseProvider.epmGetInfo.mockReturnValue({
+        ...baseResponse,
+        item: itemWithoutAlertingAssets as typeof baseResponse.item,
+      });
+      await render();
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+
+      expect(await renderResult.findByTestId('tab-alerting')).not.toBeNull();
+
+      // Reset to default
+      ExperimentalFeaturesService.init(allowedExperimentalValues);
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -51,7 +51,7 @@ import {
 import { useAgentless } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import { useGetPackageInfoByKeyQuery, useLink, useAgentPolicyContext } from '../../../../hooks';
-import { pkgKeyFromPackageInfo } from '../../../../services';
+import { ExperimentalFeaturesService, pkgKeyFromPackageInfo } from '../../../../services';
 import type { PackageInfo } from '../../../../types';
 import { InstallStatus } from '../../../../types';
 import { Error, Loading, HeaderReleaseBadge } from '../../../../components';
@@ -289,9 +289,13 @@ export function Detail() {
     packageInfo &&
     hasDocumentation({ packageInfo, integration });
 
-  const showAlertingTab = Object.keys(packageInfo?.assets?.kibana ?? {}).some((type) =>
+  const { enableIntegrationInactivityAlerting } = ExperimentalFeaturesService.get();
+  const hasArchiveAlertingAssets = Object.keys(packageInfo?.assets?.kibana ?? {}).some((type) =>
     (ALERTING_ASSET_TYPES as string[]).includes(type)
   );
+  const showAlertingTab =
+    hasArchiveAlertingAssets ||
+    (isInstalled && packageInfo?.type === 'integration' && enableIntegrationInactivityAlerting);
 
   // Track install status state
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/fleet/server/routes/epm/install_assets_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/epm/install_assets_handler.ts
@@ -7,6 +7,7 @@
 
 import type { KibanaRequest } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 
 import { FleetError, FleetNotFoundError } from '../../errors';
 import { appContextService } from '../../services';
@@ -84,8 +85,10 @@ export const installPackageKibanaAssetsHandler: FleetRequestHandler<
   const spaceIds = request.body?.space_ids ?? [spaceId];
 
   for (const spaceToInstallId of spaceIds) {
+    const spaceScopedClient = appContextService.getInternalUserSOClientForSpaceId(spaceToInstallId);
+
     await installKibanaAssetsAndReferences({
-      savedObjectsClient: appContextService.getInternalUserSOClientForSpaceId(spaceToInstallId),
+      savedObjectsClient: spaceScopedClient,
       logger,
       pkgName,
       pkgTitle: packageInfo.title,
@@ -99,9 +102,12 @@ export const installPackageKibanaAssetsHandler: FleetRequestHandler<
         archiveIterator: createArchiveIteratorFromMap(installedPkgWithAssets.assetsMap),
       },
     });
-  }
 
-  await createInactivityMonitoringTemplate({ logger, savedObjectsClient }, { packageInfo });
+    await createInactivityMonitoringTemplate(
+      { logger, savedObjectsClient: spaceScopedClient },
+      { packageInfo, spaceId: spaceToInstallId, installAsAdditionalSpace: true }
+    );
+  }
 
   return response.ok({ body: { success: true } });
 };
@@ -168,9 +174,14 @@ export const installRuleAssetsHandler: FleetRequestHandler<
 
   const { packageInfo } = installedPkgWithAssets;
 
+  const installAsAdditionalSpace =
+    (installation.attributes.installed_kibana_space_id ?? DEFAULT_SPACE_ID) !== spaceId;
+
   await stepCreateAlertingAssets({
     logger,
-    savedObjectsClient,
+    savedObjectsClient: installAsAdditionalSpace
+      ? appContextService.getInternalUserSOClientForSpaceId(spaceId)
+      : savedObjectsClient,
     packageInstallContext: {
       packageInfo,
       paths: installedPkgWithAssets.paths,
@@ -178,6 +189,7 @@ export const installRuleAssetsHandler: FleetRequestHandler<
     },
     spaceId,
     request,
+    installAsAdditionalSpace,
   });
 
   return response.ok({ body: { success: true } });

--- a/x-pack/platform/plugins/shared/fleet/server/routes/epm/install_assets_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/epm/install_assets_handler.ts
@@ -86,13 +86,15 @@ export const installPackageKibanaAssetsHandler: FleetRequestHandler<
 
   for (const spaceToInstallId of spaceIds) {
     const spaceScopedClient = appContextService.getInternalUserSOClientForSpaceId(spaceToInstallId);
+    const installAsAdditionalSpace =
+      (installation.attributes.installed_kibana_space_id ?? DEFAULT_SPACE_ID) !== spaceToInstallId;
 
     await installKibanaAssetsAndReferences({
       savedObjectsClient: spaceScopedClient,
       logger,
       pkgName,
       pkgTitle: packageInfo.title,
-      installAsAdditionalSpace: true,
+      installAsAdditionalSpace,
       spaceId: spaceToInstallId,
       assetTags: installedPkgWithAssets.packageInfo?.asset_tags,
       installedPkg: installation,
@@ -105,7 +107,7 @@ export const installPackageKibanaAssetsHandler: FleetRequestHandler<
 
     await createInactivityMonitoringTemplate(
       { logger, savedObjectsClient: spaceScopedClient },
-      { packageInfo, spaceId: spaceToInstallId, installAsAdditionalSpace: true }
+      { packageInfo, spaceId: spaceToInstallId, installAsAdditionalSpace }
     );
   }
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.test.ts
@@ -145,6 +145,36 @@ describe('createSavedObjectKibanaAsset', () => {
     expect(result.typeMigrationVersion).toEqual('8.6.0');
     expect(result.coreMigrationVersion).toEqual('8.7.0');
   });
+
+  it('should rewrite alerting_rule_template IDs when installing as additional space', () => {
+    const asset = createAsset({
+      id: 'system-logs-template',
+      type: KibanaSavedObjectType.alertingRuleTemplate,
+      attributes: { name: '[System] Logs template' },
+    });
+    const result = createSavedObjectKibanaAsset(asset, {
+      installAsAdditionalSpace: true,
+      spaceId: 'my-space',
+    });
+
+    expect(result.id).not.toEqual('system-logs-template');
+    expect(result.originId).toEqual('system-logs-template');
+  });
+
+  it('should not rewrite alerting_rule_template IDs for the primary install space', () => {
+    const asset = createAsset({
+      id: 'system-logs-template',
+      type: KibanaSavedObjectType.alertingRuleTemplate,
+      attributes: { name: '[System] Logs template' },
+    });
+    const result = createSavedObjectKibanaAsset(asset, {
+      installAsAdditionalSpace: false,
+      spaceId: 'default',
+    });
+
+    expect(result.id).toEqual('system-logs-template');
+    expect(result.originId).toBeUndefined();
+  });
 });
 
 describe('replaceIdsInKibanaAsset', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/kibana/assets/install.ts
@@ -98,8 +98,12 @@ export function createSavedObjectKibanaAsset(
     spaceId?: string;
   }
 ): SavedObjectToBe {
+  // Rewrite IDs for dashboards and multiple-isolated SO types (e.g. alerting_rule_template)
+  // to avoid conflicts when installing in additional spaces.
   const rewriteId =
-    options?.installAsAdditionalSpace && asset.type === KibanaSavedObjectType.dashboard;
+    options?.installAsAdditionalSpace &&
+    (asset.type === KibanaSavedObjectType.dashboard ||
+      asset.type === KibanaSavedObjectType.alertingRuleTemplate);
   // convert that to an object
   const so: Partial<SavedObjectToBe> = {
     type: asset.type,

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -26,6 +26,7 @@ import {
   handleInstallPackageFailure,
   installPackage,
   isPackageVersionOrLaterInstalled,
+  saveKibanaAssetsRefs,
 } from './install';
 import * as installStateMachine from './install_state_machine/_state_machine_package_install';
 import { getBundledPackageByPkgKey } from './bundled_packages';
@@ -1021,5 +1022,105 @@ describe('isPackageVersionOrLaterInstalled', () => {
     });
 
     await expect(res).rejects.toThrowError('test unexpected error');
+  });
+});
+
+describe('saveKibanaAssetsRefs', () => {
+  const soClient = savedObjectsClientMock.create();
+
+  beforeEach(() => {
+    soClient.get.mockReset();
+    soClient.update.mockReset();
+    (soClient.getCurrentNamespace as jest.Mock).mockReturnValue('my-space');
+  });
+
+  it('should append to existing additional space refs when saveAsAdditionnalSpace and append are both true', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'existing-dashboard', type: 'dashboard' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'new-template', type: 'alerting_rule_template' as any }],
+      true,
+      true
+    );
+
+    expect(soClient.update).toHaveBeenCalledWith(
+      PACKAGES_SAVED_OBJECT_TYPE,
+      'test-pkg',
+      expect.objectContaining({
+        additional_spaces_installed_kibana: {
+          'my-space': expect.arrayContaining([
+            { id: 'new-template', type: 'alerting_rule_template' },
+            { id: 'existing-dashboard', type: 'dashboard' },
+          ]),
+        },
+      }),
+      expect.anything()
+    );
+  });
+
+  it('should deduplicate refs when appending to additional space', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'existing-template', type: 'alerting_rule_template' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'existing-template', type: 'alerting_rule_template' as any }],
+      true,
+      true
+    );
+
+    const updateCall = soClient.update.mock.calls[0][2] as any;
+    const spaceRefs = updateCall.additional_spaces_installed_kibana['my-space'];
+    expect(spaceRefs).toHaveLength(1);
+    expect(spaceRefs[0].id).toBe('existing-template');
+  });
+
+  it('should overwrite additional space refs when append is false', async () => {
+    soClient.get.mockResolvedValue({
+      id: 'test-pkg',
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      references: [],
+      attributes: {
+        additional_spaces_installed_kibana: {
+          'my-space': [{ id: 'old-dashboard', type: 'dashboard' }],
+        },
+      },
+    } as any);
+    soClient.update.mockResolvedValue({} as any);
+
+    await saveKibanaAssetsRefs(
+      soClient,
+      'test-pkg',
+      [{ id: 'new-dashboard', type: 'dashboard' as any }],
+      true,
+      false
+    );
+
+    const updateCall = soClient.update.mock.calls[0][2] as any;
+    const spaceRefs = updateCall.additional_spaces_installed_kibana['my-space'];
+    expect(spaceRefs).toHaveLength(1);
+    expect(spaceRefs[0].id).toBe('new-dashboard');
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1387,13 +1387,22 @@ export const saveKibanaAssetsRefs = async (
           : undefined;
 
       if (saveAsAdditionnalSpace) {
+        let spaceAssetRefs = assetRefs !== null ? assetRefs : [];
+        if (append && installation) {
+          const existingSpaceRefs =
+            installation.attributes?.additional_spaces_installed_kibana?.[spaceId] ?? [];
+          spaceAssetRefs = uniqBy(
+            [...spaceAssetRefs, ...existingSpaceRefs],
+            (asset) => asset.id + asset.type
+          );
+        }
         return savedObjectsClient.update<Installation>(
           PACKAGES_SAVED_OBJECT_TYPE,
           pkgName,
           {
             additional_spaces_installed_kibana: {
               ...omit(installation?.attributes?.additional_spaces_installed_kibana ?? {}, spaceId),
-              ...(assetRefs !== null ? { [spaceId]: assetRefs } : {}),
+              ...(assetRefs !== null ? { [spaceId]: spaceAssetRefs } : {}),
             },
           },
           { refresh: false }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_assets.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_assets.test.ts
@@ -34,11 +34,12 @@ let internalSoClientMock: ReturnType<typeof createSavedObjectClientMock>;
 
 beforeEach(() => {
   internalSoClientMock = createSavedObjectClientMock();
+  internalSoClientMock.asScopedToNamespace.mockReturnValue(internalSoClientMock as any);
   appContextService.start(
     createAppContextStartContractMock(
       {},
       false,
-      { internal: internalSoClientMock },
+      { internal: internalSoClientMock, withoutSpaceExtensions: internalSoClientMock },
       { enableIntegrationInactivityAlerting: true }
     )
   );
@@ -248,7 +249,7 @@ describe('createInactivityMonitoringTemplate', () => {
       createAppContextStartContractMock(
         {},
         false,
-        { internal: internalSoClientMock },
+        { internal: internalSoClientMock, withoutSpaceExtensions: internalSoClientMock },
         { enableIntegrationInactivityAlerting: false }
       )
     );
@@ -429,6 +430,68 @@ describe('createInactivityMonitoringTemplate', () => {
       expect.stringContaining('Error creating inactivity monitoring template for package nginx'),
       expect.objectContaining({ error: expect.any(Error) })
     );
+  });
+
+  it('should save asset refs as additional space when installAsAdditionalSpace is true', async () => {
+    internalSoClientMock.get.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError()
+    );
+    internalSoClientMock.create.mockResolvedValue({
+      id: 'fleet-nginx-inactivity-monitoring',
+      type: 'alerting_rule_template',
+      attributes: {},
+      references: [],
+    });
+
+    await createInactivityMonitoringTemplate(
+      { logger, savedObjectsClient },
+      { packageInfo: mockIntegrationPackage, installAsAdditionalSpace: true }
+    );
+
+    expect(saveKibanaAssetsRefs).toHaveBeenCalledWith(
+      savedObjectsClient,
+      'nginx',
+      [{ id: 'fleet-nginx-inactivity-monitoring', type: 'alerting_rule_template' }],
+      true,
+      true
+    );
+  });
+
+  it('should use a space-scoped SO client and space-specific template ID when spaceId is provided', async () => {
+    const scopedClientMock = createSavedObjectClientMock();
+    internalSoClientMock.asScopedToNamespace.mockReturnValue(scopedClientMock as any);
+    scopedClientMock.get.mockRejectedValue(SavedObjectsErrorHelpers.createGenericNotFoundError());
+    scopedClientMock.create.mockResolvedValue({
+      id: 'fleet-nginx-inactivity-monitoring-my-space',
+      type: 'alerting_rule_template',
+      attributes: {},
+      references: [],
+    });
+
+    const result = await createInactivityMonitoringTemplate(
+      { logger, savedObjectsClient },
+      { packageInfo: mockIntegrationPackage, spaceId: 'my-space' }
+    );
+
+    expect(internalSoClientMock.asScopedToNamespace).toHaveBeenCalledWith('my-space');
+    expect(scopedClientMock.create).toHaveBeenCalledWith(
+      'alerting_rule_template',
+      expect.objectContaining({
+        name: '[Nginx] Idle data streams',
+      }),
+      { id: 'fleet-nginx-inactivity-monitoring-my-space' }
+    );
+    expect(saveKibanaAssetsRefs).toHaveBeenCalledWith(
+      savedObjectsClient,
+      'nginx',
+      [{ id: 'fleet-nginx-inactivity-monitoring-my-space', type: 'alerting_rule_template' }],
+      false,
+      true
+    );
+    expect(result).toEqual({
+      id: 'fleet-nginx-inactivity-monitoring-my-space',
+      type: 'alerting_rule_template',
+    });
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_create_alerting_assets.ts
@@ -108,8 +108,12 @@ export async function createAlertingRuleFromTemplate(
   }
 }
 
-function getInactivityMonitoringTemplateId(pkgName: string): string {
-  return `fleet-${pkgName}-inactivity-monitoring`;
+function getInactivityMonitoringTemplateId(pkgName: string, spaceId?: string): string {
+  const targetSpace = spaceId ?? DEFAULT_SPACE_ID;
+  if (targetSpace === DEFAULT_SPACE_ID) {
+    return `fleet-${pkgName}-inactivity-monitoring`;
+  }
+  return `fleet-${pkgName}-inactivity-monitoring-${targetSpace}`;
 }
 
 function getDataStreamPatterns(packageInfo: InstallablePackage): string[] {
@@ -124,10 +128,12 @@ export async function createInactivityMonitoringTemplate(
   deps: { logger: Logger; savedObjectsClient: SavedObjectsClientContract },
   params: {
     packageInfo: InstallablePackage;
+    spaceId?: string;
+    installAsAdditionalSpace?: boolean;
   }
 ): Promise<KibanaAssetReference | undefined> {
   const { logger, savedObjectsClient } = deps;
-  const { packageInfo } = params;
+  const { packageInfo, spaceId, installAsAdditionalSpace = false } = params;
   const { name: pkgName, title: pkgTitle } = packageInfo;
 
   if (!appContextService.getExperimentalFeatures().enableIntegrationInactivityAlerting) {
@@ -144,7 +150,7 @@ export async function createInactivityMonitoringTemplate(
     return;
   }
 
-  const templateId = getInactivityMonitoringTemplateId(pkgName);
+  const templateId = getInactivityMonitoringTemplateId(pkgName, spaceId);
   const templateRef: KibanaAssetReference = {
     id: templateId,
     type: KibanaSavedObjectType.alertingRuleTemplate,
@@ -152,7 +158,12 @@ export async function createInactivityMonitoringTemplate(
 
   return withPackageSpan(`Create inactivity monitoring template for ${pkgName}`, async () => {
     try {
-      const internalSoClient = appContextService.getInternalUserSOClient();
+      // Always use explicit namespace scoping via asScopedToNamespace because
+      // alerting_rule_template is a multiple-isolated SO type. Using an implicitly
+      // scoped or unscoped client causes incorrect namespace resolution for get/create.
+      const internalSoClient = appContextService
+        .getInternalUserSOClient()
+        .asScopedToNamespace(spaceId ?? DEFAULT_SPACE_ID);
 
       // Check if the template already exists
       const existing = await internalSoClient
@@ -192,38 +203,60 @@ export async function createInactivityMonitoringTemplate(
         }
 
         // Re-register the asset ref (it may have been overwritten by stepInstallKibanaAssets)
-        await saveKibanaAssetsRefs(savedObjectsClient, pkgName, [templateRef], false, true);
+        await saveKibanaAssetsRefs(
+          savedObjectsClient,
+          pkgName,
+          [templateRef],
+          installAsAdditionalSpace,
+          true
+        );
         return templateRef;
       }
 
       logger.debug(`Creating inactivity monitoring template ${templateId} for package ${pkgName}`);
 
-      await internalSoClient.create(
-        KibanaSavedObjectType.alertingRuleTemplate,
-        {
-          name: `[${pkgTitle}] Idle data streams`,
-          ruleTypeId: '.es-query',
-          tags: [pkgTitle],
-          schedule: { interval: '24h' },
-          params: {
-            searchType: 'esQuery',
-            esQuery: JSON.stringify({ query: { match_all: {} } }),
-            index: dataStreamPatterns,
-            timeField: '@timestamp',
-            timeWindowSize: 24,
-            timeWindowUnit: 'h',
-            threshold: [1],
-            thresholdComparator: '<',
-            size: 0,
-            aggType: 'count',
-            groupBy: 'all',
-            excludeHitsFromPreviousRun: true,
+      try {
+        await internalSoClient.create(
+          KibanaSavedObjectType.alertingRuleTemplate,
+          {
+            name: `[${pkgTitle}] Idle data streams`,
+            ruleTypeId: '.es-query',
+            tags: [pkgTitle],
+            schedule: { interval: '24h' },
+            params: {
+              searchType: 'esQuery',
+              esQuery: JSON.stringify({ query: { match_all: {} } }),
+              index: dataStreamPatterns,
+              timeField: '@timestamp',
+              timeWindowSize: 24,
+              timeWindowUnit: 'h',
+              threshold: [1],
+              thresholdComparator: '<',
+              size: 0,
+              aggType: 'count',
+              groupBy: 'all',
+              excludeHitsFromPreviousRun: true,
+            },
           },
-        },
-        { id: templateId }
-      );
+          { id: templateId }
+        );
+      } catch (createErr) {
+        if (SavedObjectsErrorHelpers.isConflictError(createErr)) {
+          logger.debug(
+            `Inactivity monitoring template ${templateId} already exists for package ${pkgName} (conflict on create)`
+          );
+        } else {
+          throw createErr;
+        }
+      }
 
-      await saveKibanaAssetsRefs(savedObjectsClient, pkgName, [templateRef], false, true);
+      await saveKibanaAssetsRefs(
+        savedObjectsClient,
+        pkgName,
+        [templateRef],
+        installAsAdditionalSpace,
+        true
+      );
 
       return templateRef;
     } catch (e) {
@@ -240,14 +273,18 @@ export async function stepCreateAlertingAssets(
   context: Pick<
     InstallContext,
     'logger' | 'savedObjectsClient' | 'packageInstallContext' | 'spaceId' | 'request'
-  >
+  > & { installAsAdditionalSpace?: boolean }
 ) {
-  const { logger, savedObjectsClient, packageInstallContext, spaceId } = context;
+  const { logger, savedObjectsClient, packageInstallContext, spaceId, installAsAdditionalSpace } =
+    context;
   const { packageInfo } = packageInstallContext;
   const { name: pkgName } = packageInfo;
 
   // Create or re-create inactivity monitoring template for integration packages
-  await createInactivityMonitoringTemplate({ logger, savedObjectsClient }, { packageInfo });
+  await createInactivityMonitoringTemplate(
+    { logger, savedObjectsClient },
+    { packageInfo, spaceId, installAsAdditionalSpace }
+  );
 
   // Create alerting rules templates from archive assets
   if (pkgName !== FLEET_ELASTIC_AGENT_PACKAGE) {


### PR DESCRIPTION
## Summary

This PR addresses two bugs:

### 1. Idle data streams alerting template broken in additional spaces

Closes https://github.com/elastic/kibana/issues/256173

The idle data streams alerting template asset was not handled correctly in spaces other than the one where the package was installed. This PR fixes it by:
* using correctly scoped SO client
* making template IDs space-aware (space suffix except for default space)
* fixing asset ref overwriting

Testing:
1. Install an integration in a custom space, check that the idle data streams template is created and can be used to create an alerting rule (NB: rules are space-scoped).
2. Go to the default space and install the missing assets for this integration. It should now have an idle data streams template that can be used to create an alerting rule in that space.

### 2. Alerting tab not shown for integration packages without archive alerting assets

The Alerting tab visibility was derived from whether the package's archive contained alerting rule template assets. For packages without those but still have a dynamically generated idle data streams template, the tab was incorrectly hidden. This PR fixes it by amending the logic to show the tab: it will appear for any installed integration package when the `enableIntegrationInactivityAlerting` feature flag is on (such packages always have an idle data streams template).

Testing: install an integration with no OOTB alerting rule templates, e.g. nginx. The Alerting tab should be visible and the idle data streams alerting rule template available.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low probability risk of affecting alerting template asset installation of packages.