### PR TITLE
[Discover] Filter out hidden menu items from app menu config

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/app_menu/app_menu_registry.ts
@@ -155,7 +155,9 @@ export class AppMenuRegistry {
       .filter((item) => item.isCustom)
       .slice(0, AppMenuRegistry.CUSTOM_ITEMS_LIMIT);
 
-    const cleanItems = [...regularItems, ...customItems].map(({ isCustom, ...item }) => item);
+    const cleanItems = [...regularItems, ...customItems]
+      .filter((item) => item.hidden !== 'all')
+      .map(({ isCustom, ...item }) => item);
 
     return {
       items: cleanItems,


### PR DESCRIPTION
## Summary

Fixes an issue where menu items registered with `hidden: 'all'` (specifically the `legacyRules` container item) rendered as empty entries in the Discover top nav overflow popover at non-xl breakpoints.

The `hidden` property is respected by `AppMenuItem` (via `EuiHideFor`), but the overflow/popover rendering path (`getPopoverPanels`) does not check it — resulting in a blank menu option visible to users.

**Fix:** Filter out items with `hidden === 'all'` in `AppMenuRegistry.getAppMenuConfig()` before they reach the rendering layer. The items remain in the internal registry map so `mergePopoverItems()` and `registerPopoverItem()` still work as expected.

### Before
<img width="535" height="220" alt="Empty menu option" src="https://github.com/user-attachments/assets/60aea7fe-b887-4bbb-8812-2fb8393c8cc9" />

### After

<img width="1511" height="462" alt="Screenshot 2026-03-25 at 10 07 37 AM" src="https://github.com/user-attachments/assets/12f1004d-428e-4e5d-8ac0-dbbbf68b10e6" />

## Context

Raised by @AlexGPlay in https://github.com/elastic/kibana/pull/247464#discussion_r2974499302

Made with [Cursor](https://cursor.com)