### PR TITLE
Skip serverless Discover request counts tests for MKI

### DIFF
--- a/x-pack/platform/test/serverless/functional/test_suites/discover/group3/_request_counts.ts
+++ b/x-pack/platform/test/serverless/functional/test_suites/discover/group3/_request_counts.ts
@@ -26,6 +26,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
 
   describe('discover request counts', function describeIndexTests() {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/259329
+    this.tags(['failsOnMKI']);
+
     before(async function () {
       await svlCommonPage.loginAsAdmin();
       await esArchiver.loadIfNeeded(


### PR DESCRIPTION
## Summary

This PR skips the serverless Discover request counts test suite for MKI runs.
Details on the failure / flakiness in #259329-.



