### PR TITLE
test: Deploy elastic-console for Forge integration testing

### DIFF
--- a/x-pack/platform/plugins/shared/elastic_console/README.md
+++ b/x-pack/platform/plugins/shared/elastic_console/README.md
@@ -248,3 +248,4 @@ yarn test:type_check --project x-pack/platform/plugins/shared/elastic_console/ts
 ```
 node scripts/eslint --fix x-pack/platform/plugins/shared/elastic_console/
 ```
+


### PR DESCRIPTION
Temporary PR to deploy a serverless observability project with the elastic-console plugin enabled.

**Purpose:** Test Forge MCP server ↔ elastic-console ↔ Kibana Conversations API integration.

**What this does:** Adds a blank line to the elastic_console README. The real purpose is the `ci:project-deploy-observability` label which triggers a serverless deployment.

**Will close after testing is complete.**