### PR TITLE
[Fleet] Send is_elastic_staff_owned to agentless-api

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
@@ -184,6 +184,7 @@ describe('Agentless Agent service', () => {
           fleet_url: 'http://fleetserver:8220',
           policy_id: 'mocked-agentless-agent-policy-id',
           stack_version: 'mocked-kibana-version-infinite',
+          is_elastic_staff_owned: false,
           labels: {
             owner: {
               org: 'elastic',
@@ -201,6 +202,73 @@ describe('Agentless Agent service', () => {
         }),
         headers: expect.anything(),
         httpsAgent: expect.anything(),
+        method: 'POST',
+        url: 'http://api.agentless.com/api/v1/ess/deployments',
+      })
+    );
+  });
+
+  it('should include is_elastic_staff_owned when cloud reports elastic staff owned deployment', async () => {
+    jest.mocked(axios).mockResolvedValueOnce(mockAgentlessDeploymentResponse);
+    const soClient = getAgentPolicyCreateMock();
+    const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    jest.spyOn(appContextService, 'getConfig').mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'http://api.agentless.com',
+          tls: {
+            certificate: '/path/to/cert',
+            key: '/path/to/key',
+            ca: '/path/to/ca',
+          },
+        },
+        deploymentSecrets: {
+          fleetAppToken: 'fleet-app-token',
+          elasticsearchAppToken: 'es-app-token',
+        },
+      },
+    } as any);
+    jest
+      .spyOn(appContextService, 'getCloud')
+      .mockReturnValue({ isCloudEnabled: true, isElasticStaffOwned: true } as any);
+    jest
+      .spyOn(appContextService, 'getKibanaVersion')
+      .mockReturnValue('mocked-kibana-version-infinite');
+    mockedFleetServerHostService.get.mockResolvedValue({
+      id: 'mocked-fleet-server-id',
+      host: 'http://fleetserver:8220',
+      active: true,
+      is_default: true,
+      host_urls: ['http://fleetserver:8220'],
+    } as any);
+    mockedListEnrollmentApiKeys.mockResolvedValue({
+      items: [
+        {
+          id: 'mocked-fleet-enrollment-token-id',
+          policy_id: 'mocked-fleet-enrollment-policy-id',
+          api_key: 'mocked-fleet-enrollment-api-key',
+        },
+      ],
+    } as any);
+
+    await agentlessAgentService.createAgentlessAgent(esClient, soClient, {
+      id: 'mocked-agentless-agent-policy-id',
+      name: 'agentless agent policy',
+      namespace: 'default',
+      fleet_server_host_id: 'mock-fleet-default-fleet-server-host',
+      data_output_id: 'mock-fleet-default-output',
+      supports_agentless: true,
+    } as AgentPolicy);
+
+    expect(axios).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          policy_id: 'mocked-agentless-agent-policy-id',
+          is_elastic_staff_owned: true,
+          stack_version: 'mocked-kibana-version-infinite',
+        }),
         method: 'POST',
         url: 'http://api.agentless.com/api/v1/ess/deployments',
       })

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -191,6 +191,7 @@ class AgentlessAgentServiceImpl implements AgentlessAgentService {
     const cloudSetup = appContextService.getCloud();
     if (!cloudSetup?.isServerlessEnabled) {
       requestConfig.data.stack_version = appContextService.getKibanaVersion();
+      requestConfig.data.is_elastic_staff_owned = cloudSetup?.isElasticStaffOwned ?? false;
     }
 
     const requestConfigDebugStatus = this.createRequestConfigDebug(requestConfig);
@@ -527,7 +528,8 @@ class AgentlessAgentServiceImpl implements AgentlessAgentService {
           'fleet_url',
           'labels',
           'resources',
-          'cloud_connectors'
+          'cloud_connectors',
+          'is_elastic_staff_owned'
         ),
         agent_policy: '[REDACTED]',
         fleet_token: '[REDACTED]',


### PR DESCRIPTION
## Summary

- Send `is_elastic_staff_owned` in the `POST /api/v1/ess/deployments` payload to agentless-api
- Value is read from `appContextService.getCloud()?.isElasticStaffOwned`, defaulting to `false`
- Added to the debug log output in `createRequestConfigDebug`

## Context

Agentless deployments in ECH lack the `k8s.elastic.co/created-by-internal-user` label that exists in Serverless. This label is used for alert triage to distinguish internal/test deployments. Kibana already knows whether the deployment is staff-owned via `xpack.cloud.is_elastic_staff_owned`, so we pass it through to agentless-api.

## Deployment ordering

The corresponding agentless-api PR must be deployed **before** this Kibana change. agentless-api uses `additionalProperties: false` in its OpenAPI spec, so it will reject unknown fields.

## Test plan

- [x] Updated existing ESS and Serverless tests to assert `is_elastic_staff_owned: false`
- [x] New test verifying `is_elastic_staff_owned: true` when Cloud reports staff-owned deployment

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks


- [ ] The corresponding agentless-api PR must be deployed **before** this Kibana change. agentless-api uses `additionalProperties: false` in its OpenAPI spec, so it will reject unknown fields.


Fixes: https://github.com/elastic/kibana/issues/259600


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->