### PR TITLE
[Traces in Discover] Restore Waterfall flyout usage test

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/waterfall_flyout_usage.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/waterfall_flyout_usage.spec.ts
@@ -14,6 +14,7 @@ import {
   spaceTest,
   TRACES,
   RICH_TRACE,
+  PRODUCER_TRACE,
   DEEP_TRACE,
   setupTracesExperience,
   teardownTracesExperience,
@@ -37,12 +38,6 @@ const openTraceTimeline = async (pageObjects: {
   const { flyout } = pageObjects.tracesExperience;
   await flyout.traceSummary.fullScreenButton.click();
   await expect(flyout.waterfallFlyout.container).toBeVisible();
-  // Dismiss the "Trace insights in Discover" tour step if shown (it has a 500ms render delay
-  // and a z-index that overlaps the child flyout, blocking subsequent interactions).
-  await flyout.traceSummary.tourOkButton
-    .waitFor({ state: 'visible', timeout: 2000 })
-    .then(() => flyout.traceSummary.tourOkButton.click())
-    .catch(() => {});
 };
 
 spaceTest.describe(
@@ -256,38 +251,36 @@ spaceTest.describe(
           }
         );
 
-        // TODO: These steps are commented out due to a buggy integration with the Flyout System.
-        // This will be addressed in a separate PR.
-        // await spaceTest.step(
-        //   'Internal span child flyout - logs Open in Discover shows the correlated logs',
-        //   async () => {
-        //     await flyout.waterfallFlyout.childDocFlyout.logs.openInDiscoverButton.click();
-        //     await pageObjects.discover.expectDocTableToContainText(
-        //       RICH_TRACE.LOGS.PROCESS_ORDER_VALIDATING
-        //     );
-        //     await pageObjects.discover.expectDocTableToContainText(
-        //       RICH_TRACE.LOGS.PROCESS_ORDER_INVENTORY
-        //     );
-        //     await pageObjects.discover.expectDocTableToContainText(
-        //       RICH_TRACE.LOGS.PROCESS_ORDER_SUCCESS
-        //     );
-        //   }
-        // );
-        //
-        // await spaceTest.step(
-        //   'Internal span child flyout - switch back to original tab',
-        //   async () => {
-        //     await pageObjects.discover.navigateToTabByName('Untitled');
-        //   }
-        // );
-        //
-        // await spaceTest.step(
-        //   'Internal span child flyout - span links Open in Discover shows the linked span',
-        //   async () => {
-        //     await flyout.waterfallFlyout.childDocFlyout.spanLinks.openInDiscoverButton.click();
-        //     await pageObjects.discover.expectDocTableToContainText(PRODUCER_TRACE.KAFKA_SPAN_NAME);
-        //   }
-        // );
+        await spaceTest.step(
+          'Internal span child flyout - logs Open in Discover shows the correlated logs',
+          async () => {
+            await flyout.waterfallFlyout.childDocFlyout.logs.openInDiscoverButton.click();
+            await pageObjects.discover.expectDocTableToContainText(
+              RICH_TRACE.LOGS.PROCESS_ORDER_VALIDATING
+            );
+            await pageObjects.discover.expectDocTableToContainText(
+              RICH_TRACE.LOGS.PROCESS_ORDER_INVENTORY
+            );
+            await pageObjects.discover.expectDocTableToContainText(
+              RICH_TRACE.LOGS.PROCESS_ORDER_SUCCESS
+            );
+          }
+        );
+
+        await spaceTest.step(
+          'Internal span child flyout - switch back to original tab',
+          async () => {
+            await pageObjects.discover.navigateToTabByName('Untitled');
+          }
+        );
+
+        await spaceTest.step(
+          'Internal span child flyout - span links Open in Discover shows the linked span',
+          async () => {
+            await flyout.waterfallFlyout.childDocFlyout.spanLinks.openInDiscoverButton.click();
+            await pageObjects.discover.expectDocTableToContainText(PRODUCER_TRACE.KAFKA_SPAN_NAME);
+          }
+        );
       }
     );
   }


### PR DESCRIPTION
## Summary

Restores `src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/waterfall_flyout_usage.spec.ts` to the version before https://github.com/elastic/kibana/commit/7567421ed9d009fd77886df8fd50f24fcf5da669

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- ~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~
- ~[ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- ~[ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
