### PR TITLE
[9.3] [Index Management] Fix incompatible inference endpoints selectable in semantic text field (#256586)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_flyout_wrapper.tsx
@@ -18,6 +18,7 @@ import {
   EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import { omit } from 'lodash';
 import React, { useCallback } from 'react';
 import type { HttpSetup, IToasts } from '@kbn/core/public';
@@ -117,6 +118,8 @@ interface InferenceFlyoutWrapperProps {
   onSubmitSuccess?: (inferenceId: string) => void;
   inferenceEndpoint?: InferenceEndpoint;
   enableEisPromoTour?: boolean;
+  /** When set, only these task types will be available for selection in the form. */
+  allowedTaskTypes?: InferenceTaskType[];
 }
 
 export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
@@ -128,6 +131,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
   onSubmitSuccess,
   inferenceEndpoint,
   enableEisPromoTour,
+  allowedTaskTypes,
 }) => {
   const inferenceCreationFlyoutId = useGeneratedHtmlId({
     prefix: 'InferenceFlyoutId',
@@ -193,6 +197,7 @@ export const InferenceFlyoutWrapper: React.FC<InferenceFlyoutWrapperProps> = ({
               isPreconfigured,
               reenterSecretsOnEdit: false,
               enableEisPromoTour,
+              allowedTaskTypes,
             }}
           />
           <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
+++ b/x-pack/platform/packages/shared/kbn-inference-endpoint-ui-common/src/components/inference_service_form_fields.tsx
@@ -7,6 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/react';
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { SolutionView } from '@kbn/spaces-plugin/common';
 import {
   getFieldValidityAndErrorMessage,
@@ -106,6 +107,8 @@ interface InferenceServicesProps {
     reenterSecretsOnEdit?: boolean;
     allowTemperature?: boolean;
     enableEisPromoTour?: boolean;
+    /** When set, only these task types will be available for selection in the form. */
+    allowedTaskTypes?: InferenceTaskType[];
   };
   http: HttpSetup;
   toasts: IToasts;
@@ -123,6 +126,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
     currentSolution,
     reenterSecretsOnEdit,
     enableEisPromoTour,
+    allowedTaskTypes,
   },
 }) => {
   const {
@@ -299,9 +303,12 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
     (provider?: string) => {
       const newProvider = updatedProviders?.find((p) => p.service === provider);
 
-      setTaskTypeOptions(getTaskTypeOptions(newProvider?.task_types ?? []));
-      if (newProvider?.task_types && newProvider?.task_types.length > 0) {
-        onTaskTypeOptionsSelect(newProvider?.task_types[0], provider);
+      const availableTaskTypes = allowedTaskTypes
+        ? (newProvider?.task_types ?? []).filter((t) => (allowedTaskTypes as string[]).includes(t))
+        : newProvider?.task_types ?? [];
+      setTaskTypeOptions(getTaskTypeOptions(availableTaskTypes));
+      if (availableTaskTypes.length > 0) {
+        onTaskTypeOptionsSelect(availableTaskTypes[0], provider);
       }
 
       const defaultProviderConfig: Record<string, unknown> = {};
@@ -345,7 +352,14 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
         },
       });
     },
-    [config, onTaskTypeOptionsSelect, updateFieldValues, updatedProviders, getOverrides]
+    [
+      config,
+      onTaskTypeOptionsSelect,
+      updateFieldValues,
+      updatedProviders,
+      getOverrides,
+      allowedTaskTypes,
+    ]
   );
 
   const onSetProviderConfigEntry = useCallback(
@@ -426,9 +440,15 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
   const getUpdatedProviders = useCallback(
     (filterBySolution?: SolutionView) => {
       if (providers) {
-        const filteredProviders = filterBySolution
+        let filteredProviders = filterBySolution
           ? providers.filter(isProviderForSolutions.bind(this, filterBySolution))
           : providers;
+
+        if (allowedTaskTypes) {
+          filteredProviders = filteredProviders.filter((provider) =>
+            provider.task_types.some((t) => (allowedTaskTypes as string[]).includes(t))
+          );
+        }
 
         // Ensure the Elastic Inference Service (EIS) appears at the top of the providers list
         const elasticServiceIndex = filteredProviders.findIndex(
@@ -446,7 +466,7 @@ export const InferenceServiceFormFields: React.FC<InferenceServicesProps> = ({
         }
       }
     },
-    [providers]
+    [providers, allowedTaskTypes]
   );
 
   useEffect(() => {

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -94,34 +94,31 @@ jest.mock('../../../public/application/components/mappings_editor/mappings_state
 
 const mockResendRequest = jest.fn();
 
-  const MockInferenceFlyoutWrapper = ({
-    onFlyoutClose,
-    onSubmitSuccess,
-    allowedTaskTypes,
-  }: {
-    onFlyoutClose: () => void;
-    onSubmitSuccess: (id: string) => void;
-    http?: unknown;
-    toasts?: unknown;
-    isEdit?: boolean;
-    enforceAdaptiveAllocations?: boolean;
-    allowedTaskTypes?: InferenceTaskType[];
-  }) => (
-    <div data-test-subj="inference-flyout-wrapper">
-      <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
-        Close Flyout
-      </button>
-      <button
-        data-test-subj="mock-flyout-submit"
-        onClick={() => onSubmitSuccess('new-endpoint-id')}
-      >
-        Submit
-      </button>
-      {allowedTaskTypes && (
-        <div data-test-subj="mock-allowed-task-types">{allowedTaskTypes.join(',')}</div>
-      )}
-    </div>
-  );
+const MockInferenceFlyoutWrapper = ({
+  onFlyoutClose,
+  onSubmitSuccess,
+  allowedTaskTypes,
+}: {
+  onFlyoutClose: () => void;
+  onSubmitSuccess: (id: string) => void;
+  http?: unknown;
+  toasts?: unknown;
+  isEdit?: boolean;
+  enforceAdaptiveAllocations?: boolean;
+  allowedTaskTypes?: InferenceTaskType[];
+}) => (
+  <div data-test-subj="inference-flyout-wrapper">
+    <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
+      Close Flyout
+    </button>
+    <button data-test-subj="mock-flyout-submit" onClick={() => onSubmitSuccess('new-endpoint-id')}>
+      Submit
+    </button>
+    {allowedTaskTypes && (
+      <div data-test-subj="mock-allowed-task-types">{allowedTaskTypes.join(',')}</div>
+    )}
+  </div>
+);
 
 jest.mock('@kbn/inference-endpoint-ui-common', () => ({
   __esModule: true,

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
+import { screen, fireEvent } from '@testing-library/react';
+import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
   Form,
@@ -92,26 +94,34 @@ jest.mock('../../../public/application/components/mappings_editor/mappings_state
 
 const mockResendRequest = jest.fn();
 
-const MockInferenceFlyoutWrapper = ({
-  onFlyoutClose,
-  onSubmitSuccess,
-}: {
-  onFlyoutClose: () => void;
-  onSubmitSuccess: (id: string) => void;
-  http?: unknown;
-  toasts?: unknown;
-  isEdit?: boolean;
-  enforceAdaptiveAllocations?: boolean;
-}) => (
-  <div data-test-subj="inference-flyout-wrapper">
-    <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
-      Close Flyout
-    </button>
-    <button data-test-subj="mock-flyout-submit" onClick={() => onSubmitSuccess('new-endpoint-id')}>
-      Submit
-    </button>
-  </div>
-);
+  const MockInferenceFlyoutWrapper = ({
+    onFlyoutClose,
+    onSubmitSuccess,
+    allowedTaskTypes,
+  }: {
+    onFlyoutClose: () => void;
+    onSubmitSuccess: (id: string) => void;
+    http?: unknown;
+    toasts?: unknown;
+    isEdit?: boolean;
+    enforceAdaptiveAllocations?: boolean;
+    allowedTaskTypes?: InferenceTaskType[];
+  }) => (
+    <div data-test-subj="inference-flyout-wrapper">
+      <button data-test-subj="mock-flyout-close" onClick={onFlyoutClose}>
+        Close Flyout
+      </button>
+      <button
+        data-test-subj="mock-flyout-submit"
+        onClick={() => onSubmitSuccess('new-endpoint-id')}
+      >
+        Submit
+      </button>
+      {allowedTaskTypes && (
+        <div data-test-subj="mock-allowed-task-types">{allowedTaskTypes.join(',')}</div>
+      )}
+    </div>
+  );
 
 jest.mock('@kbn/inference-endpoint-ui-common', () => ({
   __esModule: true,
@@ -359,6 +369,16 @@ describe('SelectInferenceId', () => {
       await actClick(await screen.findByTestId('createInferenceEndpointButton'));
 
       expect(await screen.findByTestId('inference-flyout-wrapper')).toBeInTheDocument();
+    });
+
+    it('SHOULD pass allowedTaskTypes to restrict endpoint creation to compatible types', async () => {
+      renderSelectInferenceId();
+
+      await user.click(await screen.findByTestId('inferenceIdButton'));
+      await user.click(await screen.findByTestId('createInferenceEndpointButton'));
+
+      const allowedTaskTypes = await screen.findByTestId('mock-allowed-task-types');
+      expect(allowedTaskTypes).toHaveTextContent('text_embedding,sparse_embedding');
     });
 
     describe('AND flyout close is triggered', () => {

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import { screen, fireEvent } from '@testing-library/react';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
@@ -371,8 +370,8 @@ describe('SelectInferenceId', () => {
     it('SHOULD pass allowedTaskTypes to restrict endpoint creation to compatible types', async () => {
       renderSelectInferenceId();
 
-      await user.click(await screen.findByTestId('inferenceIdButton'));
-      await user.click(await screen.findByTestId('createInferenceEndpointButton'));
+      await actClick(await screen.findByTestId('inferenceIdButton'));
+      await actClick(await screen.findByTestId('createInferenceEndpointButton'));
 
       const allowedTaskTypes = await screen.findByTestId('mock-allowed-task-types');
       expect(allowedTaskTypes).toHaveTextContent('text_embedding,sparse_embedding');

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -368,7 +368,11 @@ describe('SelectInferenceId', () => {
     });
 
     it('SHOULD pass allowedTaskTypes to restrict endpoint creation to compatible types', async () => {
-      renderSelectInferenceId();
+      render(
+        <TestFormWrapper>
+          <SelectInferenceId {...defaultProps} />
+        </TestFormWrapper>
+      );
 
       await actClick(await screen.findByTestId('inferenceIdButton'));
       await actClick(await screen.findByTestId('createInferenceEndpointButton'));

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -323,6 +323,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
                 isEdit={false}
                 onSubmitSuccess={onSubmitSuccess}
                 enforceAdaptiveAllocations={enforceAdaptiveAllocations}
+                allowedTaskTypes={['text_embedding', 'sparse_embedding']}
               />
             </Suspense>
           )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Index Management] Fix incompatible inference endpoints selectable in semantic text field (#256586)](https://github.com/elastic/kibana/pull/256586)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Amit Kanfer","email":"amit.kanfer@elastic.co"},"sourceCommit":{"committedDate":"2026-03-13T20:46:06Z","message":"[Index Management] Fix incompatible inference endpoints selectable in semantic text field (#256586)\n\n## Summary\n\nFixes https://github.com/elastic/search-team/issues/12762\n\nWhen creating a semantic_text field in the mappings editor, users could\nopen the inference endpoint creation flyout and create endpoints with\nincompatible task types (e.g. `completion`, `rerank`). These endpoints\nwould then appear in the dropdown but fail when used with\n`semantic_text`, which only supports `text_embedding` and\n`sparse_embedding`.\n\n### Approach: Restrict at the source\n\nInstead of filtering endpoints after creation (which introduces race\nconditions with optimistic updates), this PR blocks incompatible task\ntypes at the flyout level:\n\n1. **`InferenceFlyoutWrapper`** accepts a new `allowedTaskTypes` prop\n2. **`InferenceServiceFormFields`** filters both the available task type\noptions and the provider list based on `allowedTaskTypes`\n3. **`SelectInferenceId`** passes `allowedTaskTypes={['text_embedding',\n'sparse_embedding']}` when opening the flyout\n\nThis ensures users can only create compatible endpoints from the\nsemantic_text mappings editor, while the optimistic update pattern\n(which prevents UI race conditions) is preserved.\n\n### Changes\n\n- `inference_flyout_wrapper.tsx`: Added `allowedTaskTypes` prop, passed\nthrough to form config\n- `inference_service_form_fields.tsx`: Added `allowedTaskTypes` to\nconfig interface; filters task type options and providers based on\nallowed types\n- `select_inference_id.tsx`: Passes `allowedTaskTypes` to the flyout;\nrestored original optimistic update logic\n- `select_inference_id.test.tsx`: Added test verifying\n`allowedTaskTypes` is passed to flyout; removed tests for the previous\napproach\n\n## Test plan\n\n- [x] Unit tests pass (`yarn test:jest ...select_inference_id.test.tsx`)\n- [x] `check_changes.ts` passes\n- [ ] Manually verify: open mappings editor → add semantic_text field →\nclick \"Add inference endpoint\" → verify only\n`text_embedding`/`sparse_embedding` task types are shown\n- [ ] Verify providers that only support incompatible task types (e.g.\nrerank-only) are not shown in the provider list\n- [ ] Verify creating an endpoint from the flyout still works and the\nendpoint is selected in the dropdown\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b38c9a7437bbb5a08b5b2fcbe5b518a58de8512f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.4.0","v9.3.3"],"title":"[Index Management] Fix incompatible inference endpoints selectable in semantic text field","number":256586,"url":"https://github.com/elastic/kibana/pull/256586","mergeCommit":{"message":"[Index Management] Fix incompatible inference endpoints selectable in semantic text field (#256586)\n\n## Summary\n\nFixes https://github.com/elastic/search-team/issues/12762\n\nWhen creating a semantic_text field in the mappings editor, users could\nopen the inference endpoint creation flyout and create endpoints with\nincompatible task types (e.g. `completion`, `rerank`). These endpoints\nwould then appear in the dropdown but fail when used with\n`semantic_text`, which only supports `text_embedding` and\n`sparse_embedding`.\n\n### Approach: Restrict at the source\n\nInstead of filtering endpoints after creation (which introduces race\nconditions with optimistic updates), this PR blocks incompatible task\ntypes at the flyout level:\n\n1. **`InferenceFlyoutWrapper`** accepts a new `allowedTaskTypes` prop\n2. **`InferenceServiceFormFields`** filters both the available task type\noptions and the provider list based on `allowedTaskTypes`\n3. **`SelectInferenceId`** passes `allowedTaskTypes={['text_embedding',\n'sparse_embedding']}` when opening the flyout\n\nThis ensures users can only create compatible endpoints from the\nsemantic_text mappings editor, while the optimistic update pattern\n(which prevents UI race conditions) is preserved.\n\n### Changes\n\n- `inference_flyout_wrapper.tsx`: Added `allowedTaskTypes` prop, passed\nthrough to form config\n- `inference_service_form_fields.tsx`: Added `allowedTaskTypes` to\nconfig interface; filters task type options and providers based on\nallowed types\n- `select_inference_id.tsx`: Passes `allowedTaskTypes` to the flyout;\nrestored original optimistic update logic\n- `select_inference_id.test.tsx`: Added test verifying\n`allowedTaskTypes` is passed to flyout; removed tests for the previous\napproach\n\n## Test plan\n\n- [x] Unit tests pass (`yarn test:jest ...select_inference_id.test.tsx`)\n- [x] `check_changes.ts` passes\n- [ ] Manually verify: open mappings editor → add semantic_text field →\nclick \"Add inference endpoint\" → verify only\n`text_embedding`/`sparse_embedding` task types are shown\n- [ ] Verify providers that only support incompatible task types (e.g.\nrerank-only) are not shown in the provider list\n- [ ] Verify creating an endpoint from the flyout still works and the\nendpoint is selected in the dropdown\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b38c9a7437bbb5a08b5b2fcbe5b518a58de8512f"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256586","number":256586,"mergeCommit":{"message":"[Index Management] Fix incompatible inference endpoints selectable in semantic text field (#256586)\n\n## Summary\n\nFixes https://github.com/elastic/search-team/issues/12762\n\nWhen creating a semantic_text field in the mappings editor, users could\nopen the inference endpoint creation flyout and create endpoints with\nincompatible task types (e.g. `completion`, `rerank`). These endpoints\nwould then appear in the dropdown but fail when used with\n`semantic_text`, which only supports `text_embedding` and\n`sparse_embedding`.\n\n### Approach: Restrict at the source\n\nInstead of filtering endpoints after creation (which introduces race\nconditions with optimistic updates), this PR blocks incompatible task\ntypes at the flyout level:\n\n1. **`InferenceFlyoutWrapper`** accepts a new `allowedTaskTypes` prop\n2. **`InferenceServiceFormFields`** filters both the available task type\noptions and the provider list based on `allowedTaskTypes`\n3. **`SelectInferenceId`** passes `allowedTaskTypes={['text_embedding',\n'sparse_embedding']}` when opening the flyout\n\nThis ensures users can only create compatible endpoints from the\nsemantic_text mappings editor, while the optimistic update pattern\n(which prevents UI race conditions) is preserved.\n\n### Changes\n\n- `inference_flyout_wrapper.tsx`: Added `allowedTaskTypes` prop, passed\nthrough to form config\n- `inference_service_form_fields.tsx`: Added `allowedTaskTypes` to\nconfig interface; filters task type options and providers based on\nallowed types\n- `select_inference_id.tsx`: Passes `allowedTaskTypes` to the flyout;\nrestored original optimistic update logic\n- `select_inference_id.test.tsx`: Added test verifying\n`allowedTaskTypes` is passed to flyout; removed tests for the previous\napproach\n\n## Test plan\n\n- [x] Unit tests pass (`yarn test:jest ...select_inference_id.test.tsx`)\n- [x] `check_changes.ts` passes\n- [ ] Manually verify: open mappings editor → add semantic_text field →\nclick \"Add inference endpoint\" → verify only\n`text_embedding`/`sparse_embedding` task types are shown\n- [ ] Verify providers that only support incompatible task types (e.g.\nrerank-only) are not shown in the provider list\n- [ ] Verify creating an endpoint from the flyout still works and the\nendpoint is selected in the dropdown\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b38c9a7437bbb5a08b5b2fcbe5b518a58de8512f"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->