### PR TITLE
Fix Traces persists invalid filters

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/edge_contents.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/edge_contents.test.tsx
@@ -15,11 +15,23 @@ import {
   SPAN_DESTINATION_SERVICE_RESOURCE,
   SPAN_TYPE,
 } from '@kbn/observability-shared-plugin/common';
+import {
+  SERVICE_NAME as SERVICE_NAME_FIELD,
+  SPAN_DESTINATION_SERVICE_RESOURCE as SPAN_DESTINATION_SERVICE_RESOURCE_FIELD,
+} from '../../../../../common/es_fields/apm';
+import { useAnyOfApmParams } from '../../../../hooks/use_apm_params';
+import { OpenInDiscover } from '../../../shared/links/discover_links/open_in_discover';
 
 jest.mock('../../../../hooks/use_apm_params', () => ({
-  useAnyOfApmParams: () => ({
-    query: { comparisonEnabled: false, offset: undefined },
-  }),
+  useAnyOfApmParams: jest.fn(),
+}));
+
+jest.mock('../../../shared/links/discover_links/open_in_discover', () => ({
+  OpenInDiscover: jest.fn(() => (
+    <button type="button" data-test-subj="apmEdgeContentsOpenInDiscoverButton">
+      Explore traces
+    </button>
+  )),
 }));
 
 jest.mock('../../../../hooks/use_fetcher', () => ({
@@ -27,7 +39,17 @@ jest.mock('../../../../hooks/use_fetcher', () => ({
   useFetcher: () => ({ data: {}, status: 'success' }),
 }));
 
+const mockedUseAnyOfApmParams = jest.mocked(useAnyOfApmParams);
+const mockedOpenInDiscover = jest.mocked(OpenInDiscover);
+
 const TEST_SUBJ = 'apmServiceMapMessagingEdgeNoMetricsMessage';
+
+const defaultApmQuery = {
+  comparisonEnabled: false,
+  offset: undefined,
+  rangeFrom: 'now-15m',
+  rangeTo: 'now',
+};
 
 const defaultProps = {
   environment: 'ENVIRONMENT_ALL' as const,
@@ -82,7 +104,27 @@ function createGroupedMessagingIncomingEdge(): ServiceMapEdge {
   } as unknown as ServiceMapEdge;
 }
 
+/** Edge with source service + dependency so Explore traces (OpenInDiscover) renders */
+function createServiceToDependencyEdge(): ServiceMapEdge {
+  return {
+    source: 'order-service',
+    target: '>kafka/orders',
+    data: {
+      sourceData: { [SERVICE_NAME_FIELD]: 'order-service' },
+      targetData: { [SPAN_DESTINATION_SERVICE_RESOURCE_FIELD]: 'kafka/orders' },
+      resources: ['kafka/orders'],
+    },
+  } as unknown as ServiceMapEdge;
+}
+
 describe('EdgeContents', () => {
+  beforeEach(() => {
+    mockedUseAnyOfApmParams.mockReturnValue({
+      query: defaultApmQuery,
+    } as unknown as ReturnType<typeof useAnyOfApmParams>);
+    mockedOpenInDiscover.mockClear();
+  });
+
   it('shows stats for a producer edge (service to messaging queue)', () => {
     const edge = createMsgQueueProducerEdge();
 
@@ -93,6 +135,56 @@ describe('EdgeContents', () => {
     );
 
     expect(screen.queryByTestId(TEST_SUBJ)).not.toBeInTheDocument();
+  });
+
+  it('does not pass map search bar kuery to Explore traces (dependency metrics ignore KQL)', () => {
+    mockedUseAnyOfApmParams.mockReturnValue({
+      query: {
+        ...defaultApmQuery,
+        // Includes fields that overlap edge dimensions; must not be forwarded to Discover
+        kuery: `${SERVICE_NAME_FIELD}: "order-service" and http.url: *`,
+      },
+    } as unknown as ReturnType<typeof useAnyOfApmParams>);
+
+    const edge = createServiceToDependencyEdge();
+
+    render(
+      <IntlProvider locale="en">
+        <EdgeContents selection={edge} {...defaultProps} />
+      </IntlProvider>
+    );
+
+    expect(mockedOpenInDiscover).toHaveBeenCalledTimes(1);
+    const [{ queryParams, rangeFrom, rangeTo }] = mockedOpenInDiscover.mock.calls[0];
+    expect(queryParams).not.toHaveProperty('kuery');
+    expect(queryParams).toEqual({
+      serviceName: 'order-service',
+      environment: 'ENVIRONMENT_ALL',
+      dependencyName: 'kafka/orders',
+      sortDirection: 'DESC',
+    });
+    expect(rangeFrom).toBe('now-15m');
+    expect(rangeTo).toBe('now');
+  });
+
+  it('omits kuery from Explore traces when the map URL has no search bar filter', () => {
+    const edge = createServiceToDependencyEdge();
+
+    render(
+      <IntlProvider locale="en">
+        <EdgeContents selection={edge} {...defaultProps} />
+      </IntlProvider>
+    );
+
+    expect(mockedOpenInDiscover).toHaveBeenCalledTimes(1);
+    const [{ queryParams }] = mockedOpenInDiscover.mock.calls[0];
+    expect(queryParams).not.toHaveProperty('kuery');
+    expect(queryParams).toEqual({
+      serviceName: 'order-service',
+      environment: 'ENVIRONMENT_ALL',
+      dependencyName: 'kafka/orders',
+      sortDirection: 'DESC',
+    });
   });
 
   it('shows no-metrics message for a consumer edge (messaging queue to service)', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/edge_contents.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/edge_contents.tsx
@@ -68,7 +68,7 @@ export function EdgeContents({
     '/services/{serviceName}/service-map',
     '/mobile-services/{serviceName}/service-map'
   );
-  const { offset, comparisonEnabled, rangeFrom, rangeTo, kuery } = query;
+  const { offset, comparisonEnabled, rangeFrom, rangeTo } = query;
 
   const isEdgeSelection = isEdge(selection);
   const edgeSelectionData = isEdgeSelection ? selection.data : undefined;
@@ -139,7 +139,6 @@ export function EdgeContents({
               rangeFrom={rangeFrom}
               rangeTo={rangeTo}
               queryParams={{
-                kuery,
                 serviceName: sourceServiceName,
                 environment,
                 dependencyName,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/257427

## Summary

- Like it written in the issue, the kuery is not longer passed to the discover page from the service map when exploring traces because it's not used in the red metrics, now the data stays consistent when going between pages
- Add unit tests for this


### Before and After

#### Before

https://github.com/user-attachments/assets/345ac5a9-fa32-4410-afff-003db8593ed1

#### After

https://github.com/user-attachments/assets/c97944f5-f5b1-4cfa-b577-46ebbcc0fdaa


### How to run Unit Tests

`yarn test:jest x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/edge_contents.test.tsx`


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["9.2","9.3"]} ONMERGE-->