### PR TITLE
[UIAM] Implement OAuth client management Security APIs

### DIFF
--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -40,6 +40,7 @@ export type {
   UiamOAuthType,
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
+  UiamOAuthClientType,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -41,6 +41,7 @@ export type {
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
   UiamOAuthClientType,
+  UiamOAuthConnectionsSummary,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -36,6 +36,15 @@ export type {
   ConvertUiamAPIKeysResponse,
 } from './api_keys';
 
+export type {
+  UiamOAuthType,
+  UiamOAuthClientResponse,
+  UiamOAuthClientLogo,
+  UiamOAuthConnectionResponse,
+  CreateUiamOAuthClientParams,
+  UpdateUiamOAuthClientParams,
+} from './oauth';
+
 export { HTTPAuthorizationHeader } from './http_authentication';
 export {
   isCreateRestAPIKeyParams,

--- a/src/core/packages/security/server/src/authentication/index.ts
+++ b/src/core/packages/security/server/src/authentication/index.ts
@@ -45,6 +45,7 @@ export type {
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,
+  UpdateUiamOAuthConnectionParams,
 } from './oauth';
 
 export { HTTPAuthorizationHeader } from './http_authentication';

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -12,6 +12,7 @@ export type {
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
   UiamOAuthClientType,
+  UiamOAuthConnectionsSummary,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -16,4 +16,5 @@ export type {
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,
+  UpdateUiamOAuthConnectionParams,
 } from './uiam_oauth';

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -11,6 +11,7 @@ export type {
   UiamOAuthType,
   UiamOAuthClientResponse,
   UiamOAuthClientLogo,
+  UiamOAuthClientType,
   UiamOAuthConnectionResponse,
   CreateUiamOAuthClientParams,
   UpdateUiamOAuthClientParams,

--- a/src/core/packages/security/server/src/authentication/oauth/index.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type {
+  UiamOAuthType,
+  UiamOAuthClientResponse,
+  UiamOAuthClientLogo,
+  UiamOAuthConnectionResponse,
+  CreateUiamOAuthClientParams,
+  UpdateUiamOAuthClientParams,
+} from './uiam_oauth';

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -9,31 +9,20 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 
-/**
- * Represents a client logo provided as a URL.
- */
-export interface UiamOAuthClientLogoUrl {
-  type: 'url';
-  url: string;
-}
-
-/**
- * Represents a client logo provided as base64-encoded image data.
- */
-export interface UiamOAuthClientLogoBase64 {
-  type: 'base64';
+export interface UiamOAuthClientLogo {
   media_type: string;
   data: string;
 }
 
-export type UiamOAuthClientLogo = UiamOAuthClientLogoUrl | UiamOAuthClientLogoBase64;
+export interface UiamOAuthConnectionsSummary {
+  active?: string[];
+  revoked?: string[];
+}
 
-/**
- * Represents a single OAuth client returned by the UIAM service.
- */
 export interface UiamOAuthClientResponse {
   id: string;
   client_name?: string;
+  client_secret?: string;
   resource: string;
   type?: string;
   creation?: string;
@@ -42,15 +31,13 @@ export interface UiamOAuthClientResponse {
   revocation_reason?: string;
   client_metadata?: Record<string, string>;
   client_logo?: UiamOAuthClientLogo;
-  connections?: { active?: string[]; revoked?: string[] };
+  connections?: UiamOAuthConnectionsSummary;
 }
 
-/**
- * Represents a single OAuth connection returned by the UIAM service.
- */
 export interface UiamOAuthConnectionResponse {
   id: string;
   client_id: string;
+  name?: string;
   resource: string;
   creation?: string;
   revoked?: boolean;
@@ -59,22 +46,19 @@ export interface UiamOAuthConnectionResponse {
   scopes?: string[];
 }
 
-/**
- * Parameters for creating an OAuth client.
- */
+export type UiamOAuthClientType = 'public' | 'confidential';
+
 export interface CreateUiamOAuthClientParams {
   resource: string;
   client_name?: string;
+  client_type?: UiamOAuthClientType;
   client_metadata?: Record<string, string>;
   client_logo?: UiamOAuthClientLogo;
 }
 
-/**
- * Parameters for updating an OAuth client.
- */
 export interface UpdateUiamOAuthClientParams {
   client_name?: string | null;
-  client_metadata?: Record<string, string>;
+  client_metadata: Record<string, string | null>;
   client_logo?: UiamOAuthClientLogo | null;
 }
 

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+
+/**
+ * Represents a client logo provided as a URL.
+ */
+export interface UiamOAuthClientLogoUrl {
+  type: 'url';
+  url: string;
+}
+
+/**
+ * Represents a client logo provided as base64-encoded image data.
+ */
+export interface UiamOAuthClientLogoBase64 {
+  type: 'base64';
+  media_type: string;
+  data: string;
+}
+
+export type UiamOAuthClientLogo = UiamOAuthClientLogoUrl | UiamOAuthClientLogoBase64;
+
+/**
+ * Represents a single OAuth client returned by the UIAM service.
+ */
+export interface UiamOAuthClientResponse {
+  id: string;
+  client_name?: string;
+  resource: string;
+  type?: string;
+  creation?: string;
+  revoked?: boolean;
+  revocation?: string;
+  revocation_reason?: string;
+  client_metadata?: Record<string, string>;
+  client_logo?: UiamOAuthClientLogo;
+  connections?: { active?: string[]; revoked?: string[] };
+}
+
+/**
+ * Represents a single OAuth connection returned by the UIAM service.
+ */
+export interface UiamOAuthConnectionResponse {
+  id: string;
+  client_id: string;
+  resource: string;
+  creation?: string;
+  revoked?: boolean;
+  revocation?: string;
+  revocation_reason?: string;
+  scopes?: string[];
+}
+
+/**
+ * Parameters for creating an OAuth client.
+ */
+export interface CreateUiamOAuthClientParams {
+  resource: string;
+  client_name?: string;
+  client_metadata?: Record<string, string>;
+  client_logo?: UiamOAuthClientLogo;
+}
+
+/**
+ * Parameters for updating an OAuth client.
+ */
+export interface UpdateUiamOAuthClientParams {
+  client_name?: string | null;
+  client_metadata: Record<string, string>;
+  client_logo?: UiamOAuthClientLogo | null;
+}
+
+/**
+ * Interface for managing UIAM OAuth client and connection operations.
+ */
+export interface UiamOAuthType {
+  /**
+   * Creates an OAuth client.
+   * @param request The Kibana request containing the authorization header.
+   * @param params The parameters for creating the OAuth client.
+   */
+  createClient(
+    request: KibanaRequest,
+    params: CreateUiamOAuthClientParams
+  ): Promise<UiamOAuthClientResponse | null>;
+
+  /**
+   * Lists OAuth clients, optionally filtered by client ID.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId Optional client ID filter.
+   */
+  listClients(
+    request: KibanaRequest,
+    clientId?: string
+  ): Promise<{ clients: UiamOAuthClientResponse[] } | null>;
+
+  /**
+   * Updates an OAuth client's metadata.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId The ID of the client to update.
+   * @param params The parameters for updating the OAuth client.
+   */
+  updateClient(
+    request: KibanaRequest,
+    clientId: string,
+    params: UpdateUiamOAuthClientParams
+  ): Promise<UiamOAuthClientResponse | null>;
+
+  /**
+   * Revokes an OAuth client.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId The ID of the client to revoke.
+   * @param reason Optional reason for revocation.
+   */
+  revokeClient(
+    request: KibanaRequest,
+    clientId: string,
+    reason?: string
+  ): Promise<UiamOAuthClientResponse | null>;
+
+  /**
+   * Lists OAuth connections, optionally filtered by client ID and/or connection ID.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId Optional client ID filter.
+   * @param connectionId Optional connection ID filter.
+   */
+  listConnections(
+    request: KibanaRequest,
+    clientId?: string,
+    connectionId?: string
+  ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null>;
+
+  /**
+   * Revokes an OAuth connection.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId The ID of the client owning the connection.
+   * @param connectionId The ID of the connection to revoke.
+   * @param reason Optional reason for revocation.
+   */
+  revokeConnection(
+    request: KibanaRequest,
+    clientId: string,
+    connectionId: string,
+    reason?: string
+  ): Promise<UiamOAuthConnectionResponse | null>;
+}

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -19,18 +19,21 @@ export interface UiamOAuthConnectionsSummary {
   revoked?: string[];
 }
 
+export type UiamOAuthClientType = 'public' | 'confidential';
+
 export interface UiamOAuthClientResponse {
   id: string;
   client_name?: string;
   client_secret?: string;
   resource: string;
-  type?: string;
+  type?: UiamOAuthClientType;
   creation?: string;
   revoked?: boolean;
   revocation?: string;
   revocation_reason?: string;
   client_metadata?: Record<string, string>;
   client_logo?: UiamOAuthClientLogo;
+  redirect_uris?: string[];
   connections?: UiamOAuthConnectionsSummary;
 }
 
@@ -46,20 +49,24 @@ export interface UiamOAuthConnectionResponse {
   scopes?: string[];
 }
 
-export type UiamOAuthClientType = 'public' | 'confidential';
-
 export interface CreateUiamOAuthClientParams {
   resource: string;
   client_name?: string;
   client_type?: UiamOAuthClientType;
   client_metadata?: Record<string, string>;
   client_logo?: UiamOAuthClientLogo;
+  redirect_uris?: string[];
 }
 
 export interface UpdateUiamOAuthClientParams {
   client_name?: string | null;
   client_metadata?: Record<string, string | null>;
   client_logo?: UiamOAuthClientLogo | null;
+  redirect_uris?: string[];
+}
+
+export interface UpdateUiamOAuthConnectionParams {
+  name: string;
 }
 
 /**
@@ -121,6 +128,20 @@ export interface UiamOAuthType {
     clientId?: string,
     connectionId?: string
   ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null>;
+
+  /**
+   * Updates an OAuth connection's display name.
+   * @param request The Kibana request containing the authorization header.
+   * @param clientId The ID of the client owning the connection.
+   * @param connectionId The ID of the connection to update.
+   * @param params The parameters for updating the OAuth connection.
+   */
+  updateConnection(
+    request: KibanaRequest,
+    clientId: string,
+    connectionId: string,
+    params: UpdateUiamOAuthConnectionParams
+  ): Promise<UiamOAuthConnectionResponse | null>;
 
   /**
    * Revokes an OAuth connection.

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -74,7 +74,7 @@ export interface CreateUiamOAuthClientParams {
  */
 export interface UpdateUiamOAuthClientParams {
   client_name?: string | null;
-  client_metadata: Record<string, string>;
+  client_metadata?: Record<string, string>;
   client_logo?: UiamOAuthClientLogo | null;
 }
 

--- a/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
+++ b/src/core/packages/security/server/src/authentication/oauth/uiam_oauth.ts
@@ -58,7 +58,7 @@ export interface CreateUiamOAuthClientParams {
 
 export interface UpdateUiamOAuthClientParams {
   client_name?: string | null;
-  client_metadata: Record<string, string | null>;
+  client_metadata?: Record<string, string | null>;
   client_logo?: UiamOAuthClientLogo | null;
 }
 

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
@@ -210,6 +210,12 @@ describe(`#runUiamContainer()`, () => {
             "--env",
             "uiam.cosmos.container.apikey=api-keys",
             "--env",
+            "uiam.cosmos.container.oauth_authorization_code=oauth-authorization-codes",
+            "--env",
+            "uiam.cosmos.container.oauth_client=oauth-clients",
+            "--env",
+            "uiam.cosmos.container.oauth_app_connection=oauth-app-connections",
+            "--env",
             "uiam.cosmos.container.token_invalidation=token-invalidation",
             "--env",
             "uiam.cosmos.container.users=users",
@@ -352,7 +358,7 @@ describe(`#runUiamContainer()`, () => {
     await expect(
       runUiamContainer(new ToolingLog(), cosmosDbContainer)
     ).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam-cosmosdb[22m]`
+      `[Error: The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running. Check the logs with docker logs -f uiam-cosmosdb]`
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.
@@ -366,7 +372,7 @@ describe(`#runUiamContainer()`, () => {
       .mockResolvedValue({ stdout: ` running ` });
 
     await expect(runUiamContainer(new ToolingLog(), uiamContainer)).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam[22m]`
+      `[Error: The "uiam" container failed to start within the expected time. Last known status: running. Check the logs with docker logs -f uiam]`
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.test.ts
@@ -358,7 +358,7 @@ describe(`#runUiamContainer()`, () => {
     await expect(
       runUiamContainer(new ToolingLog(), cosmosDbContainer)
     ).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running. Check the logs with docker logs -f uiam-cosmosdb]`
+      `[Error: The "uiam-cosmosdb" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam-cosmosdb[22m]`
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.
@@ -372,7 +372,7 @@ describe(`#runUiamContainer()`, () => {
       .mockResolvedValue({ stdout: ` running ` });
 
     await expect(runUiamContainer(new ToolingLog(), uiamContainer)).rejects.toMatchInlineSnapshot(
-      `[Error: The "uiam" container failed to start within the expected time. Last known status: running. Check the logs with docker logs -f uiam]`
+      `[Error: The "uiam" container failed to start within the expected time. Last known status: running. Check the logs with [1mdocker logs -f uiam[22m]`
     );
 
     // Skip the first call to `docker run` as we checked it in the previous test.

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
@@ -14,11 +14,11 @@ import {
   generateCosmosDBApiRequestHeaders,
   MOCK_IDP_UIAM_COSMOS_DB_ACCESS_KEY,
   MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_API_KEYS,
+  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_APP_CONNECTIONS,
+  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_AUTHORIZATION_CODES,
+  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_CLIENTS,
   MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_TOKEN_INVALIDATION,
   MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_USERS,
-  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_CLIENTS,
-  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_AUTHORIZATION_CODES,
-  MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_APP_CONNECTIONS,
   MOCK_IDP_UIAM_COSMOS_DB_INTERNAL_URL,
   MOCK_IDP_UIAM_COSMOS_DB_NAME,
   MOCK_IDP_UIAM_COSMOS_DB_URL,
@@ -188,6 +188,12 @@ const UIAM_BASE_CONTAINERS: UiamContainer[] = [
       `uiam.cosmos.account.endpoint=${MOCK_IDP_UIAM_COSMOS_DB_INTERNAL_URL}`,
       '--env',
       `uiam.cosmos.container.apikey=${MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_API_KEYS}`,
+      '--env',
+      `uiam.cosmos.container.oauth_authorization_code=${MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_AUTHORIZATION_CODES}`,
+      '--env',
+      `uiam.cosmos.container.oauth_client=${MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_CLIENTS}`,
+      '--env',
+      `uiam.cosmos.container.oauth_app_connection=${MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_APP_CONNECTIONS}`,
       '--env',
       `uiam.cosmos.container.token_invalidation=${MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_TOKEN_INVALIDATION}`,
       '--env',
@@ -436,23 +442,28 @@ export async function initializeUiamContainers(log: ToolingLog) {
     );
   }
 
-  // 2. Create collections with their respective partition keys.
-  const collections: Array<{ name: string; partitionKeyPath: string }> = [
-    { name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_USERS, partitionKeyPath: '/id' },
-    { name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_API_KEYS, partitionKeyPath: '/id' },
-    { name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_TOKEN_INVALIDATION, partitionKeyPath: '/id' },
-    { name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_CLIENTS, partitionKeyPath: '/creator_id' },
+  // 2. Create collections.
+  // Partition key paths must match the UIAM service's CosmosDB repository expectations.
+  const collections: Array<{ id: string; partitionKeyPath: string }> = [
+    { id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_USERS, partitionKeyPath: '/id' },
+    { id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_API_KEYS, partitionKeyPath: '/id' },
+    { id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_TOKEN_INVALIDATION, partitionKeyPath: '/id' },
     {
-      name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_AUTHORIZATION_CODES,
+      id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_CLIENTS,
+      partitionKeyPath: '/creator_id',
+    },
+    {
+      id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_AUTHORIZATION_CODES,
       partitionKeyPath: '/id',
     },
     {
-      name: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_APP_CONNECTIONS,
+      id: MOCK_IDP_UIAM_COSMOS_DB_COLLECTION_OAUTH_APP_CONNECTIONS,
       partitionKeyPath: '/client_id',
     },
   ];
+
   for (const collection of collections) {
-    log.info(chalk.bold(`Creating a Cosmos DB collection (${collection.name})…`));
+    log.info(chalk.bold(`Creating a Cosmos DB collection (${collection.id})…`));
 
     const collectionRes = await fetch(
       `${MOCK_IDP_UIAM_COSMOS_DB_URL}/dbs/${MOCK_IDP_UIAM_COSMOS_DB_NAME}/colls`,
@@ -464,7 +475,7 @@ export async function initializeUiamContainers(log: ToolingLog) {
           `dbs/${MOCK_IDP_UIAM_COSMOS_DB_NAME}`
         ),
         body: JSON.stringify({
-          id: collection.name,
+          id: collection.id,
           partitionKey: { paths: [collection.partitionKeyPath], kind: 'Hash' },
         }),
         dispatcher: fetchDispatcher,
@@ -472,12 +483,12 @@ export async function initializeUiamContainers(log: ToolingLog) {
     );
 
     if (collectionRes.status === 201) {
-      log.info(chalk.green(`✓ Collection (${collection.name}) created successfully`));
+      log.info(chalk.green(`✓ Collection (${collection.id}) created successfully`));
     } else if (collectionRes.status === 409) {
-      log.info(chalk.yellow(`✓ Collection (${collection.name}) already exists`));
+      log.info(chalk.yellow(`✓ Collection (${collection.id}) already exists`));
     } else {
       throw new Error(
-        `Failed to create collection (${collection.name}): ${
+        `Failed to create collection (${collection.id}): ${
           collectionRes.status
         } ${await collectionRes.text()}`
       );

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
@@ -50,6 +50,12 @@ describe('UiamAPIKeys', () => {
       revokeApiKey: jest.fn(),
       convertApiKeys: jest.fn(),
       exchangeOAuthToken: jest.fn(),
+      createOAuthClient: jest.fn(),
+      listOAuthClients: jest.fn(),
+      updateOAuthClient: jest.fn(),
+      revokeOAuthClient: jest.fn(),
+      listOAuthConnections: jest.fn(),
+      revokeOAuthConnection: jest.fn(),
     };
 
     uiamApiKeys = new UiamAPIKeys({

--- a/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/api_keys/uiam/uiam_api_keys.test.ts
@@ -55,6 +55,7 @@ describe('UiamAPIKeys', () => {
       updateOAuthClient: jest.fn(),
       revokeOAuthClient: jest.fn(),
       listOAuthConnections: jest.fn(),
+      updateOAuthConnection: jest.fn(),
       revokeOAuthConnection: jest.fn(),
     };
 

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
@@ -19,6 +19,7 @@ export const authenticationServiceMock = {
       updateClient: jest.fn(),
       revokeClient: jest.fn(),
       listConnections: jest.fn(),
+      updateConnection: jest.fn(),
       revokeConnection: jest.fn(),
     },
     login: jest.fn(),

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.mock.ts
@@ -13,6 +13,14 @@ import type { InternalAuthenticationServiceStart } from './authentication_servic
 export const authenticationServiceMock = {
   createStart: (): DeeplyMockedKeys<InternalAuthenticationServiceStart> => ({
     apiKeys: apiKeysMock.create(),
+    oauth: {
+      createClient: jest.fn(),
+      listClients: jest.fn(),
+      updateClient: jest.fn(),
+      revokeClient: jest.fn(),
+      listConnections: jest.fn(),
+      revokeConnection: jest.fn(),
+    },
     login: jest.fn(),
     logout: jest.fn(),
     getCurrentUser: jest.fn(),

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
@@ -481,6 +481,7 @@ export class AuthenticationService {
             updateClient: uiamOAuth.updateClient.bind(uiamOAuth),
             revokeClient: uiamOAuth.revokeClient.bind(uiamOAuth),
             listConnections: uiamOAuth.listConnections.bind(uiamOAuth),
+            updateConnection: uiamOAuth.updateConnection.bind(uiamOAuth),
             revokeConnection: uiamOAuth.revokeConnection.bind(uiamOAuth),
           }
         : null,

--- a/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authentication_service.ts
@@ -19,7 +19,7 @@ import type {
   Logger,
   LoggerFactory,
 } from '@kbn/core/server';
-import type { APIKeysType } from '@kbn/core-security-server';
+import type { APIKeysType, UiamOAuthType } from '@kbn/core-security-server';
 import type { UserActivityServiceStart } from '@kbn/core-user-activity-server';
 import type { KibanaFeature } from '@kbn/features-plugin/server';
 import { i18n as i18nLib } from '@kbn/i18n';
@@ -36,6 +36,7 @@ import type { ProviderLoginAttempt } from './authenticator';
 import { Authenticator } from './authenticator';
 import { canRedirectRequest } from './can_redirect_request';
 import type { DeauthenticationResult } from './deauthentication_result';
+import { UiamOAuth } from './oauth';
 import type { AuthenticatedUser, SecurityLicense } from '../../common';
 import { KIBANA_AUTH_FULL_HEADER, NEXT_URL_QUERY_STRING_PARAMETER } from '../../common/constants';
 import { shouldProviderUseLoginForm } from '../../common/model';
@@ -90,6 +91,7 @@ export interface InternalAuthenticationServiceStart extends AuthenticationServic
     | 'invalidateAsInternalUser'
     | 'uiam'
   >;
+  oauth: UiamOAuthType | null;
   login: (request: KibanaRequest, attempt: ProviderLoginAttempt) => Promise<AuthenticationResult>;
   logout: (request: KibanaRequest) => Promise<DeauthenticationResult>;
   acknowledgeAccessAgreement: (request: KibanaRequest) => Promise<void>;
@@ -408,6 +410,14 @@ export class AuthenticationService {
         })
       : null;
 
+    const uiamOAuth = uiam
+      ? new UiamOAuth({
+          logger: this.logger.get('oauth-uiam'),
+          license: this.license,
+          uiam,
+        })
+      : null;
+
     /**
      * Retrieves server protocol name/host name/port and merges it with `xpack.security.public` config
      * to construct a server base URL (deprecated, used by the SAML provider only).
@@ -463,6 +473,17 @@ export class AuthenticationService {
             }
           : null,
       },
+
+      oauth: uiamOAuth
+        ? {
+            createClient: uiamOAuth.createClient.bind(uiamOAuth),
+            listClients: uiamOAuth.listClients.bind(uiamOAuth),
+            updateClient: uiamOAuth.updateClient.bind(uiamOAuth),
+            revokeClient: uiamOAuth.revokeClient.bind(uiamOAuth),
+            listConnections: uiamOAuth.listConnections.bind(uiamOAuth),
+            revokeConnection: uiamOAuth.revokeConnection.bind(uiamOAuth),
+          }
+        : null,
 
       login: async (request: KibanaRequest, attempt: ProviderLoginAttempt) => {
         const providerIdentifier =

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { UiamOAuth } from './uiam_oauth';

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -51,22 +51,6 @@ describe('UiamOAuth', () => {
       expect(mockUiam.createOAuthClient).not.toHaveBeenCalled();
     });
 
-    it('throws error when request has no authorization header', async () => {
-      const request = createMockRequest();
-
-      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
-        'Request does not contain an authorization header'
-      );
-    });
-
-    it('throws error when credential is not a UIAM credential', async () => {
-      const request = createMockRequest('Bearer regular_token');
-
-      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
-        'Provided credential is not compatible with UIAM'
-      );
-    });
-
     it('creates an OAuth client successfully', async () => {
       const mockResponse = { id: 'client-id', resource: 'urn:test', client_name: 'Test' };
       mockUiam.createOAuthClient.mockResolvedValue(mockResponse);

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -45,25 +45,31 @@ describe('UiamOAuth', () => {
       mockLicense.isEnabled.mockReturnValue(false);
       const request = createMockRequest('Bearer essu_token');
 
-      const result = await uiamOAuth.createClient(request, { resource: 'urn:test' });
+      const result = await uiamOAuth.createClient(request, {
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      });
 
       expect(result).toBeNull();
       expect(mockUiam.createOAuthClient).not.toHaveBeenCalled();
     });
 
     it('creates an OAuth client successfully', async () => {
-      const mockResponse = { id: 'client-id', resource: 'urn:test', client_name: 'Test' };
+      const mockResponse = {
+        id: 'client-id',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        client_name: 'Test',
+      };
       mockUiam.createOAuthClient.mockResolvedValue(mockResponse);
       const request = createMockRequest('Bearer essu_access_token');
 
       const result = await uiamOAuth.createClient(request, {
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Test',
       });
 
       expect(result).toEqual(mockResponse);
       expect(mockUiam.createOAuthClient).toHaveBeenCalledWith('essu_access_token', {
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Test',
       });
     });
@@ -71,7 +77,7 @@ describe('UiamOAuth', () => {
     it('forwards logo, metadata, and redirect_uris when provided', async () => {
       const mockResponse = {
         id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Test',
         redirect_uris: ['https://example.com/cb'],
         client_logo: { media_type: 'image/png', data: 'abc' },
@@ -80,7 +86,7 @@ describe('UiamOAuth', () => {
       const request = createMockRequest('Bearer essu_access_token');
 
       const params = {
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Test',
         client_type: 'confidential' as const,
         client_metadata: { owner: 'admin' },
@@ -98,9 +104,11 @@ describe('UiamOAuth', () => {
       mockUiam.createOAuthClient.mockRejectedValue(new Error('UIAM error'));
       const request = createMockRequest('Bearer essu_access_token');
 
-      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
-        'UIAM error'
-      );
+      await expect(
+        uiamOAuth.createClient(request, {
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        })
+      ).rejects.toThrow('UIAM error');
 
       expect(logger.error).toHaveBeenCalledWith('Failed to create OAuth client: UIAM error');
     });
@@ -117,7 +125,9 @@ describe('UiamOAuth', () => {
     });
 
     it('lists clients successfully', async () => {
-      const mockResponse = { clients: [{ id: 'c1', resource: 'urn:test' }] };
+      const mockResponse = {
+        clients: [{ id: 'c1', resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud' }],
+      };
       mockUiam.listOAuthClients.mockResolvedValue(mockResponse);
       const request = createMockRequest('Bearer essu_access_token');
 
@@ -139,7 +149,11 @@ describe('UiamOAuth', () => {
     });
 
     it('updates client successfully', async () => {
-      const mockResponse = { id: 'c1', resource: 'urn:test', client_name: 'Updated' };
+      const mockResponse = {
+        id: 'c1',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        client_name: 'Updated',
+      };
       mockUiam.updateOAuthClient.mockResolvedValue(mockResponse);
       const request = createMockRequest('Bearer essu_access_token');
 
@@ -158,7 +172,7 @@ describe('UiamOAuth', () => {
     it('forwards redirect_uris replacement to UIAM', async () => {
       const mockResponse = {
         id: 'c1',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         redirect_uris: ['https://new.example/cb'],
       };
       mockUiam.updateOAuthClient.mockResolvedValue(mockResponse);
@@ -187,7 +201,11 @@ describe('UiamOAuth', () => {
     });
 
     it('revokes client successfully', async () => {
-      const mockResponse = { id: 'c1', resource: 'urn:test', revoked: true };
+      const mockResponse = {
+        id: 'c1',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        revoked: true,
+      };
       mockUiam.revokeOAuthClient.mockResolvedValue(mockResponse);
       const request = createMockRequest('Bearer essu_access_token');
 
@@ -210,7 +228,13 @@ describe('UiamOAuth', () => {
 
     it('lists connections successfully', async () => {
       const mockResponse = {
-        connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
+        connections: [
+          {
+            id: 'conn1',
+            client_id: 'c1',
+            resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          },
+        ],
       };
       mockUiam.listOAuthConnections.mockResolvedValue(mockResponse);
       const request = createMockRequest('Bearer essu_access_token');
@@ -241,7 +265,7 @@ describe('UiamOAuth', () => {
       const mockResponse = {
         id: 'conn1',
         client_id: 'c1',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         name: 'New name',
       };
       mockUiam.updateOAuthConnection.mockResolvedValue(mockResponse);
@@ -288,7 +312,7 @@ describe('UiamOAuth', () => {
       const mockResponse = {
         id: 'conn1',
         client_id: 'c1',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         revoked: true,
       };
       mockUiam.revokeOAuthConnection.mockResolvedValue(mockResponse);

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -68,6 +68,32 @@ describe('UiamOAuth', () => {
       });
     });
 
+    it('forwards logo, metadata, and redirect_uris when provided', async () => {
+      const mockResponse = {
+        id: 'client-id',
+        resource: 'urn:test',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        client_logo: { media_type: 'image/png', data: 'abc' },
+      };
+      mockUiam.createOAuthClient.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const params = {
+        resource: 'urn:test',
+        client_name: 'Test',
+        client_type: 'confidential' as const,
+        client_metadata: { owner: 'admin' },
+        client_logo: { media_type: 'image/png', data: 'abc' },
+        redirect_uris: ['https://example.com/cb'],
+      };
+
+      const result = await uiamOAuth.createClient(request, params);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.createOAuthClient).toHaveBeenCalledWith('essu_access_token', params);
+    });
+
     it('logs and throws error when UIAM call fails', async () => {
       mockUiam.createOAuthClient.mockRejectedValue(new Error('UIAM error'));
       const request = createMockRequest('Bearer essu_access_token');
@@ -128,6 +154,26 @@ describe('UiamOAuth', () => {
         client_metadata: { k: 'v' },
       });
     });
+
+    it('forwards redirect_uris replacement to UIAM', async () => {
+      const mockResponse = {
+        id: 'c1',
+        resource: 'urn:test',
+        redirect_uris: ['https://new.example/cb'],
+      };
+      mockUiam.updateOAuthClient.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const params = {
+        client_metadata: {},
+        redirect_uris: ['https://new.example/cb'],
+      };
+
+      const result = await uiamOAuth.updateClient(request, 'c1', params);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.updateOAuthClient).toHaveBeenCalledWith('essu_access_token', 'c1', params);
+    });
   });
 
   describe('revokeClient()', () => {
@@ -176,6 +222,54 @@ describe('UiamOAuth', () => {
         'essu_access_token',
         'c1',
         'conn1'
+      );
+    });
+  });
+
+  describe('updateConnection()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.updateConnection(request, 'c1', 'conn1', { name: 'New' });
+
+      expect(result).toBeNull();
+      expect(mockUiam.updateOAuthConnection).not.toHaveBeenCalled();
+    });
+
+    it('updates connection successfully', async () => {
+      const mockResponse = {
+        id: 'conn1',
+        client_id: 'c1',
+        resource: 'urn:test',
+        name: 'New name',
+      };
+      mockUiam.updateOAuthConnection.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.updateConnection(request, 'c1', 'conn1', {
+        name: 'New name',
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.updateOAuthConnection).toHaveBeenCalledWith(
+        'essu_access_token',
+        'c1',
+        'conn1',
+        { name: 'New name' }
+      );
+    });
+
+    it('logs and throws error when UIAM call fails', async () => {
+      mockUiam.updateOAuthConnection.mockRejectedValue(new Error('UIAM error'));
+      const request = createMockRequest('Bearer essu_access_token');
+
+      await expect(
+        uiamOAuth.updateConnection(request, 'c1', 'conn1', { name: 'x' })
+      ).rejects.toThrow('UIAM error');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to update OAuth connection conn1: UIAM error'
       );
     });
   });

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core/server';
+import { httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import type { Logger } from '@kbn/logging';
+
+import { UiamOAuth } from './uiam_oauth';
+import type { SecurityLicense } from '../../../common';
+import { licenseMock } from '../../../common/licensing/index.mock';
+import type { UiamServicePublic } from '../../uiam';
+import { uiamServiceMock } from '../../uiam/uiam_service.mock';
+
+describe('UiamOAuth', () => {
+  let uiamOAuth: UiamOAuth;
+  let mockLicense: jest.Mocked<SecurityLicense>;
+  let mockUiam: jest.Mocked<UiamServicePublic>;
+  let logger: Logger;
+
+  const createMockRequest = (authHeader?: string): KibanaRequest => {
+    return httpServerMock.createKibanaRequest({
+      headers: authHeader ? { authorization: authHeader } : {},
+    });
+  };
+
+  beforeEach(() => {
+    mockLicense = licenseMock.create();
+    mockLicense.isEnabled.mockReturnValue(true);
+    logger = loggingSystemMock.create().get('oauth-uiam');
+    mockUiam = uiamServiceMock.create();
+
+    uiamOAuth = new UiamOAuth({
+      logger,
+      license: mockLicense,
+      uiam: mockUiam,
+    });
+  });
+
+  describe('createClient()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.createClient(request, { resource: 'urn:test' });
+
+      expect(result).toBeNull();
+      expect(mockUiam.createOAuthClient).not.toHaveBeenCalled();
+    });
+
+    it('throws error when request has no authorization header', async () => {
+      const request = createMockRequest();
+
+      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
+        'Request does not contain an authorization header'
+      );
+    });
+
+    it('throws error when credential is not a UIAM credential', async () => {
+      const request = createMockRequest('Bearer regular_token');
+
+      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
+        'Provided credential is not compatible with UIAM'
+      );
+    });
+
+    it('creates an OAuth client successfully', async () => {
+      const mockResponse = { id: 'client-id', resource: 'urn:test', client_name: 'Test' };
+      mockUiam.createOAuthClient.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.createClient(request, {
+        resource: 'urn:test',
+        client_name: 'Test',
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.createOAuthClient).toHaveBeenCalledWith('essu_access_token', {
+        resource: 'urn:test',
+        client_name: 'Test',
+      });
+    });
+
+    it('logs and throws error when UIAM call fails', async () => {
+      mockUiam.createOAuthClient.mockRejectedValue(new Error('UIAM error'));
+      const request = createMockRequest('Bearer essu_access_token');
+
+      await expect(uiamOAuth.createClient(request, { resource: 'urn:test' })).rejects.toThrow(
+        'UIAM error'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to create OAuth client: UIAM error');
+    });
+  });
+
+  describe('listClients()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.listClients(request);
+
+      expect(result).toBeNull();
+    });
+
+    it('lists clients successfully', async () => {
+      const mockResponse = { clients: [{ id: 'c1', resource: 'urn:test' }] };
+      mockUiam.listOAuthClients.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.listClients(request, 'c1');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.listOAuthClients).toHaveBeenCalledWith('essu_access_token', 'c1');
+    });
+  });
+
+  describe('updateClient()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.updateClient(request, 'c1', { client_metadata: {} });
+
+      expect(result).toBeNull();
+    });
+
+    it('updates client successfully', async () => {
+      const mockResponse = { id: 'c1', resource: 'urn:test', client_name: 'Updated' };
+      mockUiam.updateOAuthClient.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.updateClient(request, 'c1', {
+        client_name: 'Updated',
+        client_metadata: { k: 'v' },
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.updateOAuthClient).toHaveBeenCalledWith('essu_access_token', 'c1', {
+        client_name: 'Updated',
+        client_metadata: { k: 'v' },
+      });
+    });
+  });
+
+  describe('revokeClient()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.revokeClient(request, 'c1');
+
+      expect(result).toBeNull();
+    });
+
+    it('revokes client successfully', async () => {
+      const mockResponse = { id: 'c1', resource: 'urn:test', revoked: true };
+      mockUiam.revokeOAuthClient.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.revokeClient(request, 'c1', 'done');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.revokeOAuthClient).toHaveBeenCalledWith('essu_access_token', 'c1', 'done');
+    });
+  });
+
+  describe('listConnections()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.listConnections(request);
+
+      expect(result).toBeNull();
+    });
+
+    it('lists connections successfully', async () => {
+      const mockResponse = {
+        connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
+      };
+      mockUiam.listOAuthConnections.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.listConnections(request, 'c1', 'conn1');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.listOAuthConnections).toHaveBeenCalledWith(
+        'essu_access_token',
+        'c1',
+        'conn1'
+      );
+    });
+  });
+
+  describe('revokeConnection()', () => {
+    it('returns null when license is not enabled', async () => {
+      mockLicense.isEnabled.mockReturnValue(false);
+      const request = createMockRequest('Bearer essu_token');
+
+      const result = await uiamOAuth.revokeConnection(request, 'c1', 'conn1');
+
+      expect(result).toBeNull();
+    });
+
+    it('revokes connection successfully', async () => {
+      const mockResponse = {
+        id: 'conn1',
+        client_id: 'c1',
+        resource: 'urn:test',
+        revoked: true,
+      };
+      mockUiam.revokeOAuthConnection.mockResolvedValue(mockResponse);
+      const request = createMockRequest('Bearer essu_access_token');
+
+      const result = await uiamOAuth.revokeConnection(request, 'c1', 'conn1', 'reason');
+
+      expect(result).toEqual(mockResponse);
+      expect(mockUiam.revokeOAuthConnection).toHaveBeenCalledWith(
+        'essu_access_token',
+        'c1',
+        'conn1',
+        'reason'
+      );
+    });
+  });
+
+  describe('getAccessToken()', () => {
+    it('extracts UIAM access token from request', () => {
+      const request = createMockRequest('Bearer essu_my_token');
+
+      expect(UiamOAuth.getAccessToken(request)).toBe('essu_my_token');
+    });
+
+    it('throws when authorization header is missing', () => {
+      const request = createMockRequest();
+
+      expect(() => UiamOAuth.getAccessToken(request)).toThrow(
+        'Request does not contain an authorization header'
+      );
+    });
+
+    it('throws when credential is not a UIAM credential', () => {
+      const request = createMockRequest('Bearer regular_token');
+
+      expect(() => UiamOAuth.getAccessToken(request)).toThrow(
+        'Provided credential is not compatible with UIAM'
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -15,6 +15,7 @@ import type {
   UiamOAuthConnectionResponse,
   UiamOAuthType,
   UpdateUiamOAuthClientParams,
+  UpdateUiamOAuthConnectionParams,
 } from '@kbn/core-security-server';
 
 import type { SecurityLicense } from '../../../common';
@@ -142,6 +143,36 @@ export class UiamOAuth implements UiamOAuthType {
       return result;
     } catch (e) {
       this.logger.error(`Failed to list OAuth connections: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async updateConnection(
+    request: KibanaRequest,
+    clientId: string,
+    connectionId: string,
+    params: UpdateUiamOAuthConnectionParams
+  ): Promise<UiamOAuthConnectionResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug(`Attempting to update OAuth connection ${connectionId}`);
+
+    try {
+      const result = await this.uiam.updateOAuthConnection(
+        accessToken,
+        clientId,
+        connectionId,
+        params
+      );
+      this.logger.debug(`OAuth connection ${connectionId} updated successfully`);
+      return result;
+    } catch (e) {
+      this.logger.error(
+        `Failed to update OAuth connection ${connectionId}: ${getDetailedErrorMessage(e)}`
+      );
       throw e;
     }
   }

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest, Logger } from '@kbn/core/server';
+import { HTTPAuthorizationHeader, isUiamCredential } from '@kbn/core-security-server';
+import type {
+  CreateUiamOAuthClientParams,
+  UiamOAuthClientResponse,
+  UiamOAuthConnectionResponse,
+  UiamOAuthType,
+  UpdateUiamOAuthClientParams,
+} from '@kbn/core-security-server';
+
+import type { SecurityLicense } from '../../../common';
+import { getDetailedErrorMessage } from '../../errors';
+import type { UiamServicePublic } from '../../uiam';
+
+export interface UiamOAuthOptions {
+  logger: Logger;
+  license: SecurityLicense;
+  uiam: UiamServicePublic;
+}
+
+export class UiamOAuth implements UiamOAuthType {
+  private readonly logger: Logger;
+  private readonly license: SecurityLicense;
+  private readonly uiam: UiamServicePublic;
+
+  constructor({ logger, license, uiam }: UiamOAuthOptions) {
+    this.logger = logger;
+    this.license = license;
+    this.uiam = uiam;
+  }
+
+  async createClient(
+    request: KibanaRequest,
+    params: CreateUiamOAuthClientParams
+  ): Promise<UiamOAuthClientResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug('Trying to create an OAuth client');
+
+    try {
+      const result = await this.uiam.createOAuthClient(accessToken, params);
+      this.logger.debug(`OAuth client created successfully with id ${result.id}`);
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to create OAuth client: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async listClients(
+    request: KibanaRequest,
+    clientId?: string
+  ): Promise<{ clients: UiamOAuthClientResponse[] } | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug('Trying to list OAuth clients');
+
+    try {
+      const result = await this.uiam.listOAuthClients(accessToken, clientId);
+      this.logger.debug('OAuth clients listed successfully');
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to list OAuth clients: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async updateClient(
+    request: KibanaRequest,
+    clientId: string,
+    params: UpdateUiamOAuthClientParams
+  ): Promise<UiamOAuthClientResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug(`Trying to update OAuth client ${clientId}`);
+
+    try {
+      const result = await this.uiam.updateOAuthClient(accessToken, clientId, {
+        client_name: params.client_name,
+        client_metadata: params.client_metadata,
+      });
+      this.logger.debug(`OAuth client ${clientId} updated successfully`);
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to update OAuth client ${clientId}: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async revokeClient(
+    request: KibanaRequest,
+    clientId: string,
+    reason?: string
+  ): Promise<UiamOAuthClientResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug(`Trying to revoke OAuth client ${clientId}`);
+
+    try {
+      const result = await this.uiam.revokeOAuthClient(accessToken, clientId, reason);
+      this.logger.debug(`OAuth client ${clientId} revoked successfully`);
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to revoke OAuth client ${clientId}: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async listConnections(
+    request: KibanaRequest,
+    clientId?: string,
+    connectionId?: string
+  ): Promise<{ connections: UiamOAuthConnectionResponse[] } | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug('Trying to list OAuth connections');
+
+    try {
+      const result = await this.uiam.listOAuthConnections(accessToken, clientId, connectionId);
+      this.logger.debug('OAuth connections listed successfully');
+      return result;
+    } catch (e) {
+      this.logger.error(`Failed to list OAuth connections: ${getDetailedErrorMessage(e)}`);
+      throw e;
+    }
+  }
+
+  async revokeConnection(
+    request: KibanaRequest,
+    clientId: string,
+    connectionId: string,
+    reason?: string
+  ): Promise<UiamOAuthConnectionResponse | null> {
+    if (!this.license.isEnabled()) {
+      return null;
+    }
+
+    const accessToken = UiamOAuth.getAccessToken(request);
+    this.logger.debug(`Trying to revoke OAuth connection ${connectionId}`);
+
+    try {
+      const result = await this.uiam.revokeOAuthConnection(
+        accessToken,
+        clientId,
+        connectionId,
+        reason
+      );
+      this.logger.debug(`OAuth connection ${connectionId} revoked successfully`);
+      return result;
+    } catch (e) {
+      this.logger.error(
+        `Failed to revoke OAuth connection ${connectionId}: ${getDetailedErrorMessage(e)}`
+      );
+      throw e;
+    }
+  }
+
+  /**
+   * Extracts the Bearer access token from the request. The token must be a UIAM credential.
+   */
+  static getAccessToken(request: KibanaRequest): string {
+    const authorization = HTTPAuthorizationHeader.parseFromRequest(request);
+
+    if (!authorization) {
+      throw new Error('Request does not contain an authorization header');
+    }
+
+    if (!isUiamCredential(authorization)) {
+      throw new Error('Provided credential is not compatible with UIAM');
+    }
+
+    return authorization.credentials;
+  }
+}

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -47,7 +47,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug('Trying to create an OAuth client');
+    this.logger.debug('Attempting to create an OAuth client');
 
     try {
       const result = await this.uiam.createOAuthClient(accessToken, params);
@@ -68,7 +68,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug('Trying to list OAuth clients');
+    this.logger.debug('Attempting to list OAuth clients');
 
     try {
       const result = await this.uiam.listOAuthClients(accessToken, clientId);
@@ -90,7 +90,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug(`Trying to update OAuth client ${clientId}`);
+    this.logger.debug(`Attempting to update OAuth client ${clientId}`);
 
     try {
       const result = await this.uiam.updateOAuthClient(accessToken, clientId, params);
@@ -112,7 +112,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug(`Trying to revoke OAuth client ${clientId}`);
+    this.logger.debug(`Attempting to revoke OAuth client ${clientId}`);
 
     try {
       const result = await this.uiam.revokeOAuthClient(accessToken, clientId, reason);
@@ -134,7 +134,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug('Trying to list OAuth connections');
+    this.logger.debug('Attempting to list OAuth connections');
 
     try {
       const result = await this.uiam.listOAuthConnections(accessToken, clientId, connectionId);
@@ -157,7 +157,7 @@ export class UiamOAuth implements UiamOAuthType {
     }
 
     const accessToken = UiamOAuth.getAccessToken(request);
-    this.logger.debug(`Trying to revoke OAuth connection ${connectionId}`);
+    this.logger.debug(`Attempting to revoke OAuth connection ${connectionId}`);
 
     try {
       const result = await this.uiam.revokeOAuthConnection(

--- a/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/oauth/uiam_oauth.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
+
 import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { HTTPAuthorizationHeader, isUiamCredential } from '@kbn/core-security-server';
 import type {
@@ -91,10 +93,7 @@ export class UiamOAuth implements UiamOAuthType {
     this.logger.debug(`Trying to update OAuth client ${clientId}`);
 
     try {
-      const result = await this.uiam.updateOAuthClient(accessToken, clientId, {
-        client_name: params.client_name,
-        client_metadata: params.client_metadata,
-      });
+      const result = await this.uiam.updateOAuthClient(accessToken, clientId, params);
       this.logger.debug(`OAuth client ${clientId} updated successfully`);
       return result;
     } catch (e) {
@@ -184,11 +183,11 @@ export class UiamOAuth implements UiamOAuthType {
     const authorization = HTTPAuthorizationHeader.parseFromRequest(request);
 
     if (!authorization) {
-      throw new Error('Request does not contain an authorization header');
+      throw Boom.unauthorized('Request does not contain an authorization header');
     }
 
     if (!isUiamCredential(authorization)) {
-      throw new Error('Provided credential is not compatible with UIAM');
+      throw Boom.badRequest('Provided credential is not compatible with UIAM');
     }
 
     return authorization.credentials;

--- a/x-pack/platform/plugins/shared/security/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/index.ts
@@ -21,6 +21,7 @@ import { defineAuthorizationRoutes } from './authorization';
 import { defineDeprecationsRoutes } from './deprecations';
 import { defineSecurityFeatureRoutes } from './feature_check';
 import { defineIndicesRoutes } from './indices';
+import { defineOAuthRoutes } from './oauth';
 import { defineOAuthMetadataRoutes } from './oauth_metadata';
 import { defineRoleMappingRoutes } from './role_mapping';
 import { defineSecurityCheckupGetStateRoutes } from './security_checkup';
@@ -69,6 +70,7 @@ export function defineRoutes(params: RouteDefinitionParams) {
   defineAuthenticationRoutes(params);
   defineAuthorizationRoutes(params);
   defineOAuthMetadataRoutes(params);
+  defineOAuthRoutes(params);
   defineSessionManagementRoutes(params);
   defineUserProfileRoutes(params);
   defineUsersRoutes(params); // Temporarily allow user APIs (ToDo: move to non-serverless block below)

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -73,7 +73,7 @@ describe('Create OAuth Client route', () => {
   });
 
   it('returns 404 when OAuth is not available', async () => {
-    authc.oauth = null as any;
+    authc.oauth = null;
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -57,13 +57,20 @@ describe('Create OAuth Client route', () => {
   });
 
   it('returns created client on success', async () => {
-    const mockClient = { id: 'client-1', resource: 'urn:test', client_name: 'Test' };
+    const mockClient = {
+      id: 'client-1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      client_name: 'Test',
+    };
     oauthMock.createClient.mockResolvedValue(mockClient);
 
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        body: { resource: 'urn:test', client_name: 'Test' },
+        body: {
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          client_name: 'Test',
+        },
       }),
       kibanaResponseFactory
     );
@@ -78,7 +85,7 @@ describe('Create OAuth Client route', () => {
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        body: { resource: 'urn:test' },
+        body: { resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud' },
       }),
       kibanaResponseFactory
     );
@@ -93,7 +100,7 @@ describe('Create OAuth Client route', () => {
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        body: { resource: 'urn:test' },
+        body: { resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud' },
       }),
       kibanaResponseFactory
     );

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineCreateOAuthClientRoute } from './create_client';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('Create OAuth Client route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineCreateOAuthClientRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.post.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/oauth/clients'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns result of license checker', async () => {
+    const mockContext = getMockContext({ state: 'invalid', message: 'test forbidden message' });
+    const response = await routeHandler(
+      mockContext,
+      httpServerMock.createKibanaRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.payload).toEqual({ message: 'test forbidden message' });
+  });
+
+  it('returns created client on success', async () => {
+    const mockClient = { id: 'client-1', resource: 'urn:test', client_name: 'Test' };
+    oauthMock.createClient.mockResolvedValue(mockClient);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        body: { resource: 'urn:test', client_name: 'Test' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockClient);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        body: { resource: 'urn:test' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    const error = Boom.badRequest('Invalid resource');
+    oauthMock.createClient.mockRejectedValue(error);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        body: { resource: 'urn:test' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { clientLogoSchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -33,12 +34,7 @@ export function defineCreateOAuthClientRoute({
             schema.oneOf([schema.literal('public'), schema.literal('confidential')])
           ),
           client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-          client_logo: schema.maybe(
-            schema.object({
-              media_type: schema.string(),
-              data: schema.string(),
-            })
-          ),
+          client_logo: schema.maybe(clientLogoSchema),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -29,19 +29,15 @@ export function defineCreateOAuthClientRoute({
         body: schema.object({
           resource: schema.string(),
           client_name: schema.maybe(schema.string()),
+          client_type: schema.maybe(
+            schema.oneOf([schema.literal('public'), schema.literal('confidential')])
+          ),
           client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
           client_logo: schema.maybe(
-            schema.oneOf([
-              schema.object({
-                type: schema.literal('url'),
-                url: schema.string(),
-              }),
-              schema.object({
-                type: schema.literal('base64'),
-                media_type: schema.string(),
-                data: schema.string(),
-              }),
-            ])
+            schema.object({
+              media_type: schema.string(),
+              data: schema.string(),
+            })
           ),
         }),
       },

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -30,6 +30,19 @@ export function defineCreateOAuthClientRoute({
           resource: schema.string(),
           client_name: schema.maybe(schema.string()),
           client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+          client_logo: schema.maybe(
+            schema.oneOf([
+              schema.object({
+                type: schema.literal('url'),
+                url: schema.string(),
+              }),
+              schema.object({
+                type: schema.literal('base64'),
+                media_type: schema.string(),
+                data: schema.string(),
+              }),
+            ])
+          ),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineCreateOAuthClientRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.post(
+    {
+      path: '/internal/security/oauth/clients',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        body: schema.object({
+          resource: schema.string(),
+          client_name: schema.maybe(schema.string()),
+          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.createClient(request, request.body);
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/create_client.ts
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import { schema } from '@kbn/config-schema';
-
-import { clientLogoSchema } from './schemas';
+import { createClientBodySchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,15 +25,7 @@ export function defineCreateOAuthClientRoute({
         },
       },
       validate: {
-        body: schema.object({
-          resource: schema.string(),
-          client_name: schema.maybe(schema.string()),
-          client_type: schema.maybe(
-            schema.oneOf([schema.literal('public'), schema.literal('confidential')])
-          ),
-          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-          client_logo: schema.maybe(clientLogoSchema),
-        }),
+        body: createClientBodySchema,
       },
       options: {
         access: 'internal',

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
@@ -57,7 +57,11 @@ describe('Get OAuth Client route', () => {
   });
 
   it('returns single client on success', async () => {
-    const mockClient = { id: 'client-1', resource: 'urn:test', client_name: 'Test' };
+    const mockClient = {
+      id: 'client-1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      client_name: 'Test',
+    };
     oauthMock.listClients.mockResolvedValue({ clients: [mockClient] });
 
     const response = await routeHandler(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.test.ts
@@ -13,12 +13,12 @@ import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { UiamOAuthType } from '@kbn/core-security-server';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
-import { defineListOAuthConnectionsRoute } from './list_connections';
+import { defineGetOAuthClientRoute } from './get_client';
 import type { InternalAuthenticationServiceStart } from '../../authentication';
 import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
 import { routeDefinitionParamsMock } from '../index.mock';
 
-describe('List OAuth Connections route', () => {
+describe('Get OAuth Client route', () => {
   function getMockContext(
     licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
   ) {
@@ -36,28 +36,51 @@ describe('List OAuth Connections route', () => {
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
 
-    defineListOAuthConnectionsRoute(mockRouteDefinitionParams);
+    defineGetOAuthClientRoute(mockRouteDefinitionParams);
 
     const [, handler] = mockRouteDefinitionParams.router.get.mock.calls.find(
-      ([{ path }]) => path === '/internal/security/oauth/connections'
+      ([{ path }]) => path === '/internal/security/oauth/clients/{client_id}'
     )!;
     routeHandler = handler;
   });
 
-  it('returns connections list on success', async () => {
-    const mockResponse = {
-      connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
-    };
-    oauthMock.listConnections.mockResolvedValue(mockResponse);
+  it('returns result of license checker', async () => {
+    const mockContext = getMockContext({ state: 'invalid', message: 'test forbidden message' });
+    const response = await routeHandler(
+      mockContext,
+      httpServerMock.createKibanaRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.payload).toEqual({ message: 'test forbidden message' });
+  });
+
+  it('returns single client on success', async () => {
+    const mockClient = { id: 'client-1', resource: 'urn:test', client_name: 'Test' };
+    oauthMock.listClients.mockResolvedValue({ clients: [mockClient] });
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({ params: { client_id: 'client-1' } }),
       kibanaResponseFactory
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload).toEqual(mockResponse);
+    expect(response.payload).toEqual(mockClient);
+    expect(oauthMock.listClients).toHaveBeenCalledWith(expect.anything(), 'client-1');
+  });
+
+  it('returns 404 when client is not found', async () => {
+    oauthMock.listClients.mockResolvedValue({ clients: [] });
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ params: { client_id: 'nonexistent' } }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
   });
 
   it('returns 404 when OAuth is not available', async () => {
@@ -65,7 +88,7 @@ describe('List OAuth Connections route', () => {
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({ params: { client_id: 'client-1' } }),
       kibanaResponseFactory
     );
 
@@ -73,14 +96,14 @@ describe('List OAuth Connections route', () => {
   });
 
   it('returns error from service', async () => {
-    oauthMock.listConnections.mockRejectedValue(Boom.internal('Server error'));
+    oauthMock.listClients.mockRejectedValue(Boom.forbidden('Forbidden'));
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({ params: { client_id: 'client-1' } }),
       kibanaResponseFactory
     );
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(403);
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,7 +28,7 @@ export function defineGetOAuthClientRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_client.ts
@@ -11,13 +11,13 @@ import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 
-export function defineCreateOAuthClientRoute({
+export function defineGetOAuthClientRoute({
   router,
   getAuthenticationService,
 }: RouteDefinitionParams) {
-  router.post(
+  router.get(
     {
-      path: '/internal/security/oauth/clients',
+      path: '/internal/security/oauth/clients/{client_id}',
       security: {
         authz: {
           enabled: false,
@@ -26,19 +26,8 @@ export function defineCreateOAuthClientRoute({
         },
       },
       validate: {
-        body: schema.object({
-          resource: schema.string(),
-          client_name: schema.maybe(schema.string()),
-          client_type: schema.maybe(
-            schema.oneOf([schema.literal('public'), schema.literal('confidential')])
-          ),
-          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-          client_logo: schema.maybe(
-            schema.object({
-              media_type: schema.string(),
-              data: schema.string(),
-            })
-          ),
+        params: schema.object({
+          client_id: schema.string(),
         }),
       },
       options: {
@@ -54,14 +43,21 @@ export function defineCreateOAuthClientRoute({
           });
         }
 
-        const result = await oauth.createClient(request, request.body);
+        const result = await oauth.listClients(request, request.params.client_id);
         if (!result) {
           return response.notFound({
             body: { message: 'OAuth management is not available: security features are disabled' },
           });
         }
 
-        return response.ok({ body: result });
+        const client = result.clients[0];
+        if (!client) {
+          return response.notFound({
+            body: { message: `OAuth client [${request.params.client_id}] not found` },
+          });
+        }
+
+        return response.ok({ body: client });
       } catch (error) {
         return response.customError(wrapIntoCustomErrorResponse(error));
       }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
@@ -13,12 +13,12 @@ import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { UiamOAuthType } from '@kbn/core-security-server';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
-import { defineListOAuthConnectionsRoute } from './list_connections';
+import { defineGetOAuthConnectionRoute } from './get_connection';
 import type { InternalAuthenticationServiceStart } from '../../authentication';
 import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
 import { routeDefinitionParamsMock } from '../index.mock';
 
-describe('List OAuth Connections route', () => {
+describe('Get OAuth Connection route', () => {
   function getMockContext(
     licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
   ) {
@@ -36,28 +36,56 @@ describe('List OAuth Connections route', () => {
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
 
-    defineListOAuthConnectionsRoute(mockRouteDefinitionParams);
+    defineGetOAuthConnectionRoute(mockRouteDefinitionParams);
 
     const [, handler] = mockRouteDefinitionParams.router.get.mock.calls.find(
-      ([{ path }]) => path === '/internal/security/oauth/connections'
+      ([{ path }]) =>
+        path === '/internal/security/oauth/clients/{client_id}/connections/{connection_id}'
     )!;
     routeHandler = handler;
   });
 
-  it('returns connections list on success', async () => {
-    const mockResponse = {
-      connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
-    };
-    oauthMock.listConnections.mockResolvedValue(mockResponse);
+  it('returns result of license checker', async () => {
+    const mockContext = getMockContext({ state: 'invalid', message: 'test forbidden message' });
+    const response = await routeHandler(
+      mockContext,
+      httpServerMock.createKibanaRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.payload).toEqual({ message: 'test forbidden message' });
+  });
+
+  it('returns single connection on success', async () => {
+    const mockConnection = { id: 'conn-1', client_id: 'client-1', resource: 'urn:test' };
+    oauthMock.listConnections.mockResolvedValue({ connections: [mockConnection] });
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'client-1', connection_id: 'conn-1' },
+      }),
       kibanaResponseFactory
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload).toEqual(mockResponse);
+    expect(response.payload).toEqual(mockConnection);
+    expect(oauthMock.listConnections).toHaveBeenCalledWith(expect.anything(), 'client-1', 'conn-1');
+  });
+
+  it('returns 404 when connection is not found', async () => {
+    oauthMock.listConnections.mockResolvedValue({ connections: [] });
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'client-1', connection_id: 'nonexistent' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
   });
 
   it('returns 404 when OAuth is not available', async () => {
@@ -65,7 +93,9 @@ describe('List OAuth Connections route', () => {
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'client-1', connection_id: 'conn-1' },
+      }),
       kibanaResponseFactory
     );
 
@@ -73,14 +103,16 @@ describe('List OAuth Connections route', () => {
   });
 
   it('returns error from service', async () => {
-    oauthMock.listConnections.mockRejectedValue(Boom.internal('Server error'));
+    oauthMock.listConnections.mockRejectedValue(Boom.forbidden('Forbidden'));
 
     const response = await routeHandler(
       getMockContext(),
-      httpServerMock.createKibanaRequest({ query: {} }),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'client-1', connection_id: 'conn-1' },
+      }),
       kibanaResponseFactory
     );
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(403);
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.test.ts
@@ -58,7 +58,11 @@ describe('Get OAuth Connection route', () => {
   });
 
   it('returns single connection on success', async () => {
-    const mockConnection = { id: 'conn-1', client_id: 'client-1', resource: 'urn:test' };
+    const mockConnection = {
+      id: 'conn-1',
+      client_id: 'client-1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+    };
     oauthMock.listConnections.mockResolvedValue({ connections: [mockConnection] });
 
     const response = await routeHandler(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
@@ -11,13 +11,13 @@ import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 
-export function defineCreateOAuthClientRoute({
+export function defineGetOAuthConnectionRoute({
   router,
   getAuthenticationService,
 }: RouteDefinitionParams) {
-  router.post(
+  router.get(
     {
-      path: '/internal/security/oauth/clients',
+      path: '/internal/security/oauth/clients/{client_id}/connections/{connection_id}',
       security: {
         authz: {
           enabled: false,
@@ -26,19 +26,9 @@ export function defineCreateOAuthClientRoute({
         },
       },
       validate: {
-        body: schema.object({
-          resource: schema.string(),
-          client_name: schema.maybe(schema.string()),
-          client_type: schema.maybe(
-            schema.oneOf([schema.literal('public'), schema.literal('confidential')])
-          ),
-          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
-          client_logo: schema.maybe(
-            schema.object({
-              media_type: schema.string(),
-              data: schema.string(),
-            })
-          ),
+        params: schema.object({
+          client_id: schema.string(),
+          connection_id: schema.string(),
         }),
       },
       options: {
@@ -54,14 +44,27 @@ export function defineCreateOAuthClientRoute({
           });
         }
 
-        const result = await oauth.createClient(request, request.body);
+        const result = await oauth.listConnections(
+          request,
+          request.params.client_id,
+          request.params.connection_id
+        );
         if (!result) {
           return response.notFound({
             body: { message: 'OAuth management is not available: security features are disabled' },
           });
         }
 
-        return response.ok({ body: result });
+        const connection = result.connections[0];
+        if (!connection) {
+          return response.notFound({
+            body: {
+              message: `OAuth connection [${request.params.connection_id}] not found for client [${request.params.client_id}]`,
+            },
+          });
+        }
+
+        return response.ok({ body: connection });
       } catch (error) {
         return response.customError(wrapIntoCustomErrorResponse(error));
       }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/get_connection.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,8 +28,8 @@ export function defineGetOAuthConnectionRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
-          connection_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
+          connection_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
@@ -6,6 +6,8 @@
  */
 
 import { defineCreateOAuthClientRoute } from './create_client';
+import { defineGetOAuthClientRoute } from './get_client';
+import { defineGetOAuthConnectionRoute } from './get_connection';
 import { defineListOAuthClientsRoute } from './list_clients';
 import { defineListOAuthConnectionsRoute } from './list_connections';
 import { defineRevokeOAuthClientRoute } from './revoke_client';
@@ -15,9 +17,11 @@ import type { RouteDefinitionParams } from '..';
 
 export function defineOAuthRoutes(params: RouteDefinitionParams) {
   defineCreateOAuthClientRoute(params);
+  defineGetOAuthClientRoute(params);
   defineListOAuthClientsRoute(params);
   defineUpdateOAuthClientRoute(params);
   defineRevokeOAuthClientRoute(params);
+  defineGetOAuthConnectionRoute(params);
   defineListOAuthConnectionsRoute(params);
   defineRevokeOAuthConnectionRoute(params);
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineCreateOAuthClientRoute } from './create_client';
+import { defineListOAuthClientsRoute } from './list_clients';
+import { defineListOAuthConnectionsRoute } from './list_connections';
+import { defineRevokeOAuthClientRoute } from './revoke_client';
+import { defineRevokeOAuthConnectionRoute } from './revoke_connection';
+import { defineUpdateOAuthClientRoute } from './update_client';
+import type { RouteDefinitionParams } from '..';
+
+export function defineOAuthRoutes(params: RouteDefinitionParams) {
+  defineCreateOAuthClientRoute(params);
+  defineListOAuthClientsRoute(params);
+  defineUpdateOAuthClientRoute(params);
+  defineRevokeOAuthClientRoute(params);
+  defineListOAuthConnectionsRoute(params);
+  defineRevokeOAuthConnectionRoute(params);
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/index.ts
@@ -13,6 +13,7 @@ import { defineListOAuthConnectionsRoute } from './list_connections';
 import { defineRevokeOAuthClientRoute } from './revoke_client';
 import { defineRevokeOAuthConnectionRoute } from './revoke_connection';
 import { defineUpdateOAuthClientRoute } from './update_client';
+import { defineUpdateOAuthConnectionRoute } from './update_connection';
 import type { RouteDefinitionParams } from '..';
 
 export function defineOAuthRoutes(params: RouteDefinitionParams) {
@@ -23,5 +24,6 @@ export function defineOAuthRoutes(params: RouteDefinitionParams) {
   defineRevokeOAuthClientRoute(params);
   defineGetOAuthConnectionRoute(params);
   defineListOAuthConnectionsRoute(params);
+  defineUpdateOAuthConnectionRoute(params);
   defineRevokeOAuthConnectionRoute(params);
 }

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
@@ -70,7 +70,7 @@ describe('List OAuth Clients route', () => {
   });
 
   it('returns 404 when OAuth is not available', async () => {
-    authc.oauth = null as any;
+    authc.oauth = null;
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
@@ -56,7 +56,9 @@ describe('List OAuth Clients route', () => {
   });
 
   it('returns clients list on success', async () => {
-    const mockResponse = { clients: [{ id: 'c1', resource: 'urn:test' }] };
+    const mockResponse = {
+      clients: [{ id: 'c1', resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud' }],
+    };
     oauthMock.listClients.mockResolvedValue(mockResponse);
 
     const response = await routeHandler(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineListOAuthClientsRoute } from './list_clients';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('List OAuth Clients route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineListOAuthClientsRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.get.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/oauth/clients'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns result of license checker', async () => {
+    const mockContext = getMockContext({ state: 'invalid', message: 'test forbidden message' });
+    const response = await routeHandler(
+      mockContext,
+      httpServerMock.createKibanaRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns clients list on success', async () => {
+    const mockResponse = { clients: [{ id: 'c1', resource: 'urn:test' }] };
+    oauthMock.listClients.mockResolvedValue(mockResponse);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockResponse);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    oauthMock.listClients.mockRejectedValue(Boom.forbidden('Forbidden'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineListOAuthClientsRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.get(
+    {
+      path: '/internal/security/oauth/clients',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        query: schema.object({
+          client_id: schema.maybe(schema.string()),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.listClients(request, request.query.client_id);
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,7 +28,9 @@ export function defineListOAuthClientsRoute({
       },
       validate: {
         query: schema.object({
-          client_id: schema.maybe(schema.string()),
+          client_id: schema.maybe(
+            schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })
+          ),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_clients.ts
@@ -39,13 +39,15 @@ export function defineListOAuthClientsRoute({
         const { oauth } = getAuthenticationService();
         if (!oauth) {
           return response.notFound({
-            body: { message: 'OAuth management is not available' },
+            body: { message: 'OAuth management is not available: UIAM is not configured' },
           });
         }
 
         const result = await oauth.listClients(request, request.query.client_id);
         if (!result) {
-          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+          return response.notFound({
+            body: { message: 'OAuth management is not available: security features are disabled' },
+          });
         }
 
         return response.ok({ body: result });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineListOAuthConnectionsRoute } from './list_connections';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('List OAuth Connections route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineListOAuthConnectionsRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.get.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/oauth/connections'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns connections list on success', async () => {
+    const mockResponse = {
+      connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
+    };
+    oauthMock.listConnections.mockResolvedValue(mockResponse);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockResponse);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    oauthMock.listConnections.mockRejectedValue(Boom.internal('Server error'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({ query: {} }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.test.ts
@@ -46,7 +46,13 @@ describe('List OAuth Connections route', () => {
 
   it('returns connections list on success', async () => {
     const mockResponse = {
-      connections: [{ id: 'conn1', client_id: 'c1', resource: 'urn:test' }],
+      connections: [
+        {
+          id: 'conn1',
+          client_id: 'c1',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        },
+      ],
     };
     oauthMock.listConnections.mockResolvedValue(mockResponse);
 

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineListOAuthConnectionsRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.get(
+    {
+      path: '/internal/security/oauth/connections',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        query: schema.object({
+          client_id: schema.maybe(schema.string()),
+          connection_id: schema.maybe(schema.string()),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.listConnections(
+          request,
+          request.query.client_id,
+          request.query.connection_id
+        );
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,8 +28,12 @@ export function defineListOAuthConnectionsRoute({
       },
       validate: {
         query: schema.object({
-          client_id: schema.maybe(schema.string()),
-          connection_id: schema.maybe(schema.string()),
+          client_id: schema.maybe(
+            schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })
+          ),
+          connection_id: schema.maybe(
+            schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })
+          ),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/list_connections.ts
@@ -40,7 +40,7 @@ export function defineListOAuthConnectionsRoute({
         const { oauth } = getAuthenticationService();
         if (!oauth) {
           return response.notFound({
-            body: { message: 'OAuth management is not available' },
+            body: { message: 'OAuth management is not available: UIAM is not configured' },
           });
         }
 
@@ -50,7 +50,9 @@ export function defineListOAuthConnectionsRoute({
           request.query.connection_id
         );
         if (!result) {
-          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+          return response.notFound({
+            body: { message: 'OAuth management is not available: security features are disabled' },
+          });
         }
 
         return response.ok({ body: result });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
@@ -62,7 +62,7 @@ describe('Revoke OAuth Client route', () => {
   });
 
   it('returns 404 when OAuth is not available', async () => {
-    authc.oauth = null as any;
+    authc.oauth = null;
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineRevokeOAuthClientRoute } from './revoke_client';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('Revoke OAuth Client route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineRevokeOAuthClientRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.post.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/oauth/clients/{client_id}/_revoke'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns revoked client on success', async () => {
+    const mockClient = { id: 'c1', resource: 'urn:test', revoked: true };
+    oauthMock.revokeClient.mockResolvedValue(mockClient);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: { reason: 'no longer needed' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockClient);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    oauthMock.revokeClient.mockRejectedValue(Boom.badRequest('Already revoked'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.test.ts
@@ -45,7 +45,11 @@ describe('Revoke OAuth Client route', () => {
   });
 
   it('returns revoked client on success', async () => {
-    const mockClient = { id: 'c1', resource: 'urn:test', revoked: true };
+    const mockClient = {
+      id: 'c1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      revoked: true,
+    };
     oauthMock.revokeClient.mockResolvedValue(mockClient);
 
     const response = await routeHandler(

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineRevokeOAuthClientRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.post(
+    {
+      path: '/internal/security/oauth/clients/{client_id}/_revoke',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        params: schema.object({
+          client_id: schema.string(),
+        }),
+        body: schema.object({
+          reason: schema.maybe(schema.string()),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.revokeClient(
+          request,
+          request.params.client_id,
+          request.body.reason
+        );
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
@@ -42,7 +42,7 @@ export function defineRevokeOAuthClientRoute({
         const { oauth } = getAuthenticationService();
         if (!oauth) {
           return response.notFound({
-            body: { message: 'OAuth management is not available' },
+            body: { message: 'OAuth management is not available: UIAM is not configured' },
           });
         }
 
@@ -52,7 +52,9 @@ export function defineRevokeOAuthClientRoute({
           request.body.reason
         );
         if (!result) {
-          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+          return response.notFound({
+            body: { message: 'OAuth management is not available: security features are disabled' },
+          });
         }
 
         return response.ok({ body: result });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_client.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,10 +28,10 @@ export function defineRevokeOAuthClientRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
         body: schema.object({
-          reason: schema.maybe(schema.string()),
+          reason: schema.maybe(schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
@@ -68,7 +68,7 @@ describe('Revoke OAuth Connection route', () => {
   });
 
   it('returns 404 when OAuth is not available', async () => {
-    authc.oauth = null as any;
+    authc.oauth = null;
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineRevokeOAuthConnectionRoute } from './revoke_connection';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('Revoke OAuth Connection route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineRevokeOAuthConnectionRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.post.mock.calls.find(
+      ([{ path }]) =>
+        path === '/internal/security/oauth/clients/{client_id}/connections/{connection_id}/_revoke'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns revoked connection on success', async () => {
+    const mockConnection = {
+      id: 'conn1',
+      client_id: 'c1',
+      resource: 'urn:test',
+      revoked: true,
+    };
+    oauthMock.revokeConnection.mockResolvedValue(mockConnection);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: { reason: 'revoked by user' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockConnection);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    oauthMock.revokeConnection.mockRejectedValue(Boom.badRequest('Connection not found'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: {},
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.test.ts
@@ -49,7 +49,7 @@ describe('Revoke OAuth Connection route', () => {
     const mockConnection = {
       id: 'conn1',
       client_id: 'c1',
-      resource: 'urn:test',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
       revoked: true,
     };
     oauthMock.revokeConnection.mockResolvedValue(mockConnection);

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { OAUTH_MAX_STRING_FIELD_LENGTH } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -27,11 +28,11 @@ export function defineRevokeOAuthConnectionRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
-          connection_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
+          connection_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
         body: schema.object({
-          reason: schema.maybe(schema.string()),
+          reason: schema.maybe(schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
@@ -43,7 +43,7 @@ export function defineRevokeOAuthConnectionRoute({
         const { oauth } = getAuthenticationService();
         if (!oauth) {
           return response.notFound({
-            body: { message: 'OAuth management is not available' },
+            body: { message: 'OAuth management is not available: UIAM is not configured' },
           });
         }
 
@@ -54,7 +54,9 @@ export function defineRevokeOAuthConnectionRoute({
           request.body.reason
         );
         if (!result) {
-          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+          return response.notFound({
+            body: { message: 'OAuth management is not available: security features are disabled' },
+          });
         }
 
         return response.ok({ body: result });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/revoke_connection.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineRevokeOAuthConnectionRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.post(
+    {
+      path: '/internal/security/oauth/clients/{client_id}/connections/{connection_id}/_revoke',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        params: schema.object({
+          client_id: schema.string(),
+          connection_id: schema.string(),
+        }),
+        body: schema.object({
+          reason: schema.maybe(schema.string()),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.revokeConnection(
+          request,
+          request.params.client_id,
+          request.params.connection_id,
+          request.body.reason
+        );
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+// Max base64-encoded logo data length (256KB), consistent with the UIAM API.
+const CLIENT_LOGO_MAX_DATA_LENGTH = 262144;
+
+export const clientLogoSchema = schema.object({
+  media_type: schema.string(),
+  data: schema.string({ maxLength: CLIENT_LOGO_MAX_DATA_LENGTH }),
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
@@ -11,6 +11,37 @@ import { schema } from '@kbn/config-schema';
 const CLIENT_LOGO_MAX_DATA_LENGTH = 262144;
 
 export const clientLogoSchema = schema.object({
-  media_type: schema.string(),
-  data: schema.string({ maxLength: CLIENT_LOGO_MAX_DATA_LENGTH }),
+  media_type: schema.oneOf([
+    schema.literal('image/png'),
+    schema.literal('image/jpeg'),
+    schema.literal('image/gif'),
+  ]),
+  data: schema.string({ minLength: 1, maxLength: CLIENT_LOGO_MAX_DATA_LENGTH }),
+});
+
+export const clientTypeSchema = schema.oneOf([
+  schema.literal('public'),
+  schema.literal('confidential'),
+]);
+
+export const redirectUrisSchema = schema.arrayOf(schema.string({ minLength: 1 }));
+
+export const createClientBodySchema = schema.object({
+  resource: schema.string(),
+  client_name: schema.maybe(schema.string()),
+  client_type: schema.maybe(clientTypeSchema),
+  client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+  client_logo: schema.maybe(clientLogoSchema),
+  redirect_uris: schema.maybe(redirectUrisSchema),
+});
+
+export const updateClientBodySchema = schema.object({
+  client_name: schema.maybe(schema.nullable(schema.string())),
+  client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.nullable(schema.string()))),
+  client_logo: schema.maybe(schema.nullable(clientLogoSchema)),
+  redirect_uris: schema.maybe(redirectUrisSchema),
+});
+
+export const updateConnectionBodySchema = schema.object({
+  name: schema.string({ minLength: 1 }),
 });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
@@ -10,6 +10,12 @@ import { schema } from '@kbn/config-schema';
 // Max base64-encoded logo data length (256KB), consistent with the UIAM API.
 const CLIENT_LOGO_MAX_DATA_LENGTH = 262144;
 
+// Upper bound on registered redirect URIs per OAuth client. UIAM does not enforce
+// a server-side cap, so this guards Kibana against unbounded-array DoS inputs.
+// 32 leaves ample headroom versus realistic client usage (localhost + a handful
+// of environment-specific callbacks).
+const REDIRECT_URIS_MAX_SIZE = 32;
+
 export const clientLogoSchema = schema.object({
   media_type: schema.oneOf([
     schema.literal('image/png'),
@@ -24,7 +30,9 @@ export const clientTypeSchema = schema.oneOf([
   schema.literal('confidential'),
 ]);
 
-export const redirectUrisSchema = schema.arrayOf(schema.string({ minLength: 1 }));
+export const redirectUrisSchema = schema.arrayOf(schema.string({ minLength: 1 }), {
+  maxSize: REDIRECT_URIS_MAX_SIZE,
+});
 
 export const createClientBodySchema = schema.object({
   resource: schema.string(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/schemas.ts
@@ -16,6 +16,13 @@ const CLIENT_LOGO_MAX_DATA_LENGTH = 262144;
 // of environment-specific callbacks).
 const REDIRECT_URIS_MAX_SIZE = 32;
 
+// Generic cap for short, identifier/name-like string fields (client IDs, names,
+// metadata keys/values, revocation reasons).
+export const OAUTH_MAX_STRING_FIELD_LENGTH = 1024;
+
+// Cap for URI-like string fields (client `resource`, redirect URIs).
+export const OAUTH_MAX_URI_LENGTH = 2048;
+
 export const clientLogoSchema = schema.object({
   media_type: schema.oneOf([
     schema.literal('image/png'),
@@ -30,26 +37,41 @@ export const clientTypeSchema = schema.oneOf([
   schema.literal('confidential'),
 ]);
 
-export const redirectUrisSchema = schema.arrayOf(schema.string({ minLength: 1 }), {
-  maxSize: REDIRECT_URIS_MAX_SIZE,
-});
+export const redirectUrisSchema = schema.arrayOf(
+  schema.string({ minLength: 1, maxLength: OAUTH_MAX_URI_LENGTH }),
+  {
+    maxSize: REDIRECT_URIS_MAX_SIZE,
+  }
+);
+
+export const clientMetadataSchema = schema.recordOf(
+  schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
+  schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })
+);
+
+export const nullableClientMetadataSchema = schema.recordOf(
+  schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
+  schema.nullable(schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }))
+);
 
 export const createClientBodySchema = schema.object({
-  resource: schema.string(),
-  client_name: schema.maybe(schema.string()),
+  resource: schema.string({ minLength: 1, maxLength: OAUTH_MAX_URI_LENGTH }),
+  client_name: schema.maybe(schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH })),
   client_type: schema.maybe(clientTypeSchema),
-  client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+  client_metadata: schema.maybe(clientMetadataSchema),
   client_logo: schema.maybe(clientLogoSchema),
   redirect_uris: schema.maybe(redirectUrisSchema),
 });
 
 export const updateClientBodySchema = schema.object({
-  client_name: schema.maybe(schema.nullable(schema.string())),
-  client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.nullable(schema.string()))),
+  client_name: schema.maybe(
+    schema.nullable(schema.string({ maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }))
+  ),
+  client_metadata: schema.maybe(nullableClientMetadataSchema),
   client_logo: schema.maybe(schema.nullable(clientLogoSchema)),
   redirect_uris: schema.maybe(redirectUrisSchema),
 });
 
 export const updateConnectionBodySchema = schema.object({
-  name: schema.string({ minLength: 1 }),
+  name: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
 });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
@@ -62,7 +62,7 @@ describe('Update OAuth Client route', () => {
   });
 
   it('returns 404 when OAuth is not available', async () => {
-    authc.oauth = null as any;
+    authc.oauth = null;
 
     const response = await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+
+import type { RequestHandler } from '@kbn/core/server';
+import { kibanaResponseFactory } from '@kbn/core/server';
+import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
+import type { UiamOAuthType } from '@kbn/core-security-server';
+import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+
+import { defineUpdateOAuthClientRoute } from './update_client';
+import type { InternalAuthenticationServiceStart } from '../../authentication';
+import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
+import { routeDefinitionParamsMock } from '../index.mock';
+
+describe('Update OAuth Client route', () => {
+  function getMockContext(
+    licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
+  ) {
+    return coreMock.createCustomRequestHandlerContext({
+      licensing: { license: { check: jest.fn().mockReturnValue(licenseCheckResult) } },
+    });
+  }
+
+  let routeHandler: RequestHandler<any, any, any, any>;
+  let authc: DeeplyMockedKeys<InternalAuthenticationServiceStart>;
+  let oauthMock: jest.Mocked<UiamOAuthType>;
+  beforeEach(() => {
+    authc = authenticationServiceMock.createStart();
+    oauthMock = authc.oauth as jest.Mocked<UiamOAuthType>;
+    const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
+    mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
+
+    defineUpdateOAuthClientRoute(mockRouteDefinitionParams);
+
+    const [, handler] = mockRouteDefinitionParams.router.patch.mock.calls.find(
+      ([{ path }]) => path === '/internal/security/oauth/clients/{client_id}'
+    )!;
+    routeHandler = handler;
+  });
+
+  it('returns updated client on success', async () => {
+    const mockClient = { id: 'c1', resource: 'urn:test', client_name: 'Updated' };
+    oauthMock.updateClient.mockResolvedValue(mockClient);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: { client_name: 'Updated', client_metadata: {} },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toEqual(mockClient);
+  });
+
+  it('returns 404 when OAuth is not available', async () => {
+    authc.oauth = null as any;
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: { client_metadata: {} },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns error from service', async () => {
+    oauthMock.updateClient.mockRejectedValue(Boom.notFound('Not found'));
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1' },
+        body: { client_metadata: {} },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.test.ts
@@ -45,7 +45,11 @@ describe('Update OAuth Client route', () => {
   });
 
   it('returns updated client on success', async () => {
-    const mockClient = { id: 'c1', resource: 'urn:test', client_name: 'Updated' };
+    const mockClient = {
+      id: 'c1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      client_name: 'Updated',
+    };
     oauthMock.updateClient.mockResolvedValue(mockClient);
 
     const response = await routeHandler(
@@ -62,7 +66,10 @@ describe('Update OAuth Client route', () => {
   });
 
   it('defaults client_metadata to {} when omitted to satisfy UIAM PATCH contract', async () => {
-    oauthMock.updateClient.mockResolvedValue({ id: 'c1', resource: 'urn:test' });
+    oauthMock.updateClient.mockResolvedValue({
+      id: 'c1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+    });
 
     await routeHandler(
       getMockContext(),
@@ -80,7 +87,10 @@ describe('Update OAuth Client route', () => {
   });
 
   it('forwards redirect_uris to the service when provided', async () => {
-    oauthMock.updateClient.mockResolvedValue({ id: 'c1', resource: 'urn:test' });
+    oauthMock.updateClient.mockResolvedValue({
+      id: 'c1',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+    });
 
     await routeHandler(
       getMockContext(),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
+import { clientLogoSchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -32,14 +33,7 @@ export function defineUpdateOAuthClientRoute({
         body: schema.object({
           client_name: schema.maybe(schema.nullable(schema.string())),
           client_metadata: schema.recordOf(schema.string(), schema.nullable(schema.string())),
-          client_logo: schema.maybe(
-            schema.nullable(
-              schema.object({
-                media_type: schema.string(),
-                data: schema.string(),
-              })
-            )
-          ),
+          client_logo: schema.maybe(schema.nullable(clientLogoSchema)),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -51,13 +51,15 @@ export function defineUpdateOAuthClientRoute({
         const { oauth } = getAuthenticationService();
         if (!oauth) {
           return response.notFound({
-            body: { message: 'OAuth management is not available' },
+            body: { message: 'OAuth management is not available: UIAM is not configured' },
           });
         }
 
         const result = await oauth.updateClient(request, request.params.client_id, request.body);
         if (!result) {
-          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+          return response.notFound({
+            body: { message: 'OAuth management is not available: security features are disabled' },
+          });
         }
 
         return response.ok({ body: result });

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { updateClientBodySchema } from './schemas';
+import { OAUTH_MAX_STRING_FIELD_LENGTH, updateClientBodySchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -28,7 +28,7 @@ export function defineUpdateOAuthClientRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
         body: updateClientBodySchema,
       },

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -31,7 +31,22 @@ export function defineUpdateOAuthClientRoute({
         }),
         body: schema.object({
           client_name: schema.maybe(schema.nullable(schema.string())),
-          client_metadata: schema.recordOf(schema.string(), schema.string()),
+          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+          client_logo: schema.maybe(
+            schema.nullable(
+              schema.oneOf([
+                schema.object({
+                  type: schema.literal('url'),
+                  url: schema.string(),
+                }),
+                schema.object({
+                  type: schema.literal('base64'),
+                  media_type: schema.string(),
+                  data: schema.string(),
+                }),
+              ])
+            )
+          ),
         }),
       },
       options: {

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -31,20 +31,13 @@ export function defineUpdateOAuthClientRoute({
         }),
         body: schema.object({
           client_name: schema.maybe(schema.nullable(schema.string())),
-          client_metadata: schema.maybe(schema.recordOf(schema.string(), schema.string())),
+          client_metadata: schema.recordOf(schema.string(), schema.nullable(schema.string())),
           client_logo: schema.maybe(
             schema.nullable(
-              schema.oneOf([
-                schema.object({
-                  type: schema.literal('url'),
-                  url: schema.string(),
-                }),
-                schema.object({
-                  type: schema.literal('base64'),
-                  media_type: schema.string(),
-                  data: schema.string(),
-                }),
-              ])
+              schema.object({
+                media_type: schema.string(),
+                data: schema.string(),
+              })
             )
           ),
         }),

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -32,7 +32,9 @@ export function defineUpdateOAuthClientRoute({
         }),
         body: schema.object({
           client_name: schema.maybe(schema.nullable(schema.string())),
-          client_metadata: schema.recordOf(schema.string(), schema.nullable(schema.string())),
+          client_metadata: schema.maybe(
+            schema.recordOf(schema.string(), schema.nullable(schema.string()))
+          ),
           client_logo: schema.maybe(schema.nullable(clientLogoSchema)),
         }),
       },

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_client.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+import type { RouteDefinitionParams } from '..';
+import { wrapIntoCustomErrorResponse } from '../../errors';
+import { createLicensedRouteHandler } from '../licensed_route_handler';
+
+export function defineUpdateOAuthClientRoute({
+  router,
+  getAuthenticationService,
+}: RouteDefinitionParams) {
+  router.patch(
+    {
+      path: '/internal/security/oauth/clients/{client_id}',
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route delegates authorization to the upstream UIAM service via the forwarded access token',
+        },
+      },
+      validate: {
+        params: schema.object({
+          client_id: schema.string(),
+        }),
+        body: schema.object({
+          client_name: schema.maybe(schema.nullable(schema.string())),
+          client_metadata: schema.recordOf(schema.string(), schema.string()),
+        }),
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        const { oauth } = getAuthenticationService();
+        if (!oauth) {
+          return response.notFound({
+            body: { message: 'OAuth management is not available' },
+          });
+        }
+
+        const result = await oauth.updateClient(request, request.params.client_id, request.body);
+        if (!result) {
+          return response.badRequest({ body: { message: 'OAuth management is not available' } });
+        }
+
+        return response.ok({ body: result });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
@@ -49,7 +49,7 @@ describe('Update OAuth Connection route', () => {
     const mockConnection = {
       id: 'conn1',
       client_id: 'c1',
-      resource: 'urn:test',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
       name: 'Updated',
     };
     oauthMock.updateConnection.mockResolvedValue(mockConnection);

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.test.ts
@@ -13,12 +13,12 @@ import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { UiamOAuthType } from '@kbn/core-security-server';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
-import { defineUpdateOAuthClientRoute } from './update_client';
+import { defineUpdateOAuthConnectionRoute } from './update_connection';
 import type { InternalAuthenticationServiceStart } from '../../authentication';
 import { authenticationServiceMock } from '../../authentication/authentication_service.mock';
 import { routeDefinitionParamsMock } from '../index.mock';
 
-describe('Update OAuth Client route', () => {
+describe('Update OAuth Connection route', () => {
   function getMockContext(
     licenseCheckResult: { state: string; message?: string } = { state: 'valid' }
   ) {
@@ -36,64 +36,37 @@ describe('Update OAuth Client route', () => {
     const mockRouteDefinitionParams = routeDefinitionParamsMock.create();
     mockRouteDefinitionParams.getAuthenticationService.mockReturnValue(authc);
 
-    defineUpdateOAuthClientRoute(mockRouteDefinitionParams);
+    defineUpdateOAuthConnectionRoute(mockRouteDefinitionParams);
 
     const [, handler] = mockRouteDefinitionParams.router.patch.mock.calls.find(
-      ([{ path }]) => path === '/internal/security/oauth/clients/{client_id}'
+      ([{ path }]) =>
+        path === '/internal/security/oauth/clients/{client_id}/connections/{connection_id}'
     )!;
     routeHandler = handler;
   });
 
-  it('returns updated client on success', async () => {
-    const mockClient = { id: 'c1', resource: 'urn:test', client_name: 'Updated' };
-    oauthMock.updateClient.mockResolvedValue(mockClient);
+  it('returns updated connection on success', async () => {
+    const mockConnection = {
+      id: 'conn1',
+      client_id: 'c1',
+      resource: 'urn:test',
+      name: 'Updated',
+    };
+    oauthMock.updateConnection.mockResolvedValue(mockConnection);
 
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        params: { client_id: 'c1' },
-        body: { client_name: 'Updated', client_metadata: {} },
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: { name: 'Updated' },
       }),
       kibanaResponseFactory
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload).toEqual(mockClient);
-  });
-
-  it('defaults client_metadata to {} when omitted to satisfy UIAM PATCH contract', async () => {
-    oauthMock.updateClient.mockResolvedValue({ id: 'c1', resource: 'urn:test' });
-
-    await routeHandler(
-      getMockContext(),
-      httpServerMock.createKibanaRequest({
-        params: { client_id: 'c1' },
-        body: { client_name: 'Updated' },
-      }),
-      kibanaResponseFactory
-    );
-
-    expect(oauthMock.updateClient).toHaveBeenCalledWith(expect.anything(), 'c1', {
-      client_name: 'Updated',
-      client_metadata: {},
-    });
-  });
-
-  it('forwards redirect_uris to the service when provided', async () => {
-    oauthMock.updateClient.mockResolvedValue({ id: 'c1', resource: 'urn:test' });
-
-    await routeHandler(
-      getMockContext(),
-      httpServerMock.createKibanaRequest({
-        params: { client_id: 'c1' },
-        body: { redirect_uris: ['https://example.com/cb'] },
-      }),
-      kibanaResponseFactory
-    );
-
-    expect(oauthMock.updateClient).toHaveBeenCalledWith(expect.anything(), 'c1', {
-      redirect_uris: ['https://example.com/cb'],
-      client_metadata: {},
+    expect(response.payload).toEqual(mockConnection);
+    expect(oauthMock.updateConnection).toHaveBeenCalledWith(expect.anything(), 'c1', 'conn1', {
+      name: 'Updated',
     });
   });
 
@@ -103,8 +76,23 @@ describe('Update OAuth Client route', () => {
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        params: { client_id: 'c1' },
-        body: { client_metadata: {} },
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: { name: 'Updated' },
+      }),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when license-disabled service returns null', async () => {
+    oauthMock.updateConnection.mockResolvedValue(null);
+
+    const response = await routeHandler(
+      getMockContext(),
+      httpServerMock.createKibanaRequest({
+        params: { client_id: 'c1', connection_id: 'conn1' },
+        body: { name: 'Updated' },
       }),
       kibanaResponseFactory
     );
@@ -113,13 +101,13 @@ describe('Update OAuth Client route', () => {
   });
 
   it('returns error from service', async () => {
-    oauthMock.updateClient.mockRejectedValue(Boom.notFound('Not found'));
+    oauthMock.updateConnection.mockRejectedValue(Boom.notFound('Connection not found'));
 
     const response = await routeHandler(
       getMockContext(),
       httpServerMock.createKibanaRequest({
-        params: { client_id: 'c1' },
-        body: { client_metadata: {} },
+        params: { client_id: 'c1', connection_id: 'missing' },
+        body: { name: 'Updated' },
       }),
       kibanaResponseFactory
     );

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { updateConnectionBodySchema } from './schemas';
+import { OAUTH_MAX_STRING_FIELD_LENGTH, updateConnectionBodySchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
@@ -28,8 +28,8 @@ export function defineUpdateOAuthConnectionRoute({
       },
       validate: {
         params: schema.object({
-          client_id: schema.string(),
-          connection_id: schema.string(),
+          client_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
+          connection_id: schema.string({ minLength: 1, maxLength: OAUTH_MAX_STRING_FIELD_LENGTH }),
         }),
         body: updateConnectionBodySchema,
       },

--- a/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/oauth/update_connection.ts
@@ -7,18 +7,18 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { updateClientBodySchema } from './schemas';
+import { updateConnectionBodySchema } from './schemas';
 import type { RouteDefinitionParams } from '..';
 import { wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 
-export function defineUpdateOAuthClientRoute({
+export function defineUpdateOAuthConnectionRoute({
   router,
   getAuthenticationService,
 }: RouteDefinitionParams) {
   router.patch(
     {
-      path: '/internal/security/oauth/clients/{client_id}',
+      path: '/internal/security/oauth/clients/{client_id}/connections/{connection_id}',
       security: {
         authz: {
           enabled: false,
@@ -29,8 +29,9 @@ export function defineUpdateOAuthClientRoute({
       validate: {
         params: schema.object({
           client_id: schema.string(),
+          connection_id: schema.string(),
         }),
-        body: updateClientBodySchema,
+        body: updateConnectionBodySchema,
       },
       options: {
         access: 'internal',
@@ -45,10 +46,12 @@ export function defineUpdateOAuthClientRoute({
           });
         }
 
-        const result = await oauth.updateClient(request, request.params.client_id, {
-          ...request.body,
-          client_metadata: request.body.client_metadata ?? {},
-        });
+        const result = await oauth.updateConnection(
+          request,
+          request.params.client_id,
+          request.params.connection_id,
+          request.body
+        );
         if (!result) {
           return response.notFound({
             body: { message: 'OAuth management is not available: security features are disabled' },

--- a/x-pack/platform/plugins/shared/security/server/uiam/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/index.ts
@@ -17,4 +17,5 @@ export {
   type OAuthClientsResponse,
   type OAuthConnectionsResponse,
   type OAuthClientLogo,
+  type OAuthClientType,
 } from './uiam_service';

--- a/x-pack/platform/plugins/shared/security/server/uiam/index.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/index.ts
@@ -10,4 +10,11 @@ export {
   type UiamServicePublic,
   type ConvertUiamApiKeyRequestEntry,
   type ConvertUiamApiKeysResponse,
+  type CreateOAuthClientRequestBody,
+  type PatchOAuthClientRequestBody,
+  type OAuthClientResponse,
+  type OAuthConnectionResponse,
+  type OAuthClientsResponse,
+  type OAuthConnectionsResponse,
+  type OAuthClientLogo,
 } from './uiam_service';

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
@@ -27,5 +27,18 @@ export const uiamServiceMock = {
     exchangeOAuthToken: jest.fn().mockResolvedValue('mock-ephemeral-token'),
     revokeApiKey: jest.fn().mockResolvedValue(undefined),
     convertApiKeys: jest.fn().mockResolvedValue({ results: [] }),
+    createOAuthClient: jest.fn().mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test' }),
+    listOAuthClients: jest.fn().mockResolvedValue({ clients: [] }),
+    updateOAuthClient: jest.fn().mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test' }),
+    revokeOAuthClient: jest
+      .fn()
+      .mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test', revoked: true }),
+    listOAuthConnections: jest.fn().mockResolvedValue({ connections: [] }),
+    revokeOAuthConnection: jest.fn().mockResolvedValue({
+      id: 'mock-connection-id',
+      client_id: 'mock-client-id',
+      resource: 'urn:test',
+      revoked: true,
+    }),
   }),
 };

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
@@ -27,23 +27,31 @@ export const uiamServiceMock = {
     exchangeOAuthToken: jest.fn().mockResolvedValue('mock-ephemeral-token'),
     revokeApiKey: jest.fn().mockResolvedValue(undefined),
     convertApiKeys: jest.fn().mockResolvedValue({ results: [] }),
-    createOAuthClient: jest.fn().mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test' }),
+    createOAuthClient: jest.fn().mockResolvedValue({
+      id: 'mock-client-id',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+    }),
     listOAuthClients: jest.fn().mockResolvedValue({ clients: [] }),
-    updateOAuthClient: jest.fn().mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test' }),
-    revokeOAuthClient: jest
-      .fn()
-      .mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test', revoked: true }),
+    updateOAuthClient: jest.fn().mockResolvedValue({
+      id: 'mock-client-id',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+    }),
+    revokeOAuthClient: jest.fn().mockResolvedValue({
+      id: 'mock-client-id',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+      revoked: true,
+    }),
     listOAuthConnections: jest.fn().mockResolvedValue({ connections: [] }),
     updateOAuthConnection: jest.fn().mockResolvedValue({
       id: 'mock-connection-id',
       client_id: 'mock-client-id',
-      resource: 'urn:test',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
       name: 'mock-connection-name',
     }),
     revokeOAuthConnection: jest.fn().mockResolvedValue({
       id: 'mock-connection-id',
       client_id: 'mock-client-id',
-      resource: 'urn:test',
+      resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
       revoked: true,
     }),
   }),

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.mock.ts
@@ -34,6 +34,12 @@ export const uiamServiceMock = {
       .fn()
       .mockResolvedValue({ id: 'mock-client-id', resource: 'urn:test', revoked: true }),
     listOAuthConnections: jest.fn().mockResolvedValue({ connections: [] }),
+    updateOAuthConnection: jest.fn().mockResolvedValue({
+      id: 'mock-connection-id',
+      client_id: 'mock-client-id',
+      resource: 'urn:test',
+      name: 'mock-connection-name',
+    }),
     revokeOAuthConnection: jest.fn().mockResolvedValue({
       id: 'mock-connection-id',
       client_id: 'mock-client-id',

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -936,6 +936,56 @@ describe('UiamService', () => {
         uiamService.createOAuthClient('access-token', { resource: 'urn:test' })
       ).rejects.toThrowError('Bad request');
     });
+
+    it('forwards redirect_uris, client_logo, and client_metadata verbatim to UIAM', async () => {
+      const mockResponse: OAuthClientResponse = {
+        id: 'client-id',
+        resource: 'urn:test',
+        redirect_uris: ['https://example.com/cb'],
+        client_logo: { media_type: 'image/png', data: 'abc' },
+      };
+
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => mockResponse });
+
+      const body = {
+        resource: 'urn:test',
+        client_type: 'confidential' as const,
+        client_metadata: { owner: 'admin' },
+        client_logo: { media_type: 'image/png', data: 'abc' },
+        redirect_uris: ['https://example.com/cb'],
+      };
+
+      await expect(uiamService.createOAuthClient('access-token', body)).resolves.toEqual(
+        mockResponse
+      );
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(body) })
+      );
+    });
+
+    it('surfaces UIAM ErrorDetails (code, type, resource) in the thrown Boom message', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        json: async () => ({
+          error: {
+            code: 'INVALID_REDIRECT_URI',
+            type: 'validation_error',
+            resource: 'redirect_uris[0]',
+            message: 'Redirect URI must not contain a fragment',
+          },
+        }),
+      });
+
+      await expect(
+        uiamService.createOAuthClient('access-token', { resource: 'urn:test' })
+      ).rejects.toThrowError(
+        '[INVALID_REDIRECT_URI/validation_error] Redirect URI must not contain a fragment (resource: redirect_uris[0])'
+      );
+    });
   });
 
   describe('#listOAuthClients', () => {
@@ -1177,6 +1227,76 @@ describe('UiamService', () => {
 
       await expect(uiamService.listOAuthConnections('access-token')).rejects.toThrowError(
         'Internal Server Error'
+      );
+    });
+  });
+
+  describe('#updateOAuthConnection', () => {
+    it('properly calls UIAM service to update an OAuth connection', async () => {
+      const mockResponse: OAuthConnectionResponse = {
+        id: 'conn-id',
+        client_id: 'client-id',
+        resource: 'urn:test',
+        name: 'New name',
+      };
+
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => mockResponse });
+
+      await expect(
+        uiamService.updateOAuthConnection('access-token', 'client-id', 'conn-id', {
+          name: 'New name',
+        })
+      ).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client-id/connections/conn-id',
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          body: JSON.stringify({ name: 'New name' }),
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if update fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Connection not found' } }),
+      });
+
+      await expect(
+        uiamService.updateOAuthConnection('access-token', 'client-id', 'missing', {
+          name: 'x',
+        })
+      ).rejects.toThrowError('Connection not found');
+    });
+
+    it('encodes reserved characters in both path segments', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'conn/id?x',
+          client_id: 'client/id#y',
+          resource: 'urn:test',
+          name: 'n',
+        }),
+      });
+
+      await uiamService.updateOAuthConnection('access-token', 'client/id#y', 'conn/id?x', {
+        name: 'n',
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client%2Fid%23y/connections/conn%2Fid%3Fx',
+        expect.objectContaining({ method: 'PATCH' })
       );
     });
   });

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -895,7 +895,7 @@ describe('UiamService', () => {
     it('properly calls UIAM service to create an OAuth client', async () => {
       const mockResponse: OAuthClientResponse = {
         id: 'client-id',
-        resource: 'urn:test:resource',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Test Client',
       };
 
@@ -906,7 +906,7 @@ describe('UiamService', () => {
 
       await expect(
         uiamService.createOAuthClient('access-token', {
-          resource: 'urn:test:resource',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
           client_name: 'Test Client',
         })
       ).resolves.toEqual(mockResponse);
@@ -919,7 +919,10 @@ describe('UiamService', () => {
           [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
           Authorization: 'Bearer access-token',
         },
-        body: JSON.stringify({ resource: 'urn:test:resource', client_name: 'Test Client' }),
+        body: JSON.stringify({
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          client_name: 'Test Client',
+        }),
         dispatcher: AGENT_MOCK,
       });
     });
@@ -933,14 +936,16 @@ describe('UiamService', () => {
       });
 
       await expect(
-        uiamService.createOAuthClient('access-token', { resource: 'urn:test' })
+        uiamService.createOAuthClient('access-token', {
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        })
       ).rejects.toThrowError('Bad request');
     });
 
     it('forwards redirect_uris, client_logo, and client_metadata verbatim to UIAM', async () => {
       const mockResponse: OAuthClientResponse = {
         id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         redirect_uris: ['https://example.com/cb'],
         client_logo: { media_type: 'image/png', data: 'abc' },
       };
@@ -948,7 +953,7 @@ describe('UiamService', () => {
       fetchSpy.mockResolvedValue({ ok: true, json: async () => mockResponse });
 
       const body = {
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_type: 'confidential' as const,
         client_metadata: { owner: 'admin' },
         client_logo: { media_type: 'image/png', data: 'abc' },
@@ -981,7 +986,9 @@ describe('UiamService', () => {
       });
 
       await expect(
-        uiamService.createOAuthClient('access-token', { resource: 'urn:test' })
+        uiamService.createOAuthClient('access-token', {
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        })
       ).rejects.toThrowError(
         '[INVALID_REDIRECT_URI/validation_error] Redirect URI must not contain a fragment (resource: redirect_uris[0])'
       );
@@ -1048,7 +1055,7 @@ describe('UiamService', () => {
     it('properly calls UIAM service to update an OAuth client', async () => {
       const mockResponse: OAuthClientResponse = {
         id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         client_name: 'Updated Name',
       };
 
@@ -1098,7 +1105,10 @@ describe('UiamService', () => {
     it('encodes reserved characters in the client id path segment', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
-        json: async () => ({ id: 'weird/id?x#y', resource: 'urn:test' }),
+        json: async () => ({
+          id: 'weird/id?x#y',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+        }),
       });
 
       await uiamService.updateOAuthClient('access-token', 'weird/id?x#y', {
@@ -1116,7 +1126,7 @@ describe('UiamService', () => {
     it('properly calls UIAM service to revoke an OAuth client', async () => {
       const mockResponse: OAuthClientResponse = {
         id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         revoked: true,
       };
 
@@ -1161,7 +1171,11 @@ describe('UiamService', () => {
     it('encodes reserved characters in the client id path segment', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
-        json: async () => ({ id: 'weird/id?x#y', resource: 'urn:test', revoked: true }),
+        json: async () => ({
+          id: 'weird/id?x#y',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
+          revoked: true,
+        }),
       });
 
       await uiamService.revokeOAuthClient('access-token', 'weird/id?x#y');
@@ -1236,7 +1250,7 @@ describe('UiamService', () => {
       const mockResponse: OAuthConnectionResponse = {
         id: 'conn-id',
         client_id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         name: 'New name',
       };
 
@@ -1285,7 +1299,7 @@ describe('UiamService', () => {
         json: async () => ({
           id: 'conn/id?x',
           client_id: 'client/id#y',
-          resource: 'urn:test',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
           name: 'n',
         }),
       });
@@ -1306,7 +1320,7 @@ describe('UiamService', () => {
       const mockResponse: OAuthConnectionResponse = {
         id: 'conn-id',
         client_id: 'client-id',
-        resource: 'urn:test',
+        resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
         revoked: true,
       };
 
@@ -1354,7 +1368,7 @@ describe('UiamService', () => {
         json: async () => ({
           id: 'conn/id?x',
           client_id: 'client/id#y',
-          resource: 'urn:test',
+          resource: 'https://test-project.kb.us-central1.gcp.elastic.cloud',
           revoked: true,
         }),
       });

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -1044,6 +1044,22 @@ describe('UiamService', () => {
         })
       ).rejects.toThrowError('Client not found');
     });
+
+    it('encodes reserved characters in the client id path segment', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'weird/id?x#y', resource: 'urn:test' }),
+      });
+
+      await uiamService.updateOAuthClient('access-token', 'weird/id?x#y', {
+        client_name: 'Updated',
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/weird%2Fid%3Fx%23y',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
   });
 
   describe('#revokeOAuthClient', () => {
@@ -1089,6 +1105,20 @@ describe('UiamService', () => {
 
       await expect(uiamService.revokeOAuthClient('access-token', 'client-id')).rejects.toThrowError(
         'Already revoked'
+      );
+    });
+
+    it('encodes reserved characters in the client id path segment', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'weird/id?x#y', resource: 'urn:test', revoked: true }),
+      });
+
+      await uiamService.revokeOAuthClient('access-token', 'weird/id?x#y');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/weird%2Fid%3Fx%23y/_revoke',
+        expect.objectContaining({ method: 'POST' })
       );
     });
   });
@@ -1196,6 +1226,25 @@ describe('UiamService', () => {
       await expect(
         uiamService.revokeOAuthConnection('access-token', 'client-id', 'conn-id')
       ).rejects.toThrowError('Connection not found');
+    });
+
+    it('encodes reserved characters in both path segments', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          id: 'conn/id?x',
+          client_id: 'client/id#y',
+          resource: 'urn:test',
+          revoked: true,
+        }),
+      });
+
+      await uiamService.revokeOAuthConnection('access-token', 'client/id#y', 'conn/id?x');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client%2Fid%23y/connections/conn%2Fid%3Fx/_revoke',
+        expect.objectContaining({ method: 'POST' })
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.test.ts
@@ -14,6 +14,8 @@ import { HTTPAuthorizationHeader } from '@kbn/core-security-server';
 import {
   type GrantUiamApiKeyRequestBody,
   type GrantUiamApiKeyResponse,
+  type OAuthClientResponse,
+  type OAuthConnectionResponse,
   UiamService,
 } from './uiam_service';
 import { ES_CLIENT_AUTHENTICATION_HEADER } from '../../common/constants';
@@ -886,6 +888,314 @@ describe('UiamService', () => {
         }),
         dispatcher: AGENT_MOCK,
       });
+    });
+  });
+
+  describe('#createOAuthClient', () => {
+    it('properly calls UIAM service to create an OAuth client', async () => {
+      const mockResponse: OAuthClientResponse = {
+        id: 'client-id',
+        resource: 'urn:test:resource',
+        client_name: 'Test Client',
+      };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(
+        uiamService.createOAuthClient('access-token', {
+          resource: 'urn:test:resource',
+          client_name: 'Test Client',
+        })
+      ).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://uiam.service/uiam/api/v1/oauth/clients', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+          Authorization: 'Bearer access-token',
+        },
+        body: JSON.stringify({ resource: 'urn:test:resource', client_name: 'Test Client' }),
+        dispatcher: AGENT_MOCK,
+      });
+    });
+
+    it('throws error if creation fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Bad request' } }),
+      });
+
+      await expect(
+        uiamService.createOAuthClient('access-token', { resource: 'urn:test' })
+      ).rejects.toThrowError('Bad request');
+    });
+  });
+
+  describe('#listOAuthClients', () => {
+    it('properly calls UIAM service to list OAuth clients', async () => {
+      const mockResponse = { clients: [] };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(uiamService.listOAuthClients('access-token')).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://uiam.service/uiam/api/v1/oauth/clients', {
+        method: 'GET',
+        headers: {
+          [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+          Authorization: 'Bearer access-token',
+        },
+        dispatcher: AGENT_MOCK,
+      });
+    });
+
+    it('includes client_id query parameter when provided', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ clients: [] }),
+      });
+
+      await uiamService.listOAuthClients('access-token', 'specific-client-id');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients?client_id=specific-client-id',
+        {
+          method: 'GET',
+          headers: {
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if listing fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Forbidden' } }),
+      });
+
+      await expect(uiamService.listOAuthClients('access-token')).rejects.toThrowError('Forbidden');
+    });
+  });
+
+  describe('#updateOAuthClient', () => {
+    it('properly calls UIAM service to update an OAuth client', async () => {
+      const mockResponse: OAuthClientResponse = {
+        id: 'client-id',
+        resource: 'urn:test',
+        client_name: 'Updated Name',
+      };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(
+        uiamService.updateOAuthClient('access-token', 'client-id', {
+          client_name: 'Updated Name',
+          client_metadata: { key: 'value' },
+        })
+      ).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client-id',
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          body: JSON.stringify({ client_name: 'Updated Name', client_metadata: { key: 'value' } }),
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if update fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Client not found' } }),
+      });
+
+      await expect(
+        uiamService.updateOAuthClient('access-token', 'missing-id', {
+          client_metadata: {},
+        })
+      ).rejects.toThrowError('Client not found');
+    });
+  });
+
+  describe('#revokeOAuthClient', () => {
+    it('properly calls UIAM service to revoke an OAuth client', async () => {
+      const mockResponse: OAuthClientResponse = {
+        id: 'client-id',
+        resource: 'urn:test',
+        revoked: true,
+      };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(
+        uiamService.revokeOAuthClient('access-token', 'client-id', 'no longer needed')
+      ).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client-id/_revoke',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          body: JSON.stringify({ reason: 'no longer needed' }),
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if revocation fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Already revoked' } }),
+      });
+
+      await expect(uiamService.revokeOAuthClient('access-token', 'client-id')).rejects.toThrowError(
+        'Already revoked'
+      );
+    });
+  });
+
+  describe('#listOAuthConnections', () => {
+    it('properly calls UIAM service to list OAuth connections', async () => {
+      const mockResponse = { connections: [] };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(uiamService.listOAuthConnections('access-token')).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://uiam.service/uiam/api/v1/oauth/connections', {
+        method: 'GET',
+        headers: {
+          [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+          Authorization: 'Bearer access-token',
+        },
+        dispatcher: AGENT_MOCK,
+      });
+    });
+
+    it('includes query parameters when provided', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ connections: [] }),
+      });
+
+      await uiamService.listOAuthConnections('access-token', 'cid', 'conn-id');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/connections?client_id=cid&connection_id=conn-id',
+        {
+          method: 'GET',
+          headers: {
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if listing fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Internal Server Error' } }),
+      });
+
+      await expect(uiamService.listOAuthConnections('access-token')).rejects.toThrowError(
+        'Internal Server Error'
+      );
+    });
+  });
+
+  describe('#revokeOAuthConnection', () => {
+    it('properly calls UIAM service to revoke an OAuth connection', async () => {
+      const mockResponse: OAuthConnectionResponse = {
+        id: 'conn-id',
+        client_id: 'client-id',
+        resource: 'urn:test',
+        revoked: true,
+      };
+
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await expect(
+        uiamService.revokeOAuthConnection('access-token', 'client-id', 'conn-id', 'revoked')
+      ).resolves.toEqual(mockResponse);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://uiam.service/uiam/api/v1/oauth/clients/client-id/connections/conn-id/_revoke',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: 'secret',
+            Authorization: 'Bearer access-token',
+          },
+          body: JSON.stringify({ reason: 'revoked' }),
+          dispatcher: AGENT_MOCK,
+        }
+      );
+    });
+
+    it('throws error if revocation fails', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        json: async () => ({ error: { message: 'Connection not found' } }),
+      });
+
+      await expect(
+        uiamService.revokeOAuthConnection('access-token', 'client-id', 'conn-id')
+      ).rejects.toThrowError('Connection not found');
     });
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -606,17 +606,20 @@ export class UiamService implements UiamServicePublic {
       this.#logger.debug(`Attempting to update OAuth client: ${clientId}`);
 
       const response = await UiamService.#parseUiamResponse(
-        await fetch(`${this.#config.url}/uiam/api/v1/oauth/clients/${clientId}`, {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
-            Authorization: `Bearer ${accessToken}`,
-          },
-          body: JSON.stringify(body),
-          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
-          dispatcher: this.#dispatcher,
-        })
+        await fetch(
+          `${this.#config.url}/uiam/api/v1/oauth/clients/${encodeURIComponent(clientId)}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify(body),
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          }
+        )
       );
 
       this.#logger.debug(`Successfully updated OAuth client: ${clientId}`);
@@ -641,17 +644,20 @@ export class UiamService implements UiamServicePublic {
       this.#logger.debug(`Attempting to revoke OAuth client: ${clientId}`);
 
       const response = await UiamService.#parseUiamResponse(
-        await fetch(`${this.#config.url}/uiam/api/v1/oauth/clients/${clientId}/_revoke`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
-            Authorization: `Bearer ${accessToken}`,
-          },
-          body: JSON.stringify({ reason }),
-          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
-          dispatcher: this.#dispatcher,
-        })
+        await fetch(
+          `${this.#config.url}/uiam/api/v1/oauth/clients/${encodeURIComponent(clientId)}/_revoke`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({ reason }),
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          }
+        )
       );
 
       this.#logger.debug(`Successfully revoked OAuth client: ${clientId}`);
@@ -717,9 +723,9 @@ export class UiamService implements UiamServicePublic {
 
       const response = await UiamService.#parseUiamResponse(
         await fetch(
-          `${
-            this.#config.url
-          }/uiam/api/v1/oauth/clients/${clientId}/connections/${connectionId}/_revoke`,
+          `${this.#config.url}/uiam/api/v1/oauth/clients/${encodeURIComponent(
+            clientId
+          )}/connections/${encodeURIComponent(connectionId)}/_revoke`,
           {
             method: 'POST',
             headers: {

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -18,6 +18,7 @@ import type {
   UiamOAuthClientType,
   UiamOAuthConnectionResponse,
   UpdateUiamOAuthClientParams,
+  UpdateUiamOAuthConnectionParams,
 } from '@kbn/core-security-server';
 import type {
   ClientAuthentication,
@@ -104,6 +105,19 @@ export type OAuthClientResponse = UiamOAuthClientResponse;
 export type OAuthConnectionResponse = UiamOAuthConnectionResponse;
 export type CreateOAuthClientRequestBody = CreateUiamOAuthClientParams;
 export type PatchOAuthClientRequestBody = UpdateUiamOAuthClientParams;
+export type PatchOAuthConnectionRequestBody = UpdateUiamOAuthConnectionParams;
+
+/**
+ * Shape of the `error` object inside a UIAM non-2xx response payload, mirroring
+ * UIAM's `ErrorDetails` schema. All fields are optional per the UIAM contract.
+ * @see https://github.com/elastic/uiam/blob/main/api/openapi.yaml
+ */
+interface UiamErrorDetails {
+  code?: string;
+  message?: string;
+  resource?: string;
+  type?: string;
+}
 
 /**
  * Response containing a list of OAuth clients.
@@ -236,6 +250,20 @@ export interface UiamServicePublic {
     clientId?: string,
     connectionId?: string
   ): Promise<OAuthConnectionsResponse>;
+
+  /**
+   * Updates an OAuth connection's display name via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId The ID of the client owning the connection.
+   * @param connectionId The ID of the connection to update.
+   * @param body The request body for updating the OAuth connection.
+   */
+  updateOAuthConnection(
+    accessToken: string,
+    clientId: string,
+    connectionId: string,
+    body: PatchOAuthConnectionRequestBody
+  ): Promise<OAuthConnectionResponse>;
 
   /**
    * Revokes an OAuth connection via the UIAM service.
@@ -710,6 +738,47 @@ export class UiamService implements UiamServicePublic {
   }
 
   /**
+   * See {@link UiamServicePublic.updateOAuthConnection}.
+   */
+  async updateOAuthConnection(
+    accessToken: string,
+    clientId: string,
+    connectionId: string,
+    body: PatchOAuthConnectionRequestBody
+  ): Promise<OAuthConnectionResponse> {
+    try {
+      this.#logger.debug(`Attempting to update OAuth connection: ${connectionId}`);
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(
+          `${this.#config.url}/uiam/api/v1/oauth/clients/${encodeURIComponent(
+            clientId
+          )}/connections/${encodeURIComponent(connectionId)}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify(body),
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          }
+        )
+      );
+
+      this.#logger.debug(`Successfully updated OAuth connection: ${connectionId}`);
+      return response;
+    } catch (err) {
+      this.#logger.error(
+        () => `Failed to update OAuth connection ${connectionId}: ${getDetailedErrorMessage(err)}`
+      );
+      throw err;
+    }
+  }
+
+  /**
    * See {@link UiamServicePublic.revokeOAuthConnection}.
    */
   async revokeOAuthConnection(
@@ -794,7 +863,11 @@ export class UiamService implements UiamServicePublic {
   }
 
   /**
-   * Parses the UIAM service response as free-form JSON if it's a successful response, otherwise throws a Boom error based on the error response from the UIAM service.
+   * Parses the UIAM service response as free-form JSON if it's a successful response, otherwise
+   * throws a Boom error derived from UIAM's {@link https://github.com/elastic/uiam/blob/main/api/openapi.yaml ErrorDetails}
+   * payload (`{ code, message, resource, type }`). The full payload is preserved on
+   * `err.output.payload` so downstream loggers pick up the additional context via
+   * {@link getDetailedErrorMessage}.
    */
   static async #parseUiamResponse(response: Response) {
     if (response.ok) {
@@ -806,7 +879,17 @@ export class UiamService implements UiamServicePublic {
     }
 
     const payload = await response.json();
-    const err = new Boom.Boom(payload?.error?.message || 'Unknown error');
+    const { code, message, resource, type }: UiamErrorDetails = payload?.error ?? {};
+
+    // Build a compact, greppable summary for log output: `[code/type] message (resource: ...)`.
+    const qualifiers: string[] = [];
+    if (code) qualifiers.push(code);
+    if (type) qualifiers.push(type);
+    const prefix = qualifiers.length > 0 ? `[${qualifiers.join('/')}] ` : '';
+    const suffix = resource ? ` (resource: ${resource})` : '';
+    const summary = `${prefix}${message ?? 'Unknown error'}${suffix}`;
+
+    const err = new Boom.Boom(summary);
 
     err.output = {
       statusCode: response.status,

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -12,6 +12,13 @@ import { Agent } from 'undici';
 import type { Logger } from '@kbn/core/server';
 import { HTTPAuthorizationHeader } from '@kbn/core-security-server';
 import type {
+  CreateUiamOAuthClientParams,
+  UiamOAuthClientLogo,
+  UiamOAuthClientResponse,
+  UiamOAuthConnectionResponse,
+  UpdateUiamOAuthClientParams,
+} from '@kbn/core-security-server';
+import type {
   ClientAuthentication,
   GrantUiamAPIKeyParams,
 } from '@kbn/security-plugin-types-server';
@@ -90,82 +97,11 @@ export interface ConvertUiamApiKeysResponse {
   >;
 }
 
-/**
- * Represents a client logo provided as a URL.
- */
-export interface OAuthClientLogoUrl {
-  type: 'url';
-  url: string;
-}
-
-/**
- * Represents a client logo provided as base64-encoded image data.
- */
-export interface OAuthClientLogoBase64 {
-  type: 'base64';
-  media_type: string;
-  data: string;
-}
-
-export type OAuthClientLogo = OAuthClientLogoUrl | OAuthClientLogoBase64;
-
-/**
- * Summary of active and revoked connection IDs for a client.
- */
-export interface OAuthConnectionsSummary {
-  active?: string[];
-  revoked?: string[];
-}
-
-/**
- * Represents the request body for creating an OAuth client via UIAM.
- */
-export interface CreateOAuthClientRequestBody {
-  resource: string;
-  client_name?: string;
-  client_metadata?: Record<string, string>;
-  client_logo?: OAuthClientLogo;
-}
-
-/**
- * Represents the request body for patching an OAuth client via UIAM.
- */
-export interface PatchOAuthClientRequestBody {
-  client_name?: string | null;
-  client_metadata: Record<string, string>;
-  client_logo?: OAuthClientLogo | null;
-}
-
-/**
- * Represents a single OAuth client returned by the UIAM service.
- */
-export interface OAuthClientResponse {
-  id: string;
-  client_name?: string;
-  resource: string;
-  type?: string;
-  creation?: string;
-  revoked?: boolean;
-  revocation?: string;
-  revocation_reason?: string;
-  client_metadata?: Record<string, string>;
-  client_logo?: OAuthClientLogo;
-  connections?: OAuthConnectionsSummary;
-}
-
-/**
- * Represents a single OAuth connection returned by the UIAM service.
- */
-export interface OAuthConnectionResponse {
-  id: string;
-  client_id: string;
-  resource: string;
-  creation?: string;
-  revoked?: boolean;
-  revocation?: string;
-  revocation_reason?: string;
-  scopes?: string[];
-}
+export type OAuthClientLogo = UiamOAuthClientLogo;
+export type OAuthClientResponse = UiamOAuthClientResponse;
+export type OAuthConnectionResponse = UiamOAuthConnectionResponse;
+export type CreateOAuthClientRequestBody = CreateUiamOAuthClientParams;
+export type PatchOAuthClientRequestBody = UpdateUiamOAuthClientParams;
 
 /**
  * Response containing a list of OAuth clients.

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -91,6 +91,97 @@ export interface ConvertUiamApiKeysResponse {
 }
 
 /**
+ * Represents a client logo provided as a URL.
+ */
+export interface OAuthClientLogoUrl {
+  type: 'url';
+  url: string;
+}
+
+/**
+ * Represents a client logo provided as base64-encoded image data.
+ */
+export interface OAuthClientLogoBase64 {
+  type: 'base64';
+  media_type: string;
+  data: string;
+}
+
+export type OAuthClientLogo = OAuthClientLogoUrl | OAuthClientLogoBase64;
+
+/**
+ * Summary of active and revoked connection IDs for a client.
+ */
+export interface OAuthConnectionsSummary {
+  active?: string[];
+  revoked?: string[];
+}
+
+/**
+ * Represents the request body for creating an OAuth client via UIAM.
+ */
+export interface CreateOAuthClientRequestBody {
+  resource: string;
+  client_name?: string;
+  client_metadata?: Record<string, string>;
+  client_logo?: OAuthClientLogo;
+}
+
+/**
+ * Represents the request body for patching an OAuth client via UIAM.
+ */
+export interface PatchOAuthClientRequestBody {
+  client_name?: string | null;
+  client_metadata: Record<string, string>;
+  client_logo?: OAuthClientLogo | null;
+}
+
+/**
+ * Represents a single OAuth client returned by the UIAM service.
+ */
+export interface OAuthClientResponse {
+  id: string;
+  client_name?: string;
+  resource: string;
+  type?: string;
+  creation?: string;
+  revoked?: boolean;
+  revocation?: string;
+  revocation_reason?: string;
+  client_metadata?: Record<string, string>;
+  client_logo?: OAuthClientLogo;
+  connections?: OAuthConnectionsSummary;
+}
+
+/**
+ * Represents a single OAuth connection returned by the UIAM service.
+ */
+export interface OAuthConnectionResponse {
+  id: string;
+  client_id: string;
+  resource: string;
+  creation?: string;
+  revoked?: boolean;
+  revocation?: string;
+  revocation_reason?: string;
+  scopes?: string[];
+}
+
+/**
+ * Response containing a list of OAuth clients.
+ */
+export interface OAuthClientsResponse {
+  clients: OAuthClientResponse[];
+}
+
+/**
+ * Response containing a list of OAuth connections.
+ */
+export interface OAuthConnectionsResponse {
+  connections: OAuthConnectionResponse[];
+}
+
+/**
  * The service that integrates with UIAM for user authentication and session management.
  */
 export interface UiamServicePublic {
@@ -154,6 +245,73 @@ export interface UiamServicePublic {
    * @returns A promise that resolves to a response containing per-key success/failure results.
    */
   convertApiKeys(keys: string[]): Promise<ConvertUiamApiKeysResponse>;
+
+  /**
+   * Creates an OAuth client via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param body The request body for creating the OAuth client.
+   */
+  createOAuthClient(
+    accessToken: string,
+    body: CreateOAuthClientRequestBody
+  ): Promise<OAuthClientResponse>;
+
+  /**
+   * Lists OAuth clients via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId Optional client ID filter.
+   */
+  listOAuthClients(accessToken: string, clientId?: string): Promise<OAuthClientsResponse>;
+
+  /**
+   * Updates an OAuth client's metadata via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId The ID of the client to update.
+   * @param body The request body for updating the OAuth client.
+   */
+  updateOAuthClient(
+    accessToken: string,
+    clientId: string,
+    body: PatchOAuthClientRequestBody
+  ): Promise<OAuthClientResponse>;
+
+  /**
+   * Revokes an OAuth client via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId The ID of the client to revoke.
+   * @param reason Optional reason for revocation.
+   */
+  revokeOAuthClient(
+    accessToken: string,
+    clientId: string,
+    reason?: string
+  ): Promise<OAuthClientResponse>;
+
+  /**
+   * Lists OAuth connections via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId Optional client ID filter.
+   * @param connectionId Optional connection ID filter.
+   */
+  listOAuthConnections(
+    accessToken: string,
+    clientId?: string,
+    connectionId?: string
+  ): Promise<OAuthConnectionsResponse>;
+
+  /**
+   * Revokes an OAuth connection via the UIAM service.
+   * @param accessToken UIAM session access token.
+   * @param clientId The ID of the client owning the connection.
+   * @param connectionId The ID of the connection to revoke.
+   * @param reason Optional reason for revocation.
+   */
+  revokeOAuthConnection(
+    accessToken: string,
+    clientId: string,
+    connectionId: string,
+    reason?: string
+  ): Promise<OAuthConnectionResponse>;
 }
 
 interface UiamServiceOptions {
@@ -430,6 +588,220 @@ export class UiamService implements UiamServicePublic {
     } catch (err) {
       this.#logger.error(() => `Failed to convert API keys: ${getDetailedErrorMessage(err)}`);
 
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.createOAuthClient}.
+   */
+  async createOAuthClient(
+    accessToken: string,
+    body: CreateOAuthClientRequestBody
+  ): Promise<OAuthClientResponse> {
+    try {
+      this.#logger.debug('Attempting to create OAuth client.');
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(`${this.#config.url}/uiam/api/v1/oauth/clients`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify(body),
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
+      );
+
+      this.#logger.debug(`Successfully created OAuth client with id ${response.id}`);
+      return response;
+    } catch (err) {
+      this.#logger.error(() => `Failed to create OAuth client: ${getDetailedErrorMessage(err)}`);
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.listOAuthClients}.
+   */
+  async listOAuthClients(accessToken: string, clientId?: string): Promise<OAuthClientsResponse> {
+    try {
+      this.#logger.debug('Attempting to list OAuth clients.');
+
+      const url = new URL(`${this.#config.url}/uiam/api/v1/oauth/clients`);
+      if (clientId) {
+        url.searchParams.set('client_id', clientId);
+      }
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(url.toString(), {
+          method: 'GET',
+          headers: {
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
+      );
+
+      this.#logger.debug('Successfully listed OAuth clients.');
+      return response;
+    } catch (err) {
+      this.#logger.error(() => `Failed to list OAuth clients: ${getDetailedErrorMessage(err)}`);
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.updateOAuthClient}.
+   */
+  async updateOAuthClient(
+    accessToken: string,
+    clientId: string,
+    body: PatchOAuthClientRequestBody
+  ): Promise<OAuthClientResponse> {
+    try {
+      this.#logger.debug(`Attempting to update OAuth client: ${clientId}`);
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(`${this.#config.url}/uiam/api/v1/oauth/clients/${clientId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify(body),
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
+      );
+
+      this.#logger.debug(`Successfully updated OAuth client: ${clientId}`);
+      return response;
+    } catch (err) {
+      this.#logger.error(
+        () => `Failed to update OAuth client ${clientId}: ${getDetailedErrorMessage(err)}`
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.revokeOAuthClient}.
+   */
+  async revokeOAuthClient(
+    accessToken: string,
+    clientId: string,
+    reason?: string
+  ): Promise<OAuthClientResponse> {
+    try {
+      this.#logger.debug(`Attempting to revoke OAuth client: ${clientId}`);
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(`${this.#config.url}/uiam/api/v1/oauth/clients/${clientId}/_revoke`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ reason }),
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
+      );
+
+      this.#logger.debug(`Successfully revoked OAuth client: ${clientId}`);
+      return response;
+    } catch (err) {
+      this.#logger.error(
+        () => `Failed to revoke OAuth client ${clientId}: ${getDetailedErrorMessage(err)}`
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.listOAuthConnections}.
+   */
+  async listOAuthConnections(
+    accessToken: string,
+    clientId?: string,
+    connectionId?: string
+  ): Promise<OAuthConnectionsResponse> {
+    try {
+      this.#logger.debug('Attempting to list OAuth connections.');
+
+      const url = new URL(`${this.#config.url}/uiam/api/v1/oauth/connections`);
+      if (clientId) {
+        url.searchParams.set('client_id', clientId);
+      }
+      if (connectionId) {
+        url.searchParams.set('connection_id', connectionId);
+      }
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(url.toString(), {
+          method: 'GET',
+          headers: {
+            [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+            Authorization: `Bearer ${accessToken}`,
+          },
+          // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+          dispatcher: this.#dispatcher,
+        })
+      );
+
+      this.#logger.debug('Successfully listed OAuth connections.');
+      return response;
+    } catch (err) {
+      this.#logger.error(() => `Failed to list OAuth connections: ${getDetailedErrorMessage(err)}`);
+      throw err;
+    }
+  }
+
+  /**
+   * See {@link UiamServicePublic.revokeOAuthConnection}.
+   */
+  async revokeOAuthConnection(
+    accessToken: string,
+    clientId: string,
+    connectionId: string,
+    reason?: string
+  ): Promise<OAuthConnectionResponse> {
+    try {
+      this.#logger.debug(`Attempting to revoke OAuth connection: ${connectionId}`);
+
+      const response = await UiamService.#parseUiamResponse(
+        await fetch(
+          `${
+            this.#config.url
+          }/uiam/api/v1/oauth/clients/${clientId}/connections/${connectionId}/_revoke`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              [ES_CLIENT_AUTHENTICATION_HEADER]: this.#config.sharedSecret,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({ reason }),
+            // @ts-expect-error Undici `fetch` supports `dispatcher` option, see https://github.com/nodejs/undici/pull/1411.
+            dispatcher: this.#dispatcher,
+          }
+        )
+      );
+
+      this.#logger.debug(`Successfully revoked OAuth connection: ${connectionId}`);
+      return response;
+    } catch (err) {
+      this.#logger.error(
+        () => `Failed to revoke OAuth connection ${connectionId}: ${getDetailedErrorMessage(err)}`
+      );
       throw err;
     }
   }

--- a/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
+++ b/x-pack/platform/plugins/shared/security/server/uiam/uiam_service.ts
@@ -15,6 +15,7 @@ import type {
   CreateUiamOAuthClientParams,
   UiamOAuthClientLogo,
   UiamOAuthClientResponse,
+  UiamOAuthClientType,
   UiamOAuthConnectionResponse,
   UpdateUiamOAuthClientParams,
 } from '@kbn/core-security-server';
@@ -98,6 +99,7 @@ export interface ConvertUiamApiKeysResponse {
 }
 
 export type OAuthClientLogo = UiamOAuthClientLogo;
+export type OAuthClientType = UiamOAuthClientType;
 export type OAuthClientResponse = UiamOAuthClientResponse;
 export type OAuthConnectionResponse = UiamOAuthConnectionResponse;
 export type CreateOAuthClientRequestBody = CreateUiamOAuthClientParams;

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/.meta/api/parallel.json
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/.meta/api/parallel.json
@@ -1,6 +1,34 @@
 {
-  "sha1": "b56b1a7b72c59bdeb6acf0a6582f1f7173f6021a",
+  "sha1": "d9901ee11461e224a3e20f661c9373dd8e37d26d",
   "tests": [
+    {
+      "id": "f6d065371af5227-8e2fb993048f286",
+      "title": "[NON-MKI] UIAM OAuth client CRUD via Kibana proxy creates, reads, lists, patches (incl. redirect_uris), and revokes a client",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-serverless-security_complete",
+        "@cloud-serverless-security_complete"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts",
+        "line": 45,
+        "column": 12
+      }
+    },
+    {
+      "id": "f6d065371af5227-6c2001b07df0ffc",
+      "title": "[NON-MKI] UIAM OAuth client CRUD via Kibana proxy rejects malformed create payloads at the Kibana schema layer",
+      "expectedStatus": "passed",
+      "tags": [
+        "@local-serverless-security_complete",
+        "@cloud-serverless-security_complete"
+      ],
+      "location": {
+        "file": "x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts",
+        "line": 133,
+        "column": 12
+      }
+    },
     {
       "id": "afb06677eff5d09-36a05fbd4d8d379",
       "title": "[NON-MKI] MCP OAuth discovery and SDK client flow should discover OAuth protected resource metadata from Kibana",

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/fixtures/index.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/fixtures/index.ts
@@ -9,3 +9,8 @@ export const COMMON_HEADERS = {
   'x-elastic-internal-origin': 'kibana',
   'Content-Type': 'application/json;charset=UTF-8',
 };
+
+export const COMMON_UNSAFE_HEADERS = {
+  ...COMMON_HEADERS,
+  'kbn-xsrf': 'some-xsrf-token',
+};

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
@@ -46,9 +46,9 @@ apiTest.describe(
       'creates, reads, lists, patches (incl. redirect_uris), and revokes a client',
       async ({ apiClient }) => {
         const clientName = `scout-crud-${Date.now()}`;
-        const resource = `urn:scout-crud:${Date.now()}`;
-        const initialRedirectUri = 'https://example.test/callback';
-        const secondRedirectUri = 'https://example.test/callback-2';
+        const resource = `https://scout-crud-${Date.now()}.kb.us-central1.gcp.elastic.cloud`;
+        const initialRedirectUri = 'https://example.com/callback';
+        const secondRedirectUri = 'https://example.com/callback-2';
 
         let clientId: string | undefined;
 
@@ -137,7 +137,7 @@ apiTest.describe(
           headers: authHeaders,
           responseType: 'json',
           body: {
-            resource: 'urn:scout-crud:bad',
+            resource: 'https://scout-crud-bad.kb.us-central1.gcp.elastic.cloud',
             client_name: 'scout-bad',
             client_type: 'not-a-valid-type',
           },
@@ -148,7 +148,7 @@ apiTest.describe(
           headers: authHeaders,
           responseType: 'json',
           body: {
-            resource: 'urn:scout-crud:bad2',
+            resource: 'https://scout-crud-bad2.kb.us-central1.gcp.elastic.cloud',
             client_name: 'scout-bad2',
             client_type: 'public',
             client_logo: { media_type: 'application/json', data: 'abc' },

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
@@ -50,72 +50,82 @@ apiTest.describe(
         const initialRedirectUri = 'https://example.test/callback';
         const secondRedirectUri = 'https://example.test/callback-2';
 
-        const createResponse = await apiClient.post(CLIENTS_BASE, {
-          headers: authHeaders,
-          responseType: 'json',
-          body: {
-            resource,
-            client_name: clientName,
-            client_type: 'public',
-            client_metadata: { owner: 'scout-crud' },
-            redirect_uris: [initialRedirectUri],
-          },
-        });
-        expect(createResponse.statusCode).toBe(200);
-        const created = createResponse.body;
-        expect(created.id).toBeDefined();
-        expect(created.client_name).toBe(clientName);
-        expect(created.type).toBe('public');
-        expect(created.redirect_uris).toStrictEqual([initialRedirectUri]);
-
-        const clientId: string = created.id;
+        let clientId: string | undefined;
 
         try {
-          const getResponse = await apiClient.get(
-            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}`,
-            { headers: authHeaders, responseType: 'json' }
-          );
-          expect(getResponse.statusCode).toBe(200);
-          expect(getResponse.body.id).toBe(clientId);
-          expect(getResponse.body.redirect_uris).toStrictEqual([initialRedirectUri]);
-
-          const listResponse = await apiClient.get(CLIENTS_BASE, {
-            headers: authHeaders,
-            responseType: 'json',
-          });
-          expect(listResponse.statusCode).toBe(200);
-          const listed = (listResponse.body.clients as Array<{ id: string }>).find(
-            (c) => c.id === clientId
-          );
-          expect(listed).toBeDefined();
-
-          const patchResponse = await apiClient.patch(
-            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}`,
-            {
+          await apiTest.step('create client', async () => {
+            const createResponse = await apiClient.post(CLIENTS_BASE, {
               headers: authHeaders,
               responseType: 'json',
               body: {
-                client_name: `${clientName}-renamed`,
-                client_metadata: { owner: 'scout-crud', updated: 'true' },
-                redirect_uris: [initialRedirectUri, secondRedirectUri],
+                resource,
+                client_name: clientName,
+                client_type: 'public',
+                client_metadata: { owner: 'scout-crud' },
+                redirect_uris: [initialRedirectUri],
               },
-            }
-          );
-          expect(patchResponse.statusCode).toBe(200);
-          expect(patchResponse.body.client_name).toBe(`${clientName}-renamed`);
-          const patchedUris: string[] = patchResponse.body.redirect_uris ?? [];
-          expect(patchedUris).toContain(initialRedirectUri);
-          expect(patchedUris).toContain(secondRedirectUri);
+            });
+            expect(createResponse.statusCode).toBe(200);
+            const created = createResponse.body;
+            expect(created.id).toBeDefined();
+            expect(created.client_name).toBe(clientName);
+            expect(created.type).toBe('public');
+            expect(created.redirect_uris).toStrictEqual([initialRedirectUri]);
+
+            clientId = created.id;
+          });
+
+          await apiTest.step('get client by id', async () => {
+            const getResponse = await apiClient.get(
+              `${CLIENTS_BASE}/${encodeURIComponent(clientId!)}`,
+              { headers: authHeaders, responseType: 'json' }
+            );
+            expect(getResponse.statusCode).toBe(200);
+            expect(getResponse.body.id).toBe(clientId);
+            expect(getResponse.body.redirect_uris).toStrictEqual([initialRedirectUri]);
+          });
+
+          await apiTest.step('list clients includes the new client', async () => {
+            const listResponse = await apiClient.get(CLIENTS_BASE, {
+              headers: authHeaders,
+              responseType: 'json',
+            });
+            expect(listResponse.statusCode).toBe(200);
+            const listed = (listResponse.body.clients as Array<{ id: string }>).find(
+              (c) => c.id === clientId
+            );
+            expect(listed).toBeDefined();
+          });
+
+          await apiTest.step('patch client (including redirect_uris)', async () => {
+            const patchResponse = await apiClient.patch(
+              `${CLIENTS_BASE}/${encodeURIComponent(clientId!)}`,
+              {
+                headers: authHeaders,
+                responseType: 'json',
+                body: {
+                  client_name: `${clientName}-renamed`,
+                  client_metadata: { owner: 'scout-crud', updated: 'true' },
+                  redirect_uris: [initialRedirectUri, secondRedirectUri],
+                },
+              }
+            );
+            expect(patchResponse.statusCode).toBe(200);
+            expect(patchResponse.body.client_name).toBe(`${clientName}-renamed`);
+            const patchedUris: string[] = patchResponse.body.redirect_uris ?? [];
+            expect(patchedUris).toContain(initialRedirectUri);
+            expect(patchedUris).toContain(secondRedirectUri);
+          });
         } finally {
-          const revokeResponse = await apiClient.post(
-            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}/_revoke`,
-            {
+          // Best-effort cleanup (only if the client was successfully created above).
+          // eslint-disable-next-line playwright/no-conditional-in-test
+          if (clientId) {
+            await apiClient.post(`${CLIENTS_BASE}/${encodeURIComponent(clientId)}/_revoke`, {
               headers: authHeaders,
               responseType: 'json',
               body: { reason: 'scout cleanup' },
-            }
-          );
-          expect([200, 204]).toContain(revokeResponse.statusCode);
+            });
+          }
         }
       }
     );

--- a/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
+++ b/x-pack/platform/plugins/shared/security/test/scout_uiam_oauth_local/api/parallel_tests/uiam_oauth_clients_crud.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parse as parseCookie } from 'tough-cookie';
+
+import { createSAMLResponse } from '@kbn/mock-idp-utils';
+import { apiTest, tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/api';
+
+import { COMMON_UNSAFE_HEADERS } from '../fixtures';
+
+const CLIENTS_BASE = 'internal/security/oauth/clients';
+
+apiTest.describe(
+  '[NON-MKI] UIAM OAuth client CRUD via Kibana proxy',
+  { tag: [...tags.serverless.security.complete] },
+  () => {
+    let authHeaders: Record<string, string>;
+
+    apiTest.beforeAll(async ({ apiClient, kbnUrl, config: { organizationId, projectType } }) => {
+      const samlResponse = await createSAMLResponse({
+        kibanaUrl: kbnUrl.get('/api/security/saml/callback'),
+        username: '1234567890',
+        email: 'elastic_admin@elastic.co',
+        roles: ['admin'],
+        serverless: {
+          uiamEnabled: true,
+          organizationId: organizationId!,
+          projectType: projectType!,
+        },
+      });
+
+      const samlCallback = await apiClient.post('api/security/saml/callback', {
+        body: `SAMLResponse=${encodeURIComponent(samlResponse)}`,
+      });
+      const cookie = parseCookie(samlCallback.headers['set-cookie'][0])!.cookieString();
+
+      authHeaders = { ...COMMON_UNSAFE_HEADERS, Cookie: cookie };
+    });
+
+    apiTest(
+      'creates, reads, lists, patches (incl. redirect_uris), and revokes a client',
+      async ({ apiClient }) => {
+        const clientName = `scout-crud-${Date.now()}`;
+        const resource = `urn:scout-crud:${Date.now()}`;
+        const initialRedirectUri = 'https://example.test/callback';
+        const secondRedirectUri = 'https://example.test/callback-2';
+
+        const createResponse = await apiClient.post(CLIENTS_BASE, {
+          headers: authHeaders,
+          responseType: 'json',
+          body: {
+            resource,
+            client_name: clientName,
+            client_type: 'public',
+            client_metadata: { owner: 'scout-crud' },
+            redirect_uris: [initialRedirectUri],
+          },
+        });
+        expect(createResponse.statusCode).toBe(200);
+        const created = createResponse.body;
+        expect(created.id).toBeDefined();
+        expect(created.client_name).toBe(clientName);
+        expect(created.type).toBe('public');
+        expect(created.redirect_uris).toStrictEqual([initialRedirectUri]);
+
+        const clientId: string = created.id;
+
+        try {
+          const getResponse = await apiClient.get(
+            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}`,
+            { headers: authHeaders, responseType: 'json' }
+          );
+          expect(getResponse.statusCode).toBe(200);
+          expect(getResponse.body.id).toBe(clientId);
+          expect(getResponse.body.redirect_uris).toStrictEqual([initialRedirectUri]);
+
+          const listResponse = await apiClient.get(CLIENTS_BASE, {
+            headers: authHeaders,
+            responseType: 'json',
+          });
+          expect(listResponse.statusCode).toBe(200);
+          const listed = (listResponse.body.clients as Array<{ id: string }>).find(
+            (c) => c.id === clientId
+          );
+          expect(listed).toBeDefined();
+
+          const patchResponse = await apiClient.patch(
+            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}`,
+            {
+              headers: authHeaders,
+              responseType: 'json',
+              body: {
+                client_name: `${clientName}-renamed`,
+                client_metadata: { owner: 'scout-crud', updated: 'true' },
+                redirect_uris: [initialRedirectUri, secondRedirectUri],
+              },
+            }
+          );
+          expect(patchResponse.statusCode).toBe(200);
+          expect(patchResponse.body.client_name).toBe(`${clientName}-renamed`);
+          const patchedUris: string[] = patchResponse.body.redirect_uris ?? [];
+          expect(patchedUris).toContain(initialRedirectUri);
+          expect(patchedUris).toContain(secondRedirectUri);
+        } finally {
+          const revokeResponse = await apiClient.post(
+            `${CLIENTS_BASE}/${encodeURIComponent(clientId)}/_revoke`,
+            {
+              headers: authHeaders,
+              responseType: 'json',
+              body: { reason: 'scout cleanup' },
+            }
+          );
+          expect([200, 204]).toContain(revokeResponse.statusCode);
+        }
+      }
+    );
+
+    apiTest(
+      'rejects malformed create payloads at the Kibana schema layer',
+      async ({ apiClient }) => {
+        const badClientType = await apiClient.post(CLIENTS_BASE, {
+          headers: authHeaders,
+          responseType: 'json',
+          body: {
+            resource: 'urn:scout-crud:bad',
+            client_name: 'scout-bad',
+            client_type: 'not-a-valid-type',
+          },
+        });
+        expect(badClientType.statusCode).toBe(400);
+
+        const badLogoMedia = await apiClient.post(CLIENTS_BASE, {
+          headers: authHeaders,
+          responseType: 'json',
+          body: {
+            resource: 'urn:scout-crud:bad2',
+            client_name: 'scout-bad2',
+            client_type: 'public',
+            client_logo: { media_type: 'application/json', data: 'abc' },
+          },
+        });
+        expect(badLogoMedia.statusCode).toBe(400);
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Adds internal Security APIs for managing OAuth clients and connections via the UIAM service with core type definitions in `@kbn/core-security-server`, a `UiamOAuth` service class for handling license checks and UIAM token extraction, and new internal CRUD endpoints:

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/internal/security/oauth/clients` | Create an OAuth client |
| `GET` | `/internal/security/oauth/clients` | List OAuth clients (optional `client_id` query filter) |
| `GET` | `/internal/security/oauth/clients/{client_id}` | Get a single OAuth client |
| `PATCH` | `/internal/security/oauth/clients/{client_id}` | Update an OAuth client |
| `POST` | `/internal/security/oauth/clients/{client_id}/_revoke` | Revoke an OAuth client |
| `GET` | `/internal/security/oauth/connections` | List OAuth connections (optional `client_id`, `connection_id` query filters) |
| `GET` | `/internal/security/oauth/clients/{client_id}/connections/{connection_id}` | Get a single OAuth connection |
| `PATCH` | `/internal/security/oauth/clients/{client_id}/connections/{connection_id}` | Update an OAuth connection |
| `POST` | `/internal/security/oauth/clients/{client_id}/connections/{connection_id}/_revoke` | Revoke an OAuth connection |

Other changes include:
- Cosmos DB collection initialization for `oauth-clients`, `oauth-authorization-codes`, and `oauth-app-connections` with correct partition keys in `docker_uiam.ts`.
- Scout tests for OAuth client management APIs

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.