### PR TITLE
[Entity Analytics] Entity Store V2 Check on Risk Score Enablement UI

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/hooks/use_risk_engine_status.ts
@@ -40,7 +40,7 @@ export const useRiskEngineCountdownTime = (riskEngineStatus?: RiskEngineStatusRe
 export const useRiskEngineStatus = (
   queryOptions: Pick<
     UseQueryOptions<unknown, unknown, RiskEngineStatusResponse, string[]>,
-    'refetchInterval' | 'structuralSharing'
+    'refetchInterval' | 'structuralSharing' | 'enabled'
   > = {}
 ) => {
   const { fetchRiskEngineStatus } = useEntityAnalyticsRoutes();

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { UseMutationOptions } from '@kbn/react-query';
+import type { UseMutationOptions, UseQueryOptions } from '@kbn/react-query';
 import { useMutation, useQuery, useQueryClient } from '@kbn/react-query';
 
 import type { IHttpFetchError } from '@kbn/core-http-browser';
@@ -29,7 +29,11 @@ interface ResponseError {
   body: { message: string };
 }
 
-interface Options {
+interface Options
+  extends Omit<
+    UseQueryOptions<GetEntityStoreStatusResponse, IHttpFetchError>,
+    'queryKey' | 'queryFn'
+  > {
   withComponents?: boolean;
 }
 
@@ -45,6 +49,7 @@ export const useEntityStoreStatus = (opts: Options = {}) => {
       }
       return false;
     },
+    ...opts,
   });
 };
 
@@ -74,8 +79,13 @@ export const useEnableEntityStoreMutation = (
     },
     {
       mutationKey: ENABLE_STORE_STATUS_KEY,
-      onSuccess: () => queryClient.refetchQueries(ENTITY_STORE_STATUS),
       ...options,
+      onSuccess: (...args) => {
+        queryClient.refetchQueries(ENTITY_STORE_STATUS);
+        if (options?.onSuccess) {
+          options.onSuccess(...args);
+        }
+      },
     }
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_enable_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_management/risk_score_enable_section.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -29,6 +30,12 @@ import { useDisableRiskEngineMutation } from '../../api/hooks/use_disable_risk_e
 import { useAppToasts } from '../../../common/hooks/use_app_toasts';
 import type { RiskEngineMissingPrivilegesResponse } from '../../hooks/use_missing_risk_engine_privileges';
 import { useInvalidateRiskEngineSettingsQuery } from './hooks/risk_score_configurable_risk_engine_settings_hooks';
+import {
+  useEntityStoreStatus,
+  useEnableEntityStoreMutation,
+  useStopEntityEngineMutation,
+} from '../entity_store/hooks/use_entity_store';
+import { useEntityStoreTypes } from '../../hooks/use_enabled_entity_types';
 
 const MIN_WIDTH_TO_PREVENT_LABEL_FROM_MOVING = '50px';
 const toastOptions = {
@@ -115,9 +122,16 @@ export const RiskScoreEnableSection: React.FC<{
   selectedSettingsMatchSavedSettings: boolean;
   saveSelectedSettingsMutation: UseMutationResult<void, unknown, void, unknown>;
 }> = ({ privileges, selectedSettingsMatchSavedSettings, saveSelectedSettingsMutation }) => {
+  const [isEntityStoreV2Enabled] = useUiSetting$<boolean>('securitySolution:entityStoreEnableV2');
   const { addSuccess } = useAppToasts();
-  const { data: riskEngineStatus, isFetching: isStatusLoading } = useRiskEngineStatus();
+  const { data: riskEngineStatus, isFetching: isRiskEngineStatusLoading } = useRiskEngineStatus({
+    enabled: !isEntityStoreV2Enabled,
+  });
+  const entityStoreStatus = useEntityStoreStatus({
+    enabled: isEntityStoreV2Enabled,
+  });
   const invalidateRiskEngineSettingsQuery = useInvalidateRiskEngineSettingsQuery();
+  const entityTypes = useEntityStoreTypes();
 
   const initRiskEngineMutation = useInitRiskEngineMutation({
     onSuccess: async () => {
@@ -137,30 +151,65 @@ export const RiskScoreEnableSection: React.FC<{
     },
   });
 
-  const currentRiskEngineStatus = riskEngineStatus?.risk_engine_status;
+  const enableEntityStoreMutation = useEnableEntityStoreMutation({
+    onSuccess: () => {
+      addSuccess(i18n.RISK_ENGINE_TURNED_ON, toastOptions);
+    },
+  });
+  const stopEntityEngineMutation = useStopEntityEngineMutation(entityTypes);
+
+  const getRiskEngineStatus = () => {
+    if (!isEntityStoreV2Enabled) {
+      return riskEngineStatus?.risk_engine_status;
+    }
+    const status = entityStoreStatus.data?.status || '';
+    if (['installing', 'running', 'starting'].includes(status)) {
+      return RiskEngineStatusEnum.ENABLED;
+    }
+    if (status === 'stopped') {
+      return RiskEngineStatusEnum.DISABLED;
+    }
+    return RiskEngineStatusEnum.NOT_INSTALLED;
+  };
+
+  const currentRiskEngineStatus = getRiskEngineStatus();
 
   const isLoading =
     saveSelectedSettingsMutation.isLoading ||
     initRiskEngineMutation.isLoading ||
     enableRiskEngineMutation.isLoading ||
     disableRiskEngineMutation.isLoading ||
+    enableEntityStoreMutation.isLoading ||
+    stopEntityEngineMutation.isLoading ||
     privileges.isLoading ||
-    isStatusLoading;
+    isRiskEngineStatusLoading ||
+    (isEntityStoreV2Enabled && entityStoreStatus.isLoading);
 
   const onSwitchClick = async () => {
     if (!currentRiskEngineStatus || isLoading) {
       return;
     }
 
-    if (currentRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED) {
-      if (!selectedSettingsMatchSavedSettings) {
-        await saveSelectedSettingsMutation.mutateAsync();
+    if (isEntityStoreV2Enabled) {
+      if (currentRiskEngineStatus === RiskEngineStatusEnum.ENABLED) {
+        stopEntityEngineMutation.mutate();
+      } else {
+        if (!selectedSettingsMatchSavedSettings) {
+          await saveSelectedSettingsMutation.mutateAsync();
+        }
+        enableEntityStoreMutation.mutate({});
       }
-      await initRiskEngineMutation.mutateAsync();
-    } else if (currentRiskEngineStatus === RiskEngineStatusEnum.ENABLED) {
-      disableRiskEngineMutation.mutate();
-    } else if (currentRiskEngineStatus === RiskEngineStatusEnum.DISABLED) {
-      enableRiskEngineMutation.mutate();
+    } else {
+      if (currentRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED) {
+        if (!selectedSettingsMatchSavedSettings) {
+          await saveSelectedSettingsMutation.mutateAsync();
+        }
+        await initRiskEngineMutation.mutateAsync();
+      } else if (currentRiskEngineStatus === RiskEngineStatusEnum.ENABLED) {
+        disableRiskEngineMutation.mutate();
+      } else if (currentRiskEngineStatus === RiskEngineStatusEnum.DISABLED) {
+        enableRiskEngineMutation.mutate();
+      }
     }
   };
 
@@ -169,15 +218,23 @@ export const RiskScoreEnableSection: React.FC<{
     const errorBody = initRiskEngineMutation.error.body;
     initRiskEngineErrors = [errorBody.message];
   }
+  if (enableEntityStoreMutation.isError) {
+    initRiskEngineErrors = [enableEntityStoreMutation.error.body.message];
+  }
+
   return (
     <>
       <>
         {initRiskEngineMutation.isError && <RiskScoreErrorPanel errors={initRiskEngineErrors} />}
+        {enableEntityStoreMutation.isError && <RiskScoreErrorPanel errors={initRiskEngineErrors} />}
         {disableRiskEngineMutation.isError && (
           <RiskScoreErrorPanel errors={[disableRiskEngineMutation.error.body.message]} />
         )}
         {enableRiskEngineMutation.isError && (
           <RiskScoreErrorPanel errors={[enableRiskEngineMutation.error.body.message]} />
+        )}
+        {stopEntityEngineMutation.isError && (
+          <RiskScoreErrorPanel errors={[i18n.ERROR_PANEL_MESSAGE]} />
         )}
 
         <EuiSpacer size="m" />

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.test.tsx
@@ -34,6 +34,19 @@ jest.mock('../../common/hooks/use_experimental_features', () => ({
   useIsExperimentalFeatureEnabled: () => true,
 }));
 
+jest.mock('@kbn/kibana-react-plugin/public', () => ({
+  useUiSetting$: () => [false],
+}));
+
+jest.mock('../components/entity_store/hooks/use_entity_store', () => ({
+  useEntityStoreStatus: () => ({
+    data: {
+      status: 'stopped',
+    },
+    isFetching: false,
+  }),
+}));
+
 jest.mock('../api/hooks/use_risk_engine_status', () => ({
   useRiskEngineStatus: () => ({
     data: {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -16,6 +16,7 @@ import {
   EuiText,
   useEuiTheme,
 } from '@elastic/eui';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import moment from 'moment';
 import { useMutation } from '@kbn/react-query';
 import { RiskScorePreviewSection } from '../components/risk_score_management/risk_score_preview_section';
@@ -34,6 +35,7 @@ import { useConfigurableRiskEngineSettings } from '../components/risk_score_mana
 import { RiskScoreSaveBar } from '../components/risk_score_management/risk_score_save_bar';
 import { RiskScoreGeneralSection } from '../components/risk_score_management/risk_score_general_section';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { useEntityStoreStatus } from '../components/entity_store/hooks/use_entity_store';
 
 const TEN_SECONDS = 10000;
 
@@ -41,6 +43,7 @@ export const EntityAnalyticsManagementPage = () => {
   const { euiTheme } = useEuiTheme();
   const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
   const privileges = useMissingRiskEnginePrivileges();
+  const [isEntityStoreV2Enabled] = useUiSetting$<boolean>('securitySolution:entityStoreEnableV2');
   const {
     savedRiskEngineSettings,
     selectedRiskEngineSettings,
@@ -57,18 +60,35 @@ export const EntityAnalyticsManagementPage = () => {
   const { data: riskEngineStatus } = useRiskEngineStatus({
     refetchInterval: TEN_SECONDS,
     structuralSharing: false, // Force the component to rerender after every Risk Engine Status API call
+    enabled: !isEntityStoreV2Enabled,
   });
-  const currentRiskEngineStatus = riskEngineStatus?.risk_engine_status;
-  const runEngineEnabled = currentRiskEngineStatus === 'ENABLED';
+  const entityStoreStatus = useEntityStoreStatus({
+    enabled: isEntityStoreV2Enabled,
+  });
+
+  const getRiskEngineStatus = () => {
+    if (!isEntityStoreV2Enabled) {
+      return riskEngineStatus?.risk_engine_status;
+    }
+    const status = entityStoreStatus.data?.status || '';
+    if (['installing', 'running', 'starting'].includes(status)) {
+      return 'ENABLED';
+    }
+    return 'DISABLED'; // Default mapped status for V2 logic below
+  };
+
+  const currentRiskEngineStatus = getRiskEngineStatus();
+
+  const runEngineEnabled = currentRiskEngineStatus === 'ENABLED' && !isEntityStoreV2Enabled;
   const [isLoadingRunRiskEngine, setIsLoadingRunRiskEngine] = useState(false);
   const { mutate: scheduleNowRiskEngine } = useScheduleNowRiskEngineMutation();
   const { addSuccess, addError } = useAppToasts();
-  const userCanRunEngine =
-    (!privileges.isLoading &&
+  const userCanRunEngine = Boolean(
+    !privileges.isLoading &&
       (privileges.hasAllRequiredPrivileges ||
         (!privileges.hasAllRequiredPrivileges &&
-          privileges.missingPrivileges?.clusterPrivileges?.run?.length === 0))) ||
-    false;
+          privileges.missingPrivileges?.clusterPrivileges?.run?.length === 0))
+  );
   const riskScoreResetToZeroIsEnabled = useIsExperimentalFeatureEnabled(
     'enableRiskScoreResetToZero'
   );
@@ -98,16 +118,14 @@ export const EntityAnalyticsManagementPage = () => {
 
   const { status, runAt } = riskEngineStatus?.risk_engine_task_status || {};
 
-  const isRunning = status === 'running' || (!!runAt && new Date(runAt) < new Date());
+  const isRunning = Boolean(status === 'running' || (runAt && new Date(runAt) < new Date()));
 
-  const runEngineBtnIsDisabled =
-    !currentRiskEngineStatus || isLoadingRunRiskEngine || !userCanRunEngine || isRunning;
+  const runEngineBtnIsDisabled = Boolean(
+    !currentRiskEngineStatus || isLoadingRunRiskEngine || !userCanRunEngine || isRunning
+  );
 
-  const formatTimeFromNow = (time: string | undefined): string => {
-    if (!time) {
-      return '';
-    }
-    return i18n.RISK_ENGINE_NEXT_RUN_TIME(moment(time).fromNow(true));
+  const formatTimeFromNow = (time?: string): string => {
+    return time ? i18n.RISK_ENGINE_NEXT_RUN_TIME(moment(time).fromNow(true)) : '';
   };
 
   const countDownText = isRunning


### PR DESCRIPTION
- Updated `useRiskEngineStatus` to include an 'enabled' option for conditional fetching based on the Entity Store V2 setting.
- Modified `useEntityStoreStatus` to support the new integration, allowing for dynamic status checks based on the Entity Store V2 feature flag.
- Enhanced `RiskScoreEnableSection` to utilize the updated hooks, improving the management of risk engine states and entity store interactions.
- Adjusted `EntityAnalyticsManagementPage` to reflect the new logic for determining risk engine status based on the Entity Store V2 setting.
- Added tests to ensure the new functionality works as expected.

**Demo:** 

https://github.com/user-attachments/assets/b8e3036a-1ddf-426c-9414-22a973495202




### Desk Testing: 
**Scenario A:** Legacy Risk Engine (V2 Flag is OFF) This verifies that we haven't broken the existing functionality for users not using V2.

1. s**ecuritySolution:entityStoreEnableV2** flag set to false (default).
2. Navigate to Risk Score Management Page 
4. Enablement: Toggle the switch to ON. 
5. Wait for the toast notification confirming the risk engine is turned on.
6. Verify the switch stays in the ON position.
7. Verify the "Run Risk Score Engine" button is visible and enabled.
8. Execution: Click the Run Risk Score Engine button.
9. Verify a toast appears saying the engine run was successful.
10. Disablement: Toggle the switch back to OFF.
11. Wait for the toast confirmation.
12. Verify the switch stays in the OFF position and the "Run" button is hidden/disabled.

**Scenario B:** Entity Store V2 (V2 Flag is ON) This verifies that the new UI correctly routes to the V2 API endpoints and handles V2-specific states.

1. Go to Stack Management -> Advanced Settings and set securitySolution:entityStoreEnableV2 to true.
2. Navigate to Security -> Entity Analytics.
3. Check the Run Button: Observe the Entity risk score header.
4. Verify the "Run Risk Score Engine" button is hidden (since V2 evaluates continuously instead of in scheduled batches).
5. Enablement: Toggle the risk score switch to ON.
6. Verify the switch remains in the ON position immediately (it shouldn't jump back to OFF while in the installing or starting phases).
7. Verify the status text next to the switch says "On" and is green.
8. API Validation: Open your browser's network tab.
9. Verify that flipping the switch sent a POST request to /api/entity_store/enable (V2 endpoint) and not /api/risk_engine/enable (Legacy endpoint).
10. Disablement: Toggle the switch to OFF.
11. Verify the status text updates to "Off" and is red.
12. In the network tab, verify a POST request was sent to the /api/entity_store/engines/*/stop endpoints.