### PR TITLE
[Cases][Templates] Move templates management into Settings page as a tab

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/constants/application.ts
+++ b/x-pack/platform/plugins/shared/cases/common/constants/application.ts
@@ -29,6 +29,11 @@ export const CASE_VIEW_TAB_PATH = `${CASE_VIEW_PATH}/?tabId=:tabId` as const;
 export const CASES_TEMPLATES_PATH = '/templates' as const;
 export const CASES_CREATE_TEMPLATE_PATH = `${CASES_TEMPLATES_PATH}/create` as const;
 export const CASES_EDIT_TEMPLATE_PATH = `${CASES_TEMPLATES_PATH}/:templateId/edit` as const;
+export const CASES_CONFIGURE_TEMPLATES_PATH = `${CASES_CONFIGURE_PATH}/templates` as const;
+export const CASES_CONFIGURE_CREATE_TEMPLATE_PATH =
+  `${CASES_CONFIGURE_TEMPLATES_PATH}/create` as const;
+export const CASES_CONFIGURE_EDIT_TEMPLATE_PATH =
+  `${CASES_CONFIGURE_TEMPLATES_PATH}/:templateId/edit` as const;
 /**
  * The main Cases application is in the stack management under the
  * Alerts and Insights section. To do that, Cases registers to the management

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.test.ts
@@ -178,7 +178,7 @@ describe('getCasesDeepLinks', () => {
         },
         {
           id: 'cases_templates',
-          path: '/cases/templates',
+          path: '/cases/configure/templates',
           title: 'Templates',
         },
       ],

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/deep_links.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_BASE_PATH,
   getCreateCasePath,
   getCasesConfigurePath,
-  getCasesTemplatesPath,
+  getCasesConfigureTemplatesPath,
 } from './paths';
 
 export const CasesDeepLinkId = {
@@ -58,7 +58,7 @@ export const getCasesDeepLinks = <T extends AppDeepLink = AppDeepLink>({
       }),
       ...(extend[CasesDeepLinkId.casesTemplates] ?? {}),
       id: CasesDeepLinkId.casesTemplates,
-      path: getCasesTemplatesPath(basePath),
+      path: getCasesConfigureTemplatesPath(basePath),
     } as T & { id: ICasesDeepLinkId });
   }
 

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/hooks.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/hooks.ts
@@ -12,13 +12,13 @@ import {
   APP_ID,
   CASES_CONFIGURE_PATH,
   CASES_CREATE_PATH,
-  CASES_CREATE_TEMPLATE_PATH,
-  CASES_TEMPLATES_PATH,
+  CASES_CONFIGURE_TEMPLATES_PATH,
+  CASES_CONFIGURE_CREATE_TEMPLATE_PATH,
 } from '../../../common/constants';
 import { useNavigation } from '../lib/kibana';
 import type { ICasesDeepLinkId } from './deep_links';
 import type { CaseViewPathParams, CaseViewPathSearchParams, TemplateViewPathParams } from './paths';
-import { generateCaseViewPath, generateTemplateEditPath } from './paths';
+import { generateCaseViewPath, generateConfigureTemplateEditPath } from './paths';
 import { stringifyToURL, parseURL } from '../../components/utils';
 import { useApplication } from '../lib/kibana/use_application';
 
@@ -75,8 +75,8 @@ const navigationMapping = {
   all: { path: '/' },
   create: { path: CASES_CREATE_PATH },
   configure: { path: CASES_CONFIGURE_PATH },
-  templates: { path: CASES_TEMPLATES_PATH },
-  createTemplate: { path: CASES_CREATE_TEMPLATE_PATH },
+  templates: { path: CASES_CONFIGURE_TEMPLATES_PATH },
+  createTemplate: { path: CASES_CONFIGURE_CREATE_TEMPLATE_PATH },
 };
 
 export const useAllCasesNavigation = () => {
@@ -135,7 +135,7 @@ export const useCasesEditTemplateNavigation = () => {
       getAppUrl({
         deepLinkId,
         absolute,
-        path: generateTemplateEditPath(pathParams),
+        path: generateConfigureTemplateEditPath(pathParams),
       }),
     [deepLinkId, getAppUrl]
   );
@@ -144,7 +144,7 @@ export const useCasesEditTemplateNavigation = () => {
     (pathParams) =>
       navigateTo({
         deepLinkId,
-        path: generateTemplateEditPath(pathParams),
+        path: generateConfigureTemplateEditPath(pathParams),
       }),
     [navigateTo, deepLinkId]
   );

--- a/x-pack/platform/plugins/shared/cases/public/common/navigation/paths.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/navigation/paths.ts
@@ -17,6 +17,9 @@ import {
   CASES_TEMPLATES_PATH,
   CASES_CREATE_TEMPLATE_PATH,
   CASES_EDIT_TEMPLATE_PATH,
+  CASES_CONFIGURE_TEMPLATES_PATH,
+  CASES_CONFIGURE_CREATE_TEMPLATE_PATH,
+  CASES_CONFIGURE_EDIT_TEMPLATE_PATH,
 } from '../../../common/constants';
 import type { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 
@@ -57,6 +60,20 @@ export const generateTemplateEditPath = (params: TemplateViewPathParams): string
     generatePath(
       CASES_EDIT_TEMPLATE_PATH,
       params as ExtractRouteParams<typeof CASES_EDIT_TEMPLATE_PATH>
+    )
+  );
+};
+export const getCasesConfigureTemplatesPath = (casesBasePath: string) =>
+  normalizePath(`${casesBasePath}${CASES_CONFIGURE_TEMPLATES_PATH}`);
+export const getCasesConfigureCreateTemplatePath = (casesBasePath: string) =>
+  normalizePath(`${casesBasePath}${CASES_CONFIGURE_CREATE_TEMPLATE_PATH}`);
+export const getCasesConfigureEditTemplatePath = (casesBasePath: string) =>
+  normalizePath(`${casesBasePath}${CASES_CONFIGURE_EDIT_TEMPLATE_PATH}`);
+export const generateConfigureTemplateEditPath = (params: TemplateViewPathParams): string => {
+  return normalizePath(
+    generatePath(
+      CASES_CONFIGURE_EDIT_TEMPLATE_PATH,
+      params as ExtractRouteParams<typeof CASES_CONFIGURE_EDIT_TEMPLATE_PATH>
     )
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/app/routes.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/app/routes.tsx
@@ -24,9 +24,8 @@ import {
   getCaseViewWithCommentPath,
   useAllCasesNavigation,
   useCaseViewNavigation,
-  getCasesTemplatesPath,
-  getCasesCreateTemplatePath,
-  getCasesEditTemplatePath,
+  getCasesConfigureCreateTemplatePath,
+  getCasesConfigureEditTemplatePath,
 } from '../../common/navigation';
 import { NoPrivilegesPage } from '../no_privileges';
 import * as i18n from './translations';
@@ -45,10 +44,6 @@ const CreateTemplateLazy: FC<CreateTemplatePageProps> = lazy(
 
 const EditTemplateLazy: FC<EditTemplatePageProps> = lazy(
   () => import('../templates_v2/pages/edit_template/page')
-);
-
-const AllCasesTemplatesLazy: React.FC = lazy(
-  () => import('../templates_v2/pages/all_templates_page')
 );
 
 const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
@@ -95,24 +90,8 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
           )}
         </Route>
 
-        <Route path={getCasesConfigurePath(basePath)}>
-          {permissions.settings ? (
-            <ConfigureCases />
-          ) : (
-            <NoPrivilegesPage pageName={i18n.CONFIGURE_CASES_PAGE_NAME} />
-          )}
-        </Route>
-
         {isTemplatesEnabled && (
-          <Route exact path={getCasesTemplatesPath(basePath)}>
-            <Suspense fallback={<EuiLoadingSpinner />}>
-              <AllCasesTemplatesLazy />
-            </Suspense>
-          </Route>
-        )}
-
-        {isTemplatesEnabled && (
-          <Route exact path={getCasesCreateTemplatePath(basePath)}>
+          <Route exact path={getCasesConfigureCreateTemplatePath(basePath)}>
             <Suspense fallback={<EuiLoadingSpinner />}>
               <CreateTemplateLazy />
             </Suspense>
@@ -120,12 +99,20 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
         )}
 
         {isTemplatesEnabled && (
-          <Route exact path={getCasesEditTemplatePath(basePath)}>
+          <Route exact path={getCasesConfigureEditTemplatePath(basePath)}>
             <Suspense fallback={<EuiLoadingSpinner />}>
               <EditTemplateLazy />
             </Suspense>
           </Route>
         )}
+
+        <Route path={getCasesConfigurePath(basePath)}>
+          {permissions.settings ? (
+            <ConfigureCases />
+          ) : (
+            <NoPrivilegesPage pageName={i18n.CONFIGURE_CASES_PAGE_NAME} />
+          )}
+        </Route>
 
         {/* NOTE: current case view implementation retains some local state between renders, eg. when going from one case directly to another one. as a short term fix, we are forcing the component remount. */}
         <Route exact path={[getCaseViewWithCommentPath(basePath), getCaseViewPath(basePath)]}>

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/index.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/index.test.tsx
@@ -26,7 +26,7 @@ import {
 import { Connectors } from './connectors';
 import { ClosureOptions } from './closure_options';
 
-import { useKibana } from '../../common/lib/kibana';
+import { KibanaServices, useKibana } from '../../common/lib/kibana';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 import { usePersistConfiguration } from '../../containers/configure/use_persist_configuration';
 
@@ -1487,6 +1487,43 @@ describe('ConfigureCases', () => {
       it('should not render the warning callout', () => {
         expect(screen.queryByTestId('configure-cases-warning-callout')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('back to cases button', () => {
+    beforeEach(() => {
+      useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+      usePersistConfigurationMock.mockImplementation(() => usePersistConfigurationMockResponse);
+      useGetConnectorsMock.mockImplementation(() => ({
+        ...useConnectorsResponse,
+        data: [],
+        isLoading: false,
+      }));
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('renders when the templates feature flag is enabled', () => {
+      jest.spyOn(KibanaServices, 'getConfig').mockReturnValue({
+        templates: { enabled: true },
+      } as ReturnType<typeof KibanaServices.getConfig>);
+
+      renderWithTestingProviders(<ConfigureCases />);
+
+      expect(screen.getByTestId('configure-cases-back-to-cases')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: i18n.BACK_TO_ALL })).toBeInTheDocument();
+    });
+
+    it('does not render when the templates feature flag is disabled', () => {
+      jest.spyOn(KibanaServices, 'getConfig').mockReturnValue({
+        templates: { enabled: false },
+      } as ReturnType<typeof KibanaServices.getConfig>);
+
+      renderWithTestingProviders(<ConfigureCases />);
+
+      expect(screen.queryByTestId('configure-cases-back-to-cases')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/index.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/index.tsx
@@ -7,15 +7,18 @@
 
 /* eslint-disable complexity */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { css } from '@emotion/react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { EuiThemeComputed } from '@elastic/eui';
 import {
+  EuiButtonEmpty,
   EuiCallOut,
   EuiFlexItem,
   EuiLink,
+  EuiLoadingSpinner,
   EuiPageBody,
   EuiPageSection,
   EuiSpacer,
@@ -32,7 +35,7 @@ import type {
   ObservableTypeConfiguration,
 } from '../../../common/types/domain';
 import { getNoneConnector } from '../../../common/utils/connectors';
-import { useKibana } from '../../common/lib/kibana';
+import { KibanaServices, useKibana } from '../../common/lib/kibana';
 import { useGetActionTypes } from '../../containers/configure/use_action_types';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 
@@ -45,7 +48,8 @@ import { getConnectorById, addOrReplaceField } from '../utils';
 import { HeaderPage } from '../header_page';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useCasesBreadcrumbs } from '../use_breadcrumbs';
-import { CasesDeepLinkId } from '../../common/navigation';
+import { CasesDeepLinkId, getCasesConfigureTemplatesPath } from '../../common/navigation';
+import { useAllCasesNavigation } from '../../common/navigation/hooks';
 import { CustomFields } from '../custom_fields';
 import { CommonFlyout } from './flyout';
 import { useGetSupportedActionConnectors } from '../../containers/configure/use_get_supported_action_connectors';
@@ -60,6 +64,17 @@ import { builderMap as customFieldsBuilderMap } from '../custom_fields/builder';
 import { ObservableTypes } from '../observable_types';
 import { ObservableTypesForm } from '../observable_types/form';
 import { useCasesFeatures } from '../../common/use_cases_features';
+import { SettingsTabs } from './settings_tabs';
+
+const AllCasesTemplatesLazy = lazy(() => import('../templates_v2/pages/all_templates_page'));
+
+// Wrapper component to conditionally apply breadcrumbs without violating Rules of Hooks.
+// TODO: Remove along with the templates FF cleanup — breadcrumbs will always be handled by the templates tab.
+const ConfigureGeneralBreadcrumbs: React.FC = React.memo(() => {
+  useCasesBreadcrumbs(CasesDeepLinkId.casesConfigure);
+  return null;
+});
+ConfigureGeneralBreadcrumbs.displayName = 'ConfigureGeneralBreadcrumbs';
 
 const sectionWrapperCss = css`
   box-sizing: content-box;
@@ -115,9 +130,13 @@ const addNewCustomFieldToTemplates = ({
 };
 
 export const ConfigureCases: React.FC = React.memo(() => {
-  const { permissions } = useCasesContext();
+  const { permissions, basePath } = useCasesContext();
+  const { navigateToAllCases } = useAllCasesNavigation();
   const { triggersActionsUi, docLinks } = useKibana().services;
-  useCasesBreadcrumbs(CasesDeepLinkId.casesConfigure);
+  const isTemplatesEnabled = KibanaServices.getConfig()?.templates?.enabled ?? false;
+  const location = useLocation();
+  const isTemplatesTab =
+    isTemplatesEnabled && location.pathname === getCasesConfigureTemplatesPath(basePath);
   const license = useLicense();
   const hasMinimumLicensePermissions = license.isAtLeastGold();
   const hasMinimumLicensePermissionsForObservables = license.isAtLeastPlatinum();
@@ -624,126 +643,150 @@ export const ConfigureCases: React.FC = React.memo(() => {
     ) : null;
 
   return (
-    <EuiPageSection restrictWidth={true}>
+    <EuiPageSection paddingSize="none">
+      {!isTemplatesTab && <ConfigureGeneralBreadcrumbs />}
+      {isTemplatesEnabled && (
+        <EuiButtonEmpty
+          iconType="sortLeft"
+          size="xs"
+          flush="left"
+          onClick={navigateToAllCases}
+          data-test-subj="configure-cases-back-to-cases"
+        >
+          {i18n.BACK_TO_ALL}
+        </EuiButtonEmpty>
+      )}
       <HeaderPage data-test-subj="case-configure-title" title={i18n.CONFIGURE_CASES_PAGE_TITLE} />
-      <EuiPageBody restrictWidth={true}>
-        <div css={getFormWrapperCss(euiTheme)}>
-          {hasMinimumLicensePermissions && (
-            <>
-              {!connectorIsValid && (
-                <>
-                  <div css={sectionWrapperCss}>
-                    <EuiCallOut
-                      announceOnMount
-                      title={i18n.WARNING_NO_CONNECTOR_TITLE}
-                      color="warning"
-                      iconType="question"
-                      data-test-subj="configure-cases-warning-callout"
-                    >
-                      <FormattedMessage
-                        defaultMessage="The selected connector has been deleted or you do not have the {appropriateLicense} to use it. Either select a different connector or create a new one."
-                        id="xpack.cases.configure.connectorDeletedOrLicenseWarning"
-                        values={{
-                          appropriateLicense: (
-                            <EuiLink href={docLinks.links.subscriptions} target="_blank">
-                              {i18n.LINK_APPROPRIATE_LICENSE}
-                            </EuiLink>
-                          ),
-                        }}
-                      />
-                    </EuiCallOut>
-                  </div>
-                  <EuiSpacer size="xl" />
-                </>
-              )}
-              <div css={sectionWrapperCss}>
-                <ClosureOptions
-                  closureTypeSelected={closureType}
-                  disabled={
-                    isPersistingConfiguration || isLoadingConnectors || !permissions.settings
-                  }
-                  onChangeClosureType={onChangeClosureType}
-                />
-              </div>
-              <EuiSpacer size="xl" />
-              <div css={sectionWrapperCss}>
-                <Connectors
-                  actionTypes={actionTypes}
-                  connectors={connectors ?? []}
-                  disabled={
-                    isPersistingConfiguration || isLoadingConnectors || !permissions.settings
-                  }
-                  handleShowEditFlyout={onClickUpdateConnector}
-                  isLoading={isLoadingAny}
-                  mappings={mappings}
-                  onChangeConnector={onChangeConnector}
-                  selectedConnector={connector}
-                  updateConnectorDisabled={updateConnectorDisabled || !permissions.settings}
-                  onAddNewConnector={onAddNewConnector}
-                />
-              </div>
-              <EuiSpacer size="xl" />
-            </>
-          )}
-          <div css={sectionWrapperCss}>
-            <EuiFlexItem grow={false}>
-              <CustomFields
-                customFields={customFields}
-                isLoading={isLoadingCaseConfiguration}
-                disabled={isLoadingCaseConfiguration}
-                handleAddCustomField={() =>
-                  setFlyOutVisibility({ type: 'customField', visible: true })
-                }
-                handleDeleteCustomField={onDeleteCustomField}
-                handleEditCustomField={onEditCustomField}
-              />
-            </EuiFlexItem>
-          </div>
-
-          <EuiSpacer size="xl" />
-
-          <div css={sectionWrapperCss}>
-            <EuiFlexItem grow={false}>
-              <Templates
-                templates={templates}
-                isLoading={isLoadingCaseConfiguration}
-                disabled={isLoadingCaseConfiguration}
-                onAddTemplate={() => setFlyOutVisibility({ type: 'template', visible: true })}
-                onEditTemplate={onEditTemplate}
-                onDeleteTemplate={onDeleteTemplate}
-              />
-            </EuiFlexItem>
-          </div>
-
-          {hasMinimumLicensePermissionsForObservables && isObservablesFeatureEnabled && (
-            <>
-              <EuiSpacer size="xl" />
-
-              <div css={sectionWrapperCss}>
-                <EuiFlexItem grow={false}>
-                  <ObservableTypes
-                    observableTypes={observableTypes}
-                    isLoading={isLoadingCaseConfiguration}
-                    disabled={isLoadingCaseConfiguration}
-                    handleAddObservableType={() =>
-                      setFlyOutVisibility({ type: 'observableTypes', visible: true })
+      {isTemplatesEnabled && (
+        <>
+          <SettingsTabs activeTab={isTemplatesTab ? 'templates' : 'general'} />
+          <EuiSpacer size="l" />
+        </>
+      )}
+      <EuiPageBody restrictWidth={false}>
+        {isTemplatesTab ? (
+          <Suspense fallback={<EuiLoadingSpinner />}>
+            <AllCasesTemplatesLazy />
+          </Suspense>
+        ) : (
+          <div css={getFormWrapperCss(euiTheme)}>
+            {hasMinimumLicensePermissions && (
+              <>
+                {!connectorIsValid && (
+                  <>
+                    <div css={sectionWrapperCss}>
+                      <EuiCallOut
+                        announceOnMount
+                        title={i18n.WARNING_NO_CONNECTOR_TITLE}
+                        color="warning"
+                        iconType="question"
+                        data-test-subj="configure-cases-warning-callout"
+                      >
+                        <FormattedMessage
+                          defaultMessage="The selected connector has been deleted or you do not have the {appropriateLicense} to use it. Either select a different connector or create a new one."
+                          id="xpack.cases.configure.connectorDeletedOrLicenseWarning"
+                          values={{
+                            appropriateLicense: (
+                              <EuiLink href={docLinks.links.subscriptions} target="_blank">
+                                {i18n.LINK_APPROPRIATE_LICENSE}
+                              </EuiLink>
+                            ),
+                          }}
+                        />
+                      </EuiCallOut>
+                    </div>
+                    <EuiSpacer size="xl" />
+                  </>
+                )}
+                <div css={sectionWrapperCss}>
+                  <ClosureOptions
+                    closureTypeSelected={closureType}
+                    disabled={
+                      isPersistingConfiguration || isLoadingConnectors || !permissions.settings
                     }
-                    handleDeleteObservableType={onDeleteObservableType}
-                    handleEditObservableType={onEditObservableType}
+                    onChangeClosureType={onChangeClosureType}
                   />
-                </EuiFlexItem>
-              </div>
-            </>
-          )}
+                </div>
+                <EuiSpacer size="xl" />
+                <div css={sectionWrapperCss}>
+                  <Connectors
+                    actionTypes={actionTypes}
+                    connectors={connectors ?? []}
+                    disabled={
+                      isPersistingConfiguration || isLoadingConnectors || !permissions.settings
+                    }
+                    handleShowEditFlyout={onClickUpdateConnector}
+                    isLoading={isLoadingAny}
+                    mappings={mappings}
+                    onChangeConnector={onChangeConnector}
+                    selectedConnector={connector}
+                    updateConnectorDisabled={updateConnectorDisabled || !permissions.settings}
+                    onAddNewConnector={onAddNewConnector}
+                  />
+                </div>
+                <EuiSpacer size="xl" />
+              </>
+            )}
+            <div css={sectionWrapperCss}>
+              <EuiFlexItem grow={false}>
+                <CustomFields
+                  customFields={customFields}
+                  isLoading={isLoadingCaseConfiguration}
+                  disabled={isLoadingCaseConfiguration}
+                  handleAddCustomField={() =>
+                    setFlyOutVisibility({ type: 'customField', visible: true })
+                  }
+                  handleDeleteCustomField={onDeleteCustomField}
+                  handleEditCustomField={onEditCustomField}
+                />
+              </EuiFlexItem>
+            </div>
 
-          <EuiSpacer size="xl" />
+            <EuiSpacer size="xl" />
 
-          {ConnectorAddFlyout}
-          {ConnectorEditFlyout}
-          {AddOrEditCustomFieldFlyout}
-          {AddOrEditTemplateFlyout}
-          {AddOrEditObservableTypeFlyout}
-        </div>
+            <div css={sectionWrapperCss}>
+              <EuiFlexItem grow={false}>
+                <Templates
+                  templates={templates}
+                  isLoading={isLoadingCaseConfiguration}
+                  disabled={isLoadingCaseConfiguration}
+                  onAddTemplate={() => setFlyOutVisibility({ type: 'template', visible: true })}
+                  onEditTemplate={onEditTemplate}
+                  onDeleteTemplate={onDeleteTemplate}
+                />
+              </EuiFlexItem>
+            </div>
+
+            {hasMinimumLicensePermissionsForObservables && isObservablesFeatureEnabled && (
+              <>
+                <EuiSpacer size="xl" />
+
+                <div css={sectionWrapperCss}>
+                  <EuiFlexItem grow={false}>
+                    <ObservableTypes
+                      observableTypes={observableTypes}
+                      isLoading={isLoadingCaseConfiguration}
+                      disabled={isLoadingCaseConfiguration}
+                      handleAddObservableType={() =>
+                        setFlyOutVisibility({ type: 'observableTypes', visible: true })
+                      }
+                      handleDeleteObservableType={onDeleteObservableType}
+                      handleEditObservableType={onEditObservableType}
+                    />
+                  </EuiFlexItem>
+                </div>
+              </>
+            )}
+
+            <EuiSpacer size="xl" />
+
+            {ConnectorAddFlyout}
+            {ConnectorEditFlyout}
+            {AddOrEditCustomFieldFlyout}
+            {AddOrEditTemplateFlyout}
+            {AddOrEditObservableTypeFlyout}
+          </div>
+        )}
       </EuiPageBody>
     </EuiPageSection>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/settings_tabs.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/settings_tabs.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SettingsTabs } from './settings_tabs';
+import { renderWithTestingProviders } from '../../common/mock';
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({ push: mockHistoryPush }),
+}));
+
+describe('SettingsTabs', () => {
+  const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders General and Templates tabs', () => {
+    renderWithTestingProviders(<SettingsTabs activeTab="general" />);
+
+    expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Templates' })).toBeInTheDocument();
+  });
+
+  it('marks General tab as selected when activeTab is "general"', () => {
+    renderWithTestingProviders(<SettingsTabs activeTab="general" />);
+
+    expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Templates' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+  });
+
+  it('marks Templates tab as selected when activeTab is "templates"', () => {
+    renderWithTestingProviders(<SettingsTabs activeTab="templates" />);
+
+    expect(screen.getByRole('tab', { name: 'Templates' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('navigates to general settings when General tab is clicked', async () => {
+    renderWithTestingProviders(<SettingsTabs activeTab="templates" />);
+
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/cases/configure');
+  });
+
+  it('navigates to templates settings when Templates tab is clicked', async () => {
+    renderWithTestingProviders(<SettingsTabs activeTab="general" />);
+
+    await user.click(screen.getByRole('tab', { name: 'Templates' }));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/cases/configure/templates');
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/settings_tabs.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/settings_tabs.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiTab, EuiTabs } from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import {
+  getCasesConfigurePath,
+  getCasesConfigureTemplatesPath,
+} from '../../common/navigation/paths';
+import { SETTINGS_TAB_GENERAL, SETTINGS_TAB_TEMPLATES } from './translations';
+
+interface SettingsTabsProps {
+  activeTab: 'general' | 'templates';
+}
+
+export const SettingsTabs: React.FC<SettingsTabsProps> = ({ activeTab }) => {
+  const { basePath } = useCasesContext();
+  const history = useHistory();
+
+  return (
+    <EuiTabs>
+      <EuiTab
+        isSelected={activeTab === 'general'}
+        onClick={() => history.push(getCasesConfigurePath(basePath))}
+      >
+        {SETTINGS_TAB_GENERAL}
+      </EuiTab>
+      <EuiTab
+        isSelected={activeTab === 'templates'}
+        onClick={() => history.push(getCasesConfigureTemplatesPath(basePath))}
+      >
+        {SETTINGS_TAB_TEMPLATES}
+      </EuiTab>
+    </EuiTabs>
+  );
+};
+
+SettingsTabs.displayName = 'SettingsTabs';

--- a/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/configure_cases/translations.ts
@@ -214,3 +214,11 @@ export const SHOW_ALL_TEMPLATES = i18n.translate(
     defaultMessage: 'Show all templates',
   }
 );
+
+export const SETTINGS_TAB_GENERAL = i18n.translate('xpack.cases.settings.tabs.general', {
+  defaultMessage: 'General',
+});
+
+export const SETTINGS_TAB_TEMPLATES = i18n.translate('xpack.cases.settings.tabs.templates', {
+  defaultMessage: 'Templates',
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_header.test.tsx
@@ -34,7 +34,7 @@ describe('TemplateFormHeader', () => {
   it('renders the title', () => {
     renderWithTestingProviders(<TemplateFormHeader {...defaultProps} />);
 
-    expect(screen.getByRole('heading', { name: 'Test Template' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Test Template', level: 1 })).toBeInTheDocument();
   });
 
   it('renders back button with correct label', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_header.tsx
@@ -13,16 +13,14 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPageHeaderSection,
-  EuiPageTemplate,
   EuiSkeletonTitle,
   EuiSwitch,
   EuiTitle,
   EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
-import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
+import { css } from '@emotion/react';
 import * as i18n from '../translations';
-import { componentStyles } from './template_form_layout.styles';
 
 interface TemplateFormHeaderProps {
   title: string;
@@ -51,38 +49,38 @@ export const TemplateFormHeader: React.FC<TemplateFormHeaderProps> = ({
   onSave,
   onIsEnabledChange,
 }) => {
-  const styles = useMemoCss(componentStyles);
+  const { euiTheme } = useEuiTheme();
   const saveTooltipContent = submitError ?? undefined;
 
   return (
-    <EuiPageTemplate offset={0} minHeight={0} grow={false} css={styles.pageTemplate}>
-      <EuiPageTemplate.Header
-        css={styles.header}
-        restrictWidth={false}
-        bottomBorder={false}
-        paddingSize="m"
-        alignItems="bottom"
+    <header>
+      <EuiButtonEmpty
+        iconType="sortLeft"
+        size="xs"
+        flush="left"
+        onClick={onBack}
+        aria-label={i18n.BACK_TO_TEMPLATES}
       >
-        <EuiPageHeaderSection css={styles.headerSection}>
-          <EuiButtonEmpty
-            iconType="sortLeft"
-            size="xs"
-            flush="left"
-            onClick={onBack}
-            aria-label={i18n.BACK_TO_TEMPLATES}
-          >
-            {i18n.BACK_TO_TEMPLATES}
-          </EuiButtonEmpty>
+        {i18n.BACK_TO_TEMPLATES}
+      </EuiButtonEmpty>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+        css={css`
+          margin-bottom: ${euiTheme.size.l};
+        `}
+      >
+        <EuiFlexItem
+          css={css`
+            overflow: hidden;
+            display: block;
+          `}
+        >
           <EuiFlexGroup alignItems="center" responsive={false} gutterSize="m">
-            <EuiFlexItem grow={false} css={styles.titleItem}>
-              <EuiSkeletonTitle
-                size="m"
-                isLoading={!!isLoading}
-                contentAriaLabel={title}
-                css={styles.skeletonTitle}
-              >
-                <EuiTitle size="m" css={styles.title}>
-                  <h2>{title}</h2>
+            <EuiFlexItem grow={false}>
+              <EuiSkeletonTitle size="l" isLoading={!!isLoading} contentAriaLabel={title}>
+                <EuiTitle size="l">
+                  <h1>{title}</h1>
                 </EuiTitle>
               </EuiSkeletonTitle>
             </EuiFlexItem>
@@ -92,10 +90,9 @@ export const TemplateFormHeader: React.FC<TemplateFormHeaderProps> = ({
               </EuiFlexItem>
             )}
           </EuiFlexGroup>
-        </EuiPageHeaderSection>
-
-        <EuiPageHeaderSection>
-          <EuiFlexGroup justifyContent="flexEnd" alignItems="center" gutterSize="m">
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup justifyContent="flexEnd" alignItems="center" gutterSize="s">
             {hasChanges && (
               <EuiFlexItem grow={false}>
                 <EuiToolTip
@@ -147,9 +144,9 @@ export const TemplateFormHeader: React.FC<TemplateFormHeaderProps> = ({
               </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiPageHeaderSection>
-      </EuiPageTemplate.Header>
-    </EuiPageTemplate>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </header>
   );
 };
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.styles.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.styles.ts
@@ -11,7 +11,6 @@ import { css } from '@emotion/react';
 export const componentStyles = {
   wrapper: ({ euiTheme }: UseEuiTheme) =>
     css({
-      marginTop: `-${euiTheme.size.l}`,
       marginBottom: `-${euiTheme.size.l}`,
       overflow: 'hidden',
     }),

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_list_header.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_list_header.test.tsx
@@ -19,12 +19,6 @@ describe('TemplatesListHeader', () => {
     expect(await screen.findByTestId('all-templates-header')).toBeInTheDocument();
   });
 
-  it('renders the templates title', async () => {
-    renderWithTestingProviders(<TemplatesListHeader />);
-
-    expect(await screen.findByText('Templates')).toBeInTheDocument();
-  });
-
   it('renders the import template button', async () => {
     renderWithTestingProviders(<TemplatesListHeader />);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_list_header.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/templates_list_header.tsx
@@ -8,7 +8,6 @@
 import React, { useCallback, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { HeaderPage } from '../../header_page';
 import * as i18n from '../translations';
 import { LinkButton } from '../../links';
 import { useCasesCreateTemplateNavigation } from '../../../common/navigation';
@@ -30,52 +29,54 @@ export const TemplatesListHeader: React.FC = () => {
 
   return (
     <>
-      <HeaderPage title={i18n.TEMPLATE_TITLE} border data-test-subj="cases-all-title">
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="m"
-          wrap={true}
-          data-test-subj="all-templates-header"
-        >
-          <EuiFlexItem>
-            <EuiFlexGroup
-              responsive={false}
-              css={css`
-                & {
-                  @media only screen and (max-width: ${euiTheme.breakpoint.s}) {
-                    flex-direction: column;
-                  }
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="m"
+        wrap={true}
+        justifyContent="flexEnd"
+        data-test-subj="all-templates-header"
+        css={css`
+          padding-bottom: ${euiTheme.size.l};
+        `}
+      >
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup
+            responsive={false}
+            css={css`
+              & {
+                @media only screen and (max-width: ${euiTheme.breakpoint.s}) {
+                  flex-direction: column;
                 }
-              `}
-            >
-              <EuiFlexItem grow={false}>
-                <LinkButton
-                  onClick={openFlyout}
-                  href={'#'}
-                  iconType="importAction"
-                  isDisabled={false}
-                  aria-label={i18n.IMPORT_TEMPLATE}
-                  isEmpty={true}
-                  data-test-subj="import-template-button"
-                >
-                  {i18n.IMPORT_TEMPLATE}
-                </LinkButton>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <LinkButton
-                  fill
-                  onClick={navigateToCasesCreateTemplate}
-                  href={getCasesCreateTemplateUrl()}
-                  iconType="plusInCircle"
-                  data-test-subj="create-template-button"
-                >
-                  {i18n.CREATE_TEMPLATE}
-                </LinkButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </HeaderPage>
+              }
+            `}
+          >
+            <EuiFlexItem grow={false}>
+              <LinkButton
+                onClick={openFlyout}
+                href={'#'}
+                iconType="importAction"
+                isDisabled={false}
+                aria-label={i18n.IMPORT_TEMPLATE}
+                isEmpty={true}
+                data-test-subj="import-template-button"
+              >
+                {i18n.IMPORT_TEMPLATE}
+              </LinkButton>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <LinkButton
+                fill
+                onClick={navigateToCasesCreateTemplate}
+                href={getCasesCreateTemplateUrl()}
+                iconType="plusInCircle"
+                data-test-subj="create-template-button"
+              >
+                {i18n.CREATE_TEMPLATE}
+              </LinkButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       {isFlyoutOpen && <TemplateFlyout onClose={closeFlyout} onImport={closeFlyout} />}
     </>
   );

--- a/x-pack/platform/plugins/shared/cases/public/components/use_breadcrumbs/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/use_breadcrumbs/index.ts
@@ -142,6 +142,10 @@ export const useCasesTemplatesBreadcrumbs = (templateTitle?: string) => {
         href: getAppUrl({ deepLinkId: CasesDeepLinkId.cases }),
       },
       {
+        text: getCasesBreadcrumbTitle(CasesDeepLinkId.casesConfigure),
+        href: getAppUrl({ deepLinkId: CasesDeepLinkId.casesConfigure }),
+      },
+      {
         text: getCasesBreadcrumbTitle(CasesDeepLinkId.casesTemplates),
         ...(templateTitle
           ? { href: getAppUrl({ deepLinkId: CasesDeepLinkId.casesTemplates }) }

--- a/x-pack/solutions/security/packages/navigation/src/navigation_tree/cases_navigation_tree.ts
+++ b/x-pack/solutions/security/packages/navigation/src/navigation_tree/cases_navigation_tree.ts
@@ -9,7 +9,7 @@ import type { NodeDefinition } from '@kbn/core-chrome-browser';
 import { SecurityPageName } from '../constants';
 import { securityLink } from '../links';
 
-export const createCasesNavigationTree = (templatesEnabled: boolean = false): NodeDefinition => {
+export const createCasesNavigationTree = (): NodeDefinition => {
   const children: NodeDefinition[] = [
     {
       id: `${SecurityPageName.case}-all`,
@@ -25,18 +25,10 @@ export const createCasesNavigationTree = (templatesEnabled: boolean = false): No
     },
   ];
 
-  if (templatesEnabled) {
-    children.push({
-      id: SecurityPageName.caseTemplates,
-      link: securityLink(SecurityPageName.caseTemplates),
-    });
-  }
-
   return {
     id: SecurityPageName.case,
     link: securityLink(SecurityPageName.case),
     icon: 'briefcase',
     children,
-    ...(templatesEnabled && { renderAs: 'panelOpener' as const }),
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/app/links/app_links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/links/app_links.ts
@@ -21,7 +21,7 @@ import { alertDetectionsLinks, alertSummaryLink, alertsLink } from '../../detect
 import { links as rulesLinks } from '../../rules/links';
 import { links as siemMigrationsLinks } from '../../siem_migrations/links';
 import { links as timelinesLinks } from '../../timelines/links';
-import { getCasesLinks } from '../../cases/links';
+import { links as casesLinks } from '../../cases/links';
 import { links as managementLinks, getManagementFilteredLinks } from '../../management/links';
 import { exploreLinks } from '../../explore/links';
 import { onboardingLinks } from '../../onboarding/links';
@@ -36,7 +36,7 @@ export const appLinks: AppLinkItems = Object.freeze([
   alertSummaryLink,
   attackDiscoveryLinks,
   findingsLinks,
-  getCasesLinks(false),
+  casesLinks,
   configurationsLinks,
   timelinesLinks,
   indicatorsLinks,
@@ -64,9 +64,6 @@ export const getFilteredLinks = async (
   const chatExperience: AIChatExperience = await firstValueFrom(chatExperience$);
   const filteredConfigurationsLinks = getConfigurationsLinks(chatExperience);
 
-  const templatesEnabled = plugins.cases.config.templatesEnabled;
-  const filteredCasesLinks = getCasesLinks(templatesEnabled);
-
   return Object.freeze([
     dashboardsLinks,
     core.uiSettings.get(ENABLE_ALERTS_AND_ATTACKS_ALIGNMENT_SETTING, false)
@@ -75,7 +72,7 @@ export const getFilteredLinks = async (
     alertSummaryLink,
     attackDiscoveryLinks,
     findingsLinks,
-    filteredCasesLinks,
+    casesLinks,
     filteredConfigurationsLinks,
     timelinesLinks,
     indicatorsLinks,

--- a/x-pack/solutions/security/plugins/security_solution/public/app/links/get_filtered_links.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/links/get_filtered_links.test.ts
@@ -33,13 +33,7 @@ const createMockLinkItem = (overrides: Partial<LinkItem> = {}): LinkItem => ({
 
 describe('getFilteredLinks', () => {
   const mockCore = createCoreStartMock();
-  const mockPlugins = {
-    cases: {
-      config: {
-        templatesEnabled: false,
-      },
-    },
-  } as StartPlugins;
+  const mockPlugins = {} as StartPlugins;
   const mockManagementLinks = createMockLinkItem({
     id: SecurityPageName.administration,
     title: 'Management',

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/links.ts
@@ -14,37 +14,28 @@ import { getCasesDeepLinks } from '@kbn/cases-plugin/public';
 import { CASES_FEATURE_ID, CASES_PATH, SecurityPageName } from '../../common/constants';
 import type { LinkItem } from '../common/links/types';
 
-export const getCasesLinks = (templatesEnabled: boolean = false) => {
-  const casesLinks = getCasesDeepLinks<LinkItem>({
-    basePath: CASES_PATH,
-    templatesEnabled,
-    extend: {
-      [SecurityPageName.case]: {
-        globalNavPosition: 6,
-        capabilities: [`${CASES_FEATURE_ID}.${READ_CASES_CAPABILITY}`],
-      },
-      [SecurityPageName.caseConfigure]: {
-        capabilities: [`${CASES_FEATURE_ID}.${CASES_SETTINGS_CAPABILITY}`],
-        sideNavDisabled: true,
-      },
-      [SecurityPageName.caseCreate]: {
-        capabilities: [`${CASES_FEATURE_ID}.${CREATE_CASES_CAPABILITY}`],
-        sideNavDisabled: true,
-      },
-      [SecurityPageName.caseTemplates]: {
-        capabilities: [`${CASES_FEATURE_ID}.${CASES_SETTINGS_CAPABILITY}`],
-      },
+const casesLinks = getCasesDeepLinks<LinkItem>({
+  basePath: CASES_PATH,
+  extend: {
+    [SecurityPageName.case]: {
+      globalNavPosition: 6,
+      capabilities: [`${CASES_FEATURE_ID}.${READ_CASES_CAPABILITY}`],
     },
-  });
+    [SecurityPageName.caseConfigure]: {
+      capabilities: [`${CASES_FEATURE_ID}.${CASES_SETTINGS_CAPABILITY}`],
+      sideNavDisabled: true,
+    },
+    [SecurityPageName.caseCreate]: {
+      capabilities: [`${CASES_FEATURE_ID}.${CREATE_CASES_CAPABILITY}`],
+      sideNavDisabled: true,
+    },
+  },
+});
 
-  const { id, deepLinks, ...rest } = casesLinks;
+const { id, deepLinks, ...rest } = casesLinks;
 
-  return {
-    ...rest,
-    id: SecurityPageName.case,
-    links: deepLinks as LinkItem[],
-  };
+export const links = {
+  ...rest,
+  id: SecurityPageName.case,
+  links: deepLinks as LinkItem[],
 };
-
-// Default export for backward compatibility
-export const links = getCasesLinks(false);

--- a/x-pack/solutions/security/plugins/security_solution_ess/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution_ess/kibana.jsonc
@@ -20,8 +20,7 @@
       "management",
       "navigation",
       "licensing",
-      "cloud",
-      "cases"
+      "cloud"
     ],
     "optionalPlugins": [],
     "requiredBundles": [

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/common/__mocks__/services.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/common/__mocks__/services.mock.ts
@@ -11,7 +11,6 @@ import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import { navigationPluginMock } from '@kbn/navigation-plugin/public/mocks';
 import { managementPluginMock } from '@kbn/management-plugin/public/mocks';
 import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
-import { casesPluginMock } from '@kbn/cases-plugin/public/mocks';
 
 import type { Services } from '../services';
 
@@ -22,5 +21,4 @@ export const mockServices: Services = {
   navigation: navigationPluginMock.createStartContract(),
   management: managementPluginMock.createStartContract(),
   cloud: cloudMock.createStart(),
-  cases: casesPluginMock.createStartContract(),
 };

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -19,8 +19,7 @@ import { SOLUTION_NAME } from './translations';
 
 export const createNavigationTree = (
   services: Services,
-  chatExperience: AIChatExperience = AIChatExperience.Classic,
-  templatesEnabled: boolean = false
+  chatExperience: AIChatExperience = AIChatExperience.Classic
 ): NavigationTreeDefinition => ({
   body: [
     {
@@ -64,7 +63,7 @@ export const createNavigationTree = (
       icon: 'bullseye',
       link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
     },
-    defaultNavigationTree.cases(templatesEnabled),
+    defaultNavigationTree.cases(),
     defaultNavigationTree.entityAnalytics(),
     defaultNavigationTree.explore(),
     defaultNavigationTree.investigations(),

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/solution_navigation.ts
@@ -15,7 +15,7 @@ import { SOLUTION_NAME } from './translations';
 import { createNavigationTree } from './navigation_tree';
 
 export const registerSolutionNavigation = async (services: Services) => {
-  const { securitySolution, navigation, cases } = services;
+  const { securitySolution, navigation } = services;
 
   const chatExperience$ = services.settings.client.get$<AIChatExperience>(
     AI_CHAT_EXPERIENCE_TYPE,
@@ -25,8 +25,7 @@ export const registerSolutionNavigation = async (services: Services) => {
   // Get initial chat experience for setting initial navigation tree
   const initialChatExperience = await firstValueFrom(chatExperience$);
 
-  const templatesEnabled = cases.config.templatesEnabled;
-  const navigationTree = createNavigationTree(services, initialChatExperience, templatesEnabled);
+  const navigationTree = createNavigationTree(services, initialChatExperience);
 
   navigation.isSolutionNavEnabled$.subscribe((isSolutionNavigationEnabled) => {
     if (isSolutionNavigationEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution_ess/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/types.ts
@@ -13,7 +13,6 @@ import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import type { ManagementStart } from '@kbn/management-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
-import type { CasesPublicStart } from '@kbn/cases-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecuritySolutionEssPluginSetup {}
@@ -31,5 +30,4 @@ export interface SecuritySolutionEssPluginStartDeps {
   navigation: NavigationPublicPluginStart;
   management: ManagementStart;
   cloud: CloudStart;
-  cases: CasesPublicStart;
 }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/kibana.jsonc
@@ -25,8 +25,7 @@
       "cloud",
       "fleet",
       "actions",
-      "discover",
-      "cases"
+      "discover"
     ],
     "optionalPlugins": [
       "securitySolutionEss",

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/common/services/__mocks__/services.mock.tsx
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/common/services/__mocks__/services.mock.tsx
@@ -10,7 +10,6 @@ import { securityMock } from '@kbn/security-plugin/public/mocks';
 import { securitySolutionMock } from '@kbn/security-solution-plugin/public/mocks';
 import { managementPluginMock } from '@kbn/management-plugin/public/mocks';
 import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
-import type { CasesPublicStart } from '@kbn/cases-plugin/public';
 import type { Services } from '..';
 import { allowedExperimentalValues as genericAllowedExperimentalValues } from '@kbn/security-solution-plugin/common';
 import { allowedExperimentalValues } from '../../../../common/experimental_features';
@@ -23,11 +22,4 @@ export const mockServices: Services = {
   securitySolution: securitySolutionMock.createStart(),
   management: managementPluginMock.createStartContract(),
   cloud: cloudMock.createStart(),
-  cases: {
-    config: {
-      templatesEnabled: false,
-    },
-    api: {},
-    ui: {},
-  } as CasesPublicStart,
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
@@ -22,8 +22,7 @@ const SOLUTION_NAME = i18n.translate(
 
 export const createAiNavigationTree = (
   chatExperience: AIChatExperience = AIChatExperience.Classic,
-  workflowsUiEnabled: boolean = false,
-  templatesEnabled: boolean = false
+  workflowsUiEnabled: boolean = false
 ): NavigationTreeDefinition => ({
   body: [
     {
@@ -46,7 +45,7 @@ export const createAiNavigationTree = (
     {
       breadcrumbStatus: 'hidden',
       children: [
-        defaultNavigationTree.cases(templatesEnabled),
+        defaultNavigationTree.cases(),
         {
           id: SecurityPageName.configurations,
           link: securityLink(SecurityPageName.configurations),

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.test.ts
@@ -5,11 +5,9 @@
  * 2.0.
  */
 
-import type * as Rx from 'rxjs';
 import { of } from 'rxjs';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows/common/constants';
-import type { NavigationTreeDefinition } from '@kbn/core-chrome-browser';
 import type { ProductLine, ProductTier } from '../../common/product';
 import { mockServices } from '../common/services/__mocks__/services.mock';
 import { registerSolutionNavigation } from './navigation';
@@ -49,17 +47,10 @@ describe('Security Side Nav', () => {
     await registerSolutionNavigation(services, []);
 
     expect(initNavigationSpy).toHaveBeenCalled();
-    expect(mockedCreateNavigationTree).toHaveBeenCalledWith(
-      services,
-      AIChatExperience.Classic,
-      false
-    );
+    expect(mockedCreateNavigationTree).toHaveBeenCalledWith(services, AIChatExperience.Classic);
     expect(mockedCreateAiNavigationTree).not.toHaveBeenCalled();
 
-    const [, navigationTree$] = initNavigationSpy.mock.calls[0] as [
-      string,
-      Rx.Observable<NavigationTreeDefinition>
-    ];
+    const [, navigationTree$] = initNavigationSpy.mock.calls[0];
 
     navigationTree$.subscribe({
       next: (value) => {
@@ -79,17 +70,10 @@ describe('Security Side Nav', () => {
     ]);
 
     expect(initNavigationSpy).toHaveBeenCalled();
-    expect(mockedCreateAiNavigationTree).toHaveBeenCalledWith(
-      AIChatExperience.Classic,
-      false,
-      false
-    );
+    expect(mockedCreateAiNavigationTree).toHaveBeenCalledWith(AIChatExperience.Classic, false);
     expect(mockedCreateNavigationTree).not.toHaveBeenCalled();
 
-    const [, navigationTree$] = initNavigationSpy.mock.calls[0] as [
-      string,
-      Rx.Observable<NavigationTreeDefinition>
-    ];
+    const [, navigationTree$] = initNavigationSpy.mock.calls[0];
 
     navigationTree$.subscribe({
       next: (value) => {
@@ -109,10 +93,6 @@ describe('Security Side Nav', () => {
 
     await registerSolutionNavigation(services, []);
 
-    expect(mockedCreateNavigationTree).toHaveBeenCalledWith(
-      services,
-      AIChatExperience.Agent,
-      false
-    );
+    expect(mockedCreateNavigationTree).toHaveBeenCalledWith(services, AIChatExperience.Agent);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation.ts
@@ -38,11 +38,9 @@ export const registerSolutionNavigation = async (
   );
   const workflowsUiEnabled = await firstValueFrom(workflowsUiEnabled$);
 
-  const templatesEnabled = services.cases.config.templatesEnabled;
-
   const navigationTree = shouldUseAINavigation
-    ? createAiNavigationTree(initialChatExperience, workflowsUiEnabled, templatesEnabled)
-    : await createNavigationTree(services, initialChatExperience, templatesEnabled);
+    ? createAiNavigationTree(initialChatExperience, workflowsUiEnabled)
+    : await createNavigationTree(services, initialChatExperience);
 
   services.securitySolution.setSolutionNavigationTree(navigationTree);
 

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -26,8 +26,7 @@ const SOLUTION_NAME = i18n.translate(
 
 export const createNavigationTree = async (
   services: Services,
-  chatExperience: AIChatExperience = AIChatExperience.Classic,
-  templatesEnabled: boolean = false
+  chatExperience: AIChatExperience = AIChatExperience.Classic
 ): Promise<NavigationTreeDefinition> => ({
   body: [
     {
@@ -71,7 +70,7 @@ export const createNavigationTree = async (
       icon: 'bullseye',
       link: securityLink(SecurityPageName.cloudSecurityPostureFindings),
     },
-    defaultNavigationTree.cases(templatesEnabled),
+    defaultNavigationTree.cases(),
     defaultNavigationTree.entityAnalytics(),
     defaultNavigationTree.explore(),
     defaultNavigationTree.investigations(),

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/types.ts
@@ -15,7 +15,6 @@ import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/pu
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 import type { DiscoverSetup } from '@kbn/discover-plugin/public';
 import type { AutomaticImportPluginStart } from '@kbn/automatic-import-plugin/public';
-import type { CasesPublicStart } from '@kbn/cases-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecuritySolutionServerlessPluginSetup {}
@@ -38,5 +37,4 @@ export interface SecuritySolutionServerlessPluginStartDeps {
   management: ManagementStart;
   cloud: CloudStart;
   automaticImport?: AutomaticImportPluginStart;
-  cases: CasesPublicStart;
 }


### PR DESCRIPTION
## Summary

Moves the Cases Templates management experience from a standalone top-level route (`/cases/templates`) into the Cases Settings page as a tab (`/cases/configure/templates`), gated behind the existing `templates.enabled` feature flag. Removes the Templates entry from the Security Solution side-panel navigation tree and drops the `cases` plugin as a required dependency from `security_solution_ess` and `security_solution_serverless`.

## Motivation

Templates were previously accessible via a dedicated side-nav link, which added noise to the navigation and diverged from the mental model that templates are a *configuration* concern. Placing them as a tab inside Settings creates a more coherent UX, reduces navigation surface area, and eliminates a plugin dependency that was only needed to read the `templatesEnabled` flag for nav-tree construction.


## Changes

**Cases plugin — routing & paths**
- Added `CASES_CONFIGURE_TEMPLATES_PATH`, `CASES_CONFIGURE_CREATE_TEMPLATE_PATH`, and `CASES_CONFIGURE_EDIT_TEMPLATE_PATH` constants under `common/constants/application.ts`
- Added corresponding path helpers (`getCasesConfigureTemplatesPath`, `getCasesConfigureCreateTemplatePath`, `getCasesConfigureEditTemplatePath`, `generateConfigureTemplateEditPath`) in `public/common/navigation/paths.ts`
- Updated `deep_links.ts` and `hooks.ts` to use the new configure-scoped template paths
- Moved template create/edit routes under the `getCasesConfigurePath` prefix in `routes.tsx`; removed the standalone `AllCasesTemplatesLazy` route

**Cases plugin — ConfigureCases UI**
- Added `SettingsTabs` component (`configure_cases/settings_tabs.tsx`) rendering "General" and "Templates" `EuiTab` entries
- Refactored `ConfigureCases` (`configure_cases/index.tsx`) to detect the active tab via `useLocation()` and render `AllCasesTemplatesLazy` inline when on the templates path
- Added a "Back to Cases" `EuiButtonEmpty` (shown only when templates FF is enabled)
- Extracted `ConfigureGeneralBreadcrumbs` wrapper to conditionally apply breadcrumbs without violating Rules of Hooks
- Changed outer `EuiPageSection` from `restrictWidth` to `paddingSize="none"` to accommodate the tab layout

**Security Solution — navigation cleanup**
- Removed `caseTemplates` node and `renderAs: 'panelOpener'` from `createCasesNavigationTree()` in `@kbn/security-solution-navigation`
- Removed `templatesEnabled` parameter from `createNavigationTree()` in `security_solution_ess` and `security_solution_serverless`
- Simplified `getCasesLinks` in `security_solution` from a parameterised factory to a plain `links` constant; removed `getCasesLinks(false)` default export
- Removed `cases` from `requiredPlugins` in `security_solution_ess/kibana.jsonc` and `security_solution_serverless/kibana.jsonc`
- Removed `CasesPublicStart` from `SecuritySolutionEssPluginStartDeps` and corresponding types/mocks

## Risk & Migration

**Migration Risk Score: 3** — URL-level breaking change for the `cases_templates` deep link path, scoped entirely behind the `templates.enabled` feature flag (still experimental/unreleased).

| Surface | Change | Backward Compatible? |
|---------|--------|----------------------|
| Exported types | `getCasesLinks` factory removed from `security_solution/public/cases/links.ts`; `links` named export retained | No — callers of `getCasesLinks()` must switch to `links` (only internal consumers identified) |
| Route / deep link path | `cases_templates` deep link moves from `/cases/templates` to `/cases/configure/templates` | No — bookmarked URLs will 404; change is gated behind FF |
| Consuming plugins affected | `security_solution_ess`, `security_solution_serverless` | `cases` dep removed from `requiredPlugins`; no functional regression |

## Testing

**Manual (requires `xpack.cases.templates.enabled: true` in `kibana.yml`):**
1. Navigate to Cases → Settings. Verify two tabs appear: **General** and **Templates**.
2. Click the **Templates** tab. Verify the templates list renders at `/cases/configure/templates`.
3. Click **Create template** and confirm the route resolves to `/cases/configure/templates/create`.
4. Edit an existing template and confirm the route resolves to `/cases/configure/templates/:id/edit`.
5. Verify the **Back to Cases** button (`←`) is visible on the Settings page and navigates to the Cases list.
6. Confirm no **Templates** entry appears in the Security Solution side-panel navigation.
7. With `templates.enabled: false`, confirm Settings shows no tabs and no back button, and the old behaviour is unchanged.

**Automated:**
- [x] Unit tests added/updated: `x-pack/platform/plugins/shared/cases/public/components/configure_cases/index.test.tsx`, `settings_tabs.test.tsx`, `deep_links.test.ts`
- [x] Unit tests added/updated: `x-pack/solutions/security/plugins/security_solution/public/app/links/get_filtered_links.test.ts`, `security_solution_serverless/public/navigation/navigation.test.ts`
- [ ] Integration tests added/updated: `<!-- none required — routing is unit-testable and no API surface changed -->`

## Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Screenshots / Recordings

| Before | After |
|--------|-------|
| Templates accessible via side-nav link at `/cases/templates` | Templates accessible as a tab in Settings at `/cases/configure/templates` |