### PR TITLE
[Index Management] A11y: Announce mappings field list changes

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import { EuiLiveAnnouncer } from '@elastic/eui';
+import React, { useMemo } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { FieldsListItemContainer } from './fields_list_item_container';
 import type { NormalizedField, State } from '../../../types';
+import { useLiveAnnouncement } from '../use_live_announcement';
 
 interface Props {
   fields?: NormalizedField[];
@@ -28,28 +30,44 @@ export const FieldsList = React.memo(function FieldsListComponent({
   isAddingFields,
   pendingFieldsRef,
 }: Props) {
+  const listLabel = i18n.translate('xpack.idxMgmt.mappingsEditor.fieldListLabel', {
+    defaultMessage: 'Saved mapping fields',
+  });
+
+  const fieldsKey = useMemo(() => fields?.map((field) => field.id).join('|') ?? '', [fields]);
+  const itemsCount = fields?.length ?? 0;
+
+  const message = i18n.translate(
+    'xpack.idxMgmt.mappingsEditor.fieldListUpdatedAnnouncementWithCount',
+    {
+      defaultMessage:
+        '{listLabel} list has been updated. {itemsCount, plural, one {# item} other {# items}}.',
+      values: { listLabel, itemsCount },
+    }
+  );
+  const liveAnnouncement = useLiveAnnouncement({ message, changeKey: fieldsKey });
+
   if (fields === undefined) {
     return null;
   }
+
   return (
-    <ul
-      data-test-subj="fieldsList"
-      aria-label={i18n.translate('xpack.idxMgmt.mappingsEditor.fieldListLabel', {
-        defaultMessage: 'Saved mapping fields',
-      })}
-    >
-      {fields.map((field, index) => (
-        <FieldsListItemContainer
-          key={field.id}
-          fieldId={field.id}
-          treeDepth={treeDepth === undefined ? 0 : treeDepth}
-          isLastItem={index === fields.length - 1}
-          state={state}
-          setPreviousState={setPreviousState}
-          isAddingFields={isAddingFields}
-          pendingFieldsRef={pendingFieldsRef}
-        />
-      ))}
-    </ul>
+    <>
+      <EuiLiveAnnouncer>{liveAnnouncement}</EuiLiveAnnouncer>
+      <ul data-test-subj="fieldsList" aria-label={listLabel}>
+        {fields.map((field, index) => (
+          <FieldsListItemContainer
+            key={field.id}
+            fieldId={field.id}
+            treeDepth={treeDepth === undefined ? 0 : treeDepth}
+            isLastItem={index === fields.length - 1}
+            state={state}
+            setPreviousState={setPreviousState}
+            isAddingFields={isAddingFields}
+            pendingFieldsRef={pendingFieldsRef}
+          />
+        ))}
+      </ul>
+    </>
   );
 });

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/search_fields/search_result.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/search_fields/search_result.tsx
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
+import { EuiLiveAnnouncer } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { FixedSizeList as VirtualList, areEqual } from 'react-window';
 import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 
 import type { SearchResult as SearchResultType, State } from '../../../types';
 import { useDispatch } from '../../../mappings_state_context';
 import { SearchResultItem } from './search_result_item';
+import { useLiveAnnouncement } from '../use_live_announcement';
 
 interface Props {
   result: SearchResultType[];
@@ -59,6 +62,26 @@ export const SearchResult = React.memo(
   }: Props) => {
     const dispatch = useDispatch();
     const listHeight = Math.min(result.length * ITEM_HEIGHT, 600);
+    const resultsLabel = i18n.translate('xpack.idxMgmt.mappingsEditor.searchResultsLabel', {
+      defaultMessage: 'Saved mapping fields search results',
+    });
+
+    const resultKey = useMemo(() => result.map((item) => item.field.id).join('|'), [result]);
+    const itemsCount = result.length;
+
+    const message = i18n.translate(
+      'xpack.idxMgmt.mappingsEditor.searchResultsUpdatedAnnouncementWithCount',
+      {
+        defaultMessage:
+          '{resultsLabel} list has been updated. {itemsCount, plural, one {# item} other {# items}}.',
+        values: { resultsLabel, itemsCount },
+      }
+    );
+    const liveAnnouncement = useLiveAnnouncement({
+      message,
+      changeKey: resultKey,
+      announceOnMount: true,
+    });
 
     const clearSearch = () => {
       if (onClearSearch !== undefined) {
@@ -73,40 +96,45 @@ export const SearchResult = React.memo(
       [fieldToEdit, result, status]
     );
 
-    return result.length === 0 ? (
-      <EuiEmptyPrompt
-        data-test-subj="mappingsEditorSearchResultEmptyPrompt"
-        iconType="magnify"
-        title={
-          <h3>
-            <FormattedMessage
-              id="xpack.idxMgmt.mappingsEditor.searchResult.emptyPromptTitle"
-              defaultMessage="No fields match your search"
-            />
-          </h3>
-        }
-        actions={
-          <EuiButton onClick={clearSearch}>
-            <FormattedMessage
-              id="xpack.idxMgmt.mappingsEditor.searchResult.emptyPrompt.clearSearchButtonLabel"
-              defaultMessage="Clear search"
-            />
-          </EuiButton>
-        }
-      />
-    ) : (
-      <div data-test-subj="mappingsEditorSearchResult">
-        <VirtualList
-          style={{ overflowX: 'hidden', ...virtualListStyle }}
-          width="100%"
-          height={listHeight}
-          itemData={itemData}
-          itemCount={result.length}
-          itemSize={ITEM_HEIGHT}
-        >
-          {Row}
-        </VirtualList>
-      </div>
+    return (
+      <>
+        <EuiLiveAnnouncer>{liveAnnouncement}</EuiLiveAnnouncer>
+        {result.length === 0 ? (
+          <EuiEmptyPrompt
+            data-test-subj="mappingsEditorSearchResultEmptyPrompt"
+            iconType="magnify"
+            title={
+              <h3>
+                <FormattedMessage
+                  id="xpack.idxMgmt.mappingsEditor.searchResult.emptyPromptTitle"
+                  defaultMessage="No fields match your search"
+                />
+              </h3>
+            }
+            actions={
+              <EuiButton onClick={clearSearch}>
+                <FormattedMessage
+                  id="xpack.idxMgmt.mappingsEditor.searchResult.emptyPrompt.clearSearchButtonLabel"
+                  defaultMessage="Clear search"
+                />
+              </EuiButton>
+            }
+          />
+        ) : (
+          <div data-test-subj="mappingsEditorSearchResult" aria-label={resultsLabel}>
+            <VirtualList
+              style={{ overflowX: 'hidden', ...virtualListStyle }}
+              width="100%"
+              height={listHeight}
+              itemData={itemData}
+              itemCount={result.length}
+              itemSize={ITEM_HEIGHT}
+            >
+              {Row}
+            </VirtualList>
+          </div>
+        )}
+      </>
     );
   }
 );

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/use_live_announcement.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/use_live_announcement.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState } from 'react';
+import useUpdateEffect from 'react-use/lib/useUpdateEffect';
+
+interface UseLiveAnnouncementOptions {
+  message: string;
+  changeKey: string;
+  announceOnMount?: boolean;
+}
+
+export const useLiveAnnouncement = ({
+  message,
+  changeKey,
+  announceOnMount = false,
+}: UseLiveAnnouncementOptions): string => {
+  const [announcement, setAnnouncement] = useState<string>(() => (announceOnMount ? message : ''));
+
+  useUpdateEffect(() => {
+    setAnnouncement((current) => {
+      if (current === message) {
+        requestAnimationFrame(() => setAnnouncement(message));
+        return '';
+      }
+      return message;
+    });
+  }, [changeKey, message]);
+
+  return announcement;
+};


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/242871

## Summary
- Add screen-reader announcements for mapping fields list updates in Index Management → Index details → Mappings, including the item count.
- Announcements fire when filtering by Field types and when Search fields results change, using a shared minimal `EuiLiveAnnouncer`-based hook.

### Test plan
- Manual:
  - macOS Sequoia + Safari 18.5 + VoiceOver
  - Change Field types → verify announcement and focus stability
  - Type in Search fields → verify debounced announcement and focus stability

### Accessibility notes
- WCAG: 4.1.3 Status Messages (AA)
- **Before** (per issue): list/table updates after Field types selection but **no corresponding SR announcement**.
- **After**: SR announces “{label} list has been updated. {N items}.” for both Field types filtering and Search fields result updates, without forcing focus changes.