### PR TITLE
[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables

### DIFF
--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
@@ -64,11 +64,6 @@ describe('FormattedValue', () => {
     expect(container.textContent).toBe('N/A');
   });
 
-  it('renders plain string values as-is', () => {
-    const { container } = renderWithTheme(<FormattedValue value="hello world" keyName="msg" />);
-    expect(container.textContent).toBe('hello world');
-  });
-
   it('formats @timestamp values in UTC', () => {
     const { container } = renderWithTheme(
       <FormattedValue value="2024-06-15T14:30:45.123Z" keyName="@timestamp" />
@@ -83,10 +78,19 @@ describe('FormattedValue', () => {
     expect(container.textContent).toMatch(/Jun 15, 2024 @ \d{2}:\d{2}:45\.123/);
   });
 
-  it('does not format invalid date strings', () => {
-    const { container } = renderWithTheme(
-      <FormattedValue value="not-a-date" keyName="@timestamp" />
-    );
-    expect(container.textContent).toBe('not-a-date');
+  it.each([
+    ['hello world', 'message'],
+    ['hello world', '@timestamp'],
+    ['synth-service-2', 'service.name'],
+    ['synth-service-2', '@timestamp'],
+    ['1.3.4', 'version'],
+    ['1.3.4', '@timestamp'],
+    ['1234567', 'some.field'],
+    ['1234567', '@timestamp'],
+    ['service-1', 'host.name'],
+    ['service-1', '@timestamp'],
+  ])('renders plain string "%s" as-is when keyName is "%s"', (value, keyName) => {
+    const { container } = renderWithTheme(<FormattedValue value={value} keyName={keyName} />);
+    expect(container.textContent).toBe(value);
   });
 });

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
@@ -32,65 +32,66 @@ describe('FormattedKey', () => {
   });
 });
 
+const dateProps = {
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  dateTimezone: 'Browser',
+};
+
 describe('FormattedValue', () => {
   it('renders object values as pretty-printed JSON', () => {
     const obj = { foo: 'bar', nested: { a: 1 } };
-    const { container } = renderWithTheme(<FormattedValue value={obj} keyName="data" />);
+    const { container } = renderWithTheme(<FormattedValue value={obj} {...dateProps} />);
     expect(container.querySelector('pre')?.textContent).toBe(JSON.stringify(obj, null, 4));
   });
 
   it('renders boolean true as string', () => {
-    const { container } = renderWithTheme(<FormattedValue value={true} keyName="active" />);
+    const { container } = renderWithTheme(<FormattedValue value={true} {...dateProps} />);
     expect(container.textContent).toBe('true');
   });
 
   it('renders boolean false as string', () => {
-    const { container } = renderWithTheme(<FormattedValue value={false} keyName="active" />);
+    const { container } = renderWithTheme(<FormattedValue value={false} {...dateProps} />);
     expect(container.textContent).toBe('false');
   });
 
   it('renders number values as string', () => {
-    const { container } = renderWithTheme(<FormattedValue value={42} keyName="count" />);
+    const { container } = renderWithTheme(<FormattedValue value={42} {...dateProps} />);
     expect(container.textContent).toBe('42');
   });
 
   it('renders N/A for null values', () => {
-    const { container } = renderWithTheme(<FormattedValue value={null} keyName="missing" />);
+    const { container } = renderWithTheme(<FormattedValue value={null} {...dateProps} />);
     expect(container.textContent).toBe('N/A');
   });
 
   it('renders N/A for empty string values', () => {
-    const { container } = renderWithTheme(<FormattedValue value="" keyName="empty" />);
+    const { container } = renderWithTheme(<FormattedValue value="" {...dateProps} />);
     expect(container.textContent).toBe('N/A');
   });
 
-  it('formats @timestamp values in UTC', () => {
+  it('formats date values with default settings', () => {
     const { container } = renderWithTheme(
-      <FormattedValue value="2024-06-15T14:30:45.123Z" keyName="@timestamp" />
-    );
-    expect(container.textContent).toBe('Jun 15, 2024 @ 14:30:45.123');
-  });
-
-  it('formats non-@timestamp date values in local time', () => {
-    const { container } = renderWithTheme(
-      <FormattedValue value="2024-06-15T14:30:45.123Z" keyName="event.created" />
+      <FormattedValue value="2024-06-15T14:30:45.123Z" {...dateProps} />
     );
     expect(container.textContent).toMatch(/Jun 15, 2024 @ \d{2}:\d{2}:45\.123/);
   });
 
-  it.each([
-    ['hello world', 'message'],
-    ['hello world', '@timestamp'],
-    ['synth-service-2', 'service.name'],
-    ['synth-service-2', '@timestamp'],
-    ['1.3.4', 'version'],
-    ['1.3.4', '@timestamp'],
-    ['1234567', 'some.field'],
-    ['1234567', '@timestamp'],
-    ['service-1', 'host.name'],
-    ['service-1', '@timestamp'],
-  ])('renders plain string "%s" as-is when keyName is "%s"', (value, keyName) => {
-    const { container } = renderWithTheme(<FormattedValue value={value} keyName={keyName} />);
-    expect(container.textContent).toBe(value);
+  it('formats date values with custom settings', () => {
+    const { container } = renderWithTheme(
+      <FormattedValue
+        value="2024-06-15T14:30:45.123+01:00"
+        dateFormat="HH:mm:ss.SSS"
+        dateTimezone="UTC"
+      />
+    );
+    expect(container.textContent).toMatch('13:30:45.123');
   });
+
+  it.each([['hello world'], ['synth-service-2'], ['1.3.4'], ['1234567'], ['service-1']])(
+    'renders plain string "%s" as-is',
+    (value) => {
+      const { container } = renderWithTheme(<FormattedValue value={value} {...dateProps} />);
+      expect(container.textContent).toBe(value);
+    }
+  );
 });

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
@@ -31,9 +31,9 @@ export function FormattedValue({ value, keyName }: { value: any; keyName: string
     return <pre>{JSON.stringify(value, null, 4)}</pre>;
   } else if (isBoolean(value) || isNumber(value)) {
     return <React.Fragment>{String(value)}</React.Fragment>;
-  } else if (keyName === '@timestamp' && isString(value) && moment(value).isValid()) {
+  } else if (keyName === '@timestamp' && isString(value) && moment(value, true).isValid()) {
     return <React.Fragment>{moment(value).utc().format(TIMESTAMP_FORMAT)}</React.Fragment>;
-  } else if (isString(value) && moment(value).isValid()) {
+  } else if (isString(value) && moment(value, true).isValid()) {
     return <React.Fragment>{moment(value).format(TIMESTAMP_FORMAT)}</React.Fragment>;
   } else if (!value) {
     return (

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
@@ -11,8 +11,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { i18n } from '@kbn/i18n';
 
-const TIMESTAMP_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
-
 const EmptyValue = styled.span`
   color: ${({ theme }) => theme.euiTheme.colors.textSubdued};
   text-align: left;
@@ -26,15 +24,25 @@ export function FormattedKey({ k, value }: { k: string; value: unknown }): JSX.E
   return <React.Fragment>{k}</React.Fragment>;
 }
 
-export function FormattedValue({ value, keyName }: { value: any; keyName: string }): JSX.Element {
+export function FormattedValue({
+  value,
+  dateFormat,
+  dateTimezone,
+}: {
+  value: any;
+  dateFormat: string;
+  dateTimezone: string;
+}): JSX.Element {
+  const usableTimezone = dateTimezone === 'Browser' ? moment.tz.guess() : dateTimezone;
+
+  const valueAsDate = moment(value, moment.ISO_8601, true);
+
   if (isObject(value)) {
     return <pre>{JSON.stringify(value, null, 4)}</pre>;
   } else if (isBoolean(value) || isNumber(value)) {
     return <React.Fragment>{String(value)}</React.Fragment>;
-  } else if (keyName === '@timestamp' && isString(value) && moment(value, true).isValid()) {
-    return <React.Fragment>{moment(value).utc().format(TIMESTAMP_FORMAT)}</React.Fragment>;
-  } else if (isString(value) && moment(value, true).isValid()) {
-    return <React.Fragment>{moment(value).format(TIMESTAMP_FORMAT)}</React.Fragment>;
+  } else if (isString(value) && valueAsDate.isValid()) {
+    return <React.Fragment>{valueAsDate.tz(usableTimezone).format(dateFormat)}</React.Fragment>;
   } else if (!value) {
     return (
       <EmptyValue>

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/index.tsx
@@ -16,9 +16,13 @@ import type { KeyValuePair } from './utils/get_flattened_key_value_pairs';
 export function KeyValueTable({
   keyValuePairs,
   tableProps = {},
+  dateFormat = 'MMM D, YYYY @ HH:mm:ss.SSS',
+  dateTimezone = 'Browser',
 }: {
   keyValuePairs: KeyValuePair[];
   tableProps?: EuiTableProps & TableHTMLAttributes<HTMLTableElement>;
+  dateFormat?: string;
+  dateTimezone?: string;
 }) {
   return (
     <EuiTable compressed {...tableProps}>
@@ -27,12 +31,21 @@ export function KeyValueTable({
           const asArray = castArray(value);
           const valueList =
             asArray.length <= 1 ? (
-              <FormattedValue value={asArray[0]} keyName={key} />
+              <FormattedValue
+                value={asArray[0]}
+                dateFormat={dateFormat}
+                dateTimezone={dateTimezone}
+              />
             ) : (
               <ul>
                 {asArray.map((val, index) => (
                   <li>
-                    <FormattedValue key={index} value={val} keyName={key} />
+                    <FormattedValue
+                      key={index}
+                      value={val}
+                      dateFormat={dateFormat}
+                      dateTimezone={dateTimezone}
+                    />
                   </li>
                 ))}
               </ul>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/index.tsx
@@ -78,7 +78,7 @@ export function MetadataTable({ sections, isLoading }: Props) {
             href={docLinks.links.apm.metaData}
             target="_blank"
           >
-            <EuiIcon type="question" />
+            <EuiIcon type="question" aria-hidden />{' '}
             {i18n.translate('xpack.apm.metadata.help', {
               defaultMessage: 'How to add labels and other data',
             })}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/section.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/section.tsx
@@ -10,12 +10,20 @@ import { isEmpty } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { EuiText } from '@elastic/eui';
 import { KeyValueTable } from '@kbn/key-value-metadata-table';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { UI_SETTINGS } from '@kbn/data-plugin/common';
 
 interface Props {
   properties: Array<{ field: string; value: string[] | number[] }>;
 }
 
 export function Section({ properties }: Props) {
+  const {
+    services: { uiSettings },
+  } = useKibana();
+  const dateFormatSetting = uiSettings?.get(UI_SETTINGS.DATE_FORMAT);
+  const timezoneSetting = uiSettings?.get(UI_SETTINGS.DATEFORMAT_TZ);
+
   if (!isEmpty(properties)) {
     return (
       <KeyValueTable
@@ -23,6 +31,8 @@ export function Section({ properties }: Props) {
           key: property.field,
           value: property.value,
         }))}
+        dateFormat={dateFormatSetting}
+        dateTimezone={timezoneSetting}
       />
     );
   }


### PR DESCRIPTION
## Summary

Closes #224277
Closes #257881


This PR reworks the changes made in #255748 to both improve the original fix to align better with the intended fix described in #224277 (respecting the `datetime.tz` param in the metadata table) and also fix a regression introduced as described in #257881

This PR will also tackle the missing backports (to 9.2 and 8.19) that weren't made in #255748

## Problem statement

The initial issue we were attempting to fix is a discrepancy between how dates were rendered in discover vs metadata tables in APM. Initially, these APM metadata tables weren't formatting dates at all. Instead, they were displaying the raw string value of the timestamp. This caused the value displayed to, because of timezone discrepancies, show a different value than what the same, formatted, field would display in discover when the user clicked the "Open in Discover" button (provided the timezone used in settings was different than the timezone the timestamp was recorded in) This behaviour could confuse users when switching apps.

In an effort to homogenise how dates are rendered across plugins, #255748 introduced an update aiming to apply formatting to any date value that is rendered within APM metadata tables. But, that update still had some problems

### Hardcoded date format
Instead of reading from `uiSettings`, the date format was a hardcoded string `MMM D, YYYY @ HH:mm:ss.SSS` While this is the default value applied in Kibana and would work most of the time, not sticking by the dynamic value configured via advanced settings could still lead to discrepancies between how the date is rendered in APM vs in Discover

### `datetime.tz` still not considered
Because the advanced settings weren't being read, APM still wouldn't be rendering dates in a consistent timezone along with Discover. Instead, fields named `@timestamp` would render in UTC while other dates would render in the local timezone of the browser. This caused dates within the same component to be inconsistent and still not sync'd with Discover

### Non-date fields could be parsed as dates
The mechanism we were using to identify when a field is a date to apply formatting in APM had parsing that was too relaxed and was causing some false positives in date parsing leading to fields like `service.name` being *sometimes* rendered as dates if the service name string contained characters that could lead moment non-strict parsing to coerce it as a date

## Changes

- **Replaced non-strict `moment(value).isValid()` with strict ISO 8601 parsing** via `moment(value, moment.ISO_8601, true)`. The `true` flag enables strict mode, which rejects strings that don't conform to real ISO 8601 patterns. This ensures fields that aren't date strings will not be incorrectly parsed as dates
- **Removed the hardcoded `TIMESTAMP_FORMAT` constant.** The component now accepts `dateFormat` and `dateTimezone` as required props, allowing the consuming plugin to pass the user's configured values from `uiSettings`. Given the component resides in a shared package, we're not accessing `uiSettings` directly to avoid coupling the package to a plugin and instead consuming plugins should provide these values. To avoid runtime issues, these props have default values set to the same defaults as the advanced settings in Kibana to ensure the component can still render properly even if `uiSettings` values aren't provided
- **Applies the configured timezone** using `moment-timezone`, handling the `'Browser'` sentinel value by resolving it to the user's local timezone via `moment.tz.guess()`. This ensures the `datetime.tz` value is respected and dates will consistently render in the same timezone both in APM and Discover
- **Removed the separate `@timestamp` / non-`@timestamp` branches** — all date fields are now handled uniformly with the same strict parsing and configurable format within APM.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->