### PR TITLE
[8.19] chore(NA): add tooLongMin into ci-stats integration (#258575)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/client.ts
+++ b/.buildkite/pipeline-utils/ci-stats/client.ts
@@ -50,6 +50,7 @@ export interface TestGroupRunOrderResponse {
       names: string[];
     }>;
     tooLong?: Array<{ config: string; durationMin: number }>;
+    tooLongMin?: number;
     namesWithoutDurations: string[];
   }>;
 }
@@ -169,6 +170,7 @@ export class CiStatsClient {
       queue?: string;
       defaultMin?: number;
       maxMin: number;
+      tooLongMin?: number;
       minimumIsolationMin?: number;
       overheadMin?: number;
       warmupMin?: number;

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -39,6 +39,18 @@ function getRunGroups(bk: BuildkiteClient, allTypes: RunGroup[], typeName: strin
     throw new Error(`missing test group run order for group [${typeName}]`);
   }
 
+  const uniqueTooLongMin = [
+    ...new Set(
+      types.map((t) => t.tooLongMin).filter((value): value is number => typeof value === 'number')
+    ),
+  ];
+  const tooLongThresholdLabel =
+    uniqueTooLongMin.length > 0
+      ? `configured warning threshold${
+          uniqueTooLongMin.length === 1 ? ` of ${uniqueTooLongMin[0]} minutes` : ''
+        }`
+      : 'maximum amount of time desired for a single CI job';
+
   const misses = types.flatMap((t) => t.namesWithoutDurations);
   if (misses.length > 0) {
     bk.setAnnotation(
@@ -68,10 +80,10 @@ function getRunGroups(bk: BuildkiteClient, allTypes: RunGroup[], typeName: strin
       'warning',
       [
         tooLongs.length === 1
-          ? `The following "${typeName}" config has a duration that exceeds the maximum amount of time desired for a single CI job. ` +
+          ? `The following "${typeName}" config has a duration that exceeds the ${tooLongThresholdLabel}. ` +
             `This is not an error, and if you don't own this config then you can ignore this warning. ` +
             `If you own this config please split it up ASAP and ask Operations if you have questions about how to do that.`
-          : `The following "${typeName}" configs have durations that exceed the maximum amount of time desired for a single CI job. ` +
+          : `The following "${typeName}" configs have durations that exceed the ${tooLongThresholdLabel}. ` +
             `This is not an error, and if you don't own any of these configs then you can ignore this warning.` +
             `If you own any of these configs please split them up ASAP and ask Operations if you have questions about how to do that.`,
         '',
@@ -230,6 +242,10 @@ export async function pickTestGroupRunOrder() {
   if (Number.isNaN(FUNCTIONAL_MAX_MINUTES)) {
     throw new Error(`invalid FUNCTIONAL_MAX_MINUTES: ${process.env.FUNCTIONAL_MAX_MINUTES}`);
   }
+
+  const JEST_UNIT_TOO_LONG_MINUTES = 27;
+  const JEST_INTEGRATION_TOO_LONG_MINUTES = 27;
+  const FUNCTIONAL_TOO_LONG_MINUTES = 27;
 
   /**
    * This env variable corresponds to the env stanza within
@@ -414,6 +430,7 @@ export async function pickTestGroupRunOrder() {
         type: UNIT_TYPE,
         defaultMin: 4,
         maxMin: JEST_MAX_MINUTES,
+        tooLongMin: JEST_UNIT_TOO_LONG_MINUTES,
         overheadMin: 0.2,
         warmupMin: 4,
         names: jestUnitConfigs,
@@ -422,6 +439,7 @@ export async function pickTestGroupRunOrder() {
         type: INTEGRATION_TYPE,
         defaultMin: 60,
         maxMin: JEST_MAX_MINUTES,
+        tooLongMin: JEST_INTEGRATION_TOO_LONG_MINUTES,
         overheadMin: 0.2,
         warmupMin: 2,
         names: jestIntegrationConfigs,
@@ -431,6 +449,7 @@ export async function pickTestGroupRunOrder() {
         defaultMin: 60,
         queue,
         maxMin: FUNCTIONAL_MAX_MINUTES,
+        tooLongMin: FUNCTIONAL_TOO_LONG_MINUTES,
         minimumIsolationMin: FUNCTIONAL_MINIMUM_ISOLATION_MIN,
         overheadMin: 0,
         warmupMin: 3,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(NA): add tooLongMin into ci-stats integration (#258575)](https://github.com/elastic/kibana/pull/258575)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2026-03-24T02:19:59Z","message":"chore(NA): add tooLongMin into ci-stats integration (#258575)\n\nCloses https://github.com/elastic/kibana-operations/issues/457\n\nThis PR adds an optional tooLongMin override to the ci-stats\npick-test-group API (echoed in the response) and wires Kibana to send a\n27 min threshold for unit/integration/functional groups, with the\nBuildkite warning message reflecting the configured threshold when\npresent.\n\nNote that https://github.com/elastic/kibana-ci-stats/pull/1016 is a pre\nrequirement for this PR.\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Enhanced CI test execution monitoring with updated warning thresholds\nfor different test group types\n* Improved warning messages to provide clearer communication about test\nexecution time limits\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"edc22e4fee4191ddd1cbf25a5637f58079dcdd76","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v9.4.0","v9.3.3"],"title":"chore(NA): add tooLongMin into ci-stats integration","number":258575,"url":"https://github.com/elastic/kibana/pull/258575","mergeCommit":{"message":"chore(NA): add tooLongMin into ci-stats integration (#258575)\n\nCloses https://github.com/elastic/kibana-operations/issues/457\n\nThis PR adds an optional tooLongMin override to the ci-stats\npick-test-group API (echoed in the response) and wires Kibana to send a\n27 min threshold for unit/integration/functional groups, with the\nBuildkite warning message reflecting the configured threshold when\npresent.\n\nNote that https://github.com/elastic/kibana-ci-stats/pull/1016 is a pre\nrequirement for this PR.\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Enhanced CI test execution monitoring with updated warning thresholds\nfor different test group types\n* Improved warning messages to provide clearer communication about test\nexecution time limits\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"edc22e4fee4191ddd1cbf25a5637f58079dcdd76"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258575","number":258575,"mergeCommit":{"message":"chore(NA): add tooLongMin into ci-stats integration (#258575)\n\nCloses https://github.com/elastic/kibana-operations/issues/457\n\nThis PR adds an optional tooLongMin override to the ci-stats\npick-test-group API (echoed in the response) and wires Kibana to send a\n27 min threshold for unit/integration/functional groups, with the\nBuildkite warning message reflecting the configured threshold when\npresent.\n\nNote that https://github.com/elastic/kibana-ci-stats/pull/1016 is a pre\nrequirement for this PR.\n\n\n## Summary by CodeRabbit\n\n* **Chores**\n* Enhanced CI test execution monitoring with updated warning thresholds\nfor different test group types\n* Improved warning messages to provide clearer communication about test\nexecution time limits\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"edc22e4fee4191ddd1cbf25a5637f58079dcdd76"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259228","number":259228,"state":"MERGED","mergeCommit":{"sha":"f9b38e2669db8b64e47ffec641d7e1f23ce963d8","message":"[9.3] chore(NA): add tooLongMin into ci-stats integration (#258575) (#259228)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [chore(NA): add tooLongMin into ci-stats integration\n(#258575)](https://github.com/elastic/kibana/pull/258575)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>"}}]}] BACKPORT-->