### PR TITLE
[9.3] [ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false (#259325)

### DIFF
--- a/src/platform/packages/shared/kbn-connector-schemas/webhook/schemas/v1.test.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/webhook/schemas/v1.test.ts
@@ -49,6 +49,14 @@ describe('Webhook Schema', () => {
       expect(result.hasAuth).toBe(true);
     });
 
+    it('does not default authType when hasAuth is false', () => {
+      const result = ConfigSchema.parse({
+        url: 'https://api.example.com/webhook',
+        hasAuth: false,
+      });
+      expect(result.authType).toBeNull();
+    });
+
     it('validates all HTTP methods', () => {
       const methods = ['post', 'put', 'patch', 'get', 'delete'];
       methods.forEach((method) => {

--- a/src/platform/packages/shared/kbn-connector-schemas/webhook/schemas/v1.ts
+++ b/src/platform/packages/shared/kbn-connector-schemas/webhook/schemas/v1.ts
@@ -34,7 +34,23 @@ const configSchemaProps = {
   additionalFields: AuthConfiguration.additionalFields,
 };
 
-export const ConfigSchema = z.object(configSchemaProps).strict();
+function normalizeAuthTypeForUnauthenticatedConnectors(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const config = value as Record<string, unknown>;
+  if (config.hasAuth === false && config.authType === undefined) {
+    return { ...config, authType: null };
+  }
+
+  return value;
+}
+
+export const ConfigSchema = z.preprocess(
+  normalizeAuthTypeForUnauthenticatedConnectors,
+  z.object(configSchemaProps).strict()
+);
 
 export const ParamsSchema = z
   .object({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false (#259325)](https://github.com/elastic/kibana/pull/259325)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T10:42:35Z","message":"[ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false (#259325)\n\nAfter the Zod v4 upgrade, `.default(...).optional()` applies the default\neven when the field is absent. For webhook/http, this can cause runtime\nvalidation failures like `error validation webhook action config:\nauthType must be null or undefined if hasAuth is false`\n\nThis change preserves backwards compatibility for older saved objects /\nAPI clients that set hasAuth:false but omit authType.\n\nThis PR includes:\n\n- Fix a Zod v4 regression where connector `config.authType` defaults to\n`Basic` even when the field is missing, which can turn legacy configs\nlike `{ hasAuth: false }` into an invalid state (`hasAuth:false` +\ntruthy authType).\n- Add `z.preprocess()` normalization in `.webhook` and `.http` config\nschemas to convert `authType: undefined` to `null` when `hasAuth ===\nfalse`.\n\nI'm too scared to change the `Basic` auth type default, that's why this\napproach instead.","sha":"e2558ad2903b0ecc4f8c3a9c89751661005a83ff","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","v9.4.0"],"title":"[ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false","number":259325,"url":"https://github.com/elastic/kibana/pull/259325","mergeCommit":{"message":"[ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false (#259325)\n\nAfter the Zod v4 upgrade, `.default(...).optional()` applies the default\neven when the field is absent. For webhook/http, this can cause runtime\nvalidation failures like `error validation webhook action config:\nauthType must be null or undefined if hasAuth is false`\n\nThis change preserves backwards compatibility for older saved objects /\nAPI clients that set hasAuth:false but omit authType.\n\nThis PR includes:\n\n- Fix a Zod v4 regression where connector `config.authType` defaults to\n`Basic` even when the field is missing, which can turn legacy configs\nlike `{ hasAuth: false }` into an invalid state (`hasAuth:false` +\ntruthy authType).\n- Add `z.preprocess()` normalization in `.webhook` and `.http` config\nschemas to convert `authType: undefined` to `null` when `hasAuth ===\nfalse`.\n\nI'm too scared to change the `Basic` auth type default, that's why this\napproach instead.","sha":"e2558ad2903b0ecc4f8c3a9c89751661005a83ff"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259325","number":259325,"mergeCommit":{"message":"[ResponseOps][Connectors] Prevent Zod v4 from defaulting authType when hasAuth is false (#259325)\n\nAfter the Zod v4 upgrade, `.default(...).optional()` applies the default\neven when the field is absent. For webhook/http, this can cause runtime\nvalidation failures like `error validation webhook action config:\nauthType must be null or undefined if hasAuth is false`\n\nThis change preserves backwards compatibility for older saved objects /\nAPI clients that set hasAuth:false but omit authType.\n\nThis PR includes:\n\n- Fix a Zod v4 regression where connector `config.authType` defaults to\n`Basic` even when the field is missing, which can turn legacy configs\nlike `{ hasAuth: false }` into an invalid state (`hasAuth:false` +\ntruthy authType).\n- Add `z.preprocess()` normalization in `.webhook` and `.http` config\nschemas to convert `authType: undefined` to `null` when `hasAuth ===\nfalse`.\n\nI'm too scared to change the `Basic` auth type default, that's why this\napproach instead.","sha":"e2558ad2903b0ecc4f8c3a9c89751661005a83ff"}}]}] BACKPORT-->