### PR TITLE
[8.19] [Fleet] Fix kuery handling in bulk agent actions (#258582)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/action_runner.ts
@@ -16,7 +16,7 @@ import moment from 'moment';
 import type { Agent } from '../../types';
 import { appContextService } from '..';
 import { SO_SEARCH_LIMIT } from '../../../common/constants';
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { getAgentActions } from './actions';
 import { closePointInTime, getAgentsByKuery } from './crud';
@@ -221,9 +221,7 @@ export abstract class ActionRunner {
 
     const getAgents = async () => {
       const namespaceFilter = await agentsKueryNamespaceFilter(this.actionParams.spaceId);
-      const kuery = namespaceFilter
-        ? `${namespaceFilter} AND ${this.actionParams.kuery}`
-        : this.actionParams.kuery;
+      const kuery = buildFilterWithNamespace(namespaceFilter, this.actionParams.kuery);
 
       return getAgentsByKuery(this.esClient, this.soClient, {
         kuery,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
@@ -10,9 +10,14 @@ import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 
 import { appContextService } from '../app_context';
 import { createAppContextStartContractMock } from '../../mocks';
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
 
 import { reassignAgent, reassignAgents } from './reassign';
 import { createClientMock } from './action.mock';
+import * as crud from './crud';
+import * as reassignActionRunner from './reassign_action_runner';
 
 describe('reassignAgent', () => {
   let mocks: ReturnType<typeof createClientMock>;
@@ -149,5 +154,55 @@ describe('reassignAgent', () => {
       });
       expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
+  });
+});
+
+describe('reassignAgents kuery construction', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+  let mockReassignBatch: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: soClient,
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+    mockReassignBatch = jest
+      .spyOn(reassignActionRunner, 'reassignBatch')
+      .mockResolvedValue({ actionId: 'test-action-id' });
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    mockReassignBatch.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const kuery = 'status:online or status:error or status:offline';
+
+    await reassignAgents(soClient, esClient, { kuery }, regularAgentPolicySO2.id);
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
@@ -18,7 +18,7 @@ import {
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
 import {
@@ -121,7 +121,7 @@ export async function reassignAgents(
   } else if ('kuery' in options) {
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
-    const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+    const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
     const res = await getAgentsByKuery(esClient, soClient, {
       kuery,
       showInactive: options.showInactive ?? false,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.test.ts
@@ -1,0 +1,924 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+
+import type { Agent } from '../../types';
+import {
+  AgentRollbackError,
+  FleetUnauthorizedError,
+  HostedAgentPolicyRestrictionRelatedError,
+  AgentNotFoundError,
+} from '../../errors';
+import { SO_SEARCH_LIMIT } from '../../constants';
+import { getCurrentNamespace } from '../spaces/get_current_namespace';
+import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+
+import {
+  getValidRollbacks,
+  sendRollbackAgentAction,
+  sendRollbackAgentsActions,
+  NO_ROLLBACK_ERROR_MESSAGE,
+  EXPIRED_ROLLBACK_ERROR_MESSAGE,
+} from './rollback';
+import {
+  getAgentPolicyForAgent,
+  getAgentsById,
+  getAgentsByKuery,
+  openPointInTime,
+  updateAgent,
+} from './crud';
+import { createAgentAction } from './actions';
+import { RollbackActionRunner, rollbackBatch } from './rollback_action_runner';
+
+jest.mock('./crud', () => ({
+  getAgentPolicyForAgent: jest.fn(),
+  getAgentsById: jest.fn(),
+  getAgentsByKuery: jest.fn(),
+  openPointInTime: jest.fn(),
+  updateAgent: jest.fn(),
+}));
+
+jest.mock('./actions', () => ({
+  createAgentAction: jest.fn(),
+}));
+
+jest.mock('./rollback_action_runner', () => ({
+  RollbackActionRunner: jest.fn(),
+  rollbackBatch: jest.fn(),
+}));
+
+jest.mock('../spaces/get_current_namespace', () => ({
+  getCurrentNamespace: jest.fn(),
+}));
+
+jest.mock('../spaces/agent_namespaces', () => ({
+  agentsKueryNamespaceFilter: jest.fn(),
+  buildFilterWithNamespace: jest.requireActual('../spaces/agent_namespaces')
+    .buildFilterWithNamespace,
+}));
+
+jest.mock('../license', () => ({
+  licenseService: {
+    hasAtLeast: jest.fn(),
+  },
+}));
+
+const mockGetAgentPolicyForAgent = getAgentPolicyForAgent as jest.MockedFunction<
+  typeof getAgentPolicyForAgent
+>;
+const mockGetAgentsById = getAgentsById as jest.MockedFunction<typeof getAgentsById>;
+const mockGetAgentsByKuery = getAgentsByKuery as jest.MockedFunction<typeof getAgentsByKuery>;
+const mockOpenPointInTime = openPointInTime as jest.MockedFunction<typeof openPointInTime>;
+const mockUpdateAgent = updateAgent as jest.MockedFunction<typeof updateAgent>;
+const mockCreateAgentAction = createAgentAction as jest.MockedFunction<typeof createAgentAction>;
+const mockRollbackBatch = rollbackBatch as jest.MockedFunction<typeof rollbackBatch>;
+const mockRollbackActionRunner = RollbackActionRunner as jest.MockedClass<
+  typeof RollbackActionRunner
+>;
+const mockGetCurrentNamespace = getCurrentNamespace as jest.MockedFunction<
+  typeof getCurrentNamespace
+>;
+const mockAgentsKueryNamespaceFilter = agentsKueryNamespaceFilter as jest.MockedFunction<
+  typeof agentsKueryNamespaceFilter
+>;
+
+describe('rollback', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let soClient: jest.Mocked<SavedObjectsClientContract>;
+  let mockLicenseService: { hasAtLeast: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    soClient = savedObjectsClientMock.create();
+
+    mockGetCurrentNamespace.mockReturnValue('default');
+    mockAgentsKueryNamespaceFilter.mockResolvedValue(undefined);
+
+    // Get the mocked license service and default to having the required license
+    mockLicenseService = jest.requireMock('../license').licenseService;
+    mockLicenseService.hasAtLeast.mockReturnValue(true);
+  });
+
+  describe('getValidRollbacks', () => {
+    it('should return only valid (non-expired) rollbacks', () => {
+      const now = new Date();
+      const futureDate = new Date(now.getTime() + 1000 * 60 * 60); // 1 hour from now
+      const pastDate = new Date(now.getTime() - 1000 * 60 * 60); // 1 hour ago
+
+      const agent: Agent = {
+        id: 'agent-1',
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+            {
+              version: '8.9.0',
+              valid_until: pastDate.toISOString(),
+            },
+            {
+              version: '8.8.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const validRollbacks = getValidRollbacks(agent);
+
+      expect(validRollbacks).toHaveLength(2);
+      expect(validRollbacks[0].version).toBe('8.10.0');
+      expect(validRollbacks[1].version).toBe('8.8.0');
+    });
+
+    it('should return empty array when all rollbacks are expired', () => {
+      const now = new Date();
+      const pastDate = new Date(now.getTime() - 1000 * 60 * 60); // 1 hour ago
+
+      const agent: Agent = {
+        id: 'agent-1',
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.9.0',
+              valid_until: pastDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const validRollbacks = getValidRollbacks(agent);
+
+      expect(validRollbacks).toHaveLength(0);
+    });
+
+    it('should return empty array when agent has no rollbacks', () => {
+      const agent: Agent = {
+        id: 'agent-1',
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+      } as Agent;
+
+      const validRollbacks = getValidRollbacks(agent);
+
+      expect(validRollbacks).toHaveLength(0);
+    });
+
+    it('should return empty array when upgrade is undefined', () => {
+      const agent: Agent = {
+        id: 'agent-1',
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: undefined,
+      } as Agent;
+
+      const validRollbacks = getValidRollbacks(agent);
+
+      expect(validRollbacks).toHaveLength(0);
+    });
+  });
+
+  describe('sendRollbackAgentAction', () => {
+    const mockActionId = 'action-123';
+    const mockAgentId = 'agent-1';
+    const now = new Date();
+    const futureDate = new Date(now.getTime() + 1000 * 60 * 60); // 1 hour from now
+
+    it('should successfully send rollback action for agent with valid rollback', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const mockAgentPolicy = {
+        id: 'policy-1',
+        is_managed: false,
+      };
+
+      mockGetAgentPolicyForAgent.mockResolvedValue(mockAgentPolicy as any);
+      mockCreateAgentAction.mockResolvedValue({ id: mockActionId } as any);
+      mockUpdateAgent.mockResolvedValue(undefined);
+
+      const actionId = await sendRollbackAgentAction(soClient, esClient, agent);
+
+      expect(actionId).toBe(mockActionId);
+      expect(mockGetAgentPolicyForAgent).toHaveBeenCalledWith(soClient, esClient, mockAgentId);
+      expect(mockCreateAgentAction).toHaveBeenCalledWith(esClient, soClient, {
+        agents: [mockAgentId],
+        created_at: expect.any(String),
+        data: {
+          version: '8.10.0',
+          rollback: true,
+        },
+        ack_data: {
+          version: '8.10.0',
+          rollback: true,
+        },
+        type: 'UPGRADE',
+        namespaces: ['default'],
+      });
+      expect(mockUpdateAgent).toHaveBeenCalledWith(esClient, mockAgentId, {
+        upgraded_at: null,
+        upgrade_started_at: expect.any(String),
+      });
+    });
+
+    it('should throw error when agent has no rollbacks', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        AgentRollbackError
+      );
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        NO_ROLLBACK_ERROR_MESSAGE
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when all rollbacks are expired', async () => {
+      const pastDate = new Date(now.getTime() - 1000 * 60 * 60); // 1 hour ago
+
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.9.0',
+              valid_until: pastDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        AgentRollbackError
+      );
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        EXPIRED_ROLLBACK_ERROR_MESSAGE
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when agent policy is hosted', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const mockAgentPolicy = {
+        id: 'policy-1',
+        is_managed: true,
+      };
+
+      mockGetAgentPolicyForAgent.mockResolvedValue(mockAgentPolicy as any);
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        HostedAgentPolicyRestrictionRelatedError
+      );
+
+      expect(mockGetAgentPolicyForAgent).toHaveBeenCalledWith(soClient, esClient, mockAgentId);
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should use the first valid rollback version', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+            {
+              version: '8.9.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const mockAgentPolicy = {
+        id: 'policy-1',
+        is_managed: false,
+      };
+
+      mockGetAgentPolicyForAgent.mockResolvedValue(mockAgentPolicy as any);
+      mockCreateAgentAction.mockResolvedValue({ id: mockActionId } as any);
+      mockUpdateAgent.mockResolvedValue(undefined);
+
+      await sendRollbackAgentAction(soClient, esClient, agent);
+
+      expect(mockCreateAgentAction).toHaveBeenCalledWith(
+        esClient,
+        soClient,
+        expect.objectContaining({
+          data: {
+            version: '8.10.0',
+            rollback: true,
+          },
+        })
+      );
+    });
+
+    it('should use current namespace from soClient', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      const mockAgentPolicy = {
+        id: 'policy-1',
+        is_managed: false,
+      };
+
+      mockGetCurrentNamespace.mockReturnValue('custom-space');
+      mockGetAgentPolicyForAgent.mockResolvedValue(mockAgentPolicy as any);
+      mockCreateAgentAction.mockResolvedValue({ id: mockActionId } as any);
+      mockUpdateAgent.mockResolvedValue(undefined);
+
+      await sendRollbackAgentAction(soClient, esClient, agent);
+
+      expect(mockCreateAgentAction).toHaveBeenCalledWith(
+        esClient,
+        soClient,
+        expect.objectContaining({
+          namespaces: ['custom-space'],
+        })
+      );
+    });
+
+    it('should throw FleetUnauthorizedError when license is insufficient', async () => {
+      mockLicenseService.hasAtLeast.mockReturnValue(false);
+
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        FleetUnauthorizedError
+      );
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        'Agent upgrade rollback requires an enterprise license.'
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should throw AgentRollbackError if agent is unenrolling', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        unenrollment_started_at: '2023-06-01T00:00:00Z',
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        AgentRollbackError
+      );
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        'cannot roll back an unenrolling or unenrolled agent'
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should throw AgentRollbackError if agent is unenrolled', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: false,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        unenrolled_at: '2023-06-01T00:00:00Z',
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        AgentRollbackError
+      );
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        'cannot roll back an unenrolling or unenrolled agent'
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+
+    it('should throw AgentRollbackError if agent is upgrading', async () => {
+      const agent: Agent = {
+        id: mockAgentId,
+        type: 'PERMANENT',
+        active: true,
+        enrolled_at: '2023-01-01T00:00:00Z',
+        local_metadata: {},
+        upgrade_started_at: '2023-06-01T00:00:00Z',
+        upgrade: {
+          rollbacks: [
+            {
+              version: '8.10.0',
+              valid_until: futureDate.toISOString(),
+            },
+          ],
+        },
+      } as Agent;
+
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        AgentRollbackError
+      );
+      await expect(sendRollbackAgentAction(soClient, esClient, agent)).rejects.toThrow(
+        'cannot roll back an upgrading agent'
+      );
+
+      expect(mockGetAgentPolicyForAgent).not.toHaveBeenCalled();
+      expect(mockCreateAgentAction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendRollbackAgentsActions', () => {
+    const mockActionId1 = 'action-1';
+    const mockActionId2 = 'action-2';
+    const now = new Date();
+    const futureDate = new Date(now.getTime() + 1000 * 60 * 60); // 1 hour from now
+    mockGetCurrentNamespace.mockReturnValue('default');
+
+    describe('with agents array', () => {
+      it('should send rollback actions for multiple agents', async () => {
+        const agents: Agent[] = [
+          {
+            id: 'agent-1',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+            upgrade: {
+              rollbacks: [
+                {
+                  version: '8.10.0',
+                  valid_until: futureDate.toISOString(),
+                },
+              ],
+            },
+          },
+          {
+            id: 'agent-2',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+            upgrade: {
+              rollbacks: [
+                {
+                  version: '8.10.0',
+                  valid_until: futureDate.toISOString(),
+                },
+              ],
+            },
+          },
+        ] as Agent[];
+
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [mockActionId1, mockActionId2],
+        });
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          agents,
+        });
+
+        expect(result.actionIds).toEqual([mockActionId1, mockActionId2]);
+        expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, agents, {}, {}, ['default']);
+      });
+
+      it('should handle empty agents array', async () => {
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [],
+        });
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          agents: [],
+        });
+
+        expect(result.actionIds).toEqual([]);
+        expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, [], {}, {}, ['default']);
+      });
+    });
+
+    describe('with agentIds', () => {
+      it('should fetch agents by IDs and send rollback actions', async () => {
+        const agentIds = ['agent-1', 'agent-2'];
+        const agents: Agent[] = [
+          {
+            id: 'agent-1',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+          },
+          {
+            id: 'agent-2',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+          },
+        ] as Agent[];
+
+        mockGetAgentsById.mockResolvedValue(agents);
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [mockActionId1],
+        });
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          agentIds,
+        });
+
+        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(mockGetAgentsById).toHaveBeenCalledWith(esClient, soClient, agentIds);
+        expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, agents, {}, {}, ['default']);
+      });
+
+      it('should handle agents not found', async () => {
+        const agentIds = ['agent-1', 'agent-2'];
+        const agent1: Agent = {
+          id: 'agent-1',
+          type: 'PERMANENT',
+          active: true,
+          enrolled_at: '2023-01-01T00:00:00Z',
+          local_metadata: {},
+        } as Agent;
+
+        mockGetAgentsById.mockResolvedValue([agent1, { id: 'agent-2', notFound: true }] as any);
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [mockActionId1],
+        });
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          agentIds,
+        });
+
+        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(mockRollbackBatch).toHaveBeenCalledWith(
+          esClient,
+          [agent1],
+          { 'agent-2': expect.any(AgentNotFoundError) },
+          {},
+          ['default']
+        );
+      });
+    });
+
+    describe('with kuery', () => {
+      it('should fetch agents by kuery and send rollback actions when total <= batchSize', async () => {
+        const kuery = 'status:online';
+        const agents: Agent[] = [
+          {
+            id: 'agent-1',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+          },
+        ] as Agent[];
+
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents,
+          total: 1,
+          page: 1,
+          perPage: SO_SEARCH_LIMIT,
+        });
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [mockActionId1],
+        });
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+        });
+
+        expect(result.actionIds).toEqual([mockActionId1]);
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(esClient, soClient, {
+          kuery: `(${kuery})`,
+          showAgentless: undefined,
+          showInactive: false,
+          page: 1,
+          perPage: SO_SEARCH_LIMIT,
+        });
+        expect(mockRollbackBatch).toHaveBeenCalledWith(esClient, agents, {}, {}, ['default']);
+      });
+
+      it('should use RollbackActionRunner when total > batchSize', async () => {
+        const kuery = 'status:online';
+        const batchSize = 100;
+        const total = 250;
+        const pitId = 'pit-123';
+
+        const mockRunnerInstance = {
+          processAgentsInBatches: jest.fn().mockResolvedValue({ actionId: mockActionId1 }),
+          getAllActionIds: jest.fn().mockReturnValue([mockActionId1, mockActionId2]),
+        };
+
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents: [],
+          total,
+          page: 1,
+          perPage: batchSize,
+        });
+        mockOpenPointInTime.mockResolvedValue(pitId);
+        mockRollbackActionRunner.mockImplementation(() => mockRunnerInstance as any);
+
+        const result = await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+          batchSize,
+        });
+
+        expect(result.actionIds).toEqual([mockActionId1, mockActionId2]);
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(esClient, soClient, {
+          kuery: `(${kuery})`,
+          showAgentless: undefined,
+          showInactive: false,
+          page: 1,
+          perPage: batchSize,
+        });
+        expect(mockOpenPointInTime).toHaveBeenCalledWith(esClient);
+        expect(mockRollbackActionRunner).toHaveBeenCalledWith(
+          esClient,
+          soClient,
+          expect.objectContaining({
+            kuery,
+            batchSize,
+            total,
+            spaceId: 'default',
+          }),
+          { pitId }
+        );
+        expect(mockRunnerInstance.processAgentsInBatches).toHaveBeenCalled();
+      });
+
+      it('should apply namespace filter to kuery', async () => {
+        const kuery = 'status:online';
+        const namespaceFilter = 'namespaces:default';
+
+        mockAgentsKueryNamespaceFilter.mockResolvedValue(namespaceFilter);
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents: [],
+          total: 1,
+          page: 1,
+          perPage: SO_SEARCH_LIMIT,
+        });
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [],
+        });
+
+        await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+        });
+
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+          esClient,
+          soClient,
+          expect.objectContaining({
+            kuery: `(${namespaceFilter}) AND (${kuery})`,
+          })
+        );
+      });
+
+      it('should handle showAgentless option', async () => {
+        const kuery = 'status:online';
+
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents: [],
+          total: 1,
+          page: 1,
+          perPage: SO_SEARCH_LIMIT,
+        });
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [],
+        });
+
+        await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+          showAgentless: true,
+        });
+
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+          esClient,
+          soClient,
+          expect.objectContaining({
+            showAgentless: true,
+          })
+        );
+      });
+
+      it('should handle includeInactive option', async () => {
+        const kuery = 'status:online';
+
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents: [],
+          total: 1,
+          page: 1,
+          perPage: SO_SEARCH_LIMIT,
+        });
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [],
+        });
+
+        await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+          includeInactive: true,
+        });
+
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+          esClient,
+          soClient,
+          expect.objectContaining({
+            showInactive: true,
+          })
+        );
+      });
+
+      it('should use custom batchSize', async () => {
+        const kuery = 'status:online';
+        const customBatchSize = 50;
+
+        mockGetAgentsByKuery.mockResolvedValue({
+          agents: [],
+          total: 1,
+          page: 1,
+          perPage: customBatchSize,
+        });
+        mockRollbackBatch.mockResolvedValue({
+          actionIds: [],
+        });
+
+        await sendRollbackAgentsActions(soClient, esClient, {
+          kuery,
+          batchSize: customBatchSize,
+        });
+
+        expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+          esClient,
+          soClient,
+          expect.objectContaining({
+            perPage: customBatchSize,
+          })
+        );
+      });
+    });
+
+    describe('license check', () => {
+      it('should throw FleetUnauthorizedError when license is insufficient', async () => {
+        mockLicenseService.hasAtLeast.mockReturnValue(false);
+
+        const agents: Agent[] = [
+          {
+            id: 'agent-1',
+            type: 'PERMANENT',
+            active: true,
+            enrolled_at: '2023-01-01T00:00:00Z',
+            local_metadata: {},
+          },
+        ] as Agent[];
+
+        await expect(sendRollbackAgentsActions(soClient, esClient, { agents })).rejects.toThrow(
+          FleetUnauthorizedError
+        );
+
+        await expect(sendRollbackAgentsActions(soClient, esClient, { agents })).rejects.toThrow(
+          'Agent upgrade rollback requires an enterprise license.'
+        );
+
+        expect(mockRollbackBatch).not.toHaveBeenCalled();
+      });
+
+      it('should throw FleetUnauthorizedError when license is insufficient for agentIds', async () => {
+        mockLicenseService.hasAtLeast.mockReturnValue(false);
+
+        await expect(
+          sendRollbackAgentsActions(soClient, esClient, { agentIds: ['agent-1'] })
+        ).rejects.toThrow(FleetUnauthorizedError);
+
+        await expect(
+          sendRollbackAgentsActions(soClient, esClient, { agentIds: ['agent-1'] })
+        ).rejects.toThrow('Agent upgrade rollback requires an enterprise license.');
+
+        expect(mockGetAgentsById).not.toHaveBeenCalled();
+      });
+
+      it('should throw FleetUnauthorizedError when license is insufficient for kuery', async () => {
+        mockLicenseService.hasAtLeast.mockReturnValue(false);
+
+        await expect(
+          sendRollbackAgentsActions(soClient, esClient, { kuery: 'status:online' })
+        ).rejects.toThrow(FleetUnauthorizedError);
+
+        await expect(
+          sendRollbackAgentsActions(soClient, esClient, { kuery: 'status:online' })
+        ).rejects.toThrow('Agent upgrade rollback requires an enterprise license.');
+
+        expect(mockGetAgentsByKuery).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/rollback.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+
+import type { Agent } from '../../types';
+import {
+  AgentRollbackError,
+  FleetUnauthorizedError,
+  HostedAgentPolicyRestrictionRelatedError,
+} from '../../errors';
+import { AgentNotFoundError } from '../../errors';
+import { SO_SEARCH_LIMIT } from '../../constants';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
+import { getCurrentNamespace } from '../spaces/get_current_namespace';
+import { licenseService } from '../license';
+import { LICENSE_FOR_AGENT_ROLLBACK } from '../../../common/constants';
+import { isAgentUpgrading } from '../../../common/services';
+
+import {
+  getAgentPolicyForAgent,
+  getAgentsById,
+  getAgentsByKuery,
+  type GetAgentsOptions,
+  openPointInTime,
+  updateAgent,
+} from './crud';
+import { RollbackActionRunner } from './rollback_action_runner';
+import { rollbackBatch } from './rollback_action_runner';
+import { createAgentAction } from './actions';
+
+export const NO_ROLLBACK_ERROR_MESSAGE = 'upgrade rollback not available for agent';
+export const EXPIRED_ROLLBACK_ERROR_MESSAGE = 'upgrade rollback window has expired';
+
+function checkLicense() {
+  if (!licenseService.hasAtLeast(LICENSE_FOR_AGENT_ROLLBACK)) {
+    throw new FleetUnauthorizedError(
+      `Agent upgrade rollback requires an ${LICENSE_FOR_AGENT_ROLLBACK} license.`
+    );
+  }
+}
+
+export function getValidRollbacks(agent: Agent) {
+  const now = new Date();
+  return (agent.upgrade?.rollbacks || []).filter((rollback) => {
+    const validUntil = new Date(rollback.valid_until);
+    return validUntil > now;
+  });
+}
+
+export async function sendRollbackAgentAction(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  agent: Agent
+) {
+  checkLicense();
+
+  if (agent.unenrollment_started_at || agent.unenrolled_at) {
+    throw new AgentRollbackError('cannot roll back an unenrolling or unenrolled agent');
+  }
+
+  if (isAgentUpgrading(agent)) {
+    throw new AgentRollbackError('cannot roll back an upgrading agent');
+  }
+
+  const rollbacks = agent.upgrade?.rollbacks || [];
+  if (rollbacks.length === 0) {
+    throw new AgentRollbackError(NO_ROLLBACK_ERROR_MESSAGE);
+  }
+
+  const validRollbacks = getValidRollbacks(agent);
+  if (validRollbacks.length === 0) {
+    throw new AgentRollbackError(EXPIRED_ROLLBACK_ERROR_MESSAGE);
+  }
+
+  const agentPolicy = await getAgentPolicyForAgent(soClient, esClient, agent.id);
+  if (agentPolicy?.is_managed) {
+    throw new HostedAgentPolicyRestrictionRelatedError(
+      `Cannot roll back upgrade for agent ${agent.id} on hosted agent policy ${agentPolicy.id}`
+    );
+  }
+
+  const now = new Date().toISOString();
+  const currentSpaceId = getCurrentNamespace(soClient);
+  const data = {
+    version: validRollbacks[0].version,
+    rollback: true,
+  };
+
+  const action = await createAgentAction(esClient, soClient, {
+    agents: [agent.id],
+    created_at: now,
+    data,
+    ack_data: data,
+    type: 'UPGRADE',
+    namespaces: [currentSpaceId],
+  });
+
+  await updateAgent(esClient, agent.id, {
+    upgraded_at: null,
+    upgrade_started_at: now,
+  });
+
+  return action.id;
+}
+
+export async function sendRollbackAgentsActions(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  options: ({ agents: Agent[] } | GetAgentsOptions) & {
+    batchSize?: number;
+    includeInactive?: boolean;
+  }
+): Promise<{ actionIds: string[] }> {
+  checkLicense();
+
+  const currentSpaceId = getCurrentNamespace(soClient);
+  const errors: Record<Agent['id'], Error> = {};
+  let givenAgents: Agent[] = [];
+
+  if ('agents' in options) {
+    givenAgents = options.agents;
+  } else if ('agentIds' in options) {
+    const maybeAgents = await getAgentsById(esClient, soClient, options.agentIds);
+    for (const maybeAgent of maybeAgents) {
+      if ('notFound' in maybeAgent) {
+        errors[maybeAgent.id] = new AgentNotFoundError(`Agent ${maybeAgent.id} not found`);
+      } else {
+        givenAgents.push(maybeAgent);
+      }
+    }
+  } else if ('kuery' in options) {
+    const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
+    const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
+    const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
+
+    const res = await getAgentsByKuery(esClient, soClient, {
+      kuery,
+      showAgentless: options.showAgentless,
+      showInactive: options.includeInactive ?? false,
+      page: 1,
+      perPage: batchSize,
+    });
+
+    if (res.total <= batchSize) {
+      givenAgents = res.agents;
+    } else {
+      // Upgrade rollback returns all action IDs (one per rollback version group)
+      // Process all batches synchronously to collect all action IDs
+      const runner = new RollbackActionRunner(
+        esClient,
+        soClient,
+        {
+          ...options,
+          batchSize,
+          total: res.total,
+          spaceId: currentSpaceId,
+        },
+        { pitId: await openPointInTime(esClient) }
+      );
+      // Process all batches synchronously to collect all action IDs
+      await runner.processAgentsInBatches();
+      // Return all collected action IDs
+      return {
+        actionIds: runner.getAllActionIds(),
+      };
+    }
+  }
+
+  const result = await rollbackBatch(esClient, givenAgents, errors, {}, [currentSpaceId]);
+  return {
+    actionIds: result.actionIds,
+  };
+}

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
@@ -17,9 +17,14 @@ import { createAppContextStartContractMock } from '../../mocks';
 
 import type { Agent } from '../../types';
 
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
+
 import { unenrollAgent, unenrollAgents } from './unenroll';
 import { invalidateAPIKeysForAgents, isAgentUnenrolled } from './unenroll_action_runner';
 import { createClientMock } from './action.mock';
+import * as crud from './crud';
 
 jest.mock('../api_keys');
 
@@ -411,5 +416,49 @@ describe('unenroll', () => {
         false
       );
     });
+  });
+});
+
+describe('unenrollAgents kuery construction', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient } = createClientMock();
+    const kuery = 'status:online or status:error or status:offline';
+
+    await unenrollAgents(soClient, esClient, { kuery });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
@@ -13,7 +13,7 @@ import type { Agent } from '../../types';
 import { FleetError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { createAgentAction } from './actions';
 import type { GetAgentsOptions } from './crud';
@@ -103,7 +103,7 @@ export async function unenrollAgents(
 
   const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
   const namespaceFilter = await agentsKueryNamespaceFilter(spaceId);
-  const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+  const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
   const res = await getAgentsByKuery(esClient, soClient, {
     kuery,
     showInactive: options.showInactive ?? false,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
@@ -12,7 +12,7 @@ import { AgentReassignmentError } from '../../errors';
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
@@ -46,17 +46,21 @@ export async function updateAgentTags(
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
 
-    const filters = namespaceFilter ? [namespaceFilter] : [];
-    if (options.kuery !== '') {
-      filters.push(options.kuery);
+    const nsAndKuery = buildFilterWithNamespace(
+      namespaceFilter,
+      options.kuery !== '' ? options.kuery : undefined
+    );
+    const filters: string[] = [];
+    if (nsAndKuery) {
+      filters.push(nsAndKuery);
     }
     if (tagsToAdd.length === 1 && tagsToRemove.length === 0) {
-      filters.push(`NOT (tags:${tagsToAdd[0]})`);
+      filters.push(`(NOT (tags:${tagsToAdd[0]}))`);
     } else if (tagsToRemove.length === 1 && tagsToAdd.length === 0) {
-      filters.push(`tags:${tagsToRemove[0]}`);
+      filters.push(`(tags:${tagsToRemove[0]})`);
     }
 
-    const kuery = filters.map((filter) => `(${filter})`).join(' AND ');
+    const kuery = filters.join(' AND ');
     const pitId = await openPointInTime(esClient);
 
     // calculate total count

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
@@ -11,9 +11,14 @@ import { appContextService } from '../app_context';
 import type { Agent } from '../../types';
 import { createAppContextStartContractMock } from '../../mocks';
 
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
+
 import { sendUpgradeAgentsActions } from './upgrade';
 import { createClientMock } from './action.mock';
 import { getRollingUpgradeOptions, upgradeBatch } from './upgrade_action_runner';
+import * as crud from './crud';
 
 jest.mock('./versions', () => {
   return {
@@ -182,5 +187,51 @@ describe('getRollingUpgradeOptions', () => {
   it('should return empty options for no start time, no duration', () => {
     const options = getRollingUpgradeOptions();
     expect(options).toEqual({});
+  });
+});
+
+describe('sendUpgradeAgentsActions kuery construction', () => {
+  let upgradeMocks: ReturnType<typeof createClientMock>;
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+
+  beforeEach(async () => {
+    upgradeMocks = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: upgradeMocks.soClient,
+        withoutSpaceExtensions: upgradeMocks.soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const kuery = 'status:online or status:error or status:offline';
+
+    await sendUpgradeAgentsActions(soClient, esClient, { kuery, version: '8.5.0' });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
@@ -10,7 +10,7 @@ import type { Agent } from '../../types';
 import { AgentReassignmentError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
 import { createAgentAction } from './actions';
@@ -97,7 +97,7 @@ export async function sendUpgradeAgentsActions(
   } else if ('kuery' in options) {
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
-    const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+    const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
 
     const res = await getAgentsByKuery(esClient, soClient, {
       kuery,

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.test.ts
@@ -7,7 +7,11 @@
 
 import type { Agent } from '../../types';
 
-import { agentsKueryNamespaceFilter, isAgentInNamespace } from './agent_namespaces';
+import {
+  agentsKueryNamespaceFilter,
+  buildFilterWithNamespace,
+  isAgentInNamespace,
+} from './agent_namespaces';
 import { isSpaceAwarenessEnabled } from './helpers';
 
 jest.mock('./helpers');
@@ -114,5 +118,58 @@ describe('agentsKueryNamespaceFilter', () => {
     it('returns a kuery for custom spaces', async () => {
       expect(await agentsKueryNamespaceFilter('space1')).toEqual('namespaces:(space1)');
     });
+  });
+});
+
+describe('buildFilterWithNamespace', () => {
+  it('returns undefined when both namespace filter and kuery are undefined', () => {
+    expect(buildFilterWithNamespace(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when namespace filter is undefined and kuery is empty', () => {
+    expect(buildFilterWithNamespace(undefined, '')).toBeUndefined();
+  });
+
+  it('returns undefined when namespace filter is undefined and kuery is whitespace', () => {
+    expect(buildFilterWithNamespace(undefined, '   ')).toBeUndefined();
+  });
+
+  it('returns only the namespace filter wrapped in parentheses when kuery is undefined', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', undefined)).toEqual(
+      '(namespaces:(space1))'
+    );
+  });
+
+  it('returns only the namespace filter wrapped in parentheses when kuery is empty', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', '')).toEqual('(namespaces:(space1))');
+  });
+
+  it('returns only the kuery wrapped in parentheses when namespace filter is undefined', () => {
+    expect(buildFilterWithNamespace(undefined, 'status:online')).toEqual('(status:online)');
+  });
+
+  it('wraps both parts in parentheses before joining with AND', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', 'status:online')).toEqual(
+      '(namespaces:(space1)) AND (status:online)'
+    );
+  });
+
+  it('prevents KQL precedence issues when kuery contains OR operators', () => {
+    const namespaceFilter = 'namespaces:(custom_space)';
+    const kuery = 'status:online or status:error or status:offline';
+    const result = buildFilterWithNamespace(namespaceFilter, kuery);
+    expect(result).toEqual(
+      '(namespaces:(custom_space)) AND (status:online or status:error or status:offline)'
+    );
+  });
+
+  it('handles the default space namespace filter with OR operators in kuery', () => {
+    const namespaceFilter = '(namespaces:"default" or namespaces:"*" or not namespaces:*)';
+    const kuery =
+      'status:online or (status:error or status:degraded) or status:orphaned or status:offline';
+    const result = buildFilterWithNamespace(namespaceFilter, kuery);
+    expect(result).toEqual(
+      '((namespaces:"default" or namespaces:"*" or not namespaces:*)) AND (status:online or (status:error or status:degraded) or status:orphaned or status:offline)'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.ts
@@ -40,3 +40,26 @@ export async function agentsKueryNamespaceFilter(namespace?: string) {
     ? `namespaces:(${DEFAULT_NAMESPACE_STRING}) or not namespaces:*`
     : `namespaces:(${namespace})`;
 }
+
+/**
+ * Safely combines a namespace filter with a user-provided kuery by wrapping
+ * each part in parentheses before joining with AND. This prevents KQL operator
+ * precedence issues where OR clauses in the user kuery could bypass the
+ * namespace filter.
+ */
+export function buildFilterWithNamespace(
+  namespaceFilter: string | undefined,
+  kuery: string | undefined
+): string | undefined {
+  const filters: string[] = [];
+  if (namespaceFilter) {
+    filters.push(namespaceFilter);
+  }
+  if (kuery && kuery.trim() !== '') {
+    filters.push(kuery);
+  }
+  if (filters.length === 0) {
+    return undefined;
+  }
+  return filters.map((filter) => `(${filter})`).join(' AND ');
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Fleet] Fix kuery handling in bulk agent actions (#258582)](https://github.com/elastic/kibana/pull/258582)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-03-24T10:47:38Z","message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14"],"title":"[Fleet] Fix kuery handling in bulk agent actions","number":258582,"url":"https://github.com/elastic/kibana/pull/258582","mergeCommit":{"message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258582","number":258582,"mergeCommit":{"message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->