### PR TITLE
[ES|QL Resource Browser] Remove close button

### DIFF
--- a/src/platform/packages/shared/kbn-esql-resource-browser/src/browser_popover_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-esql-resource-browser/src/browser_popover_wrapper.tsx
@@ -124,7 +124,7 @@ export function BrowserPopoverWrapper<TItem extends { name: string }>({
       css={filterButtonStyle}
       onClick={() => setIsFilterOpen(!isFilterOpen)}
     >
-      <EuiIcon type="filter" />
+      <EuiIcon type="filter" aria-label={i18nKeys.filterTitle} />
     </EuiFilterButton>
   );
 
@@ -144,6 +144,7 @@ export function BrowserPopoverWrapper<TItem extends { name: string }>({
         ...position,
         position: 'absolute',
       }}
+      aria-label={i18nKeys.title}
     >
       <EuiSelectable
         searchable
@@ -164,6 +165,7 @@ export function BrowserPopoverWrapper<TItem extends { name: string }>({
               closePopover={() => setIsFilterOpen(false)}
               panelStyle={{ transform: `translateX(${FILTER_POPOVER_HORIZONTAL_OFFSET}px)` }}
               offset={FILTER_POPOVER_VERTICAL_OFFSET}
+              aria-label={i18nKeys.filterTitle}
             >
               {filterPanel}
             </EuiPopover>

--- a/src/platform/packages/shared/kbn-esql-resource-browser/src/browser_popover_wrapper.tsx
+++ b/src/platform/packages/shared/kbn-esql-resource-browser/src/browser_popover_wrapper.tsx
@@ -13,9 +13,6 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiSelectable,
-  EuiButtonIcon,
-  EuiFlexGroup,
-  EuiFlexItem,
   useEuiTheme,
   EuiFilterButton,
   EuiIcon,
@@ -187,19 +184,7 @@ export function BrowserPopoverWrapper<TItem extends { name: string }>({
       >
         {(list, search) => (
           <div style={{ width: BROWSER_POPOVER_WIDTH, maxHeight: BROWSER_POPOVER_HEIGHT }}>
-            <EuiPopoverTitle paddingSize="s">
-              <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-                <EuiFlexItem>{i18nKeys.title}</EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButtonIcon
-                    iconType="cross"
-                    color="text"
-                    aria-label={i18nKeys.closeLabel}
-                    onClick={onClose}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiPopoverTitle>
+            <EuiPopoverTitle paddingSize="s">{i18nKeys.title}</EuiPopoverTitle>
             <div style={{ padding: euiTheme.size.s }}>{search}</div>
             <div style={{ maxHeight: MAX_LIST_HEIGHT, overflowY: 'auto' }}>{list}</div>
           </div>


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/259034

## Summary

Now that we fixed the issue where the browser was not closing properly (fix: https://github.com/elastic/kibana/pull/259034), we are removing the close (`x`) button as it's not necessary (we can close it on clicking outside). Also, this will make the browser popover more consistent with other popovers in Kibana.


https://github.com/user-attachments/assets/6dafb4ec-16ea-4975-94ec-d91e504f08ad

