### PR TITLE
[Security Solution] add url.domain to the list of event enrichments indicator field map

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/cti/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/cti/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ENRICHMENT_DESTINATION_PATH, DEFAULT_INDICATOR_SOURCE_PATH } from '../constants';
+import { DEFAULT_INDICATOR_SOURCE_PATH, ENRICHMENT_DESTINATION_PATH } from '../constants';
 
 export const MATCHED_ATOMIC = 'matched.atomic';
 export const MATCHED_FIELD = 'matched.field';
@@ -42,6 +42,7 @@ export const EVENT_ENRICHMENT_INDICATOR_FIELD_MAP = {
   'source.ip': `${DEFAULT_INDICATOR_SOURCE_PATH}.ip`,
   'destination.ip': `${DEFAULT_INDICATOR_SOURCE_PATH}.ip`,
   'url.full': `${DEFAULT_INDICATOR_SOURCE_PATH}.url.full`,
+  'url.domain': `${DEFAULT_INDICATOR_SOURCE_PATH}.url.domain`,
   'registry.path': `${DEFAULT_INDICATOR_SOURCE_PATH}.registry.path`,
 };
 


### PR DESCRIPTION
## Summary

This PR makes a super tiny change to the `EVENT_ENRICHMENT_INDICATOR_FIELD_MAP` by adding `url.domain` to the list of fields.
This was requested by one of our solution architects.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
