### PR TITLE
[kbn-evals] Update weekly eval models to the latest

### DIFF
--- a/.buildkite/pipelines/evals/eval_pipeline.ts
+++ b/.buildkite/pipelines/evals/eval_pipeline.ts
@@ -75,10 +75,10 @@ function parseGithubPrLabels(raw: string): string[] {
  */
 const MODEL_GROUP_ALIASES: Record<string, string[]> = {
   'weekly-eis-models': [
-    'eis/anthropic-claude-4.5-sonnet',
+    'eis/anthropic-claude-4.6-sonnet',
     'eis/anthropic-claude-4.6-opus',
     'eis/google-gemini-3.0-flash',
-    'eis/google-gemini-3.0-pro',
+    'eis/google-gemini-3.1-pro',
     'eis/openai-gpt-5.2',
     'eis/openai-gpt-oss-120b',
   ],

--- a/.buildkite/pipelines/evals/llm_evals.yml
+++ b/.buildkite/pipelines/evals/llm_evals.yml
@@ -71,7 +71,7 @@ steps:
           #
           # NOTE: Use `eis/<modelId>` values (not connector ids) so we can filter purely on the discovered
           # EIS model ids in `target/eis_models.json`.
-          EVAL_MODEL_GROUPS: &weekly_eis_model_groups 'eis/anthropic-claude-4.5-sonnet,eis/anthropic-claude-4.6-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.0-pro,eis/openai-gpt-5.2,eis/openai-gpt-oss-120b'
+          EVAL_MODEL_GROUPS: &weekly_eis_model_groups 'eis/anthropic-claude-4.6-sonnet,eis/anthropic-claude-4.6-opus,eis/google-gemini-3.0-flash,eis/google-gemini-3.1-pro,eis/openai-gpt-5.2,eis/openai-gpt-oss-120b'
         timeout_in_minutes: 60
         agents:
           image: family/kibana-ubuntu-2404


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/262097

## Summary
- Update `anthropic-claude-4.5-sonnet` → `anthropic-claude-4.6-sonnet` in the weekly eval model allowlist
- Update `google-gemini-3.0-pro` → `google-gemini-3.1-pro` in the weekly eval model allowlist
- Both `llm_evals.yml` and `eval_pipeline.ts` kept in sync

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


