### PR TITLE
[Search] Set default random sample for LLM tests to 1

### DIFF
--- a/.buildkite/pipelines/agent_builder/smoke_tests.yml
+++ b/.buildkite/pipelines/agent_builder/smoke_tests.yml
@@ -49,6 +49,7 @@ steps:
     env:
       FTR_GEN_AI: '1'
       FTR_EIS_CCM: '1'
+      FTR_GEN_AI_LLM_SAMPLE_SIZE: 'all'
       FTR_CONFIG: 'x-pack/platform/test/agent_builder/smoke_tests/config.stateful.ts'
       FTR_CONFIG_GROUP_KEY: 'ftr-agent-builder-smoke-tests'
     label: Agent Builder API Smoke Tests

--- a/src/platform/packages/private/kbn-gen-ai-functional-testing/src/random_llm_sample.ts
+++ b/src/platform/packages/private/kbn-gen-ai-functional-testing/src/random_llm_sample.ts
@@ -13,7 +13,7 @@ import { sampleSize } from 'lodash';
  * Max number of LLMs (connectors / EIS models) to run per FTR suite when unset.
  * Override with {@link FTR_GEN_AI_LLM_SAMPLE_SIZE_ENV}.
  */
-export const DEFAULT_FTR_GEN_AI_LLM_SAMPLE_SIZE = 3;
+export const DEFAULT_FTR_GEN_AI_LLM_SAMPLE_SIZE = 1;
 
 /**
  * Set to a positive integer to cap how many LLMs are exercised in each FTR run.


### PR DESCRIPTION
## Summary

This makes the random sample for LLM tests smaller, and sets the daily test to test all LLMs.