### PR TITLE
[8.19] chore: util to clean cached images (#259335)

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -173,46 +173,6 @@ docker_with_retry () {
   done
 }
 
-force_clean_ports() {
-  set +e
-
-  echo "LSOF: $(which lsof)"
-  for port in "$@"; do
-    echo "Force cleaning port: '$port'"
-
-    PORT_PID=$(lsof -i ":$port" -t)
-    if [[ "$PORT_PID" != "" ]]; then
-      echo "Found process using port '$port': $PORT_PID - sending SIGTERM..."
-      kill -15 "$PORT_PID" || true
-      sleep 5
-
-      PORT_PID=$(lsof -i ":$port" -t)
-      if [[ "$PORT_PID" != "" ]]; then
-        echo "Process $PORT_PID is still using port '$port', force killing..."
-        kill -9 "$PORT_PID" || true
-      fi
-    else
-      echo "No process found using port '$port', checking docker..."
-
-      ENTRY_WITH_PORT=$(docker ps -a | grep -E ":$port->")
-      if [[ -z "$ENTRY_WITH_PORT" ]]; then
-        echo "No docker container found using port $port"
-        continue
-      else
-        CONTAINER_ID=$(echo "$ENTRY_WITH_PORT" | awk '{print $1}')
-        echo "Found docker container using port $port: $CONTAINER_ID"
-        echo "Stopping and removing container $CONTAINER_ID"
-        docker stop "$CONTAINER_ID" || true
-        docker rm "$CONTAINER_ID" || true
-        continue
-      fi
-    fi
-  done
-
-  set -e
-}
-
-
 clean_cached_images() {
   docker images -q | sort -u | xargs -r docker rmi -f || true
   docker image prune -af || true

--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -172,3 +172,48 @@ docker_with_retry () {
     fi
   done
 }
+
+force_clean_ports() {
+  set +e
+
+  echo "LSOF: $(which lsof)"
+  for port in "$@"; do
+    echo "Force cleaning port: '$port'"
+
+    PORT_PID=$(lsof -i ":$port" -t)
+    if [[ "$PORT_PID" != "" ]]; then
+      echo "Found process using port '$port': $PORT_PID - sending SIGTERM..."
+      kill -15 "$PORT_PID" || true
+      sleep 5
+
+      PORT_PID=$(lsof -i ":$port" -t)
+      if [[ "$PORT_PID" != "" ]]; then
+        echo "Process $PORT_PID is still using port '$port', force killing..."
+        kill -9 "$PORT_PID" || true
+      fi
+    else
+      echo "No process found using port '$port', checking docker..."
+
+      ENTRY_WITH_PORT=$(docker ps -a | grep -E ":$port->")
+      if [[ -z "$ENTRY_WITH_PORT" ]]; then
+        echo "No docker container found using port $port"
+        continue
+      else
+        CONTAINER_ID=$(echo "$ENTRY_WITH_PORT" | awk '{print $1}')
+        echo "Found docker container using port $port: $CONTAINER_ID"
+        echo "Stopping and removing container $CONTAINER_ID"
+        docker stop "$CONTAINER_ID" || true
+        docker rm "$CONTAINER_ID" || true
+        continue
+      fi
+    fi
+  done
+
+  set -e
+}
+
+
+clean_cached_images() {
+  docker images -q | sort -u | xargs -r docker rmi -f || true
+  docker image prune -af || true
+}

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -15,19 +15,6 @@ else
   KIBANA_IMAGE_TAG="pr-$BUILDKITE_PULL_REQUEST-$GIT_ABBREV_COMMIT"
 fi
 
-# CDN readiness file - uploaded at the very end of successful CDN asset validation
-CDN_READINESS_FILE="$GIT_ABBREV_COMMIT/.ready"
-CDN_READINESS_URL="$GCS_SA_CDN_URL/$CDN_READINESS_FILE"
-
-check_cdn_assets_ready() {
-  local url="$1"
-  if curl --output /dev/null --silent --head --fail "$url"; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 echo "--- Clean up cached images"
 clean_cached_images
 

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -15,6 +15,22 @@ else
   KIBANA_IMAGE_TAG="pr-$BUILDKITE_PULL_REQUEST-$GIT_ABBREV_COMMIT"
 fi
 
+# CDN readiness file - uploaded at the very end of successful CDN asset validation
+CDN_READINESS_FILE="$GIT_ABBREV_COMMIT/.ready"
+CDN_READINESS_URL="$GCS_SA_CDN_URL/$CDN_READINESS_FILE"
+
+check_cdn_assets_ready() {
+  local url="$1"
+  if curl --output /dev/null --silent --head --fail "$url"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+echo "--- Clean up cached images"
+clean_cached_images
+
 KIBANA_BASE_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless"
 export KIBANA_IMAGE="$KIBANA_BASE_IMAGE:$KIBANA_IMAGE_TAG"
 

--- a/.buildkite/scripts/steps/package_testing/test.sh
+++ b/.buildkite/scripts/steps/package_testing/test.sh
@@ -9,6 +9,9 @@ source "$(dirname "$0")/../../common/util.sh"
 #
 #is_test_execution_step
 
+echo "--- Clean up cached images"
+clean_cached_images
+
 echo "--- Package Testing for $TEST_PACKAGE"
 
 mkdir -p target


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore: util to clean cached images (#259335)](https://github.com/elastic/kibana/pull/259335)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tamerlan Gudabayev","email":"37669316+TamerlanG@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-24T14:40:24Z","message":"chore: util to clean cached images (#259335)","sha":"5dac63ee0cf693cf397755da249ff08f8d28cae9","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","ci:build-serverless-image","v9.4.0"],"title":"chore: util to clean cached images","number":259335,"url":"https://github.com/elastic/kibana/pull/259335","mergeCommit":{"message":"chore: util to clean cached images (#259335)","sha":"5dac63ee0cf693cf397755da249ff08f8d28cae9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259335","number":259335,"mergeCommit":{"message":"chore: util to clean cached images (#259335)","sha":"5dac63ee0cf693cf397755da249ff08f8d28cae9"}}]}] BACKPORT-->