### PR TITLE
[Agent Builder] register inference endpoint feature

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-common/constants.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const AGENT_BUILDER_PARENT_INFERENCE_FEATURE_ID = 'agent_builder_parent';
+export const AGENT_BUILDER_INFERENCE_FEATURE_ID = 'agent_builder';
+export const AGENT_BUILDER_RECOMMENDED_ENDPOINTS = [
+  '.anthropic-claude-4.6-opus-chat_completion',
+  '.anthropic-claude-4.6-sonnet-chat_completion',
+  '.google-gemini-3.0-flash-chat_completion',
+  '.google-gemini-3.1-pro-chat_completion',
+  '.openai-gpt-5.2-chat_completion',
+  '.openai-gpt-oss-20b-chat_completion',
+];

--- a/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/agent_builder/kibana.jsonc
@@ -43,6 +43,7 @@
       "licenseManagement",
       "security",
       "workflowsManagement",
+      "searchInferenceEndpoints",
       "usageCollection",
       "usageApi",
       "home",

--- a/x-pack/platform/plugins/shared/agent_builder/moon.yml
+++ b/x-pack/platform/plugins/shared/agent_builder/moon.yml
@@ -119,6 +119,7 @@ dependsOn:
   - '@kbn/shared-ux-ai-components'
   - '@kbn/fs'
   - '@kbn/react-hooks'
+  - '@kbn/search-inference-endpoints'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -9,6 +9,11 @@ import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kb
 import type { Logger } from '@kbn/logging';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { HomeServerPluginSetup } from '@kbn/home-plugin/server';
+import {
+  AGENT_BUILDER_INFERENCE_FEATURE_ID,
+  AGENT_BUILDER_PARENT_INFERENCE_FEATURE_ID,
+  AGENT_BUILDER_RECOMMENDED_ENDPOINTS,
+} from '@kbn/agent-builder-common/constants';
 import type { AgentBuilderConfig } from './config';
 import { ServiceManager } from './services';
 import type {
@@ -75,6 +80,24 @@ export class AgentBuilderPlugin
       this.logger.info('AgentBuilder telemetry initialized');
     } else {
       this.logger.warn('Usage collection plugin not available, telemetry disabled');
+    }
+
+    if (setupDeps.searchInferenceEndpoints) {
+      setupDeps.searchInferenceEndpoints.features.register({
+        featureId: AGENT_BUILDER_PARENT_INFERENCE_FEATURE_ID,
+        featureName: 'Agent Builder Parent',
+        featureDescription: 'Parent feature for Agent Builder',
+        taskType: 'chat_completion',
+        recommendedEndpoints: AGENT_BUILDER_RECOMMENDED_ENDPOINTS,
+      });
+
+      setupDeps.searchInferenceEndpoints.features.register({
+        featureId: AGENT_BUILDER_INFERENCE_FEATURE_ID,
+        featureName: 'Agent Builder',
+        featureDescription: 'Agent Builder inference endpoint configuration',
+        taskType: 'chat_completion',
+        recommendedEndpoints: AGENT_BUILDER_RECOMMENDED_ENDPOINTS,
+      });
     }
 
     // Register server-side EBT events for Agent Builder

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -85,7 +85,7 @@ export class AgentBuilderPlugin
     if (setupDeps.searchInferenceEndpoints) {
       setupDeps.searchInferenceEndpoints.features.register({
         featureId: AGENT_BUILDER_PARENT_INFERENCE_FEATURE_ID,
-        featureName: 'Agent Builder Parent',
+        featureName: 'Agent Builder',
         featureDescription: 'Parent feature for Agent Builder',
         taskType: 'chat_completion',
         recommendedEndpoints: AGENT_BUILDER_RECOMMENDED_ENDPOINTS,

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -12,6 +12,7 @@ import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type { CloudStart, CloudSetup } from '@kbn/cloud-plugin/server';
 import type { UsageApiSetup, UsageApiStart } from '@kbn/usage-api-plugin/server';
+import type { SearchInferenceEndpointsPluginSetup } from '@kbn/search-inference-endpoints/server';
 import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
@@ -50,6 +51,7 @@ export interface AgentBuilderSetupDependencies {
   taskManager: TaskManagerSetupContract;
   actions: ActionsPluginSetup;
   home: HomeServerPluginSetup;
+  searchInferenceEndpoints?: SearchInferenceEndpointsPluginSetup;
 }
 
 export interface AgentBuilderStartDependencies {

--- a/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
+++ b/x-pack/platform/plugins/shared/agent_builder/tsconfig.json
@@ -116,5 +116,6 @@
     "@kbn/shared-ux-ai-components",
     "@kbn/fs",
     "@kbn/react-hooks",
+    "@kbn/search-inference-endpoints",
   ]
 }


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/search-team/issues/13387

Register the `agent_builder` (and `agent_builder_parent`) inference endpoint feature