### PR TITLE
[Security Solution] disable endpoint metering

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/metering.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/serverless/metering.cy.ts
@@ -17,7 +17,7 @@ import {
 import type { ReturnTypeFromChainable } from '../../types';
 import { indexEndpointHeartbeats } from '../../tasks/index_endpoint_heartbeats';
 
-describe(
+describe.skip(
   'Metering',
   {
     tags: ['@serverless', '@skipInServerlessMKI'],

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_policy_datastreams.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_policy_datastreams.test.ts
@@ -73,28 +73,6 @@ describe('createPolicyDataStreamsIfNeeded()', () => {
     );
   });
 
-  it('should create heartbeat index when running in serverless', async () => {
-    (endpointServicesMock.isServerless as jest.Mock).mockReturnValue(true);
-    await createPolicyDataStreamsIfNeeded({
-      endpointServices: endpointServicesMock,
-      endpointPolicyIds: ['123'],
-    });
-
-    expect(esClientMock.indices.createDataStream).toHaveBeenCalledTimes(6);
-    [
-      '.logs-endpoint.diagnostic.collection-foo1',
-      '.logs-endpoint.diagnostic.collection-foo2',
-      '.logs-endpoint.action.responses-foo1',
-      '.logs-endpoint.action.responses-foo2',
-      '.logs-endpoint.heartbeat-foo1',
-      '.logs-endpoint.heartbeat-foo2',
-    ].forEach((indexName) => {
-      expect(esClientMock.indices.createDataStream).toHaveBeenCalledWith({
-        name: indexName,
-      });
-    });
-  });
-
   it('should not call ES if index existence was already checked', async () => {
     createPolicyDataStreamsIfNeeded.cache.set('.logs-endpoint.action.responses-foo1', true);
     await createPolicyDataStreamsIfNeeded({

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_policy_datastreams.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_policy_datastreams.ts
@@ -14,7 +14,6 @@ import { SimpleMemCache } from '../../endpoint/lib/simple_mem_cache';
 import {
   DEFAULT_DIAGNOSTIC_INDEX_PATTERN,
   ENDPOINT_ACTION_RESPONSES_DS,
-  ENDPOINT_HEARTBEAT_INDEX_PATTERN,
 } from '../../../common/endpoint/constants';
 import { stringify } from '../../endpoint/utils/stringify';
 
@@ -64,10 +63,6 @@ export const createPolicyDataStreamsIfNeeded: PolicyDataStreamsCreator = async (
       for (const namespace of namespaceList) {
         acc.add(buildIndexNameWithNamespace(DEFAULT_DIAGNOSTIC_INDEX_PATTERN, namespace));
         acc.add(buildIndexNameWithNamespace(ENDPOINT_ACTION_RESPONSES_DS, namespace));
-
-        if (endpointServices.isServerless()) {
-          acc.add(buildIndexNameWithNamespace(ENDPOINT_HEARTBEAT_INDEX_PATTERN, namespace));
-        }
       }
 
       return acc;

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint/services/metering_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint/services/metering_service.test.ts
@@ -21,7 +21,7 @@ import { METERING_TASK } from '../constants/metering';
 
 import { EndpointMeteringService } from './metering_service';
 
-describe('EndpointMeteringService', () => {
+describe.skip('EndpointMeteringService', () => {
   function buildDefaultUsageRecordArgs() {
     return {
       logger: loggingSystemMock.createLogger(),

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.test.ts
@@ -23,7 +23,7 @@ import { ensureOnlyEventCollectionIsAllowed } from '@kbn/security-solution-plugi
 
 import { setEndpointPackagePolicyServerlessBillingFlags } from './set_package_policy_flag';
 
-describe('setEndpointPackagePolicyServerlessBillingFlags', () => {
+describe.skip('setEndpointPackagePolicyServerlessBillingFlags', () => {
   let esClientMock: ElasticsearchClientMock;
   let soClientMock: jest.Mocked<SavedObjectsClientContract>;
   let packagePolicyServiceMock: jest.Mocked<PackagePolicyClient>;

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/plugin.ts
@@ -34,12 +34,7 @@ import type {
 import { SecurityUsageReportingTask } from './task_manager/usage_reporting_task';
 import { cloudSecurityMetringTaskProperties } from './cloud_security/cloud_security_metering_task_config';
 import { registerProductFeatures, getSecurityAiSocProductTier } from './product_features';
-import { METERING_TASK as ENDPOINT_METERING_TASK } from './endpoint/constants/metering';
 import { METERING_TASK as AI4SOC_METERING_TASK } from './ai4soc/constants/metering';
-import {
-  endpointMeteringService,
-  setEndpointPackagePolicyServerlessBillingFlags,
-} from './endpoint/services';
 import { NLPCleanupTask } from './task_manager/nlp_cleanup_task/nlp_cleanup_task';
 import { telemetryEvents } from './telemetry/event_based_telemetry';
 import { UsageReportingService } from './common/services/usage_reporting_service';
@@ -58,7 +53,6 @@ export class SecuritySolutionServerlessPlugin
   private kibanaVersion: string;
   private config: ServerlessSecurityConfig;
   private cloudSecurityUsageReportingTask: SecurityUsageReportingTask | undefined;
-  private endpointUsageReportingTask: SecurityUsageReportingTask | undefined;
   private ai4SocUsageReportingTask: SecurityUsageReportingTask | undefined;
   private nlpCleanupTask: NLPCleanupTask | undefined;
   private readonly logger: Logger;
@@ -146,19 +140,6 @@ export class SecuritySolutionServerlessPlugin
       usageReportingService: this.usageReportingService,
     });
 
-    this.endpointUsageReportingTask = new SecurityUsageReportingTask({
-      core: coreSetup,
-      logFactory: this.initializerContext.logger,
-      config: this.config,
-      taskType: ENDPOINT_METERING_TASK.TYPE,
-      taskTitle: ENDPOINT_METERING_TASK.TITLE,
-      version: ENDPOINT_METERING_TASK.VERSION,
-      meteringCallback: endpointMeteringService.getUsageRecords,
-      taskManager: pluginsSetup.taskManager,
-      cloudSetup: pluginsSetup.cloud,
-      usageReportingService: this.usageReportingService,
-    });
-
     this.ai4SocUsageReportingTask = new SecurityUsageReportingTask({
       core: coreSetup,
       logFactory: this.initializerContext.logger,
@@ -187,20 +168,10 @@ export class SecuritySolutionServerlessPlugin
   }
 
   public start(coreStart: CoreStart, pluginsSetup: SecuritySolutionServerlessPluginStartDeps) {
-    const internalESClient = coreStart.elasticsearch.client.asInternalUser;
-    const internalSOClient = coreStart.savedObjects.createInternalRepository();
-
     this.cloudSecurityUsageReportingTask
       ?.start({
         taskManager: pluginsSetup.taskManager,
         interval: this.config.cloudSecurityUsageReportingTaskInterval,
-      })
-      .catch(() => {});
-
-    this.endpointUsageReportingTask
-      ?.start({
-        taskManager: pluginsSetup.taskManager,
-        interval: this.config.usageReportingTaskInterval,
       })
       .catch(() => {});
 
@@ -215,11 +186,6 @@ export class SecuritySolutionServerlessPlugin
 
     this.nlpCleanupTask?.start({ taskManager: pluginsSetup.taskManager }).catch(() => {});
 
-    setEndpointPackagePolicyServerlessBillingFlags(
-      internalSOClient,
-      internalESClient,
-      pluginsSetup.fleet.packagePolicyService
-    ).catch(() => {});
     return {};
   }
 

--- a/x-pack/solutions/security/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.test.ts
@@ -152,7 +152,7 @@ describe('SecurityUsageReportingTask', () => {
     reportUsageMock = jest.fn();
   }
 
-  describe('meteringCallback integration', () => {
+  describe.skip('meteringCallback integration', () => {
     async function setupMocks() {
       await setupBaseMocks();
       taskArgs = buildTaskArgs({

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/policy/trial_license_complete_tier/datastream_index_creation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/edr_workflows/policy/trial_license_complete_tier/datastream_index_creation.ts
@@ -9,7 +9,6 @@ import expect from '@kbn/expect';
 import {
   DEFAULT_DIAGNOSTIC_INDEX_PATTERN,
   ENDPOINT_ACTION_RESPONSES_DS,
-  ENDPOINT_HEARTBEAT_INDEX_PATTERN,
 } from '@kbn/security-solution-plugin/common/endpoint/constants';
 import { buildIndexNameWithNamespace } from '@kbn/security-solution-plugin/common/endpoint/utils/index_name_utilities';
 import {
@@ -25,8 +24,6 @@ export default function ({ getService }: FtrProviderContext) {
   const kbnClient = getService('kibanaServer');
   const log = getService('log');
   const retry = getService('retry');
-  const config = getService('config');
-  const isServerless = config.get('serverless');
 
   describe('@ess @serverless Creation of DOT indices for elastic defend policies', function () {
     let testData: PolicyTestResourceInfo;
@@ -36,10 +33,6 @@ export default function ({ getService }: FtrProviderContext) {
         buildIndexNameWithNamespace(ENDPOINT_ACTION_RESPONSES_DS, namespace),
         buildIndexNameWithNamespace(DEFAULT_DIAGNOSTIC_INDEX_PATTERN, namespace),
       ];
-
-      if (isServerless) {
-        indexList.push(buildIndexNameWithNamespace(ENDPOINT_HEARTBEAT_INDEX_PATTERN, namespace));
-      }
 
       return indexList;
     };


### PR DESCRIPTION
## Summary

Makes the minimal amount of changes to disable Kibana side endpoint metering. Since there is a non-zero chance of needing the metering again in the future, this PR's goal is only to disable the parts that consume resources including:
- disable endpoint metering task
- skip tests


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios