### PR TITLE
[Discover] fix wrong alert overview tab showing up for attack documents

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import { createProfileProviderSharedServicesMock } from '../../../__mocks__';
+import { createSecurityDocumentProfileProvider } from './profile';
+import { DocumentType } from '../../..';
+
+const mockServices = createProfileProviderSharedServicesMock();
+const provider = createSecurityDocumentProfileProvider(mockServices);
+
+const buildRecord = (fields: Record<string, unknown>): DataTableRecord =>
+  ({ flattened: fields, raw: {}, id: 'test-id' } as unknown as DataTableRecord);
+
+const prevDocViewer = () => ({
+  title: 'test title',
+  docViewsRegistry: (registry: DocViewsRegistry) => registry,
+});
+
+const getDocViewerFor = (record: DataTableRecord) => {
+  const getDocViewer = provider.profile.getDocViewer!(prevDocViewer, {
+    context: { type: DocumentType.Default },
+  });
+  return getDocViewer({ actions: {}, record } as Parameters<typeof getDocViewer>[0]);
+};
+
+describe('createSecurityDocumentProfileProvider — getDocViewer', () => {
+  it('registers the overview tab for a regular alert', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(buildRecord({ 'event.kind': 'signal' }));
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]).toMatchObject({
+      id: 'doc_view_alerts_overview',
+      title: 'Alert Overview',
+    });
+  });
+
+  it('does NOT register the overview tab for a non-alert event', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(buildRecord({ 'event.kind': 'event' }));
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+
+  it('does NOT register the overview tab for a scheduled attack discovery alert', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(
+      buildRecord({
+        'event.kind': 'signal',
+        [ALERT_RULE_TYPE_ID]: 'attack-discovery',
+      })
+    );
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+
+  it('does NOT register the overview tab for an ad-hoc attack discovery alert', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(
+      buildRecord({
+        'event.kind': 'signal',
+        [ALERT_RULE_TYPE_ID]: 'attack_discovery_ad_hoc_rule_type_id',
+      })
+    );
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getFieldValue } from '@kbn/discover-utils';
 import React from 'react';
 import type { DocumentProfileProvider } from '../../../profiles';
 import { DocumentType, SolutionType } from '../../../profiles';
@@ -16,6 +15,7 @@ import { SECURITY_PROFILE_ID } from '../constants';
 import * as i18n from '../translations';
 import type { SecurityProfileProviderFactory } from '../types';
 import { AlertEventOverviewLazy } from '../components';
+import { isAlertDocument } from '../utils/is_alert_document';
 
 export const createSecurityDocumentProfileProvider: SecurityProfileProviderFactory<
   DocumentProfileProvider
@@ -25,17 +25,19 @@ export const createSecurityDocumentProfileProvider: SecurityProfileProviderFacto
     profile: {
       getDocViewer: (prev) => (params) => {
         const prevDocViewer = prev(params);
-        const isAlert = getFieldValue(params.record, 'event.kind') === 'signal';
+        const isAlert = isAlertDocument(params.record);
 
         return {
           ...prevDocViewer,
           docViewsRegistry: (registry) => {
-            registry.add({
-              id: 'doc_view_alerts_overview',
-              title: i18n.overviewTabTitle(isAlert),
-              order: 0,
-              render: (props) => <AlertEventOverviewLazy {...props} />,
-            });
+            if (isAlert) {
+              registry.add({
+                id: 'doc_view_alerts_overview',
+                title: i18n.overviewTabTitle(isAlert),
+                order: 0,
+                render: (props) => <AlertEventOverviewLazy {...props} />,
+              });
+            }
 
             return prevDocViewer.docViewsRegistry(registry);
           },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -8,14 +8,13 @@
  */
 
 import React from 'react';
-import { getFieldValue } from '@kbn/discover-utils';
-import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { EnhancedAlertEventOverviewLazy, EnhancedAlertFlyoutHeaderLazy } from './components';
 import { SECURITY_PROFILE_ID } from './constants';
 import { extendProfileProvider } from '../extend_profile_provider';
 import { createSecurityDocumentProfileProvider } from './security_document_profile';
 import type { ProfileProviderServices } from '../profile_provider_services';
 import * as i18n from './translations';
+import { isAlertDocument } from './utils/is_alert_document';
 
 export const createSecurityDocumentProfileProviders = (
   providerServices: ProfileProviderServices
@@ -27,7 +26,7 @@ export const createSecurityDocumentProfileProviders = (
     profile: {
       getDocViewer: (prev) => (params) => {
         const prevDocViewer = prev(params);
-        const isAlert = getFieldValue(params.record, EVENT_KIND) === 'signal';
+        const isAlert = isAlertDocument(params.record);
 
         return {
           ...prevDocViewer,
@@ -39,14 +38,16 @@ export const createSecurityDocumentProfileProviders = (
             />
           ),
           docViewsRegistry: (registry) => {
-            registry.add({
-              id: 'doc_view_alerts_overview',
-              title: i18n.overviewTabTitle(isAlert),
-              order: 0,
-              render: (props) => (
-                <EnhancedAlertEventOverviewLazy {...props} providerServices={providerServices} />
-              ),
-            });
+            if (isAlert) {
+              registry.add({
+                id: 'doc_view_alerts_overview',
+                title: i18n.overviewTabTitle(isAlert),
+                order: 0,
+                render: (props) => (
+                  <EnhancedAlertEventOverviewLazy {...props} providerServices={providerServices} />
+                ),
+              });
+            }
 
             return prevDocViewer.docViewsRegistry(registry);
           },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { isAlertDocument } from './is_alert_document';
+
+const buildRecord = (fields: Record<string, unknown>): DataTableRecord =>
+  ({ flattened: fields, raw: {}, id: 'test-id' } as unknown as DataTableRecord);
+
+describe('isAlertDocument', () => {
+  it('returns true for a regular security alert', () => {
+    expect(isAlertDocument(buildRecord({ 'event.kind': 'signal' }))).toBe(true);
+  });
+
+  it('returns false for a non-alert event', () => {
+    expect(isAlertDocument(buildRecord({ 'event.kind': 'event' }))).toBe(false);
+  });
+
+  it('returns false when event.kind is absent', () => {
+    expect(isAlertDocument(buildRecord({}))).toBe(false);
+  });
+
+  it('returns false for a scheduled attack discovery alert', () => {
+    expect(
+      isAlertDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: 'attack-discovery',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for an ad-hoc attack discovery alert', () => {
+    expect(
+      isAlertDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: 'attack_discovery_ad_hoc_rule_type_id',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns true for a signal with an unrelated rule type', () => {
+    expect(
+      isAlertDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: 'siem.queryRule',
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import {
+  ALERT_RULE_TYPE_ID,
+  ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+  EVENT_KIND,
+} from '@kbn/rule-data-utils';
+
+const ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID = 'attack_discovery_ad_hoc_rule_type_id' as const;
+
+/**
+ * Returns true if the document is a security alert — i.e. event.kind is 'signal'
+ * and the rule type is not an attack discovery rule type.
+ */
+export const isAlertDocument = (record: DataTableRecord): boolean => {
+  if (getFieldValue(record, EVENT_KIND) !== 'signal') return false;
+  const ruleTypeId = getFieldValue(record, ALERT_RULE_TYPE_ID);
+  return (
+    ruleTypeId !== ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID &&
+    ruleTypeId !== ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID
+  );
+};


### PR DESCRIPTION
## Summary

This PR makes a small fix for the Security profile used in Discover. We were only checking if `event.kind: signal` to determine if we showed the `Alert Overview` tab in the document flyout. But both alert and attack documents have `event.kind: signal`, so we needed to check something more.

I've reused the logic we currently have in this [isAttackDiscoveryRow](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/is_attack_discovery_row.ts) hook.

> [!NOTE]
> I decided to not extract the logic into a hook that would be shared between Discover and Security Solution, for 2 reasons:
> - I'm not sure what's the best place we'd put that hook at this time
> - the logic in the Security Solution hook is slightly more complex as it has to handle Timeline objects. Once we remove that logic, it will make more sense to have a shared hook

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
