### PR TITLE
[Obs AI Assistant] Fix kibana tool failing in VPC environments by using local server address for self-requests

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
@@ -164,6 +164,32 @@ describe('kibana tool', () => {
     expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
   });
 
+  it('maps ::1 hostname to localhost', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: '::1', port: 5601, protocol: 'http' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+  });
+
+  it('brackets IPv6 literal addresses in the URL', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: 'fe80::1', port: 5601, protocol: 'http' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('http://[fe80::1]:5601/api/status');
+  });
+
   it('provides httpsAgent when server uses https', async () => {
     const { handler } = registerFunction({
       serverInfo: { hostname: 'localhost', port: 5601, protocol: 'https' },

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
@@ -14,6 +14,7 @@ jest.mock('axios');
 const mockedAxios = jest.mocked(axios);
 
 function registerFunction(overrides: {
+  publicBaseUrl?: string;
   serverInfo?: { hostname: string; port: number; protocol: 'http' | 'https' };
   requestUrl?: URL;
   rewrittenUrl?: URL;
@@ -23,6 +24,7 @@ function registerFunction(overrides: {
   const coreStart = {
     http: {
       basePath: {
+        publicBaseUrl: overrides.publicBaseUrl,
         serverBasePath: '',
         get: jest.fn(),
       },
@@ -138,7 +140,7 @@ describe('kibana tool', () => {
     expect(forwardedRequest.headers).not.toHaveProperty('x-forwarded-user');
   });
 
-  it('maps 0.0.0.0 hostname to localhost', async () => {
+  it('maps 0.0.0.0 hostname to 127.0.0.1', async () => {
     const { handler } = registerFunction({
       serverInfo: { hostname: '0.0.0.0', port: 5601, protocol: 'http' },
     });
@@ -148,10 +150,10 @@ describe('kibana tool', () => {
     });
 
     const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
-    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+    expect(forwardedRequest.url).toBe('http://127.0.0.1:5601/api/status');
   });
 
-  it('maps :: hostname to localhost', async () => {
+  it('maps :: hostname to ::1', async () => {
     const { handler } = registerFunction({
       serverInfo: { hostname: '::', port: 5601, protocol: 'http' },
     });
@@ -161,10 +163,10 @@ describe('kibana tool', () => {
     });
 
     const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
-    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+    expect(forwardedRequest.url).toBe('http://[::1]:5601/api/status');
   });
 
-  it('maps ::1 hostname to localhost', async () => {
+  it('preserves ::1 hostname', async () => {
     const { handler } = registerFunction({
       serverInfo: { hostname: '::1', port: 5601, protocol: 'http' },
     });
@@ -174,7 +176,7 @@ describe('kibana tool', () => {
     });
 
     const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
-    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+    expect(forwardedRequest.url).toBe('http://[::1]:5601/api/status');
   });
 
   it('brackets IPv6 literal addresses in the URL', async () => {
@@ -190,9 +192,10 @@ describe('kibana tool', () => {
     expect(forwardedRequest.url).toBe('http://[fe80::1]:5601/api/status');
   });
 
-  it('provides httpsAgent when server uses https', async () => {
+  it('uses publicBaseUrl hostname for https verification when available', async () => {
     const { handler } = registerFunction({
-      serverInfo: { hostname: 'localhost', port: 5601, protocol: 'https' },
+      publicBaseUrl: 'https://kibana.example.com:5601',
+      serverInfo: { hostname: '0.0.0.0', port: 5601, protocol: 'https' },
     });
 
     await handler({
@@ -200,8 +203,44 @@ describe('kibana tool', () => {
     });
 
     const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
-    expect(forwardedRequest.url).toBe('https://localhost:5601/api/status');
+    expect(forwardedRequest.url).toBe('https://127.0.0.1:5601/api/status');
     expect(forwardedRequest.httpsAgent).toBeDefined();
+    expect((forwardedRequest.httpsAgent as any).options.servername).toBe('kibana.example.com');
+    expect((forwardedRequest.httpsAgent as any).options.checkServerIdentity).toEqual(
+      expect.any(Function)
+    );
+  });
+
+  it('uses loopback-only https verification fallback when publicBaseUrl is unavailable', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: '::1', port: 5601, protocol: 'https' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('https://[::1]:5601/api/status');
+    expect(forwardedRequest.httpsAgent).toBeDefined();
+    expect((forwardedRequest.httpsAgent as any).options.servername).toBeUndefined();
+    expect((forwardedRequest.httpsAgent as any).options.checkServerIdentity).toEqual(
+      expect.any(Function)
+    );
+  });
+
+  it('does not override hostname verification for non-loopback https targets', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: 'kibana.internal', port: 5601, protocol: 'https' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('https://kibana.internal:5601/api/status');
+    expect(forwardedRequest.httpsAgent).toBeUndefined();
   });
 
   it('does not provide httpsAgent when server uses http', async () => {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.test.ts
@@ -14,7 +14,7 @@ jest.mock('axios');
 const mockedAxios = jest.mocked(axios);
 
 function registerFunction(overrides: {
-  publicBaseUrl?: string;
+  serverInfo?: { hostname: string; port: number; protocol: 'http' | 'https' };
   requestUrl?: URL;
   rewrittenUrl?: URL;
   headers?: Record<string, string>;
@@ -23,10 +23,14 @@ function registerFunction(overrides: {
   const coreStart = {
     http: {
       basePath: {
-        publicBaseUrl: overrides.publicBaseUrl ?? 'https://kibana.example.com:5601',
         serverBasePath: '',
         get: jest.fn(),
       },
+      getServerInfo: jest
+        .fn()
+        .mockReturnValue(
+          overrides.serverInfo ?? { hostname: 'localhost', port: 5601, protocol: 'http' }
+        ),
     },
   };
 
@@ -67,7 +71,7 @@ describe('kibana tool', () => {
     mockedAxios.mockResolvedValue({ data: { ok: true } });
   });
 
-  it('forwards requests to the configured publicBaseUrl host only', async () => {
+  it('forwards requests to the local server address, ignoring user-supplied headers', async () => {
     const { handler } = registerFunction({
       headers: {
         host: 'malicious-host:9200',
@@ -86,7 +90,7 @@ describe('kibana tool', () => {
 
     const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
     expect(forwardedRequest.url).toBe(
-      'https://kibana.example.com:5601/api/saved_objects/_find?type=dashboard'
+      'http://localhost:5601/api/saved_objects/_find?type=dashboard'
     );
     expect(forwardedRequest.url).not.toContain('malicious-host');
   });
@@ -108,7 +112,7 @@ describe('kibana tool', () => {
 
     expect(mockedAxios).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://kibana.example.com:5601/s/my-space/api/apm/agent_keys',
+        url: 'http://localhost:5601/s/my-space/api/apm/agent_keys',
         data: JSON.stringify({ foo: 'bar' }),
       })
     );
@@ -134,20 +138,56 @@ describe('kibana tool', () => {
     expect(forwardedRequest.headers).not.toHaveProperty('x-forwarded-user');
   });
 
-  it('throws when server.publicBaseUrl is not configured', async () => {
-    const { handler, coreStart } = registerFunction({});
-    coreStart.http.basePath.publicBaseUrl = undefined as any;
+  it('maps 0.0.0.0 hostname to localhost', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: '0.0.0.0', port: 5601, protocol: 'http' },
+    });
 
-    await expect(
-      handler({
-        arguments: {
-          method: 'GET',
-          pathname: '/api/saved_objects/_find',
-          query: { type: 'dashboard' },
-        },
-      })
-    ).rejects.toThrow(
-      'Cannot invoke Kibana tool: "server.publicBaseUrl" must be configured in kibana.yml'
-    );
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+  });
+
+  it('maps :: hostname to localhost', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: '::', port: 5601, protocol: 'http' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('http://localhost:5601/api/status');
+  });
+
+  it('provides httpsAgent when server uses https', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: 'localhost', port: 5601, protocol: 'https' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.url).toBe('https://localhost:5601/api/status');
+    expect(forwardedRequest.httpsAgent).toBeDefined();
+  });
+
+  it('does not provide httpsAgent when server uses http', async () => {
+    const { handler } = registerFunction({
+      serverInfo: { hostname: 'localhost', port: 5601, protocol: 'http' },
+    });
+
+    await handler({
+      arguments: { method: 'GET', pathname: '/api/status' },
+    });
+
+    const forwardedRequest = mockedAxios.mock.calls[0][0] as AxiosRequestConfig;
+    expect(forwardedRequest.httpsAgent).toBeUndefined();
   });
 });

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import https from 'https';
 import axios from 'axios';
 import { format } from 'url';
 import { pickBy } from 'lodash';
@@ -54,15 +55,13 @@ export function registerKibanaFunction({
       const requestUrl = request.rewrittenUrl || request.url;
       const core = await resources.plugins.core.start();
 
-      function getParsedPublicBaseUrl() {
-        const { publicBaseUrl } = core.http.basePath;
-        if (!publicBaseUrl) {
-          const errorMessage = `Cannot invoke Kibana tool: "server.publicBaseUrl" must be configured in kibana.yml`;
-          logger.error(errorMessage);
-          throw new Error(errorMessage);
-        }
-        const parsedBaseUrl = new URL(publicBaseUrl);
-        return parsedBaseUrl;
+      function getLocalServerUrl() {
+        const serverInfo = core.http.getServerInfo();
+        const hostname =
+          serverInfo.hostname === '0.0.0.0' || serverInfo.hostname === '::'
+            ? 'localhost'
+            : serverInfo.hostname;
+        return { hostname, port: serverInfo.port, protocol: serverInfo.protocol };
       }
 
       function getPathnameWithSpaceId() {
@@ -72,10 +71,10 @@ export function registerKibanaFunction({
         return pathnameWithSpaceId;
       }
 
-      const parsedPublicBaseUrl = getParsedPublicBaseUrl();
+      const localServer = getLocalServerUrl();
       const nextUrl = {
-        host: parsedPublicBaseUrl.host,
-        protocol: parsedPublicBaseUrl.protocol,
+        host: `${localServer.hostname}:${localServer.port}`,
+        protocol: `${localServer.protocol}:`,
         pathname: getPathnameWithSpaceId(),
         query: query ? (query as Record<string, string>) : undefined,
       };
@@ -109,6 +108,13 @@ export function registerKibanaFunction({
         );
       });
 
+      // The server certificate may not cover the local hostname, so skip
+      // TLS hostname verification for this loopback self-request.
+      const httpsAgent =
+        localServer.protocol === 'https'
+          ? new https.Agent({ rejectUnauthorized: false })
+          : undefined;
+
       try {
         const response = await axios({
           method,
@@ -116,6 +122,7 @@ export function registerKibanaFunction({
           url: format(nextUrl),
           data: body ? JSON.stringify(body) : undefined,
           signal,
+          ...(httpsAgent ? { httpsAgent } : {}),
         });
         return { content: response.data };
       } catch (e) {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
@@ -57,11 +57,17 @@ export function registerKibanaFunction({
 
       function getLocalServerUrl() {
         const serverInfo = core.http.getServerInfo();
-        const hostname =
-          serverInfo.hostname === '0.0.0.0' || serverInfo.hostname === '::'
-            ? 'localhost'
-            : serverInfo.hostname;
-        return { hostname, port: serverInfo.port, protocol: serverInfo.protocol };
+        let { hostname } = serverInfo;
+
+        if (hostname === '0.0.0.0' || hostname === '::' || hostname === '::1') {
+          hostname = 'localhost';
+        }
+
+        const host = hostname.includes(':')
+          ? `[${hostname}]:${serverInfo.port}`
+          : `${hostname}:${serverInfo.port}`;
+
+        return { host, protocol: serverInfo.protocol };
       }
 
       function getPathnameWithSpaceId() {
@@ -73,7 +79,7 @@ export function registerKibanaFunction({
 
       const localServer = getLocalServerUrl();
       const nextUrl = {
-        host: `${localServer.hostname}:${localServer.port}`,
+        host: localServer.host,
         protocol: `${localServer.protocol}:`,
         pathname: getPathnameWithSpaceId(),
         query: query ? (query as Record<string, string>) : undefined,
@@ -109,10 +115,11 @@ export function registerKibanaFunction({
       });
 
       // The server certificate may not cover the local hostname, so skip
-      // TLS hostname verification for this loopback self-request.
+      // hostname verification for this loopback self-request while still
+      // validating the certificate chain.
       const httpsAgent =
         localServer.protocol === 'https'
-          ? new https.Agent({ rejectUnauthorized: false })
+          ? new https.Agent({ checkServerIdentity: () => undefined })
           : undefined;
 
       try {
@@ -122,7 +129,7 @@ export function registerKibanaFunction({
           url: format(nextUrl),
           data: body ? JSON.stringify(body) : undefined,
           signal,
-          ...(httpsAgent ? { httpsAgent } : {}),
+          httpsAgent,
         });
         return { content: response.data };
       } catch (e) {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/functions/kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import https from 'https';
+import tls from 'tls';
 import axios from 'axios';
 import { format } from 'url';
 import { pickBy } from 'lodash';
@@ -55,19 +56,40 @@ export function registerKibanaFunction({
       const requestUrl = request.rewrittenUrl || request.url;
       const core = await resources.plugins.core.start();
 
+      function stripIpv6Brackets(hostname: string) {
+        return hostname.startsWith('[') && hostname.endsWith(']')
+          ? hostname.slice(1, -1)
+          : hostname;
+      }
+
+      function isLoopbackHostname(hostname: string) {
+        return hostname === 'localhost' || hostname === '::1' || hostname.startsWith('127.');
+      }
+
       function getLocalServerUrl() {
+        const { publicBaseUrl } = core.http.basePath;
         const serverInfo = core.http.getServerInfo();
         let { hostname } = serverInfo;
 
-        if (hostname === '0.0.0.0' || hostname === '::' || hostname === '::1') {
-          hostname = 'localhost';
+        if (hostname === '0.0.0.0') {
+          hostname = '127.0.0.1';
+        } else if (hostname === '::') {
+          hostname = '::1';
         }
 
         const host = hostname.includes(':')
           ? `[${hostname}]:${serverInfo.port}`
           : `${hostname}:${serverInfo.port}`;
 
-        return { host, protocol: serverInfo.protocol };
+        let tlsHostname: string | undefined;
+        if (publicBaseUrl && serverInfo.protocol === 'https') {
+          const parsedPublicBaseUrl = new URL(publicBaseUrl);
+          if (parsedPublicBaseUrl.protocol === 'https:') {
+            tlsHostname = stripIpv6Brackets(parsedPublicBaseUrl.hostname);
+          }
+        }
+
+        return { host, hostname, protocol: serverInfo.protocol, tlsHostname };
       }
 
       function getPathnameWithSpaceId() {
@@ -114,13 +136,18 @@ export function registerKibanaFunction({
         );
       });
 
-      // The server certificate may not cover the local hostname, so skip
-      // hostname verification for this loopback self-request while still
-      // validating the certificate chain.
-      const httpsAgent =
-        localServer.protocol === 'https'
-          ? new https.Agent({ checkServerIdentity: () => undefined })
-          : undefined;
+      let httpsAgent: https.Agent | undefined;
+      if (localServer.protocol === 'https') {
+        if (localServer.tlsHostname) {
+          const { tlsHostname } = localServer;
+          httpsAgent = new https.Agent({
+            servername: tlsHostname,
+            checkServerIdentity: (_, cert) => tls.checkServerIdentity(tlsHostname, cert),
+          });
+        } else if (isLoopbackHostname(localServer.hostname)) {
+          httpsAgent = new https.Agent({ checkServerIdentity: () => undefined });
+        }
+      }
 
       try {
         const response = await axios({


### PR DESCRIPTION
## Summary

Fixes the Observability AI Assistant's `kibana` tool failing with `ENOTFOUND` DNS resolution errors in VPC environments on ECH.

### Problem

The `kibana` tool makes HTTP self-requests (Kibana calling its own API) to execute functions like retrieving rules, dashboards, and visualizations. Previously, the target URL for these self-requests was derived from externally-facing sources:
- On versions before 8.19.7: from the `origin` header of the incoming request
- On 8.19.7+ (after #236653): from `server.publicBaseUrl`

In VPC environments, both of these resolve to the VPC endpoint, which is only resolvable from within the user's VPC network. The Kibana server process on the control plane cannot resolve this DNS name, causing all `kibana` tool invocations to fail with `getaddrinfo ENOTFOUND`.

### Fix

Since the `kibana` tool is making a loopback self-request, the target URL should be the server's own listening address rather than any externally-facing URL. This PR replaces the `publicBaseUrl` usage with `core.http.getServerInfo()`, which returns the actual local address the Kibana process is bound to (hostname, port, protocol).

This approach:
- **Fixes VPC environments** - no external DNS resolution needed for self-requests
- **Fixes proxy setups** - bypasses the proxy entirely for self-requests (also resolves the auth header issue from #244017)
- **Prevents SSRF** - target URL is derived from server configuration, never from user-supplied headers
- **Removes the `server.publicBaseUrl` requirement** - the tool now works without this setting configured
- **Works across all deployment modes** - self-managed, ECH (including VPC), and serverless

Additional handling:
- Wildcard bind addresses (`0.0.0.0`, `::`) and IPv6 loopback (`::1`) are mapped to `localhost`
- IPv6 literal addresses are properly bracketed in URLs (e.g.: `[fe80::1]:5601`)
- For HTTPS, hostname verification is skipped via `checkServerIdentity` while still validating the certificate chain

## Test plan

### Unit tests
- [x] Unit tests
  - Verifies local server address is used instead of user-supplied headers (SSRF prevention)
  - Verifies space ID is preserved in forwarded URLs
  - Verifies authorization header forwarding and dangerous header stripping
  - Verifies `0.0.0.0` → `127.0.0.1` and `::` → `::1` hostname mapping
  - Verifies IPv6 literal addresses are bracketed in URLs
  - Verifies HTTPS uses `publicBaseUrl` hostname for TLS verification when available
  - Verifies loopback HTTPS fallback skips hostname verification when `publicBaseUrl` is unavailable
  - Verifies no custom httpsAgent for non-loopback HTTPS or HTTP targets

### Manual testing (simulated VPC)
- [x] Set `server.publicBaseUrl: "http://unresolvable-vpc-endpoint.example.com:5601"` in `kibana.dev.yml`
- [x] Start Kibana locally and open the Observability AI Assistant
- [x] Ask the assistant to "list my dashboards" (or any query that triggers the `kibana` tool)
- [x] Verify the tool succeeds instead of failing with `ENOTFOUND`
- [x] Check Kibana server logs confirm the request was forwarded to `http://localhost:5601/...` (not the unresolvable URL)

### ECH + VPC validation
- [ ] Deploy to an ECH environment with VPC configured
- [ ] Verify the AI assistant's kibana tool can list rules, dashboards, and visualizations without `ENOTFOUND` errors

### Screen recordings

#### Before the fix --> With `server.publicBaseUrl: 'http://unresolvable-vpc-endpoint.example.com:5601/dev'` set in `kibana.dev.yml`

https://github.com/user-attachments/assets/8451dac7-aed5-4ee8-946f-b6adf54361ea

#### After the fix --> With `server.publicBaseUrl: 'http://unresolvable-vpc-endpoint.example.com:5601/dev'` set in `kibana.dev.yml`

https://github.com/user-attachments/assets/a144f0b5-c9a3-4d9f-af36-d4a0609cc17f

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

