### PR TITLE
[Entity Analytics] [Watchlists] Install prebuilt watchlists on setup 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -106,6 +106,7 @@ import {
   getEntityResetIndexStatus,
   getEntitySnapshotIndexStatus,
 } from './elasticsearch_assets';
+import { installPrebuiltWatchlists } from '../watchlists/install_prebuilt_watchlists';
 import { RiskScoreDataClient } from '../risk_score/risk_score_data_client';
 import {
   buildEntityDefinitionId,
@@ -505,6 +506,10 @@ export class EntityStoreDataClient {
       // Create reset index required by Snapshot task
       await createEntityResetIndex({ entityType, esClient: this.esClient, namespace });
       this.log(`debug`, entityType, `Created entity reset index`);
+
+              // Initialize prebuilt watchlists
+              await installPrebuiltWatchlists(this.esClient, this.options.soClient, namespace, logger);
+      this.log(`debug`, entityType, `Checked and initialized prebuilt watchlists`);
 
       // we must create and execute the enrich policy before the pipeline is created
       // this is because the pipeline will fail if the enrich index does not exist

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/install_prebuilt_watchlists.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/install_prebuilt_watchlists.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { WatchlistConfigClient } from './management/watchlist_config';
+
+export const installPrebuiltWatchlists = async (
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract,
+  namespace: string,
+  logger: Logger
+) => {
+  const watchlistClient = new WatchlistConfigClient({
+    soClient,
+    esClient,
+    namespace,
+    logger,
+  });
+
+  const PREBUILT_WATCHLISTS = [
+    {
+      id: 'privileged-user-monitoring-watchlist-id',
+      name: 'Privileged Users',
+      description: 'System-managed watchlist for tracking privileged users',
+      managed: true,
+      riskModifier: 50,
+    },
+  ];
+
+  for (const watchlist of PREBUILT_WATCHLISTS) {
+    try {
+      await watchlistClient.get(watchlist.id);
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      if (errorMessage.includes('not found')) {
+        logger.info(`Prebuilt watchlist '${watchlist.name}' not found, initializing...`);
+        const { id, ...attrs } = watchlist;
+        await watchlistClient.create(attrs, { id });
+        logger.info(`Prebuilt watchlist '${watchlist.name}' initialized.`);
+      } else {
+        logger.error(`Error checking prebuilt watchlist '${watchlist.name}': ${errorMessage}`);
+      }
+    }
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/watchlist_config.ts
@@ -78,12 +78,13 @@ export class WatchlistConfigClient {
   constructor(private readonly deps: WatchlistConfigClientDeps) {}
 
   async create(
-    attrs: SetOptional<WatchlistSavedObjectAttributes, 'managed'>
+    attrs: SetOptional<WatchlistSavedObjectAttributes, 'managed'>,
+    options?: { id?: string }
   ): Promise<WatchlistObject> {
     const so = await this.deps.soClient.create<WatchlistSavedObjectAttributes>(
       watchlistConfigTypeName,
       { ...attrs, managed: attrs.managed ?? false },
-      { refresh: 'wait_for' }
+      { refresh: 'wait_for', id: options?.id }
     );
 
     await createOrUpdateIndex({

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entity_analytics_home_page.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_home/entity_analytics_home_page.cy.ts
@@ -101,5 +101,23 @@ describe(
       cy.get(TIMELINE_ACTION).first().should('be.visible');
       cy.get(TIMELINE_ACTION).first().click();
     });
+
+    it('creates prebuilt watchlists and their indices during initialization', () => {
+      cy.request({
+        method: 'GET',
+        url: `/api/saved_objects/watchlist-config/privileged-user-monitoring-watchlist-id`,
+        headers: { 'kbn-xsrf': 'cypress-creds' },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.attributes.managed).to.be.true;
+      });
+
+      cy.task('searchIndex', '.entity-analytics.watchlists.Privileged Users-default').then(
+        (hitsLength) => {
+          expect(hitsLength).to.not.be.null;
+        }
+      );
+    });
   }
 );


### PR DESCRIPTION
This pull request introduces the automatic initialization of a prebuilt "Privileged Users" watchlist during entity analytics setup. It ensures that this managed watchlist and its backing index are created if missing, and adds a Cypress test to verify this behavior. The changes touch both backend initialization logic and end-to-end testing.

**Prebuilt Watchlist Initialization:**

* Added a new function `installPrebuiltWatchlists` that checks for the existence of a predefined "Privileged Users" watchlist and creates it if not present, using `WatchlistConfigClient`. This function is now invoked during entity store initialization in `EntityStoreDataClient`. [[1]](diffhunk://#diff-1c5ad21852cd9dd89745356a41da932e977cc233ddb6788d3d0e18cbfa51837cR1-R49) [[2]](diffhunk://#diff-0ba2b4b8d04f3a81c56ec3c7d5b210eaae25eb7dc1260c474f9efc978bebfa22R109) [[3]](diffhunk://#diff-0ba2b4b8d04f3a81c56ec3c7d5b210eaae25eb7dc1260c474f9efc978bebfa22R510-R513)
* Updated the `WatchlistConfigClient.create` method to accept an optional `id`, allowing the prebuilt watchlist to be created with a fixed identifier.

**Testing:**

* Added a Cypress test to verify that the prebuilt watchlist and its backing index are created and properly configured during initialization.