### PR TITLE
[Agent Builder] add request to SmlContext

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -305,6 +305,7 @@ export class AgentBuilderPlugin
             esClient: elasticsearch.client.asInternalUser,
             savedObjectsClient: soClient,
             logger: this.logger.get('services.sml'),
+            request: params.request,
           });
         },
       },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -179,6 +179,7 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 includedHiddenTypes: ['action'],
               }),
               logger,
+              request,
             });
             logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
           } catch (smlError) {
@@ -256,6 +257,7 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 includedHiddenTypes: ['action'],
               }),
               logger,
+              request,
             });
             logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);
           } catch (smlError) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.test.ts
@@ -138,6 +138,7 @@ describe('createSmlIndexer', () => {
         esClient,
         savedObjectsClient: {},
         logger: contextLogger,
+        request: undefined,
       });
       expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
       expect(esClient.deleteByQuery).toHaveBeenCalledWith({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
@@ -12,6 +12,7 @@ import type {
   ISavedObjectsRepository,
 } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SmlTypeRegistry } from './sml_type_registry';
 import type { SmlIndexAction, SmlContext } from './types';
 import { createSmlStorage, smlIndexName } from './sml_storage';
@@ -34,6 +35,7 @@ export interface SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    request?: KibanaRequest;
   }) => Promise<void>;
 }
 
@@ -58,6 +60,7 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient,
     savedObjectsClient,
     logger: contextLogger,
+    request,
   }: {
     originId: string;
     attachmentType: string;
@@ -66,6 +69,7 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
+    request?: KibanaRequest;
   }): Promise<void> {
     this.logger.info(
       `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', spaces=[${spaces.join(
@@ -94,6 +98,7 @@ class SmlIndexerImpl implements SmlIndexer {
       esClient,
       savedObjectsClient,
       logger: contextLogger,
+      request,
     };
 
     this.logger.info(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
@@ -42,6 +42,8 @@ export interface SmlContext {
   esClient: ElasticsearchClient;
   savedObjectsClient: SavedObjectsClientContract;
   logger: Logger;
+  /** The current user's request, when available. Absent during background crawler runs. */
+  request?: KibanaRequest;
 }
 
 /**
@@ -219,6 +221,7 @@ export interface SmlService {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract;
     logger: Logger;
+    request?: KibanaRequest;
   }) => Promise<void>;
 
   /** Fetch SML documents by their chunk IDs, scoped to a space */


### PR DESCRIPTION
## Summary

Adds Request to Context so SML Type providers can scope their services to users request.
- request is optional, as we cannot provide it for backend crawler runs.
