### PR TITLE
[Fleet] fix bug when VersionSpecificPolicyAssignmentTask picked up more than 10k agents to reassign

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.test.ts
@@ -13,6 +13,7 @@ import { isSpaceAwarenessEnabled as _isSpaceAwarenessEnabled } from '../spaces/h
 
 import { AgentNotFoundError } from '../..';
 
+import { SO_SEARCH_LIMIT } from '../../../common/constants';
 import { AGENTS_INDEX } from '../../constants';
 import { createAppContextStartContractMock } from '../../mocks';
 import type { Agent } from '../../types';
@@ -29,6 +30,7 @@ import {
   updateAgent,
   _joinFilters,
   getByIds,
+  getAgentsById,
   fetchAllAgentsByKuery,
 } from './crud';
 
@@ -666,6 +668,47 @@ describe('Agents CRUD test', () => {
       expect(mockedAuditLoggingService.writeCustomAuditLog).toHaveBeenCalledWith({
         message: `User closing point in time query [pitId=test-pit]`,
       });
+    });
+  });
+
+  describe('getAgentsById()', () => {
+    beforeEach(() => {
+      (soClientMock.getCurrentNamespace as jest.Mock).mockReturnValue('foo');
+    });
+
+    it('chunks requests so each search stays within max_result_window (10k)', async () => {
+      const overflow = 400;
+      const firstBatch = Array.from({ length: SO_SEARCH_LIMIT }, (_, i) => `agent-${i}`);
+      const secondBatch = Array.from(
+        { length: overflow },
+        (_, i) => `agent-${SO_SEARCH_LIMIT + i}`
+      );
+      const agentIds = [...firstBatch, ...secondBatch];
+
+      searchMock
+        .mockResolvedValueOnce(
+          getEsResponse(firstBatch, firstBatch.length, 'online', (id) => ({
+            id,
+            namespaces: ['foo'],
+          }))
+        )
+        .mockResolvedValueOnce(
+          getEsResponse(secondBatch, secondBatch.length, 'online', (id) => ({
+            id,
+            namespaces: ['foo'],
+          }))
+        );
+
+      const result = await getAgentsById(esClientMock, soClientMock, agentIds);
+
+      expect(searchMock).toHaveBeenCalledTimes(2);
+      expect(searchMock.mock.calls[0][0].size).toBe(SO_SEARCH_LIMIT);
+      expect(searchMock.mock.calls[1][0].size).toBe(overflow);
+      expect(result).toHaveLength(agentIds.length);
+      expect(result[0]).toEqual(expect.objectContaining({ id: 'agent-0' }));
+      expect(result[SO_SEARCH_LIMIT]).toEqual(
+        expect.objectContaining({ id: `agent-${SO_SEARCH_LIMIT}` })
+      );
     });
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { groupBy } from 'lodash';
+import { chunk, groupBy } from 'lodash';
 import type { estypes } from '@elastic/elasticsearch';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
@@ -627,19 +627,27 @@ export async function getAgentsById(
     return [];
   }
 
-  const idsQuery = {
-    terms: {
-      _id: agentIds,
-    },
-  };
-  const { agents } = await _filterAgents(esClient, soClient, idsQuery, {
-    perPage: agentIds.length,
-  });
+  // Each search must keep from + size <= index.max_result_window (default 10_000).
+  // _filterAgents uses from: (page - 1) * perPage with page 1, so perPage must not exceed SO_SEARCH_LIMIT.
+  const idBatches = chunk(agentIds, SO_SEARCH_LIMIT);
+  const agentsById = new Map<string, Agent>();
+
+  for (const batch of idBatches) {
+    const idsQuery = {
+      terms: {
+        _id: batch,
+      },
+    };
+    const { agents } = await _filterAgents(esClient, soClient, idsQuery, {
+      perPage: batch.length,
+    });
+    for (const agent of agents) {
+      agentsById.set(agent.id, agent);
+    }
+  }
 
   // return agents in the same order as agentIds
-  return agentIds.map(
-    (agentId) => agents.find((agent) => agent.id === agentId) || { id: agentId, notFound: true }
-  );
+  return agentIds.map((agentId) => agentsById.get(agentId) || { id: agentId, notFound: true });
 }
 
 // given a list of agentPolicyIds, return a map of agent version => count of agents

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/crud.ts
@@ -632,6 +632,12 @@ export async function getAgentsById(
   const idBatches = chunk(agentIds, SO_SEARCH_LIMIT);
   const agentsById = new Map<string, Agent>();
 
+  if (idBatches.length > 1) {
+    appContextService
+      .getLogger()
+      .debug(`Querying agents in ${idBatches.length} batches because agentIds.length is > 10k`);
+  }
+
   for (const batch of idBatches) {
     const idsQuery = {
       terms: {


### PR DESCRIPTION
## Summary

Fix a bug encountered in scale tests where VersionSpecificPolicyAssignmentTask picked up more than 10k agents to reassign, the task failed with a `max_result_window` error from ES.
https://buildkite.com/elastic/observability-perf/builds/5651#019d17fe-8419-4f3c-adf2-41683f2af59c
https://platform-logging.kb.us-west2.gcp.elastic-cloud.com/app/r/s/7EfzN

Added a small fix to chunk querying agent ids to 10k batches. `getAgentsById` is called from the reassign logic.

```
[VersionSpecificPolicyAssignmentTask] Error reassigning agents to b8642a71-93f9-4e22-853d-ebaadbcc7d3a#9.2: ResponseError: search_phase_execution_exception
	Caused by:
		illegal_argument_exception: Result window is too large, from + size must be less than or equal to: [10000] but was [10400]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.
	Root causes:
		illegal_argument_exception: Result window is too large, from + size must be less than or equal to: [10000] but was [10400]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



