### PR TITLE
[Automatic Import V2] Tighten zod request and response fields

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
@@ -29,6 +29,7 @@ export {
   DeleteDataStreamRequestParams,
   ReanalyzeDataStreamRequestParams,
   ReanalyzeDataStreamRequestBody,
+  UpdateDataStreamPipelineRequestBody,
 } from './model/api/data_streams/data_stream.gen';
 
 export type {

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
@@ -4,6 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
+export {
+  UPLOAD_SAMPLES_MAX_LINES,
+  normalizeLogSamplesFromFileContent,
+  normalizeLogLinesForUpload,
+} from './upload_samples_limits';
+
+export type { NormalizeLogSamplesResult } from './upload_samples_limits';
+
 export type {
   ApproveIntegrationRequest,
   CreateAutoImportIntegrationResponse,

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.gen.ts
@@ -186,9 +186,9 @@ export type UploadSamplesToDataStreamRequestBody = z.infer<
 export const UploadSamplesToDataStreamRequestBody = z
   .object({
     /**
-     * Log lines to upload when the source is a file (omit when using sourceIndex). Each line is limited to 262144 characters (256 Ki).
+     * Log lines to upload when the source is a file (omit when using sourceIndex).
      */
-    samples: z.array(z.string().max(262144)).max(1000).optional(),
+    samples: z.array(z.string()).max(1000).optional(),
     /**
      * Index name to pick samples from.
      */

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.gen.ts
@@ -57,7 +57,7 @@ export const GetDataStreamResultsResponse = z
     /**
      * Results array as JSON objects.
      */
-    results: z.array(z.object({}).catchall(z.unknown())),
+    results: z.array(z.object({}).catchall(z.unknown())).max(10000),
   })
   .strict();
 
@@ -136,9 +136,21 @@ export type UpdateDataStreamPipelineRequestParamsInput = z.input<
 export type UpdateDataStreamPipelineRequestBody = z.infer<
   typeof UpdateDataStreamPipelineRequestBody
 >;
-export const UpdateDataStreamPipelineRequestBody = z.object({
-  ingest_pipeline: z.union([z.string(), z.object({}).catchall(z.unknown())]),
-});
+export const UpdateDataStreamPipelineRequestBody = z
+  .object({
+    /**
+     * JSON string (max 10MiB) or pipeline object. When an object, `processors` is capped at 10000 entries.
+     */
+    ingest_pipeline: z.union([
+      z.string().max(10485760),
+      z
+        .object({
+          processors: z.array(z.object({}).catchall(z.unknown())).max(10000).optional(),
+        })
+        .catchall(z.unknown()),
+    ]),
+  })
+  .strict();
 export type UpdateDataStreamPipelineRequestBodyInput = z.input<
   typeof UpdateDataStreamPipelineRequestBody
 >;
@@ -147,7 +159,7 @@ export type UpdateDataStreamPipelineResponse = z.infer<typeof UpdateDataStreamPi
 export const UpdateDataStreamPipelineResponse = z
   .object({
     ingest_pipeline: z.object({}).catchall(z.unknown()),
-    results: z.array(z.object({}).catchall(z.unknown())),
+    results: z.array(z.object({}).catchall(z.unknown())).max(10000),
   })
   .strict();
 
@@ -174,9 +186,9 @@ export type UploadSamplesToDataStreamRequestBody = z.infer<
 export const UploadSamplesToDataStreamRequestBody = z
   .object({
     /**
-     * The samples to upload (when source is file)
+     * Log lines to upload when the source is a file (omit when using sourceIndex). Each line is limited to 262144 characters (256 Ki).
      */
-    samples: z.array(z.string()).optional(),
+    samples: z.array(z.string().max(262144)).max(1000).optional(),
     /**
      * Index name to pick samples from.
      */

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.schema.yaml
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.schema.yaml
@@ -144,11 +144,9 @@ paths:
                   type: array
                   maxItems: 1000
                   description: >-
-                    Log lines to upload when the source is a file (omit when using sourceIndex). Each line is
-                    limited to 262144 characters (256 Ki).
+                    Log lines to upload when the source is a file (omit when using sourceIndex).
                   items:
                     type: string
-                    maxLength: 262144
                 sourceIndex:
                   type: string
                   minLength: 1

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.schema.yaml
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.schema.yaml
@@ -28,19 +28,29 @@ paths:
             $ref: "../../../model/primitive.schema.yaml#/components/schemas/NonEmptyString"
       requestBody:
         required: true
-        additionalProperties: false
         content:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               required:
                 - ingest_pipeline
               properties:
                 ingest_pipeline:
+                  description: >-
+                    JSON string (max 10MiB) or pipeline object. When an object, `processors` is capped at 10000 entries.
                   oneOf:
                     - type: string
+                      maxLength: 10485760
                     - type: object
                       additionalProperties: true
+                      properties:
+                        processors:
+                          type: array
+                          maxItems: 10000
+                          items:
+                            type: object
+                            additionalProperties: true
       responses:
         200:
           description: The updated data stream results are returned successfully.
@@ -58,6 +68,7 @@ paths:
                     additionalProperties: true
                   results:
                     type: array
+                    maxItems: 10000
                     items:
                       type: object
                       additionalProperties: true
@@ -131,9 +142,13 @@ paths:
               properties:
                 samples:
                   type: array
+                  maxItems: 1000
+                  description: >-
+                    Log lines to upload when the source is a file (omit when using sourceIndex). Each line is
+                    limited to 262144 characters (256 Ki).
                   items:
                     type: string
-                  description: The samples to upload (when source is file)
+                    maxLength: 262144
                 sourceIndex:
                   type: string
                   minLength: 1
@@ -229,6 +244,7 @@ paths:
                   results:
                     description: Results array as JSON objects.
                     type: array
+                    maxItems: 10000
                     items:
                       type: object
                       additionalProperties: true

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.test.ts
@@ -9,6 +9,7 @@ import { expectParseError, expectParseSuccess, stringifyZodError } from '@kbn/zo
 
 import {
   StopAutoImportDataStreamRequestParams,
+  UpdateDataStreamPipelineRequestBody,
   UploadSamplesToDataStreamRequestParams,
   UploadSamplesToDataStreamRequestBody,
   UploadSamplesToDataStreamResponse,
@@ -338,6 +339,26 @@ describe('data stream schemas', () => {
       expect(result.data.samples).toHaveLength(1000);
     });
 
+    it('rejects more than 1000 samples', () => {
+      const payload = {
+        samples: Array.from({ length: 1001 }, (_, i) => `Log line ${i}`),
+        originalSource: validOriginalSource,
+      };
+
+      const result = UploadSamplesToDataStreamRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
+
+    it('rejects a sample line longer than 262144 characters', () => {
+      const payload = {
+        samples: ['x'.repeat(262145)],
+        originalSource: validOriginalSource,
+      };
+
+      const result = UploadSamplesToDataStreamRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
+
     it('accepts file source type', () => {
       const payload = {
         samples: ['Sample 1'],
@@ -474,6 +495,42 @@ describe('data stream schemas', () => {
       expectParseSuccess(result);
 
       expect(result.data).toEqual({ success: true });
+    });
+  });
+
+  describe('UpdateDataStreamPipelineRequestBody', () => {
+    it('rejects object ingest_pipeline with more than 10000 processors', () => {
+      const payload = {
+        ingest_pipeline: {
+          processors: Array.from({ length: 10001 }, () => ({})),
+        },
+      };
+
+      const result = UpdateDataStreamPipelineRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
+
+    it('accepts object ingest_pipeline with exactly 10000 processors', () => {
+      const payload = {
+        ingest_pipeline: {
+          processors: Array.from({ length: 10000 }, () => ({})),
+        },
+      };
+
+      const result = UpdateDataStreamPipelineRequestBody.safeParse(payload);
+      expectParseSuccess(result);
+    });
+
+    it('rejects unknown top-level properties (strict schema)', () => {
+      const payload = {
+        ingest_pipeline: '{}',
+        extra: true,
+      };
+
+      const result = UpdateDataStreamPipelineRequestBody.safeParse(payload);
+      expectParseError(result);
+
+      expect(stringifyZodError(result.error)).toMatch(/unrecognized|Unrecognized/i);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.test.ts
@@ -349,16 +349,6 @@ describe('data stream schemas', () => {
       expectParseError(result);
     });
 
-    it('rejects a sample line longer than 262144 characters', () => {
-      const payload = {
-        samples: ['x'.repeat(262145)],
-        originalSource: validOriginalSource,
-      };
-
-      const result = UploadSamplesToDataStreamRequestBody.safeParse(payload);
-      expectParseError(result);
-    });
-
     it('accepts file source type', () => {
       const payload = {
         samples: ['Sample 1'],

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.gen.ts
@@ -35,7 +35,7 @@ export const ApproveIntegrationRequest = z
     /**
      * The categories of the integration
      */
-    categories: z.array(z.string()).optional(),
+    categories: z.array(z.string()).max(50).optional(),
     /**
      * The LangSmith tracing options
      */
@@ -96,7 +96,7 @@ export const CreateAutoImportIntegrationRequestBody = z
     /**
      * The data streams of the integration
      */
-    dataStreams: z.array(DataStream).optional(),
+    dataStreams: z.array(DataStream).max(50).optional(),
   })
   .strict();
 export type CreateAutoImportIntegrationRequestBodyInput = z.input<
@@ -210,14 +210,15 @@ export const UpdateAutoImportIntegrationRequestBody = z
             /**
              * The input types of the data stream
              */
-            inputTypes: z.array(InputType).optional(),
+            inputTypes: z.array(InputType).max(100).optional(),
             /**
              * The raw samples of the data stream
              */
-            rawSamples: z.array(NonEmptyString).optional(),
+            rawSamples: z.array(NonEmptyString).max(1000).optional(),
           })
           .strict()
       )
+      .max(50)
       .optional(),
   })
   .strict();

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.schema.yaml
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.schema.yaml
@@ -48,6 +48,7 @@ paths:
                 dataStreams:
                   description: The data streams of the integration
                   type: array
+                  maxItems: 50
                   items:
                     $ref: "../../../model/common_attributes.schema.yaml#/components/schemas/DataStream"
       responses:
@@ -132,6 +133,7 @@ paths:
                 dataStreams:
                   description: The data streams of the integration
                   type: array
+                  maxItems: 50
                   items:
                     type: object
                     additionalProperties: false
@@ -142,11 +144,13 @@ paths:
                       inputTypes:
                         description: The input types of the data stream
                         type: array
+                        maxItems: 100
                         items:
                           $ref: "../../../model/common_attributes.schema.yaml#/components/schemas/InputType"
                       rawSamples:
                         description: The raw samples of the data stream
                         type: array
+                        maxItems: 1000
                         items:
                           $ref: "../../../model/primitive.schema.yaml#/components/schemas/NonEmptyString"
       responses:
@@ -309,6 +313,7 @@ components:
         categories:
           description: The categories of the integration
           type: array
+          maxItems: 50
           items:
             type: string
         langSmithOptions:

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/integrations/integration.test.ts
@@ -116,6 +116,15 @@ describe('integration schemas', () => {
       const result = ApproveAutoImportIntegrationRequestBody.safeParse(payload);
       expectParseError(result);
     });
+
+    it('rejects more than 50 categories', () => {
+      const payload = {
+        ...validPayload,
+        categories: Array.from({ length: 51 }, (_, i) => `cat-${i}`),
+      };
+      const result = ApproveAutoImportIntegrationRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
   });
 
   describe('CreateAutoImportIntegrationRequestBody', () => {
@@ -187,6 +196,21 @@ describe('integration schemas', () => {
 
       const result = CreateAutoImportIntegrationRequestBody.safeParse(payload);
       expectParseSuccess(result);
+    });
+
+    it('rejects more than 50 data streams', () => {
+      const payload = {
+        ...validPayload,
+        dataStreams: Array.from({ length: 51 }, (_, i) =>
+          createValidDataStream({
+            dataStreamId: `ds-${i}`,
+            title: `stream-${i}`,
+          })
+        ),
+      };
+
+      const result = CreateAutoImportIntegrationRequestBody.safeParse(payload);
+      expectParseError(result);
     });
 
     it('accepts integration without logo', () => {
@@ -912,6 +936,43 @@ describe('integration schemas', () => {
       expectParseSuccess(result);
 
       expect(result.data).toEqual(payload);
+    });
+
+    it('rejects more than 50 data streams in update', () => {
+      const payload = {
+        dataStreams: Array.from({ length: 51 }, (_, i) => ({
+          description: `ds ${i}`,
+        })),
+      };
+
+      const result = UpdateAutoImportIntegrationRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
+
+    it('rejects more than 1000 raw samples on a data stream update', () => {
+      const payload = {
+        dataStreams: [
+          {
+            rawSamples: Array.from({ length: 1001 }, (_, i) => `s${i}`),
+          },
+        ],
+      };
+
+      const result = UpdateAutoImportIntegrationRequestBody.safeParse(payload);
+      expectParseError(result);
+    });
+
+    it('rejects more than 100 input types on a data stream update', () => {
+      const payload = {
+        dataStreams: [
+          {
+            inputTypes: Array.from({ length: 101 }, () => ({ name: 'filestream' as const })),
+          },
+        ],
+      };
+
+      const result = UpdateAutoImportIntegrationRequestBody.safeParse(payload);
+      expectParseError(result);
     });
 
     it('accepts combined updates', () => {

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/common_attributes.gen.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/common_attributes.gen.ts
@@ -63,7 +63,7 @@ export const DataStream = z.object({
   /**
    * The input types of the data stream
    */
-  inputTypes: z.array(InputType),
+  inputTypes: z.array(InputType).max(100),
 });
 
 /**
@@ -79,7 +79,7 @@ export const Integration = z
     /**
      * The data streams of the integration
      */
-    dataStreams: z.array(DataStream).optional(),
+    dataStreams: z.array(DataStream).max(50).optional(),
     /**
      * The logo of the integration
      */
@@ -154,7 +154,7 @@ export const DataStreamResponse = z.object({
   /**
    * The input types of the data stream
    */
-  inputTypes: z.array(InputType),
+  inputTypes: z.array(InputType).max(100),
   /**
    * The status of the data stream
    */

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/model/common_attributes.schema.yaml
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/model/common_attributes.schema.yaml
@@ -22,6 +22,7 @@ components:
             dataStreams:
               type: array
               description: The data streams of the integration
+              maxItems: 50
               items:
                 $ref: "#/components/schemas/DataStream"
             logo:
@@ -56,6 +57,7 @@ components:
             inputTypes:
               type: array
               description: The input types of the data stream
+              maxItems: 100
               items:
                 $ref: "#/components/schemas/InputType"
     OriginalSourceType:
@@ -136,6 +138,7 @@ components:
             inputTypes:
               type: array
               description: The input types of the data stream
+              maxItems: 100
               items:
                 $ref: "#/components/schemas/InputType"
             status:

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/upload_samples_limits.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/upload_samples_limits.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  normalizeLogLinesForUpload,
+  normalizeLogSamplesFromFileContent,
+  UPLOAD_SAMPLES_MAX_LINES,
+} from './upload_samples_limits';
+
+describe('normalizeLogSamplesFromFileContent', () => {
+  it('splits on newlines and drops empty lines', () => {
+    const { samples, linesOmittedOverLimit } = normalizeLogSamplesFromFileContent('a\n\n b \nc');
+    expect(samples).toEqual(['a', 'b', 'c']);
+    expect(linesOmittedOverLimit).toBe(0);
+  });
+
+  it('caps at UPLOAD_SAMPLES_MAX_LINES non-empty lines', () => {
+    const lines = Array.from({ length: UPLOAD_SAMPLES_MAX_LINES + 5 }, (_, i) => `L${i}`);
+    const { samples, linesOmittedOverLimit } = normalizeLogLinesForUpload(lines);
+    expect(samples).toHaveLength(UPLOAD_SAMPLES_MAX_LINES);
+    expect(linesOmittedOverLimit).toBe(5);
+  });
+});

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/upload_samples_limits.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/upload_samples_limits.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Maximum number of log lines in a single upload request.
+ */
+export const UPLOAD_SAMPLES_MAX_LINES = 1000;
+
+export interface NormalizeLogSamplesResult {
+  samples: string[];
+  linesOmittedOverLimit: number;
+}
+
+export function normalizeLogSamplesFromFileContent(content: string): NormalizeLogSamplesResult {
+  return normalizeLogLinesForUpload(content.split('\n'));
+}
+
+export function normalizeLogLinesForUpload(lines: readonly string[]): NormalizeLogSamplesResult {
+  const samples: string[] = [];
+  let linesOmittedOverLimit = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    if (samples.length >= UPLOAD_SAMPLES_MAX_LINES) {
+      linesOmittedOverLimit++;
+      continue;
+    }
+
+    samples.push(trimmed);
+  }
+
+  return { samples, linesOmittedOverLimit };
+}

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../../../../common', () => ({
   useKibana: jest.fn(() => ({
     services: {
       http: {},
-      notifications: { toasts: { addError: jest.fn() } },
+      notifications: { toasts: { addError: jest.fn(), addWarning: jest.fn() } },
     },
   })),
 }));

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.tsx
@@ -30,7 +30,12 @@ import {
 import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { css } from '@emotion/react';
 import { useParams } from 'react-router-dom';
-import type { DataStream, InputType } from '../../../../../common';
+import {
+  normalizeLogSamplesFromFileContent,
+  UPLOAD_SAMPLES_MAX_LINES,
+  type DataStream,
+  type InputType,
+} from '../../../../../common';
 import type { LogsSourceOption } from '../../forms/types';
 import { useIntegrationForm } from '../../forms/integration_form';
 import * as i18n from './translations';
@@ -269,10 +274,17 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
 
     try {
       if (logsSourceOption === 'file' && logSample) {
-        const samples = logSample
-          .split('\n')
-          .map((line) => line.trim())
-          .filter((line) => line.length > 0);
+        const { samples, linesOmittedOverLimit } = normalizeLogSamplesFromFileContent(logSample);
+
+        if (linesOmittedOverLimit > 0) {
+          notifications.toasts.addWarning({
+            title: i18n.SAMPLES_NORMALIZED_WARNING_TITLE,
+            text: i18n.SAMPLES_NORMALIZED_WARNING_LINES_OMITTED(
+              linesOmittedOverLimit,
+              UPLOAD_SAMPLES_MAX_LINES
+            ),
+          });
+        }
 
         await uploadSamplesMutation.mutateAsync({
           integrationId,

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
@@ -125,6 +125,20 @@ export const CREATE_DATA_STREAM_ERROR = i18n.translate(
   }
 );
 
+export const SAMPLES_NORMALIZED_WARNING_TITLE = i18n.translate(
+  'xpack.automaticImportV2.dataStreams.samplesNormalizedWarningTitle',
+  {
+    defaultMessage: 'Sample log limits applied',
+  }
+);
+
+export const SAMPLES_NORMALIZED_WARNING_LINES_OMITTED = (omittedCount: number, maxLines: number) =>
+  i18n.translate('xpack.automaticImportV2.dataStreams.samplesNormalizedWarningLinesOmitted', {
+    defaultMessage:
+      'Only the first {maxLines} non-empty lines are sent. {omittedCount, plural, one {# additional line was not sent.} other {# additional lines were not sent.}}',
+    values: { omittedCount, maxLines },
+  });
+
 export const LOG_FILE_ERROR = {
   CAN_NOT_READ: i18n.translate('xpack.automaticImportV2.dataStreams.logFileError.canNotRead', {
     defaultMessage: 'Failed to read the log file',

--- a/x-pack/platform/plugins/shared/automatic_import_v2/server/routes/data_stream_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/server/routes/data_stream_routes.ts
@@ -8,7 +8,6 @@
 import type { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
-import { z } from '@kbn/zod/v4';
 import type { AutomaticImportV2PluginRequestHandlerContext } from '../types';
 import { buildAutomaticImportResponse } from './utils';
 import { AUTOMATIC_IMPORT_API_PRIVILEGES } from '../feature';
@@ -18,6 +17,7 @@ import {
   ReanalyzeDataStreamRequestParams,
   ReanalyzeDataStreamRequestBody,
   UploadSamplesToDataStreamRequestBody,
+  UpdateDataStreamPipelineRequestBody,
 } from '../../common';
 
 const isSecurityExceptionError = (err: unknown): boolean => {
@@ -45,12 +45,6 @@ export const registerDataStreamRoutes = (
   getDataStreamResultsRoute(router, logger);
   reanalyzeDataStreamRoute(router, logger);
 };
-
-const UpdateDataStreamPipelineRequestBody = z
-  .object({
-    ingest_pipeline: z.union([z.string(), z.record(z.any(), z.unknown())]),
-  })
-  .strict();
 
 const uploadSamplesRoute = (
   router: IRouter<AutomaticImportV2PluginRequestHandlerContext>,

--- a/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/api/tests/input_validation_api_manager.spec.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/api/tests/input_validation_api_manager.spec.ts
@@ -17,6 +17,10 @@
  * - Raw JSON `__proto__` on PUT is sent as a string body only (avoid client-side prototype hazards).
  * - `originalSource.sourceValue` accepts arbitrary non-empty strings (including “odd” extensions /
  *   path-like names); uploads are not gated on file extension.
+ *
+ * Payload size / abuse guards (see OpenAPI + Zod in `common/model/`): e.g. upload `samples` max
+ * 1000 lines and 262144 chars per line; create `dataStreams` max 50; approve `categories` max 50;
+ * PATCH pipeline string max 10MB and object `processors` max 10000 (validated in `data_stream_routes`).
  */
 
 import { tags } from '@kbn/scout';
@@ -27,6 +31,13 @@ import {
   dataStreamsApiBasePath,
   scoutApiErrorText,
 } from '../fixtures/api_test_constants';
+
+const minimalDataStream = (i: number) => ({
+  dataStreamId: `scout-oversize-ds-${i}`,
+  title: `Stream ${i}`,
+  description: `Description ${i}`,
+  inputTypes: [{ name: 'filestream' as const }],
+});
 
 const VALIDATION_INTEGRATION_ID = 'scout-input-validation-integration';
 const VALIDATION_DS_ID = 'scout-input-validation-ds';
@@ -247,5 +258,51 @@ apiTest.describe(
         expect(scoutApiErrorText(response.body)).toMatch(/unrecognized|Unrecognized/i);
       }
     );
+
+    apiTest('POST .../upload: rejects more than 1000 samples', async ({ apiClient }) => {
+      const response = await apiClient.post(`${dsBasePath}/${VALIDATION_DS_ID}/upload`, {
+        headers: { ...COMMON_API_HEADERS, ...cookieHeader },
+        body: {
+          samples: Array.from({ length: 1001 }, (_, i) => `{"line":${i}}`),
+          originalSource: { sourceType: 'file', sourceValue: 'too-many-samples.log' },
+        },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(400);
+      expectZodBadRequest(response.body);
+    });
+
+    apiTest(
+      'POST .../upload: rejects a single sample line over max length (262144 chars)',
+      async ({ apiClient }) => {
+        const response = await apiClient.post(`${dsBasePath}/${VALIDATION_DS_ID}/upload`, {
+          headers: { ...COMMON_API_HEADERS, ...cookieHeader },
+          body: {
+            samples: ['x'.repeat(262145)],
+            originalSource: { sourceType: 'file', sourceValue: 'oversize-line.log' },
+          },
+          responseType: 'json',
+        });
+        expect(response).toHaveStatusCode(400);
+        expectZodBadRequest(response.body);
+      }
+    );
+
+    apiTest('PUT /integrations: rejects more than 50 data streams', async ({ apiClient }) => {
+      const integrationId = 'scout-oversized-ds-list';
+      const response = await apiClient.put(INTEGRATION_API_BASE_PATH, {
+        headers: { ...COMMON_API_HEADERS, ...cookieHeader },
+        body: {
+          connectorId: 'test-connector-placeholder',
+          integrationId,
+          title: 'Oversized dataStreams',
+          description: 'Request body abuse guard',
+          dataStreams: Array.from({ length: 51 }, (_, i) => minimalDataStream(i)),
+        },
+        responseType: 'json',
+      });
+      expect(response).toHaveStatusCode(400);
+      expectZodBadRequest(response.body);
+    });
   }
 );

--- a/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/api/tests/input_validation_api_manager.spec.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/api/tests/input_validation_api_manager.spec.ts
@@ -19,7 +19,7 @@
  *   path-like names); uploads are not gated on file extension.
  *
  * Payload size / abuse guards (see OpenAPI + Zod in `common/model/`): e.g. upload `samples` max
- * 1000 lines and 262144 chars per line; create `dataStreams` max 50; approve `categories` max 50;
+ * 1000 lines; create `dataStreams` max 50; approve `categories` max 50;
  * PATCH pipeline string max 10MB and object `processors` max 10000 (validated in `data_stream_routes`).
  */
 
@@ -271,22 +271,6 @@ apiTest.describe(
       expect(response).toHaveStatusCode(400);
       expectZodBadRequest(response.body);
     });
-
-    apiTest(
-      'POST .../upload: rejects a single sample line over max length (262144 chars)',
-      async ({ apiClient }) => {
-        const response = await apiClient.post(`${dsBasePath}/${VALIDATION_DS_ID}/upload`, {
-          headers: { ...COMMON_API_HEADERS, ...cookieHeader },
-          body: {
-            samples: ['x'.repeat(262145)],
-            originalSource: { sourceType: 'file', sourceValue: 'oversize-line.log' },
-          },
-          responseType: 'json',
-        });
-        expect(response).toHaveStatusCode(400);
-        expectZodBadRequest(response.body);
-      }
-    );
 
     apiTest('PUT /integrations: rejects more than 50 data streams', async ({ apiClient }) => {
       const integrationId = 'scout-oversized-ds-list';


### PR DESCRIPTION
## Summary

Hardens **Automatic Import V2** public/internal APIs by bounding request (and selected response) payloads in **OpenAPI → generated Zod** schemas, adds **Scout API** coverage for oversize rejects, and routes **PATCH data stream pipeline** validation through the **generated** `UpdateDataStreamPipelineRequestBody` instead of ad hoc route-level Zod.

## Changes

### OpenAPI / generated Zod (`common/model/**/*.schema.yaml` → `*.gen.ts`)

- **Upload samples (`POST .../upload`)**: `samples` max **1000** lines, each line `maxLength` **262144** (256×1024 — documented in schema as a power-of-two per-line cap for memory/payload abuse protection). JSDoc/description explains the **262144** rationale.
- **Integrations**: bounds aligned with validation (e.g. `dataStreams`, `inputTypes`, `rawSamples`, approve `categories`).
- **PATCH pipeline (`UpdateDataStreamPipeline`)**: `ingest_pipeline` as string **max 10MiB** (`maxLength: 10485760`); object form with **`processors` max 10000**; request body **`additionalProperties: false`** → generated **`.strict()`** object.
- **GET pipeline results**: `results` array capped where defined in the schema (e.g. **10000**).
- **Integration list/detail responses**: `IntegrationResponse.dataStreams` intentionally **not** capped with `maxItems` so large real responses are not rejected by the client.

### Tests

- **Jest**: `data_stream.test.ts` (and related) — oversize samples, integration limits, **`UpdateDataStreamPipelineRequestBody`** (processors count, strict top-level keys). Avoids allocating a **>10MiB** string in unit tests (OOM risk).
- **Scout**: `input_validation_api_manager.spec.ts` — e.g. **1001** samples, **262145** char line, **51** `dataStreams` on PUT → **400** (Zod validation).

## How to test

- `node scripts/check_changes.ts`
- `yarn test:jest x-pack/platform/plugins/shared/automatic_import_v2/common/model/api/data_streams/data_stream.test.ts`
- `yarn test:jest x-pack/platform/plugins/shared/automatic_import_v2/server/routes/data_stream_routes.test.ts`