### PR TITLE
[Significant events] Query tab duplicated refresh button 

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/queries_table/queries_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/significant_events_discovery/components/queries_table/queries_table.tsx
@@ -379,7 +379,7 @@ export function QueriesTable() {
               showQueryMenu={false}
               showQueryInput
               showDatePicker={false}
-              submitButtonStyle="iconOnly"
+              showSubmitButton={false}
               displayStyle="inPage"
               disableQueryLanguageSwitcher
               onQuerySubmit={(queryPayload) => {


### PR DESCRIPTION
## Summary

Removes the duplicate refresh icon button from the queries table toolbar by hiding the submit button on the text search bar (showSubmitButton={false}). The date picker's refresh button in StreamsAppSearchBar already serves this purpose.

This is how it looks now:
<img width="1673" height="922" alt="image" src="https://github.com/user-attachments/assets/b3091620-3c3d-46f9-b812-175f61a21131" />



