### PR TITLE
Revert "[build] Increase disk space for serverless build (#259354)"

### DIFF
--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -6,5 +6,5 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-16
-      diskSizeGb: 200
+      diskSizeGb: 150
     timeout_in_minutes: 90


### PR DESCRIPTION
This reverts commit 56dc7fbb475bbd4a4866f184029701dd07fa5ecf.

Not needed after https://github.com/elastic/kibana/pull/259335