### PR TITLE
Round of testing for unmapped fields

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/esql_fixture.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/esql_fixture.ts
@@ -55,7 +55,8 @@ export const esqlFixture = apiTest.extend<{}, EsqlFixture & EsqlFixtureOptions>(
   esql: [
     async ({ esClient, esqlDropNullColumns }, use) => {
       const executeEsqlQuery = async (query: string): Promise<EsqlResponse> => {
-        if (!/^\s*from\s+/i.test(query)) {
+        // Allow queries that start with a SET directive (e.g. SET unmapped_fields="LOAD";) before the FROM clause
+        if (!/^\s*(SET\s+\w+=\S+;\s*\n\s*)?from\s+/i.test(query)) {
           throw new Error('ES|QL query must start with a "from" clause.');
         }
 
@@ -86,7 +87,8 @@ export const esqlFixture = apiTest.extend<{}, EsqlFixture & EsqlFixtureOptions>(
           }
         );
 
-        const documents = response.values.map((valueRow: FieldValue[]) => {
+        // Build raw docs keyed by column name (includes order_id for sorting)
+        const rawDocuments = response.values.map((valueRow: FieldValue[]) => {
           const doc: Record<string, unknown> = {};
           response.columns.forEach((col: EsqlEsqlColumnInfo, idx: number) => {
             doc[col.name] = valueRow[idx];
@@ -94,24 +96,30 @@ export const esqlFixture = apiTest.extend<{}, EsqlFixture & EsqlFixtureOptions>(
           return doc;
         });
 
-        const nonKeywordColumnIndices = response.columns
-          .map((col, idx) => (!col.name.endsWith('.keyword') ? idx : -1))
-          .filter((idx) => idx !== -1);
-
-        const documentsWithoutKeywords = response.values.map((valueRow: FieldValue[]) => {
-          const doc: Record<string, unknown> = {};
-          nonKeywordColumnIndices.forEach((idx) => {
-            doc[response.columns[idx].name] = valueRow[idx];
-          });
-          return doc;
-        });
-
-        // Sort the results by the implicitly added order_id for deterministic testing
-        const sortById = (a: Record<string, unknown>, b: Record<string, unknown>) =>
+        const sortByOrderId = (a: Record<string, unknown>, b: Record<string, unknown>) =>
           (a.order_id as number) - (b.order_id as number);
 
-        const documentsOrdered = [...documents].sort(sortById);
-        const documentsWithoutKeywordsOrdered = [...documentsWithoutKeywords].sort(sortById);
+        const stripOrderId = ({ order_id: _, ...rest }: Record<string, unknown>) => rest;
+
+        // Non-keyword, non-internal column indices for the *WithoutKeywords collections
+        const nonKeywordColumnIndices = response.columns
+          .map((col, idx) => (!col.name.endsWith('.keyword') && col.name !== 'order_id' ? idx : -1))
+          .filter((idx) => idx !== -1);
+
+        const toDocWithoutKeywords = (raw: Record<string, unknown>): Record<string, unknown> => {
+          const doc: Record<string, unknown> = {};
+          nonKeywordColumnIndices.forEach((idx) => {
+            doc[response.columns[idx].name] = raw[response.columns[idx].name];
+          });
+          return doc;
+        };
+
+        const documents = rawDocuments.map(stripOrderId);
+        const documentsOrdered = [...rawDocuments].sort(sortByOrderId).map(stripOrderId);
+        const documentsWithoutKeywords = rawDocuments.map(toDocWithoutKeywords);
+        const documentsWithoutKeywordsOrdered = [...rawDocuments]
+          .sort(sortByOrderId)
+          .map(toDocWithoutKeywords);
 
         return {
           columns: response.columns,
@@ -130,7 +138,19 @@ export const esqlFixture = apiTest.extend<{}, EsqlFixture & EsqlFixtureOptions>(
             'queryOnIndex should not receive a query that already contains a "from" clause.'
           );
         }
-        const fullQuery = `from ${indexName} ${queryStr}`;
+
+        // If the query string starts with a SET directive (e.g. SET unmapped_fields="LOAD"\n),
+        // extract it and reposition it before the FROM clause, as ES|QL requires SET to precede FROM.
+        const setMatch = queryStr.match(/^(SET\s+\w+=\S+)\n/i);
+        let fullQuery: string;
+        if (setMatch) {
+          const setDirective = setMatch[1];
+          const pipeCommands = queryStr.slice(setMatch[0].length);
+          fullQuery = `${setDirective};\nFROM ${indexName} ${pipeCommands}`;
+        } else {
+          fullQuery = `from ${indexName} ${queryStr}`;
+        }
+
         return await executeEsqlQuery(fullQuery);
       };
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/fixtures/test_bed_fixture.ts
@@ -9,20 +9,32 @@ import type { Client } from '@elastic/elasticsearch';
 import type { ErrorCause, IngestProcessorContainer } from '@elastic/elasticsearch/lib/api/types';
 import { apiTest } from '@kbn/scout';
 
+export interface IngestOptions {
+  /**
+   * Controls dynamic field mapping on the target index.
+   * - `true` (default): auto-map all ingested fields
+   * - `false`: disable auto-mapping so fields are stored in `_source` only
+   */
+  dynamic?: boolean;
+}
+
 export interface TestBedFixture {
   testBed: {
     /**
      * Ingests documents into an index with an optional ingest pipeline.
-     * An `order_id` field is automatically added to each document to allow for deterministic sorting.
+     * An internal `order_id` field is automatically added to each document to allow for
+     * deterministic sorting. It is stripped from all results returned by this fixture.
      * @param indexName The name of the index.
      * @param documents An array of documents to ingest.
      * @param processors An optional array of ingest processors to create a pipeline.
+     * @param options Optional ingest settings (e.g. `dynamic: false` to disable auto-mapping).
      * @returns An object containing the number of ingested documents and an array of errors.
      */
     ingest: (
       indexName: string,
       documents: Array<Record<string, unknown>>,
-      processors?: IngestProcessorContainer[]
+      processors?: IngestProcessorContainer[],
+      options?: IngestOptions
     ) => Promise<{ errors: ErrorCause[]; docs: number }>;
     /**
      * Gets all documents from an index in their natural, non-deterministic order.
@@ -74,14 +86,15 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
       const ingest = async (
         indexName: string,
         documents: Array<Record<string, unknown>>,
-        processors?: IngestProcessorContainer[]
+        processors?: IngestProcessorContainer[],
+        options?: IngestOptions
       ) => {
         let pipelineId: string | undefined;
         if (processors && processors.length > 0) {
           pipelineId = await createPipeline(processors);
         }
 
-        await ensureIndexCreated(indexName, esClient);
+        await ensureIndexCreated(indexName, esClient, options?.dynamic);
         createdIndexes.add(indexName);
 
         if (!documents || documents.length === 0) {
@@ -89,7 +102,7 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
         }
 
         const body = documents
-          .map((doc, idx) => ({ ...doc, order_id: idx })) // Add order_id for deterministic sorting
+          .map((doc, idx) => ({ ...doc, order_id: idx })) // Add internal field for deterministic sorting
           .flatMap((doc) => [{ index: { _index: indexName } }, doc]);
 
         const bulkRequest: Record<string, unknown> = {
@@ -122,41 +135,54 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
           size: 1000,
         });
 
+        return response.hits.hits.map((hit) => {
+          const { order_id: _, ...rest } = hit._source as Record<string, unknown>;
+          return rest;
+        });
+      };
+
+      const getDocsRaw = async (indexName: string) => {
+        const response = await esClient.search({
+          index: indexName,
+          query: { match_all: {} },
+          size: 1000,
+        });
         return response.hits.hits.map((hit) => hit._source as Record<string, unknown>);
       };
 
       const getDocsOrdered = async (indexName: string) => {
-        const docs = await getDocs(indexName);
-        return docs.sort((a, b) => (a.order_id as number) - (b.order_id as number));
+        const docs = await getDocsRaw(indexName);
+        const sorted = docs.sort((a, b) => (a.order_id as number) - (b.order_id as number));
+        return sorted.map(({ order_id: _, ...rest }) => rest);
+      };
+
+      const flattenDoc = (doc: Record<string, unknown>): Record<string, unknown> => {
+        const result: Record<string, unknown> = {};
+
+        const flatten = (obj: Record<string, unknown>, prefix = '') => {
+          for (const [key, value] of Object.entries(obj)) {
+            const prefixedKey = prefix ? `${prefix}.${key}` : key;
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+              flatten(value as Record<string, unknown>, prefixedKey);
+            } else {
+              result[prefixedKey] = value;
+            }
+          }
+        };
+
+        flatten(doc);
+        return result;
       };
 
       const getFlattenedDocs = async (indexName: string) => {
         const docs = await getDocs(indexName);
-
-        const docsWithDottedNames = docs.map((doc) => {
-          const result: Record<string, unknown> = {};
-
-          const flatten = (obj: Record<string, unknown>, prefix = '') => {
-            for (const [key, value] of Object.entries(obj)) {
-              const prefixedKey = prefix ? `${prefix}.${key}` : key;
-              if (value && typeof value === 'object' && !Array.isArray(value)) {
-                flatten(value as Record<string, unknown>, prefixedKey);
-              } else {
-                result[prefixedKey] = value;
-              }
-            }
-          };
-
-          flatten(doc);
-          return result;
-        });
-
-        return docsWithDottedNames;
+        return docs.map(flattenDoc);
       };
 
       const getFlattenedDocsOrdered = async (indexName: string) => {
-        const docs = await getFlattenedDocs(indexName);
-        return docs.sort((a, b) => (a.order_id as number) - (b.order_id as number));
+        const docs = await getDocsRaw(indexName);
+        const sorted = docs.sort((a, b) => (a.order_id as number) - (b.order_id as number));
+        return sorted.map(({ order_id: _, ...rest }) => flattenDoc(rest));
       };
 
       const clean = async (indexName: string) => {
@@ -191,15 +217,29 @@ export const testBedFixture = apiTest.extend<TestBedFixture>({
   ],
 });
 
-async function ensureIndexCreated(indexName: string, esClient: Client) {
+async function ensureIndexCreated(indexName: string, esClient: Client, dynamic?: boolean) {
   if (await esClient.indices.exists({ index: indexName })) {
     return;
   }
 
+  // When dynamic is explicitly false, disable auto-mapping so fields are stored in _source only.
+  // This is required to genuinely exercise SET UNMAPPED_FIELDS=LOAD/NULLIFY in ES|QL queries.
+  // Default behaviour keeps auto-mapping enabled ('true') for backwards compatibility.
+  //
+  // `fake_test_prop` is always present (the testBed adds it to every document). We explicitly map it
+  // so the index is never *completely* unmapped — a fully-unmapped index triggers ES|QL's
+  // <no-fields> sentinel, which currently causes an optimizer crash with unmapped_fields="load"
+  // Having at least one mapped field avoids that code path while leaving all other fields unmapped for
+  // LOAD to resolve from _source.
   return esClient.indices.create({
     index: indexName,
     mappings: {
-      dynamic: 'true',
+      dynamic: dynamic === false ? false : 'true',
+      ...(dynamic === false && {
+        properties: {
+          fake_test_prop: { type: 'long' },
+        },
+      }),
     },
   });
 }

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/append.spec.ts
@@ -29,7 +29,7 @@ apiTest.describe(
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ tags: ['existing_tag'] }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0].tags).toStrictEqual(['existing_tag', 'new_tag']);
@@ -47,11 +47,11 @@ apiTest.describe(
         ],
       };
       const { query } = transpile(streamlangDSL);
-      const mappingDoc = { tags: ['initial_tag'] }; // Needed to satisfy ES|QL which needs all operand columns pre-mapped;
-      const docs = [mappingDoc, { message: 'message' }];
-      await testBed.ingest(indexName, docs);
+      // const mappingDoc = { tags: ['initial_tag'] }; // commenting out mapping docs whilst testing unmapped fields
+      const docs = [{ message: 'message' }];
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
-      expect(esqlResult.documentsOrdered[1].tags).toStrictEqual(['tag01', 'tag02']);
+      expect(esqlResult.documentsOrdered[0].tags).toStrictEqual(['tag01', 'tag02']);
     });
 
     apiTest(
@@ -70,7 +70,7 @@ apiTest.describe(
         };
         const { query } = transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag', 'new_tag'] }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
         expect(esqlResult.documents[0].tags).toStrictEqual(['existing_tag', 'new_tag']);
       }
@@ -92,7 +92,7 @@ apiTest.describe(
         };
         const { query } = transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag'] }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
         expect(esqlResult.documents[0].tags).toStrictEqual(['existing_tag', 'existing_tag']);
       }
@@ -118,7 +118,7 @@ apiTest.describe(
         { attributes: { should_exist: 'YES' }, tags: ['existing_tag'] },
         { attributes: { size: 2048 }, tags: ['existing_tag_01', 'existing_tag_02'] },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documentsOrdered[0].tags).toStrictEqual(['existing_tag', 'new_tag']);
       expect(esqlResult.documentsOrdered[1].tags).toStrictEqual([
@@ -143,7 +143,7 @@ apiTest.describe(
         };
         const { query } = transpile(streamlangDSL);
         const docs = [{ tags: ['existing_tag'] }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // Note how an ES|QL single element multi-valued field outputs a non-array value
@@ -173,7 +173,7 @@ apiTest.describe(
         { attributes: { should_exist: 'YES' }, tags: ['existing_tag'] },
         { attributes: { size: 2048 }, tags: ['existing_tag_01', 'existing_tag_02'] },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documentsOrdered[0].tags).toBe('existing_tag');
       expect(esqlResult.documentsOrdered[1].tags).toStrictEqual([

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/concat.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/concat.spec.ts
@@ -37,7 +37,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ first_name: 'john', last_name: 'doe', email_domain: 'example.com' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -75,7 +75,7 @@ apiTest.describe(
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com', has_email: true },
           { first_name: 'jane', last_name: 'smith', email_domain: 'example.com', has_email: false },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);
@@ -112,7 +112,7 @@ apiTest.describe(
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },
           { first_name: 'jane', last_name: 'smith' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);
@@ -149,7 +149,7 @@ apiTest.describe(
           { first_name: 'john', last_name: 'doe', email_domain: 'example.com' },
           { first_name: 'jane', last_name: 'smith' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/convert.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // `toHaveProperty` doesn't work with flattened ES|QL Rows/Documents
@@ -79,12 +79,13 @@ apiTest.describe(
         const { query } = transpile(streamlangDSL);
 
         const docs = [{ attributes: { size: 4096 } }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
+        // attributes.size is unmapped (dynamic: false) so ES|QL loads it as keyword — expect string.
         expect(esqlResult.documentsOrdered[0]).toStrictEqual(
           expect.objectContaining({
-            'attributes.size': 4096,
+            'attributes.size': '4096',
             'attributes.size_str': '4096',
           })
         );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/date.spec.ts
@@ -28,7 +28,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['@timestamp']).toBe('2025-01-01T12:34:56.789Z');
     }
@@ -55,7 +55,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
         { event: { created: '01/01/2025:12:34:56' } },
         { event: { created: '2025-01-02T12:34:56.789Z' } },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documentsOrdered[0]['event.created_date']).toBe('2025-01-01T12:34:56.000Z');
@@ -80,7 +80,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['custom.time']).toBe('2025-01-01T12:34:56.789Z');
     }
@@ -103,7 +103,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ log: { time: '2025-01-01T12:34:56.789Z' } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['@timestamp']).toBe('2025/01/01');
     }
@@ -129,16 +129,15 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
 
-      const mappingDoc = { '@timestamp': '2025-01-01T12:32:54.123Z' }; // Needed to satisfy ES|QL which needs all operand columns pre-mapped
+      // const mappingDoc = { '@timestamp': '2025-01-01T12:32:54.123Z' }; // commenting out mapping docs whilst testing unmapped fields
       const docs = [
-        mappingDoc,
         { attributes: { should_exist: 'YES' }, log: { time: '2025-01-01T12:34:56.789Z' } },
         { attributes: { size: 2048 }, log: { time: '2025-01-02T12:34:56.789Z' } },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
-      expect(esqlResult.documentsOrdered[1]['@timestamp']).toBe('2025-01-01T12:34:56.789Z');
-      expect(esqlResult.documentsOrdered[2]['@timestamp']).toBeNull();
+      expect(esqlResult.documentsOrdered[0]['@timestamp']).toBe('2025-01-01T12:34:56.789Z');
+      expect(esqlResult.documentsOrdered[1]['@timestamp']).toBeNull();
     }
   );
 
@@ -158,7 +157,7 @@ apiTest.describe('Streamlang to ES|QL - Date Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ log: { time: '01-01-2025' } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['log.time']).toBe('01-01-2025');
       expect(esqlResult.documents[0]['@timestamp']).toBeNull();

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/dissect.spec.ts
@@ -9,7 +9,6 @@ import { expect } from '@kbn/scout/api';
 import { tags } from '@kbn/scout';
 import type { DissectProcessor, StreamlangDSL } from '@kbn/streamlang';
 import { transpileEsql as transpile } from '@kbn/streamlang';
-import { expectDefined } from '../../../utils';
 import { streamlangApiTest as apiTest } from '../..';
 
 apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
@@ -34,7 +33,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
           message: '[2025-01-01T00:00:00.000Z] [info] 127.0.0.1 - - "GET / HTTP/1.1" 200 123',
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]).toStrictEqual(
         expect.objectContaining({
@@ -67,16 +66,15 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
 
-      // Ingest a doc with all operand fields to satisfy ES|QL requirement that any field used in the query must be pre-mapped (available as a column)
-      const mappingDoc = {
-        '@timestamp': '',
-        message: '',
-        log: { level: '' },
-        host: { name: '' },
-        client: { ip: '' },
-      };
+      // commenting out mapping docs whilst testing unmapped fields
+      // const mappingDoc = {
+      //   '@timestamp': '',
+      //   message: '',
+      //   log: { level: '' },
+      //   host: { name: '' },
+      //   client: { ip: '' },
+      // };
       const docs = [
-        mappingDoc,
         { expect: 'null', log: { level: 'undissected' } }, // Since log.level is an operand field in dissect pattern, but message is missing, it nullifies the field
         {
           expect: 'dissected',
@@ -85,22 +83,14 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         },
         { expect: 'null', log: { level: 'undissected' }, message: '2025-01-01T00:00:00.000Z]' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Get docs grouped by their expectation
-      const nullDocs = esqlResult.documents.filter((d) => d.expect === 'null');
-      const dissectedDocs = esqlResult.documents.filter((d) => d.expect === 'dissected');
-
-      // Test null docs have null log.level
-      nullDocs.forEach((doc) => {
-        expect(doc['log.level']).toBeNull();
-      });
-
-      // Test dissected docs have correct log.level
-      dissectedDocs.forEach((doc) => {
-        expect(doc['log.level']).toBe('dissected');
-      });
+      // expect is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] no-message, [1] valid match, [2] bad format.
+      expect(esqlResult.documentsOrdered[0]['log.level']).toBeNull(); // no message → dissect skipped
+      expect(esqlResult.documentsOrdered[1]['log.level']).toBe('dissected'); // valid → dissected
+      expect(esqlResult.documentsOrdered[2]['log.level']).toBeNull(); // bad format → null
     }
   );
 
@@ -121,13 +111,13 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
 
-      const mappingDoc = { message: '[2025-01-01T00:00:00.000Z] [info] 192.168.90.9' };
-      const docs = [mappingDoc, { log: { level: 'info' } }];
-      await testBed.ingest(indexName, docs);
+      const docWithMessage = { message: '[2025-01-01T00:00:00.000Z] [info] 192.168.90.9' };
+      const docs = [docWithMessage, { log: { level: 'info' } }];
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Should have filtered out the doc missing `message` field
-      expect(esqlResult.documents).toHaveLength(1); // Only the mapping doc
+      expect(esqlResult.documents).toHaveLength(1); // Only the doc with a valid message
     }
   );
 
@@ -148,7 +138,7 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ message: 'value1-value2' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]).toStrictEqual(
         expect.objectContaining({
@@ -177,20 +167,22 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         ],
       };
       const { query } = transpile(streamlangDSL);
-      const mappingDoc = { log: { level: '' } };
+      // const mappingDoc = { log: { level: '' } }; // commenting out mapping docs whilst testing unmapped fields
       const docs = [
-        mappingDoc,
         { attributes: { should_exist: 'YES' }, message: '[info]' },
         { attributes: { size: 2048 }, message: '[warn]' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Find documents by their attributes
+      // attributes.should_exist is referenced in the WHERE clause so it is a column — .find() works.
       const shouldExistDoc = esqlResult.documents.find(
         (doc) => doc['attributes.should_exist'] === 'YES'
       );
-      const sizeDocs = esqlResult.documents.filter((doc) => doc['attributes.size'] === 2048);
+      // attributes.size is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [1] is the doc with attributes.size.
+      const sizeDoc = esqlResult.documentsOrdered[1];
 
       // Verify the document with should_exist has been properly dissected
       expect(shouldExistDoc).toStrictEqual(
@@ -199,10 +191,8 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         })
       );
 
-      // Verify documents without should_exist have not been dissected
-      sizeDocs.forEach((doc) => {
-        expect(doc['log.level']).toBeNull();
-      });
+      // Verify the document without should_exist has not been dissected
+      expect(sizeDoc['log.level']).toBeNull();
     }
   );
 
@@ -249,7 +239,9 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         { log: { severity: 3, level: 'invalid' }, message: '[warn] [3] [1024] 34.2' }, // ingest log.severity as number
         { log: { size: '4096' }, message: '[info] [4] [2048] 22.4' }, // ingest size as string
       ];
-      await testBed.ingest(indexName, [...docsToDissect, ...docsToSkip]);
+      await testBed.ingest(indexName, [...docsToDissect, ...docsToSkip], undefined, {
+        dynamic: false,
+      });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Group documents by their log levels
@@ -334,17 +326,16 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
 
-      // Mapping doc to ensure columns exist so pre-cast EVALs don't error
-      const mappingDoc = {
-        case: 'mapping',
-        message: '',
-        log: { level: '', severity: '' },
-        client: { ip: '' },
-        flags: { process: '' },
-      };
+      // commenting out mapping docs whilst testing unmapped fields
+      // const mappingDoc = {
+      //   case: 'mapping',
+      //   message: '',
+      //   log: { level: '', severity: '' },
+      //   client: { ip: '' },
+      //   flags: { process: '' },
+      // };
 
       const docs = [
-        mappingDoc,
         // Both conditions true -> dissect applies
         {
           case: 'both',
@@ -370,30 +361,27 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         },
       ];
 
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Find specific documents by their case
-      const dissectedDoc = esqlResult.documents.find((d) => d.case === 'both');
-      const noMessageDoc = esqlResult.documents.find((d) => d.case === 'no_message');
-      const noWhereDoc = esqlResult.documents.find((d) => d.case === 'no_where');
-      const noneDoc = esqlResult.documents.find((d) => d.case === 'none');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] both, [1] no_message, [2] no_where, [3] none.
+      const dissectedDoc = esqlResult.documentsOrdered[0];
+      const noMessageDoc = esqlResult.documentsOrdered[1];
+      const noWhereDoc = esqlResult.documentsOrdered[2];
+      const noneDoc = esqlResult.documentsOrdered[3];
 
       // Test the properly dissected document
-      expectDefined(dissectedDoc);
       expect(dissectedDoc['log.level']).toBe('info');
       expect(dissectedDoc['client.ip']).toBe('10.1.1.1');
 
       // Test documents that should be skipped
-      expectDefined(noMessageDoc);
       expect(noMessageDoc['log.level']).toBeNull();
       expect(noMessageDoc['client.ip']).toBeNull();
 
-      expectDefined(noWhereDoc);
       expect(noWhereDoc['log.level']).toBeNull();
       expect(noWhereDoc['client.ip']).toBeNull();
 
-      expectDefined(noneDoc);
       expect(noneDoc['log.level']).toBeNull();
       expect(noneDoc['client.ip']).toBeNull();
     }
@@ -420,18 +408,18 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
 
-      const mappingDoc = {
-        '@timestamp': '',
-        user: { full_name: '' },
-        client: { ip: '' },
-        path: '',
-        message: '',
-        flags: { process: '' },
-        elapsed: 0,
-      };
+      // commenting out mapping docs whilst testing unmapped fields
+      // const mappingDoc = {
+      //   '@timestamp': '',
+      //   user: { full_name: '' },
+      //   client: { ip: '' },
+      //   path: '',
+      //   message: '',
+      //   flags: { process: '' },
+      //   elapsed: 0,
+      // };
 
       const docs = [
-        mappingDoc,
         // Full match; user pieces john & john, path parts part2 & part1
         {
           case: 'full',
@@ -466,17 +454,17 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         },
       ];
 
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Find specific documents by their case
-      const fullDoc = esqlResult.documents.find((d) => d.case === 'full');
-      const overrideDoc = esqlResult.documents.find((d) => d.case === 'override');
-      const skipMissingDoc = esqlResult.documents.find((d) => d.case === 'skip_missing');
-      const skipWhereDoc = esqlResult.documents.find((d) => d.case === 'skip_where');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] full, [1] override, [2] skip_missing, [3] skip_where.
+      const fullDoc = esqlResult.documentsOrdered[0];
+      const overrideDoc = esqlResult.documentsOrdered[1];
+      const skipMissingDoc = esqlResult.documentsOrdered[2];
+      const skipWhereDoc = esqlResult.documentsOrdered[3];
 
       // Test the fully matched document
-      expectDefined(fullDoc);
       expect(fullDoc['@timestamp']).toBe('2025-01-01T00:00:00Z');
       expect(fullDoc['user.full_name']).toBe('john doe');
       expect(fullDoc['client.ip']).toBe('10.0.0.1');
@@ -484,7 +472,6 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       expect(fullDoc.elapsed).toBe('9800');
 
       // Test the document with overridden values
-      expectDefined(overrideDoc);
       expect(overrideDoc['@timestamp']).toBe('2025-02-01T00:00:01Z');
       expect(overrideDoc['user.full_name']).toBe('alice alice');
       expect(overrideDoc['client.ip']).toBe('192.168.0.5');
@@ -492,18 +479,16 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
       expect(overrideDoc.elapsed).toBe('5500');
 
       // Test the document that should be skipped due to missing message
-      expectDefined(skipMissingDoc);
       expect(skipMissingDoc['user.full_name']).toBeNull();
       expect(skipMissingDoc['client.ip']).toBeNull();
       expect(skipMissingDoc.path).toBeNull();
 
       // Test the document that should be skipped due to where condition
-      expectDefined(skipWhereDoc);
+      // status is not referenced in the query so ES|QL does not return it as a column.
       expect(skipWhereDoc['user.full_name']).toBeNull();
       expect(skipWhereDoc['client.ip']).toBeNull();
       expect(skipWhereDoc.path).toBeNull();
       expect(skipWhereDoc.elapsed).toBeNull();
-      expect(skipWhereDoc.status).toBe(203); // Non operand field remains number
     }
   );
 
@@ -523,25 +508,24 @@ apiTest.describe('Streamlang to ES|QL - Dissect Processor', () => {
         ],
       };
       const { query } = transpile(streamlangDSL);
-      const mappingDoc = { size: 0, message: '' }; // Ingest size as long type
+      // const mappingDoc = { size: 0, message: '' }; // [UNMAPPED_FIELDS] NOTE: removing this doc changes test semantics —
+      // without it, 'size' is unmapped and loaded as keyword, so parseFloat still works but the field type changes
       const docs = [
-        mappingDoc,
         { case: 'dissected', size: 1.9, message: '3.14159265358979323846' },
         { case: 'skipped', size: 88.99 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Find specific documents by their case
-      const dissectedDoc = esqlResult.documents.find((d) => d.case === 'dissected');
-      const skippedDoc = esqlResult.documents.find((d) => d.case === 'skipped');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] dissected, [1] skipped.
+      const dissectedDoc = esqlResult.documentsOrdered[0];
+      const skippedDoc = esqlResult.documentsOrdered[1];
 
       // Test the dissected document
-      expectDefined(dissectedDoc);
       expect(parseFloat(dissectedDoc.size as string)).toBeCloseTo(3.1415);
 
       // Test the skipped document
-      expectDefined(skippedDoc);
       expect(skippedDoc.size).toBeNull();
     }
   );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/drop_document.spec.ts
@@ -36,13 +36,13 @@ apiTest.describe(
         { environment: 'production', message: 'keep-this' },
         { environment: 'non-production', message: 'drop-this' }, // should drop docs with non-production environments
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
       const source = esqlResult.documents[0];
       expect(source?.environment).toBe('production');
-      expect(source?.message).toBe('keep-this');
+      // message is not referenced in the query so ES|QL does not return it as a column.
     });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/grok.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ message: '55.3.244.1 GET /index.html 15824 0.043' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]).toStrictEqual(
         expect.objectContaining({
@@ -61,7 +61,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ message: '8.8.8.8 4.4.4.4' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['client.ip']).toStrictEqual(['8.8.8.8', '4.4.4.4']);
     }
@@ -83,7 +83,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ message: 'not_an_ip' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]['client.ip']).toBeNull(); // grok didn't extract but did map the field
     }
@@ -110,7 +110,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
             '127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"',
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]).toStrictEqual(
         expect.objectContaining({
@@ -125,7 +125,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           'url.original': '/apache_pb.gif',
           'source.address': '127.0.0.1',
           message: docs[0].message,
-          'message.keyword': docs[0].message,
+          // With dynamic: false, message is unmapped — no .keyword multi-field is generated
         })
       );
     }
@@ -152,22 +152,14 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
         { expect: '127.0.0.1', client: { ip: '192.168.1.1' }, message: 'User IP: 127.0.0.1' }, // Should grok
         { expect: null, client: { ip: '192.168.1.1' }, message: 'User IP: N/A' }, // Should grok
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Group documents by their expectation
-      const nullDocs = esqlResult.documents.filter((doc) => doc.expect === null);
-      const ipDocs = esqlResult.documents.filter((doc) => doc.expect === '127.0.0.1');
-
-      // Test all null docs have null client.ip
-      nullDocs.forEach((doc) => {
-        expect(doc['client.ip']).toBeNull();
-      });
-
-      // Test all IP docs have correct client.ip
-      ipDocs.forEach((doc) => {
-        expect(doc['client.ip']).toBe('127.0.0.1');
-      });
+      // expect is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] no-message, [1] valid IP, [2] bad IP.
+      expect(esqlResult.documentsOrdered[0]['client.ip']).toBeNull();
+      expect(esqlResult.documentsOrdered[1]['client.ip']).toBe('127.0.0.1');
+      expect(esqlResult.documentsOrdered[2]['client.ip']).toBeNull();
     }
   );
 
@@ -188,8 +180,11 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [{ log: { level: 'info' } }];
-      await testBed.ingest(indexName, docs);
-      await expect(esql.queryOnIndex(indexName, query)).rejects.toThrow('Unknown column [message]');
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
+      // [UNMAPPED_FIELDS] With SET UNMAPPED_FIELDS=LOAD, 'message' is resolved from _source as null
+      // rather than throwing 'Unknown column'. With ignore_missing=false, null source field filters out the document.
+      const esqlResult = await esql.queryOnIndex(indexName, query);
+      expect(esqlResult.documents).toHaveLength(0);
     }
   );
 
@@ -222,24 +217,19 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
         { expect: '8.8.8.8', attributes: { should_exist: 'YES' }, message: '8.8.8.8' },
         { expect: null, attributes: { size: 2048 }, message: '127.0.0.1' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Group documents by their expectation
-      const ipDocsWithShouldExist = esqlResult.documents.filter(
-        (doc) => doc.expect === '55.3.244.1' || doc.expect === '8.8.8.8'
-      );
-      const docsWithSize = esqlResult.documents.filter((doc) => doc['attributes.size'] === 2048);
+      // expect and attributes.size are not referenced in the query so ES|QL does not return them as columns.
+      // Use documentsOrdered by ingestion position: [0] first should_exist, [1] second should_exist, [2] size.
+      const [doc0, doc1, doc2] = esqlResult.documentsOrdered;
 
       // Test documents with should_exist have correct IP
-      ipDocsWithShouldExist.forEach((doc) => {
-        expect(doc['client.ip']).toBe(doc.expect);
-      });
+      expect(doc0['client.ip']).toBe('55.3.244.1');
+      expect(doc1['client.ip']).toBe('8.8.8.8');
 
-      // Test documents with size have null client.ip
-      docsWithSize.forEach((doc) => {
-        expect(doc['client.ip']).toBeNull();
-      });
+      // Test document with size has null client.ip (where condition not matched)
+      expect(doc2['client.ip']).toBeNull();
     }
   );
 
@@ -264,13 +254,8 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [
-        // Mapping doc to ensure fields exist
-        {
-          http: { response: { body: { bytes: 0 } } },
-          status: { keyword: '' },
-          flags: { process: '' },
-          message: '',
-        },
+        // [UNMAPPED_FIELDS] mapping doc removed — no longer needed with SET UNMAPPED_FIELDS=LOAD
+        // { http: { response: { body: { bytes: 0 } } }, status: { keyword: '' }, flags: { process: '' }, message: '' },
         // Will be grokked (bytes numeric in message)
         {
           case: 'grok_numeric',
@@ -287,12 +272,13 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           message: '2048 IGNORED',
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Get specific documents by case
-      const grokNumericDoc = esqlResult.documents.find((doc) => doc.case === 'grok_numeric');
-      const skipNumericDoc = esqlResult.documents.find((doc) => doc.case === 'skip_numeric');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered: grok_numeric was ingested first (index 0), skip_numeric second (index 1).
+      const grokNumericDoc = esqlResult.documentsOrdered[0];
+      const skipNumericDoc = esqlResult.documentsOrdered[1];
 
       // Test grokked document
       expectDefined(grokNumericDoc);
@@ -324,13 +310,8 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [
-        // Mapping doc for pre-cast stability
-        {
-          user: { name: '' },
-          client: { ip: '' },
-          flags: { process: '' },
-          message: '',
-        },
+        // [UNMAPPED_FIELDS] mapping doc removed — no longer needed with SET UNMAPPED_FIELDS=LOAD
+        // { user: { name: '' }, client: { ip: '' }, flags: { process: '' }, message: '' },
         // Both conditions true -> grok
         {
           case: 'both',
@@ -345,14 +326,15 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
         // Neither condition
         { case: 'none', user: { name: 'offline' } },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Find specific documents by case
-      const bothDoc = esqlResult.documents.find((doc) => doc.case === 'both');
-      const noMessageDoc = esqlResult.documents.find((doc) => doc.case === 'no_message');
-      const noWhereDoc = esqlResult.documents.find((doc) => doc.case === 'no_where');
-      const noneDoc = esqlResult.documents.find((doc) => doc.case === 'none');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: both(0), no_message(1), no_where(2), none(3).
+      const bothDoc = esqlResult.documentsOrdered[0];
+      const noMessageDoc = esqlResult.documentsOrdered[1];
+      const noWhereDoc = esqlResult.documentsOrdered[2];
+      const noneDoc = esqlResult.documentsOrdered[3];
 
       // Test document with both conditions
       expectDefined(bothDoc);
@@ -397,16 +379,9 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
       };
       const { query } = transpile(streamlangDSL);
       const docs = [
-        // Mapping / schema stabilization doc
-        {
-          client: { ip: '0.0.0.0' },
-          user: { name: 'baseline' },
-          http: { response: { body: { bytes: 0 } } },
-          event: { duration: 0 }, // mapped type is long
-          'http.response': { status: 'INIT' },
-          flags: { process: '' },
-          message: '',
-        },
+        // [UNMAPPED_FIELDS] mapping doc removed — no longer needed with SET UNMAPPED_FIELDS=LOAD
+        // { client: { ip: '0.0.0.0' }, user: { name: 'baseline' }, http: { response: { body: { bytes: 0 } } },
+        //   event: { duration: 0 }, 'http.response': { status: 'INIT' }, flags: { process: '' }, message: '' },
         // Full GROK override (all fields present & where passes)
         {
           case: 'grok_all',
@@ -449,18 +424,17 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
           'http.response': { status: 'NOOP' },
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Collect only docs with a case label (exclude mapping doc)
-      const resultDocs = esqlResult.documents.filter((d) => d.case);
-      expect(resultDocs).toHaveLength(4);
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: grok_all(0), skip_where(1), skip_missing(2), skip_both(3).
+      expect(esqlResult.documentsOrdered).toHaveLength(4);
 
-      // Find specific documents by case
-      const grokAllDoc = resultDocs.find((doc) => doc.case === 'grok_all');
-      const skipWhereDoc = resultDocs.find((doc) => doc.case === 'skip_where');
-      const skipMissingDoc = resultDocs.find((doc) => doc.case === 'skip_missing');
-      const skipBothDoc = resultDocs.find((doc) => doc.case === 'skip_both');
+      const grokAllDoc = esqlResult.documentsOrdered[0];
+      const skipWhereDoc = esqlResult.documentsOrdered[1];
+      const skipMissingDoc = esqlResult.documentsOrdered[2];
+      const skipBothDoc = esqlResult.documentsOrdered[3];
 
       // Test grokked document
       expectDefined(grokAllDoc);
@@ -514,18 +488,19 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
         ],
       };
       const { query } = transpile(streamlangDSL);
-      const mappingDoc = { size: 0, message: '' }; // Ingest size as long type
+      // const mappingDoc = { size: 0, message: '' }; // [UNMAPPED_FIELDS] NOTE: removing this changes test semantics —
+      // without pre-mapping 'size' as long, the field type is determined by first doc ingested
       const docs = [
-        mappingDoc,
         { case: 'groked', size: 1.9, message: '3.14159265358979323846' },
         { case: 'skipped', size: 88.99 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // Find specific documents by case
-      const grokedDoc = esqlResult.documents.find((doc) => doc.case === 'groked');
-      const skippedDoc = esqlResult.documents.find((doc) => doc.case === 'skipped');
+      // case is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: groked(0), skipped(1).
+      const grokedDoc = esqlResult.documentsOrdered[0];
+      const skippedDoc = esqlResult.documentsOrdered[1];
 
       // Test groked document
       expectDefined(grokedDoc);
@@ -581,7 +556,7 @@ apiTest.describe('Streamlang to ES|QL - Grok Processor', () => {
             '11-06 13:43:41.377  1702 17633 W ActivityManager: getRunningAppProcesses: caller 10113 does not hold REAL_GET_TASKS; limiting output',
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents).toHaveLength(1);
       expect(esqlResult.documents[0]?.timestamp).toBe('11-06 13:43:41.377');

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/lowercase.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -54,7 +54,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -84,7 +84,7 @@ apiTest.describe(
         { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },
         { message: 'TEST MESSAGE 2', should_lowercase: 'no' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -117,7 +117,7 @@ apiTest.describe(
           { message: 'TEST MESSAGE 1', should_lowercase: 'yes' },
           { message: 'TEST MESSAGE 2', should_lowercase: 'no' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/manual_ingest_pipeline.spec.ts
@@ -51,7 +51,7 @@ apiTest.describe(
         ];
 
         // Create a simple test index with data for ES|QL execution
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
 
         // Execute the ES|QL query - it should run without syntax errors
         const result = await esql.queryOnIndex(indexName, query);
@@ -59,11 +59,9 @@ apiTest.describe(
         // Should return the documents (the warning is just informational)
         expect(result.documents.length).toBeGreaterThan(0);
 
-        // The original fields should be preserved since manual_ingest_pipeline is not processed
-        expect(result.documents[0]?.message).toBe('test message');
-        expect(result.documents[0]?.existing_field).toBe('existing_value');
-
-        // The manual processor should NOT have been applied (no 'status' field)
+        // message and existing_field are not referenced in the query (the manual pipeline processor
+        // generates only a comment), so ES|QL does not return them as columns.
+        // Verify the manual processor was NOT applied by checking 'status' is absent.
         expect(result.documents[0]?.status).toBeUndefined();
       }
     );
@@ -105,7 +103,7 @@ apiTest.describe(
           },
         ];
 
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const result = await esql.queryOnIndex(indexName, query);
 
         // Both documents should be returned since the manual processor (and its condition) is ignored
@@ -166,7 +164,7 @@ apiTest.describe(
           },
         ];
 
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const result = await esql.queryOnIndex(indexName, query);
 
         expect(result.documents.length).toBeGreaterThan(0);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/math.spec.ts
@@ -32,7 +32,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ price: 10, quantity: 5 }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -58,7 +58,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ a: 15, b: 25 }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -84,7 +84,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ a: 100, b: 30 }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -110,7 +110,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ total: 100, count: 4 }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -137,7 +137,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ attributes: { price: 25, quantity: 4 } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -165,7 +165,7 @@ apiTest.describe(
 
       // log(e) = 1, using e ≈ 2.718281828459045
       const docs = [{ value: 2.718281828459045 }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Allow small floating-point tolerance
@@ -193,7 +193,7 @@ apiTest.describe(
         { order_id: 1, a: 5, b: 3 },
         { order_id: 2, a: 5, b: 5 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
@@ -227,7 +227,7 @@ apiTest.describe(
         { order_id: 1, a: 10, b: 5 },
         { order_id: 2, a: 3, b: 7 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
@@ -257,7 +257,7 @@ apiTest.describe(
         { order_id: 1, a: 3, b: 7 },
         { order_id: 2, a: 10, b: 5 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
@@ -287,7 +287,7 @@ apiTest.describe(
         { order_id: 1, a: 5, b: 5 },
         { order_id: 2, a: 5, b: 3 },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documentsOrdered[0]).toStrictEqual(
@@ -323,7 +323,7 @@ apiTest.describe(
         { order_id: 2, price: 10, quantity: 5, active: true, total: null },
         { order_id: 3, price: 20, quantity: 3, active: false, total: null },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Active doc should have total calculated
@@ -365,7 +365,7 @@ apiTest.describe(
           { order_id: 2, price: 10, quantity: 5, total: null },
           { order_id: 3, price: 20, quantity: null, total: null }, // quantity missing
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // First doc should have total calculated

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/network_direction.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/network_direction.spec.ts
@@ -32,7 +32,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ source_ip: '128.232.110.120', destination_ip: '192.168.1.1' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -64,7 +64,7 @@ apiTest.describe(
             test_network_direction_field: ['private'],
           },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(1);
@@ -95,7 +95,7 @@ apiTest.describe(
           { source_ip: '128.232.110.120', destination_ip: '192.168.1.1' },
           { destination_ip: '192.168.1.1' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);
@@ -132,7 +132,7 @@ apiTest.describe(
           event: { kind: 'production' },
         },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/redact.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/redact.spec.ts
@@ -33,7 +33,7 @@ apiTest.describe(
         const { query } = transpile(streamlangDSL);
 
         const docs = [{ message: 'Connection from 192.168.1.1 established' }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(1);
@@ -59,7 +59,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Contact user at john.doe@example.com for details' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -84,7 +84,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'User john@example.com connected from 10.0.0.1' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -111,7 +111,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Request from 172.16.0.1' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -136,7 +136,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Device MAC: 00:1A:2B:3C:4D:5E' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -166,13 +166,15 @@ apiTest.describe(
         const docWithField = { message: 'Connection from 192.168.1.1', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should pass through
         const docs = [docWithField, docWithoutField];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // Both documents should be present
-        expect(esqlResult.documents).toHaveLength(2);
-        const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
-        const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+        // status is not referenced in the query so ES|QL does not return it as a column.
+        // Use documentsOrdered by ingestion position: [0] doc with message, [1] doc without.
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+        const doc1 = esqlResult.documentsOrdered[0];
+        const doc2 = esqlResult.documentsOrdered[1];
         expect(doc1).toStrictEqual(expect.objectContaining({ message: 'Connection from <ip>' }));
         expect(doc2).toStrictEqual(expect.objectContaining({ message: null }));
       }
@@ -199,13 +201,14 @@ apiTest.describe(
         const docWithField = { message: 'Connection from 192.168.1.1', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should be filtered out
         const docs = [docWithField, docWithoutField];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // ES|QL filters out documents with missing field when ignore_missing: false
+        // status is not referenced in the query so ES|QL does not return it as a column.
         expect(esqlResult.documents).toHaveLength(1);
         expect(esqlResult.documents[0]).toStrictEqual(
-          expect.objectContaining({ status: 'doc1', message: 'Connection from <ip>' })
+          expect.objectContaining({ message: 'Connection from <ip>' })
         );
       }
     );
@@ -233,19 +236,20 @@ apiTest.describe(
         { message: 'Connection from 192.168.1.1', environment: 'production', status: 'doc1' },
         { message: 'Connection from 192.168.1.2', environment: 'development', status: 'doc2' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      expect(esqlResult.documents).toHaveLength(2);
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] production doc, [1] development doc.
 
       // Production doc should have IP redacted
-      const prodDoc = esqlResult.documents.find(
-        (d: Record<string, unknown>) => d.status === 'doc1'
-      );
+      const prodDoc = esqlResult.documentsOrdered[0];
       expect(prodDoc).toStrictEqual(expect.objectContaining({ message: 'Connection from <ip>' }));
 
       // Development doc should keep original IP
-      const devDoc = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      const devDoc = esqlResult.documentsOrdered[1];
       expect(devDoc).toStrictEqual(
         expect.objectContaining({ message: 'Connection from 192.168.1.2' })
       );
@@ -267,7 +271,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'User 550e8400-e29b-41d4-a716-446655440000 logged in' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -292,7 +296,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Hello world, no IP here' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove.spec.ts
@@ -30,14 +30,12 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ temp_field: 'to-be-removed', message: 'keep-this' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
+      // message is not referenced in the query so ES|QL does not return it as a column.
       expect(esqlResult.documents).toHaveLength(1);
       expect(esqlResult.documents[0]?.temp_field).toBeUndefined();
-      expect(esqlResult.documents[0]).toStrictEqual(
-        expect.objectContaining({ message: 'keep-this' })
-      );
     });
 
     apiTest(
@@ -59,12 +57,12 @@ apiTest.describe(
         const docWithField = { temp_field: 'to-be-removed', message: 'doc1' };
         const docWithoutField = { message: 'doc2' }; // Should be filtered out
         const docs = [docWithField, docWithoutField];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // ES|QL filters out documents with missing field when ignore_missing: false
+        // message is not referenced in the query so ES|QL does not return it as a column.
         expect(esqlResult.documents).toHaveLength(1);
-        expect(esqlResult.documents[0]).toStrictEqual(expect.objectContaining({ message: 'doc1' }));
         expect(esqlResult.documents[0]?.temp_field).toBeUndefined();
       }
     );
@@ -87,13 +85,15 @@ apiTest.describe(
       const docWithField = { temp_field: 'to-be-removed', message: 'doc1' };
       const docWithoutField = { message: 'doc2' }; // Should pass through
       const docs = [docWithField, docWithoutField];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Both documents should be present
-      expect(esqlResult.documents).toHaveLength(2);
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.message === 'doc1');
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.message === 'doc2');
+      // message is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] doc with field, [1] doc without.
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      const doc1 = esqlResult.documentsOrdered[0];
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc1?.temp_field).toBeUndefined();
       expect(doc2?.temp_field).toBeUndefined();
     });
@@ -120,19 +120,21 @@ apiTest.describe(
         { temp_data: 'remove-me', event: { kind: 'test' }, message: 'doc1' },
         { temp_data: 'keep-me', event: { kind: 'production' }, message: 'doc2' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      expect(esqlResult.documents).toHaveLength(2);
+      // message is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
 
       // First doc should have temp_data nulled (where condition matched)
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.message === 'doc1');
+      const doc1 = esqlResult.documentsOrdered[0];
       // Note: ESQL CASE sets to null, which is removed from the result
       expect(doc1?.temp_data).toBeNull();
       expect(doc1?.['event.kind']).toBe('test');
 
       // Second doc should keep temp_data (where condition not matched)
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.message === 'doc2');
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc2?.temp_data).toBe('keep-me');
       expect(doc2?.['event.kind']).toBe('production');
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/remove_by_prefix.spec.ts
@@ -15,34 +15,36 @@ apiTest.describe(
   'Streamlang to ES|QL - RemoveByPrefix Processor',
   { tag: [...tags.stateful.classic, ...tags.serverless.observability.complete] },
   () => {
-    apiTest(
-      'should keep the parent field when it has no nested fields',
-      async ({ testBed, esql }) => {
-        const indexName = 'stream-e2e-test-remove-by-prefix-basic';
+    apiTest('should remove sub-fields matching the prefix with DROP', async ({ testBed, esql }) => {
+      // Note: ES|QL's DROP field.* requires at least one matching mapped column.
+      // This test verifies the basic DROP field.* behaviour with dynamic mapping
+      // so that sub-fields are properly mapped and discoverable.
+      const indexName = 'stream-e2e-test-remove-by-prefix-basic';
 
-        const streamlangDSL: StreamlangDSL = {
-          steps: [
-            {
-              action: 'remove_by_prefix',
-              from: 'temp_field',
-            } as RemoveByPrefixProcessor,
-          ],
-        };
+      const streamlangDSL: StreamlangDSL = {
+        steps: [
+          {
+            action: 'remove_by_prefix',
+            from: 'temp_field',
+          } as RemoveByPrefixProcessor,
+        ],
+      };
 
-        const { query } = transpile(streamlangDSL);
+      const { query } = transpile(streamlangDSL);
 
-        const docs = [{ temp_field: 'to-be-kept', message: 'keep-this' }];
-        await testBed.ingest(indexName, docs);
-        const esqlResult = await esql.queryOnIndex(indexName, query);
+      // Use dynamic mapping so temp_field.child is properly mapped and DROP temp_field.* succeeds.
+      const docs = [{ temp_field: { child: 'remove-me' }, message: 'keep-this' }];
+      await testBed.ingest(indexName, docs);
+      const esqlResult = await esql.queryOnIndex(indexName, query);
 
-        expect(esqlResult.documents).toHaveLength(1);
-        // The parent field itself is not removed, only nested fields would be
-        expect(esqlResult.documents[0]?.temp_field).toBeDefined();
-        expect(esqlResult.documents[0]).toStrictEqual(
-          expect.objectContaining({ message: 'keep-this', temp_field: 'to-be-kept' })
-        );
-      }
-    );
+      expect(esqlResult.documents).toHaveLength(1);
+      // temp_field.child should be removed by DROP temp_field.*
+      expect(esqlResult.columnNames).not.toContain('temp_field.child');
+      // message should be preserved
+      expect(esqlResult.documents[0]).toStrictEqual(
+        expect.objectContaining({ message: 'keep-this' })
+      );
+    });
 
     apiTest('should remove nested fields (parent field removed too)', async ({ testBed, esql }) => {
       const indexName = 'stream-e2e-test-remove-by-prefix-nested';
@@ -71,6 +73,7 @@ apiTest.describe(
           message: 'keep-this',
         },
       ];
+      // Use dynamic mapping so host.* sub-fields are properly mapped and DROP host.* succeeds.
       await testBed.ingest(indexName, docs);
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
@@ -110,6 +113,7 @@ apiTest.describe(
             message: 'keep-this',
           },
         ];
+        // Use dynamic mapping so labels.* fields are properly mapped and DROP labels.* succeeds.
         await testBed.ingest(indexName, docs);
         const esqlResult = await esql.queryOnIndex(indexName, query);
 

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/rename.spec.ts
@@ -32,7 +32,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ host: { original: 'test-host' } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents[0]).toStrictEqual(
@@ -58,13 +58,13 @@ apiTest.describe(
 
         const { query } = transpile(streamlangDSL);
 
-        // Add `mappingDoc` to address ES|QL limitation that any column used as operand must be available as a column (pre-mapped)
-        const mappingDoc = { host: { original: 'new-host-0', renamed: 'old-host-0' } };
+        // commenting out mapping docs whilst testing unmapped fields
+        // const mappingDoc = { host: { original: 'new-host-0', renamed: 'old-host-0' } };
         const docWithMissingSource = { host: { renamed: 'old-host-1' } };
         const docWithMissingTarget = { host: { original: 'new-host-2' } }; // Should only pass through filter
         const docWithMissingFields = { message: 'message-3' };
-        const docs = [mappingDoc, docWithMissingSource, docWithMissingTarget, docWithMissingFields];
-        await testBed.ingest(indexName, docs);
+        const docs = [docWithMissingSource, docWithMissingTarget, docWithMissingFields];
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // ES|QL filters out documents failing the ignore_missing and override checks
@@ -101,7 +101,7 @@ apiTest.describe(
         docWithMissingTarget,
         docWithMissingFields,
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -137,7 +137,7 @@ apiTest.describe(
         docWithMissingTarget,
         docWithMissingFields,
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/replace.spec.ts
@@ -34,7 +34,7 @@ apiTest.describe(
         const { query } = transpile(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(1);
@@ -62,7 +62,7 @@ apiTest.describe(
         const { query } = transpile(streamlangDSL);
 
         const docs = [{ message: 'An error occurred' }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(1);
@@ -88,7 +88,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Error code 404 found' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -112,7 +112,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'Android.log' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -136,7 +136,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'User alice has 3 new messages' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(1);
@@ -164,12 +164,12 @@ apiTest.describe(
         const docWithField = { message: 'An error occurred', status: 'doc1' };
         const docWithoutField = { status: 'doc2' }; // Should be filtered out
         const docs = [docWithField, docWithoutField];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         // ES|QL filters out documents with missing field when ignore_missing: false
+        // status is not referenced in the query so ES|QL does not return it as a column.
         expect(esqlResult.documents).toHaveLength(1);
-        expect(esqlResult.documents[0]).toStrictEqual(expect.objectContaining({ status: 'doc1' }));
         expect(esqlResult.documents[0]?.message).toBe('An warning occurred');
       }
     );
@@ -194,13 +194,15 @@ apiTest.describe(
       const docWithField = { message: 'An error occurred', status: 'doc1' };
       const docWithoutField = { status: 'doc2' }; // Should pass through
       const docs = [docWithField, docWithoutField];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Both documents should be present
-      expect(esqlResult.documents).toHaveLength(2);
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] doc with message, [1] doc without.
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      const doc1 = esqlResult.documentsOrdered[0];
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc1?.message).toBe('An warning occurred');
       expect(doc2?.message).toBeNull();
     });
@@ -229,18 +231,20 @@ apiTest.describe(
         { message: 'An error occurred', event: { kind: 'test' }, status: 'doc1' },
         { message: 'An error occurred', event: { kind: 'production' }, status: 'doc2' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      expect(esqlResult.documents).toHaveLength(2);
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
 
       // First doc should have message replaced (where condition matched)
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+      const doc1 = esqlResult.documentsOrdered[0];
       expect(doc1?.message).toBe('An warning occurred');
       expect(doc1?.['event.kind']).toBe('test');
 
       // Second doc should keep original message (where condition not matched)
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc2?.message).toBe('An error occurred');
       expect(doc2?.['event.kind']).toBe('production');
     });
@@ -282,19 +286,21 @@ apiTest.describe(
             status: 'doc2',
           },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
-        expect(esqlResult.documents).toHaveLength(2);
+        // status is not referenced in the query so ES|QL does not return it as a column.
+        // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
 
         // First doc should have clean_message created (where condition matched)
-        const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+        const doc1 = esqlResult.documentsOrdered[0];
         expect(doc1?.message).toBe('An error occurred'); // Original preserved
         expect(doc1?.clean_message).toBe('An warning occurred'); // New field created
         expect(doc1?.['event.kind']).toBe('test');
 
         // Second doc should have clean_message as empty string (where condition not matched)
-        const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+        const doc2 = esqlResult.documentsOrdered[1];
         expect(doc2?.message).toBe('An error occurred');
         expect(doc2?.clean_message).toBe('');
         expect(doc2?.['event.kind']).toBe('production');

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/set.spec.ts
@@ -31,7 +31,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ attributes: { size: 4096 } }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // `toHaveProperty` doesn't work with flattened ES|QL Rows/Documents
@@ -79,30 +79,28 @@ apiTest.describe(
 
       const { query } = transpile(streamlangDSL);
 
-      // ES|QL errors out when unmapped fields (columns) are read
-      // The following docs helps map the fields for which ES|QL has to perform nullability checks
-      const mappingDoc = { attributes: { should_exist: null, status: 'null' } };
+      // commenting out mapping docs whilst testing unmapped fields
+      // const mappingDoc = { attributes: { should_exist: null, status: 'null' } };
       const docs = [
-        mappingDoc,
         { attributes: { size: 4096, should_exist: 'YES' } },
         { attributes: { size: 2048 } },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      // The field should be set since `attributes.status` doesn't exist where attributes.should_exist exists
-      expect(esqlResult.documentsOrdered[1]).toStrictEqual(
+      // The field should be set since `attributes.status` doesn't exist where attributes.should_exist exists.
+      // attributes.size is not referenced in the query so ES|QL does not load it.
+      expect(esqlResult.documentsOrdered[0]).toStrictEqual(
         expect.objectContaining({
-          'attributes.size': 4096,
           'attributes.should_exist': 'YES',
           'attributes.status': 'active',
         })
       );
 
-      // The field should not be set since `attributes.should_exist` doesn't exist
-      expect(esqlResult.documentsOrdered[2]).toStrictEqual(
+      // The field should not be set since `attributes.should_exist` doesn't exist.
+      // attributes.size is not referenced in the query so ES|QL does not load it.
+      expect(esqlResult.documentsOrdered[1]).toStrictEqual(
         expect.objectContaining({
-          'attributes.size': 2048,
           'attributes.status': null,
         })
       );
@@ -124,7 +122,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'should-be-copied' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
       expect(esqlResult.documents[0]).toStrictEqual(
         expect.objectContaining({
@@ -152,7 +150,7 @@ apiTest.describe(
         const { query } = transpile(streamlangDSL);
         const docWithStatus = { attributes: { status: 'active' } }; // 'attributes.status' already exists
         const docs = [docWithStatus, { attributes: { size: 1024 } }];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documentsOrdered[0]).toStrictEqual(
@@ -187,7 +185,7 @@ apiTest.describe(
 
         const { query } = transpile(streamlangDSL);
         const docs = [{ attributes: { status: 'active' } }]; // 'attributes.status' already exists
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
         expect(esqlResult.documents[0]).toStrictEqual(
           expect.objectContaining({

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/sort.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/sort.spec.ts
@@ -179,13 +179,14 @@ apiTest.describe(
 
       expect(esqlResult.documents).toHaveLength(2);
 
-      // First doc should have tags sorted (where condition matched)
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+      const doc1 = esqlResult.documentsOrdered[0];
       expect(doc1).toStrictEqual(expect.objectContaining({ tags: ['alpha', 'bravo', 'charlie'] }));
       expect(doc1?.['event.kind']).toBe('test');
 
       // Second doc: where condition not matched, processor doesn't sort
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc2?.tags).toStrictEqual(expect.arrayContaining(['zulu', 'xray', 'yankee']));
       expect(doc2?.tags).toHaveLength(3);
       expect(doc2?.['event.kind']).toBe('production');
@@ -233,8 +234,9 @@ apiTest.describe(
 
         expect(esqlResult.documents).toHaveLength(2);
 
-        // First doc should have sorted_tags created (where condition matched)
-        const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+        // status is not referenced in the query so ES|QL does not return it as a column.
+        // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+        const doc1 = esqlResult.documentsOrdered[0];
         expect(doc1).toStrictEqual(
           expect.objectContaining({
             // ES|QL returns keyword fields sorted, so original order is not preserved in the result
@@ -245,7 +247,7 @@ apiTest.describe(
         expect(doc1?.['event.kind']).toBe('test');
 
         // Second doc should have sorted_tags as the original placeholder (where condition not matched)
-        const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+        const doc2 = esqlResult.documentsOrdered[1];
         expect(doc2?.tags).toStrictEqual(expect.arrayContaining(['zulu', 'xray', 'yankee']));
         expect(doc2?.tags).toHaveLength(3);
         expect(doc2).toStrictEqual(expect.objectContaining({ sorted_tags: '' }));
@@ -276,8 +278,10 @@ apiTest.describe(
 
       // Both documents should be present
       expect(esqlResult.documents).toHaveLength(2);
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] has tags, [1] missing tags.
+      const doc1 = esqlResult.documentsOrdered[0];
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc1).toStrictEqual(expect.objectContaining({ tags: ['alpha', 'bravo', 'charlie'] }));
       expect(doc2).toStrictEqual(expect.objectContaining({ tags: null }));
     });

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
@@ -179,8 +179,10 @@ apiTest.describe(
 
       // Both documents should be present
       expect(esqlResult.documents).toHaveLength(2);
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] has tags, [1] missing tags.
+      const doc1 = esqlResult.documentsOrdered[0];
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc1).toStrictEqual(expect.objectContaining({ tags: ['foo', 'bar', 'baz'] }));
       expect(doc2).toStrictEqual(expect.objectContaining({ tags: null }));
     });
@@ -216,12 +218,12 @@ apiTest.describe(
       expect(esqlResult.documentsOrdered).toHaveLength(2);
 
       // First doc should have tags split (where condition matched)
-      const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+      const doc1 = esqlResult.documentsOrdered[0];
       expect(doc1).toStrictEqual(expect.objectContaining({ tags: ['foo', 'bar', 'baz'] }));
       expect(doc1?.['event.kind']).toBe('test');
 
       // Second doc should keep original tags (where condition not matched)
-      const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+      const doc2 = esqlResult.documentsOrdered[1];
       expect(doc2).toStrictEqual(expect.objectContaining({ tags: 'one,two,three' }));
       expect(doc2?.['event.kind']).toBe('production');
     });
@@ -267,8 +269,9 @@ apiTest.describe(
 
         expect(esqlResult.documents).toHaveLength(2);
 
-        // First doc should have tags_array created (where condition matched)
-        const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');
+        // status is not referenced in the query so ES|QL does not return it as a column.
+        // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+        const doc1 = esqlResult.documentsOrdered[0];
         expect(doc1).toStrictEqual(
           expect.objectContaining({
             tags: 'foo,bar,baz', // Original preserved
@@ -278,7 +281,7 @@ apiTest.describe(
         expect(doc1?.['event.kind']).toBe('test');
 
         // Second doc should have tags_array as empty string (where condition not matched)
-        const doc2 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc2');
+        const doc2 = esqlResult.documentsOrdered[1];
         expect(doc2).toStrictEqual(
           expect.objectContaining({
             tags: 'one,two,three',

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/split.spec.ts
@@ -174,7 +174,7 @@ apiTest.describe(
       const docWithField = { tags: 'foo,bar,baz', status: 'doc1' };
       const docWithoutField = { status: 'doc2' }; // Should pass through
       const docs = [docWithField, docWithoutField];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       // Both documents should be present
@@ -208,10 +208,12 @@ apiTest.describe(
         { tags: 'foo,bar,baz', event: { kind: 'test' }, status: 'doc1' },
         { tags: 'one,two,three', event: { kind: 'production' }, status: 'doc2' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
-      expect(esqlResult.documents).toHaveLength(2);
+      // status is not referenced in the query so ES|QL does not return it as a column.
+      // Use documentsOrdered by ingestion position: [0] event.kind=test, [1] event.kind=production.
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
 
       // First doc should have tags split (where condition matched)
       const doc1 = esqlResult.documents.find((d: Record<string, unknown>) => d.status === 'doc1');

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/trim.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -54,7 +54,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -84,7 +84,7 @@ apiTest.describe(
         { message: '   test message 1   ', should_trim: 'yes' },
         { message: '   test message 2   ', should_trim: 'no' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -117,7 +117,7 @@ apiTest.describe(
           { message: '   test message 1   ', should_trim: 'yes' },
           { message: '   test message 2   ', should_trim: 'no' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/esql/uppercase.spec.ts
@@ -30,7 +30,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -54,7 +54,7 @@ apiTest.describe(
       const { query } = transpile(streamlangDSL);
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -84,7 +84,7 @@ apiTest.describe(
         { message: 'test message 1', should_uppercase: 'yes' },
         { message: 'test message 2', should_uppercase: 'no' },
       ];
-      await testBed.ingest(indexName, docs);
+      await testBed.ingest(indexName, docs, undefined, { dynamic: false });
       const esqlResult = await esql.queryOnIndex(indexName, query);
 
       expect(esqlResult.documents).toHaveLength(2);
@@ -117,7 +117,7 @@ apiTest.describe(
           { message: 'test message 1', should_uppercase: 'yes' },
           { message: 'test message 2', should_uppercase: 'no' },
         ];
-        await testBed.ingest(indexName, docs);
+        await testBed.ingest(indexName, docs, undefined, { dynamic: false });
         const esqlResult = await esql.queryOnIndex(indexName, query);
 
         expect(esqlResult.documents).toHaveLength(2);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/__snapshots__/transpiler.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transpile - Streamlang DSL to ES|QL) should handle not conditions 1`] = `
-"  | EVAL \`attributes.not_flag\` = CASE(NOT \`attributes.status\` == \\"active\\", \\"not-active\\", \`attributes.not_flag\`)
+"SET unmapped_fields=\\"LOAD\\"
+  | EVAL \`attributes.not_flag\` = CASE(NOT \`attributes.status\` == \\"active\\", \\"not-active\\", \`attributes.not_flag\`)
   | EVAL \`attributes.not_nested\` = CASE(NOT (\`attributes.a\` == 1 OR \`attributes.b\` == 2), \\"not-a-or-b\\", \`attributes.not_nested\`)"
 `;
 
@@ -13,7 +14,8 @@ Object {
   | EVAL \`attributes.numeric_450_test\` = CASE(\`attributes.status_code\` == 450 AND \`attributes.status_code_str\` == \\"450\\" AND \`attributes.other_code\` != 450 AND \`attributes.other_code_str\` != \\"450\\", \\"matched_450_test\\", \`attributes.numeric_450_test\`)
   | EVAL \`attributes.mixed_coercion_test\` = CASE(\`attributes.response_time\` > 100 AND \`attributes.response_time_str\` > \\"100\\" AND \`attributes.port\` >= \\"8000\\" AND \`attributes.port\` <= \\"9000\\" AND \`attributes.is_enabled\` == TRUE AND \`attributes.count_str\` == \\"42\\", \\"matched_mixed_coercion\\", \`attributes.mixed_coercion_test\`)",
   ],
-  "query": "  | EVAL \`attributes.boolean_true_test\` = CASE(\`attributes.is_active\` == TRUE AND \`attributes.is_active_str\` == \\"true\\" AND \`attributes.is_inactive\` != TRUE AND \`attributes.is_inactive_str\` != \\"true\\", \\"matched_true_test\\", \`attributes.boolean_true_test\`)
+  "query": "SET unmapped_fields=\\"LOAD\\"
+  | EVAL \`attributes.boolean_true_test\` = CASE(\`attributes.is_active\` == TRUE AND \`attributes.is_active_str\` == \\"true\\" AND \`attributes.is_inactive\` != TRUE AND \`attributes.is_inactive_str\` != \\"true\\", \\"matched_true_test\\", \`attributes.boolean_true_test\`)
   | EVAL \`attributes.boolean_false_test\` = CASE(\`attributes.is_disabled\` == FALSE AND \`attributes.is_disabled_str\` == \\"false\\" AND \`attributes.is_enabled\` != FALSE AND \`attributes.is_enabled_str\` != \\"false\\", \\"matched_false_test\\", \`attributes.boolean_false_test\`)
   | EVAL \`attributes.numeric_450_test\` = CASE(\`attributes.status_code\` == 450 AND \`attributes.status_code_str\` == \\"450\\" AND \`attributes.other_code\` != 450 AND \`attributes.other_code_str\` != \\"450\\", \\"matched_450_test\\", \`attributes.numeric_450_test\`)
   | EVAL \`attributes.mixed_coercion_test\` = CASE(\`attributes.response_time\` > 100 AND \`attributes.response_time_str\` > \\"100\\" AND \`attributes.port\` >= \\"8000\\" AND \`attributes.port\` <= \\"9000\\" AND \`attributes.is_enabled\` == TRUE AND \`attributes.count_str\` == \\"42\\", \\"matched_mixed_coercion\\", \`attributes.mixed_coercion_test\`)",
@@ -21,7 +23,8 @@ Object {
 `;
 
 exports[`transpile - Streamlang DSL to ES|QL) should transpile a variety of processor steps and where blocks 1`] = `
-"  | WHERE NOT(source_ip IS NULL) AND NOT(destination_ip IS NULL)
+"SET unmapped_fields=\\"LOAD\\"
+  | WHERE NOT(source_ip IS NULL) AND NOT(destination_ip IS NULL)
   | EVAL \`network.direction\` = NETWORK_DIRECTION(TO_IP(source_ip), TO_IP(destination_ip), [\\"private\\"])
   | EVAL my_joined_field = CONCAT(field1, \\", \\", field2, \\", \\", field3)
   | EVAL full_name = CASE(first_name IS NULL OR last_name IS NULL, NULL, CONCAT(first_name, \\" \\", last_name))
@@ -57,4 +60,5 @@ exports[`transpile - Streamlang DSL to ES|QL) should transpile a variety of proc
   | EVAL \\"WARNING: Manual ingest pipeline not supported in ES|QL\\""
 `;
 
-exports[`transpile - Streamlang DSL to ES|QL) should warn when manual_ingest_pipeline is used 1`] = `"  | EVAL \\"WARNING: Manual ingest pipeline not supported in ES|QL\\""`;
+exports[`transpile - Streamlang DSL to ES|QL) should warn when manual_ingest_pipeline is used 1`] = `"SET unmapped_fields=\\"LOAD\\"
+  | EVAL \\"WARNING: Manual ingest pipeline not supported in ES|QL\\""`;

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/condition_to_esql.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/condition_to_esql.ts
@@ -47,10 +47,27 @@ export function conditionToESQLAst(condition: Condition): ESQLSingleAstItem {
     const field = Builder.expression.column(condition.field);
 
     if ('eq' in condition) {
-      return Builder.expression.func.binary('==', [field, esqlLiteralFromAny(condition.eq)]);
+      // When comparing against a boolean, wrap the field with TO_BOOLEAN() so that unmapped
+      // fields (loaded as keyword by SET unmapped_fields="LOAD") compare correctly.
+      // TO_BOOLEAN("true") == TRUE and TO_BOOLEAN(boolField) == TRUE both work.
+      const eqVal = condition.eq;
+      if (typeof eqVal === 'boolean') {
+        return Builder.expression.func.binary('==', [
+          Builder.expression.func.call('TO_BOOLEAN', [field]),
+          esqlLiteralFromAny(eqVal),
+        ]);
+      }
+      return Builder.expression.func.binary('==', [field, esqlLiteralFromAny(eqVal)]);
     }
     if ('neq' in condition) {
-      return Builder.expression.func.binary('!=', [field, esqlLiteralFromAny(condition.neq)]);
+      const neqVal = condition.neq;
+      if (typeof neqVal === 'boolean') {
+        return Builder.expression.func.binary('!=', [
+          Builder.expression.func.call('TO_BOOLEAN', [field]),
+          esqlLiteralFromAny(neqVal),
+        ]);
+      }
+      return Builder.expression.func.binary('!=', [field, esqlLiteralFromAny(neqVal)]);
     }
     if ('gt' in condition) {
       return Builder.expression.func.binary('>', [field, esqlLiteralFromAny(condition.gt)]);

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/index.ts
@@ -21,6 +21,12 @@ export interface ESQLTranspilationOptions {
   pipeTab: BasicPrettyPrinterOptions['pipeTab'];
   sourceIndex?: string;
   limit?: number;
+  /**
+   * When set, prepends a `SET UNMAPPED_FIELDS=<strategy>` directive to the query.
+   * - `load`   — costly extraction: read unmapped fields from _source
+   * - `nullify` — cheap nullification: substitute unmapped fields with null
+   */
+  unmappedFields?: 'load' | 'nullify';
 }
 
 export interface ESQLTranspilationResult {
@@ -34,7 +40,10 @@ export const conditionToESQL = (condition: Condition): string => {
 
 export const transpile = (
   streamlang: StreamlangDSL,
-  transpilationOptions: ESQLTranspilationOptions = { pipeTab: DEFAULT_PIPE_TAB }
+  transpilationOptions: ESQLTranspilationOptions = {
+    pipeTab: DEFAULT_PIPE_TAB,
+    unmappedFields: 'load',
+  }
 ): ESQLTranspilationResult => {
   const validatedStreamlang = streamlangDSLSchema.parse(streamlang);
 
@@ -43,9 +52,17 @@ export const transpile = (
   );
 
   const commandsArray = [esqlCommandsFromStreamlang].filter(Boolean);
+  const pipeQuery = `  | ${commandsArray.join('\n|')}`;
+
+  const { unmappedFields } = transpilationOptions;
+  // ES|QL SET: the setting name must be lowercase (identifier lookup is case-sensitive),
+  // and the value must be a quoted string, e.g. SET unmapped_fields="LOAD"
+  const setDirective = unmappedFields
+    ? `SET unmapped_fields="${unmappedFields.toUpperCase()}"\n`
+    : '';
 
   return {
-    query: `  | ${commandsArray.join('\n|')}`,
+    query: `${setDirective}${pipeQuery}`,
     commands: commandsArray,
   };
 };

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/date.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/date.ts
@@ -86,10 +86,18 @@ export function convertDateProcessorToESQL(processor: DateProcessor): ESQLAstCom
 
   if (where) {
     const whereCondition = conditionToESQLAst(where);
+    // The else branch must have the same type (datetime) as the then branch (DATE_PARSE result).
+    // When the target field is unmapped (loaded as keyword via SET unmapped_fields="LOAD"),
+    // using it directly in a CASE causes a type conflict. Wrapping with TO_DATETIME(TO_STRING())
+    // ensures the else branch is always datetime-typed, handling both mapped datetime fields
+    // and unmapped keyword fields (TO_DATETIME(null) = null when the field is absent).
+    const elseValue = Builder.expression.func.call('TO_DATETIME', [
+      Builder.expression.func.call('TO_STRING', [toColumn]),
+    ]);
     dateProcessorAssignment = Builder.expression.func.call('CASE', [
       whereCondition,
       dateProcessorAssignment,
-      toColumn,
+      elseValue,
     ]);
   }
 

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/math.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/transpilers/esql/processors/math.ts
@@ -65,7 +65,16 @@ function convertTinymathToESQL(node: TinymathAST): ESQLAstItem {
   if (isTinymathVariable(node)) {
     // TinyMath parses field names as variables with the field name in 'value'
     // e.g., 'price' or 'attributes.price' or 'order.item.quantity'
-    return Builder.expression.column(node.value);
+    //
+    // Cast with ::double so that unmapped fields loaded as keyword via
+    // SET unmapped_fields="LOAD" (e.g. "10" instead of 10) are coerced to
+    // numeric type before arithmetic or comparison. ::double is a no-op on
+    // fields that are already numeric, and propagates null unchanged.
+    // This is the spec-idiomatic form (see ES|QL unmapped field loading semantics doc).
+    return Builder.expression.inlineCast({
+      value: Builder.expression.column(node.value),
+      castType: 'double',
+    });
   }
 
   // Handle function
@@ -191,7 +200,13 @@ export function convertMathProcessorToESQL(processor: MathProcessor): ESQLAstCom
     ? Builder.expression.func.call('CASE', [
         conditionExpression,
         mathExpression as ESQLSingleAstItem,
-        Builder.expression.column(processor.to), // ELSE keep existing value
+        // Cast the else (keep-existing) branch to ::double to match the type
+        // produced by the then-branch. Without this, ES|QL raises a type
+        // conflict when the target field is unmapped (loaded as keyword).
+        Builder.expression.inlineCast({
+          value: Builder.expression.column(processor.to),
+          castType: 'double',
+        }),
       ])
     : mathExpression;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,7 +2455,7 @@
   resolved "https://registry.yarnpkg.com/@elastic/filesaver/-/filesaver-1.1.2.tgz#1998ffb3cd89c9da4ec12a7793bfcae10e30c77a"
   integrity sha512-YZbSufYFBhAj+S2cJgiKALoxIJevqXN2MSr6Yqr42rJdaPuM31cj6pUDwflkql1oDjupqD9la+MfxPFjXI1JFQ==
 
-"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1":
+"@elastic/kibana-d3-color@npm:@elastic/kibana-d3-color@2.0.1", "d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
   integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
@@ -12074,7 +12074,7 @@
   resolved "https://registry.yarnpkg.com/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz#5ff4b704af6a8b108f9d577fd87cf73e9e7b3178"
   integrity sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==
 
-"@redocly/ajv@8.17.4":
+"@redocly/ajv@8.17.4", "ajv@npm:@redocly/ajv@8.17.4":
   version "8.17.4"
   resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-8.17.4.tgz#f7c1022bc3e7f01366f4cb6bc5b538b81cb7cea8"
   integrity sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==
@@ -16102,16 +16102,6 @@ ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-"ajv@npm:@redocly/ajv@8.17.4":
-  version "8.17.4"
-  resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-8.17.4.tgz#f7c1022bc3e7f01366f4cb6bc5b538b81cb7cea8"
-  integrity sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
 anser@^2.1.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/anser/-/anser-2.3.2.tgz#e2da9d10759a4243a5819595f4f46ec369970c5b"
@@ -19197,11 +19187,6 @@ d3-collection@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
-
-"d3-color@1 - 2", "d3-color@npm:@elastic/kibana-d3-color@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@elastic/kibana-d3-color/-/kibana-d3-color-2.0.1.tgz#f83b9c2fea09273a918659de04d5e8098c82f65c"
-  integrity sha512-YZ8hV2bWNyYi833Yj3UWczmTxdHzmo/Xc2IVkNXr/ZqtkrTDlTLysCyJm7SfAt9iBy6EVRGWTn8cPz8QOY6Ixw==
 
 "d3-color@1 - 3", d3-color@^3.1.0:
   version "3.1.0"
@@ -32753,7 +32738,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -32770,15 +32755,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -32880,14 +32856,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -35679,7 +35648,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -35700,15 +35669,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/258548

⚠️ This **should not** be reviewed or merged, it exists to test the new unmapped fields functionality in ES|QL. Given how thorough our streamlang-tests package tests are, and how much of ES|QL they touch in various ways, I used this for round one of the testing against the prepared ES branch. 

## Setup

- Checked out [this ES branch](https://github.com/elastic/elasticsearch/pull/144503)
- Ran Scout server using `source`: `node scripts/scout.js start-server --arch stateful --domain classic --esFrom source`
- Ran the ES|QL tests with `npx playwright test --config x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/playwright.config.ts test/scout/api/tests/esql/ --project local`

## Errors

I initially hit this category of error:

```
ResponseError: illegal_state_exception  
Root causes:  
illegal_state_exception: Found 1 problem  
line 3:5: Plan [ProjectExec[[<no-fields>{r}#126, host.original{f}#628]]] optimized incorrectly due to missing references [<no-fields>{r}#126]  
at SniffingTransport._request (/Users/kerry/Documents/Elastic/Code/kibana/node_modules/@elastic/elasticsearch/node_modules/@elastic/transport/src/Transport.ts:649:17)
```

AI's take was:

> When an index has no mapped fields **at all** (i.e., `dynamic: false` with no explicit mappings), the ES|QL analyzer builds the `EsRelation` with a synthetic `<no-fields>` sentinel attribute:

```java
// Analyzer.java:360
attributes.isEmpty() ? NO_FIELDS : attributes
```

> This `<no-fields>` marker flows up into `ProjectExec`. During plan optimization, the optimizer drops it from some intermediate physical node but `ProjectExec` still holds a reference to the original `NameId`, causing the consistency checker to throw:

```
ProjectExec[[<no-fields>{r$}#126, host.original{f}#628]]
   optimized incorrectly due to missing references [<no-fields>{r$}#126]
```

> **Practical workaround**: add an explicit mapping for at least one field (e.g. `order_id`, which every testBed document always contains) so the index is never _completely_ unmapped. That avoids the `NO_FIELDS` code path entirely while leaving all other fields unmapped for LOAD to resolve from `_source`


I added one property as part of the testBed ingestion, and this did work around that issue, but wanted to call it out explicitly. There were some disabled "golden tests" that suggest this might be getting worked on.

## Results

Most of the changes in this diff were just to get our tests compatible with a world where fields are unmapped (so removing the use of mapping docs, changing the array indices asserted on (since the mapping docs were removed), removing field assertions if that field wasn't queried  etc). 

After this, there were no large test failures, which is a great sign.

<img width="1722" height="146" alt="Screenshot 2026-03-23 at 20 43 41" src="https://github.com/user-attachments/assets/3f8acc34-32e0-484a-8d28-c24796211676" />

The main considerations for us will be around casting. For example in the math processor we were previously just producing expressions (e.g. `fieldA / fieldB`) and relying on the fields being mapped correctly at the index level. With `SET unmapped_fields="load"` the fields will be delivered as keyword types. Ideally we don't want the user to have to provide a type as part of the DSL, so our best bet will probably be to run with a best effort default in something like `double` (this is what exists in this diff using the `::type` syntax). But, we obviously have the caveat of numeric types having different levels of precision.





