### PR TITLE
Add `.claude/worktrees/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target
 .jruby
 .idea
 .claude/*.local.json
+.claude/worktrees/
 .cursor
 !x-pack/solutions/security/.cursor
 !x-pack/solutions/security/test/security_solution_cypress/.cursor/


### PR DESCRIPTION
## Summary

Adds `.claude/worktrees/` to `.gitignore`, worktrees created by claude should not show up in searches or be tracked.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->