### PR TITLE
Fix incorrect left margin on Cloud Connect migration benefit cards

### DIFF
--- a/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/migration_section/index.tsx
+++ b/x-pack/platform/plugins/shared/cloud_connect/public/application/components/connected_services/migration_section/index.tsx
@@ -122,6 +122,7 @@ export const MigrationSection: React.FC = () => {
           <EuiFlexItem
             key={index}
             css={css`
+              ${index === 0 && 'margin-left: 0 !important;'}
               @media (min-width: ${euiTheme.breakpoint.m}px) {
                 & + & {
                   position: relative;


### PR DESCRIPTION
## Summary

Fixes #259638

The `EuiFlexGroup gutterSize="l"` in `MigrationSection` applies `margin-left` to all flex items including the first one. When an ancestor container has `overflow: hidden`, the compensating negative margin on the group gets clipped, leaving the benefit cards visually indented relative to the rest of the page content.

The fix zeroes out `margin-left` on the first flex item so the cards align with the heading and other page content above.

## Screenshots

| Before | After |
|--------|-------|
| Cards indented relative to page content | Cards aligned with page left edge |

![Before/After comparison](https://raw.githubusercontent.com/smith/kibana/main/.github/screenshots/259638-before-after.png)

## Testing

1. Connect a self-managed cluster to Elastic Cloud
2. Navigate to Stack Management → Cloud Connect
3. Confirm the three benefit cards at the bottom align with the left edge of all other page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
