### PR TITLE
[One Workflows] fix: bound workflow executions query array schemas for CodeQL

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.ts
+++ b/src/platform/plugins/shared/workflows_management/server/workflows_management/routes/get_workflow_executions.ts
@@ -46,7 +46,8 @@ export function registerGetWorkflowExecutionsRoute({
                     ExecutionStatusValues.map((type) => schema.literal(type)) as [
                       Type<ExecutionStatus>
                     ]
-                  )
+                  ),
+                  { maxSize: ExecutionStatusValues.length }
                 ),
               ],
               {
@@ -63,7 +64,8 @@ export function registerGetWorkflowExecutionsRoute({
                 schema.arrayOf(
                   schema.oneOf(
                     ExecutionTypeValues.map((type) => schema.literal(type)) as [Type<ExecutionType>]
-                  )
+                  ),
+                  { maxSize: ExecutionTypeValues.length }
                 ),
               ],
               {


### PR DESCRIPTION
## Summary

- Add `maxSize` to `statuses` and `executionTypes` query validation on `GET /api/workflowExecutions`, using `ExecutionStatusValues.length` and `ExecutionTypeValues.length` so array schemas are bounded.
- Resolves CodeQL `js/kibana/unbounded-array-in-schema` alerts [1605](https://github.com/elastic/kibana/security/code-scanning/1605) and [1606](https://github.com/elastic/kibana/security/code-scanning/1606).

## References

- Code scanning: alerts 1605, 1606