### PR TITLE
[Security Solution] remove index existence checks in useShowTimelineForGivenPath

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
@@ -115,11 +115,11 @@ describe('sourcererDataView', () => {
     expect(result.current).toEqual([true]);
   });
 
-  it('should not show timeline when dataViewId is not null and indices does not exist', () => {
+  it('should show timeline even when indices do not exist (data view state does not gate visibility)', () => {
     jest.mocked(useDataView).mockImplementation(defaultImplementation);
     mockUseSourcererDataView.mockReturnValueOnce({ indicesExist: false, dataViewId: 'test' });
     const { result } = renderUseShowTimeline();
-    expect(result.current).toEqual([false]);
+    expect(result.current).toEqual([true]);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
@@ -13,7 +13,7 @@ import { useNormalizedAppLinks } from '../../links/links_hooks';
 import { useKibana } from '../../lib/kibana';
 import { hasAccessToSecuritySolution } from '../../../helpers_access';
 
-export const useHiddenTimelineRoutes = () => {
+const useHiddenTimelineRoutes = () => {
   const normalizedLinks = useNormalizedAppLinks();
   const hiddenTimelineRoutes = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
@@ -8,17 +8,12 @@
 import { useCallback, useMemo } from 'react';
 import { matchPath } from 'react-router-dom';
 
-import { PageScope } from '../../../data_view_manager/constants';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import type { NormalizedLink } from '../../links';
 import { useNormalizedAppLinks } from '../../links/links_hooks';
 import { useKibana } from '../../lib/kibana';
 import { hasAccessToSecuritySolution } from '../../../helpers_access';
 
-import { useSourcererDataView } from '../../../sourcerer/containers';
-import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
-
-const useHiddenTimelineRoutes = () => {
+export const useHiddenTimelineRoutes = () => {
   const normalizedLinks = useNormalizedAppLinks();
   const hiddenTimelineRoutes = useMemo(
     () =>
@@ -37,32 +32,16 @@ export const useShowTimelineForGivenPath = () => {
   const { capabilities } = useKibana().services.application;
   const userHasSecuritySolutionVisible = hasAccessToSecuritySolution(capabilities);
 
-  const { indicesExist: oldIndicesExist, dataViewId } = useSourcererDataView(PageScope.timeline);
-
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView } = useDataView(PageScope.timeline);
-
-  const indicesExist = newDataViewPickerEnabled ? dataView.hasMatchedIndices() : oldIndicesExist;
-
   const hiddenTimelineRoutes = useHiddenTimelineRoutes();
-
-  const isTimelineAllowed = useMemo(() => {
-    // NOTE: with new Data View Picker, data view is always defined
-    if (newDataViewPickerEnabled) {
-      return userHasSecuritySolutionVisible && indicesExist;
-    }
-
-    return userHasSecuritySolutionVisible && (indicesExist || dataViewId === null);
-  }, [newDataViewPickerEnabled, userHasSecuritySolutionVisible, indicesExist, dataViewId]);
 
   const getIsTimelineVisible = useCallback(
     (pathname: string) => {
-      if (!isTimelineAllowed) {
+      if (!userHasSecuritySolutionVisible) {
         return false;
       }
       return !hiddenTimelineRoutes.some((route) => matchPath(pathname, route));
     },
-    [isTimelineAllowed, hiddenTimelineRoutes]
+    [userHasSecuritySolutionVisible, hiddenTimelineRoutes]
   );
 
   return getIsTimelineVisible;


### PR DESCRIPTION
## Summary

[See issue](https://github.com/elastic/kibana/issues/259195)

#### Written by AI
In `use_timeline_save_prompt.ts`, the `history.block` condition used `!getIsTimelineVisible(relativePath)` which depends on `isTimelineAllowed`. With `newDataViewPickerEnabled = true`,             
  `isTimelineAllowed` is computed as `userHasSecuritySolutionVisible && dataView.hasMatchedIndices()`. During the initial loading state on the attacks/alerts page, `hasMatchedIndices()` returns false, making
   `isTimelineAllowed = false` and `getIsTimelineVisible(any_path) = false`. This caused the block to fire for ALL navigations, including to attacks/alerts (which should show the timeline). 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
