### PR TITLE
[Serverless] Add OpenAI GPT-5.4 preconfigured connector

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -213,6 +213,16 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-5.2-chat_completion"
       providerConfig:
         model_id: "openai-gpt-5.2"
+  OpenAI-GPT-5-4:
+    name: OpenAI GPT-5.4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.4-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.4"
   OpenAI-GPT-OSS-20B:
     name: OpenAI GPT-OSS 20B
     actionTypeId: .inference

--- a/config/serverless.oblt.complete.yml
+++ b/config/serverless.oblt.complete.yml
@@ -127,6 +127,16 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-5.2-chat_completion"
       providerConfig:
         model_id: "openai-gpt-5.2"
+  OpenAI-GPT-5-4:
+    name: OpenAI GPT-5.4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.4-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.4"
   OpenAI-GPT-OSS-20B:
     name: OpenAI GPT-OSS 20B
     actionTypeId: .inference

--- a/config/serverless.security.complete.yml
+++ b/config/serverless.security.complete.yml
@@ -113,6 +113,16 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-5.2-chat_completion"
       providerConfig:
         model_id: "openai-gpt-5.2"
+  OpenAI-GPT-5-4:
+    name: OpenAI GPT-5.4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.4-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.4"
   OpenAI-GPT-OSS-20B:
     name: OpenAI GPT-OSS 20B
     actionTypeId: .inference

--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -218,6 +218,16 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-5.2-chat_completion"
       providerConfig:
         model_id: "openai-gpt-5.2"
+  OpenAI-GPT-5-4:
+    name: OpenAI GPT-5.4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.4-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.4"
   OpenAI-GPT-OSS-20B:
     name: OpenAI GPT-OSS 20B
     actionTypeId: .inference

--- a/config/serverless.workplaceai.yml
+++ b/config/serverless.workplaceai.yml
@@ -135,6 +135,16 @@ xpack.actions.preconfigured:
       inferenceId: ".openai-gpt-5.2-chat_completion"
       providerConfig:
         model_id: "openai-gpt-5.2"
+  OpenAI-GPT-5-4:
+    name: OpenAI GPT-5.4
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: "elastic"
+      taskType: "chat_completion"
+      inferenceId: ".openai-gpt-5.4-chat_completion"
+      providerConfig:
+        model_id: "openai-gpt-5.4"
   OpenAI-GPT-OSS-20B:
     name: OpenAI GPT-OSS 20B
     actionTypeId: .inference

--- a/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
@@ -37,6 +37,7 @@ export const INTERNAL_INFERENCE_CONNECTORS = [
   'OpenAI-GPT-4-1',
   'OpenAI-GPT-4-1-Mini',
   'OpenAI-GPT-5-2',
+  'OpenAI-GPT-5-4',
   'OpenAI-GPT-OSS-20B',
   'OpenAI-o4',
   'OpenAI-o4-Mini',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -29,6 +29,7 @@ const INTERNAL_INFERENCE_CONNECTORS = [
   'OpenAI-GPT-4-1',
   'OpenAI-GPT-4-1-Mini',
   'OpenAI-GPT-5-2',
+  'OpenAI-GPT-5-4',
   'OpenAI-GPT-OSS-20B',
   'OpenAI-o4',
   'OpenAI-o4-Mini',


### PR DESCRIPTION
## Summary
- Adds `OpenAI-GPT-5-4` preconfigured connector for the EIS `openai-gpt-5.4` model (preview)
- inferenceId: `.openai-gpt-5.4-chat_completion`
- Updated across all 5 serverless flavor configs and 2 Cypress test files

## Test plan
- [ ] Verify connector appears in serverless AI connectors lists
- [ ] Verify connector routes to the correct inference endpoint