### PR TITLE
chore: util to clean cached images

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -217,4 +217,3 @@ clean_cached_images() {
   docker images -q | sort -u | xargs -r docker rmi -f || true
   docker image prune -af || true
 }
-}

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -211,3 +211,9 @@ force_clean_ports() {
 
   set -e
 }
+
+
+clean_cached_images() {
+  docker rmi $(docker images -q | grep -v) || true
+  docker image prune -f || true
+}

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -214,7 +214,7 @@ force_clean_ports() {
 
 
 clean_cached_images() {
-  docker images -q | sort -u | xargs -r docker rmi || true
+  docker images -q | sort -u | xargs -r docker rmi -f || true
   docker image prune -af || true
 }
 }

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -214,6 +214,7 @@ force_clean_ports() {
 
 
 clean_cached_images() {
-  docker rmi $(docker images -q | grep -v) || true
-  docker image prune -f || true
+  docker images -q | sort -u | xargs -r docker rmi || true
+  docker image prune -af || true
+}
 }

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -28,10 +28,7 @@ check_cdn_assets_ready() {
 }
 
 echo "--- Clean up cached images"
-{
-  docker rmi $(docker images -q | grep -v) || true
-  docker image prune -f || true
-}
+clean_cached_images
 
 KIBANA_BASE_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless"
 export KIBANA_IMAGE="$KIBANA_BASE_IMAGE:$KIBANA_IMAGE_TAG"

--- a/.buildkite/scripts/steps/package_testing/test.sh
+++ b/.buildkite/scripts/steps/package_testing/test.sh
@@ -9,6 +9,9 @@ source "$(dirname "$0")/../../common/util.sh"
 #
 #is_test_execution_step
 
+echo "--- Clean up cached images"
+clean_cached_images
+
 echo "--- Package Testing for $TEST_PACKAGE"
 
 mkdir -p target


### PR DESCRIPTION
## Summary 

Our VMs ship with a bunch of cached Docker images that waste disk space on jobs that don't need them. Added clean_cached_images to clear them out before those jobs run.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->