### PR TITLE
[8.19] [Fleet] Improvements in enrollment settings API (#259385)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/settings/enrollment_settings_handler.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/settings/enrollment_settings_handler.test.ts
@@ -9,7 +9,7 @@ import { httpServerMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
 import { agentPolicyService } from '../../services';
 import { getFleetServerPolicies } from '../../services/fleet_server';
 
-import type { FleetRequestHandlerContext } from '../../types';
+import type { AgentPolicy, FleetRequestHandlerContext } from '../../types';
 import { GetEnrollmentSettingsResponseSchema } from '../../types';
 import { xpackMocks } from '../../mocks';
 
@@ -193,21 +193,25 @@ describe('EnrollmentSettingsHandler utils', () => {
 
   describe('getFleetServerOrAgentPolicies', () => {
     it('returns only fleet server policies if there are any when no agent policy ID is provided', async () => {
-      (getFleetServerPolicies as jest.Mock).mockResolvedValueOnce(mockFleetServerPolicies);
       const { fleetServerPolicies, scopedAgentPolicy } = await getFleetServerOrAgentPolicies(
-        mockSoClient
+        mockSoClient,
+        undefined,
+        mockFleetServerPolicies as AgentPolicy[]
       );
       expect(fleetServerPolicies).toEqual(mockFleetServerPolicies);
       expect(scopedAgentPolicy).toBeUndefined();
+      expect(getFleetServerPolicies).not.toHaveBeenCalled();
     });
 
     it('returns no fleet server policies when there are none and no agent policy ID is provided', async () => {
-      (getFleetServerPolicies as jest.Mock).mockResolvedValueOnce([]);
       const { fleetServerPolicies, scopedAgentPolicy } = await getFleetServerOrAgentPolicies(
-        mockSoClient
+        mockSoClient,
+        undefined,
+        []
       );
       expect(fleetServerPolicies).toEqual([]);
       expect(scopedAgentPolicy).toBeUndefined();
+      expect(getFleetServerPolicies).not.toHaveBeenCalled();
     });
 
     it('returns fleet server policy when specified agent policy ID is a fleet server policy', async () => {
@@ -286,6 +290,7 @@ describe('EnrollmentSettingsHandler utils', () => {
       beforeEach(() => {
         context = xpackMocks.createRequestHandlerContext() as unknown as FleetRequestHandlerContext;
         response = httpServerMock.createResponseFactory();
+        jest.clearAllMocks();
       });
 
       it('should return valid enrollment settings', async () => {
@@ -338,15 +343,11 @@ describe('EnrollmentSettingsHandler utils', () => {
             },
             policies: [
               {
-                download_source_id: 'source-2',
-                fleet_server_host_id: undefined,
                 has_fleet_server: true,
                 id: 'fs-policy-1',
                 is_default_fleet_server: true,
                 is_managed: true,
                 name: 'FS Policy 1',
-                space_ids: undefined,
-                data_output_id: undefined,
               },
             ],
           },

--- a/x-pack/platform/plugins/shared/fleet/server/routes/settings/enrollment_settings_handler.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/settings/enrollment_settings_handler.ts
@@ -8,6 +8,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { omit, pick } from 'lodash';
 
 import { FLEET_SERVER_PACKAGE } from '../../../common/constants';
@@ -41,9 +42,14 @@ export const getEnrollmentSettingsHandler: FleetRequestHandler<
   const coreContext = await context.core;
   const esClient = coreContext.elasticsearch.client.asInternalUser;
   const soClient = coreContext.savedObjects.client;
-  // Get all possible fleet server or scoped normal agent policies
+  const unscopedSoClient = appContextService.getInternalUserSOClientWithoutSpaceExtension();
+  // Fetch all fleet server policies once (cross-space). Used for both the space-filtered
+  // policy list and the global has_active check.
+  const allFleetServerPolicies = await getFleetServerPolicies(unscopedSoClient);
+
+  // Get the space-filtered policy list and the scoped agent policy for host/output lookups
   const { fleetServerPolicies, scopedAgentPolicy: scopedAgentPolicyResponse } =
-    await getFleetServerOrAgentPolicies(soClient, agentPolicyId);
+    await getFleetServerOrAgentPolicies(soClient, agentPolicyId, allFleetServerPolicies);
   const scopedAgentPolicy = scopedAgentPolicyResponse || {
     id: undefined,
     name: undefined,
@@ -54,11 +60,21 @@ export const getEnrollmentSettingsHandler: FleetRequestHandler<
 
   // Check if there is any active fleet server enrolled into the fleet server policies policies
   if (fleetServerPolicies) {
-    settingsResponse.fleet_server.policies = fleetServerPolicies;
+    settingsResponse.fleet_server.policies = fleetServerPolicies.map(
+      ({ id, name, is_managed, is_default_fleet_server, has_fleet_server }) => ({
+        id,
+        name,
+        is_managed,
+        is_default_fleet_server,
+        has_fleet_server,
+      })
+    );
+    // has_active is a global check: fleet servers in any space count as active.
+    // Use all cross-space policies
     settingsResponse.fleet_server.has_active = await hasFleetServersForPolicies(
       esClient,
-      appContextService.getInternalUserSOClientWithoutSpaceExtension(),
-      fleetServerPolicies,
+      unscopedSoClient,
+      allFleetServerPolicies,
       true
     );
   }
@@ -128,25 +144,41 @@ export const getEnrollmentSettingsHandler: FleetRequestHandler<
   return response.ok({ body: settingsResponse });
 };
 
+const mapPolicy = (policy: AgentPolicy) => ({
+  id: policy.id,
+  name: policy.name,
+  is_managed: policy.is_managed,
+  is_default_fleet_server: policy.is_default_fleet_server,
+  has_fleet_server: policy.has_fleet_server,
+  fleet_server_host_id: policy.fleet_server_host_id,
+  download_source_id: policy.download_source_id,
+  space_ids: policy.space_ids,
+  data_output_id: policy.data_output_id,
+});
+
+const filterPoliciesForCurrentSpace = (
+  soClient: SavedObjectsClientContract,
+  allFleetServerPolicies?: AgentPolicy[]
+) => {
+  // Filter the pre-fetched cross-space policies to those visible in the current space
+  const currentSpaceId = soClient.getCurrentNamespace() ?? DEFAULT_SPACE_ID;
+  const currentSpacePolicies = (allFleetServerPolicies ?? []).filter((p) => {
+    if (!p.space_ids || p.space_ids.length === 0) {
+      return currentSpaceId === DEFAULT_SPACE_ID;
+    }
+    return p.space_ids.includes(currentSpaceId);
+  });
+  return currentSpacePolicies;
+};
+
 export const getFleetServerOrAgentPolicies = async (
   soClient: SavedObjectsClientContract,
-  agentPolicyId?: string
+  agentPolicyId?: string,
+  allFleetServerPolicies?: AgentPolicy[]
 ): Promise<{
   fleetServerPolicies?: EnrollmentSettingsFleetServerPolicy[];
   scopedAgentPolicy?: EnrollmentSettingsFleetServerPolicy;
 }> => {
-  const mapPolicy = (policy: AgentPolicy) => ({
-    id: policy.id,
-    name: policy.name,
-    is_managed: policy.is_managed,
-    is_default_fleet_server: policy.is_default_fleet_server,
-    has_fleet_server: policy.has_fleet_server,
-    fleet_server_host_id: policy.fleet_server_host_id,
-    download_source_id: policy.download_source_id,
-    space_ids: policy.space_ids,
-    data_output_id: policy.data_output_id,
-  });
-
   // If an agent policy is specified, return only that policy
   if (agentPolicyId) {
     const agentPolicy = await agentPolicyService.get(soClient, agentPolicyId, true);
@@ -165,11 +197,8 @@ export const getFleetServerOrAgentPolicies = async (
     return {};
   }
 
-  // If an agent policy is not specified, return all fleet server policies
-  const fleetServerPolicies = (
-    await getFleetServerPolicies(appContextService.getInternalUserSOClientWithoutSpaceExtension())
-  ).map(mapPolicy);
-  return { fleetServerPolicies };
+  const currentSpacePolicies = filterPoliciesForCurrentSpace(soClient, allFleetServerPolicies);
+  return { fleetServerPolicies: currentSpacePolicies.map(mapPolicy) };
 };
 
 export const getDownloadSource = async (

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/settings.ts
@@ -151,10 +151,6 @@ export const GetEnrollmentSettingsResponseSchema = schema.object({
         is_managed: schema.boolean(),
         is_default_fleet_server: schema.maybe(schema.boolean()),
         has_fleet_server: schema.maybe(schema.boolean()),
-        fleet_server_host_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
-        download_source_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
-        space_ids: schema.maybe(schema.arrayOf(schema.string(), { maxSize: 10000 })),
-        data_output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
       }),
       { maxSize: 10000 }
     ),

--- a/x-pack/platform/test/fleet_api_integration/apis/settings/enrollment.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/settings/enrollment.ts
@@ -68,14 +68,20 @@ export default function (providerContext: FtrProviderContext) {
                 is_default_fleet_server: true,
                 is_managed: false,
                 name: 'Fleet Server Policy',
+<<<<<<< HEAD
                 space_ids: [],
+=======
+>>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
               {
                 id: 'fleet-server-policy-2',
                 is_default_fleet_server: false,
                 is_managed: false,
                 name: 'Fleet Server Policy 2',
+<<<<<<< HEAD
                 space_ids: [],
+=======
+>>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
             ],
             has_active: true,
@@ -125,7 +131,10 @@ export default function (providerContext: FtrProviderContext) {
                 is_default_fleet_server: false,
                 is_managed: false,
                 name: 'Fleet Server Policy 2',
+<<<<<<< HEAD
                 space_ids: [],
+=======
+>>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
             ],
             has_active: true,

--- a/x-pack/platform/test/fleet_api_integration/apis/settings/enrollment.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/settings/enrollment.ts
@@ -68,20 +68,12 @@ export default function (providerContext: FtrProviderContext) {
                 is_default_fleet_server: true,
                 is_managed: false,
                 name: 'Fleet Server Policy',
-<<<<<<< HEAD
-                space_ids: [],
-=======
->>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
               {
                 id: 'fleet-server-policy-2',
                 is_default_fleet_server: false,
                 is_managed: false,
                 name: 'Fleet Server Policy 2',
-<<<<<<< HEAD
-                space_ids: [],
-=======
->>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
             ],
             has_active: true,
@@ -131,10 +123,6 @@ export default function (providerContext: FtrProviderContext) {
                 is_default_fleet_server: false,
                 is_managed: false,
                 name: 'Fleet Server Policy 2',
-<<<<<<< HEAD
-                space_ids: [],
-=======
->>>>>>> 2aa18e30580e ([Fleet] Improvements in enrollment settings API (#259385))
               },
             ],
             has_active: true,

--- a/x-pack/platform/test/fleet_api_integration/apis/space_awareness/enrollment_settings.ts
+++ b/x-pack/platform/test/fleet_api_integration/apis/space_awareness/enrollment_settings.ts
@@ -92,6 +92,56 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
+    describe('Policy space isolation', () => {
+      let defaultSpacePolicyId: string;
+      let testSpacePolicyId: string;
+      const testSpaceId = 'test1';
+
+      before(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await kibanaServer.savedObjects.cleanStandardList({
+          space: testSpaceId,
+        });
+        await cleanFleetIndices(esClient);
+        await apiClient.postEnableSpaceAwareness();
+        await apiClient.setup();
+        const defaultPolicy = await apiClient.createFleetServerPolicy();
+        defaultSpacePolicyId = defaultPolicy.item.id;
+        const testSpacePolicy = await apiClient.createFleetServerPolicy(testSpaceId);
+        testSpacePolicyId = testSpacePolicy.item.id;
+      });
+
+      after(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await kibanaServer.savedObjects.cleanStandardList({
+          space: testSpaceId,
+        });
+        await cleanFleetIndices(esClient);
+      });
+
+      it('default space should only return fleet server policies from default space', async () => {
+        const res = await apiClient.getEnrollmentSettings();
+        const policyIds = res.fleet_server.policies.map((p) => p.id);
+        expect(policyIds).to.contain(defaultSpacePolicyId);
+        expect(policyIds).not.to.contain(testSpacePolicyId);
+      });
+
+      it('test space should only return fleet server policies from that space', async () => {
+        const res = await apiClient.getEnrollmentSettings(testSpaceId);
+        const policyIds = res.fleet_server.policies.map((p) => p.id);
+        expect(policyIds).to.contain(testSpacePolicyId);
+        expect(policyIds).not.to.contain(defaultSpacePolicyId);
+      });
+
+      it('default space has_active should be true even when the active fleet server is in another space', async () => {
+        // Enroll a fleet server agent only in the test space (no agent in default space)
+        await createFleetAgent(esClient, testSpacePolicyId, testSpaceId);
+
+        const res = await apiClient.getEnrollmentSettings();
+        expect(res.fleet_server.has_active).to.be(true);
+      });
+    });
+
     describe('With Fleet server setup in default space', () => {
       before(async () => {
         await kibanaServer.savedObjects.cleanStandardList();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
- [[Fleet] Improvements in enrollment settings API (#259385)](https://github.com/elastic/kibana/pull/259385)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Bardi","email":"90178898+juliaElastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T14:04:50Z","message":"[Fleet] Improvements in enrollment settings API (#259385)","sha":"2aa18e30580efaf1094808fa3bf52f636cecc367","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-minor","v9.4.0"],"title":"[Fleet] Improvements in enrollment settings API","number":259385,"url":"https://github.com/elastic/kibana/pull/259385","mergeCommit":{"message":"[Fleet] Improvements in enrollment settings API (#259385)","sha":"2aa18e30580efaf1094808fa3bf52f636cecc367"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->