### PR TITLE
[Osquery] Fix history replay not passing saved query params

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/map_live_hit_to_row.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/map_live_hit_to_row.test.ts
@@ -118,4 +118,56 @@ describe('mapLiveHitToRow', () => {
     const row = mapLiveHitToRow(hit);
     expect(row.tags).toEqual([]);
   });
+
+  test('maps replay parameters for single query (savedQueryId, timeout, ecsMapping, agent selection)', () => {
+    const hit = {
+      _source: {
+        action_id: 'action-replay',
+        '@timestamp': '2024-01-01T00:00:00.000Z',
+        agent_all: true,
+        agent_ids: ['agent-1', 'agent-2'],
+        agent_platforms: ['linux', 'darwin'],
+        agent_policy_ids: ['policy-1'],
+        queries: [
+          {
+            query: 'SELECT * FROM uptime',
+            id: 'q1',
+            agents: ['agent-1', 'agent-2'],
+            saved_query_id: 'saved-query-123',
+            timeout: 601,
+            ecs_mapping: { message: { field: 'days' } },
+          },
+        ],
+      },
+    };
+
+    const row = mapLiveHitToRow(hit);
+    expect(row.savedQueryId).toBe('saved-query-123');
+    expect(row.timeout).toBe(601);
+    expect(row.ecsMapping).toEqual({ message: { field: 'days' } });
+    expect(row.agentIds).toEqual(['agent-1', 'agent-2']);
+    expect(row.agentAll).toBe(true);
+    expect(row.agentPlatforms).toEqual(['linux', 'darwin']);
+    expect(row.agentPolicyIds).toEqual(['policy-1']);
+  });
+
+  test('does not map replay parameters for pack queries', () => {
+    const hit = {
+      _source: {
+        action_id: 'action-pack',
+        '@timestamp': '2024-01-01T00:00:00.000Z',
+        pack_id: 'pack-1',
+        pack_name: 'my_pack',
+        queries: [
+          { query: 'SELECT 1', id: 'q1', agents: ['agent-1'], saved_query_id: 'sq-1', timeout: 300 },
+          { query: 'SELECT 2', id: 'q2', agents: ['agent-1'] },
+        ],
+      },
+    };
+
+    const row = mapLiveHitToRow(hit);
+    expect(row.savedQueryId).toBeUndefined();
+    expect(row.timeout).toBeUndefined();
+    expect(row.ecsMapping).toBeUndefined();
+  });
 });

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/map_live_hit_to_row.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/map_live_hit_to_row.ts
@@ -50,6 +50,9 @@ export const mapLiveHitToRow = (hit: LiveActionHit): LiveHistoryRow => {
     query?: string;
     agents?: string[];
     id?: string;
+    saved_query_id?: string;
+    timeout?: number;
+    ecs_mapping?: Record<string, unknown>;
   }>;
   const isPack = queries.length > 1 || packId;
   const queryText = isPack ? '' : queries[0]?.query ?? '';
@@ -61,6 +64,10 @@ export const mapLiveHitToRow = (hit: LiveActionHit): LiveHistoryRow => {
 
   const alertIdsRaw = hitFields.alert_ids ?? source.alert_ids;
   const hasAlertIds = Array.isArray(alertIdsRaw) ? alertIdsRaw.length > 0 : !!alertIdsRaw;
+
+  const agentIdsRaw = hitFields.agent_ids ?? source.agent_ids;
+  const agentPolicyIdsRaw = hitFields.agent_policy_ids ?? source.agent_policy_ids;
+  const agentPlatformsRaw = hitFields.agent_platforms ?? source.agent_platforms;
 
   return {
     id: actionId,
@@ -77,7 +84,17 @@ export const mapLiveHitToRow = (hit: LiveActionHit): LiveHistoryRow => {
     errorCount: undefined,
     totalRows: undefined,
     userId: get('user_id') as string | undefined,
+    userProfileUid: get('user_profile_uid') as string | undefined,
     actionId,
     tags: (source.tags as string[] | undefined) ?? [],
+    savedQueryId: isPack ? undefined : (queries[0]?.saved_query_id as string | undefined),
+    timeout: isPack ? undefined : (queries[0]?.timeout as number | undefined),
+    ecsMapping: isPack
+      ? undefined
+      : (queries[0]?.ecs_mapping as Record<string, unknown> | undefined),
+    agentIds: Array.isArray(agentIdsRaw) ? (agentIdsRaw as string[]) : undefined,
+    agentAll: (get('agent_all') as boolean | undefined) ?? false,
+    agentPlatforms: Array.isArray(agentPlatformsRaw) ? (agentPlatformsRaw as string[]) : undefined,
+    agentPolicyIds: Array.isArray(agentPolicyIdsRaw) ? (agentPolicyIdsRaw as string[]) : undefined,
   };
 };


### PR DESCRIPTION
## Summary

The unified history table's `mapLiveHitToRow` mapper was not populating replay parameters from the raw ES hit data. This caused the "Run query" button in the history table to create a new query without the original saved query reference, timeout, agent selection, or ECS mappings.

Missing fields added:
- `savedQueryId` - needed so the server accepts the query for roles with `runSavedQueries` permission
- `timeout` - custom timeout was lost on replay (always defaulted to 60)
- `ecsMapping` - ECS field mappings were lost
- `agentIds`, `agentAll`, `agentPlatforms`, `agentPolicyIds` - agent selection was lost

This was a regression introduced when the unified history table replaced the legacy actions table. The legacy table read these values directly from `item._source.queries[0]`, while the new mapper simply didn't include them.

https://github.com/user-attachments/assets/aec0f54e-ee56-45a2-9f02-8e23d34a7b3b


