### PR TITLE
[Security Solution] only show notes for a saved timeline (ignoring emtpy string from draft timelines)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/store/notes.slice.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/store/notes.slice.ts
@@ -394,7 +394,9 @@ export const makeSelectNotesBySavedObjectId = () =>
   createSelector(
     [selectAllNotes, (_: State, savedObjectId: string) => savedObjectId],
     (notes, savedObjectId) =>
-      fallbackToEmptyArray(notes.filter((note) => note.timelineId === savedObjectId))
+      fallbackToEmptyArray(
+        notes.filter((note) => savedObjectId !== '' && note.timelineId === savedObjectId)
+      )
   );
 
 export const selectDocumentNotesBySavedObjectId = createSelector(


### PR DESCRIPTION
## Summary

This one-liner PR fixes a very annoying bug we've had for a while, where some unwanted notes show up in draft Timelines. While the fix is extremely simple and easy, finding why this was happening was interesting.

### Some context

For a while now, we were seeing some unwanted notes showing up when investigating in Timeline. We were not sure why sometimes these notes were showing up, and sometimes they were not. The weirdest thing is we were seeing notes that had been saved only to a document (meaning not associated with a Timeline). Those should never show up on the Timeline Notes tab...

> [!NOTE]
> All notes created in the video below are associated with a document only (not Timeline)

https://github.com/user-attachments/assets/e2aabe64-41e0-4db6-b78a-8e1fabe86ba2

As you can see in the video above, the behavior is inconsistent:
- for the first alert we investigate, no notes are showing up
- for the second alert we investigate, some random notes are showing up
- for the attack we investigate, those same random notes are showing up

### Explanation of the issue

What is happening because of the following bug: this [makeSelectNotesBySavedObjectId](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/notes/store/notes.slice.ts#L393) function is returning all notes that have the same `savedObjectId` field as the passed value. This includes empty string!

### Why isn't that happening for some alerts?

In the video above, you can see that for the first alert, the issue is not happening. This is because that alert was generated by a rule that has an investigation guide. When we investigate in Timeline for an alert generated by a rule with an investigation guide, we automatically create a note (see [this line here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx#L138)), which then triggers this middleware and saves the Timeline [here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/store/middlewares/timeline_note.ts#L49). Saving the Timeline basically sets a `savedObject` in Redux. This combined with the selector issue mentioned above results in the different behaviors we're seeing.

Investigate in Timeline for the 2 different rules:

| Rule with investigation guide  |Rule without investigation guide |
| ------------- | ------------- |
| <img width="460" height="125" alt="Screenshot 2026-03-25 at 3 34 39 PM" src="https://github.com/user-attachments/assets/927aff70-9773-4d11-b95b-c7044fe94016" /> | <img width="361" height="162" alt="Screenshot 2026-03-25 at 3 33 34 PM" src="https://github.com/user-attachments/assets/725f0db3-bbbb-40c3-bf56-0aec54823cf9" /> |

### The fix

This fix basically prevents any notes that are NOT associated with a timeline saved object to show up in the Timeline Notes tab. This is also valid for attacks!

https://github.com/user-attachments/assets/33bb193c-557d-4a15-84d7-100532e330f9

### Checklist

Check the PR satisfies following conditions. 

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/security-team/issues/16396

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->