### PR TITLE
[Lens powered by ES|QL] Fix saved data views shown as temporary after ES|QL conversion

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/data_views_service/loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/data_views_service/loader.ts
@@ -201,6 +201,43 @@ export async function ensureESQLTimeFieldOnAdHocDataViews({
       continue;
     }
 
+    // Saved data view ids (form → ES|QL): never call getESQLAdHocDataview with options.id set to
+    // that id — it creates an ES|QL ad-hoc instance under the same id and replaces the DataViews
+    // cache entry so isPersisted() becomes false (picker shows "Temporary")
+    if (layer.index && typeof dataViewsService.get === 'function') {
+      try {
+        const maybePersisted = await dataViewsService.get(layer.index);
+        if (
+          maybePersisted &&
+          typeof maybePersisted.isPersisted === 'function' &&
+          maybePersisted.isPersisted()
+        ) {
+          const specFromDv = maybePersisted.toSpec(false);
+          if (specFromDv.timeFieldName) {
+            result[layer.index] = { ...existingSpec, ...specFromDv };
+            continue;
+          }
+          const freshDataView = await getESQLAdHocDataview({
+            dataViewsService,
+            query: layer.query.esql,
+            options: {
+              skipFetchFields: true,
+              createNewInstanceEvenIfCachedOneAvailable: true,
+            },
+            http,
+          });
+          result[layer.index] = {
+            ...existingSpec,
+            ...specFromDv,
+            timeFieldName: freshDataView.timeFieldName ?? specFromDv.timeFieldName,
+          };
+          continue;
+        }
+      } catch {
+        // layer.index is not a loadable saved id — fall through to ad-hoc path below
+      }
+    }
+
     const freshDataView = await getESQLAdHocDataview({
       dataViewsService,
       query: layer.query.esql,


### PR DESCRIPTION
## Summary

Fix saved data views shown as temporary after ES|QL conversion (#257736 regression)

### Before

#### on "Cancel"


https://github.com/user-attachments/assets/9ebe25d7-2219-4ae8-8ff8-2f467be84ad7



#### on "Apply and close"

https://github.com/user-attachments/assets/d2cc99d1-d073-47d8-90a2-4b6f459225b2



## Checklist


- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
