### PR TITLE
[Streams][Streamlang][API] Fully use meta({id}) to reuse schema partials in OAS output

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -62615,694 +62615,7 @@ paths:
         content:
           application/json:
             schema:
-              anyOf:
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    dashboards:
-                      items:
-                        type: string
-                      type: array
-                    queries:
-                      items:
-                        type: object
-                        properties:
-                          description:
-                            type: string
-                          esql:
-                            type: object
-                            properties:
-                              query:
-                                type: string
-                            required:
-                              - query
-                          evidence:
-                            items:
-                              type: string
-                            type: array
-                          id:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                          severity_score:
-                            type: number
-                          title:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                        required:
-                          - id
-                          - title
-                          - description
-                          - esql
-                      type: array
-                    rules:
-                      items:
-                        type: string
-                      type: array
-                    stream:
-                      additionalProperties: false
-                      type: object
-                      properties:
-                        description:
-                          type: string
-                        ingest:
-                          additionalProperties: false
-                          type: object
-                          properties:
-                            failure_store:
-                              anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    inherit:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - inherit
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    disabled:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - disabled
-                                - anyOf:
-                                    - additionalProperties: false
-                                      type: object
-                                      properties:
-                                        lifecycle:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            enabled:
-                                              additionalProperties: false
-                                              type: object
-                                              properties:
-                                                data_retention:
-                                                  description: A non-empty string.
-                                                  minLength: 1
-                                                  type: string
-                                          required:
-                                            - enabled
-                                      required:
-                                        - lifecycle
-                                    - additionalProperties: false
-                                      type: object
-                                      properties:
-                                        lifecycle:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            disabled:
-                                              additionalProperties: false
-                                              type: object
-                                              properties: {}
-                                          required:
-                                            - disabled
-                                      required:
-                                        - lifecycle
-                            lifecycle:
-                              anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    dsl:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        data_retention:
-                                          description: A non-empty string.
-                                          minLength: 1
-                                          type: string
-                                        downsample:
-                                          items:
-                                            type: object
-                                            properties:
-                                              after:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                              fixed_interval:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                            required:
-                                              - after
-                                              - fixed_interval
-                                          type: array
-                                  required:
-                                    - dsl
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    ilm:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        policy:
-                                          description: A non-empty string.
-                                          minLength: 1
-                                          type: string
-                                      required:
-                                        - policy
-                                  required:
-                                    - ilm
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    inherit:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - inherit
-                            processing:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                steps:
-                                  items:
-                                    $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema0'
-                                  type: array
-                                updated_at: {}
-                              required:
-                                - steps
-                            settings:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                index.number_of_replicas:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      type: number
-                                  required:
-                                    - value
-                                index.number_of_shards:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      type: number
-                                  required:
-                                    - value
-                                index.refresh_interval:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      anyOf:
-                                        - type: string
-                                        - enum:
-                                            - -1
-                                          type: number
-                                  required:
-                                    - value
-                            wired:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                fields:
-                                  additionalProperties:
-                                    allOf:
-                                      - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema2'
-                                      - anyOf:
-                                          - type: object
-                                            properties:
-                                              description:
-                                                type: string
-                                              format:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                              type:
-                                                enum:
-                                                  - keyword
-                                                  - match_only_text
-                                                  - long
-                                                  - double
-                                                  - date
-                                                  - boolean
-                                                  - ip
-                                                  - geo_point
-                                                  - integer
-                                                  - short
-                                                  - byte
-                                                  - float
-                                                  - half_float
-                                                  - text
-                                                  - wildcard
-                                                  - version
-                                                  - unsigned_long
-                                                  - date_nanos
-                                                type: string
-                                            required:
-                                              - type
-                                          - type: object
-                                            properties:
-                                              description:
-                                                type: string
-                                              format:
-                                                not: {}
-                                              type:
-                                                not: {}
-                                            required:
-                                              - description
-                                          - type: object
-                                            properties:
-                                              description:
-                                                type: string
-                                              type:
-                                                enum:
-                                                  - system
-                                                type: string
-                                            required:
-                                              - type
-                                  type: object
-                                routing:
-                                  items:
-                                    type: object
-                                    properties:
-                                      destination:
-                                        description: A non-empty string.
-                                        minLength: 1
-                                        type: string
-                                      status:
-                                        enum:
-                                          - enabled
-                                          - disabled
-                                        type: string
-                                      where:
-                                        $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                                    required:
-                                      - destination
-                                      - where
-                                  type: array
-                              required:
-                                - fields
-                                - routing
-                          required:
-                            - lifecycle
-                            - processing
-                            - settings
-                            - failure_store
-                            - wired
-                        query_streams:
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                            required:
-                              - name
-                          type: array
-                        type:
-                          enum:
-                            - wired
-                          type: string
-                      required:
-                        - description
-                        - ingest
-                        - type
-                  required:
-                    - dashboards
-                    - rules
-                    - queries
-                    - stream
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    dashboards:
-                      items:
-                        type: string
-                      type: array
-                    queries:
-                      items:
-                        type: object
-                        properties:
-                          description:
-                            type: string
-                          esql:
-                            type: object
-                            properties:
-                              query:
-                                type: string
-                            required:
-                              - query
-                          evidence:
-                            items:
-                              type: string
-                            type: array
-                          id:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                          severity_score:
-                            type: number
-                          title:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                        required:
-                          - id
-                          - title
-                          - description
-                          - esql
-                      type: array
-                    rules:
-                      items:
-                        type: string
-                      type: array
-                    stream:
-                      additionalProperties: false
-                      type: object
-                      properties:
-                        description:
-                          type: string
-                        ingest:
-                          additionalProperties: false
-                          type: object
-                          properties:
-                            classic:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                field_overrides:
-                                  additionalProperties:
-                                    allOf:
-                                      - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema2'
-                                      - anyOf:
-                                          - type: object
-                                            properties:
-                                              description:
-                                                type: string
-                                              format:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                              type:
-                                                enum:
-                                                  - keyword
-                                                  - match_only_text
-                                                  - long
-                                                  - double
-                                                  - date
-                                                  - boolean
-                                                  - ip
-                                                  - geo_point
-                                                  - integer
-                                                  - short
-                                                  - byte
-                                                  - float
-                                                  - half_float
-                                                  - text
-                                                  - wildcard
-                                                  - version
-                                                  - unsigned_long
-                                                  - date_nanos
-                                                type: string
-                                            required:
-                                              - type
-                                          - type: object
-                                            properties:
-                                              description:
-                                                type: string
-                                              type:
-                                                enum:
-                                                  - system
-                                                type: string
-                                            required:
-                                              - type
-                                  type: object
-                            failure_store:
-                              anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    inherit:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - inherit
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    disabled:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - disabled
-                                - anyOf:
-                                    - additionalProperties: false
-                                      type: object
-                                      properties:
-                                        lifecycle:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            enabled:
-                                              additionalProperties: false
-                                              type: object
-                                              properties:
-                                                data_retention:
-                                                  description: A non-empty string.
-                                                  minLength: 1
-                                                  type: string
-                                          required:
-                                            - enabled
-                                      required:
-                                        - lifecycle
-                                    - additionalProperties: false
-                                      type: object
-                                      properties:
-                                        lifecycle:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            disabled:
-                                              additionalProperties: false
-                                              type: object
-                                              properties: {}
-                                          required:
-                                            - disabled
-                                      required:
-                                        - lifecycle
-                            lifecycle:
-                              anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    dsl:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        data_retention:
-                                          description: A non-empty string.
-                                          minLength: 1
-                                          type: string
-                                        downsample:
-                                          items:
-                                            type: object
-                                            properties:
-                                              after:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                              fixed_interval:
-                                                description: A non-empty string.
-                                                minLength: 1
-                                                type: string
-                                            required:
-                                              - after
-                                              - fixed_interval
-                                          type: array
-                                  required:
-                                    - dsl
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    ilm:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        policy:
-                                          description: A non-empty string.
-                                          minLength: 1
-                                          type: string
-                                      required:
-                                        - policy
-                                  required:
-                                    - ilm
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    inherit:
-                                      additionalProperties: false
-                                      type: object
-                                      properties: {}
-                                  required:
-                                    - inherit
-                            processing:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                steps:
-                                  items:
-                                    $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema0'
-                                  type: array
-                                updated_at: {}
-                              required:
-                                - steps
-                            settings:
-                              additionalProperties: false
-                              type: object
-                              properties:
-                                index.number_of_replicas:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      type: number
-                                  required:
-                                    - value
-                                index.number_of_shards:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      type: number
-                                  required:
-                                    - value
-                                index.refresh_interval:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    value:
-                                      anyOf:
-                                        - type: string
-                                        - enum:
-                                            - -1
-                                          type: number
-                                  required:
-                                    - value
-                          required:
-                            - lifecycle
-                            - processing
-                            - settings
-                            - failure_store
-                            - classic
-                        query_streams:
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                            required:
-                              - name
-                          type: array
-                        type:
-                          enum:
-                            - classic
-                          type: string
-                      required:
-                        - description
-                        - ingest
-                        - type
-                  required:
-                    - dashboards
-                    - rules
-                    - queries
-                    - stream
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    dashboards:
-                      items:
-                        type: string
-                      type: array
-                    queries:
-                      items:
-                        type: object
-                        properties:
-                          description:
-                            type: string
-                          esql:
-                            type: object
-                            properties:
-                              query:
-                                type: string
-                            required:
-                              - query
-                          evidence:
-                            items:
-                              type: string
-                            type: array
-                          id:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                          severity_score:
-                            type: number
-                          title:
-                            description: A non-empty string.
-                            minLength: 1
-                            type: string
-                        required:
-                          - id
-                          - title
-                          - description
-                          - esql
-                      type: array
-                    rules:
-                      items:
-                        type: string
-                      type: array
-                    stream:
-                      additionalProperties: false
-                      type: object
-                      properties:
-                        description:
-                          type: string
-                        query:
-                          additionalProperties: false
-                          type: object
-                          properties:
-                            esql:
-                              type: string
-                            view:
-                              type: string
-                          required:
-                            - view
-                            - esql
-                        query_streams:
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                            required:
-                              - name
-                          type: array
-                        type:
-                          enum:
-                            - query
-                          type: string
-                      required:
-                        - description
-                        - type
-                        - query
-                  required:
-                    - dashboards
-                    - rules
-                    - queries
-                    - stream
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamUpsertRequest'
       responses: {}
       summary: Create or update a stream
       tags:
@@ -63356,7 +62669,7 @@ paths:
                   required:
                     - name
                 where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_1___schema0'
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
               required:
                 - stream
                 - where
@@ -63439,122 +62752,16 @@ paths:
                       type: object
                       properties:
                         failure_store:
-                          anyOf:
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                inherit:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - inherit
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                disabled:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - disabled
-                            - anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    lifecycle:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        enabled:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            data_retention:
-                                              description: A non-empty string.
-                                              minLength: 1
-                                              type: string
-                                      required:
-                                        - enabled
-                                  required:
-                                    - lifecycle
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    lifecycle:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        disabled:
-                                          additionalProperties: false
-                                          type: object
-                                          properties: {}
-                                      required:
-                                        - disabled
-                                  required:
-                                    - lifecycle
+                          $ref: '#/components/schemas/Kibana_HTTP_APIs_FailureStore'
                         lifecycle:
-                          anyOf:
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                dsl:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    data_retention:
-                                      description: A non-empty string.
-                                      minLength: 1
-                                      type: string
-                                    downsample:
-                                      items:
-                                        type: object
-                                        properties:
-                                          after:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                          fixed_interval:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                          - after
-                                          - fixed_interval
-                                      type: array
-                              required:
-                                - dsl
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                ilm:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    policy:
-                                      description: A non-empty string.
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                    - policy
-                              required:
-                                - ilm
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                inherit:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - inherit
+                          $ref: '#/components/schemas/Kibana_HTTP_APIs_IngestStreamLifecycle'
                         processing:
                           additionalProperties: false
                           type: object
                           properties:
                             steps:
                               items:
-                                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema0'
+                                $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangStep'
                               type: array
                             updated_at: {}
                           required:
@@ -63596,62 +62803,7 @@ paths:
                           type: object
                           properties:
                             fields:
-                              additionalProperties:
-                                allOf:
-                                  - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema2'
-                                  - anyOf:
-                                      - type: object
-                                        properties:
-                                          description:
-                                            type: string
-                                          format:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                          type:
-                                            enum:
-                                              - keyword
-                                              - match_only_text
-                                              - long
-                                              - double
-                                              - date
-                                              - boolean
-                                              - ip
-                                              - geo_point
-                                              - integer
-                                              - short
-                                              - byte
-                                              - float
-                                              - half_float
-                                              - text
-                                              - wildcard
-                                              - version
-                                              - unsigned_long
-                                              - date_nanos
-                                            type: string
-                                        required:
-                                          - type
-                                      - type: object
-                                        properties:
-                                          description:
-                                            type: string
-                                          format:
-                                            not: {}
-                                          type:
-                                            not: {}
-                                        required:
-                                          - description
-                                      - type: object
-                                        properties:
-                                          description:
-                                            type: string
-                                          type:
-                                            enum:
-                                              - system
-                                            type: string
-                                        required:
-                                          - type
-                              type: object
+                              $ref: '#/components/schemas/Kibana_HTTP_APIs_FieldDefinition'
                             routing:
                               items:
                                 type: object
@@ -63666,7 +62818,7 @@ paths:
                                       - disabled
                                     type: string
                                   where:
-                                    $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
+                                    $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
                                 required:
                                   - destination
                                   - where
@@ -63688,169 +62840,18 @@ paths:
                           type: object
                           properties:
                             field_overrides:
-                              additionalProperties:
-                                allOf:
-                                  - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema2'
-                                  - anyOf:
-                                      - type: object
-                                        properties:
-                                          description:
-                                            type: string
-                                          format:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                          type:
-                                            enum:
-                                              - keyword
-                                              - match_only_text
-                                              - long
-                                              - double
-                                              - date
-                                              - boolean
-                                              - ip
-                                              - geo_point
-                                              - integer
-                                              - short
-                                              - byte
-                                              - float
-                                              - half_float
-                                              - text
-                                              - wildcard
-                                              - version
-                                              - unsigned_long
-                                              - date_nanos
-                                            type: string
-                                        required:
-                                          - type
-                                      - type: object
-                                        properties:
-                                          description:
-                                            type: string
-                                          type:
-                                            enum:
-                                              - system
-                                            type: string
-                                        required:
-                                          - type
-                              type: object
+                              $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicFieldDefinition'
                         failure_store:
-                          anyOf:
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                inherit:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - inherit
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                disabled:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - disabled
-                            - anyOf:
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    lifecycle:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        enabled:
-                                          additionalProperties: false
-                                          type: object
-                                          properties:
-                                            data_retention:
-                                              description: A non-empty string.
-                                              minLength: 1
-                                              type: string
-                                      required:
-                                        - enabled
-                                  required:
-                                    - lifecycle
-                                - additionalProperties: false
-                                  type: object
-                                  properties:
-                                    lifecycle:
-                                      additionalProperties: false
-                                      type: object
-                                      properties:
-                                        disabled:
-                                          additionalProperties: false
-                                          type: object
-                                          properties: {}
-                                      required:
-                                        - disabled
-                                  required:
-                                    - lifecycle
+                          $ref: '#/components/schemas/Kibana_HTTP_APIs_FailureStore'
                         lifecycle:
-                          anyOf:
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                dsl:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    data_retention:
-                                      description: A non-empty string.
-                                      minLength: 1
-                                      type: string
-                                    downsample:
-                                      items:
-                                        type: object
-                                        properties:
-                                          after:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                          fixed_interval:
-                                            description: A non-empty string.
-                                            minLength: 1
-                                            type: string
-                                        required:
-                                          - after
-                                          - fixed_interval
-                                      type: array
-                              required:
-                                - dsl
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                ilm:
-                                  additionalProperties: false
-                                  type: object
-                                  properties:
-                                    policy:
-                                      description: A non-empty string.
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                    - policy
-                              required:
-                                - ilm
-                            - additionalProperties: false
-                              type: object
-                              properties:
-                                inherit:
-                                  additionalProperties: false
-                                  type: object
-                                  properties: {}
-                              required:
-                                - inherit
+                          $ref: '#/components/schemas/Kibana_HTTP_APIs_IngestStreamLifecycle'
                         processing:
                           additionalProperties: false
                           type: object
                           properties:
                             steps:
                               items:
-                                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema0'
+                                $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangStep'
                               type: array
                             updated_at: {}
                           required:
@@ -69691,2320 +68692,6 @@ components:
           type: boolean
       required:
         - data_view
-    Kibana_HTTP_APIs__zod_v4_0___schema0:
-      anyOf:
-        - anyOf:
-            - additionalProperties: false
-              description: Grok processor - Extract fields from text using grok patterns
-              type: object
-              properties:
-                action:
-                  enum:
-                    - grok
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to parse with grok patterns
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                pattern_definitions:
-                  additionalProperties:
-                    type: string
-                  type: object
-                patterns:
-                  description: Grok patterns applied in order to extract fields
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - patterns
-            - additionalProperties: false
-              description: Dissect processor - Extract fields from text using a lightweight, delimiter-based parser
-              type: object
-              properties:
-                action:
-                  enum:
-                    - dissect
-                  type: string
-                append_separator:
-                  description: Separator inserted when target fields are concatenated
-                  minLength: 1
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to parse with dissect pattern
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                pattern:
-                  description: Dissect pattern describing field boundaries
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - pattern
-            - additionalProperties: false
-              description: Date processor - Parse dates from strings using one or more expected formats
-              type: object
-              properties:
-                action:
-                  enum:
-                    - date
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                formats:
-                  description: Accepted input date formats, tried in order
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  type: array
-                from:
-                  description: Source field containing the date/time text
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                locale:
-                  description: Optional locale for date parsing
-                  minLength: 1
-                  type: string
-                output_format:
-                  description: Optional output format for storing the parsed date as text
-                  minLength: 1
-                  type: string
-                timezone:
-                  description: Optional timezone for date parsing
-                  minLength: 1
-                  type: string
-                to:
-                  description: Target field for the parsed date (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - formats
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - drop_document
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - math
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                expression:
-                  description: A non-empty string.
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - expression
-                - to
-            - additionalProperties: false
-              description: Rename processor - Change a field name and optionally its location
-              type: object
-              properties:
-                action:
-                  enum:
-                    - rename
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Existing source field to rename or move
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip when source field is missing
-                  type: boolean
-                override:
-                  description: Allow overwriting the target field if it already exists
-                  type: boolean
-                to:
-                  description: New field name or destination path
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - to
-            - additionalProperties: false
-              description: Set processor - Assign a literal or copied value to a field (mutually exclusive inputs)
-              type: object
-              properties:
-                action:
-                  enum:
-                    - set
-                  type: string
-                copy_from:
-                  description: Copy value from another field instead of providing a literal
-                  minLength: 1
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                override:
-                  description: Allow overwriting an existing target field
-                  type: boolean
-                to:
-                  description: Target field to set or create
-                  minLength: 1
-                  type: string
-                value:
-                  description: Literal value to assign to the target field
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - to
-            - additionalProperties: false
-              description: Append processor - Append one or more values to an existing or new array field
-              type: object
-              properties:
-                action:
-                  enum:
-                    - append
-                  type: string
-                allow_duplicates:
-                  description: If true, do not deduplicate appended values
-                  type: boolean
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                to:
-                  description: Array field to append values to
-                  minLength: 1
-                  type: string
-                value:
-                  description: Values to append (must be literal, no templates)
-                  items: {}
-                  minItems: 1
-                  type: array
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - to
-                - value
-            - additionalProperties: false
-              description: Remove by prefix processor - Remove a field and all nested fields matching the prefix
-              type: object
-              properties:
-                action:
-                  enum:
-                    - remove_by_prefix
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Field to remove along with all its nested fields
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              description: Remove processor - Delete one or more fields from the document
-              type: object
-              properties:
-                action:
-                  enum:
-                    - remove
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Field to remove from the document
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - replace
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                pattern:
-                  minLength: 1
-                  type: string
-                replacement:
-                  type: string
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - pattern
-                - replacement
-            - additionalProperties: false
-              description: Redact processor - Mask sensitive data using Grok patterns
-              type: object
-              properties:
-                action:
-                  enum:
-                    - redact
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to redact sensitive data from
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing (defaults to true)
-                  type: boolean
-                pattern_definitions:
-                  additionalProperties:
-                    type: string
-                  description: Custom pattern definitions to use in the patterns
-                  type: object
-                patterns:
-                  description: Grok patterns to match sensitive data (for example, "%{IP:client}", "%{EMAILADDRESS:email}")
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                prefix:
-                  description: Prefix to prepend to the redacted pattern name (defaults to "<")
-                  type: string
-                suffix:
-                  description: Suffix to append to the redacted pattern name (defaults to ">")
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - patterns
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - uppercase
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - lowercase
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - trim
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - join
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                delimiter:
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  items:
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - delimiter
-                - to
-            - additionalProperties: false
-              description: Split processor - Split a field value into an array using a separator
-              type: object
-              properties:
-                action:
-                  enum:
-                    - split
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to split into an array
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                preserve_trailing:
-                  description: Preserve empty trailing fields in the split result
-                  type: boolean
-                separator:
-                  description: Regex separator used to split the field value into an array
-                  minLength: 1
-                  type: string
-                to:
-                  description: Target field for the split array (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - separator
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - sort
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Array field to sort
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                order:
-                  description: Sort order - "asc" (ascending) or "desc" (descending). Defaults to "asc"
-                  enum:
-                    - asc
-                    - desc
-                  type: string
-                to:
-                  description: Target field for the sorted array (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              description: Convert processor - Change the data type of a field value (integer, long, double, boolean, or string)
-              type: object
-              properties:
-                action:
-                  enum:
-                    - convert
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to convert to a different data type
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                to:
-                  description: Target field for the converted value (defaults to source)
-                  minLength: 1
-                  type: string
-                type:
-                  description: 'Target data type: integer, long, double, boolean, or string'
-                  enum:
-                    - integer
-                    - long
-                    - double
-                    - boolean
-                    - string
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - type
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - concat
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  items:
-                    anyOf:
-                      - type: object
-                        properties:
-                          type:
-                            enum:
-                              - field
-                            type: string
-                          value:
-                            minLength: 1
-                            type: string
-                        required:
-                          - type
-                          - value
-                      - type: object
-                        properties:
-                          type:
-                            enum:
-                              - literal
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - type
-                          - value
-                  minItems: 1
-                  type: array
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - to
-            - allOf:
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    action:
-                      enum:
-                        - network_direction
-                      type: string
-                    customIdentifier:
-                      description: Custom identifier to correlate this processor across outputs
-                      minLength: 1
-                      type: string
-                    description:
-                      description: Human-readable notes about this processor step
-                      type: string
-                    destination_ip:
-                      minLength: 1
-                      type: string
-                    ignore_failure:
-                      description: Continue pipeline execution if this processor fails
-                      type: boolean
-                    ignore_missing:
-                      type: boolean
-                    source_ip:
-                      minLength: 1
-                      type: string
-                    target_field:
-                      minLength: 1
-                      type: string
-                    where:
-                      $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                      description: Conditional expression controlling whether this processor runs
-                  required:
-                    - action
-                    - source_ip
-                    - destination_ip
-                - anyOf:
-                    - additionalProperties: false
-                      type: object
-                      properties:
-                        internal_networks:
-                          items:
-                            type: string
-                          type: array
-                      required:
-                        - internal_networks
-                    - additionalProperties: false
-                      type: object
-                      properties:
-                        internal_networks_field:
-                          minLength: 1
-                          type: string
-                      required:
-                        - internal_networks_field
-            - additionalProperties: false
-              description: Manual ingest pipeline wrapper around native Elasticsearch processors
-              type: object
-              properties:
-                action:
-                  description: Manual ingest pipeline - executes raw Elasticsearch ingest processors
-                  enum:
-                    - manual_ingest_pipeline
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                on_failure:
-                  description: Fallback processors to run when a processor fails
-                  items:
-                    additionalProperties: {}
-                    type: object
-                  type: array
-                processors:
-                  description: List of raw Elasticsearch ingest processors to run
-                  items:
-                    additionalProperties: {}
-                    type: object
-                  type: array
-                tag:
-                  description: Optional ingest processor tag for Elasticsearch
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - processors
-        - additionalProperties: false
-          type: object
-          properties:
-            condition:
-              allOf:
-                - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    steps:
-                      items:
-                        $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema0'
-                      type: array
-                  required:
-                    - steps
-            customIdentifier:
-              type: string
-          required:
-            - condition
-    Kibana_HTTP_APIs__zod_v4_0___schema1:
-      anyOf:
-        - anyOf:
-            - additionalProperties: false
-              description: A condition that compares a field to a value or range using an operator as the key.
-              type: object
-              properties:
-                contains:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Contains comparison value.
-                endsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Ends-with comparison value.
-                eq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Equality comparison value.
-                field:
-                  description: The document field to filter on.
-                  minLength: 1
-                  type: string
-                gt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than comparison value.
-                gte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than-or-equal comparison value.
-                includes:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Checks if multivalue field includes the value.
-                lt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than comparison value.
-                lte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than-or-equal comparison value.
-                neq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Inequality comparison value.
-                range:
-                  additionalProperties: false
-                  description: Range comparison values.
-                  type: object
-                  properties:
-                    gt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    gte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                startsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Starts-with comparison value.
-              required:
-                - field
-            - additionalProperties: false
-              description: A condition that checks for the existence or non-existence of a field.
-              type: object
-              properties:
-                exists:
-                  description: Indicates whether the field exists or not.
-                  type: boolean
-                field:
-                  description: The document field to check.
-                  minLength: 1
-                  type: string
-              required:
-                - field
-          description: A basic filter condition, either unary or binary.
-        - additionalProperties: false
-          description: A logical AND that groups multiple conditions.
-          type: object
-          properties:
-            and:
-              description: An array of conditions. All sub-conditions must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-              type: array
-          required:
-            - and
-        - additionalProperties: false
-          description: A logical OR that groups multiple conditions.
-          type: object
-          properties:
-            or:
-              description: An array of conditions. At least one sub-condition must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-              type: array
-          required:
-            - or
-        - additionalProperties: false
-          description: A logical NOT that negates a condition.
-          type: object
-          properties:
-            not:
-              $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema1'
-              description: A condition that negates another condition.
-          required:
-            - not
-        - additionalProperties: false
-          description: A condition that always evaluates to false.
-          type: object
-          properties:
-            never:
-              additionalProperties: false
-              description: An empty object. This condition never matches.
-              type: object
-              properties: {}
-          required:
-            - never
-        - additionalProperties: false
-          description: A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.
-          type: object
-          properties:
-            always:
-              additionalProperties: false
-              description: An empty object. This condition always matches.
-              type: object
-              properties: {}
-          required:
-            - always
-      description: The root condition object. It can be a simple filter or a combination of other conditions.
-    Kibana_HTTP_APIs__zod_v4_0___schema2:
-      additionalProperties:
-        anyOf:
-          - anyOf:
-              - type: string
-              - type: number
-              - type: boolean
-              - nullable: true
-              - {}
-          - items:
-              anyOf:
-                - type: string
-                - type: number
-                - type: boolean
-                - nullable: true
-                - {}
-            type: array
-          - items: {}
-            type: array
-          - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_0___schema2'
-      type: object
-    Kibana_HTTP_APIs__zod_v4_1___schema0:
-      anyOf:
-        - anyOf:
-            - additionalProperties: false
-              description: A condition that compares a field to a value or range using an operator as the key.
-              type: object
-              properties:
-                contains:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Contains comparison value.
-                endsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Ends-with comparison value.
-                eq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Equality comparison value.
-                field:
-                  description: The document field to filter on.
-                  minLength: 1
-                  type: string
-                gt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than comparison value.
-                gte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than-or-equal comparison value.
-                includes:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Checks if multivalue field includes the value.
-                lt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than comparison value.
-                lte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than-or-equal comparison value.
-                neq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Inequality comparison value.
-                range:
-                  additionalProperties: false
-                  description: Range comparison values.
-                  type: object
-                  properties:
-                    gt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    gte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                startsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Starts-with comparison value.
-              required:
-                - field
-            - additionalProperties: false
-              description: A condition that checks for the existence or non-existence of a field.
-              type: object
-              properties:
-                exists:
-                  description: Indicates whether the field exists or not.
-                  type: boolean
-                field:
-                  description: The document field to check.
-                  minLength: 1
-                  type: string
-              required:
-                - field
-          description: A basic filter condition, either unary or binary.
-        - additionalProperties: false
-          description: A logical AND that groups multiple conditions.
-          type: object
-          properties:
-            and:
-              description: An array of conditions. All sub-conditions must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_1___schema0'
-              type: array
-          required:
-            - and
-        - additionalProperties: false
-          description: A logical OR that groups multiple conditions.
-          type: object
-          properties:
-            or:
-              description: An array of conditions. At least one sub-condition must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_1___schema0'
-              type: array
-          required:
-            - or
-        - additionalProperties: false
-          description: A logical NOT that negates a condition.
-          type: object
-          properties:
-            not:
-              $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_1___schema0'
-              description: A condition that negates another condition.
-          required:
-            - not
-        - additionalProperties: false
-          description: A condition that always evaluates to false.
-          type: object
-          properties:
-            never:
-              additionalProperties: false
-              description: An empty object. This condition never matches.
-              type: object
-              properties: {}
-          required:
-            - never
-        - additionalProperties: false
-          description: A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.
-          type: object
-          properties:
-            always:
-              additionalProperties: false
-              description: An empty object. This condition always matches.
-              type: object
-              properties: {}
-          required:
-            - always
-      description: The root condition object. It can be a simple filter or a combination of other conditions.
-    Kibana_HTTP_APIs__zod_v4_2___schema0:
-      anyOf:
-        - anyOf:
-            - additionalProperties: false
-              description: Grok processor - Extract fields from text using grok patterns
-              type: object
-              properties:
-                action:
-                  enum:
-                    - grok
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to parse with grok patterns
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                pattern_definitions:
-                  additionalProperties:
-                    type: string
-                  type: object
-                patterns:
-                  description: Grok patterns applied in order to extract fields
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - patterns
-            - additionalProperties: false
-              description: Dissect processor - Extract fields from text using a lightweight, delimiter-based parser
-              type: object
-              properties:
-                action:
-                  enum:
-                    - dissect
-                  type: string
-                append_separator:
-                  description: Separator inserted when target fields are concatenated
-                  minLength: 1
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to parse with dissect pattern
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                pattern:
-                  description: Dissect pattern describing field boundaries
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - pattern
-            - additionalProperties: false
-              description: Date processor - Parse dates from strings using one or more expected formats
-              type: object
-              properties:
-                action:
-                  enum:
-                    - date
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                formats:
-                  description: Accepted input date formats, tried in order
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  type: array
-                from:
-                  description: Source field containing the date/time text
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                locale:
-                  description: Optional locale for date parsing
-                  minLength: 1
-                  type: string
-                output_format:
-                  description: Optional output format for storing the parsed date as text
-                  minLength: 1
-                  type: string
-                timezone:
-                  description: Optional timezone for date parsing
-                  minLength: 1
-                  type: string
-                to:
-                  description: Target field for the parsed date (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - formats
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - drop_document
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - math
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                expression:
-                  description: A non-empty string.
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - expression
-                - to
-            - additionalProperties: false
-              description: Rename processor - Change a field name and optionally its location
-              type: object
-              properties:
-                action:
-                  enum:
-                    - rename
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Existing source field to rename or move
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip when source field is missing
-                  type: boolean
-                override:
-                  description: Allow overwriting the target field if it already exists
-                  type: boolean
-                to:
-                  description: New field name or destination path
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - to
-            - additionalProperties: false
-              description: Set processor - Assign a literal or copied value to a field (mutually exclusive inputs)
-              type: object
-              properties:
-                action:
-                  enum:
-                    - set
-                  type: string
-                copy_from:
-                  description: Copy value from another field instead of providing a literal
-                  minLength: 1
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                override:
-                  description: Allow overwriting an existing target field
-                  type: boolean
-                to:
-                  description: Target field to set or create
-                  minLength: 1
-                  type: string
-                value:
-                  description: Literal value to assign to the target field
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - to
-            - additionalProperties: false
-              description: Append processor - Append one or more values to an existing or new array field
-              type: object
-              properties:
-                action:
-                  enum:
-                    - append
-                  type: string
-                allow_duplicates:
-                  description: If true, do not deduplicate appended values
-                  type: boolean
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                to:
-                  description: Array field to append values to
-                  minLength: 1
-                  type: string
-                value:
-                  description: Values to append (must be literal, no templates)
-                  items: {}
-                  minItems: 1
-                  type: array
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - to
-                - value
-            - additionalProperties: false
-              description: Remove by prefix processor - Remove a field and all nested fields matching the prefix
-              type: object
-              properties:
-                action:
-                  enum:
-                    - remove_by_prefix
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Field to remove along with all its nested fields
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              description: Remove processor - Delete one or more fields from the document
-              type: object
-              properties:
-                action:
-                  enum:
-                    - remove
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Field to remove from the document
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - replace
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                pattern:
-                  minLength: 1
-                  type: string
-                replacement:
-                  type: string
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - pattern
-                - replacement
-            - additionalProperties: false
-              description: Redact processor - Mask sensitive data using Grok patterns
-              type: object
-              properties:
-                action:
-                  enum:
-                    - redact
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to redact sensitive data from
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing (defaults to true)
-                  type: boolean
-                pattern_definitions:
-                  additionalProperties:
-                    type: string
-                  description: Custom pattern definitions to use in the patterns
-                  type: object
-                patterns:
-                  description: Grok patterns to match sensitive data (for example, "%{IP:client}", "%{EMAILADDRESS:email}")
-                  items:
-                    description: A non-empty string.
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                prefix:
-                  description: Prefix to prepend to the redacted pattern name (defaults to "<")
-                  type: string
-                suffix:
-                  description: Suffix to append to the redacted pattern name (defaults to ">")
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - patterns
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - uppercase
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - lowercase
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - trim
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - join
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                delimiter:
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  items:
-                    minLength: 1
-                    type: string
-                  minItems: 1
-                  type: array
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - delimiter
-                - to
-            - additionalProperties: false
-              description: Split processor - Split a field value into an array using a separator
-              type: object
-              properties:
-                action:
-                  enum:
-                    - split
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to split into an array
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                preserve_trailing:
-                  description: Preserve empty trailing fields in the split result
-                  type: boolean
-                separator:
-                  description: Regex separator used to split the field value into an array
-                  minLength: 1
-                  type: string
-                to:
-                  description: Target field for the split array (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - separator
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - sort
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Array field to sort
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                order:
-                  description: Sort order - "asc" (ascending) or "desc" (descending). Defaults to "asc"
-                  enum:
-                    - asc
-                    - desc
-                  type: string
-                to:
-                  description: Target field for the sorted array (defaults to source)
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-            - additionalProperties: false
-              description: Convert processor - Change the data type of a field value (integer, long, double, boolean, or string)
-              type: object
-              properties:
-                action:
-                  enum:
-                    - convert
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  description: Source field to convert to a different data type
-                  minLength: 1
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  description: Skip processing when source field is missing
-                  type: boolean
-                to:
-                  description: Target field for the converted value (defaults to source)
-                  minLength: 1
-                  type: string
-                type:
-                  description: 'Target data type: integer, long, double, boolean, or string'
-                  enum:
-                    - integer
-                    - long
-                    - double
-                    - boolean
-                    - string
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - type
-            - additionalProperties: false
-              type: object
-              properties:
-                action:
-                  enum:
-                    - concat
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                from:
-                  items:
-                    anyOf:
-                      - type: object
-                        properties:
-                          type:
-                            enum:
-                              - field
-                            type: string
-                          value:
-                            minLength: 1
-                            type: string
-                        required:
-                          - type
-                          - value
-                      - type: object
-                        properties:
-                          type:
-                            enum:
-                              - literal
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - type
-                          - value
-                  minItems: 1
-                  type: array
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                ignore_missing:
-                  type: boolean
-                to:
-                  minLength: 1
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - from
-                - to
-            - allOf:
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    action:
-                      enum:
-                        - network_direction
-                      type: string
-                    customIdentifier:
-                      description: Custom identifier to correlate this processor across outputs
-                      minLength: 1
-                      type: string
-                    description:
-                      description: Human-readable notes about this processor step
-                      type: string
-                    destination_ip:
-                      minLength: 1
-                      type: string
-                    ignore_failure:
-                      description: Continue pipeline execution if this processor fails
-                      type: boolean
-                    ignore_missing:
-                      type: boolean
-                    source_ip:
-                      minLength: 1
-                      type: string
-                    target_field:
-                      minLength: 1
-                      type: string
-                    where:
-                      $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                      description: Conditional expression controlling whether this processor runs
-                  required:
-                    - action
-                    - source_ip
-                    - destination_ip
-                - anyOf:
-                    - additionalProperties: false
-                      type: object
-                      properties:
-                        internal_networks:
-                          items:
-                            type: string
-                          type: array
-                      required:
-                        - internal_networks
-                    - additionalProperties: false
-                      type: object
-                      properties:
-                        internal_networks_field:
-                          minLength: 1
-                          type: string
-                      required:
-                        - internal_networks_field
-            - additionalProperties: false
-              description: Manual ingest pipeline wrapper around native Elasticsearch processors
-              type: object
-              properties:
-                action:
-                  description: Manual ingest pipeline - executes raw Elasticsearch ingest processors
-                  enum:
-                    - manual_ingest_pipeline
-                  type: string
-                customIdentifier:
-                  description: Custom identifier to correlate this processor across outputs
-                  minLength: 1
-                  type: string
-                description:
-                  description: Human-readable notes about this processor step
-                  type: string
-                ignore_failure:
-                  description: Continue pipeline execution if this processor fails
-                  type: boolean
-                on_failure:
-                  description: Fallback processors to run when a processor fails
-                  items:
-                    additionalProperties: {}
-                    type: object
-                  type: array
-                processors:
-                  description: List of raw Elasticsearch ingest processors to run
-                  items:
-                    additionalProperties: {}
-                    type: object
-                  type: array
-                tag:
-                  description: Optional ingest processor tag for Elasticsearch
-                  type: string
-                where:
-                  $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                  description: Conditional expression controlling whether this processor runs
-              required:
-                - action
-                - processors
-        - additionalProperties: false
-          type: object
-          properties:
-            condition:
-              allOf:
-                - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-                - additionalProperties: false
-                  type: object
-                  properties:
-                    steps:
-                      items:
-                        $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema0'
-                      type: array
-                  required:
-                    - steps
-            customIdentifier:
-              type: string
-          required:
-            - condition
-    Kibana_HTTP_APIs__zod_v4_2___schema1:
-      anyOf:
-        - anyOf:
-            - additionalProperties: false
-              description: A condition that compares a field to a value or range using an operator as the key.
-              type: object
-              properties:
-                contains:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Contains comparison value.
-                endsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Ends-with comparison value.
-                eq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Equality comparison value.
-                field:
-                  description: The document field to filter on.
-                  minLength: 1
-                  type: string
-                gt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than comparison value.
-                gte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Greater-than-or-equal comparison value.
-                includes:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Checks if multivalue field includes the value.
-                lt:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than comparison value.
-                lte:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Less-than-or-equal comparison value.
-                neq:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Inequality comparison value.
-                range:
-                  additionalProperties: false
-                  description: Range comparison values.
-                  type: object
-                  properties:
-                    gt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    gte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lt:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                    lte:
-                      anyOf:
-                        - type: string
-                        - type: number
-                        - type: boolean
-                      description: A value that can be a string, number, or boolean.
-                startsWith:
-                  anyOf:
-                    - type: string
-                    - type: number
-                    - type: boolean
-                  description: Starts-with comparison value.
-              required:
-                - field
-            - additionalProperties: false
-              description: A condition that checks for the existence or non-existence of a field.
-              type: object
-              properties:
-                exists:
-                  description: Indicates whether the field exists or not.
-                  type: boolean
-                field:
-                  description: The document field to check.
-                  minLength: 1
-                  type: string
-              required:
-                - field
-          description: A basic filter condition, either unary or binary.
-        - additionalProperties: false
-          description: A logical AND that groups multiple conditions.
-          type: object
-          properties:
-            and:
-              description: An array of conditions. All sub-conditions must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-              type: array
-          required:
-            - and
-        - additionalProperties: false
-          description: A logical OR that groups multiple conditions.
-          type: object
-          properties:
-            or:
-              description: An array of conditions. At least one sub-condition must be true for this condition to be true.
-              items:
-                $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-              type: array
-          required:
-            - or
-        - additionalProperties: false
-          description: A logical NOT that negates a condition.
-          type: object
-          properties:
-            not:
-              $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema1'
-              description: A condition that negates another condition.
-          required:
-            - not
-        - additionalProperties: false
-          description: A condition that always evaluates to false.
-          type: object
-          properties:
-            never:
-              additionalProperties: false
-              description: An empty object. This condition never matches.
-              type: object
-              properties: {}
-          required:
-            - never
-        - additionalProperties: false
-          description: A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.
-          type: object
-          properties:
-            always:
-              additionalProperties: false
-              description: An empty object. This condition always matches.
-              type: object
-              properties: {}
-          required:
-            - always
-      description: The root condition object. It can be a simple filter or a combination of other conditions.
-    Kibana_HTTP_APIs__zod_v4_2___schema2:
-      additionalProperties:
-        anyOf:
-          - anyOf:
-              - type: string
-              - type: number
-              - type: boolean
-              - nullable: true
-              - {}
-          - items:
-              anyOf:
-                - type: string
-                - type: number
-                - type: boolean
-                - nullable: true
-                - {}
-            type: array
-          - items: {}
-            type: array
-          - $ref: '#/components/schemas/Kibana_HTTP_APIs__zod_v4_2___schema2'
-      type: object
     Kibana_HTTP_APIs__zod_v4_3___schema0:
       anyOf:
         - additionalProperties: false
@@ -72057,6 +68744,267 @@ components:
                 - routing
           required:
             - objects
+    Kibana_HTTP_APIs_ClassicFieldDefinition:
+      additionalProperties:
+        $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicFieldDefinitionConfig'
+      id: ClassicFieldDefinition
+      type: object
+    Kibana_HTTP_APIs_ClassicFieldDefinitionConfig:
+      allOf:
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_RecursiveRecord'
+        - anyOf:
+            - additionalProperties: false
+              type: object
+              properties:
+                description:
+                  type: string
+                format:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+                type:
+                  enum:
+                    - keyword
+                    - match_only_text
+                    - long
+                    - double
+                    - date
+                    - boolean
+                    - ip
+                    - geo_point
+                    - integer
+                    - short
+                    - byte
+                    - float
+                    - half_float
+                    - text
+                    - wildcard
+                    - version
+                    - unsigned_long
+                    - date_nanos
+                  type: string
+              required:
+                - type
+            - additionalProperties: false
+              type: object
+              properties:
+                description:
+                  type: string
+                type:
+                  enum:
+                    - system
+                  type: string
+              required:
+                - type
+      id: ClassicFieldDefinitionConfig
+    Kibana_HTTP_APIs_ClassicStreamUpsertRequest:
+      additionalProperties: false
+      id: ClassicStreamUpsertRequest
+      type: object
+      properties:
+        dashboards:
+          items:
+            type: string
+          type: array
+        queries:
+          items:
+            type: object
+            properties:
+              description:
+                type: string
+              esql:
+                type: object
+                properties:
+                  query:
+                    type: string
+                required:
+                  - query
+              evidence:
+                items:
+                  type: string
+                type: array
+              id:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+              severity_score:
+                type: number
+              title:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+            required:
+              - id
+              - title
+              - description
+              - esql
+          type: array
+        rules:
+          items:
+            type: string
+          type: array
+        stream:
+          additionalProperties: false
+          type: object
+          properties:
+            description:
+              type: string
+            ingest:
+              additionalProperties: false
+              type: object
+              properties:
+                classic:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    field_overrides:
+                      $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicFieldDefinition'
+                failure_store:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_FailureStore'
+                lifecycle:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_IngestStreamLifecycle'
+                processing:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    steps:
+                      items:
+                        $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangStep'
+                      type: array
+                    updated_at: {}
+                  required:
+                    - steps
+                settings:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    index.number_of_replicas:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          type: number
+                      required:
+                        - value
+                    index.number_of_shards:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          type: number
+                      required:
+                        - value
+                    index.refresh_interval:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          anyOf:
+                            - type: string
+                            - enum:
+                                - -1
+                              type: number
+                      required:
+                        - value
+              required:
+                - lifecycle
+                - processing
+                - settings
+                - failure_store
+                - classic
+            query_streams:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
+            type:
+              enum:
+                - classic
+              type: string
+          required:
+            - description
+            - ingest
+            - type
+      required:
+        - dashboards
+        - rules
+        - queries
+        - stream
+    Kibana_HTTP_APIs_Condition:
+      anyOf:
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_FilterCondition'
+        - additionalProperties: false
+          description: A logical AND that groups multiple conditions.
+          type: object
+          properties:
+            and:
+              description: An array of conditions. All sub-conditions must be true for this condition to be true.
+              items:
+                $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+              type: array
+          required:
+            - and
+        - additionalProperties: false
+          description: A logical OR that groups multiple conditions.
+          type: object
+          properties:
+            or:
+              description: An array of conditions. At least one sub-condition must be true for this condition to be true.
+              items:
+                $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+              type: array
+          required:
+            - or
+        - additionalProperties: false
+          description: A logical NOT that negates a condition.
+          type: object
+          properties:
+            not:
+              $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+              description: A condition that negates another condition.
+          required:
+            - not
+        - additionalProperties: false
+          description: A condition that always evaluates to false.
+          type: object
+          properties:
+            never:
+              additionalProperties: false
+              description: An empty object. This condition never matches.
+              type: object
+              properties: {}
+          required:
+            - never
+        - additionalProperties: false
+          description: A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.
+          type: object
+          properties:
+            always:
+              additionalProperties: false
+              description: An empty object. This condition always matches.
+              type: object
+              properties: {}
+          required:
+            - always
+      description: The root condition object. It can be a simple filter or a combination of other conditions.
+      id: Condition
+    Kibana_HTTP_APIs_ConditionWithSteps:
+      allOf:
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+        - additionalProperties: false
+          type: object
+          properties:
+            steps:
+              items:
+                $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangStep'
+              type: array
+          required:
+            - steps
+      id: ConditionWithSteps
     Kibana_HTTP_APIs_core_status_redactedResponse:
       additionalProperties: false
       description: A minimal representation of Kibana's operational status.
@@ -72332,6 +69280,1444 @@ components:
         - metrics
       title: core_status_response
       type: object
+    Kibana_HTTP_APIs_FailureStore:
+      anyOf:
+        - additionalProperties: false
+          type: object
+          properties:
+            inherit:
+              additionalProperties: false
+              type: object
+              properties: {}
+          required:
+            - inherit
+        - additionalProperties: false
+          type: object
+          properties:
+            disabled:
+              additionalProperties: false
+              type: object
+              properties: {}
+          required:
+            - disabled
+        - additionalProperties: false
+          type: object
+          properties:
+            lifecycle:
+              additionalProperties: false
+              type: object
+              properties:
+                enabled:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    data_retention:
+                      description: A non-empty string.
+                      minLength: 1
+                      type: string
+              required:
+                - enabled
+          required:
+            - lifecycle
+        - additionalProperties: false
+          type: object
+          properties:
+            lifecycle:
+              additionalProperties: false
+              type: object
+              properties:
+                disabled:
+                  additionalProperties: false
+                  type: object
+                  properties: {}
+              required:
+                - disabled
+          required:
+            - lifecycle
+      id: FailureStore
+    Kibana_HTTP_APIs_FieldDefinition:
+      additionalProperties:
+        $ref: '#/components/schemas/Kibana_HTTP_APIs_FieldDefinitionConfig'
+      id: FieldDefinition
+      type: object
+    Kibana_HTTP_APIs_FieldDefinitionConfig:
+      allOf:
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_RecursiveRecord'
+        - anyOf:
+            - additionalProperties: false
+              type: object
+              properties:
+                description:
+                  type: string
+                format:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+                type:
+                  enum:
+                    - keyword
+                    - match_only_text
+                    - long
+                    - double
+                    - date
+                    - boolean
+                    - ip
+                    - geo_point
+                    - integer
+                    - short
+                    - byte
+                    - float
+                    - half_float
+                    - text
+                    - wildcard
+                    - version
+                    - unsigned_long
+                    - date_nanos
+                  type: string
+              required:
+                - type
+            - additionalProperties: false
+              type: object
+              properties:
+                description:
+                  type: string
+                format:
+                  not: {}
+                type:
+                  not: {}
+              required:
+                - description
+            - additionalProperties: false
+              type: object
+              properties:
+                description:
+                  type: string
+                type:
+                  enum:
+                    - system
+                  type: string
+              required:
+                - type
+      id: FieldDefinitionConfig
+    Kibana_HTTP_APIs_FilterCondition:
+      anyOf:
+        - additionalProperties: false
+          description: A condition that compares a field to a value or range using an operator as the key.
+          type: object
+          properties:
+            contains:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Contains comparison value.
+            endsWith:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Ends-with comparison value.
+            eq:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Equality comparison value.
+            field:
+              description: The document field to filter on.
+              minLength: 1
+              type: string
+            gt:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Greater-than comparison value.
+            gte:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Greater-than-or-equal comparison value.
+            includes:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Checks if multivalue field includes the value.
+            lt:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Less-than comparison value.
+            lte:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Less-than-or-equal comparison value.
+            neq:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Inequality comparison value.
+            range:
+              additionalProperties: false
+              description: Range comparison values.
+              type: object
+              properties:
+                gt:
+                  anyOf:
+                    - type: string
+                    - type: number
+                    - type: boolean
+                  description: A value that can be a string, number, or boolean.
+                gte:
+                  anyOf:
+                    - type: string
+                    - type: number
+                    - type: boolean
+                  description: A value that can be a string, number, or boolean.
+                lt:
+                  anyOf:
+                    - type: string
+                    - type: number
+                    - type: boolean
+                  description: A value that can be a string, number, or boolean.
+                lte:
+                  anyOf:
+                    - type: string
+                    - type: number
+                    - type: boolean
+                  description: A value that can be a string, number, or boolean.
+            startsWith:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+              description: Starts-with comparison value.
+          required:
+            - field
+        - additionalProperties: false
+          description: A condition that checks for the existence or non-existence of a field.
+          type: object
+          properties:
+            exists:
+              description: Indicates whether the field exists or not.
+              type: boolean
+            field:
+              description: The document field to check.
+              minLength: 1
+              type: string
+          required:
+            - field
+      description: A basic filter condition, either unary or binary.
+      id: FilterCondition
+    Kibana_HTTP_APIs_IngestStreamLifecycle:
+      anyOf:
+        - additionalProperties: false
+          type: object
+          properties:
+            dsl:
+              additionalProperties: false
+              type: object
+              properties:
+                data_retention:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+                downsample:
+                  items:
+                    type: object
+                    properties:
+                      after:
+                        description: A non-empty string.
+                        minLength: 1
+                        type: string
+                      fixed_interval:
+                        description: A non-empty string.
+                        minLength: 1
+                        type: string
+                    required:
+                      - after
+                      - fixed_interval
+                  type: array
+          required:
+            - dsl
+        - additionalProperties: false
+          type: object
+          properties:
+            ilm:
+              additionalProperties: false
+              type: object
+              properties:
+                policy:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+              required:
+                - policy
+          required:
+            - ilm
+        - additionalProperties: false
+          type: object
+          properties:
+            inherit:
+              additionalProperties: false
+              type: object
+              properties: {}
+          required:
+            - inherit
+      id: IngestStreamLifecycle
+    Kibana_HTTP_APIs_QueryStreamUpsertRequest:
+      additionalProperties: false
+      id: QueryStreamUpsertRequest
+      type: object
+      properties:
+        dashboards:
+          items:
+            type: string
+          type: array
+        queries:
+          items:
+            type: object
+            properties:
+              description:
+                type: string
+              esql:
+                type: object
+                properties:
+                  query:
+                    type: string
+                required:
+                  - query
+              evidence:
+                items:
+                  type: string
+                type: array
+              id:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+              severity_score:
+                type: number
+              title:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+            required:
+              - id
+              - title
+              - description
+              - esql
+          type: array
+        rules:
+          items:
+            type: string
+          type: array
+        stream:
+          additionalProperties: false
+          type: object
+          properties:
+            description:
+              type: string
+            query:
+              additionalProperties: false
+              type: object
+              properties:
+                esql:
+                  type: string
+                view:
+                  type: string
+              required:
+                - view
+                - esql
+            query_streams:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
+            type:
+              enum:
+                - query
+              type: string
+          required:
+            - description
+            - type
+            - query
+      required:
+        - dashboards
+        - rules
+        - queries
+        - stream
+    Kibana_HTTP_APIs_RecursiveRecord:
+      additionalProperties:
+        anyOf:
+          - anyOf:
+              - type: string
+              - type: number
+              - type: boolean
+              - nullable: true
+              - {}
+          - items:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+                - nullable: true
+                - {}
+            type: array
+          - items: {}
+            type: array
+          - $ref: '#/components/schemas/Kibana_HTTP_APIs_RecursiveRecord'
+      id: RecursiveRecord
+      type: object
+    Kibana_HTTP_APIs_StreamlangConditionBlock:
+      additionalProperties: false
+      id: StreamlangConditionBlock
+      type: object
+      properties:
+        condition:
+          $ref: '#/components/schemas/Kibana_HTTP_APIs_ConditionWithSteps'
+        customIdentifier:
+          type: string
+      required:
+        - condition
+    Kibana_HTTP_APIs_StreamlangStep:
+      anyOf:
+        - anyOf:
+            - additionalProperties: false
+              description: Grok processor - Extract fields from text using grok patterns
+              type: object
+              properties:
+                action:
+                  enum:
+                    - grok
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Source field to parse with grok patterns
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                pattern_definitions:
+                  additionalProperties:
+                    type: string
+                  type: object
+                patterns:
+                  description: Grok patterns applied in order to extract fields
+                  items:
+                    description: A non-empty string.
+                    minLength: 1
+                    type: string
+                  minItems: 1
+                  type: array
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - patterns
+            - additionalProperties: false
+              description: Dissect processor - Extract fields from text using a lightweight, delimiter-based parser
+              type: object
+              properties:
+                action:
+                  enum:
+                    - dissect
+                  type: string
+                append_separator:
+                  description: Separator inserted when target fields are concatenated
+                  minLength: 1
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Source field to parse with dissect pattern
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                pattern:
+                  description: Dissect pattern describing field boundaries
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - pattern
+            - additionalProperties: false
+              description: Date processor - Parse dates from strings using one or more expected formats
+              type: object
+              properties:
+                action:
+                  enum:
+                    - date
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                formats:
+                  description: Accepted input date formats, tried in order
+                  items:
+                    description: A non-empty string.
+                    minLength: 1
+                    type: string
+                  type: array
+                from:
+                  description: Source field containing the date/time text
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                locale:
+                  description: Optional locale for date parsing
+                  minLength: 1
+                  type: string
+                output_format:
+                  description: Optional output format for storing the parsed date as text
+                  minLength: 1
+                  type: string
+                timezone:
+                  description: Optional timezone for date parsing
+                  minLength: 1
+                  type: string
+                to:
+                  description: Target field for the parsed date (defaults to source)
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - formats
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - drop_document
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - math
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                expression:
+                  description: A non-empty string.
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - expression
+                - to
+            - additionalProperties: false
+              description: Rename processor - Change a field name and optionally its location
+              type: object
+              properties:
+                action:
+                  enum:
+                    - rename
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Existing source field to rename or move
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip when source field is missing
+                  type: boolean
+                override:
+                  description: Allow overwriting the target field if it already exists
+                  type: boolean
+                to:
+                  description: New field name or destination path
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - to
+            - additionalProperties: false
+              description: Set processor - Assign a literal or copied value to a field (mutually exclusive inputs)
+              type: object
+              properties:
+                action:
+                  enum:
+                    - set
+                  type: string
+                copy_from:
+                  description: Copy value from another field instead of providing a literal
+                  minLength: 1
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                override:
+                  description: Allow overwriting an existing target field
+                  type: boolean
+                to:
+                  description: Target field to set or create
+                  minLength: 1
+                  type: string
+                value:
+                  description: Literal value to assign to the target field
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - to
+            - additionalProperties: false
+              description: Append processor - Append one or more values to an existing or new array field
+              type: object
+              properties:
+                action:
+                  enum:
+                    - append
+                  type: string
+                allow_duplicates:
+                  description: If true, do not deduplicate appended values
+                  type: boolean
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                to:
+                  description: Array field to append values to
+                  minLength: 1
+                  type: string
+                value:
+                  description: Values to append (must be literal, no templates)
+                  items: {}
+                  minItems: 1
+                  type: array
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - to
+                - value
+            - additionalProperties: false
+              description: Remove by prefix processor - Remove a field and all nested fields matching the prefix
+              type: object
+              properties:
+                action:
+                  enum:
+                    - remove_by_prefix
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Field to remove along with all its nested fields
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              description: Remove processor - Delete one or more fields from the document
+              type: object
+              properties:
+                action:
+                  enum:
+                    - remove
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Field to remove from the document
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - replace
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                pattern:
+                  minLength: 1
+                  type: string
+                replacement:
+                  type: string
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - pattern
+                - replacement
+            - additionalProperties: false
+              description: Redact processor - Mask sensitive data using Grok patterns
+              type: object
+              properties:
+                action:
+                  enum:
+                    - redact
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Source field to redact sensitive data from
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing (defaults to true)
+                  type: boolean
+                pattern_definitions:
+                  additionalProperties:
+                    type: string
+                  description: Custom pattern definitions to use in the patterns
+                  type: object
+                patterns:
+                  description: Grok patterns to match sensitive data (for example, "%{IP:client}", "%{EMAILADDRESS:email}")
+                  items:
+                    description: A non-empty string.
+                    minLength: 1
+                    type: string
+                  minItems: 1
+                  type: array
+                prefix:
+                  description: Prefix to prepend to the redacted pattern name (defaults to "<")
+                  type: string
+                suffix:
+                  description: Suffix to append to the redacted pattern name (defaults to ">")
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - patterns
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - uppercase
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - lowercase
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - trim
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - join
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                delimiter:
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  items:
+                    minLength: 1
+                    type: string
+                  minItems: 1
+                  type: array
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - delimiter
+                - to
+            - additionalProperties: false
+              description: Split processor - Split a field value into an array using a separator
+              type: object
+              properties:
+                action:
+                  enum:
+                    - split
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Source field to split into an array
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                preserve_trailing:
+                  description: Preserve empty trailing fields in the split result
+                  type: boolean
+                separator:
+                  description: Regex separator used to split the field value into an array
+                  minLength: 1
+                  type: string
+                to:
+                  description: Target field for the split array (defaults to source)
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - separator
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - sort
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Array field to sort
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                order:
+                  description: Sort order - "asc" (ascending) or "desc" (descending). Defaults to "asc"
+                  enum:
+                    - asc
+                    - desc
+                  type: string
+                to:
+                  description: Target field for the sorted array (defaults to source)
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+            - additionalProperties: false
+              description: Convert processor - Change the data type of a field value (integer, long, double, boolean, or string)
+              type: object
+              properties:
+                action:
+                  enum:
+                    - convert
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  description: Source field to convert to a different data type
+                  minLength: 1
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  description: Skip processing when source field is missing
+                  type: boolean
+                to:
+                  description: Target field for the converted value (defaults to source)
+                  minLength: 1
+                  type: string
+                type:
+                  description: 'Target data type: integer, long, double, boolean, or string'
+                  enum:
+                    - integer
+                    - long
+                    - double
+                    - boolean
+                    - string
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - type
+            - additionalProperties: false
+              type: object
+              properties:
+                action:
+                  enum:
+                    - concat
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                from:
+                  items:
+                    anyOf:
+                      - type: object
+                        properties:
+                          type:
+                            enum:
+                              - field
+                            type: string
+                          value:
+                            minLength: 1
+                            type: string
+                        required:
+                          - type
+                          - value
+                      - type: object
+                        properties:
+                          type:
+                            enum:
+                              - literal
+                            type: string
+                          value:
+                            type: string
+                        required:
+                          - type
+                          - value
+                  minItems: 1
+                  type: array
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                ignore_missing:
+                  type: boolean
+                to:
+                  minLength: 1
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - from
+                - to
+            - allOf:
+                - additionalProperties: false
+                  type: object
+                  properties:
+                    action:
+                      enum:
+                        - network_direction
+                      type: string
+                    customIdentifier:
+                      description: Custom identifier to correlate this processor across outputs
+                      minLength: 1
+                      type: string
+                    description:
+                      description: Human-readable notes about this processor step
+                      type: string
+                    destination_ip:
+                      minLength: 1
+                      type: string
+                    ignore_failure:
+                      description: Continue pipeline execution if this processor fails
+                      type: boolean
+                    ignore_missing:
+                      type: boolean
+                    source_ip:
+                      minLength: 1
+                      type: string
+                    target_field:
+                      minLength: 1
+                      type: string
+                    where:
+                      $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                      description: Conditional expression controlling whether this processor runs
+                  required:
+                    - action
+                    - source_ip
+                    - destination_ip
+                - anyOf:
+                    - additionalProperties: false
+                      type: object
+                      properties:
+                        internal_networks:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - internal_networks
+                    - additionalProperties: false
+                      type: object
+                      properties:
+                        internal_networks_field:
+                          minLength: 1
+                          type: string
+                      required:
+                        - internal_networks_field
+            - additionalProperties: false
+              description: Manual ingest pipeline wrapper around native Elasticsearch processors
+              type: object
+              properties:
+                action:
+                  description: Manual ingest pipeline - executes raw Elasticsearch ingest processors
+                  enum:
+                    - manual_ingest_pipeline
+                  type: string
+                customIdentifier:
+                  description: Custom identifier to correlate this processor across outputs
+                  minLength: 1
+                  type: string
+                description:
+                  description: Human-readable notes about this processor step
+                  type: string
+                ignore_failure:
+                  description: Continue pipeline execution if this processor fails
+                  type: boolean
+                on_failure:
+                  description: Fallback processors to run when a processor fails
+                  items:
+                    additionalProperties: {}
+                    type: object
+                  type: array
+                processors:
+                  description: List of raw Elasticsearch ingest processors to run
+                  items:
+                    additionalProperties: {}
+                    type: object
+                  type: array
+                tag:
+                  description: Optional ingest processor tag for Elasticsearch
+                  type: string
+                where:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                  description: Conditional expression controlling whether this processor runs
+              required:
+                - action
+                - processors
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangConditionBlock'
+      id: StreamlangStep
+    Kibana_HTTP_APIs_StreamUpsertRequest:
+      anyOf:
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_WiredStreamUpsertRequest'
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicStreamUpsertRequest'
+        - $ref: '#/components/schemas/Kibana_HTTP_APIs_QueryStreamUpsertRequest'
+      id: StreamUpsertRequest
+    Kibana_HTTP_APIs_WiredStreamUpsertRequest:
+      additionalProperties: false
+      id: WiredStreamUpsertRequest
+      type: object
+      properties:
+        dashboards:
+          items:
+            type: string
+          type: array
+        queries:
+          items:
+            type: object
+            properties:
+              description:
+                type: string
+              esql:
+                type: object
+                properties:
+                  query:
+                    type: string
+                required:
+                  - query
+              evidence:
+                items:
+                  type: string
+                type: array
+              id:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+              severity_score:
+                type: number
+              title:
+                description: A non-empty string.
+                minLength: 1
+                type: string
+            required:
+              - id
+              - title
+              - description
+              - esql
+          type: array
+        rules:
+          items:
+            type: string
+          type: array
+        stream:
+          additionalProperties: false
+          type: object
+          properties:
+            description:
+              type: string
+            ingest:
+              additionalProperties: false
+              type: object
+              properties:
+                failure_store:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_FailureStore'
+                lifecycle:
+                  $ref: '#/components/schemas/Kibana_HTTP_APIs_IngestStreamLifecycle'
+                processing:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    steps:
+                      items:
+                        $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangStep'
+                      type: array
+                    updated_at: {}
+                  required:
+                    - steps
+                settings:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    index.number_of_replicas:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          type: number
+                      required:
+                        - value
+                    index.number_of_shards:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          type: number
+                      required:
+                        - value
+                    index.refresh_interval:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        value:
+                          anyOf:
+                            - type: string
+                            - enum:
+                                - -1
+                              type: number
+                      required:
+                        - value
+                wired:
+                  additionalProperties: false
+                  type: object
+                  properties:
+                    fields:
+                      $ref: '#/components/schemas/Kibana_HTTP_APIs_FieldDefinition'
+                    routing:
+                      items:
+                        type: object
+                        properties:
+                          destination:
+                            description: A non-empty string.
+                            minLength: 1
+                            type: string
+                          status:
+                            enum:
+                              - enabled
+                              - disabled
+                            type: string
+                          where:
+                            $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
+                        required:
+                          - destination
+                          - where
+                      type: array
+                  required:
+                    - fields
+                    - routing
+              required:
+                - lifecycle
+                - processing
+                - settings
+                - failure_store
+                - wired
+            query_streams:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
+            type:
+              enum:
+                - wired
+              type: string
+          required:
+            - description
+            - ingest
+            - type
+      required:
+        - dashboards
+        - rules
+        - queries
+        - stream
     Machine_learning_APIs_mlSync200Response:
       properties:
         datafeedsAdded:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -68747,7 +68747,6 @@ components:
     Kibana_HTTP_APIs_ClassicFieldDefinition:
       additionalProperties:
         $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicFieldDefinitionConfig'
-      id: ClassicFieldDefinition
       type: object
     Kibana_HTTP_APIs_ClassicFieldDefinitionConfig:
       allOf:
@@ -68796,10 +68795,8 @@ components:
                   type: string
               required:
                 - type
-      id: ClassicFieldDefinitionConfig
     Kibana_HTTP_APIs_ClassicStreamUpsertRequest:
       additionalProperties: false
-      id: ClassicStreamUpsertRequest
       type: object
       properties:
         dashboards:
@@ -68991,7 +68988,6 @@ components:
           required:
             - always
       description: The root condition object. It can be a simple filter or a combination of other conditions.
-      id: Condition
     Kibana_HTTP_APIs_ConditionWithSteps:
       allOf:
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
@@ -69004,7 +69000,6 @@ components:
               type: array
           required:
             - steps
-      id: ConditionWithSteps
     Kibana_HTTP_APIs_core_status_redactedResponse:
       additionalProperties: false
       description: A minimal representation of Kibana's operational status.
@@ -69334,11 +69329,9 @@ components:
                 - disabled
           required:
             - lifecycle
-      id: FailureStore
     Kibana_HTTP_APIs_FieldDefinition:
       additionalProperties:
         $ref: '#/components/schemas/Kibana_HTTP_APIs_FieldDefinitionConfig'
-      id: FieldDefinition
       type: object
     Kibana_HTTP_APIs_FieldDefinitionConfig:
       allOf:
@@ -69398,7 +69391,6 @@ components:
                   type: string
               required:
                 - type
-      id: FieldDefinitionConfig
     Kibana_HTTP_APIs_FilterCondition:
       anyOf:
         - additionalProperties: false
@@ -69514,7 +69506,6 @@ components:
           required:
             - field
       description: A basic filter condition, either unary or binary.
-      id: FilterCondition
     Kibana_HTTP_APIs_IngestStreamLifecycle:
       anyOf:
         - additionalProperties: false
@@ -69570,10 +69561,8 @@ components:
               properties: {}
           required:
             - inherit
-      id: IngestStreamLifecycle
     Kibana_HTTP_APIs_QueryStreamUpsertRequest:
       additionalProperties: false
-      id: QueryStreamUpsertRequest
       type: object
       properties:
         dashboards:
@@ -69676,11 +69665,9 @@ components:
           - items: {}
             type: array
           - $ref: '#/components/schemas/Kibana_HTTP_APIs_RecursiveRecord'
-      id: RecursiveRecord
       type: object
     Kibana_HTTP_APIs_StreamlangConditionBlock:
       additionalProperties: false
-      id: StreamlangConditionBlock
       type: object
       properties:
         condition:
@@ -70552,16 +70539,13 @@ components:
                 - action
                 - processors
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangConditionBlock'
-      id: StreamlangStep
     Kibana_HTTP_APIs_StreamUpsertRequest:
       anyOf:
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_WiredStreamUpsertRequest'
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicStreamUpsertRequest'
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_QueryStreamUpsertRequest'
-      id: StreamUpsertRequest
     Kibana_HTTP_APIs_WiredStreamUpsertRequest:
       additionalProperties: false
-      id: WiredStreamUpsertRequest
       type: object
       properties:
         dashboards:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -79534,7 +79534,6 @@ components:
     Kibana_HTTP_APIs_ClassicFieldDefinition:
       additionalProperties:
         $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicFieldDefinitionConfig'
-      id: ClassicFieldDefinition
       type: object
     Kibana_HTTP_APIs_ClassicFieldDefinitionConfig:
       allOf:
@@ -79583,10 +79582,8 @@ components:
                   type: string
               required:
                 - type
-      id: ClassicFieldDefinitionConfig
     Kibana_HTTP_APIs_ClassicStreamUpsertRequest:
       additionalProperties: false
-      id: ClassicStreamUpsertRequest
       type: object
       properties:
         dashboards:
@@ -79778,7 +79775,6 @@ components:
           required:
             - always
       description: The root condition object. It can be a simple filter or a combination of other conditions.
-      id: Condition
     Kibana_HTTP_APIs_ConditionWithSteps:
       allOf:
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_Condition'
@@ -79791,7 +79787,6 @@ components:
               type: array
           required:
             - steps
-      id: ConditionWithSteps
     Kibana_HTTP_APIs_core_status_redactedResponse:
       additionalProperties: false
       description: A minimal representation of Kibana's operational status.
@@ -80121,11 +80116,9 @@ components:
                 - disabled
           required:
             - lifecycle
-      id: FailureStore
     Kibana_HTTP_APIs_FieldDefinition:
       additionalProperties:
         $ref: '#/components/schemas/Kibana_HTTP_APIs_FieldDefinitionConfig'
-      id: FieldDefinition
       type: object
     Kibana_HTTP_APIs_FieldDefinitionConfig:
       allOf:
@@ -80185,7 +80178,6 @@ components:
                   type: string
               required:
                 - type
-      id: FieldDefinitionConfig
     Kibana_HTTP_APIs_FilterCondition:
       anyOf:
         - additionalProperties: false
@@ -80301,7 +80293,6 @@ components:
           required:
             - field
       description: A basic filter condition, either unary or binary.
-      id: FilterCondition
     Kibana_HTTP_APIs_IngestStreamLifecycle:
       anyOf:
         - additionalProperties: false
@@ -80357,10 +80348,8 @@ components:
               properties: {}
           required:
             - inherit
-      id: IngestStreamLifecycle
     Kibana_HTTP_APIs_QueryStreamUpsertRequest:
       additionalProperties: false
-      id: QueryStreamUpsertRequest
       type: object
       properties:
         dashboards:
@@ -80463,11 +80452,9 @@ components:
           - items: {}
             type: array
           - $ref: '#/components/schemas/Kibana_HTTP_APIs_RecursiveRecord'
-      id: RecursiveRecord
       type: object
     Kibana_HTTP_APIs_StreamlangConditionBlock:
       additionalProperties: false
-      id: StreamlangConditionBlock
       type: object
       properties:
         condition:
@@ -81339,16 +81326,13 @@ components:
                 - action
                 - processors
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_StreamlangConditionBlock'
-      id: StreamlangStep
     Kibana_HTTP_APIs_StreamUpsertRequest:
       anyOf:
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_WiredStreamUpsertRequest'
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_ClassicStreamUpsertRequest'
         - $ref: '#/components/schemas/Kibana_HTTP_APIs_QueryStreamUpsertRequest'
-      id: StreamUpsertRequest
     Kibana_HTTP_APIs_WiredStreamUpsertRequest:
       additionalProperties: false
-      id: WiredStreamUpsertRequest
       type: object
       properties:
         dashboards:

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/oas_converter/zod/lib.ts
@@ -937,6 +937,13 @@ export const convert = (schema: z.ZodTypeAny) => {
           return;
         }
 
+        // Zod v4's toJSONSchema() writes the .meta({ id }) value as a plain
+        // `id` property on the JSON schema node. OAS 3.0 Schema Objects do not
+        // allow `id`, so we strip it unconditionally here and track the
+        // component name via our own COMPONENT_ID_MARKER instead.
+        // See https://github.com/colinhacks/zod/issues/5731
+        delete (js as any).id;
+
         // Inject stable OAS component name and optional OAS extensions for
         // schemas that declare .meta({ id }) / .meta({ openapi: { ... } }).
         // Picked up by extractDefsToShared (for $defs entries) and

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/oas_definitions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/oas_definitions.ts
@@ -41,11 +41,13 @@ import {
 
 export const streamlangOasDefinitions = {
   // Core condition — recursive schema referenced throughout routing and processing
-  Condition: conditionSchema.meta({ id: 'Condition' }),
+  // .meta({ id: 'Condition' }) is applied at definition time in types/conditions.ts
+  Condition: conditionSchema,
 
   // DSL root and step types
   StreamlangDSL: streamlangDSLSchema.meta({ id: 'StreamlangDSL' }),
-  StreamlangStep: streamlangStepSchema.meta({ id: 'StreamlangStep' }),
+  // .meta({ id: 'StreamlangStep' }) is applied at definition time in types/streamlang.ts
+  StreamlangStep: streamlangStepSchema,
 
   // Union of all processors (useful for $ref in generic processing endpoints)
   StreamlangProcessor: streamlangProcessorSchema.meta({ id: 'StreamlangProcessor' }),

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/schema/__snapshots__/get_json_schema_from_streamlang_schema.test.ts.snap
@@ -5,7 +5,356 @@ Object {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": Object {
-    "__schema0": Object {
+    "Condition": Object {
+      "anyOf": Array [
+        Object {
+          "$ref": "#/definitions/FilterCondition",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A logical AND that groups multiple conditions.",
+          "properties": Object {
+            "and": Object {
+              "description": "An array of conditions. All sub-conditions must be true for this condition to be true.",
+              "items": Object {
+                "$ref": "#/definitions/Condition",
+              },
+              "type": "array",
+            },
+          },
+          "required": Array [
+            "and",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A logical OR that groups multiple conditions.",
+          "properties": Object {
+            "or": Object {
+              "description": "An array of conditions. At least one sub-condition must be true for this condition to be true.",
+              "items": Object {
+                "$ref": "#/definitions/Condition",
+              },
+              "type": "array",
+            },
+          },
+          "required": Array [
+            "or",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A logical NOT that negates a condition.",
+          "properties": Object {
+            "not": Object {
+              "allOf": Array [
+                Object {
+                  "$ref": "#/definitions/Condition",
+                },
+              ],
+              "description": "A condition that negates another condition.",
+            },
+          },
+          "required": Array [
+            "not",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A condition that always evaluates to false.",
+          "properties": Object {
+            "never": Object {
+              "additionalProperties": false,
+              "description": "An empty object. This condition never matches.",
+              "properties": Object {},
+              "type": "object",
+            },
+          },
+          "required": Array [
+            "never",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.",
+          "properties": Object {
+            "always": Object {
+              "additionalProperties": false,
+              "description": "An empty object. This condition always matches.",
+              "properties": Object {},
+              "type": "object",
+            },
+          },
+          "required": Array [
+            "always",
+          ],
+          "type": "object",
+        },
+      ],
+      "description": "The root condition object. It can be a simple filter or a combination of other conditions.",
+      "id": "Condition",
+    },
+    "ConditionWithSteps": Object {
+      "allOf": Array [
+        Object {
+          "$ref": "#/definitions/Condition",
+        },
+        Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "steps": Object {
+              "items": Object {
+                "$ref": "#/definitions/StreamlangStep",
+              },
+              "type": "array",
+            },
+          },
+          "required": Array [
+            "steps",
+          ],
+          "type": "object",
+        },
+      ],
+      "id": "ConditionWithSteps",
+    },
+    "FilterCondition": Object {
+      "anyOf": Array [
+        Object {
+          "additionalProperties": false,
+          "description": "A condition that compares a field to a value or range using an operator as the key.",
+          "properties": Object {
+            "contains": Object {
+              "description": "Contains comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "endsWith": Object {
+              "description": "Ends-with comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "eq": Object {
+              "description": "Equality comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "field": Object {
+              "description": "The document field to filter on.",
+              "minLength": 1,
+              "type": "string",
+            },
+            "gt": Object {
+              "description": "Greater-than comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "gte": Object {
+              "description": "Greater-than-or-equal comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "includes": Object {
+              "description": "Checks if multivalue field includes the value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "lt": Object {
+              "description": "Less-than comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "lte": Object {
+              "description": "Less-than-or-equal comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "neq": Object {
+              "description": "Inequality comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+            "range": Object {
+              "additionalProperties": false,
+              "description": "Range comparison values.",
+              "properties": Object {
+                "gt": Object {
+                  "description": "A value that can be a string, number, or boolean.",
+                  "type": Array [
+                    "string",
+                    "number",
+                    "boolean",
+                  ],
+                },
+                "gte": Object {
+                  "description": "A value that can be a string, number, or boolean.",
+                  "type": Array [
+                    "string",
+                    "number",
+                    "boolean",
+                  ],
+                },
+                "lt": Object {
+                  "description": "A value that can be a string, number, or boolean.",
+                  "type": Array [
+                    "string",
+                    "number",
+                    "boolean",
+                  ],
+                },
+                "lte": Object {
+                  "description": "A value that can be a string, number, or boolean.",
+                  "type": Array [
+                    "string",
+                    "number",
+                    "boolean",
+                  ],
+                },
+              },
+              "type": "object",
+            },
+            "startsWith": Object {
+              "description": "Starts-with comparison value.",
+              "type": Array [
+                "string",
+                "number",
+                "boolean",
+              ],
+            },
+          },
+          "required": Array [
+            "field",
+          ],
+          "type": "object",
+        },
+        Object {
+          "additionalProperties": false,
+          "description": "A condition that checks for the existence or non-existence of a field.",
+          "properties": Object {
+            "exists": Object {
+              "description": "Indicates whether the field exists or not.",
+              "type": "boolean",
+            },
+            "field": Object {
+              "description": "The document field to check.",
+              "minLength": 1,
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "field",
+          ],
+          "type": "object",
+        },
+      ],
+      "description": "A basic filter condition, either unary or binary.",
+      "id": "FilterCondition",
+    },
+    "StreamlangConditionBlock": Object {
+      "additionalProperties": false,
+      "defaultSnippets": Array [
+        Object {
+          "body": Object {
+            "condition": Object {
+              "eq": "\${2:value}",
+              "field": "\${1:field.name}",
+              "steps": Array [
+                "\${3}",
+              ],
+            },
+          },
+          "description": "Conditional step execution with field equals condition",
+          "label": "Condition block",
+        },
+        Object {
+          "body": Object {
+            "condition": Object {
+              "and": Array [
+                Object {
+                  "eq": "\${2:value1}",
+                  "field": "\${1:field1.name}",
+                },
+                Object {
+                  "eq": "\${4:value2}",
+                  "field": "\${3:field2.name}",
+                },
+              ],
+              "steps": Array [
+                "\${5}",
+              ],
+            },
+          },
+          "description": "Execute steps if all conditions are true",
+          "label": "Condition block (AND)",
+        },
+        Object {
+          "body": Object {
+            "condition": Object {
+              "or": Array [
+                Object {
+                  "eq": "\${2:value1}",
+                  "field": "\${1:field1.name}",
+                },
+                Object {
+                  "eq": "\${4:value2}",
+                  "field": "\${3:field2.name}",
+                },
+              ],
+              "steps": Array [
+                "\${5}",
+              ],
+            },
+          },
+          "description": "Execute steps if any condition is true",
+          "label": "Condition block (OR)",
+        },
+      ],
+      "id": "StreamlangConditionBlock",
+      "properties": Object {
+        "condition": Object {
+          "$ref": "#/definitions/ConditionWithSteps",
+        },
+        "customIdentifier": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "condition",
+      ],
+      "title": "Condition block",
+      "type": "object",
+    },
+    "StreamlangStep": Object {
       "anyOf": Array [
         Object {
           "anyOf": Array [
@@ -61,7 +410,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -118,7 +467,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -190,7 +539,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -228,7 +577,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -276,7 +625,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -332,7 +681,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -387,7 +736,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -439,7 +788,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -520,7 +869,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -575,7 +924,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -651,7 +1000,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -700,7 +1049,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -748,7 +1097,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -796,7 +1145,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -851,7 +1200,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -913,7 +1262,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -973,7 +1322,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -1035,7 +1384,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -1123,7 +1472,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -1177,7 +1526,7 @@ Object {
                     "where": Object {
                       "allOf": Array [
                         Object {
-                          "$ref": "#/definitions/__schema1",
+                          "$ref": "#/definitions/Condition",
                         },
                       ],
                       "description": "Conditional expression controlling whether this processor runs",
@@ -1269,7 +1618,7 @@ Object {
                 "where": Object {
                   "allOf": Array [
                     Object {
-                      "$ref": "#/definitions/__schema1",
+                      "$ref": "#/definitions/Condition",
                     },
                   ],
                   "description": "Conditional expression controlling whether this processor runs",
@@ -1319,869 +1668,10 @@ Object {
           "type": "object",
         },
         Object {
-          "additionalProperties": false,
-          "defaultSnippets": Array [
-            Object {
-              "body": Object {
-                "condition": Object {
-                  "eq": "\${2:value}",
-                  "field": "\${1:field.name}",
-                  "steps": Array [
-                    "\${3}",
-                  ],
-                },
-              },
-              "description": "Conditional step execution with field equals condition",
-              "label": "Condition block",
-            },
-            Object {
-              "body": Object {
-                "condition": Object {
-                  "and": Array [
-                    Object {
-                      "eq": "\${2:value1}",
-                      "field": "\${1:field1.name}",
-                    },
-                    Object {
-                      "eq": "\${4:value2}",
-                      "field": "\${3:field2.name}",
-                    },
-                  ],
-                  "steps": Array [
-                    "\${5}",
-                  ],
-                },
-              },
-              "description": "Execute steps if all conditions are true",
-              "label": "Condition block (AND)",
-            },
-            Object {
-              "body": Object {
-                "condition": Object {
-                  "or": Array [
-                    Object {
-                      "eq": "\${2:value1}",
-                      "field": "\${1:field1.name}",
-                    },
-                    Object {
-                      "eq": "\${4:value2}",
-                      "field": "\${3:field2.name}",
-                    },
-                  ],
-                  "steps": Array [
-                    "\${5}",
-                  ],
-                },
-              },
-              "description": "Execute steps if any condition is true",
-              "label": "Condition block (OR)",
-            },
-          ],
-          "properties": Object {
-            "condition": Object {
-              "anyOf": Array [
-                Object {
-                  "anyOf": Array [
-                    Object {
-                      "additionalProperties": false,
-                      "defaultSnippets": Array [
-                        Object {
-                          "body": Object {
-                            "eq": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field equals a value",
-                          "label": "Field equals",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "neq": "\${2:value}",
-                          },
-                          "description": "Check if field does not equal a value",
-                          "label": "Field not equals",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "lt": "\${2:value}",
-                          },
-                          "description": "Check if field is less than a value",
-                          "label": "Field less than",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "lte": "\${2:value}",
-                          },
-                          "description": "Check if field is less than or equal to a value",
-                          "label": "Field less than or equal",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "gt": "\${2:value}",
-                          },
-                          "description": "Check if field is greater than a value",
-                          "label": "Field greater than",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "gte": "\${2:value}",
-                          },
-                          "description": "Check if field is greater than or equal to a value",
-                          "label": "Field greater than or equal",
-                        },
-                        Object {
-                          "body": Object {
-                            "contains": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field contains a value",
-                          "label": "Field contains",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "startsWith": "\${2:value}",
-                          },
-                          "description": "Check if field starts with a value",
-                          "label": "Field starts with",
-                        },
-                        Object {
-                          "body": Object {
-                            "endsWith": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field ends with a value",
-                          "label": "Field ends with",
-                        },
-                        Object {
-                          "body": Object {
-                            "exists": true,
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field exists",
-                          "label": "Field exists",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "range": Object {
-                              "gte": "\${2:minValue}",
-                              "lte": "\${3:maxValue}",
-                            },
-                          },
-                          "description": "Check if field is within a range",
-                          "label": "Field range",
-                        },
-                      ],
-                      "description": "Compare a field value using operators like eq, neq, lt, gt, contains",
-                      "properties": Object {
-                        "contains": Object {
-                          "description": "Contains comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "endsWith": Object {
-                          "description": "Ends-with comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "eq": Object {
-                          "description": "Equality comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "field": Object {
-                          "description": "The document field to filter on.",
-                          "minLength": 1,
-                          "type": "string",
-                        },
-                        "gt": Object {
-                          "description": "Greater-than comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "gte": Object {
-                          "description": "Greater-than-or-equal comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "includes": Object {
-                          "description": "Checks if multivalue field includes the value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "lt": Object {
-                          "description": "Less-than comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "lte": Object {
-                          "description": "Less-than-or-equal comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "neq": Object {
-                          "description": "Inequality comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "range": Object {
-                          "additionalProperties": false,
-                          "description": "Range comparison values.",
-                          "properties": Object {
-                            "gt": Object {
-                              "description": "A value that can be a string, number, or boolean.",
-                              "type": Array [
-                                "string",
-                                "number",
-                                "boolean",
-                              ],
-                            },
-                            "gte": Object {
-                              "description": "A value that can be a string, number, or boolean.",
-                              "type": Array [
-                                "string",
-                                "number",
-                                "boolean",
-                              ],
-                            },
-                            "lt": Object {
-                              "description": "A value that can be a string, number, or boolean.",
-                              "type": Array [
-                                "string",
-                                "number",
-                                "boolean",
-                              ],
-                            },
-                            "lte": Object {
-                              "description": "A value that can be a string, number, or boolean.",
-                              "type": Array [
-                                "string",
-                                "number",
-                                "boolean",
-                              ],
-                            },
-                          },
-                          "type": "object",
-                        },
-                        "startsWith": Object {
-                          "description": "Starts-with comparison value.",
-                          "type": Array [
-                            "string",
-                            "number",
-                            "boolean",
-                          ],
-                        },
-                        "steps": Object {
-                          "items": Object {
-                            "$ref": "#/definitions/__schema0",
-                          },
-                          "type": "array",
-                        },
-                      },
-                      "required": Array [
-                        "field",
-                        "steps",
-                      ],
-                      "title": "Filter condition",
-                      "type": "object",
-                    },
-                    Object {
-                      "additionalProperties": false,
-                      "defaultSnippets": Array [
-                        Object {
-                          "body": Object {
-                            "eq": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field equals a value",
-                          "label": "Field equals",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "neq": "\${2:value}",
-                          },
-                          "description": "Check if field does not equal a value",
-                          "label": "Field not equals",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "lt": "\${2:value}",
-                          },
-                          "description": "Check if field is less than a value",
-                          "label": "Field less than",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "lte": "\${2:value}",
-                          },
-                          "description": "Check if field is less than or equal to a value",
-                          "label": "Field less than or equal",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "gt": "\${2:value}",
-                          },
-                          "description": "Check if field is greater than a value",
-                          "label": "Field greater than",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "gte": "\${2:value}",
-                          },
-                          "description": "Check if field is greater than or equal to a value",
-                          "label": "Field greater than or equal",
-                        },
-                        Object {
-                          "body": Object {
-                            "contains": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field contains a value",
-                          "label": "Field contains",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "startsWith": "\${2:value}",
-                          },
-                          "description": "Check if field starts with a value",
-                          "label": "Field starts with",
-                        },
-                        Object {
-                          "body": Object {
-                            "endsWith": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field ends with a value",
-                          "label": "Field ends with",
-                        },
-                        Object {
-                          "body": Object {
-                            "exists": true,
-                            "field": "\${1:field.name}",
-                          },
-                          "description": "Check if field exists",
-                          "label": "Field exists",
-                        },
-                        Object {
-                          "body": Object {
-                            "field": "\${1:field.name}",
-                            "range": Object {
-                              "gte": "\${2:minValue}",
-                              "lte": "\${3:maxValue}",
-                            },
-                          },
-                          "description": "Check if field is within a range",
-                          "label": "Field range",
-                        },
-                      ],
-                      "description": "Compare a field value using operators like eq, neq, lt, gt, contains",
-                      "properties": Object {
-                        "exists": Object {
-                          "description": "Indicates whether the field exists or not.",
-                          "type": "boolean",
-                        },
-                        "field": Object {
-                          "description": "The document field to check.",
-                          "minLength": 1,
-                          "type": "string",
-                        },
-                        "steps": Object {
-                          "items": Object {
-                            "$ref": "#/definitions/__schema0",
-                          },
-                          "type": "array",
-                        },
-                      },
-                      "required": Array [
-                        "field",
-                        "steps",
-                      ],
-                      "title": "Filter condition",
-                      "type": "object",
-                    },
-                  ],
-                  "description": "A basic filter condition, either unary or binary.",
-                },
-                Object {
-                  "additionalProperties": false,
-                  "defaultSnippets": Array [
-                    Object {
-                      "body": Object {
-                        "and": Array [
-                          Object {
-                            "eq": "\${2:value1}",
-                            "field": "\${1:field1.name}",
-                          },
-                          Object {
-                            "eq": "\${4:value2}",
-                            "field": "\${3:field2.name}",
-                          },
-                        ],
-                      },
-                      "description": "Combine conditions with AND logic",
-                      "label": "AND condition",
-                    },
-                  ],
-                  "description": "All conditions must be true",
-                  "properties": Object {
-                    "and": Object {
-                      "description": "An array of conditions. All sub-conditions must be true for this condition to be true.",
-                      "items": Object {
-                        "$ref": "#/definitions/__schema1",
-                      },
-                      "type": "array",
-                    },
-                    "steps": Object {
-                      "items": Object {
-                        "$ref": "#/definitions/__schema0",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "and",
-                    "steps",
-                  ],
-                  "title": "AND condition",
-                  "type": "object",
-                },
-                Object {
-                  "additionalProperties": false,
-                  "defaultSnippets": Array [
-                    Object {
-                      "body": Object {
-                        "or": Array [
-                          Object {
-                            "eq": "\${2:value1}",
-                            "field": "\${1:field1.name}",
-                          },
-                          Object {
-                            "eq": "\${4:value2}",
-                            "field": "\${3:field2.name}",
-                          },
-                        ],
-                      },
-                      "description": "Combine conditions with OR logic",
-                      "label": "OR condition",
-                    },
-                  ],
-                  "description": "At least one condition must be true",
-                  "properties": Object {
-                    "or": Object {
-                      "description": "An array of conditions. At least one sub-condition must be true for this condition to be true.",
-                      "items": Object {
-                        "$ref": "#/definitions/__schema1",
-                      },
-                      "type": "array",
-                    },
-                    "steps": Object {
-                      "items": Object {
-                        "$ref": "#/definitions/__schema0",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "or",
-                    "steps",
-                  ],
-                  "title": "OR condition",
-                  "type": "object",
-                },
-                Object {
-                  "additionalProperties": false,
-                  "defaultSnippets": Array [
-                    Object {
-                      "body": Object {
-                        "not": Object {
-                          "eq": "\${2:value}",
-                          "field": "\${1:field.name}",
-                        },
-                      },
-                      "description": "Negate a condition",
-                      "label": "NOT condition",
-                    },
-                  ],
-                  "description": "Negate a condition",
-                  "properties": Object {
-                    "not": Object {
-                      "allOf": Array [
-                        Object {
-                          "$ref": "#/definitions/__schema1",
-                        },
-                      ],
-                      "description": "A condition that negates another condition.",
-                    },
-                    "steps": Object {
-                      "items": Object {
-                        "$ref": "#/definitions/__schema0",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "not",
-                    "steps",
-                  ],
-                  "title": "NOT condition",
-                  "type": "object",
-                },
-                Object {
-                  "additionalProperties": false,
-                  "description": "A condition that always evaluates to false.",
-                  "properties": Object {
-                    "never": Object {
-                      "additionalProperties": false,
-                      "description": "An empty object. This condition never matches.",
-                      "properties": Object {},
-                      "type": "object",
-                    },
-                    "steps": Object {
-                      "items": Object {
-                        "$ref": "#/definitions/__schema0",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "never",
-                    "steps",
-                  ],
-                  "type": "object",
-                },
-                Object {
-                  "additionalProperties": false,
-                  "description": "A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.",
-                  "properties": Object {
-                    "always": Object {
-                      "additionalProperties": false,
-                      "description": "An empty object. This condition always matches.",
-                      "properties": Object {},
-                      "type": "object",
-                    },
-                    "steps": Object {
-                      "items": Object {
-                        "$ref": "#/definitions/__schema0",
-                      },
-                      "type": "array",
-                    },
-                  },
-                  "required": Array [
-                    "always",
-                    "steps",
-                  ],
-                  "type": "object",
-                },
-              ],
-              "properties": Object {
-                "steps": Object {
-                  "items": Object {
-                    "$ref": "#/definitions/__schema0",
-                  },
-                  "type": "array",
-                },
-              },
-              "required": Array [
-                "steps",
-              ],
-              "type": "object",
-            },
-            "customIdentifier": Object {
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "condition",
-          ],
-          "title": "Condition block",
-          "type": "object",
+          "$ref": "#/definitions/StreamlangConditionBlock",
         },
       ],
-    },
-    "__schema1": Object {
-      "anyOf": Array [
-        Object {
-          "anyOf": Array [
-            Object {
-              "additionalProperties": false,
-              "description": "A condition that compares a field to a value or range using an operator as the key.",
-              "properties": Object {
-                "contains": Object {
-                  "description": "Contains comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "endsWith": Object {
-                  "description": "Ends-with comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "eq": Object {
-                  "description": "Equality comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "field": Object {
-                  "description": "The document field to filter on.",
-                  "minLength": 1,
-                  "type": "string",
-                },
-                "gt": Object {
-                  "description": "Greater-than comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "gte": Object {
-                  "description": "Greater-than-or-equal comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "includes": Object {
-                  "description": "Checks if multivalue field includes the value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "lt": Object {
-                  "description": "Less-than comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "lte": Object {
-                  "description": "Less-than-or-equal comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "neq": Object {
-                  "description": "Inequality comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-                "range": Object {
-                  "additionalProperties": false,
-                  "description": "Range comparison values.",
-                  "properties": Object {
-                    "gt": Object {
-                      "description": "A value that can be a string, number, or boolean.",
-                      "type": Array [
-                        "string",
-                        "number",
-                        "boolean",
-                      ],
-                    },
-                    "gte": Object {
-                      "description": "A value that can be a string, number, or boolean.",
-                      "type": Array [
-                        "string",
-                        "number",
-                        "boolean",
-                      ],
-                    },
-                    "lt": Object {
-                      "description": "A value that can be a string, number, or boolean.",
-                      "type": Array [
-                        "string",
-                        "number",
-                        "boolean",
-                      ],
-                    },
-                    "lte": Object {
-                      "description": "A value that can be a string, number, or boolean.",
-                      "type": Array [
-                        "string",
-                        "number",
-                        "boolean",
-                      ],
-                    },
-                  },
-                  "type": "object",
-                },
-                "startsWith": Object {
-                  "description": "Starts-with comparison value.",
-                  "type": Array [
-                    "string",
-                    "number",
-                    "boolean",
-                  ],
-                },
-              },
-              "required": Array [
-                "field",
-              ],
-              "type": "object",
-            },
-            Object {
-              "additionalProperties": false,
-              "description": "A condition that checks for the existence or non-existence of a field.",
-              "properties": Object {
-                "exists": Object {
-                  "description": "Indicates whether the field exists or not.",
-                  "type": "boolean",
-                },
-                "field": Object {
-                  "description": "The document field to check.",
-                  "minLength": 1,
-                  "type": "string",
-                },
-              },
-              "required": Array [
-                "field",
-              ],
-              "type": "object",
-            },
-          ],
-          "description": "A basic filter condition, either unary or binary.",
-        },
-        Object {
-          "additionalProperties": false,
-          "description": "A logical AND that groups multiple conditions.",
-          "properties": Object {
-            "and": Object {
-              "description": "An array of conditions. All sub-conditions must be true for this condition to be true.",
-              "items": Object {
-                "$ref": "#/definitions/__schema1",
-              },
-              "type": "array",
-            },
-          },
-          "required": Array [
-            "and",
-          ],
-          "type": "object",
-        },
-        Object {
-          "additionalProperties": false,
-          "description": "A logical OR that groups multiple conditions.",
-          "properties": Object {
-            "or": Object {
-              "description": "An array of conditions. At least one sub-condition must be true for this condition to be true.",
-              "items": Object {
-                "$ref": "#/definitions/__schema1",
-              },
-              "type": "array",
-            },
-          },
-          "required": Array [
-            "or",
-          ],
-          "type": "object",
-        },
-        Object {
-          "additionalProperties": false,
-          "description": "A logical NOT that negates a condition.",
-          "properties": Object {
-            "not": Object {
-              "allOf": Array [
-                Object {
-                  "$ref": "#/definitions/__schema1",
-                },
-              ],
-              "description": "A condition that negates another condition.",
-            },
-          },
-          "required": Array [
-            "not",
-          ],
-          "type": "object",
-        },
-        Object {
-          "additionalProperties": false,
-          "description": "A condition that always evaluates to false.",
-          "properties": Object {
-            "never": Object {
-              "additionalProperties": false,
-              "description": "An empty object. This condition never matches.",
-              "properties": Object {},
-              "type": "object",
-            },
-          },
-          "required": Array [
-            "never",
-          ],
-          "type": "object",
-        },
-        Object {
-          "additionalProperties": false,
-          "description": "A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.",
-          "properties": Object {
-            "always": Object {
-              "additionalProperties": false,
-              "description": "An empty object. This condition always matches.",
-              "properties": Object {},
-              "type": "object",
-            },
-          },
-          "required": Array [
-            "always",
-          ],
-          "type": "object",
-        },
-      ],
-      "description": "The root condition object. It can be a simple filter or a combination of other conditions.",
+      "id": "StreamlangStep",
     },
   },
   "properties": Object {
@@ -2242,7 +1732,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2299,7 +1789,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2371,7 +1861,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2409,7 +1899,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2457,7 +1947,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2513,7 +2003,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2568,7 +2058,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2620,7 +2110,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2701,7 +2191,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2756,7 +2246,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2832,7 +2322,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2881,7 +2371,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2929,7 +2419,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -2977,7 +2467,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3032,7 +2522,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3094,7 +2584,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3154,7 +2644,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3216,7 +2706,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3304,7 +2794,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3358,7 +2848,7 @@ Object {
                       "where": Object {
                         "allOf": Array [
                           Object {
-                            "$ref": "#/definitions/__schema1",
+                            "$ref": "#/definitions/Condition",
                           },
                         ],
                         "description": "Conditional expression controlling whether this processor runs",
@@ -3450,7 +2940,7 @@ Object {
                   "where": Object {
                     "allOf": Array [
                       Object {
-                        "$ref": "#/definitions/__schema1",
+                        "$ref": "#/definitions/Condition",
                       },
                     ],
                     "description": "Conditional expression controlling whether this processor runs",
@@ -3500,622 +2990,10 @@ Object {
             "type": "object",
           },
           Object {
-            "additionalProperties": false,
-            "defaultSnippets": Array [
-              Object {
-                "body": Object {
-                  "condition": Object {
-                    "eq": "\${2:value}",
-                    "field": "\${1:field.name}",
-                    "steps": Array [
-                      "\${3}",
-                    ],
-                  },
-                },
-                "description": "Conditional step execution with field equals condition",
-                "label": "Condition block",
-              },
-              Object {
-                "body": Object {
-                  "condition": Object {
-                    "and": Array [
-                      Object {
-                        "eq": "\${2:value1}",
-                        "field": "\${1:field1.name}",
-                      },
-                      Object {
-                        "eq": "\${4:value2}",
-                        "field": "\${3:field2.name}",
-                      },
-                    ],
-                    "steps": Array [
-                      "\${5}",
-                    ],
-                  },
-                },
-                "description": "Execute steps if all conditions are true",
-                "label": "Condition block (AND)",
-              },
-              Object {
-                "body": Object {
-                  "condition": Object {
-                    "or": Array [
-                      Object {
-                        "eq": "\${2:value1}",
-                        "field": "\${1:field1.name}",
-                      },
-                      Object {
-                        "eq": "\${4:value2}",
-                        "field": "\${3:field2.name}",
-                      },
-                    ],
-                    "steps": Array [
-                      "\${5}",
-                    ],
-                  },
-                },
-                "description": "Execute steps if any condition is true",
-                "label": "Condition block (OR)",
-              },
-            ],
-            "properties": Object {
-              "condition": Object {
-                "anyOf": Array [
-                  Object {
-                    "anyOf": Array [
-                      Object {
-                        "additionalProperties": false,
-                        "defaultSnippets": Array [
-                          Object {
-                            "body": Object {
-                              "eq": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field equals a value",
-                            "label": "Field equals",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "neq": "\${2:value}",
-                            },
-                            "description": "Check if field does not equal a value",
-                            "label": "Field not equals",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "lt": "\${2:value}",
-                            },
-                            "description": "Check if field is less than a value",
-                            "label": "Field less than",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "lte": "\${2:value}",
-                            },
-                            "description": "Check if field is less than or equal to a value",
-                            "label": "Field less than or equal",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "gt": "\${2:value}",
-                            },
-                            "description": "Check if field is greater than a value",
-                            "label": "Field greater than",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "gte": "\${2:value}",
-                            },
-                            "description": "Check if field is greater than or equal to a value",
-                            "label": "Field greater than or equal",
-                          },
-                          Object {
-                            "body": Object {
-                              "contains": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field contains a value",
-                            "label": "Field contains",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "startsWith": "\${2:value}",
-                            },
-                            "description": "Check if field starts with a value",
-                            "label": "Field starts with",
-                          },
-                          Object {
-                            "body": Object {
-                              "endsWith": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field ends with a value",
-                            "label": "Field ends with",
-                          },
-                          Object {
-                            "body": Object {
-                              "exists": true,
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field exists",
-                            "label": "Field exists",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "range": Object {
-                                "gte": "\${2:minValue}",
-                                "lte": "\${3:maxValue}",
-                              },
-                            },
-                            "description": "Check if field is within a range",
-                            "label": "Field range",
-                          },
-                        ],
-                        "description": "Compare a field value using operators like eq, neq, lt, gt, contains",
-                        "properties": Object {
-                          "contains": Object {
-                            "description": "Contains comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "endsWith": Object {
-                            "description": "Ends-with comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "eq": Object {
-                            "description": "Equality comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "field": Object {
-                            "description": "The document field to filter on.",
-                            "minLength": 1,
-                            "type": "string",
-                          },
-                          "gt": Object {
-                            "description": "Greater-than comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "gte": Object {
-                            "description": "Greater-than-or-equal comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "includes": Object {
-                            "description": "Checks if multivalue field includes the value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "lt": Object {
-                            "description": "Less-than comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "lte": Object {
-                            "description": "Less-than-or-equal comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "neq": Object {
-                            "description": "Inequality comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "range": Object {
-                            "additionalProperties": false,
-                            "description": "Range comparison values.",
-                            "properties": Object {
-                              "gt": Object {
-                                "description": "A value that can be a string, number, or boolean.",
-                                "type": Array [
-                                  "string",
-                                  "number",
-                                  "boolean",
-                                ],
-                              },
-                              "gte": Object {
-                                "description": "A value that can be a string, number, or boolean.",
-                                "type": Array [
-                                  "string",
-                                  "number",
-                                  "boolean",
-                                ],
-                              },
-                              "lt": Object {
-                                "description": "A value that can be a string, number, or boolean.",
-                                "type": Array [
-                                  "string",
-                                  "number",
-                                  "boolean",
-                                ],
-                              },
-                              "lte": Object {
-                                "description": "A value that can be a string, number, or boolean.",
-                                "type": Array [
-                                  "string",
-                                  "number",
-                                  "boolean",
-                                ],
-                              },
-                            },
-                            "type": "object",
-                          },
-                          "startsWith": Object {
-                            "description": "Starts-with comparison value.",
-                            "type": Array [
-                              "string",
-                              "number",
-                              "boolean",
-                            ],
-                          },
-                          "steps": Object {
-                            "items": Object {
-                              "$ref": "#/definitions/__schema0",
-                            },
-                            "type": "array",
-                          },
-                        },
-                        "required": Array [
-                          "field",
-                          "steps",
-                        ],
-                        "title": "Filter condition",
-                        "type": "object",
-                      },
-                      Object {
-                        "additionalProperties": false,
-                        "defaultSnippets": Array [
-                          Object {
-                            "body": Object {
-                              "eq": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field equals a value",
-                            "label": "Field equals",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "neq": "\${2:value}",
-                            },
-                            "description": "Check if field does not equal a value",
-                            "label": "Field not equals",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "lt": "\${2:value}",
-                            },
-                            "description": "Check if field is less than a value",
-                            "label": "Field less than",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "lte": "\${2:value}",
-                            },
-                            "description": "Check if field is less than or equal to a value",
-                            "label": "Field less than or equal",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "gt": "\${2:value}",
-                            },
-                            "description": "Check if field is greater than a value",
-                            "label": "Field greater than",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "gte": "\${2:value}",
-                            },
-                            "description": "Check if field is greater than or equal to a value",
-                            "label": "Field greater than or equal",
-                          },
-                          Object {
-                            "body": Object {
-                              "contains": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field contains a value",
-                            "label": "Field contains",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "startsWith": "\${2:value}",
-                            },
-                            "description": "Check if field starts with a value",
-                            "label": "Field starts with",
-                          },
-                          Object {
-                            "body": Object {
-                              "endsWith": "\${2:value}",
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field ends with a value",
-                            "label": "Field ends with",
-                          },
-                          Object {
-                            "body": Object {
-                              "exists": true,
-                              "field": "\${1:field.name}",
-                            },
-                            "description": "Check if field exists",
-                            "label": "Field exists",
-                          },
-                          Object {
-                            "body": Object {
-                              "field": "\${1:field.name}",
-                              "range": Object {
-                                "gte": "\${2:minValue}",
-                                "lte": "\${3:maxValue}",
-                              },
-                            },
-                            "description": "Check if field is within a range",
-                            "label": "Field range",
-                          },
-                        ],
-                        "description": "Compare a field value using operators like eq, neq, lt, gt, contains",
-                        "properties": Object {
-                          "exists": Object {
-                            "description": "Indicates whether the field exists or not.",
-                            "type": "boolean",
-                          },
-                          "field": Object {
-                            "description": "The document field to check.",
-                            "minLength": 1,
-                            "type": "string",
-                          },
-                          "steps": Object {
-                            "items": Object {
-                              "$ref": "#/definitions/__schema0",
-                            },
-                            "type": "array",
-                          },
-                        },
-                        "required": Array [
-                          "field",
-                          "steps",
-                        ],
-                        "title": "Filter condition",
-                        "type": "object",
-                      },
-                    ],
-                    "description": "A basic filter condition, either unary or binary.",
-                  },
-                  Object {
-                    "additionalProperties": false,
-                    "defaultSnippets": Array [
-                      Object {
-                        "body": Object {
-                          "and": Array [
-                            Object {
-                              "eq": "\${2:value1}",
-                              "field": "\${1:field1.name}",
-                            },
-                            Object {
-                              "eq": "\${4:value2}",
-                              "field": "\${3:field2.name}",
-                            },
-                          ],
-                        },
-                        "description": "Combine conditions with AND logic",
-                        "label": "AND condition",
-                      },
-                    ],
-                    "description": "All conditions must be true",
-                    "properties": Object {
-                      "and": Object {
-                        "description": "An array of conditions. All sub-conditions must be true for this condition to be true.",
-                        "items": Object {
-                          "$ref": "#/definitions/__schema1",
-                        },
-                        "type": "array",
-                      },
-                      "steps": Object {
-                        "items": Object {
-                          "$ref": "#/definitions/__schema0",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": Array [
-                      "and",
-                      "steps",
-                    ],
-                    "title": "AND condition",
-                    "type": "object",
-                  },
-                  Object {
-                    "additionalProperties": false,
-                    "defaultSnippets": Array [
-                      Object {
-                        "body": Object {
-                          "or": Array [
-                            Object {
-                              "eq": "\${2:value1}",
-                              "field": "\${1:field1.name}",
-                            },
-                            Object {
-                              "eq": "\${4:value2}",
-                              "field": "\${3:field2.name}",
-                            },
-                          ],
-                        },
-                        "description": "Combine conditions with OR logic",
-                        "label": "OR condition",
-                      },
-                    ],
-                    "description": "At least one condition must be true",
-                    "properties": Object {
-                      "or": Object {
-                        "description": "An array of conditions. At least one sub-condition must be true for this condition to be true.",
-                        "items": Object {
-                          "$ref": "#/definitions/__schema1",
-                        },
-                        "type": "array",
-                      },
-                      "steps": Object {
-                        "items": Object {
-                          "$ref": "#/definitions/__schema0",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": Array [
-                      "or",
-                      "steps",
-                    ],
-                    "title": "OR condition",
-                    "type": "object",
-                  },
-                  Object {
-                    "additionalProperties": false,
-                    "defaultSnippets": Array [
-                      Object {
-                        "body": Object {
-                          "not": Object {
-                            "eq": "\${2:value}",
-                            "field": "\${1:field.name}",
-                          },
-                        },
-                        "description": "Negate a condition",
-                        "label": "NOT condition",
-                      },
-                    ],
-                    "description": "Negate a condition",
-                    "properties": Object {
-                      "not": Object {
-                        "allOf": Array [
-                          Object {
-                            "$ref": "#/definitions/__schema1",
-                          },
-                        ],
-                        "description": "A condition that negates another condition.",
-                      },
-                      "steps": Object {
-                        "items": Object {
-                          "$ref": "#/definitions/__schema0",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": Array [
-                      "not",
-                      "steps",
-                    ],
-                    "title": "NOT condition",
-                    "type": "object",
-                  },
-                  Object {
-                    "additionalProperties": false,
-                    "description": "A condition that always evaluates to false.",
-                    "properties": Object {
-                      "never": Object {
-                        "additionalProperties": false,
-                        "description": "An empty object. This condition never matches.",
-                        "properties": Object {},
-                        "type": "object",
-                      },
-                      "steps": Object {
-                        "items": Object {
-                          "$ref": "#/definitions/__schema0",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": Array [
-                      "never",
-                      "steps",
-                    ],
-                    "type": "object",
-                  },
-                  Object {
-                    "additionalProperties": false,
-                    "description": "A condition that always evaluates to true. Useful for catch-all scenarios, but use with caution as partitions are ordered.",
-                    "properties": Object {
-                      "always": Object {
-                        "additionalProperties": false,
-                        "description": "An empty object. This condition always matches.",
-                        "properties": Object {},
-                        "type": "object",
-                      },
-                      "steps": Object {
-                        "items": Object {
-                          "$ref": "#/definitions/__schema0",
-                        },
-                        "type": "array",
-                      },
-                    },
-                    "required": Array [
-                      "always",
-                      "steps",
-                    ],
-                    "type": "object",
-                  },
-                ],
-                "properties": Object {
-                  "steps": Object {
-                    "items": Object {
-                      "$ref": "#/definitions/__schema0",
-                    },
-                    "type": "array",
-                  },
-                },
-                "required": Array [
-                  "steps",
-                ],
-                "type": "object",
-              },
-              "customIdentifier": Object {
-                "type": "string",
-              },
-            },
-            "required": Array [
-              "condition",
-            ],
-            "title": "Condition block",
-            "type": "object",
+            "$ref": "#/definitions/StreamlangConditionBlock",
           },
         ],
+        "id": "StreamlangStep",
       },
       "type": "array",
     },

--- a/x-pack/platform/packages/shared/kbn-streamlang/src/schema/get_json_schema_from_streamlang_schema.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/src/schema/get_json_schema_from_streamlang_schema.ts
@@ -252,19 +252,43 @@ function enhanceStreamlangSchemaForEditor(
     return opt && typeof opt === 'object' && Array.isArray(opt.anyOf) && !props?.condition;
   }) as Record<string, unknown> | undefined;
 
-  const conditionBlockSchema = stepOptions.find((option: unknown) => {
-    const opt = option as Record<string, unknown>;
-    const props = opt?.properties as Record<string, unknown> | undefined;
-    return opt && typeof opt === 'object' && props?.condition;
-  }) as Record<string, unknown> | undefined;
-
-  if (!actionUnionSchema || !conditionBlockSchema) {
+  if (!actionUnionSchema) {
     return;
   }
 
-  // Enhance action steps with metadata and aggregated action enum
+  // Enhance action steps with metadata and aggregated action enum.
+  // This also applies the stream-type filter (e.g. removing manual_ingest_pipeline
+  // for wired streams). Must run before the conditionBlockSchema check so that the
+  // filter always takes effect, even when the condition block is a $ref rather than
+  // an inline object (e.g. when streamlangStepSchema has .meta({ id }) and Zod v4
+  // emits a $ref instead of inlining the schema).
   if (Array.isArray(actionUnionSchema.anyOf)) {
     enhanceActionSchema(actionUnionSchema, streamType);
+  }
+
+  // Find the condition block — it may be an inline object (properties.condition) or a
+  // $ref that resolves to one (when streamlangConditionBlockSchema is a named component).
+  const conditionBlockRef = stepOptions.find((option: unknown) => {
+    const opt = option as Record<string, unknown>;
+    const props = opt?.properties as Record<string, unknown> | undefined;
+    if (props?.condition) {
+      return true;
+    }
+    if (typeof opt?.$ref === 'string') {
+      const resolved = resolveJsonPointer(schema, opt.$ref) as Record<string, unknown> | undefined;
+      return !!(resolved?.properties as Record<string, unknown> | undefined)?.condition;
+    }
+    return false;
+  }) as Record<string, unknown> | undefined;
+
+  // Resolve $ref to get the actual condition block schema object for mutation
+  const conditionBlockSchema =
+    conditionBlockRef && typeof conditionBlockRef.$ref === 'string'
+      ? (resolveJsonPointer(schema, conditionBlockRef.$ref) as Record<string, unknown> | undefined)
+      : conditionBlockRef;
+
+  if (!conditionBlockSchema) {
+    return;
   }
 
   // Enhance condition blocks with metadata and flattened condition property

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/conditions.ts
@@ -128,7 +128,8 @@ export type FilterCondition = ShorthandBinaryFilterCondition | ShorthandUnaryFil
 
 export const filterConditionSchema = z
   .union([shorthandBinaryFilterConditionSchema, shorthandUnaryFilterConditionSchema])
-  .describe('A basic filter condition, either unary or binary.');
+  .describe('A basic filter condition, either unary or binary.')
+  .meta({ id: 'FilterCondition' });
 
 export interface AndCondition {
   and: Condition[];
@@ -171,7 +172,8 @@ export const conditionSchema: z.Schema<Condition> = z
   )
   .describe(
     'The root condition object. It can be a simple filter or a combination of other conditions.'
-  );
+  )
+  .meta({ id: 'Condition' });
 
 export const andConditionSchema = z
   .object({

--- a/x-pack/platform/packages/shared/kbn-streamlang/types/streamlang.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang/types/streamlang.ts
@@ -21,14 +21,16 @@ import type { StreamlangStepWithUIAttributes } from './ui';
 export type StreamType = 'wired' | 'classic';
 
 // Recursive schema for ConditionWithSteps
-export const conditionWithStepsSchema: z.ZodType<ConditionWithSteps> = z.lazy(() =>
-  z.intersection(
-    conditionSchema,
-    z.object({
-      steps: z.array(streamlangStepSchema),
-    })
+export const conditionWithStepsSchema: z.ZodType<ConditionWithSteps> = z
+  .lazy(() =>
+    z.intersection(
+      conditionSchema,
+      z.object({
+        steps: z.array(streamlangStepSchema),
+      })
+    )
   )
-);
+  .meta({ id: 'ConditionWithSteps' });
 
 export type ConditionWithSteps = Condition & { steps: StreamlangStep[] };
 
@@ -43,10 +45,12 @@ export interface StreamlangConditionBlock {
 /**
  * Zod schema for a condition block
  */
-export const streamlangConditionBlockSchema: z.ZodType<StreamlangConditionBlock> = z.object({
-  customIdentifier: z.string().optional(),
-  condition: conditionWithStepsSchema,
-});
+export const streamlangConditionBlockSchema: z.ZodType<StreamlangConditionBlock> = z
+  .object({
+    customIdentifier: z.string().optional(),
+    condition: conditionWithStepsSchema,
+  })
+  .meta({ id: 'StreamlangConditionBlock' });
 
 export const isConditionBlockSchema = (obj: unknown): obj is StreamlangConditionBlock => {
   return isSchema(streamlangConditionBlockSchema, obj);
@@ -67,9 +71,9 @@ export const isConditionBlock = (obj: unknown): obj is StreamlangConditionBlock 
  * A step can be either a processor or a condition block (optionally recursive)
  */
 export type StreamlangStep = StreamlangProcessorDefinition | StreamlangConditionBlock;
-export const streamlangStepSchema: z.ZodType<StreamlangStep> = z.lazy(() =>
-  z.union([streamlangProcessorSchema, streamlangConditionBlockSchema])
-);
+export const streamlangStepSchema: z.ZodType<StreamlangStep> = z
+  .lazy(() => z.union([streamlangProcessorSchema, streamlangConditionBlockSchema]))
+  .meta({ id: 'StreamlangStep' });
 
 export const isActionBlockSchema = (obj: unknown): obj is StreamlangProcessorDefinition => {
   return isSchema(streamlangProcessorSchema, obj);

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/fields/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/fields/index.ts
@@ -85,26 +85,28 @@ export type FieldDefinitionConfigAdvancedParameters = Omit<
   'type' | 'format' | 'description'
 >;
 
-export const fieldDefinitionConfigSchema = z.intersection(
-  recursiveRecord,
-  z.union([
-    z.object({
-      type: z.enum(FIELD_DEFINITION_TYPES),
-      format: z.optional(NonEmptyString),
-      description: z.optional(z.string()),
-    }),
-    z.object({
-      // Documentation-only override: require description and forbid type entirely
-      description: z.string(),
-      type: z.never().optional(),
-      format: z.never().optional(),
-    }),
-    z.object({
-      type: z.literal('system'),
-      description: z.optional(z.string()),
-    }),
-  ])
-) as z.ZodType<FieldDefinitionConfig>;
+export const fieldDefinitionConfigSchema = (
+  z.intersection(
+    recursiveRecord,
+    z.union([
+      z.object({
+        type: z.enum(FIELD_DEFINITION_TYPES),
+        format: z.optional(NonEmptyString),
+        description: z.optional(z.string()),
+      }),
+      z.object({
+        // Documentation-only override: require description and forbid type entirely
+        description: z.string(),
+        type: z.never().optional(),
+        format: z.never().optional(),
+      }),
+      z.object({
+        type: z.literal('system'),
+        description: z.optional(z.string()),
+      }),
+    ])
+  ) as z.ZodType<FieldDefinitionConfig>
+).meta({ id: 'FieldDefinitionConfig' });
 
 export interface FieldDefinition {
   [x: string]: FieldDefinitionConfig;
@@ -136,10 +138,9 @@ export function isMappingProperties(value: FieldDefinition): value is StreamsMap
   return Object.values(value).every((prop) => Boolean(prop.type) && prop.type !== 'system');
 }
 
-export const fieldDefinitionSchema: z.Schema<FieldDefinition> = z.record(
-  z.string(),
-  fieldDefinitionConfigSchema
-);
+export const fieldDefinitionSchema: z.Schema<FieldDefinition> = z
+  .record(z.string(), fieldDefinitionConfigSchema)
+  .meta({ id: 'FieldDefinition' });
 
 /**
  * Schema for classic stream field overrides.
@@ -157,29 +158,30 @@ export type ClassicFieldDefinitionConfig =
       description?: string;
     };
 
-export const classicFieldDefinitionConfigSchema = z.intersection(
-  recursiveRecord,
-  z.union([
-    z.object({
-      type: z.enum(FIELD_DEFINITION_TYPES),
-      format: z.optional(NonEmptyString),
-      description: z.optional(z.string()),
-    }),
-    z.object({
-      type: z.literal('system'),
-      description: z.optional(z.string()),
-    }),
-  ])
-) as z.ZodType<ClassicFieldDefinitionConfig>;
+export const classicFieldDefinitionConfigSchema = (
+  z.intersection(
+    recursiveRecord,
+    z.union([
+      z.object({
+        type: z.enum(FIELD_DEFINITION_TYPES),
+        format: z.optional(NonEmptyString),
+        description: z.optional(z.string()),
+      }),
+      z.object({
+        type: z.literal('system'),
+        description: z.optional(z.string()),
+      }),
+    ])
+  ) as z.ZodType<ClassicFieldDefinitionConfig>
+).meta({ id: 'ClassicFieldDefinitionConfig' });
 
 export interface ClassicFieldDefinition {
   [x: string]: ClassicFieldDefinitionConfig;
 }
 
-export const classicFieldDefinitionSchema: z.Schema<ClassicFieldDefinition> = z.record(
-  z.string(),
-  classicFieldDefinitionConfigSchema
-);
+export const classicFieldDefinitionSchema: z.Schema<ClassicFieldDefinition> = z
+  .record(z.string(), classicFieldDefinitionConfigSchema)
+  .meta({ id: 'ClassicFieldDefinition' });
 
 export type InheritedFieldDefinitionConfig = FieldDefinitionConfig & {
   from: string;
@@ -190,16 +192,18 @@ export interface InheritedFieldDefinition {
   [x: string]: InheritedFieldDefinitionConfig;
 }
 
-export const inheritedFieldDefinitionSchema: z.Schema<InheritedFieldDefinition> = z.record(
-  z.string(),
-  z.intersection(
-    fieldDefinitionConfigSchema,
-    z.object({
-      from: NonEmptyString,
-      alias_for: z.optional(NonEmptyString),
-    })
+export const inheritedFieldDefinitionSchema: z.Schema<InheritedFieldDefinition> = z
+  .record(
+    z.string(),
+    z.intersection(
+      fieldDefinitionConfigSchema,
+      z.object({
+        from: NonEmptyString,
+        alias_for: z.optional(NonEmptyString),
+      })
+    )
   )
-);
+  .meta({ id: 'InheritedFieldDefinition' });
 
 export type NamedFieldDefinitionConfig = FieldDefinitionConfig & {
   name: string;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/classic.ts
@@ -115,21 +115,25 @@ const classicStreamDefinitionSchema = ingestBaseStreamDefinitionSchema
   })
   .meta({ id: 'ClassicStreamDefinition' });
 
-const classicStreamGetResponseSchema = ingestBaseStreamGetResponseSchema.extend({
-  stream: classicStreamDefinitionSchema,
-  elasticsearch_assets: z.optional(elasticsearchAssetsSchema),
-  data_stream_exists: z.boolean(),
-  effective_lifecycle: classicIngestStreamEffectiveLifecycleSchema,
-  effective_settings: ingestStreamSettingsSchema,
-  effective_failure_store: effectiveFailureStoreSchema,
-});
+const classicStreamGetResponseSchema = ingestBaseStreamGetResponseSchema
+  .extend({
+    stream: classicStreamDefinitionSchema,
+    elasticsearch_assets: z.optional(elasticsearchAssetsSchema),
+    data_stream_exists: z.boolean(),
+    effective_lifecycle: classicIngestStreamEffectiveLifecycleSchema,
+    effective_settings: ingestStreamSettingsSchema,
+    effective_failure_store: effectiveFailureStoreSchema,
+  })
+  .meta({ id: 'ClassicStreamGetResponse' });
 
-const classicStreamUpsertRequestSchema = ingestBaseStreamUpsertRequestSchema.extend({
-  stream: ingestBaseStreamUpsertDefinitionSchema.extend({
-    type: z.literal('classic'),
-    ingest: classicIngestUpsertSchemaObject,
-  }),
-});
+const classicStreamUpsertRequestSchema = ingestBaseStreamUpsertRequestSchema
+  .extend({
+    stream: ingestBaseStreamUpsertDefinitionSchema.extend({
+      type: z.literal('classic'),
+      ingest: classicIngestUpsertSchemaObject,
+    }),
+  })
+  .meta({ id: 'ClassicStreamUpsertRequest' });
 
 export const ClassicStream: {
   Definition: Validation<BaseStream.Model['Definition'], ClassicStream.Definition>;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/failure_store/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/failure_store/index.ts
@@ -80,26 +80,27 @@ const effectiveWithLifecycleFailureStoreSchema: z.Schema<EffectiveFailureStoreEn
     }),
   });
 
-const effectiveEnabledFailureStoreSchema: z.Schema<EffectiveFailureStoreEnabled> = z.union([
-  effectiveWithLifecycleFailureStoreSchema,
-  enabledWithoutLifecycleFailureStoreSchema,
-]);
-
-export const effectiveFailureStoreSchema: z.Schema<EffectiveFailureStore> = z.union([
-  effectiveEnabledFailureStoreSchema,
-  disabledFailureStoreSchema,
-]);
+export const effectiveFailureStoreSchema: z.Schema<EffectiveFailureStore> = z
+  .union([
+    effectiveWithLifecycleFailureStoreSchema,
+    enabledWithoutLifecycleFailureStoreSchema,
+    disabledFailureStoreSchema,
+  ])
+  .meta({ id: 'EffectiveFailureStore' });
 
 export const enabledFailureStoreSchema: z.Schema<FailureStoreEnabled> = z.union([
   enabledWithLifecycleFailureStoreSchema,
   enabledWithoutLifecycleFailureStoreSchema,
 ]);
 
-export const failureStoreSchema: z.Schema<FailureStore> = z.union([
-  inheritFailureStoreSchema,
-  disabledFailureStoreSchema,
-  enabledFailureStoreSchema,
-]);
+export const failureStoreSchema: z.Schema<FailureStore> = z
+  .union([
+    inheritFailureStoreSchema,
+    disabledFailureStoreSchema,
+    enabledWithLifecycleFailureStoreSchema,
+    enabledWithoutLifecycleFailureStoreSchema,
+  ])
+  .meta({ id: 'FailureStore' });
 
 export const failureStoreStatsSchema: z.Schema<FailureStoreStatsResponse> = z.object({
   size: z.number().min(0).optional(),
@@ -134,7 +135,8 @@ export const isEnabledFailureStore = (
 ): input is FailureStoreEnabled | EffectiveFailureStoreEnabled => {
   return (
     isSchema(enabledFailureStoreSchema, input) ||
-    isSchema(effectiveEnabledFailureStoreSchema, input)
+    isSchema(effectiveWithLifecycleFailureStoreSchema, input) ||
+    isSchema(enabledWithoutLifecycleFailureStoreSchema, input)
   );
 };
 

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
@@ -84,20 +84,28 @@ const errorLifecycleSchema = z.object({
   }),
 });
 
-export const ingestStreamLifecycleSchema: z.Schema<IngestStreamLifecycle> = z.union([
-  dslLifecycleSchema,
-  ilmLifecycleSchema,
-  inheritLifecycleSchema,
-]);
+export const ingestStreamLifecycleSchema: z.Schema<IngestStreamLifecycle> = z
+  .union([dslLifecycleSchema, ilmLifecycleSchema, inheritLifecycleSchema])
+  .meta({ id: 'IngestStreamLifecycle' });
 
 export const classicIngestStreamEffectiveLifecycleSchema: z.Schema<ClassicIngestStreamEffectiveLifecycle> =
-  z.union([ingestStreamLifecycleSchema, disabledLifecycleSchema, errorLifecycleSchema]);
+  z
+    .union([
+      dslLifecycleSchema,
+      ilmLifecycleSchema,
+      inheritLifecycleSchema,
+      disabledLifecycleSchema,
+      errorLifecycleSchema,
+    ])
+    .meta({ id: 'ClassicIngestStreamEffectiveLifecycle' });
 
 export const wiredIngestStreamEffectiveLifecycleSchema: z.Schema<WiredIngestStreamEffectiveLifecycle> =
-  z.union([
-    dslLifecycleSchema.extend({ from: NonEmptyString }),
-    ilmLifecycleSchema.extend({ from: NonEmptyString }),
-  ]);
+  z
+    .union([
+      dslLifecycleSchema.extend({ from: NonEmptyString }),
+      ilmLifecycleSchema.extend({ from: NonEmptyString }),
+    ])
+    .meta({ id: 'WiredIngestStreamEffectiveLifecycle' });
 
 export const ingestStreamEffectiveLifecycleSchema: z.Schema<IngestStreamEffectiveLifecycle> =
   z.union([classicIngestStreamEffectiveLifecycleSchema, wiredIngestStreamEffectiveLifecycleSchema]);

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/wired.ts
@@ -123,21 +123,25 @@ const wiredStreamDefinitionSchema = ingestBaseStreamDefinitionSchema
   })
   .meta({ id: 'WiredStreamDefinition' });
 
-const wiredStreamGetResponseSchema = ingestBaseStreamGetResponseSchema.extend({
-  stream: wiredStreamDefinitionSchema,
-  data_stream_exists: z.boolean(),
-  inherited_fields: inheritedFieldDefinitionSchema,
-  effective_lifecycle: wiredIngestStreamEffectiveLifecycleSchema,
-  effective_settings: wiredIngestStreamEffectiveSettingsSchema,
-  effective_failure_store: wiredIngestStreamEffectiveFailureStoreSchema,
-});
+const wiredStreamGetResponseSchema = ingestBaseStreamGetResponseSchema
+  .extend({
+    stream: wiredStreamDefinitionSchema,
+    data_stream_exists: z.boolean(),
+    inherited_fields: inheritedFieldDefinitionSchema,
+    effective_lifecycle: wiredIngestStreamEffectiveLifecycleSchema,
+    effective_settings: wiredIngestStreamEffectiveSettingsSchema,
+    effective_failure_store: wiredIngestStreamEffectiveFailureStoreSchema,
+  })
+  .meta({ id: 'WiredStreamGetResponse' });
 
-const wiredStreamUpsertRequestSchema = ingestBaseStreamUpsertRequestSchema.extend({
-  stream: ingestBaseStreamUpsertDefinitionSchema.extend({
-    type: z.literal('wired'),
-    ingest: wiredIngestUpsertSchemaObject,
-  }),
-});
+const wiredStreamUpsertRequestSchema = ingestBaseStreamUpsertRequestSchema
+  .extend({
+    stream: ingestBaseStreamUpsertDefinitionSchema.extend({
+      type: z.literal('wired'),
+      ingest: wiredIngestUpsertSchemaObject,
+    }),
+  })
+  .meta({ id: 'WiredStreamUpsertRequest' });
 
 export const WiredStream: {
   Definition: Validation<BaseStream.Model['Definition'], WiredStream.Definition>;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/query/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/query/index.ts
@@ -79,17 +79,21 @@ const queryStreamDefinitionSchema = baseStreamDefinitionSchema
   })
   .meta({ id: 'QueryStreamDefinition' });
 
-const queryStreamGetResponseSchema = baseStreamGetResponseSchema.extend({
-  stream: queryStreamDefinitionSchema,
-  inherited_fields: inheritedFieldDefinitionSchema,
-});
+const queryStreamGetResponseSchema = baseStreamGetResponseSchema
+  .extend({
+    stream: queryStreamDefinitionSchema,
+    inherited_fields: inheritedFieldDefinitionSchema,
+  })
+  .meta({ id: 'QueryStreamGetResponse' });
 
-const queryStreamUpsertRequestSchema = baseStreamUpsertRequestSchema.extend({
-  stream: baseStreamUpsertDefinitionSchema.extend({
-    type: z.literal('query'),
-    query: QueryWithEsql.right,
-  }),
-});
+const queryStreamUpsertRequestSchema = baseStreamUpsertRequestSchema
+  .extend({
+    stream: baseStreamUpsertDefinitionSchema.extend({
+      type: z.literal('query'),
+      query: QueryWithEsql.right,
+    }),
+  })
+  .meta({ id: 'QueryStreamUpsertRequest' });
 
 export const QueryStream: {
   Definition: Validation<BaseStream.Model['Definition'], QueryStream.Definition>;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/streams.ts
@@ -41,16 +41,20 @@ export namespace Streams {
     nClassicStream.Source.right,
     nQueryStream.Source.right,
   ]);
-  const allGetResponseSchema = z.union([
-    nWiredStream.GetResponse.right,
-    nClassicStream.GetResponse.right,
-    nQueryStream.GetResponse.right,
-  ]);
-  const allUpsertRequestSchema = z.union([
-    nWiredStream.UpsertRequest.right,
-    nClassicStream.UpsertRequest.right,
-    nQueryStream.UpsertRequest.right,
-  ]);
+  const allGetResponseSchema = z
+    .union([
+      nWiredStream.GetResponse.right,
+      nClassicStream.GetResponse.right,
+      nQueryStream.GetResponse.right,
+    ])
+    .meta({ id: 'StreamGetResponse' });
+  const allUpsertRequestSchema = z
+    .union([
+      nWiredStream.UpsertRequest.right,
+      nClassicStream.UpsertRequest.right,
+      nQueryStream.UpsertRequest.right,
+    ])
+    .meta({ id: 'StreamUpsertRequest' });
 
   export const all: {
     Definition: Validation<BaseStream.Model['Definition'], all.Definition>;
@@ -83,9 +87,9 @@ Streams.ClassicStream = nClassicStream;
 Streams.QueryStream = nQueryStream;
 
 /**
- * Flat Zod union of all three stream definition schemas, discriminated by the
- * `type` literal field. Registered as a named OAS component (`StreamDefinition`)
- * with a `discriminator` extension so code generators can produce properly typed
+ * Union of all three stream definition schemas, discriminated by the `type`
+ * literal field. Registered as a named OAS component (`StreamDefinition`) with
+ * a `discriminator` extension so code generators can produce properly typed
  * sealed-class / tagged-union structs.
  */
 export const streamDefinitionSchema = z

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/oas_definitions.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/oas_definitions.ts
@@ -16,23 +16,49 @@ import { WiredStream } from './models/ingest/wired';
 import { ClassicStream, ClassicIngest } from './models/ingest/classic';
 import { WiredIngest } from './models/ingest/wired';
 import { QueryStream } from './models/query';
-import { streamDefinitionSchema } from './models/streams';
-import { fieldDefinitionSchema } from './fields';
+import { streamDefinitionSchema, Streams } from './models/streams';
+import {
+  fieldDefinitionSchema,
+  fieldDefinitionConfigSchema,
+  classicFieldDefinitionSchema,
+  classicFieldDefinitionConfigSchema,
+  inheritedFieldDefinitionSchema,
+} from './fields';
 import { routingDefinitionSchema } from './models/ingest/routing';
-import { ingestStreamLifecycleSchema } from './models/ingest/lifecycle';
+import {
+  ingestStreamLifecycleSchema,
+  classicIngestStreamEffectiveLifecycleSchema,
+  wiredIngestStreamEffectiveLifecycleSchema,
+} from './models/ingest/lifecycle';
+import { effectiveFailureStoreSchema, failureStoreSchema } from './models/ingest/failure_store';
 
 export const streamsOasDefinitions = {
   /**
-   * Top-level discriminated union of all stream definition variants.
-   * Registered with a `discriminator` extension so OAS code generators can
-   * produce typed structs without inspecting nested properties.
+   * Top-level union of all stream definition variants, with an explicit OAS
+   * discriminator on `type`. .meta({ id: 'StreamDefinition', openapi: { discriminator } })
+   * is applied at definition time in models/streams.ts.
    */
   StreamDefinition: streamDefinitionSchema,
 
   // Individual stream definition variants
+  // .meta({ id }) applied at definition time in their respective files
   WiredStreamDefinition: WiredStream.Definition.right,
   ClassicStreamDefinition: ClassicStream.Definition.right,
   QueryStreamDefinition: QueryStream.Definition.right,
+
+  // Get response union and variants
+  // .meta({ id }) applied at definition time in their respective files
+  StreamGetResponse: Streams.all.GetResponse.right,
+  WiredStreamGetResponse: WiredStream.GetResponse.right,
+  ClassicStreamGetResponse: ClassicStream.GetResponse.right,
+  QueryStreamGetResponse: QueryStream.GetResponse.right,
+
+  // Upsert request union and variants
+  // .meta({ id }) applied at definition time in their respective files
+  StreamUpsertRequest: Streams.all.UpsertRequest.right,
+  WiredStreamUpsertRequest: WiredStream.UpsertRequest.right,
+  ClassicStreamUpsertRequest: ClassicStream.UpsertRequest.right,
+  QueryStreamUpsertRequest: QueryStream.UpsertRequest.right,
 
   // Ingest configs
   WiredIngest: WiredIngest.right,
@@ -40,10 +66,22 @@ export const streamsOasDefinitions = {
 
   // Fields & routing
   FieldDefinition: fieldDefinitionSchema,
+  FieldDefinitionConfig: fieldDefinitionConfigSchema,
+  ClassicFieldDefinition: classicFieldDefinitionSchema,
+  ClassicFieldDefinitionConfig: classicFieldDefinitionConfigSchema,
+  InheritedFieldDefinition: inheritedFieldDefinitionSchema,
   RoutingDefinition: routingDefinitionSchema,
 
   // Lifecycle
+  // .meta({ id }) applied at definition time in lifecycle/index.ts
   IngestStreamLifecycle: ingestStreamLifecycleSchema,
+  ClassicIngestStreamEffectiveLifecycle: classicIngestStreamEffectiveLifecycleSchema,
+  WiredIngestStreamEffectiveLifecycle: wiredIngestStreamEffectiveLifecycleSchema,
+
+  // Failure store
+  // .meta({ id }) applied at definition time in failure_store/index.ts
+  FailureStore: failureStoreSchema,
+  EffectiveFailureStore: effectiveFailureStoreSchema,
 } as const;
 
 export type StreamsOasDefinitions = typeof streamsOasDefinitions;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/shared/record_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/shared/record_types.ts
@@ -21,12 +21,14 @@ export interface RecursiveRecord {
   [key: PropertyKey]: Primitive | Primitive[] | unknown[] | RecursiveRecord;
 }
 
-export const recursiveRecord: z.ZodType<RecursiveRecord> = z.lazy(() =>
-  z.record(
-    z.string(),
-    z.union([primitive, z.array(primitive), z.array(z.unknown()), recursiveRecord])
+export const recursiveRecord: z.ZodType<RecursiveRecord> = z
+  .lazy(() =>
+    z.record(
+      z.string(),
+      z.union([primitive, z.array(primitive), z.array(z.unknown()), recursiveRecord])
+    )
   )
-);
+  .meta({ id: 'RecursiveRecord' });
 
 export type FlattenRecord = Record<PropertyKey, Primitive | Primitive[] | unknown[]>;
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/259277

## Summary

Improves the Streams and Streamlang OAS output by eliminating deeply nested `anyOf > anyOf > allOf` structures in the generated spec. The root cause was that `.meta({ id })` calls for most schemas lived only in the `oas_definitions.ts` registry files rather than at definition time. Because Zod v4's `.meta()` is immutable (it returns a new schema without modifying the original), the exported schema variables themselves were never registered — so every consumer inlined the full schema instead of emitting a `$ref`.

## Root cause

```typescript
// oas_definitions.ts — old pattern: .meta() result is stored but the original
// conditionSchema variable remains unregistered
Condition: conditionSchema.meta({ id: 'Condition' }),
```

When conditionSchema was used in `routingDefinitionSchema.where`, the OAS generator had no id to look up, so it inlined the full recursive union. The fix is to call `.meta({ id })` at definition time so the exported variable itself is the registered schema.

## Before / after

`PUT /api/streams/{name}` request body

```
# Before
schema:
  anyOf:
    - anyOf:
        - allOf: ...

# After
schema:
  $ref: '#/components/schemas/StreamUpsertRequest'
```

`GET /api/streams/{name}` response

```
# Before: three large inline objects
anyOf:
  - type: object
    properties: { ... hundreds of lines ... }
# After
$ref: '#/components/schemas/StreamGetResponse'
```