### PR TITLE
[9.2] [Fleet] Fix kuery handling in bulk agent actions (#258582)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/action_runner.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/action_runner.ts
@@ -16,7 +16,7 @@ import moment from 'moment';
 import type { Agent } from '../../types';
 import { appContextService } from '..';
 import { SO_SEARCH_LIMIT } from '../../../common/constants';
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { getAgentActions } from './actions';
 import { closePointInTime, getAgentsByKuery } from './crud';
@@ -221,11 +221,7 @@ export abstract class ActionRunner {
 
     const getAgents = async () => {
       const namespaceFilter = await agentsKueryNamespaceFilter(this.actionParams.spaceId);
-
-      const kuery = [
-        ...(namespaceFilter ? [namespaceFilter] : []),
-        ...(this.actionParams.kuery ? [this.actionParams.kuery] : []),
-      ].join(' AND ');
+      const kuery = buildFilterWithNamespace(namespaceFilter, this.actionParams.kuery);
 
       return getAgentsByKuery(this.esClient, this.soClient, {
         kuery,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.test.ts
@@ -10,9 +10,14 @@ import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 
 import { appContextService } from '../app_context';
 import { createAppContextStartContractMock } from '../../mocks';
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
 
 import { reassignAgent, reassignAgents } from './reassign';
 import { createClientMock } from './action.mock';
+import * as crud from './crud';
+import * as reassignActionRunner from './reassign_action_runner';
 
 describe('reassignAgent', () => {
   let mocks: ReturnType<typeof createClientMock>;
@@ -167,5 +172,55 @@ describe('reassignAgent', () => {
       });
       expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
+  });
+});
+
+describe('reassignAgents kuery construction', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+  let mockReassignBatch: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: soClient,
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+    mockReassignBatch = jest
+      .spyOn(reassignActionRunner, 'reassignBatch')
+      .mockResolvedValue({ actionId: 'test-action-id' });
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    mockReassignBatch.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient, regularAgentPolicySO2 } = createClientMock();
+    const kuery = 'status:online or status:error or status:offline';
+
+    await reassignAgents(soClient, esClient, { kuery }, regularAgentPolicySO2.id);
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/reassign.ts
@@ -18,7 +18,7 @@ import {
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
 import {
@@ -124,7 +124,7 @@ export async function reassignAgents(
   } else if ('kuery' in options) {
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
-    const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+    const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
     const res = await getAgentsByKuery(esClient, soClient, {
       kuery,
       showAgentless: options.showAgentless,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.test.ts
@@ -17,9 +17,14 @@ import { createAppContextStartContractMock } from '../../mocks';
 
 import type { Agent } from '../../types';
 
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
+
 import { unenrollAgent, unenrollAgents } from './unenroll';
 import { invalidateAPIKeysForAgents, isAgentUnenrolled } from './unenroll_action_runner';
 import { createClientMock } from './action.mock';
+import * as crud from './crud';
 
 jest.mock('../api_keys');
 
@@ -411,5 +416,49 @@ describe('unenroll', () => {
         false
       );
     });
+  });
+});
+
+describe('unenrollAgents kuery construction', () => {
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const { soClient } = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        withoutSpaceExtensions: soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient } = createClientMock();
+    const kuery = 'status:online or status:error or status:offline';
+
+    await unenrollAgents(soClient, esClient, { kuery });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
@@ -13,7 +13,7 @@ import type { Agent } from '../../types';
 import { FleetError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { createAgentAction } from './actions';
 import type { GetAgentsOptions } from './crud';
@@ -103,7 +103,7 @@ export async function unenrollAgents(
 
   const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
   const namespaceFilter = await agentsKueryNamespaceFilter(spaceId);
-  const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+  const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
   const res = await getAgentsByKuery(esClient, soClient, {
     kuery,
     showAgentless: options.showAgentless,

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/update_agent_tags.ts
@@ -13,7 +13,7 @@ import { AgentReassignmentError, FleetVersionConflictError } from '../../errors'
 
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
@@ -47,17 +47,21 @@ export async function updateAgentTags(
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
 
-    const filters = namespaceFilter ? [namespaceFilter] : [];
-    if (options.kuery !== '') {
-      filters.push(options.kuery);
+    const nsAndKuery = buildFilterWithNamespace(
+      namespaceFilter,
+      options.kuery !== '' ? options.kuery : undefined
+    );
+    const filters: string[] = [];
+    if (nsAndKuery) {
+      filters.push(nsAndKuery);
     }
     if (tagsToAdd.length === 1 && tagsToRemove.length === 0) {
-      filters.push(`NOT (tags:${tagsToAdd[0]})`);
+      filters.push(`(NOT (tags:${tagsToAdd[0]}))`);
     } else if (tagsToRemove.length === 1 && tagsToAdd.length === 0) {
-      filters.push(`tags:${tagsToRemove[0]}`);
+      filters.push(`(tags:${tagsToRemove[0]})`);
     }
 
-    const kuery = filters.map((filter) => `(${filter})`).join(' AND ');
+    const kuery = filters.join(' AND ');
     const pitId = await openPointInTime(esClient);
 
     // calculate total count

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.test.ts
@@ -11,9 +11,14 @@ import { appContextService } from '../app_context';
 import type { Agent } from '../../types';
 import { createAppContextStartContractMock } from '../../mocks';
 
+import { SO_SEARCH_LIMIT } from '../../constants';
+
+import * as agentNamespaces from '../spaces/agent_namespaces';
+
 import { sendUpgradeAgentsActions } from './upgrade';
 import { createClientMock } from './action.mock';
 import { getRollingUpgradeOptions, upgradeBatch } from './upgrade_action_runner';
+import * as crud from './crud';
 
 jest.mock('./versions', () => {
   return {
@@ -163,5 +168,51 @@ describe('getRollingUpgradeOptions', () => {
   it('should return empty options for no start time, no duration', () => {
     const options = getRollingUpgradeOptions();
     expect(options).toEqual({});
+  });
+});
+
+describe('sendUpgradeAgentsActions kuery construction', () => {
+  let upgradeMocks: ReturnType<typeof createClientMock>;
+  let mockGetAgentsByKuery: jest.SpyInstance;
+  let mockAgentsKueryNamespaceFilter: jest.SpyInstance;
+
+  beforeEach(async () => {
+    upgradeMocks = createClientMock();
+    appContextService.start(
+      createAppContextStartContractMock({}, false, {
+        internal: upgradeMocks.soClient,
+        withoutSpaceExtensions: upgradeMocks.soClient,
+      })
+    );
+    mockGetAgentsByKuery = jest.spyOn(crud, 'getAgentsByKuery').mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+    });
+    mockAgentsKueryNamespaceFilter = jest
+      .spyOn(agentNamespaces, 'agentsKueryNamespaceFilter')
+      .mockResolvedValue('namespaces:custom_space');
+  });
+
+  afterEach(() => {
+    mockGetAgentsByKuery.mockRestore();
+    mockAgentsKueryNamespaceFilter.mockRestore();
+    appContextService.stop();
+  });
+
+  it('wraps namespace filter and kuery containing OR in parentheses', async () => {
+    const { soClient, esClient } = upgradeMocks;
+    const kuery = 'status:online or status:error or status:offline';
+
+    await sendUpgradeAgentsActions(soClient, esClient, { kuery, version: '8.5.0' });
+
+    expect(mockGetAgentsByKuery).toHaveBeenCalledWith(
+      esClient,
+      soClient,
+      expect.objectContaining({
+        kuery: `(namespaces:custom_space) AND (${kuery})`,
+      })
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/upgrade.ts
@@ -10,7 +10,7 @@ import type { Agent } from '../../types';
 import { AgentReassignmentError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 
-import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
+import { agentsKueryNamespaceFilter, buildFilterWithNamespace } from '../spaces/agent_namespaces';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
 import { createAgentAction } from './actions';
@@ -97,7 +97,7 @@ export async function sendUpgradeAgentsActions(
   } else if ('kuery' in options) {
     const batchSize = options.batchSize ?? SO_SEARCH_LIMIT;
     const namespaceFilter = await agentsKueryNamespaceFilter(currentSpaceId);
-    const kuery = namespaceFilter ? `${namespaceFilter} AND ${options.kuery}` : options.kuery;
+    const kuery = buildFilterWithNamespace(namespaceFilter, options.kuery);
 
     const res = await getAgentsByKuery(esClient, soClient, {
       kuery,

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.test.ts
@@ -7,7 +7,11 @@
 
 import type { Agent } from '../../types';
 
-import { agentsKueryNamespaceFilter, isAgentInNamespace } from './agent_namespaces';
+import {
+  agentsKueryNamespaceFilter,
+  buildFilterWithNamespace,
+  isAgentInNamespace,
+} from './agent_namespaces';
 import { isSpaceAwarenessEnabled } from './helpers';
 
 jest.mock('./helpers');
@@ -114,5 +118,58 @@ describe('agentsKueryNamespaceFilter', () => {
     it('returns a kuery for custom spaces', async () => {
       expect(await agentsKueryNamespaceFilter('space1')).toEqual('namespaces:(space1)');
     });
+  });
+});
+
+describe('buildFilterWithNamespace', () => {
+  it('returns undefined when both namespace filter and kuery are undefined', () => {
+    expect(buildFilterWithNamespace(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when namespace filter is undefined and kuery is empty', () => {
+    expect(buildFilterWithNamespace(undefined, '')).toBeUndefined();
+  });
+
+  it('returns undefined when namespace filter is undefined and kuery is whitespace', () => {
+    expect(buildFilterWithNamespace(undefined, '   ')).toBeUndefined();
+  });
+
+  it('returns only the namespace filter wrapped in parentheses when kuery is undefined', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', undefined)).toEqual(
+      '(namespaces:(space1))'
+    );
+  });
+
+  it('returns only the namespace filter wrapped in parentheses when kuery is empty', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', '')).toEqual('(namespaces:(space1))');
+  });
+
+  it('returns only the kuery wrapped in parentheses when namespace filter is undefined', () => {
+    expect(buildFilterWithNamespace(undefined, 'status:online')).toEqual('(status:online)');
+  });
+
+  it('wraps both parts in parentheses before joining with AND', () => {
+    expect(buildFilterWithNamespace('namespaces:(space1)', 'status:online')).toEqual(
+      '(namespaces:(space1)) AND (status:online)'
+    );
+  });
+
+  it('prevents KQL precedence issues when kuery contains OR operators', () => {
+    const namespaceFilter = 'namespaces:(custom_space)';
+    const kuery = 'status:online or status:error or status:offline';
+    const result = buildFilterWithNamespace(namespaceFilter, kuery);
+    expect(result).toEqual(
+      '(namespaces:(custom_space)) AND (status:online or status:error or status:offline)'
+    );
+  });
+
+  it('handles the default space namespace filter with OR operators in kuery', () => {
+    const namespaceFilter = '(namespaces:"default" or namespaces:"*" or not namespaces:*)';
+    const kuery =
+      'status:online or (status:error or status:degraded) or status:orphaned or status:offline';
+    const result = buildFilterWithNamespace(namespaceFilter, kuery);
+    expect(result).toEqual(
+      '((namespaces:"default" or namespaces:"*" or not namespaces:*)) AND (status:online or (status:error or status:degraded) or status:orphaned or status:offline)'
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/spaces/agent_namespaces.ts
@@ -39,3 +39,26 @@ export async function agentsKueryNamespaceFilter(namespace?: string) {
   }
   return namespace === DEFAULT_SPACE_ID ? DEFAULT_NAMESPACES_FILTER : `namespaces:(${namespace})`;
 }
+
+/**
+ * Safely combines a namespace filter with a user-provided kuery by wrapping
+ * each part in parentheses before joining with AND. This prevents KQL operator
+ * precedence issues where OR clauses in the user kuery could bypass the
+ * namespace filter.
+ */
+export function buildFilterWithNamespace(
+  namespaceFilter: string | undefined,
+  kuery: string | undefined
+): string | undefined {
+  const filters: string[] = [];
+  if (namespaceFilter) {
+    filters.push(namespaceFilter);
+  }
+  if (kuery && kuery.trim() !== '') {
+    filters.push(kuery);
+  }
+  if (filters.length === 0) {
+    return undefined;
+  }
+  return filters.map((filter) => `(${filter})`).join(' AND ');
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Fleet] Fix kuery handling in bulk agent actions (#258582)](https://github.com/elastic/kibana/pull/258582)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2026-03-24T10:47:38Z","message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14"],"title":"[Fleet] Fix kuery handling in bulk agent actions","number":258582,"url":"https://github.com/elastic/kibana/pull/258582","mergeCommit":{"message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258582","number":258582,"mergeCommit":{"message":"[Fleet] Fix kuery handling in bulk agent actions (#258582)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/258069\n\nTesting:\n* Create two spaces and enroll some agents in both\n* In space 2, upgrade some agents so that their runtime status is\n`updating`\n* In space 1, force unenroll agents with a kuery that contains an OR on\nstatus, e.g.:\n   ```\n   POST kbn:/api/fleet/agents/bulk_unenroll\n   {\n     \"agents\": \"status:online or status:updating\",\n     \"force\": true\n   }\n   ```\n* On `main`, the updating agents in space 2 would be unenrolled; with\nthis fix they shouldn't be affected\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n### Identify risks\n\nLow probability risk of incorrectly selecting agents by kuery in Fleet\nbulk agent actions.\n\n## Release note\n\nFixes space-awareness for Fleet bulk agent actions (unenroll, upgrade,\nreassign to policy).\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"abad64f043642b0f71c7668ba0e60e228f021a1f"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259380","number":259380,"state":"OPEN"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259392","number":259392,"state":"OPEN"}]}] BACKPORT-->