### PR TITLE
[8.19] [APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/moon.yml
@@ -20,6 +20,7 @@ project:
 dependsOn:
   - '@kbn/i18n'
   - '@kbn/kibana-react-plugin'
+  - '@kbn/react-kibana-context-styled'
 tags:
   - shared-common
   - package

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { EuiThemeProvider } from '@elastic/eui';
+import { FormattedValue, FormattedKey } from './formatted_value';
+
+const renderWithTheme = (component: React.ReactNode) =>
+  render(<EuiThemeProvider>{component}</EuiThemeProvider>);
+
+describe('FormattedKey', () => {
+  it('renders the key when value is present', () => {
+    const { container } = renderWithTheme(<FormattedKey k="host.name" value="my-host" />);
+    expect(container.textContent).toBe('host.name');
+  });
+
+  it('renders the key with subdued style when value is null', () => {
+    const { container } = renderWithTheme(<FormattedKey k="host.name" value={null} />);
+    expect(container.textContent).toBe('host.name');
+    expect(container.querySelector('span')).not.toBeNull();
+  });
+
+  it('renders the key with subdued style when value is undefined', () => {
+    const { container } = renderWithTheme(<FormattedKey k="host.name" value={undefined} />);
+    expect(container.textContent).toBe('host.name');
+    expect(container.querySelector('span')).not.toBeNull();
+  });
+});
+
+const dateProps = {
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
+  dateTimezone: 'Browser',
+};
+
+describe('FormattedValue', () => {
+  it('renders object values as pretty-printed JSON', () => {
+    const obj = { foo: 'bar', nested: { a: 1 } };
+    const { container } = renderWithTheme(<FormattedValue value={obj} {...dateProps} />);
+    expect(container.querySelector('pre')?.textContent).toBe(JSON.stringify(obj, null, 4));
+  });
+
+  it('renders boolean true as string', () => {
+    const { container } = renderWithTheme(<FormattedValue value={true} {...dateProps} />);
+    expect(container.textContent).toBe('true');
+  });
+
+  it('renders boolean false as string', () => {
+    const { container } = renderWithTheme(<FormattedValue value={false} {...dateProps} />);
+    expect(container.textContent).toBe('false');
+  });
+
+  it('renders number values as string', () => {
+    const { container } = renderWithTheme(<FormattedValue value={42} {...dateProps} />);
+    expect(container.textContent).toBe('42');
+  });
+
+  it('renders N/A for null values', () => {
+    const { container } = renderWithTheme(<FormattedValue value={null} {...dateProps} />);
+    expect(container.textContent).toBe('N/A');
+  });
+
+  it('renders N/A for empty string values', () => {
+    const { container } = renderWithTheme(<FormattedValue value="" {...dateProps} />);
+    expect(container.textContent).toBe('N/A');
+  });
+
+  it('formats date values with default settings', () => {
+    const { container } = renderWithTheme(
+      <FormattedValue value="2024-06-15T14:30:45.123Z" {...dateProps} />
+    );
+    expect(container.textContent).toMatch(/Jun 15, 2024 @ \d{2}:\d{2}:45\.123/);
+  });
+
+  it('formats date values with custom settings', () => {
+    const { container } = renderWithTheme(
+      <FormattedValue
+        value="2024-06-15T14:30:45.123+01:00"
+        dateFormat="HH:mm:ss.SSS"
+        dateTimezone="UTC"
+      />
+    );
+    expect(container.textContent).toMatch('13:30:45.123');
+  });
+
+  it.each([['hello world'], ['synth-service-2'], ['1.3.4'], ['1234567'], ['service-1']])(
+    'renders plain string "%s" as-is',
+    (value) => {
+      const { container } = renderWithTheme(<FormattedValue value={value} {...dateProps} />);
+      expect(container.textContent).toBe(value);
+    }
+  );
+});

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.test.tsx
@@ -7,11 +7,11 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { EuiThemeProvider } from '@elastic/eui';
 import { FormattedValue, FormattedKey } from './formatted_value';
+import { KibanaStyledComponentsThemeProvider } from '@kbn/react-kibana-context-styled';
 
 const renderWithTheme = (component: React.ReactNode) =>
-  render(<EuiThemeProvider>{component}</EuiThemeProvider>);
+  render(<KibanaStyledComponentsThemeProvider>{component}</KibanaStyledComponentsThemeProvider>);
 
 describe('FormattedKey', () => {
   it('renders the key when value is present', () => {

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/formatted_value.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { isBoolean, isNumber, isObject } from 'lodash';
+import { isBoolean, isNumber, isObject, isString } from 'lodash';
 import React from 'react';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { i18n } from '@kbn/i18n';
+import moment from 'moment-timezone';
 
 const EmptyValue = euiStyled.span`
   color: ${({ theme }) => theme.eui.euiColorMediumShade};
@@ -23,11 +24,25 @@ export function FormattedKey({ k, value }: { k: string; value: unknown }): JSX.E
   return <React.Fragment>{k}</React.Fragment>;
 }
 
-export function FormattedValue({ value }: { value: any }): JSX.Element {
+export function FormattedValue({
+  value,
+  dateFormat,
+  dateTimezone,
+}: {
+  value: any;
+  dateFormat: string;
+  dateTimezone: string;
+}): JSX.Element {
+  const usableTimezone = dateTimezone === 'Browser' ? moment.tz.guess() : dateTimezone;
+
+  const valueAsDate = moment(value, moment.ISO_8601, true);
+
   if (isObject(value)) {
     return <pre>{JSON.stringify(value, null, 4)}</pre>;
   } else if (isBoolean(value) || isNumber(value)) {
     return <React.Fragment>{String(value)}</React.Fragment>;
+  } else if (isString(value) && valueAsDate.isValid()) {
+    return <React.Fragment>{valueAsDate.tz(usableTimezone).format(dateFormat)}</React.Fragment>;
   } else if (!value) {
     return (
       <EmptyValue>

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/src/index.tsx
@@ -16,9 +16,13 @@ import { KeyValuePair } from './utils/get_flattened_key_value_pairs';
 export function KeyValueTable({
   keyValuePairs,
   tableProps = {},
+  dateFormat = 'MMM D, YYYY @ HH:mm:ss.SSS',
+  dateTimezone = 'Browser',
 }: {
   keyValuePairs: KeyValuePair[];
   tableProps?: EuiTableProps & TableHTMLAttributes<HTMLTableElement>;
+  dateFormat?: string;
+  dateTimezone?: string;
 }) {
   return (
     <EuiTable compressed {...tableProps}>
@@ -27,12 +31,21 @@ export function KeyValueTable({
           const asArray = castArray(value);
           const valueList =
             asArray.length <= 1 ? (
-              <FormattedValue value={asArray[0]} />
+              <FormattedValue
+                value={asArray[0]}
+                dateFormat={dateFormat}
+                dateTimezone={dateTimezone}
+              />
             ) : (
               <ul>
                 {asArray.map((val, index) => (
                   <li>
-                    <FormattedValue key={index} value={val} />
+                    <FormattedValue
+                      key={index}
+                      value={val}
+                      dateFormat={dateFormat}
+                      dateTimezone={dateTimezone}
+                    />
                   </li>
                 ))}
               </ul>

--- a/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-key-value-metadata-table/tsconfig.json
@@ -17,6 +17,7 @@
   ],
   "kbn_references": [
     "@kbn/i18n",
-    "@kbn/kibana-react-plugin"
+    "@kbn/kibana-react-plugin",
+    "@kbn/react-kibana-context-styled"
   ]
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/index.tsx
@@ -78,7 +78,7 @@ export function MetadataTable({ sections, isLoading }: Props) {
             href={docLinks.links.apm.metaData}
             target="_blank"
           >
-            <EuiIcon type="question" />
+            <EuiIcon type="question" aria-hidden />{' '}
             {i18n.translate('xpack.apm.metadata.help', {
               defaultMessage: 'How to add labels and other data',
             })}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/section.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/metadata_table/section.tsx
@@ -10,12 +10,20 @@ import { isEmpty } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { EuiText } from '@elastic/eui';
 import { KeyValueTable } from '@kbn/key-value-metadata-table';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { UI_SETTINGS } from '@kbn/data-plugin/common';
 
 interface Props {
   properties: Array<{ field: string; value: string[] | number[] }>;
 }
 
 export function Section({ properties }: Props) {
+  const {
+    services: { uiSettings },
+  } = useKibana();
+  const dateFormatSetting = uiSettings?.get(UI_SETTINGS.DATE_FORMAT);
+  const timezoneSetting = uiSettings?.get(UI_SETTINGS.DATEFORMAT_TZ);
+
   if (!isEmpty(properties)) {
     return (
       <KeyValueTable
@@ -23,6 +31,8 @@ export function Section({ properties }: Props) {
           key: property.field,
           value: property.value,
         }))}
+        dateFormat={dateFormatSetting}
+        dateTimezone={timezoneSetting}
       />
     );
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337)](https://github.com/elastic/kibana/pull/259337)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T06:45:24Z","message":"[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337)\n\n## Summary\n\nCloses #224277\nCloses #257881\n\n\nThis PR reworks the changes made in #255748 to both improve the original\nfix to align better with the intended fix described in #224277\n(respecting the `datetime.tz` param in the metadata table) and also fix\na regression introduced as described in #257881\n\nThis PR will also tackle the missing backports (to 9.2 and 8.19) that\nweren't made in #255748\n\n## Problem statement\n\nThe initial issue we were attempting to fix is a discrepancy between how\ndates were rendered in discover vs metadata tables in APM. Initially,\nthese APM metadata tables weren't formatting dates at all. Instead, they\nwere displaying the raw string value of the timestamp. This caused the\nvalue displayed to, because of timezone discrepancies, show a different\nvalue than what the same, formatted, field would display in discover\nwhen the user clicked the \"Open in Discover\" button (provided the\ntimezone used in settings was different than the timezone the timestamp\nwas recorded in) This behaviour could confuse users when switching apps.\n\nIn an effort to homogenise how dates are rendered across plugins,\n#255748 introduced an update aiming to apply formatting to any date\nvalue that is rendered within APM metadata tables. But, that update\nstill had some problems\n\n### Hardcoded date format\nInstead of reading from `uiSettings`, the date format was a hardcoded\nstring `MMM D, YYYY @ HH:mm:ss.SSS` While this is the default value\napplied in Kibana and would work most of the time, not sticking by the\ndynamic value configured via advanced settings could still lead to\ndiscrepancies between how the date is rendered in APM vs in Discover\n\n### `datetime.tz` still not considered\nBecause the advanced settings weren't being read, APM still wouldn't be\nrendering dates in a consistent timezone along with Discover. Instead,\nfields named `@timestamp` would render in UTC while other dates would\nrender in the local timezone of the browser. This caused dates within\nthe same component to be inconsistent and still not sync'd with Discover\n\n### Non-date fields could be parsed as dates\nThe mechanism we were using to identify when a field is a date to apply\nformatting in APM had parsing that was too relaxed and was causing some\nfalse positives in date parsing leading to fields like `service.name`\nbeing *sometimes* rendered as dates if the service name string contained\ncharacters that could lead moment non-strict parsing to coerce it as a\ndate\n\n## Changes\n\n- **Replaced non-strict `moment(value).isValid()` with strict ISO 8601\nparsing** via `moment(value, moment.ISO_8601, true)`. The `true` flag\nenables strict mode, which rejects strings that don't conform to real\nISO 8601 patterns. This ensures fields that aren't date strings will not\nbe incorrectly parsed as dates\n- **Removed the hardcoded `TIMESTAMP_FORMAT` constant.** The component\nnow accepts `dateFormat` and `dateTimezone` as required props, allowing\nthe consuming plugin to pass the user's configured values from\n`uiSettings`. Given the component resides in a shared package, we're not\naccessing `uiSettings` directly to avoid coupling the package to a\nplugin and instead consuming plugins should provide these values. To\navoid runtime issues, these props have default values set to the same\ndefaults as the advanced settings in Kibana to ensure the component can\nstill render properly even if `uiSettings` values aren't provided\n- **Applies the configured timezone** using `moment-timezone`, handling\nthe `'Browser'` sentinel value by resolving it to the user's local\ntimezone via `moment.tz.guess()`. This ensures the `datetime.tz` value\nis respected and dates will consistently render in the same timezone\nboth in APM and Discover\n- **Removed the separate `@timestamp` / non-`@timestamp` branches** —\nall date fields are now handled uniformly with the same strict parsing\nand configurable format within APM.","sha":"97247a032c23d5a1dc9438406bb29b1767df961e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation","v9.3.3"],"title":"[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables","number":259337,"url":"https://github.com/elastic/kibana/pull/259337","mergeCommit":{"message":"[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337)\n\n## Summary\n\nCloses #224277\nCloses #257881\n\n\nThis PR reworks the changes made in #255748 to both improve the original\nfix to align better with the intended fix described in #224277\n(respecting the `datetime.tz` param in the metadata table) and also fix\na regression introduced as described in #257881\n\nThis PR will also tackle the missing backports (to 9.2 and 8.19) that\nweren't made in #255748\n\n## Problem statement\n\nThe initial issue we were attempting to fix is a discrepancy between how\ndates were rendered in discover vs metadata tables in APM. Initially,\nthese APM metadata tables weren't formatting dates at all. Instead, they\nwere displaying the raw string value of the timestamp. This caused the\nvalue displayed to, because of timezone discrepancies, show a different\nvalue than what the same, formatted, field would display in discover\nwhen the user clicked the \"Open in Discover\" button (provided the\ntimezone used in settings was different than the timezone the timestamp\nwas recorded in) This behaviour could confuse users when switching apps.\n\nIn an effort to homogenise how dates are rendered across plugins,\n#255748 introduced an update aiming to apply formatting to any date\nvalue that is rendered within APM metadata tables. But, that update\nstill had some problems\n\n### Hardcoded date format\nInstead of reading from `uiSettings`, the date format was a hardcoded\nstring `MMM D, YYYY @ HH:mm:ss.SSS` While this is the default value\napplied in Kibana and would work most of the time, not sticking by the\ndynamic value configured via advanced settings could still lead to\ndiscrepancies between how the date is rendered in APM vs in Discover\n\n### `datetime.tz` still not considered\nBecause the advanced settings weren't being read, APM still wouldn't be\nrendering dates in a consistent timezone along with Discover. Instead,\nfields named `@timestamp` would render in UTC while other dates would\nrender in the local timezone of the browser. This caused dates within\nthe same component to be inconsistent and still not sync'd with Discover\n\n### Non-date fields could be parsed as dates\nThe mechanism we were using to identify when a field is a date to apply\nformatting in APM had parsing that was too relaxed and was causing some\nfalse positives in date parsing leading to fields like `service.name`\nbeing *sometimes* rendered as dates if the service name string contained\ncharacters that could lead moment non-strict parsing to coerce it as a\ndate\n\n## Changes\n\n- **Replaced non-strict `moment(value).isValid()` with strict ISO 8601\nparsing** via `moment(value, moment.ISO_8601, true)`. The `true` flag\nenables strict mode, which rejects strings that don't conform to real\nISO 8601 patterns. This ensures fields that aren't date strings will not\nbe incorrectly parsed as dates\n- **Removed the hardcoded `TIMESTAMP_FORMAT` constant.** The component\nnow accepts `dateFormat` and `dateTimezone` as required props, allowing\nthe consuming plugin to pass the user's configured values from\n`uiSettings`. Given the component resides in a shared package, we're not\naccessing `uiSettings` directly to avoid coupling the package to a\nplugin and instead consuming plugins should provide these values. To\navoid runtime issues, these props have default values set to the same\ndefaults as the advanced settings in Kibana to ensure the component can\nstill render properly even if `uiSettings` values aren't provided\n- **Applies the configured timezone** using `moment-timezone`, handling\nthe `'Browser'` sentinel value by resolving it to the user's local\ntimezone via `moment.tz.guess()`. This ensures the `datetime.tz` value\nis respected and dates will consistently render in the same timezone\nboth in APM and Discover\n- **Removed the separate `@timestamp` / non-`@timestamp` branches** —\nall date fields are now handled uniformly with the same strict parsing\nand configurable format within APM.","sha":"97247a032c23d5a1dc9438406bb29b1767df961e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259337","number":259337,"mergeCommit":{"message":"[APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337)\n\n## Summary\n\nCloses #224277\nCloses #257881\n\n\nThis PR reworks the changes made in #255748 to both improve the original\nfix to align better with the intended fix described in #224277\n(respecting the `datetime.tz` param in the metadata table) and also fix\na regression introduced as described in #257881\n\nThis PR will also tackle the missing backports (to 9.2 and 8.19) that\nweren't made in #255748\n\n## Problem statement\n\nThe initial issue we were attempting to fix is a discrepancy between how\ndates were rendered in discover vs metadata tables in APM. Initially,\nthese APM metadata tables weren't formatting dates at all. Instead, they\nwere displaying the raw string value of the timestamp. This caused the\nvalue displayed to, because of timezone discrepancies, show a different\nvalue than what the same, formatted, field would display in discover\nwhen the user clicked the \"Open in Discover\" button (provided the\ntimezone used in settings was different than the timezone the timestamp\nwas recorded in) This behaviour could confuse users when switching apps.\n\nIn an effort to homogenise how dates are rendered across plugins,\n#255748 introduced an update aiming to apply formatting to any date\nvalue that is rendered within APM metadata tables. But, that update\nstill had some problems\n\n### Hardcoded date format\nInstead of reading from `uiSettings`, the date format was a hardcoded\nstring `MMM D, YYYY @ HH:mm:ss.SSS` While this is the default value\napplied in Kibana and would work most of the time, not sticking by the\ndynamic value configured via advanced settings could still lead to\ndiscrepancies between how the date is rendered in APM vs in Discover\n\n### `datetime.tz` still not considered\nBecause the advanced settings weren't being read, APM still wouldn't be\nrendering dates in a consistent timezone along with Discover. Instead,\nfields named `@timestamp` would render in UTC while other dates would\nrender in the local timezone of the browser. This caused dates within\nthe same component to be inconsistent and still not sync'd with Discover\n\n### Non-date fields could be parsed as dates\nThe mechanism we were using to identify when a field is a date to apply\nformatting in APM had parsing that was too relaxed and was causing some\nfalse positives in date parsing leading to fields like `service.name`\nbeing *sometimes* rendered as dates if the service name string contained\ncharacters that could lead moment non-strict parsing to coerce it as a\ndate\n\n## Changes\n\n- **Replaced non-strict `moment(value).isValid()` with strict ISO 8601\nparsing** via `moment(value, moment.ISO_8601, true)`. The `true` flag\nenables strict mode, which rejects strings that don't conform to real\nISO 8601 patterns. This ensures fields that aren't date strings will not\nbe incorrectly parsed as dates\n- **Removed the hardcoded `TIMESTAMP_FORMAT` constant.** The component\nnow accepts `dateFormat` and `dateTimezone` as required props, allowing\nthe consuming plugin to pass the user's configured values from\n`uiSettings`. Given the component resides in a shared package, we're not\naccessing `uiSettings` directly to avoid coupling the package to a\nplugin and instead consuming plugins should provide these values. To\navoid runtime issues, these props have default values set to the same\ndefaults as the advanced settings in Kibana to ensure the component can\nstill render properly even if `uiSettings` values aren't provided\n- **Applies the configured timezone** using `moment-timezone`, handling\nthe `'Browser'` sentinel value by resolving it to the user's local\ntimezone via `moment.tz.guess()`. This ensures the `datetime.tz` value\nis respected and dates will consistently render in the same timezone\nboth in APM and Discover\n- **Removed the separate `@timestamp` / non-`@timestamp` branches** —\nall date fields are now handled uniformly with the same strict parsing\nand configurable format within APM.","sha":"97247a032c23d5a1dc9438406bb29b1767df961e"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259490","number":259490,"state":"MERGED","mergeCommit":{"sha":"123e969648d9367e8765d4c49ca40114feb7a513","message":"[9.3] [APM] Respect date formatting ui settings and fix incorrect date parsing in metadata tables (#259337) (#259490)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[APM] Respect date formatting ui settings and fix incorrect date\nparsing in metadata tables\n(#259337)](https://github.com/elastic/kibana/pull/259337)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Fernandez <47327793+AlejandroFrndz@users.noreply.github.com>"}}]}] BACKPORT-->