### PR TITLE
Move elastic-console plugin ownership to obs-elastic-brain-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1112,7 +1112,7 @@ x-pack/platform/plugins/shared/data_catalog @elastic/workchat-eng
 x-pack/platform/plugins/shared/data_quality @elastic/obs-onboarding-team
 x-pack/platform/plugins/shared/data_sources @elastic/workchat-eng
 x-pack/platform/plugins/shared/dataset_quality @elastic/obs-onboarding-team
-x-pack/platform/plugins/shared/elastic_console @elastic/obs-onboarding-team
+x-pack/platform/plugins/shared/elastic_console @elastic/obs-elastic-brain-team
 x-pack/platform/plugins/shared/embeddable_alerts_table @elastic/response-ops
 x-pack/platform/plugins/shared/encrypted_saved_objects @elastic/kibana-security
 x-pack/platform/plugins/shared/entity_manager @elastic/core-analysis

--- a/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/elastic_console/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/elastic-console-plugin",
-  "owner": "@elastic/obs-onboarding-team",
+  "owner": "@elastic/obs-elastic-brain-team",
   "group": "platform",
   "visibility": "shared",
   "plugin": {

--- a/x-pack/platform/plugins/shared/elastic_console/moon.yml
+++ b/x-pack/platform/plugins/shared/elastic_console/moon.yml
@@ -6,7 +6,7 @@ $schema: https://moonrepo.dev/schemas/project.json
 id: '@kbn/elastic-console-plugin'
 layer: unknown
 owners:
-  defaultOwner: '@elastic/obs-onboarding-team'
+  defaultOwner: '@elastic/obs-elastic-brain-team'
 toolchains:
   default: node
 language: typescript
@@ -14,7 +14,7 @@ project:
   title: '@kbn/elastic-console-plugin'
   description: Moon project for @kbn/elastic-console-plugin
   channel: ''
-  owner: '@elastic/obs-onboarding-team'
+  owner: '@elastic/obs-elastic-brain-team'
   sourceRoot: x-pack/platform/plugins/shared/elastic_console
 dependsOn:
   - '@kbn/core'


### PR DESCRIPTION
## Summary
- Transfer ownership of the `elastic-console` plugin from `@elastic/obs-onboarding-team` to `@elastic/obs-elastic-brain-team`
- Regenerate CODEOWNERS file

## Test plan
- [x] Verify `kibana.jsonc` owner field updated
- [x] Verify CODEOWNERS regenerated via `node scripts/generate codeowners`

🤖 Generated with [Claude Code](https://claude.com/claude-code)