### PR TITLE
[8.19] [ci] Make auto-approve token configurable per whitelist rule (#258172)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2563,8 +2563,8 @@ x-pack/platform/plugins/shared/fleet/server/saved_objects/index.ts @elastic/flee
 ####
 
 # Appex QA to own auto-generated scout metadata
-/**/scout/.meta/** @kibanamachine @elastic/appex-qa
-/**/scout_*/.meta/** @kibanamachine @elastic/appex-qa
+/**/scout/.meta/**
+/**/scout_*/.meta/**
 
 # These files influence agent behavior and are loaded into every new agent session.
 # Changes here can have repo-wide impact (what instructions/tools/context an agent sees), so require

--- a/.github/workflows/auto-approve-machine-prs.yml
+++ b/.github/workflows/auto-approve-machine-prs.yml
@@ -1,5 +1,10 @@
 # Generic auto-approve for machine-created PRs.
 # Add new rules to the whitelist in the check step; approval runs when any rule matches.
+# Each rule can optionally specify a `token` field to control the approving identity:
+#   'kibana' - approve as kibanamachine using KIBANAMACHINE_TOKEN
+#   'github' - approve as github-actions[bot] using the default GITHUB_TOKEN
+name: Auto-approve machine PRs
+
 on:
   pull_request_target:
     types:
@@ -21,10 +26,10 @@ jobs:
             const baseRef = context.payload.pull_request.base.ref;
 
             const whitelist = [
-              // { user: 'kibanamachine', branchPrefix: 'api_docs', baseMatch: /^main$/ },
-              // { user: 'kibanamachine', branchPrefix: 'backport', baseNotMatch: /^main$/ },
-              { user: 'kibanamachine', branchPrefix: 'scout_metadata_update' },
-              // { user: 'elasticmachine', branchPrefix: 'update-bundled-packages', paths: ['fleet_packages.json'] },
+              // { user: 'kibanamachine', branchPrefix: 'api_docs', baseMatch: /^main$/, token: 'kibana' },
+              // { user: 'kibanamachine', branchPrefix: 'backport', baseNotMatch: /^main$/, token: 'kibana' },
+              { user: 'kibanamachine', branchPrefix: 'scout_metadata_update', token: 'github' },
+              // { user: 'elasticmachine', branchPrefix: 'update-bundled-packages', paths: ['fleet_packages.json'], token: 'kibana' },
             ];
 
             // Fetch the list of changed files in the PR
@@ -37,7 +42,7 @@ jobs:
             const changedFiles = files.data.map(file => file.filename);
             core.info(`Changed files: ${changedFiles.join(', ')}`);
 
-            const matches = whitelist.some((rule) => {
+            const matchedRule = whitelist.find((rule) => {
               if (rule.user !== user) return false;
               if (!headRef.startsWith(rule.branchPrefix)) return false;
               if (rule.baseMatch && !rule.baseMatch.test(baseRef)) return false;
@@ -45,7 +50,7 @@ jobs:
 
               // If paths is specified, verify at least one changed file matches
               if (rule.paths) {
-                const hasMatchingFile = changedFiles.some(file => 
+                const hasMatchingFile = changedFiles.some(file =>
                   rule.paths.some(path => {
                     // Support glob patterns
                     if (path.includes('*')) {
@@ -64,9 +69,15 @@ jobs:
               return true;
             });
 
-            core.setOutput('should_approve', matches ? 'true' : 'false');
+            core.setOutput('should_approve', matchedRule ? 'true' : 'false');
+            core.setOutput('token', matchedRule?.token ?? 'kibana');
 
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
-        if: steps.check.outputs.should_approve == 'true'
+        if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'github'
+        with:
+          github-token: ${{ github.token }}
+
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        if: steps.check.outputs.should_approve == 'true' && steps.check.outputs.token == 'kibana'
         with:
           github-token: ${{ secrets.KIBANAMACHINE_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ci] Make auto-approve token configurable per whitelist rule (#258172)](https://github.com/elastic/kibana/pull/258172)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tamerlan Gudabayev","email":"37669316+TamerlanG@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-20T11:13:23Z","message":"[ci] Make auto-approve token configurable per whitelist rule (#258172)\n\n## Summary\n\nFollow-up to #256650. The scout metadata update pipeline (#252560)\ncreates PRs as `kibanamachine`, which means `kibanamachine` cannot also\napprove them (GitHub blocks self-approval). The solution is to use\n`github-actions[bot]` (via the default `GITHUB_TOKEN`) as the approver\nfor scout metadata PRs instead.\n\nThis PR makes the approving identity configurable per whitelist rule in\nthe `auto-approve-machine-prs` workflow, and removes the `CODEOWNERS`\nentries for scout `.meta` files (required so that `github-actions[bot]`\ncan satisfy the review requirement without needing to be a member of\n`@elastic/appex-qa`).\n\n### Changes\n\n**`.github/workflows/auto-approve-machine-prs.yml`**\n- Each whitelist rule can now specify a `token` field:\n- `'kibana'` (default) — approve as `kibanamachine` via\n`KIBANAMACHINE_TOKEN`\n- `'github'` — approve as `github-actions[bot]` via the default\n`GITHUB_TOKEN`\n- `scout_metadata_update` rule now uses `token: 'github'`\n- Changed `whitelist.some()` → `whitelist.find()` to access the matched\nrule's token\n- Split the single approve step into two mutually exclusive steps based\non the `token` output\n- Added `token` to the commented-out example rules for documentation\n\n**`.github/CODEOWNERS`**\n- Removed `/**/scout/.meta/**` and `/**/scout_*/.meta/**` ownership\nentries so that `github-actions[bot]` can satisfy the review requirement\non auto-generated scout metadata PRs\n\n### Related\n- #252560 — original scout metadata pipeline\n- #254182 — first round of fixes\n- #256650 — second round of fixes\n\n\n## Summary by CodeRabbit\n\n## Chores\n* Updated repository ownership rules to clarify delegated day-to-day\nedit permissions and tech-lead oversight for agent-related content.\n* Enhanced the automated approval workflow to support token-based\nrouting for conditional approval paths, improving delegation and review\ngating.\n\n\n---------\n\nCo-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>","sha":"b7a933188b94ade3605da35482093d6a9ec194f3","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[ci] Make auto-approve token configurable per whitelist rule","number":258172,"url":"https://github.com/elastic/kibana/pull/258172","mergeCommit":{"message":"[ci] Make auto-approve token configurable per whitelist rule (#258172)\n\n## Summary\n\nFollow-up to #256650. The scout metadata update pipeline (#252560)\ncreates PRs as `kibanamachine`, which means `kibanamachine` cannot also\napprove them (GitHub blocks self-approval). The solution is to use\n`github-actions[bot]` (via the default `GITHUB_TOKEN`) as the approver\nfor scout metadata PRs instead.\n\nThis PR makes the approving identity configurable per whitelist rule in\nthe `auto-approve-machine-prs` workflow, and removes the `CODEOWNERS`\nentries for scout `.meta` files (required so that `github-actions[bot]`\ncan satisfy the review requirement without needing to be a member of\n`@elastic/appex-qa`).\n\n### Changes\n\n**`.github/workflows/auto-approve-machine-prs.yml`**\n- Each whitelist rule can now specify a `token` field:\n- `'kibana'` (default) — approve as `kibanamachine` via\n`KIBANAMACHINE_TOKEN`\n- `'github'` — approve as `github-actions[bot]` via the default\n`GITHUB_TOKEN`\n- `scout_metadata_update` rule now uses `token: 'github'`\n- Changed `whitelist.some()` → `whitelist.find()` to access the matched\nrule's token\n- Split the single approve step into two mutually exclusive steps based\non the `token` output\n- Added `token` to the commented-out example rules for documentation\n\n**`.github/CODEOWNERS`**\n- Removed `/**/scout/.meta/**` and `/**/scout_*/.meta/**` ownership\nentries so that `github-actions[bot]` can satisfy the review requirement\non auto-generated scout metadata PRs\n\n### Related\n- #252560 — original scout metadata pipeline\n- #254182 — first round of fixes\n- #256650 — second round of fixes\n\n\n## Summary by CodeRabbit\n\n## Chores\n* Updated repository ownership rules to clarify delegated day-to-day\nedit permissions and tech-lead oversight for agent-related content.\n* Enhanced the automated approval workflow to support token-based\nrouting for conditional approval paths, improving delegation and review\ngating.\n\n\n---------\n\nCo-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>","sha":"b7a933188b94ade3605da35482093d6a9ec194f3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258172","number":258172,"mergeCommit":{"message":"[ci] Make auto-approve token configurable per whitelist rule (#258172)\n\n## Summary\n\nFollow-up to #256650. The scout metadata update pipeline (#252560)\ncreates PRs as `kibanamachine`, which means `kibanamachine` cannot also\napprove them (GitHub blocks self-approval). The solution is to use\n`github-actions[bot]` (via the default `GITHUB_TOKEN`) as the approver\nfor scout metadata PRs instead.\n\nThis PR makes the approving identity configurable per whitelist rule in\nthe `auto-approve-machine-prs` workflow, and removes the `CODEOWNERS`\nentries for scout `.meta` files (required so that `github-actions[bot]`\ncan satisfy the review requirement without needing to be a member of\n`@elastic/appex-qa`).\n\n### Changes\n\n**`.github/workflows/auto-approve-machine-prs.yml`**\n- Each whitelist rule can now specify a `token` field:\n- `'kibana'` (default) — approve as `kibanamachine` via\n`KIBANAMACHINE_TOKEN`\n- `'github'` — approve as `github-actions[bot]` via the default\n`GITHUB_TOKEN`\n- `scout_metadata_update` rule now uses `token: 'github'`\n- Changed `whitelist.some()` → `whitelist.find()` to access the matched\nrule's token\n- Split the single approve step into two mutually exclusive steps based\non the `token` output\n- Added `token` to the commented-out example rules for documentation\n\n**`.github/CODEOWNERS`**\n- Removed `/**/scout/.meta/**` and `/**/scout_*/.meta/**` ownership\nentries so that `github-actions[bot]` can satisfy the review requirement\non auto-generated scout metadata PRs\n\n### Related\n- #252560 — original scout metadata pipeline\n- #254182 — first round of fixes\n- #256650 — second round of fixes\n\n\n## Summary by CodeRabbit\n\n## Chores\n* Updated repository ownership rules to clarify delegated day-to-day\nedit permissions and tech-lead oversight for agent-related content.\n* Enhanced the automated approval workflow to support token-based\nrouting for conditional approval paths, improving delegation and review\ngating.\n\n\n---------\n\nCo-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>","sha":"b7a933188b94ade3605da35482093d6a9ec194f3"}}]}] BACKPORT-->