### PR TITLE
[One workflows] Workflow composition telemetry

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/index.ts
@@ -30,6 +30,7 @@ const baseWorkflowExecutionSchema: RootSchema<{
   ruleId?: string;
   compositionDepth?: number;
   parentWorkflowId?: string;
+  parentWorkflowInvocation?: 'sync' | 'async';
 }> = {
   workflowExecutionId: {
     type: 'keyword',
@@ -88,6 +89,14 @@ const baseWorkflowExecutionSchema: RootSchema<{
     _meta: {
       description:
         'The workflow ID of the parent workflow that invoked this sub-workflow. Only present for sub-workflow executions.',
+      optional: true,
+    },
+  },
+  parentWorkflowInvocation: {
+    type: 'keyword',
+    _meta: {
+      description:
+        'Whether the parent started this sub-workflow with workflow.execute (sync) or workflow.executeAsync (async). Only present for sub-workflow executions.',
       optional: true,
     },
   },

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/index.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/index.ts
@@ -25,9 +25,11 @@ const baseWorkflowExecutionSchema: RootSchema<{
   workflowExecutionId: string;
   workflowId: string;
   spaceId: string;
-  triggerType: 'manual' | 'scheduled' | 'alert';
+  triggerType: 'manual' | 'scheduled' | 'alert' | 'workflow-step';
   isTestRun: boolean;
   ruleId?: string;
+  compositionDepth?: number;
+  parentWorkflowId?: string;
 }> = {
   workflowExecutionId: {
     type: 'keyword',
@@ -53,7 +55,8 @@ const baseWorkflowExecutionSchema: RootSchema<{
   triggerType: {
     type: 'keyword',
     _meta: {
-      description: 'How the workflow was triggered: manual, scheduled, or alert',
+      description:
+        'How the workflow was triggered: manual, scheduled, alert, or workflow-step for sub-workflows',
       optional: false,
     },
   },
@@ -69,6 +72,22 @@ const baseWorkflowExecutionSchema: RootSchema<{
     _meta: {
       description:
         'The alert rule ID if triggered by alert. Only present when triggerType is alert.',
+      optional: true,
+    },
+  },
+  compositionDepth: {
+    type: 'integer',
+    _meta: {
+      description:
+        'Cross-workflow nesting depth for sub-workflow executions (1 = direct child). Only present for sub-workflow executions.',
+      optional: true,
+    },
+  },
+  parentWorkflowId: {
+    type: 'keyword',
+    _meta: {
+      description:
+        'The workflow ID of the parent workflow that invoked this sub-workflow. Only present for sub-workflow executions.',
       optional: true,
     },
   },

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/types.ts
@@ -24,9 +24,9 @@ export interface BaseWorkflowExecutionTelemetryParams {
    */
   spaceId: string;
   /**
-   * How the workflow was triggered: 'manual', 'scheduled', or 'alert'
+   * How the workflow was triggered: 'manual', 'scheduled', 'alert', or 'workflow-step' for sub-workflows.
    */
-  triggerType: 'manual' | 'scheduled' | 'alert';
+  triggerType: 'manual' | 'scheduled' | 'alert' | 'workflow-step';
   /**
    * Whether this is a test run
    */
@@ -35,6 +35,16 @@ export interface BaseWorkflowExecutionTelemetryParams {
    * The alert rule ID if triggered by alert. Only present when triggerType is 'alert'.
    */
   ruleId?: string;
+  /**
+   * Cross-workflow nesting depth for sub-workflow executions (1 = direct child).
+   * Only present for sub-workflow executions.
+   */
+  compositionDepth?: number;
+  /**
+   * The workflow ID of the parent workflow that invoked this sub-workflow.
+   * Only present for sub-workflow executions.
+   */
+  parentWorkflowId?: string;
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/events/workflows_execution/types.ts
@@ -45,6 +45,11 @@ export interface BaseWorkflowExecutionTelemetryParams {
    * Only present for sub-workflow executions.
    */
   parentWorkflowId?: string;
+  /**
+   * Whether the parent used workflow.execute (sync) or workflow.executeAsync to start this run.
+   * Only present for sub-workflow executions when recorded on the execution context.
+   */
+  parentWorkflowInvocation?: 'sync' | 'async';
 }
 
 /**

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.test.ts
@@ -23,15 +23,31 @@ describe('extractCompositionContext', () => {
     expect(extractCompositionContext(compositionFixture('manual', {}))).toEqual({});
   });
 
-  it('returns compositionDepth and parentWorkflowId for child execution', () => {
+  it('returns compositionDepth, parentWorkflowId, and parentWorkflowInvocation when set', () => {
     expect(
       extractCompositionContext(
         compositionFixture('workflow-step', {
           parentDepth: 0,
           parentWorkflowId: 'parent-wf-id',
+          parentWorkflowInvocation: 'sync',
         })
       )
-    ).toEqual({ compositionDepth: 1, parentWorkflowId: 'parent-wf-id' });
+    ).toEqual({
+      compositionDepth: 1,
+      parentWorkflowId: 'parent-wf-id',
+      parentWorkflowInvocation: 'sync',
+    });
+  });
+
+  it('includes parentWorkflowInvocation async', () => {
+    expect(
+      extractCompositionContext(
+        compositionFixture('workflow-step', {
+          parentDepth: 0,
+          parentWorkflowInvocation: 'async',
+        })
+      )
+    ).toEqual({ compositionDepth: 1, parentWorkflowInvocation: 'async' });
   });
 
   it('uses compositionDepth 1 when parentDepth is not a number', () => {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { EsWorkflowExecution } from '@kbn/workflows';
+import { extractCompositionContext } from './extract_execution_metadata';
+
+/** Minimal fixture: extractCompositionContext only reads triggeredBy and context. */
+function compositionFixture(
+  triggeredBy: string,
+  context: Record<string, unknown>
+): EsWorkflowExecution {
+  return { triggeredBy, context } as unknown as EsWorkflowExecution;
+}
+
+describe('extractCompositionContext', () => {
+  it('returns empty object when not triggered by workflow-step', () => {
+    expect(extractCompositionContext(compositionFixture('manual', {}))).toEqual({});
+  });
+
+  it('returns compositionDepth and parentWorkflowId for child execution', () => {
+    expect(
+      extractCompositionContext(
+        compositionFixture('workflow-step', {
+          parentDepth: 0,
+          parentWorkflowId: 'parent-wf-id',
+        })
+      )
+    ).toEqual({ compositionDepth: 1, parentWorkflowId: 'parent-wf-id' });
+  });
+
+  it('uses compositionDepth 1 when parentDepth is not a number', () => {
+    expect(
+      extractCompositionContext(
+        compositionFixture('workflow-step', {
+          parentDepth: 'invalid',
+          parentWorkflowId: 'parent-wf-id',
+        })
+      )
+    ).toEqual({ compositionDepth: 1, parentWorkflowId: 'parent-wf-id' });
+  });
+
+  it('omits parentWorkflowId when empty string', () => {
+    expect(
+      extractCompositionContext(
+        compositionFixture('workflow-step', {
+          parentDepth: 0,
+          parentWorkflowId: '',
+        })
+      )
+    ).toEqual({ compositionDepth: 1 });
+  });
+
+  it('omits parentWorkflowId when not a string', () => {
+    expect(
+      extractCompositionContext(
+        compositionFixture('workflow-step', {
+          parentDepth: 0,
+          parentWorkflowId: 123,
+        })
+      )
+    ).toEqual({ compositionDepth: 1 });
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.ts
@@ -91,6 +91,16 @@ export interface WorkflowExecutionTelemetryMetadata {
    * E.g., { "if": 100, "console": 40, "elasticsearch_search": 250 }
    */
   stepAvgDurationsByType?: Record<string, number>;
+  /**
+   * Cross-workflow nesting depth for sub-workflow executions (1 = direct child).
+   * Only present when triggered by a parent workflow step.
+   */
+  compositionDepth?: number;
+  /**
+   * The workflow ID of the parent that invoked this sub-workflow.
+   * Only present for sub-workflow executions when available in context.
+   */
+  parentWorkflowId?: string;
 }
 
 /**
@@ -195,6 +205,8 @@ export function extractExecutionMetadata(
   // Extract alert rule ID
   const ruleId = extractAlertRuleId(workflowExecution);
 
+  const compositionContext = extractCompositionContext(workflowExecution);
+
   // Extract or calculate queue delay
   const queueDelayMs = extractQueueDelayMs(workflowExecution);
 
@@ -221,6 +233,7 @@ export function extractExecutionMetadata(
     hasErrorHandling,
     uniqueStepIdsExecuted: uniqueStepIdsSet.size,
     ...(ruleId && { ruleId }),
+    ...compositionContext,
     ...(timeToFirstStep !== undefined && { timeToFirstStep }),
     ...(queueDelayMs !== undefined && { queueDelayMs }),
     timedOut: timeoutInfo.timedOut,
@@ -230,6 +243,33 @@ export function extractExecutionMetadata(
     }),
     ...(stepDurations.length > 0 && { stepDurations }),
     ...(Object.keys(stepAvgDurationsByType).length > 0 && { stepAvgDurationsByType }),
+  };
+}
+
+/**
+ * Extracts composition context for sub-workflow executions (triggered by workflow.execute / workflow.executeAsync).
+ * Returns empty object for top-level executions.
+ *
+ * @param workflowExecution - The workflow execution
+ * @returns compositionDepth and optional parentWorkflowId when this is a child execution
+ */
+export function extractCompositionContext(workflowExecution: EsWorkflowExecution): {
+  compositionDepth?: number;
+  parentWorkflowId?: string;
+} {
+  if (workflowExecution.triggeredBy !== 'workflow-step') {
+    return {};
+  }
+
+  const context = workflowExecution.context || {};
+  const parentDepth = context.parentDepth;
+  const compositionDepth = typeof parentDepth === 'number' ? parentDepth + 1 : 1;
+  const parentWorkflowId =
+    typeof context.parentWorkflowId === 'string' ? context.parentWorkflowId : undefined;
+
+  return {
+    compositionDepth,
+    ...(parentWorkflowId && { parentWorkflowId }),
   };
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/utils/extract_execution_metadata.ts
@@ -101,6 +101,11 @@ export interface WorkflowExecutionTelemetryMetadata {
    * Only present for sub-workflow executions when available in context.
    */
   parentWorkflowId?: string;
+  /**
+   * Whether the parent invoked this sub-workflow via workflow.execute (sync) or workflow.executeAsync.
+   * Only present for sub-workflow executions when set on the execution context.
+   */
+  parentWorkflowInvocation?: 'sync' | 'async';
 }
 
 /**
@@ -246,30 +251,37 @@ export function extractExecutionMetadata(
   };
 }
 
+/** How the parent started this sub-workflow (persisted on child execution context by execute strategies). */
+type ParentWorkflowInvocationMode = 'sync' | 'async';
+
 /**
  * Extracts composition context for sub-workflow executions (triggered by workflow.execute / workflow.executeAsync).
  * Returns empty object for top-level executions.
  *
  * @param workflowExecution - The workflow execution
- * @returns compositionDepth and optional parentWorkflowId when this is a child execution
+ * @returns compositionDepth and optional parentWorkflowId / parentWorkflowInvocation when this is a child execution
  */
 export function extractCompositionContext(workflowExecution: EsWorkflowExecution): {
   compositionDepth?: number;
   parentWorkflowId?: string;
+  parentWorkflowInvocation?: ParentWorkflowInvocationMode;
 } {
   if (workflowExecution.triggeredBy !== 'workflow-step') {
     return {};
   }
 
-  const context = workflowExecution.context || {};
+  const context = (workflowExecution.context || {}) as Record<string, unknown>;
   const parentDepth = context.parentDepth;
   const compositionDepth = typeof parentDepth === 'number' ? parentDepth + 1 : 1;
   const parentWorkflowId =
     typeof context.parentWorkflowId === 'string' ? context.parentWorkflowId : undefined;
+  const parentWorkflowInvocation =
+    (context.parentWorkflowInvocation as ParentWorkflowInvocationMode) || undefined;
 
   return {
     compositionDepth,
     ...(parentWorkflowId && { parentWorkflowId }),
+    ...(parentWorkflowInvocation && { parentWorkflowInvocation }),
   };
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.test.ts
@@ -245,6 +245,41 @@ describe('WorkflowExecutionTelemetryClient', () => {
       const [, eventData] = telemetry.reportEvent.mock.calls[0];
       expect(eventData).not.toHaveProperty('queueDelayMs');
     });
+
+    it('should omit composition fields for top-level executions', () => {
+      const workflowExecution = createMockWorkflowExecution({ triggeredBy: 'manual' });
+
+      client.reportWorkflowExecutionCompleted({
+        workflowExecution,
+        stepExecutions: [],
+      });
+
+      const [, eventData] = telemetry.reportEvent.mock.calls[0];
+      expect(eventData).not.toHaveProperty('compositionDepth');
+      expect(eventData).not.toHaveProperty('parentWorkflowId');
+    });
+
+    it('should include compositionDepth and parentWorkflowId for sub-workflow executions', () => {
+      const workflowExecution = createMockWorkflowExecution({
+        triggeredBy: 'workflow-step',
+        context: {
+          parentDepth: 0,
+          parentWorkflowId: 'parent-wf-id',
+        },
+      });
+
+      client.reportWorkflowExecutionCompleted({
+        workflowExecution,
+        stepExecutions: [],
+      });
+
+      const [, eventData] = telemetry.reportEvent.mock.calls[0];
+      expect(eventData).toMatchObject({
+        triggerType: 'workflow-step',
+        compositionDepth: 1,
+        parentWorkflowId: 'parent-wf-id',
+      });
+    });
   });
 
   describe('reportWorkflowExecutionFailed', () => {
@@ -342,6 +377,34 @@ describe('WorkflowExecutionTelemetryClient', () => {
         timeoutExceededByMs: 30000, // 30 seconds over
       });
     });
+
+    it('should include composition fields for failed sub-workflow executions', () => {
+      const workflowExecution = createMockWorkflowExecution({
+        status: ExecutionStatus.FAILED,
+        triggeredBy: 'workflow-step',
+        context: {
+          parentDepth: 1,
+          parentWorkflowId: 'parent-wf-id',
+        },
+        error: {
+          message: 'Child failed',
+          type: 'ExecutionError',
+        },
+      });
+
+      client.reportWorkflowExecutionFailed({
+        workflowExecution,
+        stepExecutions: [],
+      });
+
+      const [, eventData] = telemetry.reportEvent.mock.calls[0];
+      expect(eventData).toMatchObject({
+        triggerType: 'workflow-step',
+        compositionDepth: 2,
+        parentWorkflowId: 'parent-wf-id',
+        errorMessage: 'Child failed',
+      });
+    });
   });
 
   describe('reportWorkflowExecutionCancelled', () => {
@@ -382,6 +445,32 @@ describe('WorkflowExecutionTelemetryClient', () => {
         successfulStepCount: 1,
         queueDelayMs: 100,
         timedOut: false,
+      });
+    });
+
+    it('should include composition fields for cancelled sub-workflow executions', () => {
+      const workflowExecution = createMockWorkflowExecution({
+        status: ExecutionStatus.CANCELLED,
+        triggeredBy: 'workflow-step',
+        context: {
+          parentDepth: 0,
+          parentWorkflowId: 'parent-wf-id',
+        },
+        cancellationReason: 'Parent cancelled',
+        cancelledAt: '2024-01-01T00:00:30.000Z',
+      });
+
+      client.reportWorkflowExecutionCancelled({
+        workflowExecution,
+        stepExecutions: [],
+      });
+
+      const [, eventData] = telemetry.reportEvent.mock.calls[0];
+      expect(eventData).toMatchObject({
+        triggerType: 'workflow-step',
+        compositionDepth: 1,
+        parentWorkflowId: 'parent-wf-id',
+        cancellationReason: 'Parent cancelled',
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.test.ts
@@ -257,6 +257,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
       const [, eventData] = telemetry.reportEvent.mock.calls[0];
       expect(eventData).not.toHaveProperty('compositionDepth');
       expect(eventData).not.toHaveProperty('parentWorkflowId');
+      expect(eventData).not.toHaveProperty('parentWorkflowInvocation');
     });
 
     it('should include compositionDepth and parentWorkflowId for sub-workflow executions', () => {
@@ -265,6 +266,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         context: {
           parentDepth: 0,
           parentWorkflowId: 'parent-wf-id',
+          parentWorkflowInvocation: 'sync',
         },
       });
 
@@ -278,6 +280,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         triggerType: 'workflow-step',
         compositionDepth: 1,
         parentWorkflowId: 'parent-wf-id',
+        parentWorkflowInvocation: 'sync',
       });
     });
   });
@@ -385,6 +388,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         context: {
           parentDepth: 1,
           parentWorkflowId: 'parent-wf-id',
+          parentWorkflowInvocation: 'async',
         },
         error: {
           message: 'Child failed',
@@ -402,6 +406,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         triggerType: 'workflow-step',
         compositionDepth: 2,
         parentWorkflowId: 'parent-wf-id',
+        parentWorkflowInvocation: 'async',
         errorMessage: 'Child failed',
       });
     });
@@ -455,6 +460,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         context: {
           parentDepth: 0,
           parentWorkflowId: 'parent-wf-id',
+          parentWorkflowInvocation: 'sync',
         },
         cancellationReason: 'Parent cancelled',
         cancelledAt: '2024-01-01T00:00:30.000Z',
@@ -470,6 +476,7 @@ describe('WorkflowExecutionTelemetryClient', () => {
         triggerType: 'workflow-step',
         compositionDepth: 1,
         parentWorkflowId: 'parent-wf-id',
+        parentWorkflowInvocation: 'sync',
         cancellationReason: 'Parent cancelled',
       });
     });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
@@ -49,6 +49,9 @@ function buildBaseExecutionTelemetryFields(
     ...(executionMetadata.parentWorkflowId && {
       parentWorkflowId: executionMetadata.parentWorkflowId,
     }),
+    ...(executionMetadata.parentWorkflowInvocation && {
+      parentWorkflowInvocation: executionMetadata.parentWorkflowInvocation,
+    }),
   };
 }
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/lib/telemetry/workflow_execution_telemetry_client.ts
@@ -21,8 +21,36 @@ import {
   type WorkflowExecutionTelemetryEventsMap,
   WorkflowExecutionTelemetryEventTypes,
 } from './events/workflows_execution/types';
-import { extractExecutionMetadata } from './utils/extract_execution_metadata';
+import {
+  extractExecutionMetadata,
+  type WorkflowExecutionTelemetryMetadata,
+} from './utils/extract_execution_metadata';
 import { extractWorkflowMetadata } from './utils/extract_workflow_metadata';
+
+/**
+ * Shared base fields for all workflow execution telemetry events (IDs, trigger, alert rule, composition).
+ */
+function buildBaseExecutionTelemetryFields(
+  workflowExecution: EsWorkflowExecution,
+  executionMetadata: WorkflowExecutionTelemetryMetadata
+) {
+  return {
+    workflowExecutionId: workflowExecution.id,
+    workflowId: workflowExecution.workflowId,
+    spaceId: workflowExecution.spaceId,
+    triggerType:
+      (workflowExecution.triggeredBy as 'manual' | 'scheduled' | 'alert' | 'workflow-step') ||
+      'manual',
+    isTestRun: workflowExecution.isTestRun || false,
+    ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
+    ...(executionMetadata.compositionDepth !== undefined && {
+      compositionDepth: executionMetadata.compositionDepth,
+    }),
+    ...(executionMetadata.parentWorkflowId && {
+      parentWorkflowId: executionMetadata.parentWorkflowId,
+    }),
+  };
+}
 
 /**
  * Base telemetry client for workflow execution engine.
@@ -118,12 +146,7 @@ export class WorkflowExecutionTelemetryClient {
         workflowExecutionEventNames[
           WorkflowExecutionTelemetryEventTypes.WorkflowExecutionCompleted
         ],
-      workflowExecutionId: workflowExecution.id,
-      workflowId: workflowExecution.workflowId,
-      spaceId: workflowExecution.spaceId,
-      triggerType: (workflowExecution.triggeredBy as 'manual' | 'scheduled' | 'alert') || 'manual',
-      isTestRun: workflowExecution.isTestRun || false,
-      ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
+      ...buildBaseExecutionTelemetryFields(workflowExecution, executionMetadata),
       startedAt: workflowExecution.createdAt,
       completedAt,
       duration,
@@ -197,12 +220,7 @@ export class WorkflowExecutionTelemetryClient {
     const eventData: WorkflowExecutionFailedParams = {
       eventName:
         workflowExecutionEventNames[WorkflowExecutionTelemetryEventTypes.WorkflowExecutionFailed],
-      workflowExecutionId: workflowExecution.id,
-      workflowId: workflowExecution.workflowId,
-      spaceId: workflowExecution.spaceId,
-      triggerType: (workflowExecution.triggeredBy as 'manual' | 'scheduled' | 'alert') || 'manual',
-      isTestRun: workflowExecution.isTestRun || false,
-      ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
+      ...buildBaseExecutionTelemetryFields(workflowExecution, executionMetadata),
       startedAt: workflowExecution.createdAt,
       failedAt,
       duration,
@@ -270,12 +288,7 @@ export class WorkflowExecutionTelemetryClient {
         workflowExecutionEventNames[
           WorkflowExecutionTelemetryEventTypes.WorkflowExecutionCancelled
         ],
-      workflowExecutionId: workflowExecution.id,
-      workflowId: workflowExecution.workflowId,
-      spaceId: workflowExecution.spaceId,
-      triggerType: (workflowExecution.triggeredBy as 'manual' | 'scheduled' | 'alert') || 'manual',
-      isTestRun: workflowExecution.isTestRun || false,
-      ...(executionMetadata.ruleId && { ruleId: executionMetadata.ruleId }),
+      ...buildBaseExecutionTelemetryFields(workflowExecution, executionMetadata),
       startedAt: workflowExecution.createdAt,
       cancelledAt,
       duration,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_async_strategy.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_async_strategy.test.ts
@@ -87,6 +87,7 @@ describe('WorkflowExecuteAsyncStrategy', () => {
         spaceId: 'default',
         inputs: { param1: 'value1' },
         triggeredBy: 'workflow-step',
+        parentWorkflowInvocation: 'async',
         parentWorkflowId: 'parent-workflow-id',
         parentWorkflowExecutionId: 'parent-exec-1',
         parentStepId: 'async-step-1',

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_async_strategy.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_async_strategy.ts
@@ -41,6 +41,7 @@ export class WorkflowExecuteAsyncStrategy {
           spaceId,
           inputs,
           triggeredBy: 'workflow-step',
+          parentWorkflowInvocation: 'async',
           parentWorkflowId: workflowExecution.workflowId,
           parentWorkflowExecutionId: workflowExecution.id,
           parentStepId: this.stepExecutionRuntime.node.stepId,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.test.ts
@@ -97,6 +97,7 @@ describe('WorkflowExecuteSyncStrategy', () => {
           spaceId: 'default',
           inputs: { param1: 'value1' },
           triggeredBy: 'workflow-step',
+          parentWorkflowInvocation: 'sync',
           parentWorkflowId: 'parent-workflow-id',
           parentWorkflowExecutionId: 'parent-exec-1',
           parentStepId: 'sync-step-1',

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/workflow_execute_step/strategies/workflow_execute_sync_strategy.ts
@@ -122,6 +122,7 @@ export class WorkflowExecuteSyncStrategy {
           spaceId,
           inputs,
           triggeredBy: 'workflow-step',
+          parentWorkflowInvocation: 'sync',
           parentWorkflowId: workflowExecution.workflowId,
           parentWorkflowExecutionId: workflowExecution.id,
           parentStepId: this.stepExecutionRuntime.node.stepId,


### PR DESCRIPTION
closes: https://github.com/elastic/security-team/issues/16382

Add `compositionDepth` and `parentWorkflowId` to workflow telemetry data for nested executions