### PR TITLE
[alerting_v2] Convert Rules API endpoints from internal to public (experimental)

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
@@ -19,7 +19,7 @@ jest.mock('react-use/lib/useAsync', () => ({
 }));
 
 const mockHttp = httpServiceMock.createStartContract();
-const GET_RULES_BULK_ENDPOINT = '/internal/alerting/v2/rule/_bulk';
+const GET_RULES_BULK_ENDPOINT = '/api/alerting/v2/rule/_bulk';
 
 describe('useAlertingRulesIndex', () => {
   beforeEach(() => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
@@ -10,7 +10,7 @@ import { useAlertingRulesIndex } from './use_alerting_rules_index';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 
-const RULE_API_PATH = '/api/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rules';
 
 jest.mock('react-use/lib/useAsync', () => ({
   __esModule: true,

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
@@ -8,6 +8,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useAlertingRulesIndex } from './use_alerting_rules_index';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 
 jest.mock('react-use/lib/useAsync', () => ({
@@ -19,7 +20,6 @@ jest.mock('react-use/lib/useAsync', () => ({
 }));
 
 const mockHttp = httpServiceMock.createStartContract();
-const GET_RULES_BULK_ENDPOINT = '/api/alerting/v2/rule/_bulk';
 
 describe('useAlertingRulesIndex', () => {
   beforeEach(() => {
@@ -71,7 +71,7 @@ describe('useAlertingRulesIndex', () => {
     );
 
     await waitFor(() =>
-      expect(mockHttp.get).toHaveBeenCalledWith(GET_RULES_BULK_ENDPOINT, {
+      expect(mockHttp.get).toHaveBeenCalledWith(`${ALERTING_V2_RULE_API_PATH}/_bulk`, {
         query: { ids: [ruleId] },
       })
     );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
@@ -10,6 +10,7 @@ import { useAlertingRulesIndex } from './use_alerting_rules_index';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 
+// Must match RULE_API_PATH in use_alerting_rules_index.ts
 const RULE_API_PATH = '/api/alerting/v2/rules';
 
 jest.mock('react-use/lib/useAsync', () => ({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.test.ts
@@ -8,8 +8,9 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useAlertingRulesIndex } from './use_alerting_rules_index';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+
+const RULE_API_PATH = '/api/alerting/v2/rule';
 
 jest.mock('react-use/lib/useAsync', () => ({
   __esModule: true,
@@ -71,7 +72,7 @@ describe('useAlertingRulesIndex', () => {
     );
 
     await waitFor(() =>
-      expect(mockHttp.get).toHaveBeenCalledWith(`${ALERTING_V2_RULE_API_PATH}/_bulk`, {
+      expect(mockHttp.get).toHaveBeenCalledWith(`${RULE_API_PATH}/_bulk`, {
         query: { ids: [ruleId] },
       })
     );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -8,8 +8,9 @@
 import { useRef } from 'react';
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import useAsync from 'react-use/lib/useAsync';
+
+const RULE_API_PATH = '/api/alerting/v2/rule';
 
 export interface UseAlertingRulesIndexOptions {
   ruleIds: string[];
@@ -35,7 +36,7 @@ export const useAlertingRulesIndex = ({ ruleIds, services }: UseAlertingRulesInd
     }
 
     const rulesResponse = await services.http.get<FindRulesResponse>(
-      `${ALERTING_V2_RULE_API_PATH}/_bulk`,
+      `${RULE_API_PATH}/_bulk`,
       {
         query: { ids: uncachedIds },
       }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -8,9 +8,8 @@
 import { useRef } from 'react';
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import useAsync from 'react-use/lib/useAsync';
-
-const GET_RULES_BULK_ENDPOINT = '/api/alerting/v2/rule/_bulk';
 
 export interface UseAlertingRulesIndexOptions {
   ruleIds: string[];
@@ -35,7 +34,7 @@ export const useAlertingRulesIndex = ({ ruleIds, services }: UseAlertingRulesInd
       return;
     }
 
-    const rulesResponse = await services.http.get<FindRulesResponse>(GET_RULES_BULK_ENDPOINT, {
+    const rulesResponse = await services.http.get<FindRulesResponse>(`${ALERTING_V2_RULE_API_PATH}/_bulk`, {
       query: { ids: uncachedIds },
     });
     rulesResponse.items.forEach((rule) => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -10,7 +10,7 @@ import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
 import useAsync from 'react-use/lib/useAsync';
 
-const RULE_API_PATH = '/api/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rules';
 
 export interface UseAlertingRulesIndexOptions {
   ruleIds: string[];

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -35,12 +35,9 @@ export const useAlertingRulesIndex = ({ ruleIds, services }: UseAlertingRulesInd
       return;
     }
 
-    const rulesResponse = await services.http.get<FindRulesResponse>(
-      `${RULE_API_PATH}/_bulk`,
-      {
-        query: { ids: uncachedIds },
-      }
-    );
+    const rulesResponse = await services.http.get<FindRulesResponse>(`${RULE_API_PATH}/_bulk`, {
+      query: { ids: uncachedIds },
+    });
     rulesResponse.items.forEach((rule) => {
       cacheRef.current[rule.id] = rule;
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -34,9 +34,12 @@ export const useAlertingRulesIndex = ({ ruleIds, services }: UseAlertingRulesInd
       return;
     }
 
-    const rulesResponse = await services.http.get<FindRulesResponse>(`${ALERTING_V2_RULE_API_PATH}/_bulk`, {
-      query: { ids: uncachedIds },
-    });
+    const rulesResponse = await services.http.get<FindRulesResponse>(
+      `${ALERTING_V2_RULE_API_PATH}/_bulk`,
+      {
+        query: { ids: uncachedIds },
+      }
+    );
     rulesResponse.items.forEach((rule) => {
       cacheRef.current[rule.id] = rule;
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -10,7 +10,7 @@ import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
 import useAsync from 'react-use/lib/useAsync';
 
-const GET_RULES_BULK_ENDPOINT = '/internal/alerting/v2/rule/_bulk';
+const GET_RULES_BULK_ENDPOINT = '/api/alerting/v2/rule/_bulk';
 
 export interface UseAlertingRulesIndexOptions {
   ruleIds: string[];

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
@@ -10,6 +10,8 @@ import type { HttpStart } from '@kbn/core-http-browser';
 import type { FindRulesResponse } from '@kbn/alerting-v2-plugin/public/services/rules_api';
 import useAsync from 'react-use/lib/useAsync';
 
+// Duplicated from alerting_v2 plugin server/routes/constants.ts to avoid circular dependency.
+// Must match ALERTING_V2_RULE_API_PATH there.
 const RULE_API_PATH = '/api/alerting/v2/rules';
 
 export interface UseAlertingRulesIndexOptions {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/kibana.jsonc
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "shared-browser",
   "id": "@kbn/alerting-v2-episodes-ui",
-  "owner": "@elastic/response-ops",
+  "owner": "@elastic/rna-project-team",
   "group": "platform",
   "visibility": "shared"
 }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
@@ -92,7 +92,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/internal/alerting/v2/rule', expect.any(Object));
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', expect.any(Object));
     });
   });
 
@@ -116,7 +116,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/internal/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
         body: JSON.stringify(expectedApiPayload),
       });
     });
@@ -373,7 +373,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/internal/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
         body: JSON.stringify(expectedPayload),
       });
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
@@ -8,6 +8,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { createQueryClientWrapper } from '../../test_utils';
 import { useCreateRule } from './use_create_rule';
 import type { FormValues } from '../types';
@@ -92,7 +93,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', expect.any(Object));
+      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, expect.any(Object));
     });
   });
 
@@ -116,7 +117,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
         body: JSON.stringify(expectedApiPayload),
       });
     });
@@ -373,7 +374,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
         body: JSON.stringify(expectedPayload),
       });
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
@@ -8,7 +8,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { createQueryClientWrapper } from '../../test_utils';
 import { useCreateRule } from './use_create_rule';
 import type { FormValues } from '../types';
@@ -93,7 +92,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, expect.any(Object));
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', expect.any(Object));
     });
   });
 
@@ -117,7 +116,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
         body: JSON.stringify(expectedApiPayload),
       });
     });
@@ -374,7 +373,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith(ALERTING_V2_RULE_API_PATH, {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
         body: JSON.stringify(expectedPayload),
       });
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.test.tsx
@@ -92,7 +92,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', expect.any(Object));
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rules', expect.any(Object));
     });
   });
 
@@ -116,7 +116,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rules', {
         body: JSON.stringify(expectedApiPayload),
       });
     });
@@ -373,7 +373,7 @@ describe('useCreateRule', () => {
     });
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rule', {
+      expect(http.post).toHaveBeenCalledWith('/api/alerting/v2/rules', {
         body: JSON.stringify(expectedPayload),
       });
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -19,7 +19,7 @@ interface UseCreateRuleProps {
 export const useCreateRule = ({ http, notifications }: UseCreateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.post<RuleResponse>('/api/alerting/v2/rule', {
+      return http.post<RuleResponse>('/api/alerting/v2/rules', {
         body: JSON.stringify(mapFormValuesToCreateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -19,7 +19,7 @@ interface UseCreateRuleProps {
 export const useCreateRule = ({ http, notifications }: UseCreateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.post<RuleResponse>('/internal/alerting/v2/rule', {
+      return http.post<RuleResponse>('/api/alerting/v2/rule', {
         body: JSON.stringify(mapFormValuesToCreateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -8,6 +8,7 @@
 import { useMutation } from '@kbn/react-query';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import type { FormValues } from '../types';
 import { mapFormValuesToCreateRequest } from '../utils/rule_request_mappers';
 
@@ -19,7 +20,7 @@ interface UseCreateRuleProps {
 export const useCreateRule = ({ http, notifications }: UseCreateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.post<RuleResponse>('/api/alerting/v2/rule', {
+      return http.post<RuleResponse>(ALERTING_V2_RULE_API_PATH, {
         body: JSON.stringify(mapFormValuesToCreateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -19,6 +19,8 @@ interface UseCreateRuleProps {
 export const useCreateRule = ({ http, notifications }: UseCreateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
+      // Path duplicated from alerting_v2 plugin server/routes/constants.ts (ALERTING_V2_RULE_API_PATH)
+      // to avoid circular dependency. Keep in sync.
       return http.post<RuleResponse>('/api/alerting/v2/rules', {
         body: JSON.stringify(mapFormValuesToCreateRequest(formValues)),
       });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
@@ -8,7 +8,6 @@
 import { useMutation } from '@kbn/react-query';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import type { FormValues } from '../types';
 import { mapFormValuesToCreateRequest } from '../utils/rule_request_mappers';
 
@@ -20,7 +19,7 @@ interface UseCreateRuleProps {
 export const useCreateRule = ({ http, notifications }: UseCreateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.post<RuleResponse>(ALERTING_V2_RULE_API_PATH, {
+      return http.post<RuleResponse>('/api/alerting/v2/rule', {
         body: JSON.stringify(mapFormValuesToCreateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
@@ -8,6 +8,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { createQueryClientWrapper } from '../../test_utils';
 import { useUpdateRule } from './use_update_rule';
 import type { FormValues } from '../types';
@@ -67,7 +68,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
         expect.any(Object)
       );
     });
@@ -136,7 +137,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
         { body: JSON.stringify(expectedPayload) }
       );
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
@@ -67,7 +67,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rules/${encodeURIComponent(ruleId)}`,
         expect.any(Object)
       );
     });
@@ -136,7 +136,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rules/${encodeURIComponent(ruleId)}`,
         { body: JSON.stringify(expectedPayload) }
       );
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
@@ -8,7 +8,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import { createQueryClientWrapper } from '../../test_utils';
 import { useUpdateRule } from './use_update_rule';
 import type { FormValues } from '../types';
@@ -68,7 +67,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
         expect.any(Object)
       );
     });
@@ -137,7 +136,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
         { body: JSON.stringify(expectedPayload) }
       );
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.test.tsx
@@ -67,7 +67,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/internal/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
         expect.any(Object)
       );
     });
@@ -136,7 +136,7 @@ describe('useUpdateRule', () => {
 
     await waitFor(() => {
       expect(http.patch).toHaveBeenCalledWith(
-        `/internal/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
         { body: JSON.stringify(expectedPayload) }
       );
     });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -20,7 +20,7 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.patch<RuleResponse>(`/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`, {
+      return http.patch<RuleResponse>(`/api/alerting/v2/rules/${encodeURIComponent(ruleId)}`, {
         body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -8,6 +8,7 @@
 import { useMutation } from '@kbn/react-query';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import type { FormValues } from '../types';
 import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
 
@@ -20,7 +21,7 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.patch<RuleResponse>(`/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`, {
+      return http.patch<RuleResponse>(`${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`, {
         body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -20,12 +20,9 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.patch<RuleResponse>(
-        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
-        {
-          body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
-        }
-      );
+      return http.patch<RuleResponse>(`/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`, {
+        body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
+      });
     },
     {
       onSuccess: (data: RuleResponse) => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -20,7 +20,7 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.patch<RuleResponse>(`/internal/alerting/v2/rule/${encodeURIComponent(ruleId)}`, {
+      return http.patch<RuleResponse>(`/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`, {
         body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
       });
     },

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -20,6 +20,8 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
+      // Path duplicated from alerting_v2 plugin server/routes/constants.ts (ALERTING_V2_RULE_API_PATH)
+      // to avoid circular dependency. Keep in sync.
       return http.patch<RuleResponse>(`/api/alerting/v2/rules/${encodeURIComponent(ruleId)}`, {
         body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
       });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -21,9 +21,12 @@ interface UseUpdateRuleProps {
 export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProps) => {
   const mutation = useMutation(
     (formValues: FormValues) => {
-      return http.patch<RuleResponse>(`${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`, {
-        body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
-      });
+      return http.patch<RuleResponse>(
+        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
+        {
+          body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
+        }
+      );
     },
     {
       onSuccess: (data: RuleResponse) => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
@@ -8,7 +8,6 @@
 import { useMutation } from '@kbn/react-query';
 import type { HttpStart, NotificationsStart } from '@kbn/core/public';
 import type { RuleResponse } from '@kbn/alerting-v2-schemas';
-import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-plugin/public/constants';
 import type { FormValues } from '../types';
 import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
 
@@ -22,7 +21,7 @@ export const useUpdateRule = ({ http, notifications, ruleId }: UseUpdateRuleProp
   const mutation = useMutation(
     (formValues: FormValues) => {
       return http.patch<RuleResponse>(
-        `${ALERTING_V2_RULE_API_PATH}/${encodeURIComponent(ruleId)}`,
+        `/api/alerting/v2/rule/${encodeURIComponent(ruleId)}`,
         {
           body: JSON.stringify(mapFormValuesToUpdateRequest(formValues)),
         }

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
@@ -40,7 +40,8 @@
     "@kbn/field-types",
     "@kbn/lens-plugin",
     "@kbn/visualization-utils",
-    "@kbn/expressions-plugin"
+    "@kbn/expressions-plugin",
+    "@kbn/alerting-v2-plugin"
   ]
 }
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/tsconfig.json
@@ -40,8 +40,7 @@
     "@kbn/field-types",
     "@kbn/lens-plugin",
     "@kbn/visualization-utils",
-    "@kbn/expressions-plugin",
-    "@kbn/alerting-v2-plugin"
+    "@kbn/expressions-plugin"
   ]
 }
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -11,7 +11,7 @@ export const ALERTING_V2_APP_ROUTE = '/alerting_v2';
 export const ALERTING_V2_MANAGEMENT_PATH = 'insightsAndAlerting/alerting_v2';
 export const MANAGEMENT_APP_ID = 'management';
 export const ALERTING_V2_NOTIFICATION_POLICIES_PATH = `${ALERTING_V2_BASE_PATH}/notification_policies`;
-export const INTERNAL_ALERTING_V2_RULE_API_PATH = '/internal/alerting/v2/rule' as const;
+export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rule' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
   '/internal/alerting/v2/notification_policies' as const;
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -11,6 +11,7 @@ export const ALERTING_V2_APP_ROUTE = '/alerting_v2';
 export const ALERTING_V2_MANAGEMENT_PATH = 'insightsAndAlerting/alerting_v2';
 export const MANAGEMENT_APP_ID = 'management';
 export const ALERTING_V2_NOTIFICATION_POLICIES_PATH = `${ALERTING_V2_BASE_PATH}/notification_policies`;
+// Must match ALERTING_V2_RULE_API_PATH in server/routes/constants.ts
 export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
   '/internal/alerting/v2/notification_policies' as const;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -11,7 +11,7 @@ export const ALERTING_V2_APP_ROUTE = '/alerting_v2';
 export const ALERTING_V2_MANAGEMENT_PATH = 'insightsAndAlerting/alerting_v2';
 export const MANAGEMENT_APP_ID = 'management';
 export const ALERTING_V2_NOTIFICATION_POLICIES_PATH = `${ALERTING_V2_BASE_PATH}/notification_policies`;
-export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rule' as const;
+export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
   '/internal/alerting/v2/notification_policies' as const;
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
@@ -9,7 +9,7 @@ import { inject, injectable } from 'inversify';
 import type { HttpStart } from '@kbn/core/public';
 import { CoreStart } from '@kbn/core-di-browser';
 import type { CreateRuleData, RuleResponse, UpdateRuleData } from '@kbn/alerting-v2-schemas';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 /** Re-exported from the shared schemas package. */
 export type { RuleResponse as RuleApiResponse };
@@ -46,48 +46,48 @@ export class RulesApi {
   constructor(@inject(CoreStart('http')) private readonly http: HttpStart) {}
 
   public async listRules(params: ListRulesParams) {
-    return this.http.get<FindRulesResponse>(INTERNAL_ALERTING_V2_RULE_API_PATH, {
+    return this.http.get<FindRulesResponse>(ALERTING_V2_RULE_API_PATH, {
       query: { page: params.page, perPage: params.perPage, search: params.search },
     });
   }
 
   public async createRule(payload: CreateRuleData) {
-    return this.http.post<RuleResponse>(INTERNAL_ALERTING_V2_RULE_API_PATH, {
+    return this.http.post<RuleResponse>(ALERTING_V2_RULE_API_PATH, {
       body: JSON.stringify(payload),
     });
   }
 
   public async getRule(id: string) {
-    return this.http.get<RuleResponse>(`${INTERNAL_ALERTING_V2_RULE_API_PATH}/${id}`);
+    return this.http.get<RuleResponse>(`${ALERTING_V2_RULE_API_PATH}/${id}`);
   }
 
   public async updateRule(id: string, payload: UpdateRuleData) {
-    return this.http.patch<RuleResponse>(`${INTERNAL_ALERTING_V2_RULE_API_PATH}/${id}`, {
+    return this.http.patch<RuleResponse>(`${ALERTING_V2_RULE_API_PATH}/${id}`, {
       body: JSON.stringify(payload),
     });
   }
 
   public async deleteRule(id: string) {
-    return this.http.delete<RuleResponse>(`${INTERNAL_ALERTING_V2_RULE_API_PATH}/${id}`);
+    return this.http.delete<RuleResponse>(`${ALERTING_V2_RULE_API_PATH}/${id}`);
   }
 
   public async bulkDeleteRules(params: BulkOperationParams) {
     return this.http.post<BulkOperationResponse>(
-      `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_delete`,
+      `${ALERTING_V2_RULE_API_PATH}/_bulk_delete`,
       { body: JSON.stringify(params) }
     );
   }
 
   public async bulkEnableRules(params: BulkOperationParams) {
     return this.http.post<BulkOperationResponse>(
-      `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_enable`,
+      `${ALERTING_V2_RULE_API_PATH}/_bulk_enable`,
       { body: JSON.stringify(params) }
     );
   }
 
   public async bulkDisableRules(params: BulkOperationParams) {
     return this.http.post<BulkOperationResponse>(
-      `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_disable`,
+      `${ALERTING_V2_RULE_API_PATH}/_bulk_disable`,
       { body: JSON.stringify(params) }
     );
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/rules_api.ts
@@ -72,23 +72,20 @@ export class RulesApi {
   }
 
   public async bulkDeleteRules(params: BulkOperationParams) {
-    return this.http.post<BulkOperationResponse>(
-      `${ALERTING_V2_RULE_API_PATH}/_bulk_delete`,
-      { body: JSON.stringify(params) }
-    );
+    return this.http.post<BulkOperationResponse>(`${ALERTING_V2_RULE_API_PATH}/_bulk_delete`, {
+      body: JSON.stringify(params),
+    });
   }
 
   public async bulkEnableRules(params: BulkOperationParams) {
-    return this.http.post<BulkOperationResponse>(
-      `${ALERTING_V2_RULE_API_PATH}/_bulk_enable`,
-      { body: JSON.stringify(params) }
-    );
+    return this.http.post<BulkOperationResponse>(`${ALERTING_V2_RULE_API_PATH}/_bulk_enable`, {
+      body: JSON.stringify(params),
+    });
   }
 
   public async bulkDisableRules(params: BulkOperationParams) {
-    return this.http.post<BulkOperationResponse>(
-      `${ALERTING_V2_RULE_API_PATH}/_bulk_disable`,
-      { body: JSON.stringify(params) }
-    );
+    return this.http.post<BulkOperationResponse>(`${ALERTING_V2_RULE_API_PATH}/_bulk_disable`, {
+      body: JSON.stringify(params),
+    });
   }
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rule' as const;
+export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
 export const INTERNAL_ALERTING_V2_ALERT_API_PATH = '/internal/alerting/v2/alerts' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
   '/internal/alerting/v2/notification_policies' as const;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const INTERNAL_ALERTING_V2_RULE_API_PATH = '/internal/alerting/v2/rule' as const;
+export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rule' as const;
 export const INTERNAL_ALERTING_V2_ALERT_API_PATH = '/internal/alerting/v2/alerts' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
   '/internal/alerting/v2/notification_policies' as const;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
@@ -5,6 +5,13 @@
  * 2.0.
  */
 
+// This path is duplicated as a hardcoded string in packages that cannot import from this plugin
+// without causing circular dependencies. If you change this value, also update:
+//   - x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+//   - x-pack/platform/packages/shared/response-ops/alerting-v2-episodes-ui/hooks/use_alerting_rules_index.ts
+//   - x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_create_rule.ts
+//   - x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/hooks/use_update_rule.ts
+//   - x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
 export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
 export const INTERNAL_ALERTING_V2_ALERT_API_PATH = '/internal/alerting/v2/alerts' as const;
 export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_delete_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_delete_rules_route.ts
@@ -16,21 +16,22 @@ import type { BulkOperationParams } from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 @injectable()
 export class BulkDeleteRulesRoute {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_delete`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/_bulk_delete`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Delete rules in bulk',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_disable_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_disable_rules_route.ts
@@ -16,21 +16,22 @@ import type { BulkOperationParams } from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 @injectable()
 export class BulkDisableRulesRoute {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_disable`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/_bulk_disable`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Disable rules in bulk',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_enable_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/bulk_enable_rules_route.ts
@@ -16,21 +16,22 @@ import type { BulkOperationParams } from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 @injectable()
 export class BulkEnableRulesRoute {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk_enable`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/_bulk_enable`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Enable rules in bulk',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/create_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/create_rule_route.ts
@@ -19,7 +19,7 @@ import { createRuleDataSchema, ruleResponseSchema } from '@kbn/alerting-v2-schem
 import type { CreateRuleData, RuleResponse } from '@kbn/alerting-v2-schemas';
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 const createRuleParamsSchema = z.object({
   id: z
@@ -31,16 +31,17 @@ const createRuleParamsSchema = z.object({
 @injectable()
 export class CreateRuleRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/{id?}`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/{id?}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Create a rule',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/delete_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/delete_rule_route.ts
@@ -15,22 +15,23 @@ import type { z } from '@kbn/zod/v4';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { ruleIdParamsSchema } from './route_schemas';
 
 @injectable()
 export class DeleteRuleRoute {
   static method = 'delete' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Delete a rule',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rule_route.ts
@@ -16,22 +16,23 @@ import { ruleResponseSchema } from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { ruleIdParamsSchema } from './route_schemas';
 
 @injectable()
 export class GetRuleRoute {
   static method = 'get' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.read],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Get a rule',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rules_bulk_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rules_bulk_route.ts
@@ -14,7 +14,7 @@ import { z } from '@kbn/zod/v4';
 import { findRulesResponseSchema } from '@kbn/alerting-v2-schemas';
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 const getRulesBulkQuerySchema = z.object({
   ids: z
@@ -28,16 +28,17 @@ const getRulesBulkQuerySchema = z.object({
 @injectable()
 export class BulkGetRulesRoute {
   static method = 'get' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/_bulk`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/_bulk`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.read],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Get rules in bulk',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rules_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/get_rules_route.ts
@@ -16,7 +16,7 @@ import { findRulesResponseSchema } from '@kbn/alerting-v2-schemas';
 
 import { RulesClient } from '../../lib/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 
 const getRulesQuerySchema = z.object({
   page: z.coerce.number().min(1).optional().describe('The page number to return.'),
@@ -34,16 +34,17 @@ const getRulesQuerySchema = z.object({
 @injectable()
 export class GetRulesRoute {
   static method = 'get' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}`;
+  static path = `${ALERTING_V2_RULE_API_PATH}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.read],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'List rules',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_rule_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/rules/update_rule_route.ts
@@ -17,22 +17,23 @@ import { ruleResponseSchema } from '@kbn/alerting-v2-schemas';
 import { updateRuleDataSchema, type UpdateRuleData } from '../../lib/rules_client';
 import { RulesClient } from '../../lib/rules_client/rules_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_RULE_API_PATH } from '../constants';
+import { ALERTING_V2_RULE_API_PATH } from '../constants';
 import { ruleIdParamsSchema } from './route_schemas';
 
 @injectable()
 export class UpdateRuleRoute {
   static method = 'patch' as const;
-  static path = `${INTERNAL_ALERTING_V2_RULE_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_RULE_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.rules.write],
     },
   };
   static options = {
-    access: 'internal',
+    access: 'public',
     summary: 'Update a rule',
     tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
   } as const;
   static validate = {
     request: {

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
@@ -9,5 +9,5 @@ export const API_HEADERS = {
   'kbn-xsrf': 'true',
 };
 
-export const RULE_API_PATH = '/api/alerting/v2/rule';
+export const RULE_API_PATH = '/api/alerting/v2/rules';
 export const ALERTING_EVENTS_INDEX = '.rule-events';

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-export const INTERNAL_API_HEADERS = {
+export const API_HEADERS = {
   'kbn-xsrf': 'true',
-  'x-elastic-internal-origin': 'kibana',
 };
 
-export const RULE_API_PATH = '/internal/alerting/v2/rule';
+export const RULE_API_PATH = '/api/alerting/v2/rule';
 export const ALERTING_EVENTS_INDEX = '.rule-events';

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/constants.ts
@@ -9,5 +9,6 @@ export const API_HEADERS = {
   'kbn-xsrf': 'true',
 };
 
+// Must match ALERTING_V2_RULE_API_PATH in server/routes/constants.ts
 export const RULE_API_PATH = '/api/alerting/v2/rules';
 export const ALERTING_EVENTS_INDEX = '.rule-events';

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/fixtures/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { INTERNAL_API_HEADERS, RULE_API_PATH, ALERTING_EVENTS_INDEX } from './constants';
+export { API_HEADERS, RULE_API_PATH, ALERTING_EVENTS_INDEX } from './constants';

--- a/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/episode_lifecycle.spec.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/test/scout_alerting_v2/api/tests/episode_lifecycle.spec.ts
@@ -8,7 +8,7 @@
 import type { Client as EsClient } from '@elastic/elasticsearch';
 import { expect } from '@kbn/scout/api';
 import { apiTest, tags } from '@kbn/scout';
-import { INTERNAL_API_HEADERS, RULE_API_PATH, ALERTING_EVENTS_INDEX } from '../fixtures';
+import { API_HEADERS, RULE_API_PATH, ALERTING_EVENTS_INDEX } from '../fixtures';
 
 /**
  * E2E episode lifecycle tests for alerting_v2 alert rules.
@@ -59,7 +59,7 @@ apiTest.describe('Episode lifecycle for alert rules', { tag: tags.stateful.class
     for (const ruleId of ruleIds) {
       await apiClient
         .delete(`${RULE_API_PATH}/${ruleId}`, {
-          headers: { ...INTERNAL_API_HEADERS, ...apiKeyHeader },
+          headers: { ...API_HEADERS, ...apiKeyHeader },
         })
         .catch(() => {});
     }
@@ -227,7 +227,7 @@ apiTest.describe('Episode lifecycle for alert rules', { tag: tags.stateful.class
 
       // Create an alert rule that queries the source index
       const createResponse = await apiClient.post(RULE_API_PATH, {
-        headers: { ...INTERNAL_API_HEADERS, ...apiKeyHeader },
+        headers: { ...API_HEADERS, ...apiKeyHeader },
         body: {
           kind: 'alert',
           metadata: { name: 'e2e-lifecycle-pending-active' },
@@ -299,7 +299,7 @@ apiTest.describe('Episode lifecycle for alert rules', { tag: tags.stateful.class
 
       // Create rule with pending_count=0 and recovering_count=0 (skip intermediate states)
       const createResponse = await apiClient.post(RULE_API_PATH, {
-        headers: { ...INTERNAL_API_HEADERS, ...apiKeyHeader },
+        headers: { ...API_HEADERS, ...apiKeyHeader },
         body: {
           kind: 'alert',
           metadata: { name: 'e2e-lifecycle-recovery' },
@@ -376,7 +376,7 @@ apiTest.describe('Episode lifecycle for alert rules', { tag: tags.stateful.class
       });
 
       const createResponse = await apiClient.post(RULE_API_PATH, {
-        headers: { ...INTERNAL_API_HEADERS, ...apiKeyHeader },
+        headers: { ...API_HEADERS, ...apiKeyHeader },
         body: {
           kind: 'alert',
           metadata: { name: 'e2e-lifecycle-multi-group' },
@@ -452,7 +452,7 @@ apiTest.describe('Episode lifecycle for alert rules', { tag: tags.stateful.class
       //   Exec 1: no previous → enters pending (statusCount=1)
       //   Exec 2: statusCount=1, nextCount=2 >= 2 → transitions to active
       const createResponse = await apiClient.post(RULE_API_PATH, {
-        headers: { ...INTERNAL_API_HEADERS, ...apiKeyHeader },
+        headers: { ...API_HEADERS, ...apiKeyHeader },
         body: {
           kind: 'alert',
           metadata: { name: 'e2e-lifecycle-threshold' },

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/bulk_delete_rules.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/bulk_delete_rules.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/bulk_enable_disable_rules.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/bulk_enable_disable_rules.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/create_rule.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/create_rule.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/delete_rule.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/delete_rule.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/get_rule.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/get_rule.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/list_rules.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/list_rules.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/update_rule.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/rule/update_rule.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const RULE_API_PATH = '/internal/alerting/v2/rule';
+const RULE_API_PATH = '/api/alerting/v2/rule';
 const RULE_SO_TYPE = 'alerting_rule';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {


### PR DESCRIPTION
Closes #259138

Information and justification for these changes in the issue. 

## Summary

Convert the 9 Rules API route files from `access: 'internal'` to `access: 'public'` with `stability: 'experimental'`, add OAS metadata (`summary`, `description`, `tags: ['oas-tag:alerting']`), and update paths from `/internal/` to `/api/`.