### PR TITLE
[Codeowners] add missing codeowners for security_solution_api_integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2765,6 +2765,7 @@ x-pack/solutions/security/test/serverless/functional/configs/config.context_awar
 
 /x-pack/platform/test/fixtures/es_archives/auditbeat/overview @elastic/security-threat-hunting-investigations
 
+/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation @elastic/security-threat-hunting-investigations
 
 /x-pack/solutions/security/test/serverless/functional/configs/config.context_awareness.ts @elastic/security-threat-hunting-investigations
 


### PR DESCRIPTION
## Summary

This PR adds 1 missing codeowners for some integration tests:
- @elastic/security-threat-hunting-investigations for the `/x-pack/solutions/security/test/security_solution_api_integration/test_suites/investigation` folder 

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
