### PR TITLE
[kbn-eval-kql] Enable array support

### DIFF
--- a/src/platform/packages/shared/kbn-eval-kql/src/eval_kql.test.ts
+++ b/src/platform/packages/shared/kbn-eval-kql/src/eval_kql.test.ts
@@ -47,6 +47,27 @@ describe('evaluateKql', () => {
       expect(evaluateKql(kql, { matchesCount: 0 })).toBe(false);
     });
 
+    it('should treat array fields as multi-valued: term matches if any element matches', () => {
+      const kql = 'tags: "prod"';
+      expect(evaluateKql(kql, { tags: ['dev', 'prod'] })).toBe(true);
+      expect(evaluateKql(kql, { tags: ['dev', 'staging'] })).toBe(false);
+      expect(evaluateKql(kql, { tags: 'prod' })).toBe(true);
+    });
+
+    it('should match nested fields when value is an array', () => {
+      const kql = 'event.category: "alerts" and event.labels: "demo"';
+      expect(
+        evaluateKql(kql, {
+          event: { category: 'alerts', labels: ['example', 'demo'] },
+        })
+      ).toBe(true);
+      expect(
+        evaluateKql(kql, {
+          event: { category: 'alerts', labels: ['example'] },
+        })
+      ).toBe(false);
+    });
+
     it('should support array index access in property path', () => {
       const kql = 'users[0].name: "Alice"';
       expect(evaluateKql(kql, { users: [{ name: 'Alice' }, { name: 'Bob' }] })).toBe(true);
@@ -88,6 +109,13 @@ describe('evaluateKql', () => {
         expect(evaluateKql(kql, { matchesCount: 1001 })).toBe(false);
       });
 
+      it('should match range if any array element satisfies the range', () => {
+        const kql = 'scores >= 10';
+        expect(evaluateKql(kql, { scores: [1, 5, 12] })).toBe(true);
+        expect(evaluateKql(kql, { scores: [1, 5, 7] })).toBe(false);
+        expect(evaluateKql(kql, { scores: [] })).toBe(false);
+      });
+
       it('should return false when field refers to object in property', () => {
         const kql = 'user < 90';
         expect(evaluateKql(kql, { user: { name: 'Jane Doe' } })).toBe(false);
@@ -107,6 +135,12 @@ describe('evaluateKql', () => {
         const kql = 'user.name: John*';
         expect(evaluateKql(kql, { user: { name: 'John Doe' } })).toBe(true);
         expect(evaluateKql(kql, { user: { name: 'Jane Doe' } })).toBe(false);
+      });
+
+      it('should evaluate wildcards against any string element in an array field', () => {
+        const kql = 'tags: demo*';
+        expect(evaluateKql(kql, { tags: ['x', 'demo-1'] })).toBe(true);
+        expect(evaluateKql(kql, { tags: ['x', 'prod'] })).toBe(false);
       });
 
       it('should do anything', () => {
@@ -155,6 +189,40 @@ describe('evaluateKql', () => {
         const kql = 'user.name: J*n D*';
         expect(evaluateKql(kql, { user: { name: 'John Doe' } })).toBe(true);
         expect(evaluateKql(kql, { user: { name: 'Jane Doe' } })).toBe(false);
+      });
+
+      it('should run wildcard patterns against stringified numeric and boolean scalars', () => {
+        expect(evaluateKql('n: foo*', { n: 5 })).toBe(false);
+        expect(evaluateKql('n: foo*', { n: true })).toBe(false);
+        expect(evaluateKql('n: 23*', { n: 2339 })).toBe(true);
+        expect(evaluateKql('n: tr*', { n: true })).toBe(true);
+      });
+    });
+
+    describe('array membership', () => {
+      it('should match when array contains the value', () => {
+        const kql = 'tags: "production"';
+        expect(evaluateKql(kql, { tags: ['production', 'critical'] })).toBe(true);
+      });
+
+      it('should not match when array does not contain the value', () => {
+        const kql = 'tags: "staging"';
+        expect(evaluateKql(kql, { tags: ['production', 'critical'] })).toBe(false);
+      });
+
+      it('should match wildcard against array elements', () => {
+        const kql = 'tags: prod*';
+        expect(evaluateKql(kql, { tags: ['production', 'critical'] })).toBe(true);
+      });
+
+      it('should match existence wildcard against array', () => {
+        const kql = 'tags: *';
+        expect(evaluateKql(kql, { tags: ['production', 'critical'] })).toBe(true);
+      });
+
+      it('should not match when array is empty', () => {
+        const kql = 'tags: "production"';
+        expect(evaluateKql(kql, { tags: [] })).toBe(false);
       });
     });
   });

--- a/src/platform/packages/shared/kbn-eval-kql/src/eval_kql.ts
+++ b/src/platform/packages/shared/kbn-eval-kql/src/eval_kql.ts
@@ -55,21 +55,50 @@ function visitIs(node: KqlFunctionNode, context: Record<string, any>): boolean {
   }
 
   if ((rightLiteral as KqlWildcardNode).type === KQL_NODE_TYPE_WILDCARD) {
-    if (typeof contextValue === 'string') {
-      return nodeTypes.wildcard.test(rightLiteral as KqlWildcardNode, String(contextValue));
-    }
+    return isWildcardIsMatch(contextValue, rightLiteral as KqlWildcardNode);
+  }
 
-    return contextValue != null && contextValue !== undefined;
+  return isExactIsMatch(contextValue, rightLiteral as KqlLiteralNode);
+}
+
+/**
+ * KQL term equality for in-memory context: if the field is an array, any element may match
+ * (aligned with multi-valued field semantics in Elasticsearch).
+ */
+function isExactIsMatch(contextValue: unknown, rightLiteral: KqlLiteralNode): boolean {
+  if (Array.isArray(contextValue)) {
+    return contextValue.some((element) => isExactIsMatch(element, rightLiteral));
   }
 
   try {
     return (
       contextValue ===
-      convertLiteralToValue(rightLiteral as KqlLiteralNode, typeof contextValue as any)
+      convertLiteralToValue(rightLiteral, typeof contextValue as 'string' | 'number' | 'boolean')
     );
-  } catch (error) {
+  } catch {
     return false;
   }
+}
+
+function isWildcardIsMatch(contextValue: unknown, rightLiteral: KqlWildcardNode): boolean {
+  if (typeof contextValue === 'string') {
+    return nodeTypes.wildcard.test(rightLiteral, contextValue);
+  }
+
+  if (Array.isArray(contextValue)) {
+    return contextValue.some((element) => isWildcardIsMatch(element, rightLiteral));
+  }
+
+  if (
+    typeof contextValue === 'number' ||
+    typeof contextValue === 'boolean' ||
+    typeof contextValue === 'bigint'
+  ) {
+    return nodeTypes.wildcard.test(rightLiteral, String(contextValue));
+  }
+
+  // Objects and other non-scalars: only "value present" semantics (e.g. `field:*`), not pattern match.
+  return contextValue != null && contextValue !== undefined;
 }
 
 function visitRange(functionNode: KqlFunctionNode, context: Record<string, any>): boolean {
@@ -85,23 +114,42 @@ function visitRange(functionNode: KqlFunctionNode, context: Record<string, any>)
     return false; // Path does not exist in context
   }
 
-  let rightRangeValue;
+  if (Array.isArray(leftRangeValue)) {
+    return leftRangeValue.some((element) =>
+      compareRangeScalar(element, operator, rightRangeLiteral)
+    );
+  }
+
+  return compareRangeScalar(leftRangeValue, operator, rightRangeLiteral);
+}
+
+function compareRangeScalar(
+  leftRangeValue: unknown,
+  operator: string,
+  rightRangeLiteral: KqlLiteralNode
+): boolean {
+  let rightRangeValue: string | number | boolean;
 
   try {
-    rightRangeValue = convertLiteralToValue(rightRangeLiteral, typeof leftRangeValue as any);
-  } catch (error) {
+    rightRangeValue = convertLiteralToValue(
+      rightRangeLiteral,
+      typeof leftRangeValue as 'string' | 'number' | 'boolean'
+    );
+  } catch {
     return false;
   }
 
+  const left = leftRangeValue as string | number | boolean;
+
   switch (operator) {
     case 'gte':
-      return leftRangeValue >= rightRangeValue;
+      return left >= rightRangeValue;
     case 'lte':
-      return leftRangeValue <= rightRangeValue;
+      return left <= rightRangeValue;
     case 'gt':
-      return leftRangeValue > rightRangeValue;
+      return left > rightRangeValue;
     case 'lt':
-      return leftRangeValue < rightRangeValue;
+      return left < rightRangeValue;
     default:
       throw new Error(`Unsupported range operator: ${operator}`);
   }


### PR DESCRIPTION
## Summary

Improves in-memory KQL evaluation when context fields hold **arrays** (multi-valued semantics) and tightens **wildcard** matching for numeric, boolean, and bigint scalars. Range queries over array fields now succeed if **any** element satisfies the predicate.

## Motivation

Elasticsearch treats multi-valued fields so that term and range clauses match if **any** value in the field matches. `evaluateKql` previously compared the raw array to literals or applied wildcard/range logic only to scalars.

After this change semantics are aligned with **multi-valued field** behavior in `es`, not with “array as a single value” equality.

## How to test

```bash
yarn test:jest src/platform/packages/shared/kbn-eval-kql/src/eval_kql.test.ts
```