### PR TITLE
Minimize dispatcher integration test server setup

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/setup_test_servers.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/setup_test_servers.ts
@@ -14,6 +14,7 @@ export async function setupTestServers(settings = {}) {
     settings: {
       es: {
         license: 'trial',
+        esArgs: ['xpack.ml.enabled=false', 'xpack.watcher.enabled=false'],
       },
     },
   });
@@ -25,6 +26,10 @@ export async function setupTestServers(settings = {}) {
       {
         xpack: {
           alerting_v2: { enabled: true },
+          reporting: { enabled: false },
+          canvas: { enabled: false },
+          uptime: { enabled: false },
+          fleet: { enabled: false },
           task_manager: { unsafe: { exclude_task_types: ['alerting_v2:dispatcher'] } },
         },
         ...settings,


### PR DESCRIPTION
## Summary

- Adds `esArgs` to disable ML and Watcher at the Elasticsearch level during dispatcher integration tests, reducing memory usage and startup time.
- Disables unnecessary Kibana plugins (`reporting`, `canvas`, `uptime`, `fleet`) that are not needed by the alerting_v2 dispatcher tests.

## Test plan

- [ ] Run `yarn test:jest_integration x-pack/platform/plugins/shared/alerting_v2/server/lib/dispatcher/integration_tests/dispatcher.test.ts` and verify all tests pass
- [ ] Confirm reduced startup time / resource usage compared to baseline


Made with [Cursor](https://cursor.com)