### PR TITLE
[Security Solution] unify automatic troubleshooting types

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.gen.ts
@@ -19,9 +19,37 @@ import { ArrayFromString } from '@kbn/zod-helpers/v4';
 
 import { SuccessResponse } from '../model/schema/common.gen';
 
+export type WorkflowInsightType = z.infer<typeof WorkflowInsightType>;
+export const WorkflowInsightType = z.enum([
+  'incompatible_antivirus',
+  'policy_response_failure',
+  'custom',
+]);
+export type WorkflowInsightTypeEnum = typeof WorkflowInsightType.enum;
+export const WorkflowInsightTypeEnum = WorkflowInsightType.enum;
+
+export type WorkflowInsightCategory = z.infer<typeof WorkflowInsightCategory>;
+export const WorkflowInsightCategory = z.literal('endpoint');
+
+export type WorkflowInsightSourceType = z.infer<typeof WorkflowInsightSourceType>;
+export const WorkflowInsightSourceType = z.literal('llm-connector');
+
+export type WorkflowInsightTargetType = z.infer<typeof WorkflowInsightTargetType>;
+export const WorkflowInsightTargetType = z.literal('endpoint');
+
+export type WorkflowInsightActionType = z.infer<typeof WorkflowInsightActionType>;
+export const WorkflowInsightActionType = z.enum([
+  'refreshed',
+  'remediated',
+  'suppressed',
+  'dismissed',
+]);
+export type WorkflowInsightActionTypeEnum = typeof WorkflowInsightActionType.enum;
+export const WorkflowInsightActionTypeEnum = WorkflowInsightActionType.enum;
+
 export type CreateWorkflowInsightRequestBody = z.infer<typeof CreateWorkflowInsightRequestBody>;
 export const CreateWorkflowInsightRequestBody = z.object({
-  insightType: z.enum(['incompatible_antivirus', 'policy_response_failure']),
+  insightType: WorkflowInsightType,
 });
 export type CreateWorkflowInsightRequestBodyInput = z.input<
   typeof CreateWorkflowInsightRequestBody
@@ -36,7 +64,7 @@ export type GetPendingWorkflowInsightsRequestQuery = z.infer<
   typeof GetPendingWorkflowInsightsRequestQuery
 >;
 export const GetPendingWorkflowInsightsRequestQuery = z.object({
-  insightType: z.enum(['incompatible_antivirus', 'policy_response_failure']).optional(),
+  insightType: WorkflowInsightType.optional(),
 });
 export type GetPendingWorkflowInsightsRequestQueryInput = z.input<
   typeof GetPendingWorkflowInsightsRequestQuery
@@ -59,13 +87,13 @@ export const GetWorkflowInsightsRequestQuery = z.object({
   size: z.coerce.number().int().optional(),
   from: z.coerce.number().int().optional(),
   ids: ArrayFromString(z.string()).optional(),
-  categories: ArrayFromString(z.literal('endpoint')).optional(),
-  types: ArrayFromString(z.enum(['incompatible_antivirus', 'policy_response_failure'])).optional(),
-  sourceTypes: ArrayFromString(z.literal('llm-connector')).optional(),
+  categories: ArrayFromString(WorkflowInsightCategory).optional(),
+  types: ArrayFromString(WorkflowInsightType).optional(),
+  sourceTypes: ArrayFromString(WorkflowInsightSourceType).optional(),
   sourceIds: ArrayFromString(z.string()).optional(),
-  targetTypes: ArrayFromString(z.literal('endpoint')).optional(),
+  targetTypes: ArrayFromString(WorkflowInsightTargetType).optional(),
   targetIds: ArrayFromString(z.string()).optional(),
-  actionTypes: ArrayFromString(z.enum(['refreshed', 'remediated', 'suppressed', 'dismissed'])),
+  actionTypes: ArrayFromString(WorkflowInsightActionType),
 });
 export type GetWorkflowInsightsRequestQueryInput = z.input<typeof GetWorkflowInsightsRequestQuery>;
 
@@ -84,11 +112,11 @@ export type UpdateWorkflowInsightRequestBody = z.infer<typeof UpdateWorkflowInsi
 export const UpdateWorkflowInsightRequestBody = z.object({
   '@timestamp': z.string().optional(),
   message: z.string().optional(),
-  category: z.literal('endpoint').optional(),
-  type: z.enum(['incompatible_antivirus', 'policy_response_failure']).optional(),
+  category: WorkflowInsightCategory.optional(),
+  type: WorkflowInsightType.optional(),
   source: z
     .object({
-      type: z.literal('llm-connector').optional(),
+      type: WorkflowInsightSourceType.optional(),
       id: z.string().optional(),
       data_range_start: z.string().optional(),
       data_range_end: z.string().optional(),
@@ -96,13 +124,13 @@ export const UpdateWorkflowInsightRequestBody = z.object({
     .optional(),
   target: z
     .object({
-      type: z.literal('endpoint').optional(),
+      type: WorkflowInsightTargetType.optional(),
       ids: z.array(z.string()).optional(),
     })
     .optional(),
   action: z
     .object({
-      type: z.enum(['refreshed', 'remediated', 'suppressed', 'dismissed']).optional(),
+      type: WorkflowInsightActionType.optional(),
       timestamp: z.string().optional(),
     })
     .optional(),

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.schema.yaml
@@ -2,6 +2,33 @@ openapi: 3.0.0
 info:
   title: Workflow Insights API
   version: '1'
+components:
+  schemas:
+    WorkflowInsightType:
+      type: string
+      enum:
+        - incompatible_antivirus
+        - policy_response_failure
+        - custom
+    WorkflowInsightCategory:
+      type: string
+      enum:
+        - endpoint
+    WorkflowInsightSourceType:
+      type: string
+      enum:
+        - llm-connector
+    WorkflowInsightTargetType:
+      type: string
+      enum:
+        - endpoint
+    WorkflowInsightActionType:
+      type: string
+      enum:
+        - refreshed
+        - remediated
+        - suppressed
+        - dismissed
 paths:
   /internal/api/endpoint/workflow_insights:
     get:
@@ -34,28 +61,21 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              enum:
-                - endpoint
+              $ref: '#/components/schemas/WorkflowInsightCategory'
         - name: types
           in: query
           required: false
           schema:
             type: array
             items:
-              type: string
-              enum:
-                - incompatible_antivirus
-                - policy_response_failure
+              $ref: '#/components/schemas/WorkflowInsightType'
         - name: sourceTypes
           in: query
           required: false
           schema:
             type: array
             items:
-              type: string
-              enum:
-                - llm-connector
+              $ref: '#/components/schemas/WorkflowInsightSourceType'
         - name: sourceIds
           in: query
           required: false
@@ -69,9 +89,7 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              enum:
-                - endpoint
+              $ref: '#/components/schemas/WorkflowInsightTargetType'
         - name: targetIds
           in: query
           required: false
@@ -85,12 +103,7 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              enum:
-                - refreshed
-                - remediated
-                - suppressed
-                - dismissed
+              $ref: '#/components/schemas/WorkflowInsightActionType'
 
       responses:
         '200':
@@ -116,10 +129,7 @@ paths:
                 - insightType
               properties:
                 insightType:
-                  type: string
-                  enum:
-                    - incompatible_antivirus
-                    - policy_response_failure
+                  $ref: '#/components/schemas/WorkflowInsightType'
       responses:
         '200':
           description: OK
@@ -161,21 +171,14 @@ paths:
                 message:
                   type: string
                 category:
-                  type: string
-                  enum:
-                    - endpoint
+                  $ref: '#/components/schemas/WorkflowInsightCategory'
                 type:
-                  type: string
-                  enum:
-                    - incompatible_antivirus
-                    - policy_response_failure
+                  $ref: '#/components/schemas/WorkflowInsightType'
                 source:
                   type: object
                   properties:
                     type:
-                      type: string
-                      enum:
-                        - llm-connector
+                      $ref: '#/components/schemas/WorkflowInsightSourceType'
                     id:
                       type: string
                     data_range_start:
@@ -186,9 +189,7 @@ paths:
                   type: object
                   properties:
                     type:
-                      type: string
-                      enum:
-                        - endpoint
+                      $ref: '#/components/schemas/WorkflowInsightTargetType'
                     ids:
                       type: array
                       items:
@@ -197,12 +198,7 @@ paths:
                   type: object
                   properties:
                     type:
-                      type: string
-                      enum:
-                        - refreshed
-                        - remediated
-                        - suppressed
-                        - dismissed
+                      $ref: '#/components/schemas/WorkflowInsightActionType'
                     timestamp:
                       type: string
                 value:
@@ -264,10 +260,7 @@ paths:
           in: query
           required: false
           schema:
-            type: string
-            enum:
-              - incompatible_antivirus
-              - policy_response_failure
+            $ref: '#/components/schemas/WorkflowInsightType'
       responses:
         '200':
           description: OK

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.test.ts
@@ -57,6 +57,26 @@ describe('Workflow Insights', () => {
 
         expect(() => validateQuery(validQuery)).not.toThrow();
       });
+
+      it('should validate successfully with custom type', () => {
+        const validQuery = {
+          query: {
+            types: ['custom'],
+          },
+        };
+
+        expect(() => validateQuery(validQuery)).not.toThrow();
+      });
+
+      it('should validate successfully with all three types', () => {
+        const validQuery = {
+          query: {
+            types: ['incompatible_antivirus', 'policy_response_failure', 'custom'],
+          },
+        };
+
+        expect(() => validateQuery(validQuery)).not.toThrow();
+      });
     });
 
     it('should throw an error for invalid types', () => {
@@ -228,7 +248,8 @@ describe('Workflow Insights', () => {
       expect(() => validateRequest(invalidRequest)).toThrowErrorMatchingInlineSnapshot(`
     "[body.type]: types that failed validation:
     - [body.type.0]: expected value to equal [incompatible_antivirus]
-    - [body.type.1]: expected value to equal [policy_response_failure]"
+    - [body.type.1]: expected value to equal [policy_response_failure]
+    - [body.type.2]: expected value to equal [custom]"
     `);
     });
 
@@ -322,6 +343,39 @@ describe('Workflow Insights', () => {
               },
               message_variables: ['policy_id', 'failure_reason', 'agent_version'],
             },
+          },
+        };
+
+        expect(() => validateRequest(validRequest)).not.toThrow();
+      });
+    });
+
+    describe('custom type validation in PUT requests', () => {
+      it('should validate successfully with custom type', () => {
+        const validRequest = {
+          params: {
+            insightId: 'valid-insight-id',
+          },
+          body: {
+            type: 'custom',
+            action: { type: 'refreshed' },
+          },
+        };
+
+        expect(() => validateRequest(validRequest)).not.toThrow();
+      });
+
+      it('should validate successfully with custom type and body fields', () => {
+        const validRequest = {
+          params: {
+            insightId: 'valid-insight-id',
+          },
+          body: {
+            type: 'custom',
+            message: 'Custom insight message',
+            category: 'endpoint',
+            action: { type: 'remediated', timestamp: '2024-11-29T00:00:00Z' },
+            value: 'custom-value',
           },
         };
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/workflow_insights/workflow_insights.ts
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-import { schema, type TypeOf } from '@kbn/config-schema';
+import { schema, type TypeOf, type Type } from '@kbn/config-schema';
+
+import {
+  WORKFLOW_INSIGHT_TYPE_VALUES,
+  WORKFLOW_INSIGHT_CATEGORY_VALUES,
+  WORKFLOW_INSIGHT_SOURCE_TYPE_VALUES,
+  WORKFLOW_INSIGHT_TARGET_TYPE_VALUES,
+  WORKFLOW_INSIGHT_ACTION_TYPE_VALUES,
+} from '../../../endpoint/types/workflow_insights';
 
 const arrayWithNonEmptyString = (field: string) =>
   schema.arrayOf(
@@ -19,10 +27,14 @@ const arrayWithNonEmptyString = (field: string) =>
     })
   );
 
-const insightTypeOneOf = schema.oneOf([
-  schema.literal('incompatible_antivirus'),
-  schema.literal('policy_response_failure'),
-]);
+const schemaOneOfValues = (values: readonly string[]) =>
+  schema.oneOf(values.map((v) => schema.literal(v)) as [Type<string>]);
+
+const insightTypeOneOf = schemaOneOfValues(WORKFLOW_INSIGHT_TYPE_VALUES);
+const categoryOneOf = schemaOneOfValues(WORKFLOW_INSIGHT_CATEGORY_VALUES);
+const sourceTypeOneOf = schemaOneOfValues(WORKFLOW_INSIGHT_SOURCE_TYPE_VALUES);
+const targetTypeOneOf = schemaOneOfValues(WORKFLOW_INSIGHT_TARGET_TYPE_VALUES);
+const actionTypeOneOf = schemaOneOfValues(WORKFLOW_INSIGHT_ACTION_TYPE_VALUES);
 
 export const UpdateWorkflowInsightRequestSchema = {
   params: schema.object({
@@ -38,11 +50,11 @@ export const UpdateWorkflowInsightRequestSchema = {
   body: schema.object({
     '@timestamp': schema.maybe(schema.string()),
     message: schema.maybe(schema.string()),
-    category: schema.maybe(schema.oneOf([schema.literal('endpoint')])),
+    category: schema.maybe(categoryOneOf),
     type: schema.maybe(insightTypeOneOf),
     source: schema.maybe(
       schema.object({
-        type: schema.maybe(schema.oneOf([schema.literal('llm-connector')])),
+        type: schema.maybe(sourceTypeOneOf),
         id: schema.maybe(schema.string()),
         data_range_start: schema.maybe(schema.string()),
         data_range_end: schema.maybe(schema.string()),
@@ -50,20 +62,13 @@ export const UpdateWorkflowInsightRequestSchema = {
     ),
     target: schema.maybe(
       schema.object({
-        type: schema.maybe(schema.oneOf([schema.literal('endpoint')])),
+        type: schema.maybe(targetTypeOneOf),
         ids: schema.maybe(arrayWithNonEmptyString('target.id')),
       })
     ),
     action: schema.maybe(
       schema.object({
-        type: schema.maybe(
-          schema.oneOf([
-            schema.literal('refreshed'),
-            schema.literal('remediated'),
-            schema.literal('suppressed'),
-            schema.literal('dismissed'),
-          ])
-        ),
+        type: schema.maybe(actionTypeOneOf),
         timestamp: schema.maybe(schema.string()),
       })
     ),
@@ -100,22 +105,13 @@ export const GetWorkflowInsightsRequestSchema = {
     size: schema.maybe(schema.number()),
     from: schema.maybe(schema.number()),
     ids: schema.maybe(arrayWithNonEmptyString('ids')),
-    categories: schema.maybe(schema.arrayOf(schema.oneOf([schema.literal('endpoint')]))),
+    categories: schema.maybe(schema.arrayOf(categoryOneOf, { maxSize: 20 })),
     types: schema.maybe(schema.arrayOf(insightTypeOneOf, { maxSize: 20 })),
-    sourceTypes: schema.maybe(schema.arrayOf(schema.oneOf([schema.literal('llm-connector')]))),
+    sourceTypes: schema.maybe(schema.arrayOf(sourceTypeOneOf, { maxSize: 20 })),
     sourceIds: schema.maybe(arrayWithNonEmptyString('sourceId')),
-    targetTypes: schema.maybe(schema.arrayOf(schema.oneOf([schema.literal('endpoint')]))),
+    targetTypes: schema.maybe(schema.arrayOf(targetTypeOneOf, { maxSize: 20 })),
     targetIds: schema.maybe(arrayWithNonEmptyString('targetId')),
-    actionTypes: schema.maybe(
-      schema.arrayOf(
-        schema.oneOf([
-          schema.literal('refreshed'),
-          schema.literal('remediated'),
-          schema.literal('suppressed'),
-          schema.literal('dismissed'),
-        ])
-      )
-    ),
+    actionTypes: schema.maybe(schema.arrayOf(actionTypeOneOf, { maxSize: 20 })),
   }),
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
@@ -10,11 +10,12 @@ import moment from 'moment';
 import type { ToolingLog } from '@kbn/tooling-log';
 import type { Client, estypes } from '@elastic/elasticsearch';
 import {
-  ActionType,
-  Category,
+  WorkflowInsightActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
+  WorkflowInsightType,
   type SecurityWorkflowInsight,
-  SourceType,
-  TargetType,
 } from '../types/workflow_insights';
 
 export interface IndexedWorkflowInsights {
@@ -178,22 +179,22 @@ const generateWorkflowInsightsDoc = ({
     },
     '@timestamp': currentTime,
     action: {
-      type: ActionType.Refreshed,
+      type: WorkflowInsightActionType.enum.refreshed,
       timestamp: currentTime,
     },
     source: {
       data_range_end: currentTime.clone().add(24, 'hours'),
       id: '7184ab52-c318-4c91-b765-805f889e34e2',
-      type: SourceType.LlmConnector,
+      type: WorkflowInsightSourceType.enum['llm-connector'],
       data_range_start: currentTime,
     },
     message: 'Incompatible antiviruses detected',
-    category: Category.Endpoint,
-    type: 'incompatible_antivirus',
+    category: WorkflowInsightCategory.enum.endpoint,
+    type: WorkflowInsightType.enum.incompatible_antivirus,
     value: `${antivirus} ${path}${signatureValue ? ` ${signatureValue}` : ''}`,
     target: {
       ids: [endpointId],
-      type: TargetType.Endpoint,
+      type: WorkflowInsightTargetType.enum.endpoint,
     },
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/workflow_insights.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/workflow_insights.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DefendInsightType as ExternalDefendInsightType } from '@kbn/elastic-assistant-common';
+import type { DefendInsight as ExternalDefendInsight } from '@kbn/elastic-assistant-common';
+import { WORKFLOW_INSIGHT_TYPE_VALUES } from './workflow_insights';
+import type { DefendInsight } from './workflow_insights';
+
+/**
+ * Drift-detection tests: validate that the local canonical types stay in sync
+ * with @kbn/elastic-assistant-common during the deprecation period.
+ * Remove these tests when the @kbn/elastic-assistant-common dependency is
+ * fully eliminated from security_solution.
+ */
+describe('workflow insight type sync with @kbn/elastic-assistant-common', () => {
+  it('WORKFLOW_INSIGHT_TYPE_VALUES matches DefendInsightType.options', () => {
+    expect([...WORKFLOW_INSIGHT_TYPE_VALUES].sort()).toEqual(
+      [...ExternalDefendInsightType.options].sort()
+    );
+  });
+
+  it('local DefendInsight is structurally compatible with external DefendInsight', () => {
+    // Compile-time check: a local DefendInsight must be assignable to the external type.
+    // If the external schema adds a required field, this will fail to compile.
+    const local: DefendInsight = { group: 'test' };
+    const external: ExternalDefendInsight = local;
+    expect(external).toBeDefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/workflow_insights.ts
@@ -6,28 +6,66 @@
  */
 
 import type { Moment } from 'moment';
+import { z } from '@kbn/zod/v4';
 
-import type { DefendInsightType } from '@kbn/elastic-assistant-common';
 import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 
-export enum Category {
-  Endpoint = 'endpoint',
+/**
+ * Single source of truth for all workflow insight enum values.
+ * All schemas (Zod, kbn/config-schema, OpenAPI YAML) must match these lists.
+ */
+
+export const WORKFLOW_INSIGHT_TYPE_VALUES = [
+  'incompatible_antivirus',
+  'policy_response_failure',
+  'custom',
+] as const;
+
+export const WORKFLOW_INSIGHT_CATEGORY_VALUES = ['endpoint'] as const;
+
+export const WORKFLOW_INSIGHT_SOURCE_TYPE_VALUES = ['llm-connector'] as const;
+
+export const WORKFLOW_INSIGHT_TARGET_TYPE_VALUES = ['endpoint'] as const;
+
+export const WORKFLOW_INSIGHT_ACTION_TYPE_VALUES = [
+  'refreshed',
+  'remediated',
+  'suppressed',
+  'dismissed',
+] as const;
+
+export const WorkflowInsightType = z.enum(WORKFLOW_INSIGHT_TYPE_VALUES);
+export type WorkflowInsightType = z.infer<typeof WorkflowInsightType>;
+
+export const WorkflowInsightCategory = z.enum(WORKFLOW_INSIGHT_CATEGORY_VALUES);
+export type WorkflowInsightCategory = z.infer<typeof WorkflowInsightCategory>;
+
+export const WorkflowInsightSourceType = z.enum(WORKFLOW_INSIGHT_SOURCE_TYPE_VALUES);
+export type WorkflowInsightSourceType = z.infer<typeof WorkflowInsightSourceType>;
+
+export const WorkflowInsightTargetType = z.enum(WORKFLOW_INSIGHT_TARGET_TYPE_VALUES);
+export type WorkflowInsightTargetType = z.infer<typeof WorkflowInsightTargetType>;
+
+export const WorkflowInsightActionType = z.enum(WORKFLOW_INSIGHT_ACTION_TYPE_VALUES);
+export type WorkflowInsightActionType = z.infer<typeof WorkflowInsightActionType>;
+
+/**
+ * DefendInsight is the raw insight produced by the LLM,
+ * SecurityWorkflowInsight is the enriched final insight
+ */
+export interface DefendInsightEvent {
+  id: string;
+  endpointId: string;
+  value: string;
 }
 
-export enum SourceType {
-  LlmConnector = 'llm-connector',
+export interface DefendInsight {
+  group: string;
+  events?: DefendInsightEvent[];
+  remediation?: Record<string, unknown>;
 }
 
-export enum TargetType {
-  Endpoint = 'endpoint',
-}
-
-export enum ActionType {
-  Refreshed = 'refreshed', // new or refreshed
-  Remediated = 'remediated',
-  Suppressed = 'suppressed', // temporarily supressed, can be refreshed
-  Dismissed = 'dismissed', // "permanently" dismissed, cannot be normally refreshed
-}
+export type DefendInsights = DefendInsight[];
 
 export type ExceptionListRemediationType = Pick<
   ExceptionListItemSchema,
@@ -38,20 +76,20 @@ export interface SecurityWorkflowInsight {
   id?: string;
   '@timestamp': Moment;
   message: string;
-  category: Category;
-  type: DefendInsightType;
+  category: WorkflowInsightCategory;
+  type: WorkflowInsightType;
   source: {
-    type: SourceType;
+    type: WorkflowInsightSourceType;
     id: string;
     data_range_start: Moment;
     data_range_end: Moment;
   };
   target: {
-    type: TargetType;
+    type: WorkflowInsightTargetType;
     ids: string[];
   };
   action: {
-    type: ActionType;
+    type: WorkflowInsightActionType;
     timestamp: Moment;
   };
   value: string;
@@ -71,11 +109,11 @@ export interface SearchParams {
   size?: number;
   from?: number;
   ids?: string[];
-  categories?: Category[];
-  types?: DefendInsightType[];
-  sourceTypes?: SourceType[];
+  categories?: WorkflowInsightCategory[];
+  types?: WorkflowInsightType[];
+  sourceTypes?: WorkflowInsightSourceType[];
   sourceIds?: string[];
-  targetTypes?: TargetType[];
+  targetTypes?: WorkflowInsightTargetType[];
   targetIds?: string[];
-  actionTypes?: ActionType[];
+  actionTypes?: WorkflowInsightActionType[];
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_mark_workflow_insight_as_remediated.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/artifact_list_page/hooks/use_mark_workflow_insight_as_remediated.ts
@@ -8,7 +8,7 @@
 import { useMutation } from '@kbn/react-query';
 import { WORKFLOW_INSIGHTS } from '../../../pages/endpoint_hosts/view/translations';
 import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
-import { ActionType } from '../../../../../common/endpoint/types/workflow_insights';
+import { WorkflowInsightActionType } from '../../../../../common/endpoint/types/workflow_insights';
 import { resolvePathVariables } from '../../../../common/utils/resolve_path_variables';
 import { WORKFLOW_INSIGHTS_UPDATE_ROUTE } from '../../../../../common/endpoint/constants';
 import { useKibana, useToasts } from '../../../../common/lib/kibana';
@@ -27,7 +27,7 @@ export const useMarkInsightAsRemediated = (backUrl?: string) => {
           version: '1',
           body: JSON.stringify({
             action: {
-              type: ActionType.Remediated,
+              type: WorkflowInsightActionType.enum.remediated,
             },
           }),
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -10,7 +10,7 @@ import type {
 } from '@kbn/actions-plugin/common/routes/connector/response';
 import { DEFEND_INSIGHTS } from '@kbn/elastic-assistant-common';
 import { request } from './common';
-import { ActionType } from '../../../../common/endpoint/types/workflow_insights';
+import { WorkflowInsightActionType } from '../../../../common/endpoint/types/workflow_insights';
 import {
   WORKFLOW_INSIGHTS_ROUTE,
   WORKFLOW_INSIGHTS_UPDATE_ROUTE,
@@ -288,7 +288,7 @@ export const fetchWorkflowInsights = (overrides?: Record<string, unknown>) => {
     method: 'GET',
     url: WORKFLOW_INSIGHTS_ROUTE,
     qs: {
-      actionTypes: JSON.stringify([ActionType.Refreshed]),
+      actionTypes: JSON.stringify([WorkflowInsightActionType.enum.refreshed]),
       targetIds: JSON.stringify(['test']),
     },
     headers: { 'Elastic-Api-Version': '1' },
@@ -302,7 +302,7 @@ export const updateWorkflowInsights = () => {
     url: WORKFLOW_INSIGHTS_UPDATE_ROUTE.replace('{insightId}', 'test'),
     body: JSON.stringify({
       action: {
-        type: ActionType.Remediated,
+        type: WorkflowInsightActionType.enum.remediated,
       },
     }),
     headers: { 'Elastic-Api-Version': '1' },

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
@@ -14,7 +14,6 @@ import { useAssistantContext } from '@kbn/elastic-assistant';
 import {
   WorkflowInsightType,
   WorkflowInsightActionType,
-  type WorkflowInsightType as WorkflowInsightTypeValue,
 } from '../../../../../../../../common/endpoint/types/workflow_insights';
 import { useIsExperimentalFeatureEnabled } from '../../../../../../../common/hooks/use_experimental_features';
 import { useFetchInsights } from '../../../hooks/insights/use_fetch_insights';
@@ -58,8 +57,8 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
     setInsightGenerationFailures(true);
   };
 
-  const insightTypes = useMemo<WorkflowInsightTypeValue[]>(() => {
-    const typesToQuery: WorkflowInsightTypeValue[] = [
+  const insightTypes = useMemo<WorkflowInsightType[]>(() => {
+    const typesToQuery: WorkflowInsightType[] = [
       WorkflowInsightType.enum.incompatible_antivirus,
     ];
     if (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
@@ -11,9 +11,11 @@ import moment from 'moment';
 import { EuiSpacer, EuiText, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 import { useKnowledgeBaseStatus } from '@kbn/elastic-assistant/impl/assistant/api/knowledge_base/use_knowledge_base_status';
 import { useAssistantContext } from '@kbn/elastic-assistant';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
-
-import { ActionType } from '../../../../../../../../common/endpoint/types/workflow_insights';
+import {
+  WorkflowInsightType,
+  WorkflowInsightActionType,
+  type WorkflowInsightType as WorkflowInsightTypeValue,
+} from '../../../../../../../../common/endpoint/types/workflow_insights';
 import { useIsExperimentalFeatureEnabled } from '../../../../../../../common/hooks/use_experimental_features';
 import { useFetchInsights } from '../../../hooks/insights/use_fetch_insights';
 import { useTriggerScan } from '../../../hooks/insights/use_trigger_scan';
@@ -56,14 +58,16 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
     setInsightGenerationFailures(true);
   };
 
-  const insightTypes = useMemo<DefendInsightType[]>(() => {
-    const typesToQuery: DefendInsightType[] = [DefendInsightType.enum.incompatible_antivirus];
+  const insightTypes = useMemo<WorkflowInsightTypeValue[]>(() => {
+    const typesToQuery: WorkflowInsightTypeValue[] = [
+      WorkflowInsightType.enum.incompatible_antivirus,
+    ];
     if (
       defendInsightsPolicyResponseFailureEnabled &&
       // we only want to run `policy_response_failure` type with KB
       (kbStatus?.defend_insights_exists || kbStatus?.is_setup_in_progress)
     ) {
-      typesToQuery.push(DefendInsightType.enum.policy_response_failure);
+      typesToQuery.push(WorkflowInsightType.enum.policy_response_failure);
     }
     return typesToQuery;
   }, [defendInsightsPolicyResponseFailureEnabled, kbStatus]);
@@ -120,7 +124,9 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
 
     const insightTypesSet = new Set(insightTypes);
     return (insights ?? []).filter(
-      (insight) => insightTypesSet.has(insight.type) && insight.action.type === ActionType.Refreshed
+      (insight) =>
+        insightTypesSet.has(insight.type) &&
+        insight.action.type === WorkflowInsightActionType.enum.refreshed
     );
   }, [isScanRunning, insights, insightTypes]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
@@ -58,9 +58,7 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
   };
 
   const insightTypes = useMemo<WorkflowInsightType[]>(() => {
-    const typesToQuery: WorkflowInsightType[] = [
-      WorkflowInsightType.enum.incompatible_antivirus,
-    ];
+    const typesToQuery: WorkflowInsightType[] = [WorkflowInsightType.enum.incompatible_antivirus];
     if (
       defendInsightsPolicyResponseFailureEnabled &&
       // we only want to run `policy_response_failure` type with KB

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_results.tsx
@@ -17,7 +17,7 @@ import {
   EuiHorizontalRule,
   EuiLink,
 } from '@elastic/eui';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
+import { WorkflowInsightType } from '../../../../../../../../common/endpoint/types/workflow_insights';
 
 import type { SecurityWorkflowInsight } from '../../../../../../../../common/endpoint/types/workflow_insights';
 import { WORKFLOW_INSIGHTS_SURVEY_URL } from '../../../../constants';
@@ -71,7 +71,7 @@ export const WorkflowInsightsResults = ({
     } else if (results?.length) {
       return results.flatMap((insight, index) => {
         switch (insight.type) {
-          case DefendInsightType.enum.incompatible_antivirus:
+          case WorkflowInsightType.enum.incompatible_antivirus:
             return (
               <WorkflowInsightsIncompatibleAntivirusResult
                 insight={insight}
@@ -79,7 +79,7 @@ export const WorkflowInsightsResults = ({
                 endpointId={endpointId}
               />
             );
-          case DefendInsightType.enum.policy_response_failure:
+          case WorkflowInsightType.enum.policy_response_failure:
             return <WorkflowInsightsPolicyResponseFailureResult insight={insight} index={index} />;
           default:
             return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_insights.ts
@@ -8,10 +8,12 @@
 import type { Moment } from 'moment';
 import moment from 'moment';
 import { useQuery } from '@kbn/react-query';
-import type { DefendInsightType } from '@kbn/elastic-assistant-common';
 import { API_VERSIONS } from '@kbn/elastic-assistant-common';
+import type {
+  WorkflowInsightType,
+  SecurityWorkflowInsight,
+} from '../../../../../../../common/endpoint/types/workflow_insights';
 
-import type { SecurityWorkflowInsight } from '../../../../../../../common/endpoint/types/workflow_insights';
 import { WORKFLOW_INSIGHTS_ROUTE } from '../../../../../../../common/endpoint/constants';
 import { useKibana, useToasts } from '../../../../../../common/lib/kibana';
 import { WORKFLOW_INSIGHTS } from '../../translations';
@@ -22,7 +24,7 @@ interface UseFetchInsightsConfig {
   scanCompleted: boolean;
   expectedCount: number | null;
   expectedTimestamp: Moment | null;
-  insightTypes: DefendInsightType[];
+  insightTypes: WorkflowInsightType[];
 }
 
 const MAX_RETRIES = 5;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_ongoing_tasks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_fetch_ongoing_tasks.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { DefendInsightsResponse, DefendInsightType } from '@kbn/elastic-assistant-common';
+import type { DefendInsightsResponse } from '@kbn/elastic-assistant-common';
 import type { Moment } from 'moment';
 import moment from 'moment';
 import { useQuery } from '@kbn/react-query';
@@ -13,6 +13,7 @@ import {
   DEFEND_INSIGHTS,
   DefendInsightStatusEnum,
 } from '@kbn/elastic-assistant-common';
+import type { WorkflowInsightType } from '../../../../../../../common/endpoint/types/workflow_insights';
 
 import { WORKFLOW_INSIGHTS } from '../../translations';
 import { useKibana, useToasts } from '../../../../../../common/lib/kibana';
@@ -20,7 +21,7 @@ import { useKibana, useToasts } from '../../../../../../common/lib/kibana';
 interface UseFetchOngoingScansConfig {
   isPolling: boolean;
   endpointId: string;
-  insightTypes: DefendInsightType[];
+  insightTypes: WorkflowInsightType[];
   onSuccess: (expectedCount: number, timestamp: Moment | null) => void;
   onInsightGenerationFailure: () => void;
 }
@@ -57,7 +58,7 @@ export const useFetchLatestScan = ({
           }
 
           return acc;
-        }, {} as Record<DefendInsightType, DefendInsightsResponse>);
+        }, {} as Record<WorkflowInsightType, DefendInsightsResponse>);
         const insights = Object.values(insightsMap);
 
         const processQueryResults = (insightResults: DefendInsightsResponse[]) => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_trigger_scan.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/hooks/insights/use_trigger_scan.ts
@@ -6,9 +6,10 @@
  */
 
 import { useMutation } from '@kbn/react-query';
-import type { DefendInsightsResponse, DefendInsightType } from '@kbn/elastic-assistant-common';
+import type { DefendInsightsResponse } from '@kbn/elastic-assistant-common';
 import { API_VERSIONS, DEFEND_INSIGHTS } from '@kbn/elastic-assistant-common';
 import { useFetchAnonymizationFields } from '@kbn/elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields';
+import type { WorkflowInsightType } from '../../../../../../../common/endpoint/types/workflow_insights';
 import { useKibana, useToasts } from '../../../../../../common/lib/kibana';
 import { WORKFLOW_INSIGHTS } from '../../translations';
 
@@ -16,7 +17,7 @@ interface UseTriggerScanPayload {
   endpointId: string;
   connectorId: string;
   actionTypeId: string;
-  insightTypes: DefendInsightType[];
+  insightTypes: WorkflowInsightType[];
 }
 
 interface UseTriggerScanConfig {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
@@ -6,12 +6,15 @@
  */
 
 import type { ScopedModel, ToolHandlerResult } from '@kbn/agent-builder-server';
-import type { DefendInsights } from '@kbn/elastic-assistant-common';
 import { StateGraph, Annotation } from '@langchain/langgraph';
 import { z } from '@kbn/zod/v4';
 import { ToolResultType } from '@kbn/agent-builder-common/tools';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
 
+import {
+  WorkflowInsightType,
+  type WorkflowInsightType as WorkflowInsightTypeValue,
+  type DefendInsights,
+} from '../../../../../../common/endpoint/types/workflow_insights';
 import { securityWorkflowInsightsService } from '../../../../../endpoint/services';
 import { getDefendInsightsOutputSchema } from './schemas';
 import { getPrompts } from './prompts';
@@ -21,7 +24,7 @@ const GENERATE_INSIGHT_NODE_NAME = 'generateInsights';
 const CREATE_WORKFLOW_INSIGHTS_NODE_NAME = 'createWorkflowInsights';
 
 const StateAnnotation = Annotation.Root({
-  insightType: Annotation<DefendInsightType>(),
+  insightType: Annotation<WorkflowInsightTypeValue>(),
   insights: Annotation<DefendInsights>(),
   error: Annotation<string>(),
   results: Annotation<ToolHandlerResult[]>({
@@ -45,16 +48,18 @@ export const createGenerateInsightGraph = ({
   endpointIds: string[];
   data: unknown[];
 }) => {
-  async function categorizeInsightType(): Promise<{ insightType: DefendInsightType }> {
+  async function categorizeInsightType(): Promise<{ insightType: WorkflowInsightTypeValue }> {
     const output = await model.chatModel.withStructuredOutput(
-      z.object({ insightType: DefendInsightType.default(DefendInsightType.enum.custom) })
+      z.object({ insightType: WorkflowInsightType.default(WorkflowInsightType.enum.custom) })
     ).invoke(`
-Categorize the following problem description into one of the following Defend Insight Types: ${DefendInsightType}. If no good match exists, use 'custom'.
+Categorize the following problem description into one of the following Defend Insight Types: ${WorkflowInsightType.options.join(
+      ', '
+    )}. If no good match exists, use 'custom'.
 
 ## Problem Description:
 ${problemDescription}
     `);
-    return { insightType: output.insightType || DefendInsightType.enum.custom };
+    return { insightType: output.insightType || WorkflowInsightType.enum.custom };
   }
 
   async function generateInsights({ insightType }: StateType): Promise<{

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/graph.ts
@@ -12,7 +12,6 @@ import { ToolResultType } from '@kbn/agent-builder-common/tools';
 
 import {
   WorkflowInsightType,
-  type WorkflowInsightType as WorkflowInsightTypeValue,
   type DefendInsights,
 } from '../../../../../../common/endpoint/types/workflow_insights';
 import { securityWorkflowInsightsService } from '../../../../../endpoint/services';
@@ -24,7 +23,7 @@ const GENERATE_INSIGHT_NODE_NAME = 'generateInsights';
 const CREATE_WORKFLOW_INSIGHTS_NODE_NAME = 'createWorkflowInsights';
 
 const StateAnnotation = Annotation.Root({
-  insightType: Annotation<WorkflowInsightTypeValue>(),
+  insightType: Annotation<WorkflowInsightType>(),
   insights: Annotation<DefendInsights>(),
   error: Annotation<string>(),
   results: Annotation<ToolHandlerResult[]>({
@@ -48,7 +47,7 @@ export const createGenerateInsightGraph = ({
   endpointIds: string[];
   data: unknown[];
 }) => {
-  async function categorizeInsightType(): Promise<{ insightType: WorkflowInsightTypeValue }> {
+  async function categorizeInsightType(): Promise<{ insightType: WorkflowInsightType }> {
     const output = await model.chatModel.withStructuredOutput(
       z.object({ insightType: WorkflowInsightType.default(WorkflowInsightType.enum.custom) })
     ).invoke(`

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
@@ -6,9 +6,8 @@
  */
 
 import { WorkflowInsightType } from '../../../../../../common/endpoint/types/workflow_insights';
-import type { WorkflowInsightType as WorkflowInsightTypeValue } from '../../../../../../common/endpoint/types/workflow_insights';
 
-export function getPrompts(insightType: WorkflowInsightTypeValue) {
+export function getPrompts(insightType: WorkflowInsightType) {
   switch (insightType) {
     case WorkflowInsightType.enum.policy_response_failure:
       return PROMPTS.POLICY_RESPONSE_FAILURE;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/prompts.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
+import { WorkflowInsightType } from '../../../../../../common/endpoint/types/workflow_insights';
+import type { WorkflowInsightType as WorkflowInsightTypeValue } from '../../../../../../common/endpoint/types/workflow_insights';
 
-export function getPrompts(insightType: DefendInsightType) {
+export function getPrompts(insightType: WorkflowInsightTypeValue) {
   switch (insightType) {
-    case DefendInsightType.enum.policy_response_failure:
+    case WorkflowInsightType.enum.policy_response_failure:
       return PROMPTS.POLICY_RESPONSE_FAILURE;
-    case DefendInsightType.enum.incompatible_antivirus:
+    case WorkflowInsightType.enum.incompatible_antivirus:
       return PROMPTS.INCOMPATIBLE_ANTIVIRUS;
-    case DefendInsightType.enum.custom:
+    case WorkflowInsightType.enum.custom:
       return PROMPTS.CUSTOM;
     default:
       throw new Error(`Unsupported insight type: ${insightType}`);

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
@@ -8,10 +8,9 @@
 import { z } from '@kbn/zod/v4';
 
 import { WorkflowInsightType } from '../../../../../../common/endpoint/types/workflow_insights';
-import type { WorkflowInsightType as WorkflowInsightTypeValue } from '../../../../../../common/endpoint/types/workflow_insights';
 import { PROMPTS } from './prompts';
 
-export function getDefendInsightsOutputSchema({ type }: { type: WorkflowInsightTypeValue }) {
+export function getDefendInsightsOutputSchema({ type }: { type: WorkflowInsightType }) {
   switch (type) {
     case WorkflowInsightType.enum.incompatible_antivirus:
       const antivirusPrompts = PROMPTS.INCOMPATIBLE_ANTIVIRUS;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/skills/automatic_troubleshooting/tools/generate_insight/schemas.ts
@@ -6,13 +6,14 @@
  */
 
 import { z } from '@kbn/zod/v4';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
 
+import { WorkflowInsightType } from '../../../../../../common/endpoint/types/workflow_insights';
+import type { WorkflowInsightType as WorkflowInsightTypeValue } from '../../../../../../common/endpoint/types/workflow_insights';
 import { PROMPTS } from './prompts';
 
-export function getDefendInsightsOutputSchema({ type }: { type: DefendInsightType }) {
+export function getDefendInsightsOutputSchema({ type }: { type: WorkflowInsightTypeValue }) {
   switch (type) {
-    case DefendInsightType.enum.incompatible_antivirus:
+    case WorkflowInsightType.enum.incompatible_antivirus:
       const antivirusPrompts = PROMPTS.INCOMPATIBLE_ANTIVIRUS;
       return z.object({
         insights: z.array(
@@ -29,7 +30,7 @@ export function getDefendInsightsOutputSchema({ type }: { type: DefendInsightTyp
           })
         ),
       });
-    case DefendInsightType.enum.policy_response_failure:
+    case WorkflowInsightType.enum.policy_response_failure:
       const policyResponsePrompts = PROMPTS.POLICY_RESPONSE_FAILURE;
       return z.object({
         insights: z.array(

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.test.ts
@@ -11,10 +11,10 @@ import moment from 'moment';
 import type { EndpointMetadataService } from '../../metadata';
 import type { BuildWorkflowInsightParams } from '.';
 import {
-  Category,
-  SourceType,
-  TargetType,
-  ActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
+  WorkflowInsightActionType,
 } from '../../../../../common/endpoint/types/workflow_insights';
 import { createMockEndpointAppContext } from '../../../mocks';
 import { buildCustomWorkflowInsights } from './custom';
@@ -70,20 +70,20 @@ describe('buildCustomWorkflowInsights', () => {
     expect.objectContaining({
       '@timestamp': expect.any(moment),
       message: 'Policy response failure detected',
-      category: Category.Endpoint,
+      category: WorkflowInsightCategory.enum.endpoint,
       type: 'policy_response_failure',
       source: {
-        type: SourceType.LlmConnector,
+        type: WorkflowInsightSourceType.enum['llm-connector'],
         id: 'connector-id-1',
         data_range_start: expect.any(moment),
         data_range_end: expect.any(moment),
       },
       target: {
-        type: TargetType.Endpoint,
+        type: WorkflowInsightTargetType.enum.endpoint,
         ids: ['endpoint-1', 'endpoint-2'],
       },
       action: {
-        type: ActionType.Refreshed,
+        type: WorkflowInsightActionType.enum.refreshed,
         timestamp: expect.any(moment),
       },
       value: group,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.ts
@@ -8,10 +8,7 @@
 import moment from 'moment';
 
 import type { BuildWorkflowInsightParams } from '.';
-import type {
-  SecurityWorkflowInsight,
-  WorkflowInsightType as WorkflowInsightTypeValue,
-} from '../../../../../common/endpoint/types/workflow_insights';
+import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
 import {
   WorkflowInsightType,
   WorkflowInsightActionType,
@@ -22,7 +19,7 @@ import {
 
 const groupSeparator = ':::';
 
-function getMessage(insightType: WorkflowInsightTypeValue): string {
+function getMessage(insightType: WorkflowInsightType): string {
   switch (insightType) {
     case WorkflowInsightType.enum.policy_response_failure:
       return 'Policy response failure detected';

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/custom.ts
@@ -5,23 +5,26 @@
  * 2.0.
  */
 
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
 import moment from 'moment';
 
 import type { BuildWorkflowInsightParams } from '.';
-import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
+import type {
+  SecurityWorkflowInsight,
+  WorkflowInsightType as WorkflowInsightTypeValue,
+} from '../../../../../common/endpoint/types/workflow_insights';
 import {
-  ActionType,
-  Category,
-  SourceType,
-  TargetType,
+  WorkflowInsightType,
+  WorkflowInsightActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
 } from '../../../../../common/endpoint/types/workflow_insights';
 
 const groupSeparator = ':::';
 
-function getMessage(insightType: DefendInsightType): string {
+function getMessage(insightType: WorkflowInsightTypeValue): string {
   switch (insightType) {
-    case DefendInsightType.enum.policy_response_failure:
+    case WorkflowInsightType.enum.policy_response_failure:
       return 'Policy response failure detected';
     default:
       return 'Potential issue detected';
@@ -42,20 +45,20 @@ export async function buildCustomWorkflowInsights({
       const workflowInsight: SecurityWorkflowInsight = {
         '@timestamp': currentTime,
         message: getMessage(insightType),
-        category: Category.Endpoint,
+        category: WorkflowInsightCategory.enum.endpoint,
         type: insightType,
         source: {
-          type: SourceType.LlmConnector,
+          type: WorkflowInsightSourceType.enum['llm-connector'],
           id: connectorId ?? '',
           data_range_start: currentTime,
           data_range_end: currentTime,
         },
         target: {
-          type: TargetType.Endpoint,
+          type: WorkflowInsightTargetType.enum.endpoint,
           ids: endpointIds,
         },
         action: {
-          type: ActionType.Refreshed,
+          type: WorkflowInsightActionType.enum.refreshed,
           timestamp: currentTime,
         },
         value: insight.group,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
@@ -12,10 +12,10 @@ import moment from 'moment';
 import type { EndpointMetadataService } from '../../metadata';
 import type { BuildWorkflowInsightParams } from '.';
 import {
-  Category,
-  SourceType,
-  TargetType,
-  ActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
+  WorkflowInsightActionType,
 } from '../../../../../common/endpoint/types/workflow_insights';
 import { createMockEndpointAppContext } from '../../../mocks';
 import { groupEndpointIdsByOS } from '../helpers';
@@ -71,20 +71,20 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
     expect.objectContaining({
       '@timestamp': expect.any(moment),
       message: 'Incompatible antiviruses detected',
-      category: Category.Endpoint,
+      category: WorkflowInsightCategory.enum.endpoint,
       type: 'incompatible_antivirus',
       source: {
-        type: SourceType.LlmConnector,
+        type: WorkflowInsightSourceType.enum['llm-connector'],
         id: 'connector-id-1',
         data_range_start: expect.any(moment),
         data_range_end: expect.any(moment),
       },
       target: {
-        type: TargetType.Endpoint,
+        type: WorkflowInsightTargetType.enum.endpoint,
         ids: ['endpoint-1'],
       },
       action: {
-        type: ActionType.Refreshed,
+        type: WorkflowInsightActionType.enum.refreshed,
         timestamp: expect.any(moment),
       },
       value: `/Applications/AVGAntivirus.app/Contents/Backend/services/com.avg.activity${

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
@@ -8,20 +8,21 @@
 import moment from 'moment';
 import { uniqBy } from 'lodash';
 
-import type { DefendInsight } from '@kbn/elastic-assistant-common';
-
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
+import type {
+  DefendInsight,
+  SecurityWorkflowInsight,
+} from '../../../../../common/endpoint/types/workflow_insights';
 
-import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
 import type { SupportedHostOsType } from '../../../../../common/endpoint/constants';
 import type { BuildWorkflowInsightParams } from '.';
 
 import { FILE_EVENTS_INDEX_PATTERN } from '../../../../../common/endpoint/constants';
 import {
-  ActionType,
-  Category,
-  SourceType,
-  TargetType,
+  WorkflowInsightActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
 } from '../../../../../common/endpoint/types/workflow_insights';
 import type { FileEventDoc } from '../helpers';
 import { getValidCodeSignature, groupEndpointIdsByOS } from '../helpers';
@@ -84,21 +85,21 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
           '@timestamp': currentTime,
           // TODO add i18n support
           message: 'Incompatible antiviruses detected',
-          category: Category.Endpoint,
+          category: WorkflowInsightCategory.enum.endpoint,
           type: insightType,
           source: {
-            type: SourceType.LlmConnector,
+            type: WorkflowInsightSourceType.enum['llm-connector'],
             id: connectorId ?? '',
             // TODO use actual time range when we add support
             data_range_start: currentTime,
             data_range_end: currentTime.clone().add(24, 'hours'),
           },
           target: {
-            type: TargetType.Endpoint,
+            type: WorkflowInsightTargetType.enum.endpoint,
             ids: endpointIds,
           },
           action: {
-            type: ActionType.Refreshed,
+            type: WorkflowInsightActionType.enum.refreshed,
             timestamp: currentTime,
           },
           value: `${filePath}${signatureValue ? ` ${signatureValue}` : ''}`,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
@@ -6,11 +6,13 @@
  */
 
 import type { ElasticsearchClient } from '@kbn/core/server';
-import type { DefendInsight } from '@kbn/elastic-assistant-common';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
-import { InvalidDefendInsightTypeError } from '@kbn/elastic-assistant-plugin/server/lib/defend_insights/errors';
 
-import type { SecurityWorkflowInsight } from '../../../../../common/endpoint/types/workflow_insights';
+import type {
+  DefendInsight,
+  SecurityWorkflowInsight,
+  WorkflowInsightType,
+} from '../../../../../common/endpoint/types/workflow_insights';
+import { WorkflowInsightType as WorkflowInsightTypeEnum } from '../../../../../common/endpoint/types/workflow_insights';
 import type { EndpointMetadataService } from '../../metadata';
 import { buildIncompatibleAntivirusWorkflowInsights } from './incompatible_antivirus';
 import { buildCustomWorkflowInsights } from './custom';
@@ -20,7 +22,7 @@ export interface BuildWorkflowInsightParams {
   endpointMetadataService: EndpointMetadataService;
   esClient: ElasticsearchClient;
   options: {
-    insightType: DefendInsightType;
+    insightType: WorkflowInsightType;
     endpointIds: string[];
     connectorId?: string;
     model?: string;
@@ -31,13 +33,13 @@ export function buildWorkflowInsights(
   params: BuildWorkflowInsightParams
 ): Promise<SecurityWorkflowInsight[]> {
   switch (params.options.insightType) {
-    case DefendInsightType.enum.incompatible_antivirus:
+    case WorkflowInsightTypeEnum.enum.incompatible_antivirus:
       return buildIncompatibleAntivirusWorkflowInsights(params);
-    case DefendInsightType.enum.policy_response_failure:
+    case WorkflowInsightTypeEnum.enum.policy_response_failure:
       return buildCustomWorkflowInsights(params);
-    case DefendInsightType.enum.custom:
+    case WorkflowInsightTypeEnum.enum.custom:
       return buildCustomWorkflowInsights(params);
     default:
-      throw new InvalidDefendInsightTypeError();
+      throw new Error('Invalid insight type');
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/index.ts
@@ -10,10 +10,9 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import type {
   DefendInsight,
   SecurityWorkflowInsight,
-  WorkflowInsightType,
 } from '../../../../../common/endpoint/types/workflow_insights';
-import { WorkflowInsightType as WorkflowInsightTypeEnum } from '../../../../../common/endpoint/types/workflow_insights';
 import type { EndpointMetadataService } from '../../metadata';
+import { WorkflowInsightType } from '../../../../../common/endpoint/types/workflow_insights';
 import { buildIncompatibleAntivirusWorkflowInsights } from './incompatible_antivirus';
 import { buildCustomWorkflowInsights } from './custom';
 
@@ -33,11 +32,11 @@ export function buildWorkflowInsights(
   params: BuildWorkflowInsightParams
 ): Promise<SecurityWorkflowInsight[]> {
   switch (params.options.insightType) {
-    case WorkflowInsightTypeEnum.enum.incompatible_antivirus:
+    case WorkflowInsightType.enum.incompatible_antivirus:
       return buildIncompatibleAntivirusWorkflowInsights(params);
-    case WorkflowInsightTypeEnum.enum.policy_response_failure:
+    case WorkflowInsightType.enum.policy_response_failure:
       return buildCustomWorkflowInsights(params);
-    case WorkflowInsightTypeEnum.enum.custom:
+    case WorkflowInsightType.enum.custom:
       return buildCustomWorkflowInsights(params);
     default:
       throw new Error('Invalid insight type');

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/helpers.test.ts
@@ -13,7 +13,13 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import { DataStreamSpacesAdapter } from '@kbn/data-stream-adapter';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { kibanaPackageJson } from '@kbn/repo-info';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
+import {
+  WorkflowInsightType,
+  WorkflowInsightActionType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
+} from '../../../../common/endpoint/types/workflow_insights';
 
 import type { HostMetadata } from '../../../../common/endpoint/types';
 import type {
@@ -21,12 +27,6 @@ import type {
   SecurityWorkflowInsight,
 } from '../../../../common/endpoint/types/workflow_insights';
 
-import {
-  ActionType,
-  Category,
-  SourceType,
-  TargetType,
-} from '../../../../common/endpoint/types/workflow_insights';
 import type { EndpointMetadataService } from '../metadata';
 import type { FileEventDoc } from './helpers';
 import {
@@ -61,20 +61,20 @@ function getDefaultInsight(overrides?: Partial<SecurityWorkflowInsight>): Securi
   const defaultInsight = {
     '@timestamp': moment(),
     message: 'This is a test message',
-    category: Category.Endpoint,
-    type: DefendInsightType.enum.incompatible_antivirus,
+    category: WorkflowInsightCategory.enum.endpoint,
+    type: WorkflowInsightType.enum.incompatible_antivirus,
     source: {
-      type: SourceType.LlmConnector,
+      type: WorkflowInsightSourceType.enum['llm-connector'],
       id: 'openai-connector-id',
       data_range_start: moment(),
       data_range_end: moment(),
     },
     target: {
-      type: TargetType.Endpoint,
+      type: WorkflowInsightTargetType.enum.endpoint,
       ids: ['endpoint-1', 'endpoint-2'],
     },
     action: {
-      type: ActionType.Refreshed,
+      type: WorkflowInsightActionType.enum.refreshed,
       timestamp: moment(),
     },
     value: 'unique-key',
@@ -163,12 +163,12 @@ describe('helpers', () => {
     it('should build query with valid keys', () => {
       const searchParams: SearchParams = {
         ids: ['id1', 'id2'],
-        categories: [Category.Endpoint],
+        categories: [WorkflowInsightCategory.enum.endpoint],
         types: ['incompatible_antivirus'],
-        sourceTypes: [SourceType.LlmConnector],
+        sourceTypes: [WorkflowInsightSourceType.enum['llm-connector']],
         sourceIds: ['source1'],
         targetIds: ['target1'],
-        actionTypes: [ActionType.Refreshed],
+        actionTypes: [WorkflowInsightActionType.enum.refreshed],
       };
       const result = buildEsQueryParams(searchParams);
       expect(result).toEqual([
@@ -199,7 +199,7 @@ describe('helpers', () => {
 
     it('should handle nested query for actionTypes', () => {
       const searchParams: SearchParams = {
-        actionTypes: [ActionType.Refreshed],
+        actionTypes: [WorkflowInsightActionType.enum.refreshed],
       };
       const result = buildEsQueryParams(searchParams);
       expect(result).toEqual([
@@ -372,7 +372,7 @@ describe('helpers', () => {
   describe('checkIfRemediationExists', () => {
     it('should return false for non-incompatible_antivirus types', async () => {
       const insight = getDefaultInsight({
-        type: 'other-type' as DefendInsightType,
+        type: 'other-type' as WorkflowInsightType,
       });
 
       // For non-incompatible_antivirus types, getHostMetadata should not be called.
@@ -402,7 +402,7 @@ describe('helpers', () => {
       };
 
       const insight = getDefaultInsight({
-        type: DefendInsightType.enum.incompatible_antivirus,
+        type: WorkflowInsightType.enum.incompatible_antivirus,
         remediation: {
           exception_list_items: [
             {
@@ -457,7 +457,7 @@ describe('helpers', () => {
 
       // Here the entry field is not valid, so generateTrustedAppsFilter returns an empty string.
       const insight = getDefaultInsight({
-        type: DefendInsightType.enum.incompatible_antivirus,
+        type: WorkflowInsightType.enum.incompatible_antivirus,
         remediation: {
           exception_list_items: [
             {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/helpers.ts
@@ -14,11 +14,11 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 import { DataStreamSpacesAdapter } from '@kbn/data-stream-adapter';
 
 import type { ExceptionListClient } from '@kbn/lists-plugin/server';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
 import type {
   SearchParams,
   SecurityWorkflowInsight,
 } from '../../../../common/endpoint/types/workflow_insights';
+import { WorkflowInsightType } from '../../../../common/endpoint/types/workflow_insights';
 import type { SupportedHostOsType } from '../../../../common/endpoint/constants';
 
 import type { EndpointMetadataService } from '../metadata';
@@ -229,7 +229,7 @@ export const checkIfRemediationExists = async ({
   exceptionListsClient: ExceptionListClient;
   endpointMetadataClient: EndpointMetadataService;
 }): Promise<boolean> => {
-  if (insight.type !== DefendInsightType.enum.incompatible_antivirus) {
+  if (insight.type !== WorkflowInsightType.enum.incompatible_antivirus) {
     return false;
   }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.test.ts
@@ -11,30 +11,30 @@ import { ReplaySubject } from 'rxjs';
 
 import type { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
 import type {
-  DefendInsight,
   DefendInsightsGetRequestQuery,
   DefendInsightsPostRequestBody,
 } from '@kbn/elastic-assistant-common';
 import type { SearchHit, UpdateResponse } from '@elastic/elasticsearch/lib/api/types';
 
 import { DataStreamSpacesAdapter } from '@kbn/data-stream-adapter';
-import { DefendInsightType } from '@kbn/elastic-assistant-common';
+import type {
+  DefendInsight,
+  SearchParams,
+  SecurityWorkflowInsight,
+} from '../../../../common/endpoint/types/workflow_insights';
+import {
+  WorkflowInsightType,
+  WorkflowInsightCategory,
+  WorkflowInsightSourceType,
+  WorkflowInsightTargetType,
+  WorkflowInsightActionType,
+} from '../../../../common/endpoint/types/workflow_insights';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { kibanaPackageJson } from '@kbn/repo-info';
 import { loggerMock } from '@kbn/logging-mocks';
 
-import type {
-  SearchParams,
-  SecurityWorkflowInsight,
-} from '../../../../common/endpoint/types/workflow_insights';
 import type { EndpointAppContextService } from '../../endpoint_app_context_services';
 
-import {
-  Category,
-  SourceType,
-  TargetType,
-  ActionType,
-} from '../../../../common/endpoint/types/workflow_insights';
 import { createMockEndpointAppContext } from '../../mocks';
 import {
   checkIfRemediationExists,
@@ -68,20 +68,20 @@ function getDefaultInsight(overrides?: Partial<SecurityWorkflowInsight>): Securi
   const defaultInsight = {
     '@timestamp': moment(),
     message: 'This is a test message',
-    category: Category.Endpoint,
-    type: DefendInsightType.enum.incompatible_antivirus,
+    category: WorkflowInsightCategory.enum.endpoint,
+    type: WorkflowInsightType.enum.incompatible_antivirus,
     source: {
-      type: SourceType.LlmConnector,
+      type: WorkflowInsightSourceType.enum['llm-connector'],
       id: 'openai-connector-id',
       data_range_start: moment(),
       data_range_end: moment(),
     },
     target: {
-      type: TargetType.Endpoint,
+      type: WorkflowInsightTargetType.enum.endpoint,
       ids: ['endpoint-1', 'endpoint-2'],
     },
     action: {
-      type: ActionType.Refreshed,
+      type: WorkflowInsightActionType.enum.refreshed,
       timestamp: moment(),
     },
     value: 'unique-key',
@@ -338,7 +338,7 @@ describe('SecurityWorkflowInsightsService', () => {
         expect.objectContaining({
           document: expect.objectContaining({
             action: expect.objectContaining({
-              type: ActionType.Remediated,
+              type: WorkflowInsightActionType.enum.remediated,
             }),
           }),
         })
@@ -414,13 +414,16 @@ describe('SecurityWorkflowInsightsService', () => {
         size: 50,
         from: 50,
         ids: ['id1', 'id2'],
-        categories: [Category.Endpoint],
-        types: [DefendInsightType.enum.incompatible_antivirus],
-        sourceTypes: [SourceType.LlmConnector],
+        categories: [WorkflowInsightCategory.enum.endpoint],
+        types: [WorkflowInsightType.enum.incompatible_antivirus],
+        sourceTypes: [WorkflowInsightSourceType.enum['llm-connector']],
         sourceIds: ['source-id1', 'source-id2'],
-        targetTypes: [TargetType.Endpoint],
+        targetTypes: [WorkflowInsightTargetType.enum.endpoint],
         targetIds: ['target-id1', 'target-id2'],
-        actionTypes: [ActionType.Refreshed, ActionType.Remediated],
+        actionTypes: [
+          WorkflowInsightActionType.enum.refreshed,
+          WorkflowInsightActionType.enum.remediated,
+        ],
       };
       await securityWorkflowInsightsService.fetch(searchParams);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/index.ts
@@ -13,20 +13,20 @@ import type {
 import type { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
 import type { DataStreamSpacesAdapter } from '@kbn/data-stream-adapter';
 import type {
-  DefendInsight,
-  DefendInsightType,
   DefendInsightsGetRequestQuery,
   DefendInsightsPostRequestBody,
 } from '@kbn/elastic-assistant-common';
 import { CallbackIds } from '@kbn/elastic-assistant-plugin/server/types';
 import { combineLatest, firstValueFrom, ReplaySubject } from 'rxjs';
 import { cloneDeep } from 'lodash';
-
-import {
-  ActionType,
-  type SearchParams,
-  type SecurityWorkflowInsight,
+import type {
+  DefendInsight,
+  WorkflowInsightType,
+  SearchParams,
+  SecurityWorkflowInsight,
 } from '../../../../common/endpoint/types/workflow_insights';
+import { WorkflowInsightActionType } from '../../../../common/endpoint/types/workflow_insights';
+
 import type { EndpointAppContextService } from '../../endpoint_app_context_services';
 import { SecurityWorkflowInsightsFailedInitialized } from './errors';
 import {
@@ -143,7 +143,7 @@ class SecurityWorkflowInsightsService {
     });
 
     if (remediationExists) {
-      insightToCreate.action.type = ActionType.Remediated;
+      insightToCreate.action.type = WorkflowInsightActionType.enum.remediated;
     }
 
     const id = generateInsightId(insightToCreate);
@@ -252,12 +252,12 @@ class SecurityWorkflowInsightsService {
     registerCallback(CallbackIds.DefendInsightsPostFetch, this.onAfterFetch.bind(this));
   }
 
-  private async suppressExistingInsights(endpointIds: string[], types: DefendInsightType[]) {
+  private async suppressExistingInsights(endpointIds: string[], types: WorkflowInsightType[]) {
     const existingInsights = await this.fetch({
       size: DEFAULT_SUPPRESS_SIZE,
       targetIds: endpointIds,
       types,
-      actionTypes: [ActionType.Refreshed],
+      actionTypes: [WorkflowInsightActionType.enum.refreshed],
     });
 
     return Promise.all(
@@ -269,7 +269,7 @@ class SecurityWorkflowInsightsService {
         const source = existingInsight._source as SecurityWorkflowInsight;
         return this.update(
           existingInsight._id as string,
-          { action: { ...source.action, type: ActionType.Suppressed } },
+          { action: { ...source.action, type: WorkflowInsightActionType.enum.suppressed } },
           existingInsight._index
         );
       })
@@ -293,7 +293,7 @@ class SecurityWorkflowInsightsService {
   public async createFromDefendInsights(
     defendInsights: DefendInsight[],
     endpointIds: string[],
-    insightType: DefendInsightType,
+    insightType: WorkflowInsightType,
     connectorId: string,
     model: string = ''
   ) {


### PR DESCRIPTION
## Summary

Creates new canonical WorkflowInsight / DefendInsight types within `security_solution` (`x-pack/solutions/security/plugins/security_solution/common/endpoint/types/workflow_insights.ts`). Migrate usage of Automatic Troubleshooting types from `@kbn/elastic-assistant-common` to these new canonical types.

The purpose of this PR is to:
1) create a single source of truth for Automatic Troubleshooting types
2) reduce `@kbn/elastic-assistant-common` footprint to make Agent Builder migration simpler

Since we cannot completely stop using `@kbn/elastic-assistant-common` until we fully migrate to Agent Builder (specifically, we are still using 2 elastic_assistant housed APIs), there is minor risk of type drift during this period. New type drift detection tests are included to mitigate this issue.

Confirmed locally that existing functionality is unchanged:
<img width="1148" height="756" alt="Screenshot 2026-03-24 at 10 10 12 PM" src="https://github.com/user-attachments/assets/cd07baf5-58e3-4e61-925f-71b388b801a0" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios