### PR TITLE
[One Workflow] Fix AB confusion with triggers.event and step output paths

### DIFF
--- a/src/platform/packages/shared/kbn-workflows/spec/builtin_trigger_definitions.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/builtin_trigger_definitions.ts
@@ -73,9 +73,29 @@ export const builtInTriggerDefinitions: BaseTriggerDefinition[] = [
     description: 'Trigger a workflow when an alerting rule fires',
     schema: AlertRuleTriggerSchema,
     documentation: {
+      details:
+        'When an alert trigger fires, the event data is available via `{{ event }}` (NOT `triggers.event`). ' +
+        '`event.alerts` is an array of alert objects, `event.rule` contains the rule metadata (id, name, tags), ' +
+        'and `event.spaceId` is the space where the event was emitted.',
       examples: [
         `triggers:
   - type: alert`,
+        `# Alert-triggered workflow referencing event data in steps:
+triggers:
+  - type: alert
+steps:
+  - name: log_alert
+    type: console
+    with:
+      message: "Alert from rule: {{ event.rule.name }}"
+  - name: process_alerts
+    type: foreach
+    foreach: "{{ event.alerts }}"
+    steps:
+      - name: log_each_alert
+        type: console
+        with:
+          message: "Alert ID: {{ foreach.item._id }}"`,
       ],
     },
   },

--- a/src/platform/packages/shared/kbn-workflows/spec/schema.ts
+++ b/src/platform/packages/shared/kbn-workflows/spec/schema.ts
@@ -924,7 +924,10 @@ export const EventTimestampSchema = z.object({
  * Full event schema (used for runtime validation of alert-triggered workflows).
  * For autocomplete, use getEventSchemaForTriggers() to get a trigger-aware schema.
  */
-export const EventSchema = BaseEventSchema.merge(AlertEventPropsSchema);
+export const AlertEventSchema = z.object({
+  ...BaseEventSchema.shape,
+  ...AlertEventPropsSchema.shape,
+});
 
 // Recursive type for workflow inputs that supports nested objects from JSON Schema
 const WorkflowInputValueSchema: z.ZodType<unknown> = z.lazy(() =>
@@ -940,7 +943,7 @@ const WorkflowInputValueSchema: z.ZodType<unknown> = z.lazy(() =>
 );
 
 export const WorkflowContextSchema = z.object({
-  event: EventSchema.optional(),
+  event: AlertEventSchema.optional(),
   execution: WorkflowExecutionContextSchema,
   workflow: WorkflowDataContextSchema,
   kibanaUrl: z.string(),

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/attachments/workflow_yaml_attachment.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/attachments/workflow_yaml_attachment.ts
@@ -164,12 +164,16 @@ const createWorkflowYamlAttachmentType = (api: WorkflowsManagementApi) => ({
     `\`condition\` is a config param specific to the \`if\` step type (alongside \`steps\`/\`else\`).\n\n` +
     `## Common Fixes\n\n` +
     `- Liquid expressions must be quoted in YAML: \`"{{ steps.name.output.field }}"\`\n` +
+    `- Step outputs are accessed via \`steps.<name>.output\` — NEVER \`steps.<name>.with.*\` or \`steps.<name>.<input_param>\`. A step's input parameters (\`with\` block) are NOT accessible as variables; only \`output\` is. Use \`${workflowTools.getStepDefinitions}\` with \`includeOutputSummary\` to learn what a step's output contains.\n` +
+    `- NEVER reference \`triggers.event\`, \`trigger.event\`, or \`triggers.event.*\` — use \`event\` directly (e.g. \`{{ event.alerts }}\`, \`{{ event.rule.name }}\`). The \`triggers\` block configures trigger types, not runtime data.\n` +
+    `- For alert triggers: \`event.alerts\` is an array, \`event.rule\` has \`id\`/\`name\`/\`tags\`, \`event.spaceId\` is the space\n` +
     `- ES|QL params must be an array of positional values (\`?\` placeholder), not a named map\n` +
     `- All workflows need \`version: '1'\` at the root\n` +
     `- Each step needs a unique \`name\` and valid \`type\`\n` +
     `- Step input parameters go in the \`with\` block\n` +
     `- Config params are step-level fields outside \`with\` (e.g. \`condition\`/\`steps\`/\`else\` for the \`if\` step type, \`foreach\`/\`steps\` for \`foreach\`)\n` +
-    `- Connector-based steps require a \`connector-id\` field`,
+    `- Connector-based steps require a \`connector-id\` field\n` +
+    `- When fixing an error, scan the entire YAML for other occurrences of the same mistake and fix them all`,
 });
 
 export function registerWorkflowYamlAttachment(

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/skills/workflow_authoring_skill.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/skills/workflow_authoring_skill.ts
@@ -170,11 +170,26 @@ Using an incorrect type ID will produce a validation error — verify the ID fir
 ### Liquid Templating
 
 Use Liquid syntax for dynamic values:
-- \`{{ steps.step_name.output.field }}\` - Reference step outputs
+- \`{{ steps.step_name.output.field }}\` - Reference step outputs (ONLY \`output\` is accessible — NEVER \`steps.<name>.with.*\` or \`steps.<name>.<input_param>\`). Use \`${workflowTools.getStepDefinitions}\` with \`includeOutputSummary\` to learn what a step's output contains.
 - \`{{ inputs.input_name }}\` - Reference workflow inputs
 - \`{{ consts.constant_name }}\` - Reference constants
 - \`{{ foreach.item }}\` - Current item in a foreach loop
-- \`{{ event }}\` - Trigger event data (for alert triggers)
+- \`{{ event }}\` - Trigger event data (available for all trigger types)
+
+**IMPORTANT — event variable path:** The trigger event is accessed via \`{{ event }}\` directly — NEVER \`{{ triggers.event }}\`, \`{{ trigger.event }}\`, or \`{{ triggers.event.* }}\`. The \`triggers\` block only configures which triggers activate the workflow; it does NOT contain runtime event data.
+
+**Alert trigger event structure** (available when \`triggers\` includes \`type: alert\`):
+- \`{{ event.alerts }}\` - Array of alert objects that fired
+- \`{{ event.alerts[0]._id }}\` - Alert ID
+- \`{{ event.alerts[0]._index }}\` - Alert index
+- \`{{ event.alerts[0].kibana.alert }}\` - Alert details
+- \`{{ event.alerts[0]["@timestamp"] }}\` - Alert timestamp
+- \`{{ event.rule.id }}\` - Rule ID
+- \`{{ event.rule.name }}\` - Rule name
+- \`{{ event.rule.tags }}\` - Rule tags
+- \`{{ event.spaceId }}\` - Space where the event was emitted
+
+Use \`${workflowTools.getTriggerDefinitions}\` to get the full event context schema for any trigger type.
 
 Useful filters:
 - \`| json\` - Convert to JSON string
@@ -201,6 +216,7 @@ When fixing validation errors:
 3. If a step type does NOT exist: tell the user and list similar alternatives from the included step definitions
 4. Use edit tools to fix the issues, then check the \`validation\` field in the edit tool response to confirm the fix
 5. NEVER guess or replace a step type with something unrelated
+6. **After fixing an error, scan the entire YAML for other occurrences of the same mistake.** For example, if you fix \`triggers.event\` → \`event\` in one place, check all other Liquid expressions for the same incorrect pattern and fix them all in one pass
 
 ### Proposing Changes (Edit Tools)
 

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
@@ -8,7 +8,7 @@
  */
 
 import { ToolType } from '@kbn/agent-builder-common';
-import { builtInTriggerDefinitions } from '@kbn/workflows';
+import { AlertEventPropsSchema, BaseEventSchema, builtInTriggerDefinitions } from '@kbn/workflows';
 import { WORKFLOWS_AI_AGENT_SETTING_ID } from '@kbn/workflows/common/constants';
 import { z } from '@kbn/zod/v4';
 import { workflowTools } from '../../../common/agent_builder/constants';
@@ -55,6 +55,22 @@ function compactLargeEnums(node: unknown): unknown {
   return result;
 }
 
+/**
+ * Returns the JSON Schema for `{{ event.* }}` variables available at runtime for a given trigger type.
+ * Alert triggers get the full alert event context (alerts array, rule, params);
+ * other built-in triggers only get `BaseEventSchema` (spaceId).
+ */
+function getEventContextSchema(triggerTypeId: string): unknown {
+  if (triggerTypeId === 'alert') {
+    const merged = z.object({
+      ...(BaseEventSchema as z.ZodObject<z.ZodRawShape>).shape,
+      ...(AlertEventPropsSchema as z.ZodObject<z.ZodRawShape>).shape,
+    });
+    return zodToJsonSchemaSafe(merged);
+  }
+  return zodToJsonSchemaSafe(BaseEventSchema);
+}
+
 export function registerGetTriggerDefinitionsTool(
   agentBuilder: AgentBuilderPluginSetupContract
 ): void {
@@ -63,10 +79,10 @@ export function registerGetTriggerDefinitionsTool(
     type: ToolType.builtin,
     description: `Get available workflow trigger types with schemas and YAML examples.
 
-**When to use:** To learn how to configure the \`triggers\` section of a workflow.
+**When to use:** To learn how to configure the \`triggers\` section of a workflow, or to understand what \`{{ event.* }}\` variables are available at runtime for a given trigger type.
 **When NOT to use:** For step definitions (use get_step_definitions) or connector instances (use get_connectors).
 
-Returns built-in trigger types (manual, scheduled, alert).`,
+Returns built-in trigger types (manual, scheduled, alert) including the event context schema that describes what \`{{ event.* }}\` contains at runtime.`,
     schema: z.object({
       triggerType: z
         .string()
@@ -89,6 +105,10 @@ Returns built-in trigger types (manual, scheduled, alert).`,
         label: def.label,
         description: def.description,
         jsonSchema: zodToJsonSchemaSafe(def.schema),
+        eventContextSchema: getEventContextSchema(def.id),
+        eventContextNote:
+          'The event context is available via {{ event.* }} in Liquid templates. ' +
+          'NEVER use {{ triggers.event }} or {{ trigger.event }} — the correct variable is {{ event }}.',
         examples: def.documentation.examples,
       }));
 

--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/tools/get_trigger_definitions_tool.ts
@@ -8,7 +8,7 @@
  */
 
 import { ToolType } from '@kbn/agent-builder-common';
-import { AlertEventPropsSchema, BaseEventSchema, builtInTriggerDefinitions } from '@kbn/workflows';
+import { AlertEventSchema, BaseEventSchema, builtInTriggerDefinitions } from '@kbn/workflows';
 import { WORKFLOWS_AI_AGENT_SETTING_ID } from '@kbn/workflows/common/constants';
 import { z } from '@kbn/zod/v4';
 import { workflowTools } from '../../../common/agent_builder/constants';
@@ -61,12 +61,9 @@ function compactLargeEnums(node: unknown): unknown {
  * other built-in triggers only get `BaseEventSchema` (spaceId).
  */
 function getEventContextSchema(triggerTypeId: string): unknown {
+  // TODO: support custom trigger event schemas
   if (triggerTypeId === 'alert') {
-    const merged = z.object({
-      ...(BaseEventSchema as z.ZodObject<z.ZodRawShape>).shape,
-      ...(AlertEventPropsSchema as z.ZodObject<z.ZodRawShape>).shape,
-    });
-    return zodToJsonSchemaSafe(merged);
+    return zodToJsonSchemaSafe(AlertEventSchema);
   }
   return zodToJsonSchemaSafe(BaseEventSchema);
 }


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16446

## Summary

The Agent Builder LLM consistently writes `{{ triggers.event }}` instead of `{{ event }}` for alert-triggered workflows, and hallucinates `steps.<name>.with.*` paths instead of `steps.<name>.output`. This PR addresses the root cause by giving the AB structured knowledge of event schemas and explicit guidance on variable paths.

#### Before
<img width="2317" height="1397" alt="Screenshot 2026-03-24 at 16 44 00" src="https://github.com/user-attachments/assets/65c5349a-3af0-4c11-b0c1-ddc9918ce6a8" />

#### After
<img width="2319" height="1400" alt="Screenshot 2026-03-24 at 16 44 15" src="https://github.com/user-attachments/assets/23475ba9-f5e3-436c-b7b3-c31474da3e0e" />


### Changes

**1. `get_trigger_definitions_tool.ts` — Event context schema in tool response**
- Each trigger definition now includes `eventContextSchema` (JSON Schema of what `{{ event.* }}` contains at runtime)
- For `alert` triggers: includes `alerts[]`, `rule`, `params`, `spaceId`
- Includes `eventContextNote` explicitly stating to use `{{ event }}`, not `{{ triggers.event }}`

**2. `workflow_authoring_skill.ts` — Strengthened Liquid Templating guidance**
- Added explicit warning: never use `triggers.event` / `trigger.event`
- Added full alert event structure reference (`event.alerts[0]._id`, `event.rule.name`, etc.)
- Added step output rule: only `steps.<name>.output` is accessible, never `steps.<name>.with.*`
- Added "scan for similar errors" instruction when fixing validation errors

**3. `workflow_yaml_attachment.ts` — Common Fixes for attachment (always visible)**
- Added `triggers.event` → `event` fix
- Added `steps.<name>.output` rule with pointer to `get_step_definitions` + `includeOutputSummary`
- Added "scan for same mistake" instruction

**4. `builtin_trigger_definitions.ts` — Alert trigger usage examples**
- Added `details` field explaining alert event structure
- Added usage example showing `{{ event.rule.name }}` and `{{ event.alerts }}` in workflow steps

## Test plan

- [x] `get_trigger_definitions_tool.test.ts` — 7 tests pass
- [x] `builtin_trigger_definitions.test.ts` — 16 tests pass
- [x] `validate_workflow_tool.test.ts` — 3 tests pass
- [x] No linter errors
- [ ] Manual: create an alert-triggered workflow via AB and verify it uses `{{ event.* }}` correctly