### PR TITLE
add input text sanitization

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
@@ -199,19 +199,6 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
       setSelectedStepExecutionId(id);
     }, []);
 
-    const handleChange = useCallback(
-      (newValue: string) => {
-        setValue(newValue);
-        try {
-          JSON.parse(newValue);
-          setErrors(null);
-        } catch {
-          setErrors(translations.invalidJson);
-        }
-      },
-      [setValue, setErrors]
-    );
-
     // Hook Monaco on mount to register the schema for validation + suggestions
     const handleMount = useCallback(
       (editor: monaco.editor.IStandaloneCodeEditor) => {
@@ -279,7 +266,7 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
                       maxLines: 15,
                     }}
                     width="100%"
-                    onChange={handleChange}
+                    onChange={setValue}
                     editorDidMount={handleMount}
                     dataTestSubj="workflow-test-step-historical-json-editor"
                     overflowWidgetsContainerZIndexOverride={6001}
@@ -339,9 +326,6 @@ const translations = {
     }),
   testRun: i18n.translate('workflows.testStepModal.testRun', {
     defaultMessage: 'Test Run',
-  }),
-  invalidJson: i18n.translate('workflows.testStepModal.invalidJson', {
-    defaultMessage: 'Invalid JSON',
   }),
   selectStepExecutionLabel: i18n.translate('workflows.testStepModal.selectStepExecutionLabel', {
     defaultMessage: 'Select step execution',

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.test.tsx
@@ -41,7 +41,7 @@ describe('StepExecuteManualForm', () => {
 
   const defaultProps = {
     value: '{"foo":"bar"}',
-    onChange: mockOnChange,
+    setValue: mockOnChange,
     errors: null as string | null,
     warnings: null as string | null,
   };

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
@@ -20,14 +20,14 @@ const SCHEMA_URI = `inmemory://schemas/test-step-json-manual-editor-schema`;
 
 export interface StepExecuteManualFormProps {
   value: string;
-  onChange: (value: string) => void;
+  setValue: (value: string) => void;
   errors: string | null;
   warnings: string | null;
   contextJsonSchema?: z.core.JSONSchema.BaseSchema;
 }
 
 export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
-  ({ value, onChange, errors, warnings, contextJsonSchema }) => {
+  ({ value, setValue, errors, warnings, contextJsonSchema }) => {
     // Hook Monaco on mount to register the schema for validation + suggestions
     const mountedOnce = useRef(false);
     const handleMount = useCallback(
@@ -80,7 +80,7 @@ export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
               languageId="json"
               value={value}
               editorDidMount={handleMount}
-              onChange={onChange}
+              onChange={setValue}
               fitToContent={{
                 minLines: 5,
                 maxLines: 15,

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.test.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.test.tsx
@@ -20,28 +20,28 @@ jest.mock('../../../widgets/workflow_yaml_editor/styles/use_workflows_monaco_the
 }));
 
 jest.mock('./step_execute_manual_form', () => ({
-  StepExecuteManualForm: ({ value, onChange, errors, warnings }: any) => (
+  StepExecuteManualForm: ({ value, setValue, errors, warnings }: any) => (
     <div data-test-subj="mockManualForm">
       <span data-test-subj="manualFormValue">{value}</span>
       {errors && <span data-test-subj="manualFormErrors">{errors}</span>}
       {warnings && <span data-test-subj="manualFormWarnings">{warnings}</span>}
       <button
         data-test-subj="manualFormChange"
-        onClick={() => onChange('{"updated":"value"}')}
+        onClick={() => setValue('{"updated":"value"}')}
         type="button"
       >
         {'change'}
       </button>
       <button
         data-test-subj="manualFormInvalidChange"
-        onClick={() => onChange('invalid-json')}
+        onClick={() => setValue('invalid-json')}
         type="button"
       >
         {'invalid change'}
       </button>
       <button
         data-test-subj="manualFormValidMatchingSchema"
-        onClick={() => onChange('{"requiredField":"ok"}')}
+        onClick={() => setValue('{"requiredField":"ok"}')}
         type="button"
       >
         {'valid matching schema'}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
@@ -29,6 +29,7 @@ import type { WorkflowGraph } from '@kbn/workflows/graph';
 import { z } from '@kbn/zod/v4';
 import { NOT_READY_SENTINEL, StepExecuteHistoricalForm } from './step_execute_historical_form';
 import { StepExecuteManualForm } from './step_execute_manual_form';
+import { sanitizeText } from '../../../shared/lib/sanitize_text';
 import type { ContextOverrideData } from '../../../shared/utils/build_step_context_override/build_step_context_override';
 import { useWorkflowsMonacoTheme } from '../../../widgets/workflow_yaml_editor/styles/use_workflows_monaco_theme';
 
@@ -127,7 +128,7 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
     const modalTitleId = useGeneratedHtmlId();
 
     const handleInputChange = useCallback((value: string) => {
-      setInputsJson(value);
+      setInputsJson(sanitizeText(value));
     }, []);
 
     const handleChangeTab = useCallback(
@@ -240,7 +241,7 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
               {selectedTab === 'manual' && (
                 <StepExecuteManualForm
                   value={inputsJson}
-                  onChange={handleInputChange}
+                  setValue={handleInputChange}
                   errors={executionInputErrors}
                   warnings={executionInputWarnings}
                   contextJsonSchema={contextJsonSchema}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
@@ -143,13 +143,6 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
       setSelectedExecutionId(id);
     }, []);
 
-    const handleChange = useCallback(
-      (newValue: string) => {
-        setValue(newValue);
-      },
-      [setValue]
-    );
-
     const handleMount = useCallback(
       (editor: monaco.editor.IStandaloneCodeEditor) => {
         if (!inputs) return;
@@ -221,7 +214,7 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
                       maxLines: 15,
                     }}
                     width="100%"
-                    onChange={handleChange}
+                    onChange={setValue}
                     editorDidMount={handleMount}
                     dataTestSubj={'workflow-historical-json-editor'}
                     overflowWidgetsContainerZIndexOverride={6001}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -35,6 +35,7 @@ import { WorkflowExecuteEventForm } from './workflow_execute_event_form';
 import { WorkflowExecuteHistoricalForm } from './workflow_execute_historical_form';
 import { WorkflowExecuteIndexForm } from './workflow_execute_index_form';
 import { WorkflowExecuteManualForm } from './workflow_execute_manual_form';
+import { sanitizeText } from '../../../shared/lib/sanitize_text';
 
 function getDefaultTrigger(definition: WorkflowYaml | null): WorkflowTriggerTab {
   if (!definition) {
@@ -75,6 +76,10 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
     const [executionInputErrors, setExecutionInputErrors] = useState<string | null>(null);
 
     const { euiTheme } = useEuiTheme();
+
+    const handleInputChange = useCallback((value: string) => {
+      setExecutionInput(sanitizeText(value));
+    }, []);
 
     const handleSubmit = useCallback(() => {
       onSubmit(JSON.parse(executionInput), selectedTrigger);
@@ -271,7 +276,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                 {selectedTrigger === 'alert' && (
                   <WorkflowExecuteEventForm
                     value={executionInput}
-                    setValue={setExecutionInput}
+                    setValue={handleInputChange}
                     errors={executionInputErrors}
                     setErrors={setExecutionInputErrors}
                   />
@@ -282,12 +287,12 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                     inputs={normalizedInputs}
                     errors={executionInputErrors}
                     setErrors={setExecutionInputErrors}
-                    setValue={setExecutionInput}
+                    setValue={handleInputChange}
                   />
                 )}
                 {selectedTrigger === 'index' && (
                   <WorkflowExecuteIndexForm
-                    setValue={setExecutionInput}
+                    setValue={handleInputChange}
                     errors={executionInputErrors}
                     setErrors={setExecutionInputErrors}
                   />
@@ -298,7 +303,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
                     inputs={normalizedInputs}
                     initialExecutionId={initialExecutionId}
                     value={executionInput}
-                    setValue={setExecutionInput}
+                    setValue={handleInputChange}
                     errors={executionInputErrors}
                     setErrors={setExecutionInputErrors}
                   />

--- a/src/platform/plugins/shared/workflows_management/public/shared/lib/sanitize_text.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/lib/sanitize_text.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { sanitizeText } from './sanitize_text';
+
+describe('sanitizeText', () => {
+  it('should return clean text unchanged', () => {
+    expect(sanitizeText('hello world')).toBe('hello world');
+  });
+
+  it('should normalize Windows line endings (\\r\\n) to \\n', () => {
+    expect(sanitizeText('line1\r\nline2')).toBe('line1\nline2');
+  });
+
+  it('should normalize bare carriage returns (\\r) to \\n', () => {
+    expect(sanitizeText('line1\rline2')).toBe('line1\nline2');
+  });
+
+  it('should replace non-breaking spaces (U+00A0) with regular spaces', () => {
+    expect(sanitizeText('key:\u00A0value')).toBe('key: value');
+  });
+
+  it('should replace en spaces (U+2002) with regular spaces', () => {
+    expect(sanitizeText('key:\u2002value')).toBe('key: value');
+  });
+
+  it('should replace em spaces (U+2003) with regular spaces', () => {
+    expect(sanitizeText('key:\u2003value')).toBe('key: value');
+  });
+
+  it('should replace thin spaces (U+2009) with regular spaces', () => {
+    expect(sanitizeText('key:\u2009value')).toBe('key: value');
+  });
+
+  it('should remove zero-width spaces (U+200B)', () => {
+    expect(sanitizeText('hel\u200Blo')).toBe('hello');
+  });
+
+  it('should remove byte order marks (U+FEFF)', () => {
+    expect(sanitizeText('\uFEFFhello')).toBe('hello');
+  });
+
+  it('should replace left/right single smart quotes with ASCII single quote', () => {
+    expect(sanitizeText('\u2018hello\u2019')).toBe("'hello'");
+  });
+
+  it('should replace left/right double smart quotes with ASCII double quote', () => {
+    expect(sanitizeText('\u201Chello\u201D')).toBe('"hello"');
+  });
+
+  it('should handle multiple replacements in a single input', () => {
+    const input = '\uFEFFkey:\u00A0\u2018value\u2019\r\n';
+    expect(sanitizeText(input)).toBe("key: 'value'\n");
+  });
+
+  it('should return an empty string unchanged', () => {
+    expect(sanitizeText('')).toBe('');
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/public/shared/lib/sanitize_text.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/lib/sanitize_text.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Sanitizes text input (yaml, json, text...) from the Monaco editor to remove invisible or
+ * non-standard Unicode characters that cause parser failures.
+ *
+ * Primary trigger: French (AZERTY) keyboards inject non-breaking spaces
+ * (U+00A0) instead of regular spaces, which are visually identical but
+ * treated as non-whitespace by text parsers.
+ *
+ * Also normalizes other common copy-paste artifacts (smart quotes,
+ * zero-width characters, Windows line endings) that can silently break
+ * text or template parsing.
+ */
+export const sanitizeText = (input: string): string => {
+  return (
+    input
+      // Normalize line endings
+      .replace(/\r\n?/g, '\n')
+      // Replace non-breaking and Unicode whitespace with regular space
+      .replace(/[\u00A0\u2002\u2003\u2009]/g, ' ')
+      // Remove zero-width characters and BOM
+      .replace(/[\u200B\uFEFF]/g, '')
+      // Replace smart quotes with ASCII equivalents
+      .replace(/[\u2018\u2019]/g, "'")
+      .replace(/[\u201C\u201D]/g, '"')
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/yaml_editor/yaml_editor.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { CodeEditorProps } from '@kbn/code-editor';
 import { CodeEditor } from '@kbn/code-editor';
 import { yamlLanguageService } from './yaml_language_service';
+import { sanitizeText } from '../../lib/sanitize_text';
 
 export interface YamlEditorProps extends Omit<CodeEditorProps, 'languageId' | 'onChange'> {
   onChange: (value: string) => void;
@@ -55,12 +56,13 @@ export const YamlEditor = React.memo(
 
     const onChangeInternal = useCallback(
       (newValue: string) => {
+        const sanitizedValue = sanitizeText(newValue);
         // Update internal state quickly so the change is reflected instantly in the editor
-        setInternalValue(newValue);
+        setInternalValue(sanitizedValue);
         // Notify that the changes are not synced since we have pending changes
         onSyncStateChange?.(false);
         // Debounce the call to onChange to prevent excessive re-renders upstream
-        onChangeDebounced(newValue);
+        onChangeDebounced(sanitizedValue);
       },
       [onChangeDebounced, onSyncStateChange]
     );


### PR DESCRIPTION
## Summary

Fix internationalization issue where non-standard Unicode characters from keyboard layouts (e.g. French AZERTY non-breaking spaces) and copy-paste artifacts (smart quotes, zero-width characters, BOM) silently break JSON/YAML parsing in workflow editor inputs.

- Add a `sanitizeText` utility that normalizes invisible Unicode characters to their ASCII equivalents before text reaches the parsers
- Apply `sanitizeText` at the input boundary in `YamlEditor`, `StepExecuteModal`, and `WorkflowExecuteModal` so all editor-based inputs are sanitized consistently
- Remove now-redundant `handleChange` wrappers in `StepExecuteHistoricalForm` and `WorkflowExecuteHistoricalForm` that added unnecessary indirection
- Rename `onChange` to `setValue` in `StepExecuteManualForm` props to better reflect the setter pattern used by the parent
- Add comprehensive unit tests for `sanitizeText` covering all replacement branches

