### PR TITLE
[Connectors] Validate MCP server redirects against allowedHosts for MCP connector requests

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
@@ -406,9 +406,9 @@ describe('buildCustomFetch', () => {
 
         await customFetch(targetUrl, { method: 'POST', body: '{"data":true}' });
 
-        const secondCallInit = globalFetchSpy.mock.calls[1][1];
-        expect(secondCallInit.method).toBe('GET');
-        expect(secondCallInit.body).toBeUndefined();
+        const { method, body } = globalFetchSpy.mock.calls[1][1];
+        expect(method).toBe('GET');
+        expect(body).toBeUndefined();
       }
     );
 
@@ -426,6 +426,80 @@ describe('buildCustomFetch', () => {
       expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(
         'https://mcp-server.example.com/v2/mcp'
       );
+    });
+
+    it('follows multiple redirects through allowed hosts', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/step1'))
+        .mockResolvedValueOnce(mockRedirectResponse(301, 'https://mcp-server.example.com/step2'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      const result = await customFetch(targetUrl);
+      expect(result.status).toBe(200);
+      expect(globalFetchSpy).toHaveBeenCalledTimes(3);
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(
+        'https://allowed.example.com/step1'
+      );
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(
+        'https://mcp-server.example.com/step2'
+      );
+    });
+
+    it('blocks a multi-hop redirect when an intermediate hop is disallowed', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/step1'))
+        .mockResolvedValueOnce(
+          mockRedirectResponse(302, 'https://evil.internal.example.com/steal')
+        );
+
+      await expect(customFetch(targetUrl)).rejects.toThrow(
+        'target url "https://evil.internal.example.com/steal" is not added to the Kibana config xpack.actions.allowedHosts'
+      );
+
+      expect(globalFetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('strips authorization header on cross-origin redirects', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/v1/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret-token', 'Content-Type': 'application/json' },
+      });
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
+      const redirectHeaderEntries =
+        redirectHeaders instanceof Headers
+          ? Object.fromEntries(redirectHeaders.entries())
+          : redirectHeaders;
+
+      expect(redirectHeaderEntries).not.toHaveProperty('authorization');
+      expect(redirectHeaderEntries).toHaveProperty('content-type', 'application/json');
+    });
+
+    it('preserves authorization header on same-origin redirects', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://mcp-server.example.com/v2/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret-token', 'Content-Type': 'application/json' },
+      });
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
+      expect(redirectHeaders).toHaveProperty('Authorization', 'Bearer secret-token');
+      expect(redirectHeaders).toHaveProperty('Content-Type', 'application/json');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
@@ -412,6 +412,61 @@ describe('buildCustomFetch', () => {
       }
     );
 
+    it.each([301, 302, 303])('strips request-body-headers on %i method change', async (status) => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(
+          mockRedirectResponse(status, 'https://mcp-server.example.com/v2/mcp')
+        )
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Encoding': 'gzip',
+          'Content-Language': 'en',
+          'Content-Location': '/resource',
+          'X-Custom-Header': 'keep-me',
+        },
+      });
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
+      const entries =
+        redirectHeaders instanceof Headers
+          ? Object.fromEntries(redirectHeaders.entries())
+          : redirectHeaders;
+
+      expect(entries).not.toHaveProperty('content-type');
+      expect(entries).not.toHaveProperty('content-encoding');
+      expect(entries).not.toHaveProperty('content-language');
+      expect(entries).not.toHaveProperty('content-location');
+      expect(entries).toHaveProperty('x-custom-header', 'keep-me');
+    });
+
+    it.each([307, 308])('preserves request-body-headers on %i redirects', async (status) => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(
+          mockRedirectResponse(status, 'https://mcp-server.example.com/v2/mcp')
+        )
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Encoding': 'gzip',
+        },
+      });
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
+      expect(redirectHeaders).toHaveProperty('Content-Type', 'application/json');
+      expect(redirectHeaders).toHaveProperty('Content-Encoding', 'gzip');
+    });
+
     it('resolves relative Location URLs against the request URL', async () => {
       const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
 
@@ -467,7 +522,7 @@ describe('buildCustomFetch', () => {
       const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
 
       globalFetchSpy
-        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/v1/mcp'))
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://allowed.example.com/v1/mcp'))
         .mockResolvedValueOnce(new Response('final', { status: 200 }));
 
       await customFetch(targetUrl, {
@@ -489,7 +544,7 @@ describe('buildCustomFetch', () => {
       const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
 
       globalFetchSpy
-        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://mcp-server.example.com/v2/mcp'))
+        .mockResolvedValueOnce(mockRedirectResponse(307, 'https://mcp-server.example.com/v2/mcp'))
         .mockResolvedValueOnce(new Response('final', { status: 200 }));
 
       await customFetch(targetUrl, {
@@ -500,6 +555,37 @@ describe('buildCustomFetch', () => {
       const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
       expect(redirectHeaders).toHaveProperty('Authorization', 'Bearer secret-token');
       expect(redirectHeaders).toHaveProperty('Content-Type', 'application/json');
+    });
+
+    it('strips both authorization and request-body-headers on cross-origin method change', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, 'https://allowed.example.com/v1/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer secret-token',
+          'Content-Type': 'application/json',
+          'X-Custom-Header': 'keep-me',
+        },
+      });
+
+      const redirectHeaders = globalFetchSpy.mock.calls[1][1].headers;
+      const entries =
+        redirectHeaders instanceof Headers
+          ? Object.fromEntries(redirectHeaders.entries())
+          : redirectHeaders;
+
+      expect(entries).not.toHaveProperty('authorization');
+      expect(entries).not.toHaveProperty('content-type');
+      expect(entries).toHaveProperty('x-custom-header', 'keep-me');
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('GET');
+      expect(body).toBeUndefined();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.test.ts
@@ -289,11 +289,143 @@ describe('buildCustomFetch', () => {
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          redirect: 'manual',
           dispatcher: expect.anything(),
         })
       );
 
       globalFetchSpy.mockRestore();
+    });
+  });
+
+  describe('handles redirects', () => {
+    let globalFetchSpy: jest.SpyInstance;
+
+    const allowedHosts = ['mcp-server.example.com', 'allowed.example.com'];
+
+    const mockRedirectResponse = (status: number, location: string | null): Response => {
+      const headers = new Headers();
+      if (location !== null) {
+        headers.set('location', location);
+      }
+      return new Response(null, { status, headers });
+    };
+
+    beforeEach(() => {
+      globalFetchSpy = jest.spyOn(globalThis, 'fetch');
+
+      configurationUtilities.getSSLSettings.mockReturnValue({});
+      configurationUtilities.getProxySettings.mockReturnValue(undefined);
+      configurationUtilities.getCustomHostSettings.mockReturnValue(undefined);
+
+      configurationUtilities.ensureUriAllowed.mockImplementation((uri: string) => {
+        const { hostname } = new URL(uri);
+        if (!allowedHosts.includes(hostname)) {
+          throw new Error(
+            `target url "${uri}" is not added to the Kibana config xpack.actions.allowedHosts`
+          );
+        }
+      });
+    });
+
+    afterEach(() => {
+      globalFetchSpy.mockRestore();
+    });
+
+    it('follows a redirect to an allowlisted host', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      const redirectUrl = 'https://allowed.example.com/v1/mcp';
+      const finalResponse = new Response('final', { status: 200 });
+      globalFetchSpy.mockResolvedValueOnce(mockRedirectResponse(302, redirectUrl));
+      globalFetchSpy.mockResolvedValueOnce(finalResponse);
+
+      const result = await customFetch(targetUrl, { method: 'POST' });
+      expect(result).toBe(finalResponse);
+      expect(globalFetchSpy).toHaveBeenCalledTimes(2);
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(redirectUrl);
+    });
+
+    it('blocks a redirect to a disallowed host', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      const redirectUrl = 'https://evil.internal.example.com/steal';
+      globalFetchSpy.mockResolvedValueOnce(mockRedirectResponse(302, redirectUrl));
+
+      await expect(customFetch(targetUrl, { method: 'POST' })).rejects.toThrow(
+        `target url "${redirectUrl}" is not added to the Kibana config xpack.actions.allowedHosts`
+      );
+
+      expect(globalFetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when max redirects is exceeded', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy.mockResolvedValue(
+        mockRedirectResponse(302, 'https://allowed.example.com/loop')
+      );
+
+      await expect(customFetch(targetUrl)).rejects.toThrow('Max redirects (20) exceeded');
+
+      expect(globalFetchSpy).toHaveBeenCalledTimes(21);
+    });
+
+    it('throws when a redirect response is missing the Location header', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy.mockResolvedValueOnce(mockRedirectResponse(302, null));
+
+      await expect(customFetch(targetUrl)).rejects.toThrow(
+        'Redirect response 302 missing Location header'
+      );
+    });
+
+    it.each([307, 308])('preserves method and body for %i redirects', async (status) => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(status, 'https://allowed.example.com/v1/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+      const { method, body } = globalFetchSpy.mock.calls[1][1];
+      expect(method).toBe('POST');
+      expect(body).toBe('{"data":true}');
+    });
+
+    it.each([301, 302, 303])(
+      'downgrades method to GET and drops body for %i redirects',
+      async (status) => {
+        const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+        globalFetchSpy
+          .mockResolvedValueOnce(mockRedirectResponse(status, 'https://allowed.example.com/v1/mcp'))
+          .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+        await customFetch(targetUrl, { method: 'POST', body: '{"data":true}' });
+
+        const secondCallInit = globalFetchSpy.mock.calls[1][1];
+        expect(secondCallInit.method).toBe('GET');
+        expect(secondCallInit.body).toBeUndefined();
+      }
+    );
+
+    it('resolves relative Location URLs against the request URL', async () => {
+      const customFetch = buildCustomFetch(configurationUtilities, logger, targetUrl);
+
+      globalFetchSpy
+        .mockResolvedValueOnce(mockRedirectResponse(302, '/v2/mcp'))
+        .mockResolvedValueOnce(new Response('final', { status: 200 }));
+
+      await customFetch(targetUrl);
+
+      const secondCallUrl = globalFetchSpy.mock.calls[1][0];
+      expect(secondCallUrl).toBe('https://mcp-server.example.com/v2/mcp');
+      expect(configurationUtilities.ensureUriAllowed).toHaveBeenCalledWith(
+        'https://mcp-server.example.com/v2/mcp'
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
@@ -190,10 +190,21 @@ function createFetchWithDispatcher(
     configurationUtilities.ensureUriAllowed(resolvedUrl);
     logger.debug(`MCP connector: following redirect (${response.status}) to ${resolvedUrl}`);
 
+    await response.body?.cancel();
+
     const preserveMethod = response.status === 307 || response.status === 308;
     const redirectInit: RequestInit = preserveMethod
       ? { ...init }
       : { ...init, method: 'GET', body: undefined };
+
+    // Per WHATWG Fetch, strip authorization header on cross-origin redirects
+    const requestOrigin = new URL(url).origin;
+    const redirectOrigin = new URL(resolvedUrl).origin;
+    if (requestOrigin !== redirectOrigin && redirectInit.headers) {
+      const sanitized = new Headers(redirectInit.headers);
+      sanitized.delete('authorization');
+      redirectInit.headers = sanitized;
+    }
 
     return followRedirects(resolvedUrl, redirectInit, redirectCount + 1);
   };

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
@@ -154,7 +154,16 @@ export function buildCustomFetch(
 }
 
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
-const MAX_REDIRECTS = 20; // standard per WHATWG Fetch spec
+
+// WHATWG Fetch specification constants
+const MAX_REDIRECTS = 20;
+const BLOCKED_CROSS_ORIGIN_HEADERS = ['authorization']; // spec also mentions 'cookie', 'proxy-authorization', 'host'. Not applicable here
+const STRIPPED_METHOD_CHANGE_HEADERS = [
+  'content-encoding',
+  'content-language',
+  'content-location',
+  'content-type',
+];
 
 function createFetchWithDispatcher(
   dispatcher: Dispatcher,
@@ -190,20 +199,32 @@ function createFetchWithDispatcher(
     configurationUtilities.ensureUriAllowed(resolvedUrl);
     logger.debug(`MCP connector: following redirect (${response.status}) to ${resolvedUrl}`);
 
-    await response.body?.cancel();
+    // undici explicitly recommends reading/cancelling the body to free up resources
+    try {
+      await response.body?.cancel();
+    } catch {
+      // body may be already cancelled or not readable, ignore
+    }
 
     const preserveMethod = response.status === 307 || response.status === 308;
-    const redirectInit: RequestInit = preserveMethod
-      ? { ...init }
-      : { ...init, method: 'GET', body: undefined };
+    const redirectInit: RequestInit = { ...init };
+
+    if (!preserveMethod) {
+      const sanitizedHeaders = new Headers(redirectInit.headers);
+      STRIPPED_METHOD_CHANGE_HEADERS.forEach((header) => sanitizedHeaders.delete(header));
+
+      redirectInit.headers = sanitizedHeaders;
+      redirectInit.method = 'GET';
+      delete redirectInit.body;
+    }
 
     // Per WHATWG Fetch, strip authorization header on cross-origin redirects
     const requestOrigin = new URL(url).origin;
     const redirectOrigin = new URL(resolvedUrl).origin;
     if (requestOrigin !== redirectOrigin && redirectInit.headers) {
-      const sanitized = new Headers(redirectInit.headers);
-      sanitized.delete('authorization');
-      redirectInit.headers = sanitized;
+      const sanitizedHeaders = new Headers(redirectInit.headers);
+      BLOCKED_CROSS_ORIGIN_HEADERS.forEach((header) => sanitizedHeaders.delete(header));
+      redirectInit.headers = sanitizedHeaders;
     }
 
     return followRedirects(resolvedUrl, redirectInit, redirectCount + 1);

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
@@ -106,7 +106,8 @@ function shouldUseProxy(logger: Logger, proxySettings: ProxySettings, targetUrl:
  *
  * This allows the MCP connector to respect the same `xpack.actions.ssl`,
  * `xpack.actions.customHostSettings`, and `xpack.actions.proxyUrl` settings
- * as all other stack connectors.
+ * as all other stack connectors. Redirect responses are followed manually
+ * so that each hop is validated against `xpack.actions.allowedHosts`.
  */
 export function buildCustomFetch(
   configurationUtilities: ActionsConfigurationUtilities,
@@ -129,7 +130,7 @@ export function buildCustomFetch(
       logger.warn(`invalid proxy URL "${proxySettings.proxyUrl}" ignored, using direct connection`);
       dispatcher = new Agent({ connect: tlsOptions });
 
-      return createFetchWithDispatcher(dispatcher);
+      return createFetchWithDispatcher(dispatcher, configurationUtilities, logger);
     }
 
     logger.debug(`MCP connector: using proxy ${proxySettings.proxyUrl} for ${targetUrl}`);
@@ -149,15 +150,53 @@ export function buildCustomFetch(
     dispatcher = new Agent({ connect: tlsOptions });
   }
 
-  return createFetchWithDispatcher(dispatcher);
+  return createFetchWithDispatcher(dispatcher, configurationUtilities, logger);
 }
 
-function createFetchWithDispatcher(dispatcher: Dispatcher): FetchLike {
-  return (url: string | URL, init?: RequestInit): Promise<Response> => {
-    return fetch(url, {
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 20;
+
+function createFetchWithDispatcher(
+  dispatcher: Dispatcher,
+  configurationUtilities: ActionsConfigurationUtilities,
+  logger: Logger
+): FetchLike {
+  const followRedirects = async (
+    url: string | URL,
+    init?: RequestInit,
+    redirectCount = 0
+  ): Promise<Response> => {
+    const response = await fetch(url, {
       ...init,
-      // Node.js's built-in fetch (undici) supports `dispatcher` as a non-standard option
+      redirect: 'manual',
       dispatcher,
     } as RequestInit);
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    if (redirectCount >= MAX_REDIRECTS) {
+      throw new Error(`Max redirects (${MAX_REDIRECTS}) exceeded`);
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new Error(`Redirect response ${response.status} missing Location header`);
+    }
+
+    const resolvedUrl = new URL(location, url).toString();
+
+    configurationUtilities.ensureUriAllowed(resolvedUrl);
+    logger.debug(`MCP connector: following redirect (${response.status}) to ${resolvedUrl}`);
+
+    const preserveMethod = response.status === 307 || response.status === 308;
+    const redirectInit: RequestInit = preserveMethod
+      ? { ...init }
+      : { ...init, method: 'GET', body: undefined };
+
+    return followRedirects(resolvedUrl, redirectInit, redirectCount + 1);
   };
+
+  return (url: string | URL, init?: RequestInit): Promise<Response> => followRedirects(url, init);
 }

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/mcp/build_custom_fetch.ts
@@ -154,7 +154,7 @@ export function buildCustomFetch(
 }
 
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
-const MAX_REDIRECTS = 20;
+const MAX_REDIRECTS = 20; // standard per WHATWG Fetch spec
 
 function createFetchWithDispatcher(
   dispatcher: Dispatcher,


### PR DESCRIPTION
## Summary

The MCP connector currently defaults to Node fetch's behaviour of `redirect: 'follow'` for requests against the MCP server. This PR changes that behaviour to reference Kibana's allowed hosts (`xpack.actions.allowedHosts`) to ensure the Kibana instance doesn't end up with any unexpected redirects.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->