### PR TITLE
[8.19] [Query Rules UI] Fix query rules UI rejecting case variants as duplicate values (#259506)

### DIFF
--- a/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
+++ b/x-pack/solutions/search/plugins/search_query_rules/public/components/query_ruleset_detail/query_rule_flyout/query_rule_metadata_editor.tsx
@@ -274,6 +274,7 @@ export const QueryRuleMetadataEditor: React.FC<QueryRuleMetadataEditorProps> = (
                   error={error?.values ? error.values.message : undefined}
                 >
                   <EuiComboBox
+                    isCaseSensitive
                     isDisabled={criteria.type === 'always'}
                     data-test-subj="searchQueryRulesQueryRuleMetadataEditorValues"
                     fullWidth


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Query Rules UI] Fix query rules UI rejecting case variants as duplicate values (#259506)](https://github.com/elastic/kibana/pull/259506)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T15:36:53Z","message":"[Query Rules UI] Fix query rules UI rejecting case variants as duplicate values (#259506)\n\n## Summary\n\nEuiComboBox defaults to case-insensitive duplicate detection, which\nprevented users from adding case variants (e.g. \"home\", \"Home\", \"HOME\")\nas separate criteria values. Added isCaseSensitive prop to allow\ncase-sensitive value entry.\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"491e06bda31ace0742e3ba8a298683439262ed04","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Search","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14"],"title":"[Query Rules UI] Fix query rules UI rejecting case variants as duplicate values","number":259506,"url":"https://github.com/elastic/kibana/pull/259506","mergeCommit":{"message":"[Query Rules UI] Fix query rules UI rejecting case variants as duplicate values (#259506)\n\n## Summary\n\nEuiComboBox defaults to case-insensitive duplicate detection, which\nprevented users from adding case variants (e.g. \"home\", \"Home\", \"HOME\")\nas separate criteria values. Added isCaseSensitive prop to allow\ncase-sensitive value entry.\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"491e06bda31ace0742e3ba8a298683439262ed04"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259506","number":259506,"mergeCommit":{"message":"[Query Rules UI] Fix query rules UI rejecting case variants as duplicate values (#259506)\n\n## Summary\n\nEuiComboBox defaults to case-insensitive duplicate detection, which\nprevented users from adding case variants (e.g. \"home\", \"Home\", \"HOME\")\nas separate criteria values. Added isCaseSensitive prop to allow\ncase-sensitive value entry.\n\nCo-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>","sha":"491e06bda31ace0742e3ba8a298683439262ed04"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259610","number":259610,"state":"OPEN"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/259609","number":259609,"state":"OPEN"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->