### PR TITLE
Swap ES v1 check with v2 in Graph

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store_v2_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store_v2_status.ts
@@ -7,7 +7,7 @@
 
 import { useQuery } from '@kbn/react-query';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
-import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/common';
+import { ENTITY_STORE_ROUTES, API_VERSIONS } from '@kbn/entity-store/common';
 import type { GetEntityStoreStatusResponse } from '../../../../../common/api/entity_analytics/entity_store/status.gen';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 
@@ -15,7 +15,6 @@ const ENTITY_STORE_V2_STATUS = ['GET', 'ENTITY_STORE_V2_STATUS'];
 
 /**
  * Hook to fetch Entity Store v2 status.
- * Calls `GET /internal/security/entity_store/status?apiVersion=2`.
  * Treats errors gracefully (v2 disabled → not running).
  */
 export const useEntityStoreV2Status = () => {
@@ -24,9 +23,11 @@ export const useEntityStoreV2Status = () => {
   return useQuery<GetEntityStoreStatusResponse, IHttpFetchError>({
     queryKey: ENTITY_STORE_V2_STATUS,
     queryFn: () =>
-      http.fetch<GetEntityStoreStatusResponse>(ENTITY_STORE_ROUTES.STATUS, {
+      http.fetch<GetEntityStoreStatusResponse>(ENTITY_STORE_ROUTES.public.STATUS, {
         method: 'GET',
-        query: { apiVersion: '2', include_components: false },
+        // Public Entity Store routes use `v1` constant
+        version: API_VERSIONS.public.v1,
+        query: { include_components: false },
       }),
     retry: false,
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store_v2_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store_v2_status.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { ENTITY_STORE_ROUTES } from '@kbn/entity-store/common';
+import type { GetEntityStoreStatusResponse } from '../../../../../common/api/entity_analytics/entity_store/status.gen';
+import { useKibana } from '../../../../common/lib/kibana/kibana_react';
+
+const ENTITY_STORE_V2_STATUS = ['GET', 'ENTITY_STORE_V2_STATUS'];
+
+/**
+ * Hook to fetch Entity Store v2 status.
+ * Calls `GET /internal/security/entity_store/status?apiVersion=2`.
+ * Treats errors gracefully (v2 disabled → not running).
+ */
+export const useEntityStoreV2Status = () => {
+  const { http } = useKibana().services;
+
+  return useQuery<GetEntityStoreStatusResponse, IHttpFetchError>({
+    queryKey: ENTITY_STORE_V2_STATUS,
+    queryFn: () =>
+      http.fetch<GetEntityStoreStatusResponse>(ENTITY_STORE_ROUTES.STATUS, {
+        method: 'GET',
+        query: { apiVersion: '2', include_components: false },
+      }),
+    retry: false,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_is_entity_store_v2_available.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_is_entity_store_v2_available.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lastValueFrom } from 'rxjs';
+import { useQuery } from '@kbn/react-query';
+import type { IKibanaSearchResponse } from '@kbn/search-types';
+import type { IHttpFetchError } from '@kbn/core-http-browser';
+import { getLatestEntitiesIndexName } from '@kbn/entity-store/common';
+import { useKibana } from '../../../../common/lib/kibana/kibana_react';
+import { useSpaceId } from '../../../../common/hooks/use_space_id';
+
+interface EntitiesIndexExistsResult {
+  indexExists: boolean;
+}
+
+const ENTITY_STORE_V2_AVAILABLE = ['GET', 'ENTITY_STORE_V2_AVAILABLE'];
+
+/**
+ * Hook to check if the Entity Store v2 entities index exists.
+ *
+ * TEMPORARY WORKAROUND: This hook exists because the "editor" and "viewer"
+ * Serverless roles lack saved-object permissions for the Entity Store plugin's
+ * SO types (entity-engine-descriptor-v2, entity-store-global-state), causing the
+ * Entity Store `/status` endpoint to fail with a 403 for those roles.
+ * Once those roles are compatible with the Entity Store `/status` endpoint,
+ * this hook should be updated to check the status endpoint instead.
+ *
+ * Uses the data search service to run a lightweight ES search (size: 0)
+ * against the entities latest index. Both editor and viewer roles have
+ * read access to `.entities.v2.latest.security_*` indices.
+ */
+export const useIsEntityStoreV2Available = () => {
+  const { data } = useKibana().services;
+  const spaceId = useSpaceId();
+
+  return useQuery<EntitiesIndexExistsResult, IHttpFetchError>({
+    queryKey: [...ENTITY_STORE_V2_AVAILABLE, spaceId],
+    queryFn: async () => {
+      const index = getLatestEntitiesIndexName(spaceId ?? 'default');
+
+      try {
+        const response = await lastValueFrom(
+          data.search.search<
+            { params: Record<string, unknown> },
+            IKibanaSearchResponse<{ _shards: { total: number } }>
+          >({
+            params: {
+              index,
+              size: 0,
+              allow_no_indices: true,
+              terminate_after: 1,
+            },
+          })
+        );
+
+        return { indexExists: (response.rawResponse._shards?.total ?? 0) > 0 };
+      } catch {
+        return { indexExists: false };
+      }
+    },
+    enabled: spaceId != null,
+    retry: false,
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.test.tsx
@@ -21,9 +21,11 @@ import {
 jest.mock('../../../../common/hooks/use_has_graph_visualization_license');
 const mockUseHasGraphVisualizationLicense = useHasGraphVisualizationLicense as jest.Mock;
 
-jest.mock('../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status');
-import { useEntityStoreV2Status } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status';
-const mockUseEntityStoreV2Status = useEntityStoreV2Status as jest.Mock;
+jest.mock(
+  '../../../../entity_analytics/components/entity_store/hooks/use_is_entity_store_v2_available'
+);
+import { useIsEntityStoreV2Available } from '../../../../entity_analytics/components/entity_store/hooks/use_is_entity_store_v2_available';
+const mockUseIsEntityStoreV2Available = useIsEntityStoreV2Available as jest.Mock;
 
 // All EUID source fields (must explicitly handle to avoid mockFieldData bleed-through)
 const ALL_EUID_SOURCE_FIELDS: readonly string[] = [
@@ -79,8 +81,8 @@ describe('useGraphPreview', () => {
     jest.clearAllMocks();
     // Default mock: graph visualization feature is available
     mockUseHasGraphVisualizationLicense.mockReturnValue(true);
-    // Default mock: entity store is running
-    mockUseEntityStoreV2Status.mockReturnValue({ data: { status: 'running' } });
+    // Default mock: entity store v2 entities index exists
+    mockUseIsEntityStoreV2Available.mockReturnValue({ data: { indexExists: true } });
   });
 
   it(`should return false when missing actor and target`, () => {
@@ -646,8 +648,8 @@ describe('useGraphPreview', () => {
     });
   });
 
-  it('should return false for shouldShowGraph when entity store is not running', () => {
-    mockUseEntityStoreV2Status.mockReturnValue({ data: { status: 'not_installed' } });
+  it('should return false for shouldShowGraph when entity store v2 index does not exist', () => {
+    mockUseIsEntityStoreV2Available.mockReturnValue({ data: { indexExists: false } });
 
     const hookResult = renderHook((props: UseGraphPreviewParams) => useGraphPreview(props), {
       initialProps: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.test.tsx
@@ -21,9 +21,9 @@ import {
 jest.mock('../../../../common/hooks/use_has_graph_visualization_license');
 const mockUseHasGraphVisualizationLicense = useHasGraphVisualizationLicense as jest.Mock;
 
-jest.mock('../../../../entity_analytics/components/entity_store/hooks/use_entity_store');
-import { useEntityStoreStatus } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store';
-const mockUseEntityStoreStatus = useEntityStoreStatus as jest.Mock;
+jest.mock('../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status');
+import { useEntityStoreV2Status } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status';
+const mockUseEntityStoreV2Status = useEntityStoreV2Status as jest.Mock;
 
 // All EUID source fields (must explicitly handle to avoid mockFieldData bleed-through)
 const ALL_EUID_SOURCE_FIELDS: readonly string[] = [
@@ -80,7 +80,7 @@ describe('useGraphPreview', () => {
     // Default mock: graph visualization feature is available
     mockUseHasGraphVisualizationLicense.mockReturnValue(true);
     // Default mock: entity store is running
-    mockUseEntityStoreStatus.mockReturnValue({ data: { status: 'running' } });
+    mockUseEntityStoreV2Status.mockReturnValue({ data: { status: 'running' } });
   });
 
   it(`should return false when missing actor and target`, () => {
@@ -647,7 +647,7 @@ describe('useGraphPreview', () => {
   });
 
   it('should return false for shouldShowGraph when entity store is not running', () => {
-    mockUseEntityStoreStatus.mockReturnValue({ data: { status: 'not_installed' } });
+    mockUseEntityStoreV2Status.mockReturnValue({ data: { status: 'not_installed' } });
 
     const hookResult = renderHook((props: UseGraphPreviewParams) => useGraphPreview(props), {
       initialProps: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.ts
@@ -16,7 +16,7 @@ import type { GetFieldsData } from './use_get_fields_data';
 import { getField, getFieldArray } from '../utils';
 import { useBasicDataFromDetailsData } from './use_basic_data_from_details_data';
 import { useHasGraphVisualizationLicense } from '../../../../common/hooks/use_has_graph_visualization_license';
-import { useEntityStoreV2Status } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status';
+import { useIsEntityStoreV2Available } from '../../../../entity_analytics/components/entity_store/hooks/use_is_entity_store_v2_available';
 
 export interface UseGraphPreviewParams {
   /**
@@ -112,9 +112,9 @@ export const useGraphPreview = ({
   // Check if user license is high enough to access graph visualization
   const hasRequiredLicense = useHasGraphVisualizationLicense();
 
-  // Check if entity store v2 is running
-  const { data: entityStoreStatus } = useEntityStoreV2Status();
-  const isEntityStoreRunning = entityStoreStatus?.status === 'running';
+  // Check if entity store v2 entities index exists
+  const { data: entitiesIndexExists } = useIsEntityStoreV2Available();
+  const isEntityStoreRunning = entitiesIndexExists?.indexExists === true;
 
   // Check if graph has all required data fields for graph visualization
   const hasGraphData =

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_graph_preview.ts
@@ -16,7 +16,7 @@ import type { GetFieldsData } from './use_get_fields_data';
 import { getField, getFieldArray } from '../utils';
 import { useBasicDataFromDetailsData } from './use_basic_data_from_details_data';
 import { useHasGraphVisualizationLicense } from '../../../../common/hooks/use_has_graph_visualization_license';
-import { useEntityStoreStatus } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store';
+import { useEntityStoreV2Status } from '../../../../entity_analytics/components/entity_store/hooks/use_entity_store_v2_status';
 
 export interface UseGraphPreviewParams {
   /**
@@ -112,8 +112,8 @@ export const useGraphPreview = ({
   // Check if user license is high enough to access graph visualization
   const hasRequiredLicense = useHasGraphVisualizationLicense();
 
-  // Check if entity store is running
-  const { data: entityStoreStatus } = useEntityStoreStatus();
+  // Check if entity store v2 is running
+  const { data: entityStoreStatus } = useEntityStoreV2Status();
   const isEntityStoreRunning = entityStoreStatus?.status === 'running';
 
   // Check if graph has all required data fields for graph visualization

--- a/x-pack/solutions/security/test/cloud_security_posture_api/utils/entity_store.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/utils/entity_store.ts
@@ -10,6 +10,7 @@ import type { ToolingLog } from '@kbn/tooling-log';
 import type { RetryService } from '@kbn/ftr-common-functional-services';
 import type { Agent } from 'supertest';
 import { CLOUD_ASSET_DISCOVERY_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
+import { ENTITY_STORE_ROUTES, API_VERSIONS } from '@kbn/entity-store/common';
 
 export interface EntityStoreHelpersDeps {
   es: Client;
@@ -298,9 +299,9 @@ export const installCloudAssetInventoryPackage = async ({
 
 // --- Entity Store V2 helpers ---
 
-const V2_HEADERS = {
+const PUBLIC_HEADERS = {
   'kbn-xsrf': 'true',
-  'elastic-api-version': '2',
+  'elastic-api-version': API_VERSIONS.public.v1,
   'x-elastic-internal-origin': 'kibana',
 };
 
@@ -317,8 +318,8 @@ export const installEntityStoreV2 = async ({
   logger.debug(`Installing Entity Store V2 for space: ${spaceLabel}`);
 
   const response = await supertest
-    .post(`${spacePath}/internal/security/entity_store/install?apiVersion=2`)
-    .set(V2_HEADERS)
+    .post(`${spacePath}${ENTITY_STORE_ROUTES.public.INSTALL}`)
+    .set(PUBLIC_HEADERS)
     .send({});
 
   if (response.status !== 200 && response.status !== 201) {
@@ -345,8 +346,8 @@ export const uninstallEntityStoreV2 = async ({
 
   try {
     await supertest
-      .post(`${spacePath}/internal/security/entity_store/uninstall?apiVersion=2`)
-      .set(V2_HEADERS)
+      .post(`${spacePath}${ENTITY_STORE_ROUTES.public.UNINSTALL}`)
+      .set(PUBLIC_HEADERS)
       .send({})
       .expect(200);
     logger.debug(`Entity Store V2 uninstalled for space: ${spaceLabel}`);
@@ -376,8 +377,8 @@ export const waitForEntityStoreV2Running = async ({
 
   await retry.waitForWithTimeout('Entity Store V2 to be running', 60000, async () => {
     const response = await supertest
-      .get(`${spacePath}/internal/security/entity_store/status?apiVersion=2`)
-      .set(V2_HEADERS);
+      .get(`${spacePath}${ENTITY_STORE_ROUTES.public.STATUS}`)
+      .set(PUBLIC_HEADERS);
 
     if (response.status !== 200) {
       logger.debug(`Entity Store V2 status check failed with status: ${response.status}`);

--- a/x-pack/solutions/security/test/cloud_security_posture_api/utils/entity_store.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/utils/entity_store.ts
@@ -295,3 +295,104 @@ export const installCloudAssetInventoryPackage = async ({
     .expect(200);
   logger.debug(`Cloud asset inventory package installed for space: ${spaceId || 'default'}`);
 };
+
+// --- Entity Store V2 helpers ---
+
+const V2_HEADERS = {
+  'kbn-xsrf': 'true',
+  'elastic-api-version': '2',
+  'x-elastic-internal-origin': 'kibana',
+};
+
+/**
+ * Helper to install Entity Store V2
+ */
+export const installEntityStoreV2 = async ({
+  supertest,
+  logger,
+  spaceId,
+}: Pick<EntityStoreHelpersDeps, 'supertest' | 'logger'> & { spaceId?: string }) => {
+  const spacePath = spaceId ? `/s/${spaceId}` : '';
+  const spaceLabel = spaceId || 'default';
+  logger.debug(`Installing Entity Store V2 for space: ${spaceLabel}`);
+
+  const response = await supertest
+    .post(`${spacePath}/internal/security/entity_store/install?apiVersion=2`)
+    .set(V2_HEADERS)
+    .send({});
+
+  if (response.status !== 200 && response.status !== 201) {
+    logger.error(`Failed to install Entity Store V2: ${response.status}`);
+    logger.error(JSON.stringify(response.body));
+    throw new Error(`Failed to install Entity Store V2: ${response.status}`);
+  }
+
+  logger.debug(`Entity Store V2 installed for space: ${spaceLabel}`);
+  return response;
+};
+
+/**
+ * Helper to uninstall Entity Store V2
+ */
+export const uninstallEntityStoreV2 = async ({
+  supertest,
+  logger,
+  spaceId,
+}: Pick<EntityStoreHelpersDeps, 'supertest' | 'logger'> & { spaceId?: string }) => {
+  const spacePath = spaceId ? `/s/${spaceId}` : '';
+  const spaceLabel = spaceId || 'default';
+  logger.debug(`Uninstalling Entity Store V2 for space: ${spaceLabel}`);
+
+  try {
+    await supertest
+      .post(`${spacePath}/internal/security/entity_store/uninstall?apiVersion=2`)
+      .set(V2_HEADERS)
+      .send({})
+      .expect(200);
+    logger.debug(`Entity Store V2 uninstalled for space: ${spaceLabel}`);
+  } catch (e) {
+    if (e.status !== 404) {
+      logger.debug(
+        `Error uninstalling Entity Store V2 for space ${spaceLabel}: ${
+          e && e.message ? e.message : JSON.stringify(e)
+        }`
+      );
+    }
+  }
+};
+
+/**
+ * Helper to wait for Entity Store V2 to reach 'running' status
+ */
+export const waitForEntityStoreV2Running = async ({
+  supertest,
+  retry,
+  logger,
+  spaceId,
+}: Pick<EntityStoreHelpersDeps, 'supertest' | 'retry' | 'logger'> & { spaceId?: string }) => {
+  const spacePath = spaceId ? `/s/${spaceId}` : '';
+  const spaceLabel = spaceId || 'default';
+  logger.debug(`Waiting for Entity Store V2 to be running in space: ${spaceLabel}`);
+
+  await retry.waitForWithTimeout('Entity Store V2 to be running', 60000, async () => {
+    const response = await supertest
+      .get(`${spacePath}/internal/security/entity_store/status?apiVersion=2`)
+      .set(V2_HEADERS);
+
+    if (response.status !== 200) {
+      logger.debug(`Entity Store V2 status check failed with status: ${response.status}`);
+      return false;
+    }
+
+    const { status } = response.body;
+    logger.debug(`Entity Store V2 status: ${status}`);
+
+    if (status === 'error') {
+      throw new Error(
+        `Entity Store V2 is in error state: ${response.body.error?.message || 'Unknown error'}`
+      );
+    }
+
+    return status === 'running';
+  });
+};

--- a/x-pack/solutions/security/test/cloud_security_posture_api/utils/index.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_api/utils/index.ts
@@ -13,5 +13,8 @@ export {
   enableAssetInventory,
   installCloudAssetInventoryPackage,
   initEntityEnginesWithRetry,
+  installEntityStoreV2,
+  uninstallEntityStoreV2,
+  waitForEntityStoreV2Running,
 } from './entity_store';
 export type { EntityStoreHelpersDeps, EntityType } from './entity_store';

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/alerts_flyout.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/alerts_flyout.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { getEntitiesLatestIndexName } from '@kbn/cloud-security-posture-common/utils/helpers';
 import {
   waitForPluginInitialized,
-  cleanupEntityStore,
   waitForEntityDataIndexed,
   dataViewRouteHelpersFactory,
-  initEntityEnginesWithRetry,
+  installEntityStoreV2,
+  uninstallEntityStoreV2,
+  waitForEntityStoreV2Running,
 } from '../../../cloud_security_posture_api/utils';
 import type { SecurityTelemetryFtrProviderContext } from '../../config.base';
 
@@ -62,24 +62,23 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await waitForPluginInitialized({ retry, supertest, logger });
       await ebtUIHelper.setOptIn(true); // starts the recording of events from this moment
 
-      // Enable asset inventory setting (required for entity store with 'generic' type)
-      await kibanaServer.uiSettings.update({ 'securitySolution:enableAssetInventory': true });
+      // Enable asset inventory and entity store v2 settings
+      await kibanaServer.uiSettings.update({
+        'securitySolution:enableAssetInventory': true,
+        'securitySolution:entityStoreEnableV2': true,
+      });
 
       // Initialize security-solution-default data-view (required by entity store)
       const dataView = dataViewRouteHelpersFactory(supertest);
       await dataView.create('security-solution');
 
-      // Initialize entity engine (required for graph visualization)
-      await initEntityEnginesWithRetry({
-        supertest,
-        retry,
-        logger,
-        entityTypes: ['generic'],
-      });
+      // Install Entity Store V2 (required for graph visualization)
+      await installEntityStoreV2({ supertest, logger });
+      await waitForEntityStoreV2Running({ supertest, retry, logger });
     });
 
     after(async () => {
-      await cleanupEntityStore({ supertest, logger });
+      await uninstallEntityStoreV2({ supertest, logger });
       await es.deleteByQuery({
         index: '.internal.alerts-*',
         query: { match_all: {} },
@@ -284,8 +283,8 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
     });
 
     describe('ECS fields only', function () {
-      // Entity store engine is already initialized at the parent level — reused here.
-      // Tests run sequentially: first v1 (ENRICH), then v2 (LOOKUP JOIN)
+      // Entity store v2 is installed at the parent level for graph visibility.
+      // Enrichment tests use LOOKUP JOIN (v2) with custom entity data loaded via esArchiver.
       before(async () => {
         await es.deleteByQuery({
           index: '.internal.alerts-*',
@@ -293,24 +292,10 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
           conflicts: 'proceed',
         });
 
-        try {
-          // delete v2 index manually since its not being deleted by the cleanupEntityStore function
-          await es.indices.delete({
-            index: getEntitiesLatestIndexName(),
-            ignore_unavailable: true,
-          });
-        } catch (e) {
-          // Ignore if index doesn't exist
-        }
-
-        // Load alerts data (shared by both v1 and v2 tests)
+        // Load alerts data
         await esArchiver.load(
           'x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/security_alerts_ecs_only_mappings'
         );
-      });
-
-      after(async () => {
-        // Entity store cleanup is handled by the parent after hook
       });
 
       // Shared test suite that registers all test cases - called from both v1 and v2 describe blocks
@@ -438,17 +423,7 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
 
       describe('via LOOKUP JOIN (v2)', () => {
         before(async () => {
-          // Delete v2 manually since its not being deleted by the cleanupEntityStore function
-          try {
-            await es.indices.delete({
-              index: getEntitiesLatestIndexName(),
-              ignore_unavailable: true,
-            });
-          } catch (e) {
-            // Ignore if index doesn't exist
-          }
-
-          // Load v2 entity data
+          // Load v2 entity data into the entity store index created by v2 install
           await esArchiver.load(
             'x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2'
           );

--- a/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/events_flyout.ts
+++ b/x-pack/solutions/security/test/cloud_security_posture_functional/group5/pages/events_flyout.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import { getEntitiesLatestIndexName } from '@kbn/cloud-security-posture-common/utils/helpers';
 import {
   waitForPluginInitialized,
-  cleanupEntityStore,
   waitForEntityDataIndexed,
   dataViewRouteHelpersFactory,
-  initEntityEnginesWithRetry,
+  installEntityStoreV2,
+  uninstallEntityStoreV2,
+  waitForEntityStoreV2Running,
 } from '../../../cloud_security_posture_api/utils';
 import type { SecurityTelemetryFtrProviderContext } from '../../config.base';
 
@@ -62,24 +62,23 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
       await waitForPluginInitialized({ retry, supertest, logger });
       await ebtUIHelper.setOptIn(true); // starts the recording of events from this moment
 
-      // Enable asset inventory setting (required for entity store with 'generic' type)
-      await kibanaServer.uiSettings.update({ 'securitySolution:enableAssetInventory': true });
+      // Enable asset inventory and entity store v2 settings
+      await kibanaServer.uiSettings.update({
+        'securitySolution:enableAssetInventory': true,
+        'securitySolution:entityStoreEnableV2': true,
+      });
 
       // Initialize security-solution-default data-view (required by entity store)
       const dataView = dataViewRouteHelpersFactory(supertest);
       await dataView.create('security-solution');
 
-      // Initialize entity engine (required for graph visualization)
-      await initEntityEnginesWithRetry({
-        supertest,
-        retry,
-        logger,
-        entityTypes: ['generic'],
-      });
+      // Install Entity Store V2 (required for graph visualization)
+      await installEntityStoreV2({ supertest, logger });
+      await waitForEntityStoreV2Running({ supertest, retry, logger });
     });
 
     after(async () => {
-      await cleanupEntityStore({ supertest, logger });
+      await uninstallEntityStoreV2({ supertest, logger });
       // Using unload destroys index's alias of .alerts-security.alerts-default which causes a failure in other tests
       // Instead we delete all alerts from the index
       await es.deleteByQuery({
@@ -343,47 +342,8 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
     });
 
     describe('ECS fields only', function () {
-      // Entity store is initialized once at the parent level to avoid race conditions
-      // Tests run sequentially: first v1 (ENRICH), then v2 (LOOKUP JOIN)
-      before(async () => {
-        // Clean up any leftover resources from previous runs
-        await cleanupEntityStore({ supertest, logger });
-
-        // Delete entity indices completely to start fresh
-        try {
-          await es.indices.delete({
-            index: getEntitiesLatestIndexName(),
-            ignore_unavailable: true,
-          });
-        } catch (e) {
-          // Ignore if index doesn't exist
-        }
-
-        // Enable asset inventory setting
-        await kibanaServer.uiSettings.update({ 'securitySolution:enableAssetInventory': true });
-
-        // Initialize security-solution-default data-view (required by entity store)
-        const dataView = dataViewRouteHelpersFactory(supertest);
-        await dataView.create('security-solution');
-
-        // Initialize entity engine for 'generic' type ONCE - this is reused by both v1 and v2 tests
-        await initEntityEnginesWithRetry({
-          supertest,
-          retry,
-          logger,
-          entityTypes: ['generic'],
-        });
-      });
-
-      after(async () => {
-        // Clean up entity store resources
-        await cleanupEntityStore({ supertest, logger });
-
-        // Disable asset inventory setting
-        await kibanaServer.uiSettings.update({
-          'securitySolution:enableAssetInventory': false,
-        });
-      });
+      // Entity store v2 is installed at the parent level for graph visibility.
+      // Enrichment tests use LOOKUP JOIN (v2) with custom entity data loaded via esArchiver.
 
       // Shared test suite that registers all test cases - called from both v1 and v2 describe blocks
       const runEnrichmentTests = () => {
@@ -500,17 +460,7 @@ export default function ({ getPageObjects, getService }: SecurityTelemetryFtrPro
 
       describe('via LOOKUP JOIN (v2)', () => {
         before(async () => {
-          // Delete v2 manually since its not being deleted by the cleanupEntityStore function
-          try {
-            await es.indices.delete({
-              index: getEntitiesLatestIndexName(),
-              ignore_unavailable: true,
-            });
-          } catch (e) {
-            // Ignore if index doesn't exist
-          }
-
-          // Load v2 entity data
+          // Load v2 entity data into the entity store index created by v2 install
           await esArchiver.load(
             'x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2'
           );

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/graph_alerts_flyout.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/graph_alerts_flyout.ts
@@ -7,9 +7,10 @@
 
 import {
   waitForPluginInitialized,
-  cleanupEntityStore,
   dataViewRouteHelpersFactory,
-  initEntityEnginesWithRetry,
+  installEntityStoreV2,
+  uninstallEntityStoreV2,
+  waitForEntityStoreV2Running,
 } from '../../../../../cloud_security_posture_api/utils';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 import type { SupertestWithRoleScopeType } from '../../../services';
@@ -62,43 +63,23 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       await waitForPluginInitialized({ retry, supertest: adminSupertest, logger });
 
-      // Enable asset inventory setting (required for entity store with 'generic' type)
-      await kibanaServer.uiSettings.update({ 'securitySolution:enableAssetInventory': true });
+      // Enable asset inventory and entity store v2 settings
+      await kibanaServer.uiSettings.update({
+        'securitySolution:enableAssetInventory': true,
+        'securitySolution:entityStoreEnableV2': true,
+      });
 
       // Initialize security-solution-default data-view (required by entity store)
       const dataView = dataViewRouteHelpersFactory(adminSupertest);
       await dataView.create('security-solution');
 
-      // Initialize entity engine (required for graph visualization)
-      await initEntityEnginesWithRetry({
-        supertest: adminSupertest,
-        retry,
-        logger,
-        entityTypes: ['generic'],
-      });
-
-      // Create v2 lookup index so the graph ESQL query can use LOOKUP JOIN for entity enrichment.
-      await es.indices.create({
-        index: '.entities.v2.latest.security_default',
-        settings: { index: { mode: 'lookup' } },
-        mappings: {
-          properties: {
-            'entity.id': { type: 'keyword' },
-            'entity.name': { type: 'keyword' },
-            'entity.type': { type: 'keyword' },
-            'entity.sub_type': { type: 'keyword' },
-            'host.ip': { type: 'ip' },
-          },
-        },
-      });
+      // Install Entity Store V2 (required for graph visualization)
+      await installEntityStoreV2({ supertest: adminSupertest, logger });
+      await waitForEntityStoreV2Running({ supertest: adminSupertest, retry, logger });
     });
 
     after(async () => {
-      await cleanupEntityStore({ supertest: adminSupertest, logger });
-      await es.indices.delete({
-        index: '.entities.v2.latest.security_default',
-        ignore_unavailable: true,
-      });
+      await uninstallEntityStoreV2({ supertest: adminSupertest, logger });
       // Using unload destroys index's alias of .alerts-security.alerts-default which causes a failure in other tests
       // Instead we delete all alerts from the index
       await es.deleteByQuery({

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/graph_events_flyout.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cloud_security_posture/graph_events_flyout.ts
@@ -7,9 +7,10 @@
 
 import {
   waitForPluginInitialized,
-  cleanupEntityStore,
   dataViewRouteHelpersFactory,
-  initEntityEnginesWithRetry,
+  installEntityStoreV2,
+  uninstallEntityStoreV2,
+  waitForEntityStoreV2Running,
 } from '../../../../../cloud_security_posture_api/utils';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 import type { SupertestWithRoleScopeType } from '../../../services';
@@ -62,43 +63,23 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       await waitForPluginInitialized({ retry, supertest: adminSupertest, logger });
 
-      // Enable asset inventory setting (required for entity store with 'generic' type)
-      await kibanaServer.uiSettings.update({ 'securitySolution:enableAssetInventory': true });
+      // Enable asset inventory and entity store v2 settings
+      await kibanaServer.uiSettings.update({
+        'securitySolution:enableAssetInventory': true,
+        'securitySolution:entityStoreEnableV2': true,
+      });
 
       // Initialize security-solution-default data-view (required by entity store)
       const dataView = dataViewRouteHelpersFactory(adminSupertest);
       await dataView.create('security-solution');
 
-      // Initialize entity engine (required for graph visualization)
-      await initEntityEnginesWithRetry({
-        supertest: adminSupertest,
-        retry,
-        logger,
-        entityTypes: ['generic'],
-      });
-
-      // Create v2 lookup index so the graph ESQL query can use LOOKUP JOIN for entity enrichment.
-      await es.indices.create({
-        index: '.entities.v2.latest.security_default',
-        settings: { index: { mode: 'lookup' } },
-        mappings: {
-          properties: {
-            'entity.id': { type: 'keyword' },
-            'entity.name': { type: 'keyword' },
-            'entity.type': { type: 'keyword' },
-            'entity.sub_type': { type: 'keyword' },
-            'host.ip': { type: 'ip' },
-          },
-        },
-      });
+      // Install Entity Store V2 (required for graph visualization)
+      await installEntityStoreV2({ supertest: adminSupertest, logger });
+      await waitForEntityStoreV2Running({ supertest: adminSupertest, retry, logger });
     });
 
     after(async () => {
-      await cleanupEntityStore({ supertest: adminSupertest, logger });
-      await es.indices.delete({
-        index: '.entities.v2.latest.security_default',
-        ignore_unavailable: true,
-      });
+      await uninstallEntityStoreV2({ supertest: adminSupertest, logger });
       // Using unload destroys index's alias of .alerts-security.alerts-default which causes a failure in other tests
       // Instead we delete all alerts from the index
       await es.deleteByQuery({


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/16424.

Continuation of https://github.com/elastic/kibana/pull/256019.

### Screenshots

| ES v2 NOT running | ES v2 running |
|--------|--------|
| <img width="747" height="1445" alt="Screenshot 2026-04-06 at 13 06 21" src="https://github.com/user-attachments/assets/91f33041-0afd-404a-8f90-3f33aa5865a3" /> | <img width="745" height="1445" alt="Screenshot 2026-04-06 at 13 05 52" src="https://github.com/user-attachments/assets/8388cda4-4fcf-4b89-a5b0-332a4e50fdc9" /> | 

### How to test

1. Run Elasticsearch and Kibana with this flag in `kibana.dev.yml`:
    ```yml
    uiSettings.overrides.securitySolution:entityStoreEnableV2: true
    ```
2. Load fixtures with:
    ```bash
    node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/logs_gcp_audit --es-url http://elastic:changeme@localhost:9200 --kibana-url http://elastic:changeme@localhost:5601
    
    node scripts/es_archiver load x-pack/solutions/security/test/cloud_security_posture_functional/es_archives/entity_store_v2 --es-url http://elastic:changeme@localhost:9200 --kibana-url http://elastic:changeme@localhost:5601
    ```
4. Open Kibana Dev Tools and run these 2 requests to verify both Entity Store versions are NOT running:
    ```
    // v1
    GET kbn:/api/entity_store/status
    // v2
    GET kbn:/api/security/entity_store/status
    ```
5. Go to Security > Explore > Hosts, open an event and check the flyout does NOT render Graph
6. Install ES v2 from Dev Tools with:
    ```yml
    POST kbn:/api/security/entity_store/install
    {
    }
    ```
7. Check the status of both versions, only v2 must be running
8. Go again to Hosts page and check Graph IS running

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Entity Store is removing v1 support, so risk of not exposing graph through the correct endpoint.