### PR TITLE
[Entity Store v2] Export maintainer update client and asset criticality type

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/common/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/common/index.ts
@@ -86,7 +86,7 @@ export interface IdentitySourceFields {
   identitySourceFields: string[];
 }
 
-export type { Entity } from './domain/definitions/entity.gen';
+export type { Entity, AssetCriticalityLevel } from './domain/definitions/entity.gen';
 
 export {
   ENTITY_LATEST,

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/crud_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/crud_client.ts
@@ -57,9 +57,9 @@ interface BulkUpdateEntityParams {
   force?: boolean;
 }
 
-// EntityUpdateClient is a stripped CRUD client allowing only for updates. Used
-// by Entity Maintainers.
-export type EntityUpdateClient = Pick<CRUDClient, 'updateEntity' | 'bulkUpdateEntity'>;
+// EntityUpdateClient is the maintainer-safe CRUD surface: all CRUD methods
+// except create/delete.
+export type EntityUpdateClient = Omit<CRUDClient, 'createEntity' | 'deleteEntity'>;
 
 export class CRUDClient {
   private readonly logger: Logger;

--- a/x-pack/solutions/security/plugins/entity_store/server/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/index.ts
@@ -10,6 +10,7 @@ import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 export type {
   EntityStoreSetupContract,
   EntityStoreStartContract,
+  EntityUpdateClient,
   EntityStoreCRUDClient,
 } from './types';
 export type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';

--- a/x-pack/solutions/security/plugins/entity_store/server/index.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/index.ts
@@ -10,11 +10,10 @@ import type { PluginInitializerContext } from '@kbn/core-plugins-server';
 export type {
   EntityStoreSetupContract,
   EntityStoreStartContract,
-  EntityUpdateClient,
   EntityStoreCRUDClient,
 } from './types';
 export type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
-export type { BulkObject, BulkObjectResponse } from './domain/crud';
+export type { EntityUpdateClient, BulkObject, BulkObjectResponse } from './domain/crud';
 export { getLatestEntitiesIndexName } from '../common';
 export { getHistorySnapshotIndexPattern } from './domain/asset_manager/history_snapshot_index';
 

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -29,7 +29,7 @@ import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
 import type { CcsLogsExtractionClient, LogsExtractionClient } from './domain/logs_extraction';
 import type { HistorySnapshotClient } from './domain/history_snapshot';
-import type { CRUDClient } from './domain/crud';
+import type { CRUDClient, EntityUpdateClient as MaintainerEntityUpdateClient } from './domain/crud';
 import type { ResolutionClient } from './domain/resolution';
 import type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
 
@@ -70,6 +70,7 @@ export type EntityStorePluginRouter = IRouter<EntityStoreRequestHandlerContext>;
 
 export type RegisterEntityMaintainer = (config: RegisterEntityMaintainerConfig) => void;
 
+export type EntityUpdateClient = MaintainerEntityUpdateClient;
 export type EntityStoreCRUDClient = Omit<CRUDClient, 'createEntity'>;
 
 export interface EntityStoreStartContract {

--- a/x-pack/solutions/security/plugins/entity_store/server/types.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/types.ts
@@ -29,7 +29,7 @@ import type { EntityMaintainersClient } from './domain/entity_maintainers';
 import type { FeatureFlags } from './infra/feature_flags';
 import type { CcsLogsExtractionClient, LogsExtractionClient } from './domain/logs_extraction';
 import type { HistorySnapshotClient } from './domain/history_snapshot';
-import type { CRUDClient, EntityUpdateClient as MaintainerEntityUpdateClient } from './domain/crud';
+import type { CRUDClient } from './domain/crud';
 import type { ResolutionClient } from './domain/resolution';
 import type { RegisterEntityMaintainerConfig } from './tasks/entity_maintainers/types';
 
@@ -70,7 +70,6 @@ export type EntityStorePluginRouter = IRouter<EntityStoreRequestHandlerContext>;
 
 export type RegisterEntityMaintainer = (config: RegisterEntityMaintainerConfig) => void;
 
-export type EntityUpdateClient = MaintainerEntityUpdateClient;
 export type EntityStoreCRUDClient = Omit<CRUDClient, 'createEntity'>;
 
 export interface EntityStoreStartContract {


### PR DESCRIPTION
## Summary

A few tweaks which will help with maintainer development:

- export `AssetCriticalityLevel` from `@kbn/entity-store/common` - I think entity store should be the owner of asset criticality going forward
- define `EntityUpdateClient` with an omit-based contract (`Omit<CRUDClient, 'createEntity' | 'deleteEntity'>`) (agreed in slack)
- export `EntityUpdateClient` from `@kbn/entity-store/server` for maintainer consumers 
