### PR TITLE
[Code Coverage]Remove scheduled job from kibana code coverage job

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -42,10 +42,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
-      schedules:
-        Daily 6 am UTC:
-          cronline: 0 5 * * *
-          message: Daily 6 am UTC
-          branch: main
       tags:
         - kibana


### PR DESCRIPTION
## Summary

Removing the scheduling as we're planning to decommission the code coverage jobs. It will be left like that for a couple weeks to see if any issues arise from it. Once we make sure nothing is broken with the job being disabled, we can completely delete it. 




