### PR TITLE
CODEOWNERS: disown version_dependencies.txt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3249,6 +3249,7 @@ x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetic
 
 # No owner - generated files covered by CI checks
 **/moon.yml
+**/version_dependencies.txt
 
 # Operations (last-match override)
 /src/platform/test/package @elastic/kibana-operations

--- a/src/platform/packages/private/kbn-scout-reporting/src/cli/check_test_code_owners.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/cli/check_test_code_owners.ts
@@ -13,7 +13,7 @@ import { getRepoFiles } from '@kbn/get-repo-files';
 import { getCodeOwnersEntries } from '@kbn/code-owners';
 import ignore from 'ignore';
 
-const IGNORED_FILENAMES = ['moon.yml'];
+const IGNORED_FILENAMES = ['moon.yml', 'version_dependencies.txt'];
 
 const isIgnoredFile = (repoRel: string): boolean =>
   IGNORED_FILENAMES.some((fileName) => repoRel.endsWith(`/${fileName}`));


### PR DESCRIPTION
This file is generated by moon, and covered by CI checks. No reason to have it trigger a codeowner review when bumping versions, etc.

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->