### PR TITLE
[POC] Add configurable fast model for ESQL generation tools

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/graph.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/graph.ts
@@ -47,11 +47,13 @@ export type StateType = typeof StateAnnotation.State;
 
 export const createSearchToolGraph = ({
   model,
+  fastModel,
   esClient,
   logger,
   events,
 }: {
   model: ScopedModel;
+  fastModel?: ScopedModel;
   esClient: ElasticsearchClient;
   logger: Logger;
   events: ToolEventEmitter;
@@ -59,7 +61,7 @@ export const createSearchToolGraph = ({
   const getTools = (state: StateType) => {
     const relevanceTool = createRelevanceSearchTool({ model, esClient, events, logger });
     const nlSearchTool = createNaturalLanguageSearchTool({
-      model,
+      model: fastModel ?? model,
       esClient,
       events,
       logger,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/run_search_tool.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/search/run_search_tool.ts
@@ -21,6 +21,7 @@ export const runSearchTool = async ({
   customInstructions,
   timeRange,
   model,
+  fastModel,
   esClient,
   logger,
   events,
@@ -31,12 +32,14 @@ export const runSearchTool = async ({
   customInstructions?: string;
   timeRange?: TimeRange;
   model: ScopedModel;
+  fastModel?: ScopedModel;
   esClient: ElasticsearchClient;
   logger: Logger;
   events: ToolEventEmitter;
 }): Promise<ToolHandlerResult[]> => {
   const toolGraph = createSearchToolGraph({
     model,
+    fastModel,
     esClient,
     logger,
     events,

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/model_provider.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/runner/model_provider.ts
@@ -41,6 +41,12 @@ export interface ModelProvider {
    */
   getDefaultModel: () => Promise<ScopedModel>;
   /**
+   * Returns a faster/lighter model for latency-sensitive tool operations
+   * (e.g. ESQL generation). Falls back to the default model if no fast
+   * connector is configured or the configured one is unavailable.
+   */
+  getFastModel: () => Promise<ScopedModel>;
+  /**
    * Returns a model using the given connectorId.
    *
    * Will throw if connector doesn't exist, user has no access, or connector

--- a/x-pack/platform/plugins/shared/agent_builder/server/config.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/config.ts
@@ -11,6 +11,7 @@ import { schema, type TypeOf } from '@kbn/config-schema';
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
   githubBaseUrl: schema.string({ defaultValue: 'https://github.com' }),
+  fastToolConnectorId: schema.maybe(schema.string()),
 });
 
 export type AgentBuilderConfig = TypeOf<typeof configSchema>;

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -257,6 +257,8 @@ export class AgentBuilderPlugin
       inference,
       uiSettings,
       savedObjects,
+      logger: this.logger.get('modelProvider'),
+      fastToolConnectorId: this.config.fastToolConnectorId,
       trackingService: this.trackingService,
     });
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -172,6 +172,7 @@ export class ServiceManager {
       trackingService,
       analyticsService,
       hooks,
+      fastToolConnectorId: this.config.fastToolConnectorId,
     });
     runner = runnerFactory.getRunner();
 

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
@@ -152,7 +152,7 @@ export const createModelProvider = ({
       return await getModel(fastToolConnectorId);
     } catch (e) {
       logger.debug(
-        `Fast tool connector "${fastToolConnectorId}" unavailable, falling back to default model`
+        `Fast tool connector "${fastToolConnectorId}" unavailable, falling back to default model: ${e instanceof Error ? e.message : String(e)}`
       );
       return getModel(await getDefaultConnectorId());
     }

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/model_provider.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { Logger } from '@kbn/logging';
 import type { UiSettingsServiceStart } from '@kbn/core-ui-settings-server';
 import type { SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type {
@@ -25,6 +26,8 @@ export interface CreateModelProviderOpts {
   inference: InferenceServerStart;
   request: KibanaRequest;
   defaultConnectorId?: string;
+  fastToolConnectorId?: string;
+  logger: Logger;
   trackingService?: TrackingService;
   uiSettings: UiSettingsServiceStart;
   savedObjects: SavedObjectsServiceStart;
@@ -34,9 +37,12 @@ export type CreateModelProviderFactoryFn = (
   opts: Omit<CreateModelProviderOpts, 'request' | 'defaultConnectorId'>
 ) => ModelProviderFactoryFn;
 
-export type ModelProviderFactoryFn = (
-  opts: Pick<CreateModelProviderOpts, 'request' | 'defaultConnectorId'>
-) => ModelProvider;
+export type ModelProviderFactoryOpts = Pick<
+  CreateModelProviderOpts,
+  'request' | 'defaultConnectorId'
+>;
+
+export type ModelProviderFactoryFn = (opts: ModelProviderFactoryOpts) => ModelProvider;
 
 /**
  * Utility function to creates a {@link ModelProviderFactoryFn}
@@ -55,6 +61,8 @@ export const createModelProvider = ({
   inference,
   request,
   defaultConnectorId,
+  fastToolConnectorId,
+  logger,
   trackingService,
   uiSettings,
   savedObjects,
@@ -136,8 +144,23 @@ export const createModelProvider = ({
     };
   };
 
+  const getFastModel = async (): Promise<ScopedModel> => {
+    if (!fastToolConnectorId) {
+      return getModel(await getDefaultConnectorId());
+    }
+    try {
+      return await getModel(fastToolConnectorId);
+    } catch (e) {
+      logger.debug(
+        `Fast tool connector "${fastToolConnectorId}" unavailable, falling back to default model`
+      );
+      return getModel(await getDefaultConnectorId());
+    }
+  };
+
   return {
     getDefaultModel: async () => getModel(await getDefaultConnectorId()),
+    getFastModel,
     getModel: ({ connectorId }) => getModel(connectorId),
     getUsageStats,
   };

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner_factory.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/runner_factory.ts
@@ -29,6 +29,8 @@ export class RunnerFactoryImpl implements RunnerFactory {
       uiSettings,
       hooks,
       savedObjects,
+      fastToolConnectorId,
+      logger,
       ...otherDeps
     } = this.deps;
     return {
@@ -38,8 +40,11 @@ export class RunnerFactoryImpl implements RunnerFactory {
       trackingService,
       analyticsService,
       hooks,
+      logger,
       modelProviderFactory: createModelProviderFactory({
         inference,
+        fastToolConnectorId,
+        logger,
         trackingService,
         uiSettings,
         savedObjects,

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/runner/types.ts
@@ -41,6 +41,8 @@ export interface RunnerFactoryDeps {
   trackingService?: TrackingService;
   analyticsService?: AnalyticsService;
   hooks: HooksServiceStart;
+  // config
+  fastToolConnectorId?: string;
 }
 
 export interface RunnerFactory {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/index_search/tool_type.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/tool_types/index_search/tool_type.ts
@@ -35,13 +35,18 @@ export const getIndexSearchToolType = (): ToolTypeDefinition<
               row_limit: rowLimit,
               custom_instructions: customInstructions,
             } = config;
+            const [model, fastModel] = await Promise.all([
+              modelProvider.getDefaultModel(),
+              modelProvider.getFastModel(),
+            ]);
             const results = await runSearchTool({
               nlQuery,
               index: pattern,
               rowLimit,
               customInstructions,
               esClient: esClient.asCurrentUser,
-              model: await modelProvider.getDefaultModel(),
+              model,
+              fastModel,
               events,
               logger,
             });

--- a/x-pack/platform/plugins/shared/agent_builder/server/test_utils/model_provider.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/test_utils/model_provider.ts
@@ -17,6 +17,7 @@ export type ModelProviderFactoryMock = jest.MockedFn<
 export const createModelProviderMock = (): ModelProviderMock => {
   return {
     getDefaultModel: jest.fn(),
+    getFastModel: jest.fn(),
     getModel: jest.fn(),
     getUsageStats: jest.fn(),
   };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/generate_esql.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/generate_esql.ts
@@ -73,7 +73,7 @@ export const generateEsqlTool = (): BuiltinToolDefinition<typeof nlToEsqlToolSch
       },
       { esClient, modelProvider, logger, events, attachments }
     ) => {
-      const model = await modelProvider.getDefaultModel();
+      const model = await modelProvider.getFastModel();
 
       const timeRange = resolveTimeRange(attachments, explicitTimeRange);
 

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/search.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/tools/search.ts
@@ -62,12 +62,17 @@ Note:
     ) => {
       logger.debug(`search tool called with query: ${nlQuery}, index: ${index}`);
       const timeRange = resolveTimeRange(attachments, explicitTimeRange);
+      const [model, fastModel] = await Promise.all([
+        modelProvider.getDefaultModel(),
+        modelProvider.getFastModel(),
+      ]);
       const results = await runSearchTool({
         nlQuery,
         index,
         timeRange,
         esClient: esClient.asCurrentUser,
-        model: await modelProvider.getDefaultModel(),
+        model,
+        fastModel,
         events,
         logger,
       });


### PR DESCRIPTION
### Summary

This POC adds support for routing ESQL generation LLM calls to a faster/lighter model (e.g. Gemini 3 Flash, Claude Haiku 4.5, GPT-5.4) to reduce tool latency, while keeping index selection and search strategy routing on the default orchestration model.

The goal is to measure the latency vs. factuality tradeoff of using a cheaper/faster model for the most time-consuming step in the agent builder pipeline: NL-to-ESQL generation.

### Motivation / Follow up
https://github.com/elastic/search-team/issues/13308

### What uses the fast model

| LLM call | Location | Uses fast model? |
|----------|----------|-----------------|
| Orchestrator research/answer | `default/graph.ts` | No |
| `indexExplorer.selectResources` | `index_explorer.ts` | No |
| `callSearchAgent` (picks relevance vs NL search) | `search/graph.ts` | No |
| `requestDocumentation` (ESQL doc keywords) | `generate_esql/graph.ts` | **Yes** |
| `generateEsql` (NL to ESQL query) | `generate_esql/graph.ts` | **Yes** |
| `relevance_search` | `relevance_search.ts` | N/A (no LLM calls) |

### Configuration

Set the fast connector in `config/kibana.dev.yml`:

```yaml
xpack.agentBuilder.fastToolConnectorId: 'gemini-3-flash-preview-connector'
```
### Results:
Trace: https://oblt-apps.elastic.dev/phoenix-ai/projects/UHJvamVjdDozNzM0/spans/ef25e2ddb796942376d8a65c9a780eb6?selectedSpanNodeId=U3Bhbjo1MzYzNDY%3D

SS:
generateESQL chatcomplete
<img width="1589" height="786" alt="Screenshot 2026-03-23 at 11 01 14 PM" src="https://github.com/user-attachments/assets/04e42c06-4af6-42c4-8bc6-7d95df442869" />

Chatcomplete external to nl_search
<img width="1587" height="744" alt="Screenshot 2026-03-23 at 11 01 37 PM" src="https://github.com/user-attachments/assets/07bcaf65-a32b-4b4a-8dbb-015f4395ab96" />


AI Assisted: Cursor + Claude-4.6-Opus