### PR TITLE
[Significant events] Header and breadcrumbs rename

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/page.tsx
@@ -53,7 +53,7 @@ export function SignificantEventsDiscoveryPage() {
     return [
       {
         title: i18n.translate('xpack.streams.significantEventsDiscovery.breadcrumbTitle', {
-          defaultMessage: 'Significant events Discovery',
+          defaultMessage: 'Significant Events',
         }),
         path: '/_discovery',
       },
@@ -144,7 +144,7 @@ export function SignificantEventsDiscoveryPage() {
             <EuiFlexItem>
               <EuiFlexGroup alignItems="center" gutterSize="m">
                 {i18n.translate('xpack.streams.significantEventsDiscovery.pageHeaderTitle', {
-                  defaultMessage: 'Significant Events Discovery',
+                  defaultMessage: 'Significant Events',
                 })}
               </EuiFlexGroup>
             </EuiFlexItem>


### PR DESCRIPTION
## Summary

Simple PR to rename Significant Event Discovery in the top header and breadcrumbs to Significant Events

<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/3c65a78c-0df5-44e1-99da-1600ef6b5fe0" />
