### PR TITLE
Fix: Convert to lookup index always disabled on index list view

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nProvider } from '@kbn/i18n-react';
+import { of } from 'rxjs';
 
 import { AppContextProvider } from '../../../../app_context';
 import type { AppDependencies } from '../../../../app_context';
@@ -16,6 +17,7 @@ import { IndexActionsContextMenu } from './index_actions_context_menu';
 import type { Index } from '@kbn/index-management-shared-types';
 import { notificationService } from '../../../../services/notification';
 import { navigateToIndexDetailsPage, getIndexDetailsLink } from '../../../../services/routing';
+import { RequestResultType } from '../index_table/get_doc_count';
 
 // EUI context menus keep inactive panels mounted with `pointer-events: none`,
 // which can cause user-event to throw when interacting with menu items.
@@ -577,6 +579,38 @@ describe('IndexActionsContextMenu', () => {
               isFrozen: false,
             } satisfies Partial<Index>,
           ] as Index[],
+        };
+
+        renderWithProviders(<IndexActionsContextMenu {...convertible} />);
+
+        await openContextMenu();
+        const convertBtn = await screen.findByTestId('convertToLookupIndexButton');
+
+        expect(convertBtn).not.toBeDisabled();
+      });
+
+      it('SHOULD use loaded doc count when index documents are missing', async () => {
+        const props = getBaseProps();
+        const docCount$ = of({
+          'index-1': { status: RequestResultType.Success, count: 10 },
+        });
+        const convertible: MenuProps = {
+          ...props,
+          indices: [
+            {
+              name: 'index-1',
+              status: 'open' as Index['status'],
+              primary: 1,
+              hidden: false,
+              aliases: [],
+              isFrozen: false,
+            } satisfies Partial<Index>,
+          ] as Index[],
+          docCountApi: {
+            getByName: jest.fn(),
+            getObservable: () => docCount$,
+            abort: jest.fn(),
+          },
         };
 
         renderWithProviders(<IndexActionsContextMenu {...convertible} />);

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.test.tsx
@@ -17,7 +17,7 @@ import { IndexActionsContextMenu } from './index_actions_context_menu';
 import type { Index } from '@kbn/index-management-shared-types';
 import { notificationService } from '../../../../services/notification';
 import { navigateToIndexDetailsPage, getIndexDetailsLink } from '../../../../services/routing';
-import { RequestResultType } from '../index_table/get_doc_count';
+import { type DocCountResult, RequestResultType } from '../index_table/get_doc_count';
 
 // EUI context menus keep inactive panels mounted with `pointer-events: none`,
 // which can cause user-event to throw when interacting with menu items.
@@ -621,6 +621,41 @@ describe('IndexActionsContextMenu', () => {
         expect(convertBtn).not.toBeDisabled();
       });
 
+      it('SHOULD keep convert action disabled when docCountApi emits an error and documents are missing', async () => {
+        // Fail-safe: if the doc-count request errors out and the index has no cached
+        // document count, we cannot determine convertibility, so the action stays
+        // disabled rather than allowing a potentially invalid conversion.
+        const props = getBaseProps();
+        const docCount$ = of<Record<string, DocCountResult>>({
+          'index-1': { status: RequestResultType.Error },
+        });
+        const errorProps: MenuProps = {
+          ...props,
+          indices: [
+            {
+              name: 'index-1',
+              status: 'open' as Index['status'],
+              primary: 1,
+              hidden: false,
+              aliases: [],
+              isFrozen: false,
+            } satisfies Partial<Index>,
+          ] as Index[],
+          docCountApi: {
+            getByName: jest.fn(),
+            getObservable: () => docCount$,
+            abort: jest.fn(),
+          },
+        };
+
+        renderWithProviders(<IndexActionsContextMenu {...errorProps} />);
+
+        await openContextMenu();
+        const convertBtn = await screen.findByTestId('convertToLookupIndexButton');
+
+        expect(convertBtn).toBeDisabled();
+      });
+
       it('SHOULD open the Convert to Lookup modal', async () => {
         const props = getBaseProps();
         const convertible: MenuProps = {
@@ -675,6 +710,89 @@ describe('IndexActionsContextMenu', () => {
 
         const tooltip = await screen.findByText(/less than 2 billion documents/i);
         expect(tooltip).toBeInTheDocument();
+      });
+    });
+
+    describe('AND WHEN doc count is missing and not yet cached', () => {
+      it('SHOULD call getByName when the popover opens', async () => {
+        const props = getBaseProps();
+        const getByName = jest.fn();
+        const emptyDocCount$ = of<Record<string, DocCountResult>>({});
+        const missingDocsProps: MenuProps = {
+          ...props,
+          indices: [
+            {
+              name: 'index-1',
+              status: 'open' as Index['status'],
+              primary: 1,
+              hidden: false,
+              aliases: [],
+              isFrozen: false,
+              // documents intentionally omitted to simulate a missing count
+            } satisfies Partial<Index>,
+          ] as Index[],
+          docCountApi: {
+            getByName,
+            getObservable: () => emptyDocCount$,
+            abort: jest.fn(),
+          },
+        };
+
+        renderWithProviders(<IndexActionsContextMenu {...missingDocsProps} />);
+        await openContextMenu();
+
+        expect(getByName).toHaveBeenCalledWith('index-1');
+      });
+
+      it('SHOULD NOT call getByName when documents are already present on the index', async () => {
+        const props = getBaseProps(); // has documents: 100
+        const getByName = jest.fn();
+        const docCount$ = of<Record<string, DocCountResult>>({});
+        const propsWithDocs: MenuProps = {
+          ...props,
+          docCountApi: {
+            getByName,
+            getObservable: () => docCount$,
+            abort: jest.fn(),
+          },
+        };
+
+        renderWithProviders(<IndexActionsContextMenu {...propsWithDocs} />);
+        await openContextMenu();
+
+        expect(getByName).not.toHaveBeenCalled();
+      });
+
+      it('SHOULD NOT call getByName when the doc count is already in the observable cache', async () => {
+        const props = getBaseProps();
+        const getByName = jest.fn();
+        const cachedDocCount$ = of<Record<string, DocCountResult>>({
+          'index-1': { status: RequestResultType.Success, count: 10 },
+        });
+        const propsWithCache: MenuProps = {
+          ...props,
+          indices: [
+            {
+              name: 'index-1',
+              status: 'open' as Index['status'],
+              primary: 1,
+              hidden: false,
+              aliases: [],
+              isFrozen: false,
+              // documents intentionally omitted
+            } satisfies Partial<Index>,
+          ] as Index[],
+          docCountApi: {
+            getByName,
+            getObservable: () => cachedDocCount$,
+            abort: jest.fn(),
+          },
+        };
+
+        renderWithProviders(<IndexActionsContextMenu {...propsWithCache} />);
+        await openContextMenu();
+
+        expect(getByName).not.toHaveBeenCalled();
       });
     });
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.tsx
@@ -76,7 +76,7 @@ export interface IndexActionsContextMenuProps {
   // this function is called to "refresh" the indices data after and extension service action that uses a modal
   reloadIndices: () => void;
 
-  // observable API for doc counts already loaded in the index table
+  // observable API for doc counts
   docCountApi?: DocCountApi;
 
   /**
@@ -142,6 +142,17 @@ export const IndexActionsContextMenu = ({
   `;
 
   const onButtonClick = () => {
+    // When opening for a single index, trigger a doc-count fetch if neither the
+    // index data nor the observable cache already has a result. Without this,
+    // isConvertableToLookupIndex returns false until the index list page
+    // populates the count, so the action may appear disabled incorrectly.
+    if (!isPopoverOpen && indexNames.length === 1 && docCountApi) {
+      const indexName = indexNames[0];
+      const selectedIndex = indices.find((index) => index.name === indexName);
+      if (selectedIndex?.documents === undefined && !docCountMap?.[indexName]) {
+        docCountApi.getByName(indexName);
+      }
+    }
     setIsPopoverOpen((prevState) => !prevState);
   };
 

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.tsx
@@ -20,6 +20,8 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import useObservable from 'react-use/lib/useObservable';
+import { EMPTY } from 'rxjs';
 
 import type { HttpSetup } from '@kbn/core-http-browser';
 import { flattenPanelTree } from '../../../../lib/flatten_panel_tree';
@@ -32,6 +34,7 @@ import {
 import { getIndexDetailsLink, navigateToIndexDetailsPage } from '../../../../services/routing';
 import { useAppContext } from '../../../../app_context';
 import type { Index } from '../../../../../../common';
+import { type DocCountApi, RequestResultType } from '../index_table/get_doc_count';
 import { ModalHost, type ModalHostHandles } from './modal_host/modal_host';
 
 export interface IndexActionsContextMenuProps {
@@ -73,6 +76,9 @@ export interface IndexActionsContextMenuProps {
   // this function is called to "refresh" the indices data after and extension service action that uses a modal
   reloadIndices: () => void;
 
+  // observable API for doc counts already loaded in the index table
+  docCountApi?: DocCountApi;
+
   /**
    * Props added to use the context menu on the new index details page
    */
@@ -100,6 +106,7 @@ export const IndexActionsContextMenu = ({
   forcemergeIndices,
   deleteIndices,
   indexStatusByName,
+  docCountApi,
   performExtensionAction,
   reloadIndices,
   fill = true,
@@ -117,6 +124,8 @@ export const IndexActionsContextMenu = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const modalRef = useRef<ModalHostHandles | null>(null);
   const { euiTheme } = useEuiTheme();
+  const docCountMap = useObservable(docCountApi?.getObservable() ?? EMPTY);
+
   const computedAnchorPosition: EuiPopoverProps['anchorPosition'] =
     anchorPosition ?? (isOnListView ? 'downLeft' : 'downRight');
 
@@ -151,8 +160,16 @@ export const IndexActionsContextMenu = ({
 
   const isConvertableToLookupIndex = (indexName: string) => {
     const selectedIndex = indices.find((index) => index.name === indexName);
+    if (!selectedIndex) {
+      return false;
+    }
 
-    if (!selectedIndex || selectedIndex.documents === undefined) {
+    const docCount = docCountMap?.[indexName];
+    const documents =
+      selectedIndex.documents ??
+      (docCount?.status === RequestResultType.Success ? docCount.count : undefined);
+
+    if (documents === undefined) {
       return false;
     }
 
@@ -162,8 +179,7 @@ export const IndexActionsContextMenu = ({
     }
 
     const isWithinDocumentLimit =
-      selectedIndex.documents >= 0 &&
-      selectedIndex.documents <= MAX_DOCUMENTS_FOR_CONVERT_TO_LOOKUP_INDEX;
+      documents >= 0 && documents <= MAX_DOCUMENTS_FOR_CONVERT_TO_LOOKUP_INDEX;
 
     const hasSinglePrimaryShard =
       Number(selectedIndex.primary) === MAX_SHARDS_FOR_CONVERT_TO_LOOKUP_INDEX;

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/get_doc_count.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/get_doc_count.test.ts
@@ -133,6 +133,42 @@ describe('docCountApi', () => {
     sub.unsubscribe();
   });
 
+  it('replays the latest accumulated map to a late subscriber without issuing a new request', async () => {
+    const httpSetup = {
+      post: jest.fn().mockResolvedValue({ 'index-a': 42 }),
+    } as any;
+
+    const api = docCountApi(httpSetup);
+
+    // Early subscriber triggers the first batch.
+    const earlyEmissions: Array<Record<string, any>> = [];
+    const earlySub = api.getObservable().subscribe((v) => earlyEmissions.push(v));
+
+    api.getByName('index-a');
+    jest.advanceTimersByTime(100);
+    await flushPromises();
+
+    expect(httpSetup.post).toHaveBeenCalledTimes(1);
+    expect(earlyEmissions[earlyEmissions.length - 1]).toEqual({
+      'index-a': { status: RequestResultType.Success, count: 42 },
+    });
+
+    // Late subscriber attaches after the first emission has already occurred.
+    const lateEmissions: Array<Record<string, any>> = [];
+    const lateSub = api.getObservable().subscribe((v) => lateEmissions.push(v));
+
+    // shareReplay must replay the buffered state synchronously — no timers or promises needed.
+    expect(lateEmissions).toEqual([
+      { 'index-a': { status: RequestResultType.Success, count: 42 } },
+    ]);
+
+    // No additional HTTP request should have been made.
+    expect(httpSetup.post).toHaveBeenCalledTimes(1);
+
+    earlySub.unsubscribe();
+    lateSub.unsubscribe();
+  });
+
   it('does not emit error results for an aborted in-flight request', async () => {
     const d = deferred<Record<string, number>>();
     const httpSetup = {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/get_doc_count.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/get_doc_count.tsx
@@ -16,7 +16,7 @@ import {
   map,
   of,
   scan,
-  share,
+  shareReplay,
 } from 'rxjs';
 import type { HttpSetup } from '@kbn/core-http-browser';
 import { INTERNAL_API_BASE_PATH } from '../../../../../../common/constants';
@@ -29,6 +29,8 @@ export enum RequestResultType {
   Success = 'success',
   Error = 'error',
 }
+
+export type DocCountApi = ReturnType<typeof docCountApi>;
 
 export const docCountApi = (httpSetup: HttpSetup) => {
   const subj = new Subject<string>();
@@ -84,8 +86,8 @@ export const docCountApi = (httpSetup: HttpSetup) => {
         return next;
       }
     }, {} as Record<string, DocCountResult>),
-    // share the observable so it can be used multiple times
-    share()
+    // replay the latest accumulated state to late subscribers (e.g. the index actions context menu)
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   return {

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/index_table.js
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/index_table/index_table.js
@@ -741,6 +741,7 @@ export class IndexTable extends Component {
                           indexNames={Object.keys(selectedIndicesMap)}
                           isOnListView={true}
                           indicesListURLParams={location.search || ''}
+                          docCountApi={this.docCountApi}
                           resetSelection={() => {
                             this.setState({ selectedIndicesMap: {} });
                           }}


### PR DESCRIPTION
## Summary

Fixes the `Convert to lookup index` context menu action being permanently disabled on the stateful index list view, even when the selected index meets all conversion criteria.

Changes were previously made to get doc counts on the index list via `docCountApi` observable, bypassing the Redux store. However, `isConvertableToLookupIndex()` still read `selectedIndex.documents` from the store, which is no longer populated in stateful deployments.

This PR wires the existing `docCountApi` observable into the context menu as a fallback. To avoid additional API calls, the context menu reuses doc counts already fetched by the table's `DocCountCell` components. The following changes were made:

- `get_doc_count.tsx`: Changed `share()` to `shareReplay({ bufferSize: 1, refCount: true })` so that late subscribers (like the context menu) receive the latest accumulated doc count state
- `index_actions_context_menu.tsx`: Added an optional `docCountApi` prop. Subscribes via `useObservable` and uses the observable's doc count as a fallback when `selectedIndex.documents` is `undefined`

### Video of the bug

https://github.com/user-attachments/assets/b01bac90-17d7-4b28-b560-53322b89c0e1

### Testing
1. Start a local stateful Kibana instance
2. Create a test index
3. View the test index on the index management/index list page
4. Select the test index checkbox
5. Click `Manage index`
6. Verify the Convert to lookup index action is enabled (not greyed out)
7. Select an index with more than one primary shard or that is hidden/already a lookup index, and verify the action is correctly disabled
8. Navigate to the index details page for the test index, click `Manage index`, and verify the action is also enabled there (existing behavior, should not regress)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

## Release note

Fixes the `Convert to lookup index` action being permanently disabled on the index list view in stateful deployments.

