### PR TITLE
[9.2] [CI] Add optimistic cancellation for PR pipeline gate failures (#252647)

### DIFF
--- a/.buildkite/pipeline-utils/buildkite/client.test.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.test.ts
@@ -7,9 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { execFileSync } from 'child_process';
 import { BuildkiteClient } from './client';
 import type { Build } from './types/build';
 import type { Job } from './types/job';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execFileSync: jest.fn(),
+}));
+
+const execFileSyncMock = execFileSync as jest.MockedFunction<typeof execFileSync>;
 
 describe('BuildkiteClient', () => {
   let buildkite: BuildkiteClient;
@@ -254,6 +262,24 @@ describe('BuildkiteClient', () => {
 
       const result = buildkite.getJobStatus(build, job);
       expect(result.success).toEqual(true);
+    });
+  });
+
+  describe('cancelStep', () => {
+    afterEach(() => {
+      execFileSyncMock.mockReset();
+    });
+
+    it('calls buildkite-agent step cancel for the specified step', () => {
+      buildkite.cancelStep('step-id-1');
+
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'buildkite-agent',
+        ['step', 'cancel', '--step', 'step-id-1'],
+        {
+          stdio: ['pipe', 'inherit', 'inherit'],
+        }
+      );
     });
   });
 });

--- a/.buildkite/pipeline-utils/buildkite/client.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.ts
@@ -10,7 +10,7 @@
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
 import type { ExecSyncOptions } from 'child_process';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 
 import { dump } from 'js-yaml';
 
@@ -367,8 +367,27 @@ export class BuildkiteClient {
     return (await this.http.post(url, options)).data;
   };
 
+  cancelStep = (stepIdOrKey: string): void => {
+    execFileSync('buildkite-agent', ['step', 'cancel', '--step', stepIdOrKey], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+  };
+
+  getMetadataKeys = (): string[] => {
+    const stdout = execFileSync('buildkite-agent', ['meta-data', 'keys'], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+
+    const output = stdout?.toString().trim() ?? '';
+    if (!output) {
+      return [];
+    }
+
+    return output.split('\n').filter(Boolean);
+  };
+
   setMetadata = (key: string, value: string) => {
-    this.exec(`buildkite-agent meta-data set '${key}'`, {
+    execFileSync('buildkite-agent', ['meta-data', 'set', key], {
       input: value,
       stdio: ['pipe', 'inherit', 'inherit'],
     });
@@ -376,7 +395,7 @@ export class BuildkiteClient {
 
   getMetadata(key: string, defaultValue: string | null = null): string | null {
     try {
-      const stdout = this.exec(`buildkite-agent meta-data get '${key}'`, {
+      const stdout = execFileSync('buildkite-agent', ['meta-data', 'get', key], {
         stdio: ['pipe'],
       });
       return stdout?.toString().trim() || defaultValue;

--- a/.buildkite/pipeline-utils/buildkite/types/job.ts
+++ b/.buildkite/pipeline-utils/buildkite/types/job.ts
@@ -36,11 +36,21 @@ export interface Job {
   id: string;
   type: string;
   name: string;
-  step_key: string;
+  step_key: string | null;
+  /**
+   * A job is an execution of a step. When a step is run with `parallelism`,
+   * multiple jobs will share the same `step.id`.
+   *
+   * This is present in the Buildkite Builds API response for jobs.
+   */
+  step?: {
+    id: string;
+    signature?: string | null;
+  };
   state: JobState;
   logs_url: string;
   raw_log_url: string;
-  command: string;
+  command: string | null;
   exit_status: null | number;
   artifact_paths: string;
   artifacts_url: string;

--- a/.buildkite/pipeline-utils/buildkite/utils.test.ts
+++ b/.buildkite/pipeline-utils/buildkite/utils.test.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { load as loadYaml } from 'js-yaml';
+
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
+import { getPipeline } from './utils';
+
+const execFileSyncMock = execFileSync as jest.MockedFunction<typeof execFileSync>;
+
+describe('getPipeline', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'buildkite-utils-'));
+    execFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const writePipeline = (contents: string): string => {
+    const filename = path.join(tempDir, 'pipeline.yml');
+    fs.writeFileSync(filename, contents);
+    return filename;
+  };
+
+  it('ignores comment-only steps when registering cancel-on-gate-failure metadata', () => {
+    const filename = writePipeline(`steps:
+#  - command: .buildkite/scripts/steps/checks/api_contracts.sh
+#    key: check_api_contracts
+`);
+
+    expect(() => getPipeline(filename, { cancelOnGateFailure: true })).not.toThrow();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-command steps when registering cancel-on-gate-failure metadata', () => {
+    const filename = writePipeline(`steps:
+  - wait: ~
+`);
+
+    expect(() => getPipeline(filename, { cancelOnGateFailure: true })).not.toThrow();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('registers metadata for keyed steps', () => {
+    const filename = writePipeline(`steps:
+  - command: echo test
+    key: test_step
+`);
+
+    getPipeline(filename, { cancelOnGateFailure: true });
+
+    expect(execFileSyncMock).toHaveBeenCalledWith('buildkite-agent', [
+      'meta-data',
+      'set',
+      'cancel_on_gate_failure:test_step',
+      'true',
+    ]);
+  });
+
+  it('still throws when an active step is missing a key', () => {
+    const filename = writePipeline(`steps:
+  - command: echo test
+`);
+
+    expect(() => getPipeline(filename, { cancelOnGateFailure: true })).toThrow(
+      'is missing a "key"'
+    );
+  });
+
+  it('verifies manually registered base.yml step keys exist', () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const pipelineSource = fs.readFileSync(
+      path.resolve(__dirname, '../../scripts/pipelines/pull_request/pipeline.ts'),
+      'utf8'
+    );
+
+    // Extract step keys from the manual registration loop in pipeline.ts
+    const manualKeysMatch = pipelineSource.match(/for \(const stepKey of \[([^\]]+)\]\)/s);
+    expect(manualKeysMatch).not.toBeNull();
+
+    const manualKeys = [...manualKeysMatch![1].matchAll(/'([^']+)'/g)].map(([, key]) => key);
+    expect(manualKeys.length).toBeGreaterThan(0);
+
+    // Parse base.yml and collect all step keys
+    const baseYml = fs.readFileSync(
+      path.resolve(repoRoot, '.buildkite/pipelines/pull_request/base.yml'),
+      'utf8'
+    );
+    const baseDoc = loadYaml(baseYml) as { steps: Array<{ key?: string }> };
+    const baseKeys = new Set(
+      baseDoc.steps
+        .filter((s: Record<string, unknown>) => typeof s.key === 'string')
+        .map((s: Record<string, unknown>) => s.key)
+    );
+
+    for (const key of manualKeys) {
+      expect(baseKeys).toContain(key);
+    }
+  });
+
+  it('accepts every cancelable pull request pipeline fragment', () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const pullRequestPipeline = path.resolve(
+      __dirname,
+      '../../scripts/pipelines/pull_request/pipeline.ts'
+    );
+    const pipelineSource = fs.readFileSync(pullRequestPipeline, 'utf8');
+    const cancelablePipelines = [
+      ...new Set(
+        [...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs)].map(
+          ([, filename]) => path.resolve(repoRoot, filename)
+        )
+      ),
+    ];
+
+    expect(cancelablePipelines.length).toBeGreaterThan(0);
+
+    for (const filename of cancelablePipelines) {
+      expect(() => getPipeline(filename, { cancelOnGateFailure: true })).not.toThrow();
+    }
+  });
+
+  it('has no duplicate step keys across cancelable pipeline files and base.yml', () => {
+    const repoRoot = path.resolve(__dirname, '../../..');
+    const pullRequestPipeline = path.resolve(
+      __dirname,
+      '../../scripts/pipelines/pull_request/pipeline.ts'
+    );
+    const pipelineSource = fs.readFileSync(pullRequestPipeline, 'utf8');
+
+    // Collect all cancelable pipeline files
+    const cancelablePipelines = [
+      ...new Set(
+        [...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs)].map(
+          ([, filename]) => path.resolve(repoRoot, filename)
+        )
+      ),
+    ];
+
+    // Also include base.yml
+    cancelablePipelines.push(path.resolve(repoRoot, '.buildkite/pipelines/pull_request/base.yml'));
+
+    // These pipeline pairs are in if/else branches in pipeline.ts and can never
+    // both be uploaded in the same build, so shared keys are safe.
+    const mutuallyExclusivePairs = new Set([
+      'build_project.yml:deploy_project.yml',
+      'deploy_project.yml:build_project.yml',
+    ]);
+
+    const allKeys = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const filename of cancelablePipelines) {
+      const doc = loadYaml(fs.readFileSync(filename, 'utf8'));
+      if (!doc || !Array.isArray(doc.steps)) continue;
+
+      const collectKeys = (steps: Array<Record<string, unknown>>) => {
+        for (const step of steps) {
+          if (typeof step !== 'object' || step === null) continue;
+          if (typeof step.key === 'string') {
+            const rel = path.relative(repoRoot, filename);
+            if (allKeys.has(step.key as string)) {
+              const existingFile = allKeys.get(step.key as string)!;
+              const pair = `${path.basename(existingFile)}:${path.basename(rel)}`;
+              if (!mutuallyExclusivePairs.has(pair)) {
+                duplicates.push(`key "${step.key}" in ${rel} conflicts with ${existingFile}`);
+              }
+            } else {
+              allKeys.set(step.key as string, rel);
+            }
+          }
+          if (Array.isArray(step.steps)) {
+            collectKeys(step.steps as Array<Record<string, unknown>>);
+          }
+        }
+      };
+
+      collectKeys(doc.steps);
+    }
+
+    expect(duplicates).toEqual([]);
+  });
+});

--- a/.buildkite/pipeline-utils/buildkite/utils.ts
+++ b/.buildkite/pipeline-utils/buildkite/utils.ts
@@ -7,14 +7,114 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { execFileSync } from 'child_process';
 import fs from 'fs';
+import { load as loadYaml } from 'js-yaml';
 
 export function emitPipeline(pipelineSteps: string[]) {
   const pipelineStr = [...new Set(pipelineSteps)].join('\n');
   console.log(pipelineStr);
 }
 
-export const getPipeline = (filename: string, removeSteps = true) => {
+export interface GetPipelineOptions {
+  removeSteps?: boolean;
+  cancelOnGateFailure?: boolean;
+}
+
+function isObj(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+
+function isCommandStep(step: Record<string, unknown>): step is Record<string, unknown> & {
+  command: string;
+} {
+  return typeof step.command === 'string';
+}
+
+function getSteps(filename: string, doc: unknown): unknown[] {
+  if (!isObj(doc)) {
+    throw new Error(`${filename}: expected a YAML document with a "steps" array`);
+  }
+
+  if (doc.steps == null) {
+    return [];
+  }
+
+  if (!Array.isArray(doc.steps)) {
+    throw new Error(`${filename}: expected a YAML document with a "steps" array`);
+  }
+
+  return doc.steps;
+}
+
+/**
+ * Extracts cancelable step keys from a parsed pipeline YAML document.
+ * For group steps, recurses into child steps instead of registering the
+ * group key (buildkite-agent step cancel does not work on group keys).
+ * Throws if any command step is missing a key.
+ */
+function extractStepKeys(filename: string, doc: unknown): string[] {
+  const keys: string[] = [];
+  const steps = getSteps(filename, doc);
+
+  for (const step of steps) {
+    if (!isObj(step)) continue;
+
+    // Group step: recurse into child steps instead of registering the group key
+    if (typeof step.group === 'string' && Array.isArray(step.steps)) {
+      for (const child of step.steps) {
+        if (!isObj(child)) continue;
+
+        if (!isCommandStep(child)) {
+          continue;
+        }
+
+        if (typeof child.key === 'string') {
+          keys.push(child.key);
+        } else {
+          const label = String(child.label ?? child.command ?? 'unknown');
+          throw new Error(
+            `${filename}: group "${step.group}" child step "${label}" is missing a "key" (required for cancelOnGateFailure)`
+          );
+        }
+      }
+      continue;
+    }
+
+    if (!isCommandStep(step)) {
+      continue;
+    }
+
+    if (typeof step.key === 'string') {
+      keys.push(step.key);
+    } else {
+      const label = String(step.label ?? step.group ?? step.command ?? 'unknown');
+      throw new Error(
+        `${filename}: step "${label}" is missing a "key" (required for cancelOnGateFailure)`
+      );
+    }
+  }
+
+  return keys;
+}
+
+function registerCancelOnGateFailureMetadata(keys: string[]) {
+  for (const key of keys) {
+    execFileSync('buildkite-agent', ['meta-data', 'set', `cancel_on_gate_failure:${key}`, 'true']);
+  }
+}
+
+export const getPipeline = (filename: string, options?: boolean | GetPipelineOptions) => {
+  const opts: GetPipelineOptions =
+    typeof options === 'boolean' ? { removeSteps: options } : { removeSteps: true, ...options };
+
   const str = fs.readFileSync(filename).toString();
-  return removeSteps ? str.replace(/^steps:/, '') : str;
+
+  if (opts.cancelOnGateFailure) {
+    const doc = loadYaml(str);
+    const keys = extractStepKeys(filename, doc);
+    registerCancelOnGateFailureMetadata(keys);
+  }
+
+  return opts.removeSteps ? str.replace(/^steps:/, '') : str;
 };

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -525,89 +525,103 @@ export async function pickTestGroupRunOrder() {
     bk.uploadArtifacts('ftr_run_order.json');
   }
 
+  const steps = [
+    unit.count > 0
+      ? {
+          label: 'Jest Tests',
+          command: getRequiredEnv('JEST_UNIT_SCRIPT'),
+          parallelism: unit.count,
+          timeout_in_minutes: 120,
+          key: 'jest',
+          agents: expandAgentQueue('n2-4-spot', 110),
+          depends_on: JEST_CONFIGS_DEPS,
+          retry: {
+            automatic: [
+              { exit_status: '-1', limit: 3 },
+              ...(JEST_CONFIGS_RETRY_COUNT > 0
+                ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
+                : []),
+            ],
+          },
+        }
+      : [],
+    integration.count > 0
+      ? {
+          label: 'Jest Integration Tests',
+          command: getRequiredEnv('JEST_INTEGRATION_SCRIPT'),
+          parallelism: integration.count,
+          // TODO: Reduce once we have identified the cause of random long-running tests
+          timeout_in_minutes: 75,
+          key: 'jest-integration',
+          agents: expandAgentQueue('n2-4-spot', 105),
+          depends_on: JEST_CONFIGS_DEPS,
+          retry: {
+            automatic: [
+              { exit_status: '-1', limit: 3 },
+              ...(JEST_CONFIGS_RETRY_COUNT > 0
+                ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
+                : []),
+            ],
+          },
+        }
+      : [],
+    functionalGroups.length
+      ? {
+          group: 'FTR Configs',
+          key: 'ftr-configs',
+          depends_on: FTR_CONFIGS_DEPS,
+          steps: functionalGroups
+            .sort((a, b) =>
+              // if both groups are sorted by number then sort by that
+              typeof a.sortBy === 'number' && typeof b.sortBy === 'number'
+                ? a.sortBy - b.sortBy
+                : // if both groups are sorted by string, sort by that
+                typeof a.sortBy === 'string' && typeof b.sortBy === 'string'
+                ? a.sortBy.localeCompare(b.sortBy)
+                : // if a is sorted by number then order it later than b
+                typeof a.sortBy === 'number'
+                ? 1
+                : -1
+            )
+            .map(
+              ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
+                label: title,
+                command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
+                timeout_in_minutes: 120,
+                agents: expandAgentQueue(queue, 105),
+                env: {
+                  FTR_CONFIG_GROUP_KEY: key,
+                  ...ftrExtraArgs,
+                  ...envFromlabels,
+                },
+                retry: {
+                  automatic: [
+                    { exit_status: '-1', limit: 3 },
+                    ...(FTR_CONFIGS_RETRY_COUNT > 0
+                      ? [{ exit_status: '*', limit: FTR_CONFIGS_RETRY_COUNT }]
+                      : []),
+                  ],
+                },
+              })
+            ),
+        }
+      : [],
+  ].flat();
+
+   // Register cancelable child keys before uploading so a concurrent gate failure
+  // can discover and short-circuit these jobs immediately.
+  if (unit.count > 0) {
+    bk.setMetadata('cancel_on_gate_failure:jest', 'true');
+  }
+  if (integration.count > 0) {
+    bk.setMetadata('cancel_on_gate_failure:jest-integration', 'true');
+  }
+  // Register child step keys (not the group key) because `buildkite-agent step cancel`
+  // does not work on group keys.
+  for (const fg of functionalGroups) {
+    bk.setMetadata(`cancel_on_gate_failure:${fg.key}`, 'true');
+  }
+
   // upload the step definitions to Buildkite
-  bk.uploadSteps(
-    [
-      unit.count > 0
-        ? {
-            label: 'Jest Tests',
-            command: getRequiredEnv('JEST_UNIT_SCRIPT'),
-            parallelism: unit.count,
-            timeout_in_minutes: 120,
-            key: 'jest',
-            agents: expandAgentQueue('n2-4-spot', 110),
-            depends_on: JEST_CONFIGS_DEPS,
-            retry: {
-              automatic: [
-                { exit_status: '-1', limit: 3 },
-                ...(JEST_CONFIGS_RETRY_COUNT > 0
-                  ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
-                  : []),
-              ],
-            },
-          }
-        : [],
-      integration.count > 0
-        ? {
-            label: 'Jest Integration Tests',
-            command: getRequiredEnv('JEST_INTEGRATION_SCRIPT'),
-            parallelism: integration.count,
-            // TODO: Reduce once we have identified the cause of random long-running tests
-            timeout_in_minutes: 75,
-            key: 'jest-integration',
-            agents: expandAgentQueue('n2-4-spot', 105),
-            depends_on: JEST_CONFIGS_DEPS,
-            retry: {
-              automatic: [
-                { exit_status: '-1', limit: 3 },
-                ...(JEST_CONFIGS_RETRY_COUNT > 0
-                  ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
-                  : []),
-              ],
-            },
-          }
-        : [],
-      functionalGroups.length
-        ? {
-            group: 'FTR Configs',
-            key: 'ftr-configs',
-            depends_on: FTR_CONFIGS_DEPS,
-            steps: functionalGroups
-              .sort((a, b) =>
-                // if both groups are sorted by number then sort by that
-                typeof a.sortBy === 'number' && typeof b.sortBy === 'number'
-                  ? a.sortBy - b.sortBy
-                  : // if both groups are sorted by string, sort by that
-                  typeof a.sortBy === 'string' && typeof b.sortBy === 'string'
-                  ? a.sortBy.localeCompare(b.sortBy)
-                  : // if a is sorted by number then order it later than b
-                  typeof a.sortBy === 'number'
-                  ? 1
-                  : -1
-              )
-              .map(
-                ({ title, key, queue = defaultQueue }): BuildkiteStep => ({
-                  label: title,
-                  command: getRequiredEnv('FTR_CONFIGS_SCRIPT'),
-                  timeout_in_minutes: 120,
-                  agents: expandAgentQueue(queue, 105),
-                  env: {
-                    FTR_CONFIG_GROUP_KEY: key,
-                    ...ftrExtraArgs,
-                    ...envFromlabels,
-                  },
-                  retry: {
-                    automatic: [
-                      { exit_status: '-1', limit: 3 },
-                      ...(FTR_CONFIGS_RETRY_COUNT > 0
-                        ? [{ exit_status: '*', limit: FTR_CONFIGS_RETRY_COUNT }]
-                        : []),
-                    ],
-                  },
-                })
-              ),
-          }
-        : [],
-    ].flat()
-  );
+  bk.uploadSteps(steps);
 }

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -608,7 +608,7 @@ export async function pickTestGroupRunOrder() {
       : [],
   ].flat();
 
-   // Register cancelable child keys before uploading so a concurrent gate failure
+  // Register cancelable child keys before uploading so a concurrent gate failure
   // can discover and short-circuit these jobs immediately.
   if (unit.count > 0) {
     bk.setMetadata('cancel_on_gate_failure:jest', 'true');

--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -356,7 +356,7 @@ export async function pickTestGroupRunOrder() {
     ? globby.sync(getJestConfigGlobs(['**/jest.config.js', '!**/__fixtures__/**']), {
         cwd: process.cwd(),
         absolute: false,
-        ignore: DISABLED_JEST_CONFIGS,
+        ignore: [...DISABLED_JEST_CONFIGS, '**/node_modules/**'],
       })
     : [];
 
@@ -364,7 +364,7 @@ export async function pickTestGroupRunOrder() {
     ? globby.sync(getJestConfigGlobs(['**/jest.integration.config.js', '!**/__fixtures__/**']), {
         cwd: process.cwd(),
         absolute: false,
-        ignore: DISABLED_JEST_CONFIGS,
+        ignore: [...DISABLED_JEST_CONFIGS, '**/node_modules/**'],
       })
     : [];
 

--- a/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/scout/pick_scout_test_group_run_order.ts
@@ -36,6 +36,7 @@ if (process.env.SERVERLESS_TESTS_ONLY) {
 export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
   const bk = new BuildkiteClient();
   const envFromlabels: Record<string, string> = collectEnvFromLabels();
+
   if (!Fs.existsSync(scoutConfigsPath)) {
     throw new Error(`Scout configs file not found at ${scoutConfigsPath}`);
   }
@@ -69,34 +70,43 @@ export async function pickScoutTestGroupRunOrder(scoutConfigsPath: string) {
     };
   });
 
+  const steps = [
+    {
+      group: 'Scout Configs',
+      key: 'scout-configs',
+      depends_on: SCOUT_CONFIGS_DEPS,
+      steps: scoutCiRunGroups.map(
+        ({ label, key, group, agents }): BuildkiteStep => ({
+          label,
+          command: getRequiredEnv('SCOUT_CONFIGS_SCRIPT'),
+          timeout_in_minutes: 60,
+          key,
+          agents,
+          env: {
+            SCOUT_CONFIG_GROUP_KEY: key,
+            SCOUT_CONFIG_GROUP_TYPE: group,
+            ...envFromlabels,
+            ...scoutExtraEnv,
+          },
+          retry: {
+            automatic: [
+              { exit_status: '-1', limit: 3 },
+              { exit_status: '*', limit: 1 },
+            ],
+          },
+        })
+      ),
+    },
+  ].flat();
+
+  // Register each Scout child step for cancel-on-gate-failure before uploading
+  // so a concurrent gate failure can cancel or short-circuit them immediately.
+  // We register child step keys (not the group key) because `buildkite-agent step cancel`
+  // does not work on group keys.
+  for (const { key } of scoutCiRunGroups) {
+    bk.setMetadata(`cancel_on_gate_failure:${key}`, 'true');
+  }
+
   // upload the step definitions to Buildkite
-  bk.uploadSteps(
-    [
-      {
-        group: 'Scout Configs',
-        key: 'scout-configs',
-        depends_on: SCOUT_CONFIGS_DEPS,
-        steps: scoutCiRunGroups.map(
-          ({ label, key, group, agents }): BuildkiteStep => ({
-            label,
-            command: getRequiredEnv('SCOUT_CONFIGS_SCRIPT'),
-            timeout_in_minutes: 60,
-            agents,
-            env: {
-              SCOUT_CONFIG_GROUP_KEY: key,
-              SCOUT_CONFIG_GROUP_TYPE: group,
-              ...envFromlabels,
-              ...scoutExtraEnv,
-            },
-            retry: {
-              automatic: [
-                { exit_status: '-1', limit: 3 },
-                { exit_status: '*', limit: 1 },
-              ],
-            },
-          })
-        ),
-      },
-    ].flat()
-  );
+  bk.uploadSteps(steps);
 }

--- a/.buildkite/pipeline-utils/scout/test_distribution_strategies.test.ts
+++ b/.buildkite/pipeline-utils/scout/test_distribution_strategies.test.ts
@@ -16,11 +16,13 @@ let mockKibanaDir: string;
 
 const mockUploadSteps = jest.fn();
 const mockUploadArtifacts = jest.fn();
+const mockSetMetadata = jest.fn();
 
 jest.mock('../buildkite', () => ({
   BuildkiteClient: jest.fn().mockImplementation(() => ({
     uploadSteps: mockUploadSteps,
     uploadArtifacts: mockUploadArtifacts,
+    setMetadata: mockSetMetadata,
   })),
 }));
 
@@ -244,6 +246,26 @@ describe('scoutTestDistributionStrategies', () => {
 
       const uploadedGroup = mockUploadSteps.mock.calls[0][0][0];
       expect(uploadedGroup.depends_on).toEqual([]);
+    });
+
+    it('registers each lane step for cancel-on-gate-failure before uploading', async () => {
+      const track = createMockTrack('local', 'stateful', 'classic', 'default', [
+        createMockLane(1, 'n2-4-spot', ['config-a.ts']),
+        createMockLane(2, 'n2-4-spot', ['config-b.ts']),
+      ]);
+
+      mockDefinitionsAll.mockReturnValue(['/mock/tracks.json']);
+      mockDefinitionsLoadFromPath.mockReturnValue(createMockTrackDefinition([track]));
+
+      await scoutTestDistributionStrategies.lanes();
+
+      expect(mockSetMetadata.mock.calls).toEqual([
+        ['cancel_on_gate_failure:scout_test_lane_1', 'true'],
+        ['cancel_on_gate_failure:scout_test_lane_2', 'true'],
+      ]);
+      expect(mockSetMetadata.mock.invocationCallOrder[1]).toBeLessThan(
+        mockUploadSteps.mock.invocationCallOrder[0]
+      );
     });
   });
 });

--- a/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
+++ b/.buildkite/pipeline-utils/scout/test_distribution_strategies.ts
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import { SCOUT_TEST_LANE_LOADS_PATH, SCOUT_TEST_TRACKS_ROOT } from './paths';
 import { scoutTestTrack, type ScoutTestTrack } from './test_tracks';
 import { pickScoutTestGroupRunOrder } from './pick_scout_test_group_run_order';
-import { BuildkiteClient, type BuildkiteStep } from '../buildkite';
+import { BuildkiteClient, type BuildkiteCommandStep } from '../buildkite';
 import { getKibanaDir } from '../utils';
 import { expandAgentQueue } from '../agent_images';
 import { collectEnvFromLabels } from '../pr_labels';
@@ -57,7 +57,7 @@ async function distributeScoutTestsOnLanes() {
     throw new Error(`No Scout test tracks definition files found under ${SCOUT_TEST_TRACKS_ROOT}`);
   }
 
-  const steps: BuildkiteStep[] = [];
+  const steps: BuildkiteCommandStep[] = [];
   const loadIDsByStepKey: Record<string, string[]> = {};
   const testLaneLoadsFilePath = path.relative(getKibanaDir(), SCOUT_TEST_LANE_LOADS_PATH);
 
@@ -111,11 +111,7 @@ async function distributeScoutTestsOnLanes() {
       loadIDsByStepKey[stepKey] = lane.loads;
     });
 
-  // Write the test lane load IDs to disk in preparation of uploading as an artifact
-  fs.writeFileSync(testLaneLoadsFilePath, JSON.stringify(loadIDsByStepKey));
-
   const bk = new BuildkiteClient();
-  bk.uploadArtifacts(testLaneLoadsFilePath);
 
   const lanesGroupStepDependencies: string[] = [];
 
@@ -130,6 +126,14 @@ async function distributeScoutTestsOnLanes() {
     // Default dependencies
     lanesGroupStepDependencies.push('build_scout_tests');
   }
+
+  for (const { key } of steps) {
+    bk.setMetadata(`cancel_on_gate_failure:${key}`, 'true');
+  }
+
+  // Write the test lane load IDs to disk in preparation of uploading as an artifact
+  fs.writeFileSync(testLaneLoadsFilePath, JSON.stringify(loadIDsByStepKey));
+  bk.uploadArtifacts(testLaneLoadsFilePath);
 
   // Send it 🚀
   bk.uploadSteps([

--- a/.buildkite/pipelines/fips/verify_fips_enabled.yml
+++ b/.buildkite/pipelines/fips/verify_fips_enabled.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/pipelines/fips/verify_fips_enabled.sh
     label: 'Verify FIPS Enabled'
+    key: verify_fips_enabled
     depends_on: build
     timeout_in_minutes: 10
     retry:

--- a/.buildkite/pipelines/pull_request/apm_cypress.yml
+++ b/.buildkite/pipelines/pull_request/apm_cypress.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/apm_cypress.sh
     label: 'APM Cypress Tests'
+    key: apm-cypress
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -23,6 +23,8 @@ steps:
       diskSizeGb: 105
     key: quick_checks
     timeout_in_minutes: 60
+    env:
+      CHECK_GATE: 'true'
     retry:
       automatic:
         - exit_status: '-1'
@@ -30,13 +32,15 @@ steps:
 
   - command: .buildkite/scripts/steps/checks.sh
     label: 'Checks'
+    key: checks
+    env:
+      CHECK_GATE: 'true'
     agents:
       machineType: n2d-standard-2
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
       diskSizeGb: 105
     timeout_in_minutes: 60
-    key: checks
     retry:
       automatic:
         - exit_status: '-1'
@@ -51,6 +55,8 @@ steps:
       diskSizeGb: 105
     key: linting
     timeout_in_minutes: 60
+    env:
+      CHECK_GATE: 'true'
     retry:
       automatic:
         - exit_status: '-1'
@@ -65,6 +71,8 @@ steps:
       diskSizeGb: 105
     key: linting_with_types
     timeout_in_minutes: 60
+    env:
+      CHECK_GATE: 'true'
     retry:
       automatic:
         - exit_status: '-1'
@@ -77,7 +85,11 @@ steps:
       preemptible: true
       spotZones: us-central1-b,us-central1-c,us-central1-f
     key: check_oas_snapshot
+    depends_on:
+      - build
     timeout_in_minutes: 60
+    env:
+      CHECK_GATE: 'true'
     retry:
       automatic:
         - exit_status: '-1'
@@ -92,6 +104,8 @@ steps:
       diskSizeGb: 105
     key: check_types
     timeout_in_minutes: 60
+    env:
+      CHECK_GATE: 'true'
     retry:
       automatic:
         - exit_status: '-1'
@@ -99,6 +113,7 @@ steps:
 
   - command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
     label: 'Pick Test Group Run Order'
+    key: pick_test_group_run_order
     agents:
       machineType: n2-standard-2
       diskSizeGb: 115
@@ -135,6 +150,7 @@ steps:
     label: Mark CI Stats as ready
     agents:
       machineType: n2-standard-2
+    key: ci_stats_ready
     timeout_in_minutes: 10
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_fips_image.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/fips/build_cloud_fips_image.sh
     label: 'Build Cloud FIPS Image'
+    key: build_cloud_fips_image
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/build_cloud_image.yml
+++ b/.buildkite/pipelines/pull_request/build_cloud_image.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/cloud/build_cloud_image.sh
     label: 'Build Cloud Image'
+    key: build_cloud_image
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/build_project.yml
+++ b/.buildkite/pipelines/pull_request/build_project.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/artifacts/docker_image.sh
     label: 'Build Project Image'
+    key: build_project_image
     agents:
       machineType: n2-standard-16
       preemptible: true

--- a/.buildkite/pipelines/pull_request/check_next_docs.yml
+++ b/.buildkite/pipelines/pull_request/check_next_docs.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/next_docs/build_and_validate_docs.sh
     label: 'Build and Validate Next Docs'
+    key: check_next_docs
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/check_saved_objects.yml
+++ b/.buildkite/pipelines/pull_request/check_saved_objects.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/check_saved_objects.sh
     label: 'Check changes in Saved Objects'
+    key: check_saved_objects
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/deploy_cloud.yml
+++ b/.buildkite/pipelines/pull_request/deploy_cloud.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/cloud/build_and_deploy.sh
     label: 'Build and Deploy to Cloud'
+    key: deploy_cloud
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/deploy_project.yml
+++ b/.buildkite/pipelines/pull_request/deploy_project.yml
@@ -13,6 +13,7 @@ steps:
           limit: 3
   - command: .buildkite/scripts/steps/serverless/deploy.sh
     label: 'Deploy Project'
+    key: deploy_project
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/fips.yml
+++ b/.buildkite/pipelines/pull_request/fips.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/fips/build.sh
     label: 'Build FIPS Image'
+    key: build_fips_image
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/fleet_cypress.yml
+++ b/.buildkite/pipelines/pull_request/fleet_cypress.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/fleet_cypress.sh
     label: 'Fleet Cypress Tests'
+    key: fleet-cypress
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/ftr_bench.yml
+++ b/.buildkite/pipelines/pull_request/ftr_bench.yml
@@ -1,11 +1,11 @@
 steps:
   - command: .buildkite/scripts/steps/ftr_bench.sh
     label: 'FTR Bench'
+    key: ftr_bench
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
       zones: us-central1-c,us-central1-a
       diskSizeGb: 200
-    key: ftr_bench
     timeout_in_minutes: 120
     soft_fail: true

--- a/.buildkite/pipelines/pull_request/jest_bench.yml
+++ b/.buildkite/pipelines/pull_request/jest_bench.yml
@@ -1,11 +1,11 @@
 steps:
   - command: .buildkite/scripts/steps/jest_bench.sh
     label: 'Jest Bench'
+    key: jest_bench
     agents:
       machineType: c4d-standard-16
       diskType: hyperdisk-balanced
       zones: us-central1-c,us-central1-a
       diskSizeGb: 100
-    key: jest_bench
     timeout_in_minutes: 60
     soft_fail: true

--- a/.buildkite/pipelines/pull_request/kbn_handlebars.yml
+++ b/.buildkite/pipelines/pull_request/kbn_handlebars.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/test/kbn_handlebars.sh
     label: 'Check @kbn/handlebars for upstream differences'
+    key: kbn_handlebars
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/prompt_changes.yml
+++ b/.buildkite/pipelines/pull_request/prompt_changes.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/checks/prompt_changes_detector.sh
     label: 'Check Prompt Changes'
+    key: prompt_changes
     agents:
       machineType: n2-standard-2
       preemptible: true

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/response_ops.sh
     label: 'Rules, Alerts and Exceptions ResponseOps Cypress Tests on Security Solution'
+    key: response-ops
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/response_ops_cases.sh
     label: 'Cases Cypress Tests on Security Solution'
+    key: response-ops-cases
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_ai_assistant.sh
     label: 'AI Assistant - Security Solution Cypress Tests'
+    key: security-ai-assistant
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/asset_inventory.sh
     label: 'Asset Inventory Cypress Tests'
+    key: asset-inventory
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/cloud_security_posture.sh
     label: 'Cloud Security Posture Cypress Tests'
+    key: cloud-security-posture
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows_burn.sh
     label: '[Soft fail] Defend Workflows Cypress Tests, burning changed specs'
+    key: defend-workflows-burn
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
@@ -16,6 +17,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_burn.sh
     label: '[Soft fail] Security Solution Cypress tests, burning changed specs'
+    key: security-solution-burn
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -30,6 +32,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress_burn.sh
     label: '[Soft fail] Osquery Cypress Tests, burning changed specs'
+    key: osquery-cypress-burn
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/defend_workflows.sh
     label: 'Defend Workflows Cypress Tests'
+    key: defend-workflows
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4

--- a/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/detection_engine.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
+    key: security-detection-engine
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -18,6 +19,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine_exceptions.sh
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
+    key: security-detection-engine-exceptions
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
+    key: security-entity-analytics
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/explore.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/explore.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
+    key: security-explore
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
+    key: security-investigations
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
+    key: osquery-cypress
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/playwright.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/playwright.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_playwright.sh
     label: 'Playwright - Security Solution Tests'
+    key: cspm-agentless-scout
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/rule_management.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management.sh
     label: 'Rule Management - Security Solution Cypress Tests'
+    key: security-rule-management
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -18,6 +19,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_customization.sh
     label: 'Rule Management - Prebuilt Rules Customization - Security Solution Cypress Tests'
+    key: security-rule-management-prebuilt-customization
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -35,6 +37,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_installation.sh
     label: 'Rule Management - Prebuilt Rules Installation - Security Solution Cypress Tests'
+    key: security-rule-management-prebuilt-installation
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -52,6 +55,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_management.sh
     label: 'Rule Management - Prebuilt Rules Management - Security Solution Cypress Tests'
+    key: security-rule-management-prebuilt-management
     agents:
       machineType: n2-standard-4
       preemptible: true
@@ -69,6 +73,7 @@ steps:
 
   - command: .buildkite/scripts/steps/functional/security_solution_rule_management_prebuilt_rules_upgrade.sh
     label: 'Rule Management - Prebuilt Rules Upgrade - Security Solution Cypress Tests'
+    key: security-rule-management-prebuilt-upgrade
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/pull_request/trigger_entity_store_performance.yml
+++ b/.buildkite/pipelines/pull_request/trigger_entity_store_performance.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/entity_store_performance/trigger_performance_tests.sh
     label: 'Entity Store Performance Tests'
+    key: entity_store_performance
     agents:
       provider: gcp
       image: family/kibana-ubuntu-2404
@@ -12,4 +13,3 @@ steps:
       automatic:
         - exit_status: '-1'
           limit: 1
-

--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -71,4 +71,16 @@ if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then
   if [ -n "${PING_SLACK_TEAM:-}" ]; then
     buildkite-agent meta-data set 'slack:ping_team:body' "${PING_SLACK_TEAM}, can you please take a look at the test failures?"
   fi
+
+  # Cancel steps registered for cancel-on-gate-failure when a check gate fails.
+  if [[ "${CHECK_GATE:-}" == "true" ]]; then
+    # Spot/preemptible retries use Buildkite's synthetic `-1` status. Do not
+    # poison the build until a non-retryable gate attempt actually fails.
+    if [[ $BUILDKITE_COMMAND_EXIT_STATUS -eq -1 ]]; then
+      echo '--- Gate step exited with retryable status -1; skipping cancel-on-gate-failure'
+    else
+      echo '--- Cancel steps on gate failure'
+      .buildkite/scripts/steps/gate_failure/cancel.sh || true
+    fi
+  fi
 fi

--- a/.buildkite/scripts/pipelines/pull_request/README.md
+++ b/.buildkite/scripts/pipelines/pull_request/README.md
@@ -1,0 +1,26 @@
+# Pull Request Pipeline
+
+## Gate failure cancellation
+
+E2E steps (FTR, Scout, Cypress) start as soon as `build` completes. If a gate step (linting, type checks, etc.) fails, registered E2E steps are automatically canceled to minimize cost from running expensive jobs when there are obvious failures.
+
+### How it works
+
+1. **Gate steps** in `base.yml` are tagged with `env: { CHECK_GATE: 'true' }`.
+2. **E2E steps** are registered at pipeline upload time by passing `{ cancelOnGateFailure: true }` to `getPipeline()`, or by calling `bk.setMetadata('cancel_on_gate_failure:<step-key>', 'true')` in dynamic step uploaders.
+3. When a gate step fails permanently, `post_command.sh` runs `scripts/steps/gate_failure/cancel.ts`, which reads `cancel_on_gate_failure:*` metadata keys and cancels those steps.
+
+### Important: `step cancel` does not work on group keys
+
+`buildkite-agent step cancel` only cancels individual **command** steps. It silently fails on **group** keys (e.g., `ftr-configs`, `scout-configs`). Always register child step keys for cancellation, not the parent group key.
+
+### Adding a new cancelable step
+
+- **Static YAML pipeline**: Add a `key:` to every command step in the YAML file, then pass `{ cancelOnGateFailure: true }` to `getPipeline()`. If a step is a group, `extractStepKeys()` will automatically recurse into its children and register their keys instead. Missing keys on command steps will cause a build-time error.
+- **Dynamic step uploader**: Add a `key` to each child step in `bk.uploadSteps()`, then register each child key individually:
+  ```ts
+  for (const step of childSteps) {
+    bk.setMetadata(`cancel_on_gate_failure:${step.key}`, 'true');
+  }
+  ```
+  Do **not** register the group key — it will silently fail to cancel.

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -15,6 +15,8 @@
             }
         ] */
 
+import { execFileSync } from 'child_process';
+
 import prConfigs from '../../../pull_requests.json';
 import { runPreBuild } from './pre_build';
 import {
@@ -23,11 +25,13 @@ import {
   emitPipeline,
   getAgentImageConfig,
   getPipeline,
+  type GetPipelineOptions,
   prHasFIPSLabel,
 } from '#pipeline-utils';
 
 const prConfig = prConfigs.jobs.find((job) => job.pipelineSlug === 'kibana-pull-request');
 const emptyStep = `steps: []`;
+const cancelable: GetPipelineOptions = { cancelOnGateFailure: true };
 
 if (!prConfig) {
   console.error(`'kibana-pull-request' pipeline not found in .buildkite/pull_requests.json`);
@@ -63,12 +67,30 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     await runPreBuild();
     pipeline.push(getPipeline('.buildkite/pipelines/pull_request/base.yml', false));
 
+    // Register steps from base.yml that should still be canceled on gate failure.
+    // base.yml itself is not loaded with cancelOnGateFailure because it contains the gate steps.
+    for (const stepKey of [
+      'pick_test_group_run_order',
+      'build_scout_tests',
+      'check_oas_snapshot',
+      'build_api_docs',
+    ]) {
+      execFileSync('buildkite-agent', [
+        'meta-data',
+        'set',
+        `cancel_on_gate_failure:${stepKey}`,
+        'true',
+      ]);
+    }
+
     if (prHasFIPSLabel()) {
-      pipeline.push(getPipeline('.buildkite/pipelines/fips/verify_fips_enabled.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/fips/verify_fips_enabled.yml', cancelable));
     }
 
     if (await doAnyChangesMatch([/^src\/platform\/packages\/private\/kbn-handlebars/])) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/kbn_handlebars.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/kbn_handlebars.yml', cancelable)
+      );
     }
 
     if (
@@ -83,7 +105,7 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/response_ops.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/response_ops.yml', cancelable));
     }
 
     if (
@@ -91,7 +113,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/response_ops_cases.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/response_ops_cases.yml', cancelable)
+      );
     }
 
     if (
@@ -102,7 +126,7 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/apm_cypress.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/apm_cypress.yml', cancelable));
     }
 
     if (
@@ -120,7 +144,7 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/fleet_cypress.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/fleet_cypress.yml', cancelable));
     }
 
     if (
@@ -134,7 +158,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ])) ||
       GITHUB_PR_LABELS.includes('ci:all-gen-ai-suites')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/ai_infra_gen_ai.yml', cancelable)
+      );
     }
 
     if (
@@ -143,7 +169,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       !GITHUB_PR_LABELS.includes('ci:cloud-deploy') &&
       !GITHUB_PR_LABELS.includes('ci:cloud-redeploy')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_cloud_image.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/build_cloud_image.yml', cancelable)
+      );
     }
 
     if (
@@ -152,7 +180,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       !GITHUB_PR_LABELS.includes('ci:cloud-deploy') &&
       !GITHUB_PR_LABELS.includes('ci:cloud-redeploy')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_cloud_fips_image.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/build_cloud_fips_image.yml', cancelable)
+      );
     }
 
     if (
@@ -160,11 +190,11 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:cloud-deploy') ||
       GITHUB_PR_LABELS.includes('ci:cloud-redeploy')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/deploy_cloud.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/deploy_cloud.yml', cancelable));
     }
 
     if (GITHUB_PR_LABELS.includes('ci:build-docker-fips')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/fips.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/fips.yml', cancelable));
     }
 
     if (
@@ -174,20 +204,24 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:project-deploy-security') ||
       GITHUB_PR_LABELS.includes('ci:project-deploy-ai4soc')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/deploy_project.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/deploy_project.yml', cancelable)
+      );
     } else if (GITHUB_PR_LABELS.includes('ci:build-serverless-image')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_project.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_project.yml', cancelable));
     }
 
     if (
       (await doAnyChangesMatch([/.*stor(ies|y).*/])) ||
       GITHUB_PR_LABELS.includes('ci:build-storybooks')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/storybooks.yml', cancelable));
     }
 
     if (GITHUB_PR_LABELS.includes('ci:build-webpack-bundle-analyzer')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/webpack_bundle_analyzer.yml', cancelable)
+      );
     }
 
     if (
@@ -201,7 +235,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
         process.env.GITHUB_PR_TARGET_BRANCH === 'main') ||
       GITHUB_PR_LABELS.includes('ci:build-next-docs')
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/check_next_docs.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/check_next_docs.yml', cancelable)
+      );
     }
 
     if (
@@ -210,7 +246,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml',
+          cancelable
+        )
       );
     }
 
@@ -227,7 +266,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml',
+          cancelable
+        )
       );
     }
 
@@ -261,20 +303,37 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml')
-      );
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml'));
-      pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/automatic_import.yml')
-      );
-      pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/detection_engine.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml',
+          cancelable
+        )
       );
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml')
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml', cancelable)
       );
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/rule_management.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/automatic_import.yml',
+          cancelable
+        )
+      );
+      pipeline.push(
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/detection_engine.yml',
+          cancelable
+        )
+      );
+      pipeline.push(
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml',
+          cancelable
+        )
+      );
+      pipeline.push(
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/rule_management.yml',
+          cancelable
+        )
       );
     }
 
@@ -342,7 +401,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites') ||
       ALL_UI_TEST_SUITES
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml', cancelable)
+      );
     }
 
     if (
@@ -407,7 +468,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/investigations.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/investigations.yml',
+          cancelable
+        )
       );
     }
 
@@ -422,7 +486,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml',
+          cancelable
+        )
       );
     }
 
@@ -438,7 +505,8 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
     ) {
       pipeline.push(
         getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml'
+          '.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml',
+          cancelable
         )
       );
     }
@@ -449,7 +517,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml',
+          cancelable
+        )
       );
     }
 
@@ -462,7 +533,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml')
+        getPipeline(
+          '.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml',
+          cancelable
+        )
       );
     }
 
@@ -475,7 +549,9 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
         /^x-pack\/solutions\/security\/plugins\/elastic_assistant\/server\/lib\/prompt\/prompts\.ts$/,
       ])
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/prompt_changes.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/prompt_changes.yml', cancelable)
+      );
     }
 
     // Run Saved Objects checks conditionally
@@ -486,17 +562,20 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
         /^src\/core\/server\/integration_tests\/ci_checks\/saved_objects\/check_registered_types.test.ts/,
       ])
     ) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/check_saved_objects.yml'));
+      pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/check_saved_objects.yml', cancelable)
+      );
     }
 
     if (GITHUB_PR_LABELS.includes('ci:bench-jest')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/jest_bench.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/jest_bench.yml', cancelable));
     }
 
     if (GITHUB_PR_LABELS.includes('ci:bench-ftr')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/ftr_bench.yml'));
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/ftr_bench.yml', cancelable));
     }
 
+    // post_build is not cancelable — cleanup/reporting should always run
     pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
 
     emitPipeline(pipeline);

--- a/.buildkite/scripts/setup_es_snapshot_cache.sh
+++ b/.buildkite/scripts/setup_es_snapshot_cache.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source .buildkite/scripts/common/util.sh
+
 # If cached snapshots are baked into the agent, move them into our workspace first
 # We are doing this rather than simply changing the ES base path because many workers
 #   run with the workspace mounted in memory or on a local ssd

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -42,4 +42,3 @@ upload_scout_cypress_events() {
     echo "SCOUT_REPORTER_ENABLED=$SCOUT_REPORTER_ENABLED, skipping event upload."
   fi
 }
-

--- a/.buildkite/scripts/steps/gate_failure/cancel.sh
+++ b/.buildkite/scripts/steps/gate_failure/cancel.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# cancel.ts only depends on .buildkite/node_modules (ts-node, #pipeline-utils,
+# buildkite-agent CLI). A full repo bootstrap is unnecessary and can fail if
+# cache steps haven't finished yet.
+.buildkite/node_modules/.bin/ts-node "$(dirname "${0}")/cancel.ts"

--- a/.buildkite/scripts/steps/gate_failure/cancel.ts
+++ b/.buildkite/scripts/steps/gate_failure/cancel.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BuildkiteClient } from '#pipeline-utils';
+
+const METADATA_PREFIX = 'cancel_on_gate_failure:';
+
+function run(): void {
+  const bk = new BuildkiteClient();
+
+  // Discover cancelable step keys from metadata set at pipeline upload time
+  const stepKeys = bk
+    .getMetadataKeys()
+    .filter((key) => key.startsWith(METADATA_PREFIX))
+    .map((key) => key.slice(METADATA_PREFIX.length));
+
+  if (stepKeys.length === 0) {
+    return;
+  }
+
+  const canceled: string[] = [];
+  const skipped: string[] = [];
+  const failures: string[] = [];
+
+  for (const stepKey of stepKeys) {
+    try {
+      bk.cancelStep(stepKey);
+      canceled.push(stepKey);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const stderr =
+        error instanceof Error && 'stderr' in error
+          ? String((error as NodeJS.ErrnoException & { stderr: unknown }).stderr)
+          : '';
+      const combined = `${message}\n${stderr}`;
+      // Steps that already finished (passed, failed, canceled) cannot be canceled again.
+      // This is expected in race conditions and not a real failure. We check both the
+      // error message and stderr to be resilient to CLI wording changes.
+      if (/already (finished|been canceled)|not found|cannot cancel/i.test(combined)) {
+        skipped.push(stepKey);
+      } else {
+        failures.push(`${stepKey}: ${message}`);
+      }
+    }
+  }
+
+  const gateStepKey = process.env.BUILDKITE_STEP_KEY ?? 'unknown';
+  const gateLabel = process.env.BUILDKITE_LABEL ?? gateStepKey;
+  const summary = [
+    `Check gate **${gateLabel}** failed.`,
+    `Canceled ${canceled.length} step(s): ${canceled.length ? canceled.join(', ') : 'none'}`,
+    ...(skipped.length ? [`Already finished: ${skipped.join(', ')}`] : []),
+    ...(failures.length ? ['Failed to cancel:', ...failures.map((line) => `- ${line}`)] : []),
+  ].join('\n');
+
+  // Include the gate step key in the annotation context so multiple gate failures
+  // each get their own annotation instead of overwriting each other.
+  const annotationContext = `cancel-on-gate-failure:${gateStepKey}`;
+  bk.setAnnotation(annotationContext, failures.length ? 'warning' : 'info', summary);
+
+  if (failures.length > 0) {
+    throw new Error('Some steps could not be canceled');
+  }
+}
+
+try {
+  run();
+} catch (error) {
+  console.error('Cancel-on-gate-failure failed:', error);
+  process.exit(1);
+}

--- a/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
+++ b/.buildkite/scripts/steps/test/pick_test_group_run_order.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source .buildkite/scripts/common/util.sh
+source .buildkite/scripts/bootstrap.sh
 
 echo '--- Pick Test Group Run Order'
 ts-node "$(dirname "${0}")/pick_test_group_run_order.ts"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] Add optimistic cancellation for PR pipeline gate failures (#252647)](https://github.com/elastic/kibana/pull/252647)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-03-16T16:24:42Z","message":"[CI] Add optimistic cancellation for PR pipeline gate failures (#252647)\n\nMarks seven base pipeline steps (linting, type checks, etc.) as check gates. When a gate fails, a `post_command` hook cancels all registered downstream steps (Jest, FTR, Scout, Cypress) via metadata-driven cancellation, saving fleet capacity on PRs that clearly need fixes.\n\nUses metadata instead of `depends_on` so tests can start optimistically in parallel rather than waiting for all gates to pass. Spot/preemptible retries (exit status `-1`) are excluded from triggering cancellation.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7e85cf3442cceeb36a1366d116c7c98b2a9f3ef2","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip","v9.4.0"],"title":"[CI] Add optimistic cancellation for PR pipeline gate failures","number":252647,"url":"https://github.com/elastic/kibana/pull/252647","mergeCommit":{"message":"[CI] Add optimistic cancellation for PR pipeline gate failures (#252647)\n\nMarks seven base pipeline steps (linting, type checks, etc.) as check gates. When a gate fails, a `post_command` hook cancels all registered downstream steps (Jest, FTR, Scout, Cypress) via metadata-driven cancellation, saving fleet capacity on PRs that clearly need fixes.\n\nUses metadata instead of `depends_on` so tests can start optimistically in parallel rather than waiting for all gates to pass. Spot/preemptible retries (exit status `-1`) are excluded from triggering cancellation.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7e85cf3442cceeb36a1366d116c7c98b2a9f3ef2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/252647","number":252647,"mergeCommit":{"message":"[CI] Add optimistic cancellation for PR pipeline gate failures (#252647)\n\nMarks seven base pipeline steps (linting, type checks, etc.) as check gates. When a gate fails, a `post_command` hook cancels all registered downstream steps (Jest, FTR, Scout, Cypress) via metadata-driven cancellation, saving fleet capacity on PRs that clearly need fixes.\n\nUses metadata instead of `depends_on` so tests can start optimistically in parallel rather than waiting for all gates to pass. Spot/preemptible retries (exit status `-1`) are excluded from triggering cancellation.\n\n---------\n\nSigned-off-by: Tyler Smalley <tyler.smalley@elastic.co>","sha":"7e85cf3442cceeb36a1366d116c7c98b2a9f3ef2"}}]}] BACKPORT-->