### PR TITLE
[ML] POC: Change point view in Discover

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -73,11 +73,12 @@ export {
   hasChangePointCommand,
   getChangePointOutputColumnNames,
   getSourceQueryBeforeChangePoint,
-  // TODO: FORK command specific code needs to be updated once CHANGE_POINT BY command is available
-  getSourceQueriesFromForkWithChangePoint,
   getForkWithChangePoint,
   getBranchLabelFromForkBranch,
-  type ForkBranchSourceQuery,
+  getForkBranchLabels,
+  getTemplateSourceQueryFromForkWithChangePoint,
+  replaceEntityValueInSourceQuery,
+  type ForkBranchLabel,
   type ESQLStatsQueryMeta,
 } from './src';
 

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -70,6 +70,14 @@ export {
   isComputedColumn,
   getQuerySummary,
   getEsqlControls,
+  hasChangePointCommand,
+  getChangePointOutputColumnNames,
+  getSourceQueryBeforeChangePoint,
+  // TODO: FORK command specific code needs to be updated once CHANGE_POINT BY command is available
+  getSourceQueriesFromForkWithChangePoint,
+  getForkWithChangePoint,
+  getBranchLabelFromForkBranch,
+  type ForkBranchSourceQuery,
   type ESQLStatsQueryMeta,
 } from './src';
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -30,6 +30,14 @@ export {
   convertTimeseriesCommandToFrom,
   hasOnlySourceCommand,
   hasTimeseriesInfoCommand,
+  hasChangePointCommand,
+  getChangePointOutputColumnNames,
+  getSourceQueryBeforeChangePoint,
+  // TODO: FORK command specific code needs to be updated once CHANGE_POINT BY command is available
+  getForkWithChangePoint,
+  getBranchLabelFromForkBranch,
+  getSourceQueriesFromForkWithChangePoint,
+  type ForkBranchSourceQuery,
 } from './utils/query_parsing_helpers';
 export {
   getIndexPatternFromESQLQuery,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -31,13 +31,15 @@ export {
   hasOnlySourceCommand,
   hasTimeseriesInfoCommand,
   hasChangePointCommand,
+  getChangePointEntityFieldName,
   getChangePointOutputColumnNames,
   getSourceQueryBeforeChangePoint,
-  // TODO: FORK command specific code needs to be updated once CHANGE_POINT BY command is available
   getForkWithChangePoint,
   getBranchLabelFromForkBranch,
-  getSourceQueriesFromForkWithChangePoint,
-  type ForkBranchSourceQuery,
+  getForkBranchLabels,
+  getTemplateSourceQueryFromForkWithChangePoint,
+  replaceEntityValueInSourceQuery,
+  type ForkBranchLabel,
 } from './utils/query_parsing_helpers';
 export {
   getIndexPatternFromESQLQuery,

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -33,6 +33,11 @@ import {
   missingSortBeforeLimit,
   hasOnlySourceCommand,
   hasTimeseriesInfoCommand,
+  hasChangePointCommand,
+  getChangePointOutputColumnNames,
+  getSourceQueryBeforeChangePoint,
+  getForkWithChangePoint,
+  getSourceQueriesFromForkWithChangePoint,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -1131,6 +1136,139 @@ describe('esql query helpers', () => {
 
     it('should return false when query does not contain METRICS_INFO or TS_INFO', () => {
       expect(hasTimeseriesInfoCommand('FROM index | STATS count()')).toBe(false);
+    });
+  });
+
+  describe('hasChangePointCommand', () => {
+    it('should return false for undefined or empty esql', () => {
+      expect(hasChangePointCommand(undefined)).toBe(false);
+      expect(hasChangePointCommand('')).toBe(false);
+    });
+
+    it('should return false when query has no CHANGE_POINT command', () => {
+      expect(hasChangePointCommand('FROM index | STATS count = COUNT(*)')).toBe(false);
+      expect(hasChangePointCommand('FROM index | WHERE field > 0')).toBe(false);
+    });
+
+    it('should return true when query contains CHANGE_POINT command', () => {
+      expect(hasChangePointCommand('FROM a | CHANGE_POINT value')).toBe(true);
+      expect(hasChangePointCommand('FROM a | CHANGE_POINT value ON key')).toBe(true);
+      expect(
+        hasChangePointCommand(
+          'FROM a | STATS count = COUNT(*) BY bucket | CHANGE_POINT count ON bucket'
+        )
+      ).toBe(true);
+    });
+
+    it('should return true when CHANGE_POINT is inside FORK branches', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://domainsigma.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+  ( WHERE referer == "https://www.google.com/" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL
+| KEEP provider, bucket, avg_bytes, type, pvalue`;
+      expect(hasChangePointCommand(forkQuery)).toBe(true);
+    });
+  });
+
+  describe('getChangePointOutputColumnNames', () => {
+    it('should return undefined for undefined or when no CHANGE_POINT command', () => {
+      expect(getChangePointOutputColumnNames(undefined)).toBeUndefined();
+      expect(getChangePointOutputColumnNames('FROM index')).toBeUndefined();
+    });
+
+    it('should return default type and pvalue column names when AS is not used', () => {
+      const result = getChangePointOutputColumnNames('FROM a | CHANGE_POINT value');
+      expect(result).toEqual({ typeColumn: 'type', pvalueColumn: 'pvalue' });
+    });
+
+    it('should return custom column names when AS type_name, pvalue_name is used', () => {
+      const result = getChangePointOutputColumnNames(
+        'FROM a | CHANGE_POINT value AS change_type, p_value'
+      );
+      expect(result?.typeColumn).toBe('change_type');
+      expect(result?.pvalueColumn).toBe('p_value');
+    });
+
+    it('should return column names when CHANGE_POINT is inside FORK branches', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL`;
+      const result = getChangePointOutputColumnNames(forkQuery);
+      expect(result).toEqual({ typeColumn: 'type', pvalueColumn: 'pvalue' });
+    });
+  });
+
+  describe('getSourceQueryBeforeChangePoint', () => {
+    it('should return undefined for undefined or when no CHANGE_POINT command', () => {
+      expect(getSourceQueryBeforeChangePoint(undefined)).toBeUndefined();
+      expect(getSourceQueryBeforeChangePoint('FROM index')).toBeUndefined();
+    });
+
+    it('should return query before CHANGE_POINT when CHANGE_POINT is present', () => {
+      expect(getSourceQueryBeforeChangePoint('FROM a | CHANGE_POINT value')).toBe('FROM a');
+      expect(
+        getSourceQueryBeforeChangePoint(
+          'FROM a | STATS count = COUNT(*) BY bucket | CHANGE_POINT count ON bucket'
+        )
+      ).toBe('FROM a | STATS count = COUNT(*) BY bucket');
+    });
+
+    it('should return undefined when CHANGE_POINT is the first command', () => {
+      expect(getSourceQueryBeforeChangePoint('CHANGE_POINT value')).toBeUndefined();
+    });
+  });
+
+  describe('getForkWithChangePoint', () => {
+    it('should return undefined for undefined or when no FORK', () => {
+      expect(getForkWithChangePoint(undefined)).toBeUndefined();
+      expect(getForkWithChangePoint('FROM a | CHANGE_POINT value')).toBeUndefined();
+    });
+
+    it('should return undefined when FORK has no CHANGE_POINT in branches', () => {
+      const forkQuery = 'FROM a | FORK ( WHERE x == 1 | STATS c = COUNT(*) )';
+      expect(getForkWithChangePoint(forkQuery)).toBeUndefined();
+    });
+
+    it('should return fork command and index when CHANGE_POINT is inside a FORK branch', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL`;
+      const result = getForkWithChangePoint(forkQuery);
+      expect(result).toBeDefined();
+      expect(result?.forkCommand.name).toBe('fork');
+      expect(result?.forkIndex).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getSourceQueriesFromForkWithChangePoint', () => {
+    it('should return undefined for undefined or when no FORK with CHANGE_POINT', () => {
+      expect(getSourceQueriesFromForkWithChangePoint(undefined)).toBeUndefined();
+      expect(
+        getSourceQueriesFromForkWithChangePoint('FROM a | CHANGE_POINT value')
+      ).toBeUndefined();
+    });
+
+    it('should return source query per branch when CHANGE_POINT is inside FORK', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+  ( WHERE referer == "http://b.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL`;
+      const result = getSourceQueriesFromForkWithChangePoint(forkQuery);
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(2);
+      expect(result![0].branchLabel).toBe('http://a.com');
+      expect(result![0].branchIndex).toBe(0);
+      expect(result![0].sourceQuery).toContain('FROM gallery-*');
+      expect(result![0].sourceQuery).toContain('WHERE referer == "http://a.com"');
+      expect(result![0].sourceQuery).toContain('STATS avg_bytes');
+      expect(result![0].sourceQuery).not.toContain('CHANGE_POINT');
+      expect(result![1].branchLabel).toBe('http://b.com');
+      expect(result![1].branchIndex).toBe(1);
+      expect(result![1].sourceQuery).toContain('WHERE referer == "http://b.com"');
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -34,10 +34,13 @@ import {
   hasOnlySourceCommand,
   hasTimeseriesInfoCommand,
   hasChangePointCommand,
+  getChangePointEntityFieldName,
   getChangePointOutputColumnNames,
   getSourceQueryBeforeChangePoint,
   getForkWithChangePoint,
-  getSourceQueriesFromForkWithChangePoint,
+  getForkBranchLabels,
+  getTemplateSourceQueryFromForkWithChangePoint,
+  replaceEntityValueInSourceQuery,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -1200,6 +1203,28 @@ describe('esql query helpers', () => {
     });
   });
 
+  describe('getChangePointEntityFieldName', () => {
+    it('should return undefined for undefined or when no CHANGE_POINT', () => {
+      expect(getChangePointEntityFieldName(undefined)).toBeUndefined();
+      expect(getChangePointEntityFieldName('FROM index')).toBeUndefined();
+    });
+
+    it('should return entity field from STATS BY when CHANGE_POINT has ON clause', () => {
+      const esql =
+        'FROM gallery-* | STATS avg_bytes = AVG(bytes) BY provider, bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket';
+      expect(getChangePointEntityFieldName(esql)).toBe('provider');
+    });
+
+    it('should return WHERE field when CHANGE_POINT is inside FORK', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+  ( WHERE referer == "http://b.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL`;
+      expect(getChangePointEntityFieldName(forkQuery)).toBe('referer');
+    });
+  });
+
   describe('getSourceQueryBeforeChangePoint', () => {
     it('should return undefined for undefined or when no CHANGE_POINT command', () => {
       expect(getSourceQueryBeforeChangePoint(undefined)).toBeUndefined();
@@ -1243,32 +1268,64 @@ describe('esql query helpers', () => {
     });
   });
 
-  describe('getSourceQueriesFromForkWithChangePoint', () => {
+  describe('getForkBranchLabels', () => {
     it('should return undefined for undefined or when no FORK with CHANGE_POINT', () => {
-      expect(getSourceQueriesFromForkWithChangePoint(undefined)).toBeUndefined();
-      expect(
-        getSourceQueriesFromForkWithChangePoint('FROM a | CHANGE_POINT value')
-      ).toBeUndefined();
+      expect(getForkBranchLabels(undefined)).toBeUndefined();
+      expect(getForkBranchLabels('FROM a | CHANGE_POINT value')).toBeUndefined();
     });
 
-    it('should return source query per branch when CHANGE_POINT is inside FORK', () => {
+    it('should return branch labels and indices when CHANGE_POINT is inside FORK', () => {
       const forkQuery = `FROM gallery-*
 | FORK
   ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
   ( WHERE referer == "http://b.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
 | WHERE type IS NOT NULL`;
-      const result = getSourceQueriesFromForkWithChangePoint(forkQuery);
+      const result = getForkBranchLabels(forkQuery);
       expect(result).toBeDefined();
       expect(result).toHaveLength(2);
       expect(result![0].branchLabel).toBe('http://a.com');
       expect(result![0].branchIndex).toBe(0);
-      expect(result![0].sourceQuery).toContain('FROM gallery-*');
-      expect(result![0].sourceQuery).toContain('WHERE referer == "http://a.com"');
-      expect(result![0].sourceQuery).toContain('STATS avg_bytes');
-      expect(result![0].sourceQuery).not.toContain('CHANGE_POINT');
       expect(result![1].branchLabel).toBe('http://b.com');
       expect(result![1].branchIndex).toBe(1);
-      expect(result![1].sourceQuery).toContain('WHERE referer == "http://b.com"');
+    });
+  });
+
+  describe('getTemplateSourceQueryFromForkWithChangePoint', () => {
+    it('should return undefined for undefined or when no FORK with CHANGE_POINT', () => {
+      expect(getTemplateSourceQueryFromForkWithChangePoint(undefined)).toBeUndefined();
+      expect(
+        getTemplateSourceQueryFromForkWithChangePoint('FROM a | CHANGE_POINT value')
+      ).toBeUndefined();
+    });
+
+    it('should return first branch source query when CHANGE_POINT is inside FORK', () => {
+      const forkQuery = `FROM gallery-*
+| FORK
+  ( WHERE referer == "http://a.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+  ( WHERE referer == "http://b.com" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
+| WHERE type IS NOT NULL`;
+      const result = getTemplateSourceQueryFromForkWithChangePoint(forkQuery);
+      expect(result).toBeDefined();
+      expect(result).toContain('FROM gallery-*');
+      expect(result).toContain('WHERE referer == "http://a.com"');
+      expect(result).toContain('STATS avg_bytes');
+      expect(result).not.toContain('CHANGE_POINT');
+    });
+  });
+
+  describe('replaceEntityValueInSourceQuery', () => {
+    it('should replace entity value in WHERE clause', () => {
+      const sourceQuery =
+        'FROM gallery-* | WHERE provider == "http://a.com" | STATS count = COUNT(*) BY @timestamp';
+      const result = replaceEntityValueInSourceQuery(sourceQuery, 'http://b.com');
+      expect(result).toContain('WHERE provider == "http://b.com"');
+      expect(result).not.toContain('http://a.com');
+    });
+
+    it('should return source query unchanged when no match', () => {
+      const sourceQuery = 'FROM gallery-* | STATS count = COUNT(*) BY @timestamp';
+      const result = replaceEntityValueInSourceQuery(sourceQuery, 'http://b.com');
+      expect(result).toBe(sourceQuery);
     });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -25,7 +25,9 @@ import type {
   ESQLSingleAstItem,
   ESQLInlineCast,
   ESQLCommandOption,
+  ESQLAstCommand,
   ESQLAstForkCommand,
+  ESQLForkParens,
 } from '@elastic/esql/types';
 import { type ESQLControlVariable, ESQLVariableType } from '@kbn/esql-types';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
@@ -633,4 +635,167 @@ export const hasTimeseriesInfoCommand = (esql?: string): boolean => {
   return root.commands.some(
     ({ name }) => name === CommandNames.METRICS_INFO || name === CommandNames.TS_INFO
   );
+};
+
+/**
+ * Returns true if the ES|QL query contains a CHANGE_POINT command.
+ * Matches both top-level CHANGE_POINT and CHANGE_POINT inside FORK branches.
+ * @param esql - The ES|QL query string
+ */
+export const hasChangePointCommand = (esql?: string): boolean => {
+  if (!esql) return false;
+  try {
+    const { root } = Parser.parse(esql);
+    const changePointCommands = Walker.findAll(
+      root,
+      (node) => node.type === 'command' && node.name === 'change_point'
+    );
+    return changePointCommands.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Output column names for the CHANGE_POINT command (type and pvalue).
+ * Defaults are 'type' and 'pvalue' unless the query uses AS type_name, pvalue_name.
+ * Finds CHANGE_POINT in top-level commands or inside FORK branches.
+ * @param esql - The ES|QL query string
+ * @returns Object with typeColumn and pvalueColumn names, or undefined if no CHANGE_POINT command
+ */
+export const getChangePointOutputColumnNames = (
+  esql?: string
+): { typeColumn: string; pvalueColumn: string } | undefined => {
+  if (!esql) return undefined;
+  try {
+    const { root } = Parser.parse(esql);
+    const changePointCommands = Walker.findAll(
+      root,
+      (node) => node.type === 'command' && node.name === 'change_point'
+    );
+    const changePointCommand = changePointCommands[0];
+    if (!changePointCommand) return undefined;
+    const cmd = changePointCommand as {
+      target?: { type?: { name: string }; pvalue?: { name: string } };
+    };
+    const typeColumn = cmd.target?.type?.name ?? 'type';
+    const pvalueColumn = cmd.target?.pvalue?.name ?? 'pvalue';
+    return { typeColumn, pvalueColumn };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Returns the ES|QL query that produces the input to CHANGE_POINT (pipeline before the CHANGE_POINT command).
+ * Use this to visualize the underlying time series that was used for change point detection.
+ * @param esql - The full ES|QL query string containing CHANGE_POINT
+ * @returns The source query without CHANGE_POINT and any following commands, or undefined if no CHANGE_POINT
+ */
+export const getSourceQueryBeforeChangePoint = (esql?: string): string | undefined => {
+  if (!esql) return undefined;
+  try {
+    const { root } = Parser.parse(esql);
+    const changePointIndex = root.commands.findIndex((cmd) => cmd.name === 'change_point');
+    if (changePointIndex <= 0) return undefined;
+    const commandsBeforeChangePoint = root.commands.slice(0, changePointIndex);
+    const newRoot = { ...root, commands: commandsBeforeChangePoint };
+    return BasicPrettyPrinter.print(newRoot);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Returns the FORK command if CHANGE_POINT is inside a FORK, otherwise undefined.
+ */
+export const getForkWithChangePoint = (
+  esql?: string
+): { forkCommand: ESQLAstForkCommand; forkIndex: number } | undefined => {
+  if (!esql) return undefined;
+  try {
+    const { root } = Parser.parse(esql);
+    const forkIndex = root.commands.findIndex((cmd) => cmd.name === 'fork');
+    if (forkIndex < 0) return undefined;
+    const forkCommand = root.commands[forkIndex] as ESQLAstForkCommand;
+    const forkArgs = forkCommand?.args as ESQLForkParens[] | undefined;
+    if (!forkArgs?.length) return undefined;
+    const hasChangePointInBranch = forkArgs.some((parens) => {
+      const branch = parens.child;
+      if (branch?.type !== 'query' || !branch.commands) return false;
+      return branch.commands.some((cmd: ESQLAstCommand) => cmd.name === 'change_point');
+    });
+    if (!hasChangePointInBranch) return undefined;
+    return { forkCommand, forkIndex };
+  } catch {
+    return undefined;
+  }
+};
+
+export interface ForkBranchSourceQuery {
+  sourceQuery: string;
+  branchLabel: string;
+  branchIndex: number;
+}
+
+/**
+ * Derives a human-readable entity label from a FORK branch's commands.
+ * Extracts only the field value from the first WHERE clause (e.g. field == "value" -> "value").
+ * Falls back to "Branch N" if no field/value pair is found.
+ */
+export const getBranchLabelFromForkBranch = (
+  branchCommands: ESQLAstCommand[],
+  branchIndex: number
+): string => {
+  const whereCmd = branchCommands.find((cmd: ESQLAstCommand) => cmd.name === 'where');
+  if (!whereCmd?.text) return `Branch ${branchIndex + 1}`;
+
+  const eqMatch = whereCmd.text.trim().match(/(\w+)\s*==\s*["']([^"']+)["']/);
+  if (eqMatch) {
+    const [, , value] = eqMatch;
+    return value;
+  }
+  return `Branch ${branchIndex + 1}`;
+};
+
+/**
+ * Returns source queries for each FORK branch that contains CHANGE_POINT.
+ * Use when CHANGE_POINT is inside FORK to show each branch's source data as a separate line.
+ * @param esql - The full ES|QL query string
+ * @returns Array of { sourceQuery, branchLabel, branchIndex } for each branch with CHANGE_POINT, or undefined if not a FORK with CHANGE_POINT
+ */
+export const getSourceQueriesFromForkWithChangePoint = (
+  esql?: string
+): ForkBranchSourceQuery[] | undefined => {
+  const forkInfo = getForkWithChangePoint(esql);
+  if (!forkInfo) return undefined;
+
+  const { root } = Parser.parse(esql!);
+  const { forkCommand, forkIndex } = forkInfo;
+  const prefixCommands = root.commands.slice(0, forkIndex);
+  const forkArgs = forkCommand.args as ESQLForkParens[];
+
+  const results: ForkBranchSourceQuery[] = [];
+  for (let i = 0; i < forkArgs.length; i++) {
+    const parens = forkArgs[i];
+    const branch = parens?.child;
+    if (branch?.type !== 'query' || !branch.commands) continue;
+
+    const changePointIdx = branch.commands.findIndex(
+      (cmd: ESQLAstCommand) => cmd.name === 'change_point'
+    );
+    if (changePointIdx <= 0) continue;
+
+    const branchCommandsBeforeChangePoint = branch.commands.slice(
+      0,
+      changePointIdx
+    ) as ESQLAstCommand[];
+    const fullCommands: ESQLAstCommand[] = [...prefixCommands, ...branchCommandsBeforeChangePoint];
+    const newRoot = { ...root, commands: fullCommands };
+    const sourceQuery = BasicPrettyPrinter.print(newRoot);
+    const branchLabel = getBranchLabelFromForkBranch(branch.commands, i);
+    results.push({ sourceQuery, branchLabel, branchIndex: i });
+  }
+
+  return results.length > 0 ? results : undefined;
 };

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -12,6 +12,8 @@ import {
   Parser,
   isFunctionExpression,
   isColumn,
+  isAssignment,
+  isOptionNode,
   WrappingPrettyPrinter,
   BasicPrettyPrinter,
   isStringLiteral,
@@ -687,6 +689,79 @@ export const getChangePointOutputColumnNames = (
 };
 
 /**
+ * Returns the entity/grouping field name from a CHANGE_POINT query.
+ * For non-FORK: STATS ... BY entityField, timeField | CHANGE_POINT value ON timeField -> returns entityField.
+ * For FORK: returns the field from the first WHERE clause (e.g. field == "value" -> field).
+ * @param esql - The full ES|QL query string
+ * @returns The entity field name, or undefined if not determinable
+ */
+export const getChangePointEntityFieldName = (esql?: string): string | undefined => {
+  if (!esql) return undefined;
+  try {
+    const { root } = Parser.parse(esql);
+    const changePointCommands = Walker.findAll(
+      root,
+      (node) => node.type === 'command' && node.name === 'change_point'
+    );
+    const changePointCommand = changePointCommands[0] as ESQLAstCommand | undefined;
+    if (!changePointCommand) return undefined;
+
+    const onOption = changePointCommand.args?.find(
+      (arg) => isOptionNode(arg) && arg.name === 'on'
+    ) as ESQLCommandOption | undefined;
+    const onFieldName = onOption?.args?.[0];
+    const onColumnName = onFieldName && isColumn(onFieldName) ? onFieldName.name : '@timestamp';
+
+    const forkInfo = getForkWithChangePoint(esql);
+    const commandsToSearch = forkInfo
+      ? (() => {
+          const forkArgs = forkInfo.forkCommand.args as ESQLForkParens[];
+          for (let i = 0; i < forkArgs.length; i++) {
+            const branch = forkArgs[i]?.child;
+            if (branch?.type !== 'query' || !branch.commands) continue;
+            const changePointIdx = branch.commands.findIndex(
+              (cmd: ESQLAstCommand) => cmd.name === 'change_point'
+            );
+            if (changePointIdx <= 0) continue;
+            return branch.commands.slice(0, changePointIdx) as ESQLAstCommand[];
+          }
+          return [];
+        })()
+      : root.commands.slice(
+          0,
+          root.commands.findIndex((cmd) => cmd.name === 'change_point')
+        );
+
+    const whereCmd = commandsToSearch.find((c) => c.name === 'where');
+    if (whereCmd?.text) {
+      const eqMatch = whereCmd.text.trim().match(/(\w+)\s*==\s*["']([^"']+)["']/);
+      if (eqMatch) return eqMatch[1];
+    }
+
+    const statsCommand = commandsToSearch.find((c) => c.name === 'stats');
+    if (!statsCommand) return undefined;
+
+    const options: ESQLCommandOption[] = [];
+    walk(statsCommand, { visitCommandOption: (node) => options.push(node) });
+    const byOption = options.find((o) => o.name === 'by');
+    if (!byOption?.args?.length) return undefined;
+
+    const byOutputNames: string[] = [];
+    for (const arg of byOption.args) {
+      if (isColumn(arg)) {
+        byOutputNames.push(arg.name);
+      } else if (isAssignment(arg) && isColumn(arg.args?.[0])) {
+        byOutputNames.push((arg.args[0] as ESQLColumn).name);
+      }
+    }
+
+    return byOutputNames.find((name) => name !== onColumnName);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Returns the ES|QL query that produces the input to CHANGE_POINT (pipeline before the CHANGE_POINT command).
  * Use this to visualize the underlying time series that was used for change point detection.
  * @param esql - The full ES|QL query string containing CHANGE_POINT
@@ -732,8 +807,8 @@ export const getForkWithChangePoint = (
   }
 };
 
-export interface ForkBranchSourceQuery {
-  sourceQuery: string;
+/** Entity metadata for a FORK branch (label and index). Used when deriving entities from change point results. */
+export interface ForkBranchLabel {
   branchLabel: string;
   branchIndex: number;
 }
@@ -759,14 +834,46 @@ export const getBranchLabelFromForkBranch = (
 };
 
 /**
- * Returns source queries for each FORK branch that contains CHANGE_POINT.
- * Use when CHANGE_POINT is inside FORK to show each branch's source data as a separate line.
+ * Returns entity labels and indices for each FORK branch that contains CHANGE_POINT.
+ * Use with change point results to derive which entities to show; source data is loaded
+ * via getTemplateSourceQueryFromForkWithChangePoint + replaceEntityValueInSourceQuery.
  * @param esql - The full ES|QL query string
- * @returns Array of { sourceQuery, branchLabel, branchIndex } for each branch with CHANGE_POINT, or undefined if not a FORK with CHANGE_POINT
+ * @returns Array of { branchLabel, branchIndex } for each branch with CHANGE_POINT, or undefined if not a FORK with CHANGE_POINT
  */
-export const getSourceQueriesFromForkWithChangePoint = (
+export const getForkBranchLabels = (esql?: string): ForkBranchLabel[] | undefined => {
+  const forkInfo = getForkWithChangePoint(esql);
+  if (!forkInfo) return undefined;
+
+  const { forkCommand } = forkInfo;
+  const forkArgs = forkCommand.args as ESQLForkParens[];
+
+  const results: ForkBranchLabel[] = [];
+  for (let i = 0; i < forkArgs.length; i++) {
+    const parens = forkArgs[i];
+    const branch = parens?.child;
+    if (branch?.type !== 'query' || !branch.commands) continue;
+
+    const changePointIdx = branch.commands.findIndex(
+      (cmd: ESQLAstCommand) => cmd.name === 'change_point'
+    );
+    if (changePointIdx <= 0) continue;
+
+    const branchLabel = getBranchLabelFromForkBranch(branch.commands, i);
+    results.push({ branchLabel, branchIndex: i });
+  }
+
+  return results.length > 0 ? results : undefined;
+};
+
+/**
+ * Returns the source query (everything before CHANGE_POINT) from the first FORK branch.
+ * Use as template for per-entity queries via replaceEntityValueInSourceQuery.
+ * @param esql - The full ES|QL query string
+ * @returns The first branch's source query, or undefined if not a FORK with CHANGE_POINT
+ */
+export const getTemplateSourceQueryFromForkWithChangePoint = (
   esql?: string
-): ForkBranchSourceQuery[] | undefined => {
+): string | undefined => {
   const forkInfo = getForkWithChangePoint(esql);
   if (!forkInfo) return undefined;
 
@@ -775,7 +882,6 @@ export const getSourceQueriesFromForkWithChangePoint = (
   const prefixCommands = root.commands.slice(0, forkIndex);
   const forkArgs = forkCommand.args as ESQLForkParens[];
 
-  const results: ForkBranchSourceQuery[] = [];
   for (let i = 0; i < forkArgs.length; i++) {
     const parens = forkArgs[i];
     const branch = parens?.child;
@@ -792,10 +898,26 @@ export const getSourceQueriesFromForkWithChangePoint = (
     ) as ESQLAstCommand[];
     const fullCommands: ESQLAstCommand[] = [...prefixCommands, ...branchCommandsBeforeChangePoint];
     const newRoot = { ...root, commands: fullCommands };
-    const sourceQuery = BasicPrettyPrinter.print(newRoot);
-    const branchLabel = getBranchLabelFromForkBranch(branch.commands, i);
-    results.push({ sourceQuery, branchLabel, branchIndex: i });
+    return BasicPrettyPrinter.print(newRoot);
   }
 
-  return results.length > 0 ? results : undefined;
+  return undefined;
+};
+
+/**
+ * Replaces the entity value in a source query's first WHERE clause (field == "value" pattern).
+ * Use when deriving per-entity source queries from a single template.
+ * @param sourceQuery - The template source query (e.g. from one FORK branch)
+ * @param newEntityValue - The entity value to substitute (e.g. from change point results)
+ * @returns The query with the entity value replaced
+ */
+export const replaceEntityValueInSourceQuery = (
+  sourceQuery: string,
+  newEntityValue: string
+): string => {
+  const match = sourceQuery.match(/(\w+)\s*==\s*["']([^"']+)["']/);
+  if (!match) return sourceQuery;
+  const [fullMatch, fieldName] = match;
+  const escaped = newEntityValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return sourceQuery.replace(fullMatch, `${fieldName} == "${escaped}"`);
 };

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -122,6 +122,7 @@ export function DiscoverGridFlyout({
       renderCustomHeader={docViewer.renderHeader}
       renderCustomFooter={docViewer.renderFooter}
       isEsqlQuery={isESQLQuery}
+      query={query}
       hit={hit}
       hits={hits}
       dataView={dataView}

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
+import { Axis, BarSeries, Chart, Position, ScaleType, Settings } from '@elastic/charts';
+import { i18n } from '@kbn/i18n';
+import type { ChangePointBurstHistogramProps } from './types';
+
+const CHART_HEIGHT = 300;
+
+export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps> = ({
+  data,
+  charts,
+}) => {
+  const baseTheme = charts.theme.useChartsBaseTheme();
+
+  const xAxisTitle = useMemo(
+    () =>
+      i18n.translate('discover.contextAwareness.changePointBurstHistogram.xAxisTitle', {
+        defaultMessage: 'Timeline',
+      }),
+    []
+  );
+
+  const yAxisTitle = useMemo(
+    () =>
+      i18n.translate('discover.contextAwareness.changePointBurstHistogram.yAxisTitle', {
+        defaultMessage: 'Entities with change point',
+      }),
+    []
+  );
+
+  return (
+    <div
+      css={css({
+        minHeight: CHART_HEIGHT,
+        padding: 16,
+        position: 'relative',
+      })}
+      data-test-subj="changePointBurstHistogram"
+    >
+      <Chart size={{ height: CHART_HEIGHT }}>
+        <Settings
+          baseTheme={baseTheme}
+          showLegend={true}
+          legendPosition={Position.Right}
+          locale={i18n.getLocale()}
+        />
+        <Axis
+          id="burst-timeline-axis"
+          position={Position.Bottom}
+          title={xAxisTitle}
+          tickFormat={(d) =>
+            new Date(d).toLocaleString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })
+          }
+          gridLine={{ visible: true }}
+        />
+        <Axis
+          id="burst-entity-count-axis"
+          position={Position.Left}
+          title={yAxisTitle}
+          tickFormat={(d) => String(Math.round(d))}
+          gridLine={{ visible: true }}
+        />
+        <BarSeries
+          id="burst-detection"
+          name={yAxisTitle}
+          xScaleType={ScaleType.Time}
+          yScaleType={ScaleType.Linear}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['g']}
+          data={data}
+          timeZone="UTC"
+          enableHistogramMode={true}
+          histogramModeAlignment="center"
+        />
+      </Chart>
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
@@ -7,122 +7,64 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
-import { Axis, BarSeries, Chart, Position, ScaleType, Settings, Tooltip } from '@elastic/charts';
-import { i18n } from '@kbn/i18n';
+import React from 'react';
 import type { ChangePointBurstHistogramProps } from './types';
+import {
+  ChangePointLensEmbeddable,
+  changePointExperienceLensWrapperCss,
+} from './change_point_lens_embeddable';
 
-const CHART_HEIGHT = 300;
+const CHART_MIN_HEIGHT = 300;
 
-const createBurstHistogramTooltip =
-  (theme: { backgroundColor: string; color: string }) =>
-  ({ values }: { values: unknown[] }) => {
-    if (values.length === 0) return null;
-    const count = (values as { value?: number }[]).reduce((s, v) => s + (v.value ?? 0), 0);
-    const label = i18n.translate(
-      'discover.contextAwareness.changePointBurstHistogram.entityCountLabel',
-      {
-        defaultMessage: '{count} {count, plural, one {entity} other {entities}}',
-        values: { count: Math.round(count) },
-      }
-    );
-    return (
-      <div
-        style={{
-          padding: 8,
-          backgroundColor: theme.backgroundColor,
-          color: theme.color,
-          borderRadius: 4,
-        }}
-      >
-        {label}
-      </div>
-    );
-  };
-
+/**
+ * Burst detection timeline as a Lens bar chart (ES|QL): total entity count per time bucket.
+ */
 export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps> = ({
-  data,
-  charts,
+  lens,
+  attributes,
+  abortController,
+  lastReloadRequestTime,
+  searchSessionId,
+  timeRange,
+  onBrushEnd,
+  onFilter,
 }) => {
-  const baseTheme = charts.theme.useChartsBaseTheme();
   const { euiTheme } = useEuiTheme();
+  const wrapperCss = changePointExperienceLensWrapperCss(euiTheme);
 
-  const tooltipOptions = useMemo(
-    () => ({
-      customTooltip: createBurstHistogramTooltip({
-        backgroundColor: euiTheme.colors.darkestShade,
-        color: euiTheme.colors.emptyShade,
-      }),
-    }),
-    [euiTheme.colors.darkestShade, euiTheme.colors.emptyShade]
-  );
-
-  const xAxisTitle = useMemo(
-    () =>
-      i18n.translate('discover.contextAwareness.changePointBurstHistogram.xAxisTitle', {
-        defaultMessage: 'Timeline',
-      }),
-    []
-  );
-
-  const yAxisTitle = useMemo(
-    () =>
-      i18n.translate('discover.contextAwareness.changePointBurstHistogram.yAxisTitle', {
-        defaultMessage: 'Count of Entities',
-      }),
-    []
-  );
+  if (!attributes) {
+    return null;
+  }
 
   return (
     <div
       css={css({
-        minHeight: CHART_HEIGHT,
-        padding: 16,
-        position: 'relative',
+        minHeight: CHART_MIN_HEIGHT,
+        padding: euiTheme.size.m,
+        flex: 1,
+        minWidth: 0,
+        display: 'flex',
+        flexDirection: 'column',
       })}
       data-test-subj="changePointBurstHistogram"
     >
-      <Chart size={{ height: CHART_HEIGHT }}>
-        <Tooltip {...tooltipOptions} />
-        <Settings baseTheme={baseTheme} showLegend={false} locale={i18n.getLocale()} />
-        <Axis
-          id="burst-timeline-axis"
-          position={Position.Bottom}
-          title={xAxisTitle}
-          tickFormat={(d) =>
-            new Date(d).toLocaleString(undefined, {
-              month: 'short',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })
-          }
-          gridLine={{ visible: true }}
-        />
-        <Axis
-          id="burst-entity-count-axis"
-          position={Position.Left}
-          title={yAxisTitle}
-          tickFormat={(d) => String(Math.round(d))}
-          gridLine={{ visible: true }}
-        />
-        <BarSeries
-          id="burst-detection"
-          name={yAxisTitle}
-          xScaleType={ScaleType.Time}
-          yScaleType={ScaleType.Linear}
-          xAccessor="x"
-          yAccessors={['y']}
-          splitSeriesAccessors={['g']}
-          stackAccessors={['g']}
-          color={() => euiTheme.colors.primary}
-          data={data}
-          timeZone="UTC"
-          enableHistogramMode={true}
-        />
-      </Chart>
+      <ChangePointLensEmbeddable
+        lens={lens}
+        attributes={attributes}
+        executionContextDescription="Discover change point burst histogram"
+        id="discover-change-point-burst-lens"
+        abortController={abortController}
+        lastReloadRequestTime={lastReloadRequestTime}
+        searchSessionId={searchSessionId}
+        timeRange={timeRange}
+        onBrushEnd={onBrushEnd}
+        onFilter={onFilter}
+        syncCursor={true}
+        syncTooltips={true}
+        wrapperCss={wrapperCss}
+      />
     </div>
   );
 };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_burst_histogram.tsx
@@ -9,17 +9,55 @@
 
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
-import { Axis, BarSeries, Chart, Position, ScaleType, Settings } from '@elastic/charts';
+import { useEuiTheme } from '@elastic/eui';
+import { Axis, BarSeries, Chart, Position, ScaleType, Settings, Tooltip } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
 import type { ChangePointBurstHistogramProps } from './types';
 
 const CHART_HEIGHT = 300;
+
+const createBurstHistogramTooltip =
+  (theme: { backgroundColor: string; color: string }) =>
+  ({ values }: { values: unknown[] }) => {
+    if (values.length === 0) return null;
+    const count = (values as { value?: number }[]).reduce((s, v) => s + (v.value ?? 0), 0);
+    const label = i18n.translate(
+      'discover.contextAwareness.changePointBurstHistogram.entityCountLabel',
+      {
+        defaultMessage: '{count} {count, plural, one {entity} other {entities}}',
+        values: { count: Math.round(count) },
+      }
+    );
+    return (
+      <div
+        style={{
+          padding: 8,
+          backgroundColor: theme.backgroundColor,
+          color: theme.color,
+          borderRadius: 4,
+        }}
+      >
+        {label}
+      </div>
+    );
+  };
 
 export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps> = ({
   data,
   charts,
 }) => {
   const baseTheme = charts.theme.useChartsBaseTheme();
+  const { euiTheme } = useEuiTheme();
+
+  const tooltipOptions = useMemo(
+    () => ({
+      customTooltip: createBurstHistogramTooltip({
+        backgroundColor: euiTheme.colors.darkestShade,
+        color: euiTheme.colors.emptyShade,
+      }),
+    }),
+    [euiTheme.colors.darkestShade, euiTheme.colors.emptyShade]
+  );
 
   const xAxisTitle = useMemo(
     () =>
@@ -32,7 +70,7 @@ export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps>
   const yAxisTitle = useMemo(
     () =>
       i18n.translate('discover.contextAwareness.changePointBurstHistogram.yAxisTitle', {
-        defaultMessage: 'Entities with change point',
+        defaultMessage: 'Count of Entities',
       }),
     []
   );
@@ -47,12 +85,8 @@ export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps>
       data-test-subj="changePointBurstHistogram"
     >
       <Chart size={{ height: CHART_HEIGHT }}>
-        <Settings
-          baseTheme={baseTheme}
-          showLegend={true}
-          legendPosition={Position.Right}
-          locale={i18n.getLocale()}
-        />
+        <Tooltip {...tooltipOptions} />
+        <Settings baseTheme={baseTheme} showLegend={false} locale={i18n.getLocale()} />
         <Axis
           id="burst-timeline-axis"
           position={Position.Bottom}
@@ -83,10 +117,10 @@ export const ChangePointBurstHistogram: React.FC<ChangePointBurstHistogramProps>
           yAccessors={['y']}
           splitSeriesAccessors={['g']}
           stackAccessors={['g']}
+          color={() => euiTheme.colors.primary}
           data={data}
           timeZone="UTC"
           enableHistogramMode={true}
-          histogramModeAlignment="center"
         />
       </Chart>
     </div>

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_context.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_context.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type { DataSourceContext } from '../../../profiles';
+import type { ContextWithProfileId } from '../../../profile_service';
+import type { ChangePointLensFetchSlice } from './change_point_lens_embeddable';
+
+export const CHANGE_POINT_DATA_SOURCE_PROFILE_ID = 'change-point-data-source-profile';
+
+/**
+ * Lens chart data for the change point document tab, keyed by {@link DataTableRecord.id}
+ * (ES|QL rows use String(rowIndex)).
+ */
+export interface ChangePointLensDocContext {
+  lensAttributesByRecordId: Record<string, TypedLensByValueInput['attributes']>;
+  fetchSlice: ChangePointLensFetchSlice;
+}
+
+export interface ChangePointLensDataSourceContext {
+  changePointLensContext$: BehaviorSubject<ChangePointLensDocContext | undefined>;
+}
+
+export const isChangePointDataSourceContext = (
+  dataSourceContext: ContextWithProfileId<DataSourceContext>
+): dataSourceContext is ContextWithProfileId<
+  DataSourceContext & ChangePointLensDataSourceContext
+> =>
+  dataSourceContext.profileId === CHANGE_POINT_DATA_SOURCE_PROFILE_ID &&
+  'changePointLensContext$' in dataSourceContext &&
+  (dataSourceContext as DataSourceContext & ChangePointLensDataSourceContext)
+    .changePointLensContext$ instanceof BehaviorSubject;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
@@ -1,0 +1,916 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingChart,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { isOfAggregateQueryType } from '@kbn/es-query';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import { ChartType, getLensAttributesFromSuggestion } from '@kbn/visualization-utils';
+import {
+  getSourceQueryBeforeChangePoint,
+  getSourceQueriesFromForkWithChangePoint,
+  getChangePointOutputColumnNames,
+  getESQLQueryColumns,
+} from '@kbn/esql-utils';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import { ChangePointBurstHistogram } from './change_point_burst_histogram';
+import { ChangePointForkHeatmap } from './change_point_fork_heatmap';
+import {
+  applyLineChartStyleToDataLayers,
+  deriveEntityAttributes,
+  formatChangePointAnnotationLabel,
+  getBurstDetectionHistogram,
+  getChangePointResultsFromTable,
+  getTimeColumnId,
+  getValueColumnId,
+} from './helpers';
+import { CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID, FORK_COLUMN_ID } from './constants';
+import type { ChangePointResult, ChangePointExperienceViewProps, DataLayerLike } from './types';
+
+/**
+ * Custom chart section view shown when the ES|QL query contains CHANGE_POINT.
+ * Containes multiple view modes including line charts of the source data with change point annotations,
+ * similar to the AIOps change point detection UI.
+ */
+export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps> = ({
+  histogramCss,
+  chartToolbarCss,
+  renderToggleActions,
+  isComponentVisible,
+  fetchParams,
+  services,
+  onBrushEnd,
+  onFilter,
+}) => {
+  const { data, lens } = services;
+  const { charts } = useDiscoverServices();
+  const { euiTheme } = useEuiTheme();
+  const [lensAttributes, setLensAttributes] = useState<TypedLensByValueInput['attributes'] | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const columns = useMemo(
+    () =>
+      fetchParams.columns ?? (fetchParams.columnsMap ? Object.values(fetchParams.columnsMap) : []),
+    [fetchParams.columns, fetchParams.columnsMap]
+  );
+
+  // The bridge between the ES|QL CHANGE_POINT output and the table columns used for charts and heatmaps
+  const changePointColumnNames = useMemo(() => {
+    const query = fetchParams.query as { esql?: string } | undefined;
+    return query?.esql ? getChangePointOutputColumnNames(query.esql) : undefined;
+  }, [fetchParams.query]);
+
+  const sourceQuery = useMemo(() => {
+    const query = fetchParams.query as { esql?: string } | undefined;
+    return query?.esql ? getSourceQueryBeforeChangePoint(query.esql) : undefined;
+  }, [fetchParams.query]);
+
+  // The array of source queries for each fork branch
+  const forkBranchQueries = useMemo(() => {
+    const query = fetchParams.query as { esql?: string } | undefined;
+    return query?.esql ? getSourceQueriesFromForkWithChangePoint(query.esql) : undefined;
+  }, [fetchParams.query]);
+
+  const multipleEntityMode = Boolean(forkBranchQueries?.length);
+
+  const [viewMode, setViewMode] = useState<
+    'heatmap' | 'line' | 'multiple-line' | 'burst-detection'
+  >('multiple-line');
+  const [selectedEntityIndices, setSelectedEntityIndices] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (forkBranchQueries && selectedEntityIndices.length > 0) {
+      const valid = selectedEntityIndices.filter((i) => i < forkBranchQueries.length);
+      if (valid.length !== selectedEntityIndices.length) {
+        setSelectedEntityIndices(valid);
+      }
+    }
+  }, [selectedEntityIndices, forkBranchQueries]);
+
+  const sourceColumns = useMemo(() => {
+    if (!changePointColumnNames) return columns;
+    return columns.filter(
+      (c) =>
+        c.id !== changePointColumnNames.typeColumn && c.id !== changePointColumnNames.pvalueColumn
+    );
+  }, [columns, changePointColumnNames]);
+
+  const heatmapResults = useMemo((): ChangePointResult[] => {
+    const table = fetchParams.table;
+    if (!table?.rows?.length || !multipleEntityMode || !forkBranchQueries?.length) return [];
+    const colsToUse = table.columns?.length ? table.columns : columns;
+    const timeColumnId = getTimeColumnId(colsToUse);
+    const typeColumnId = changePointColumnNames?.typeColumn;
+    const pvalueColumnId = changePointColumnNames?.pvalueColumn;
+    const valueColumnId = timeColumnId
+      ? getValueColumnId(colsToUse, timeColumnId, typeColumnId, pvalueColumnId)
+      : undefined;
+    if (!timeColumnId || !valueColumnId) return [];
+    return getChangePointResultsFromTable(
+      table,
+      timeColumnId,
+      typeColumnId,
+      pvalueColumnId,
+      valueColumnId,
+      FORK_COLUMN_ID,
+      forkBranchQueries
+    );
+  }, [fetchParams.table, multipleEntityMode, forkBranchQueries, columns, changePointColumnNames]);
+
+  const entityLabels = useMemo(
+    () => forkBranchQueries?.map((b) => b.branchLabel) ?? [],
+    [forkBranchQueries]
+  );
+
+  const burstDetectionHistogramData = useMemo(() => {
+    if (!multipleEntityMode || !forkBranchQueries?.length || heatmapResults.length === 0) return [];
+    return getBurstDetectionHistogram(heatmapResults, entityLabels, fetchParams.timeRange);
+  }, [heatmapResults, forkBranchQueries, multipleEntityMode, entityLabels, fetchParams.timeRange]);
+
+  const entityAttributesMap = useMemo(() => {
+    if (!lensAttributes || !multipleEntityMode || !forkBranchQueries) return {};
+    const dataViewId = fetchParams.dataView?.id ?? '';
+    const forkLineColors = [
+      euiTheme.colors.borderBaseProminent,
+      euiTheme.colors.primary,
+      euiTheme.colors.accent,
+      euiTheme.colors.success,
+      euiTheme.colors.warning,
+    ];
+    const map: Record<number, TypedLensByValueInput['attributes']> = {};
+    for (let i = 0; i < forkBranchQueries.length; i++) {
+      const entityResults = heatmapResults.filter(
+        (r) => r.forkIndex === i || r.forkIndex === forkBranchQueries[i].branchIndex
+      );
+      const attrs = deriveEntityAttributes(
+        lensAttributes,
+        i,
+        entityResults,
+        forkBranchQueries[i].branchLabel,
+        dataViewId,
+        forkLineColors
+      );
+      if (attrs) map[i] = attrs;
+    }
+    return map;
+  }, [
+    lensAttributes,
+    multipleEntityMode,
+    forkBranchQueries,
+    heatmapResults,
+    fetchParams.dataView?.id,
+    euiTheme.colors,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+
+    // Creates Lens attributes for a line chart of the source data with change point annotations, then stores them in lensAttributes via setLensAttributes
+    const loadXYAttributes = async () => {
+      if (
+        !fetchParams.isESQLQuery ||
+        !isOfAggregateQueryType(fetchParams.query) ||
+        !fetchParams.dataView
+      ) {
+        setLensAttributes(null);
+        setIsLoading(false);
+        return;
+      }
+
+      const forkBranches = forkBranchQueries;
+      const isForkMode = Boolean(forkBranches?.length);
+      const effectiveSourceQuery = isForkMode ? forkBranches?.[0]?.sourceQuery : sourceQuery;
+
+      if (!effectiveSourceQuery && !isForkMode) {
+        setLensAttributes(null);
+        setError('Could not derive source query for change point');
+        setIsLoading(false);
+        return;
+      }
+
+      if (!isForkMode && !sourceColumns.length) {
+        setLensAttributes(null);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const stateHelper = await lens.stateHelperApi();
+        const dataViewSpec = fetchParams.dataView.toSpec();
+        const timeRange = fetchParams.timeRange;
+
+        let attributes: TypedLensByValueInput['attributes'];
+
+        if (isForkMode && forkBranches) {
+          const branchColumns = await Promise.all(
+            forkBranches.map((branch) =>
+              getESQLQueryColumns({
+                esqlQuery: branch.sourceQuery,
+                search: data.search.search,
+                signal: fetchParams.abortController?.signal,
+                timeRange: timeRange
+                  ? { from: timeRange.from, to: timeRange.to }
+                  : data.query.timefilter.timefilter.getAbsoluteTime(),
+              })
+            )
+          );
+
+          if (cancelled) return;
+
+          const validBranches = forkBranches
+            .map((branch, i) => ({ branch, cols: branchColumns[i] }))
+            .filter((b) => b.cols?.length);
+          if (!validBranches.length) {
+            setLensAttributes(null);
+            setError('Could not get columns for fork branches');
+            setIsLoading(false);
+            return;
+          }
+
+          const firstBranch = validBranches[0];
+          const context = {
+            dataViewSpec,
+            fieldName: '',
+            textBasedColumns: firstBranch.cols,
+            query: { esql: firstBranch.branch.sourceQuery },
+          };
+          const suggestions = stateHelper.suggestions(
+            context,
+            fetchParams.dataView,
+            [],
+            ChartType.XY,
+            undefined
+          );
+          if (cancelled) return;
+          if (!suggestions?.length) {
+            setLensAttributes(null);
+            setError('No XY chart suggestion for fork source data');
+            setIsLoading(false);
+            return;
+          }
+
+          const firstSuggestion = suggestions[0];
+
+          const datasourceLayers: Record<
+            string,
+            { index: string; query: { esql: string }; columns: unknown[]; timeField?: string }
+          > = {};
+          const visDataLayers: DataLayerLike[] = [];
+          const forkLineColors = [
+            euiTheme.colors.borderBaseProminent,
+            euiTheme.colors.primary,
+            euiTheme.colors.accent,
+            euiTheme.colors.success,
+            euiTheme.colors.warning,
+          ];
+
+          validBranches.forEach(({ branch, cols: branchCols }) => {
+            const layerId = `fork-branch-${branch.branchIndex}`;
+            const timeCol = branchCols.find(
+              (c) =>
+                c.meta?.type === 'date' ||
+                (typeof c.meta?.type === 'string' && c.meta.type.startsWith('date'))
+            );
+            const valueCol =
+              branchCols.find((c) => c.id !== timeCol?.id && c.meta?.type === 'number') ??
+              branchCols.find((c) => c.id !== timeCol?.id);
+            if (!timeCol || !valueCol) return;
+
+            const entityLabel = branch.branchLabel;
+            const valueColumnId = `${layerId}-${valueCol.id}`;
+            const textBasedColumns = branchCols.map((c) => {
+              const isValueCol = c.id === valueCol.id;
+              return {
+                columnId: isValueCol ? valueColumnId : c.id,
+                fieldName: c.id,
+                label: isValueCol ? entityLabel : c.name,
+                meta: c.meta,
+                ...(isValueCol ? { customLabel: true } : {}),
+              };
+            });
+            datasourceLayers[layerId] = {
+              index: fetchParams.dataView.id ?? dataViewSpec.id ?? '',
+              query: { esql: branch.sourceQuery },
+              columns: textBasedColumns,
+              timeField: dataViewSpec.timeFieldName,
+            };
+            const color = forkLineColors[branch.branchIndex % forkLineColors.length];
+            visDataLayers.push({
+              layerId,
+              layerType: 'data',
+              seriesType: 'line',
+              xAccessor: timeCol.id,
+              accessors: [valueColumnId],
+              yConfig: [{ forAccessor: valueColumnId, color }],
+            });
+          });
+
+          const forkSuggestion = {
+            ...firstSuggestion,
+            datasourceState: {
+              ...(firstSuggestion.datasourceState ?? {}),
+              layers: datasourceLayers,
+              indexPatternRefs: [
+                {
+                  id: fetchParams.dataView.id ?? dataViewSpec.id ?? '',
+                  title: dataViewSpec.title ?? '',
+                  timeField: dataViewSpec.timeFieldName,
+                },
+              ],
+            },
+            visualizationState: {
+              ...(firstSuggestion.visualizationState ?? {}),
+              layers: visDataLayers,
+              preferredSeriesType: 'line',
+            },
+          };
+          attributes = getLensAttributesFromSuggestion({
+            filters: fetchParams.filters ?? [],
+            query: fetchParams.query as { esql: string },
+            suggestion: forkSuggestion,
+            dataView: fetchParams.dataView,
+          }) as TypedLensByValueInput['attributes'];
+        } else {
+          if (!sourceQuery) {
+            setLensAttributes(null);
+            setIsLoading(false);
+            return;
+          }
+          const singleSourceQuery = sourceQuery;
+          const context = {
+            dataViewSpec,
+            fieldName: '',
+            textBasedColumns: sourceColumns,
+            query: { esql: singleSourceQuery },
+          };
+
+          const suggestions = stateHelper.suggestions(
+            context,
+            fetchParams.dataView,
+            [],
+            ChartType.XY,
+            undefined
+          );
+
+          if (cancelled) return;
+          if (!suggestions?.length) {
+            setLensAttributes(null);
+            setError('No XY chart suggestion for source data');
+            setIsLoading(false);
+            return;
+          }
+
+          attributes = getLensAttributesFromSuggestion({
+            filters: fetchParams.filters ?? [],
+            query: { esql: singleSourceQuery },
+            suggestion: suggestions[0],
+            dataView: fetchParams.dataView,
+          }) as TypedLensByValueInput['attributes'];
+
+          const visStateForLine = attributes?.state?.visualization as
+            | { layers?: DataLayerLike[]; preferredSeriesType?: string }
+            | undefined;
+          if (visStateForLine?.layers?.length) {
+            const lineLayers = applyLineChartStyleToDataLayers(
+              visStateForLine.layers,
+              euiTheme.colors.borderBaseProminent
+            );
+            attributes = {
+              ...attributes,
+              state: {
+                ...attributes.state,
+                visualization: {
+                  ...visStateForLine,
+                  preferredSeriesType: 'line',
+                  layers: lineLayers,
+                },
+              } as TypedLensByValueInput['attributes']['state'],
+            };
+          }
+        }
+
+        const table = fetchParams.table;
+        const timeColumnId = changePointColumnNames ? getTimeColumnId(columns) : undefined;
+        const typeColumnId = changePointColumnNames?.typeColumn;
+        const pvalueColumnId = changePointColumnNames?.pvalueColumn;
+        const valueColumnId = timeColumnId
+          ? getValueColumnId(columns, timeColumnId, typeColumnId, pvalueColumnId)
+          : undefined;
+        const forkColumnId = isForkMode ? FORK_COLUMN_ID : undefined;
+
+        const visState = attributes?.state?.visualization as
+          | { layers?: Array<{ layerId: string }> }
+          | undefined;
+        if (table?.rows?.length && timeColumnId && valueColumnId && visState?.layers) {
+          const results = getChangePointResultsFromTable(
+            table,
+            timeColumnId,
+            typeColumnId,
+            pvalueColumnId,
+            valueColumnId,
+            forkColumnId,
+            forkBranches
+          );
+          // Add change point annotations over the line chart (like AIOps)
+          if (results.length > 0) {
+            const forkLineColors = [
+              euiTheme.colors.borderBaseProminent,
+              euiTheme.colors.primary,
+              euiTheme.colors.accent,
+              euiTheme.colors.success,
+              euiTheme.colors.warning,
+            ];
+
+            let annotationLayers: DataLayerLike[] = [];
+
+            const hasForkIndex = results.some((r) => r.forkIndex !== undefined);
+            if (isForkMode && forkBranches && hasForkIndex) {
+              forkBranches.forEach((branch, branchIdx) => {
+                const branchResults = results.filter(
+                  (r) => r.forkIndex === branch.branchIndex || r.forkIndex === branchIdx
+                );
+                if (branchResults.length === 0) return;
+                const color = forkLineColors[branchIdx % forkLineColors.length];
+                const annotations = branchResults.map((r, idx) => ({
+                  id: `change-point-annotation-b${branchIdx}-${idx}`,
+                  type: 'manual' as const,
+                  icon: 'triangle' as const,
+                  textVisibility: true,
+                  label: formatChangePointAnnotationLabel(
+                    r.type,
+                    r.pvalue ?? null,
+                    branch.branchLabel
+                  ),
+                  key: { type: 'point_in_time' as const, timestamp: r.timestamp },
+                  isHidden: false,
+                  color,
+                  lineStyle: 'solid' as const,
+                  lineWidth: 1,
+                  outside: false,
+                }));
+                annotationLayers.push({
+                  layerId: `${CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID}-branch-${branchIdx}`,
+                  layerType: 'annotations' as const,
+                  indexPatternId: fetchParams.dataView.id ?? '',
+                  annotations,
+                  ignoreGlobalFilters: true,
+                } as DataLayerLike);
+              });
+            } else {
+              const entityName =
+                table.columns.find((c) => c.id === valueColumnId || c.name === valueColumnId)
+                  ?.name ?? valueColumnId;
+              const annotations = results.map((r, idx) => ({
+                id: `change-point-annotation-${idx}`,
+                type: 'manual' as const,
+                icon: 'triangle' as const,
+                textVisibility: true,
+                label: formatChangePointAnnotationLabel(r.type, r.pvalue ?? null, entityName),
+                key: { type: 'point_in_time' as const, timestamp: r.timestamp },
+                isHidden: false,
+                color: euiTheme.colors.danger,
+                lineStyle: 'solid' as const,
+                lineWidth: 1,
+                outside: false,
+              }));
+              annotationLayers = [
+                {
+                  layerId: CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID,
+                  layerType: 'annotations' as const,
+                  indexPatternId: fetchParams.dataView.id ?? '',
+                  annotations,
+                  ignoreGlobalFilters: true,
+                } as DataLayerLike,
+              ];
+            }
+
+            if (annotationLayers.length > 0) {
+              const visWithLayers = attributes.state?.visualization as {
+                layers?: DataLayerLike[];
+                [key: string]: unknown;
+              };
+              const newLayers = [...(visWithLayers?.layers ?? []), ...annotationLayers];
+
+              attributes = {
+                ...attributes,
+                state: {
+                  ...attributes.state,
+                  visualization: {
+                    ...visWithLayers,
+                    layers: newLayers,
+                  },
+                } as TypedLensByValueInput['attributes']['state'],
+              };
+            }
+          }
+        }
+
+        setLensAttributes(attributes);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load chart');
+          setLensAttributes(null);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    loadXYAttributes();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    fetchParams.query,
+    fetchParams.dataView,
+    fetchParams.isESQLQuery,
+    fetchParams.filters,
+    fetchParams.table,
+    fetchParams.timeRange,
+    fetchParams.abortController,
+    sourceQuery,
+    sourceColumns,
+    forkBranchQueries,
+    columns,
+    changePointColumnNames,
+    lens,
+    data.search,
+    data.query.timefilter.timefilter,
+    euiTheme,
+  ]);
+
+  const handleBrushEnd = useCallback(
+    (event: Parameters<NonNullable<typeof onBrushEnd>>[0]) => {
+      event.preventDefault();
+      if (onBrushEnd) {
+        onBrushEnd(event);
+      } else if (event.range?.length >= 2) {
+        const [min, max] = event.range;
+        data.query.timefilter.timefilter.setTime({
+          from: new Date(min).toISOString(),
+          to: new Date(max).toISOString(),
+          mode: 'absolute',
+        });
+      }
+    },
+    [onBrushEnd, data.query.timefilter.timefilter]
+  );
+
+  if (!isComponentVisible) {
+    return null;
+  }
+
+  const chartCss = css({
+    flex: 1,
+    marginBlock: euiTheme.size.xs,
+    minHeight: 350,
+    position: 'relative',
+    '& > div': {
+      height: '100%',
+      position: 'absolute',
+      width: '100%',
+    },
+  });
+
+  const showHeatmap =
+    lensAttributes && !error && !isLoading && multipleEntityMode && viewMode === 'heatmap';
+  const showLineChart =
+    lensAttributes &&
+    !error &&
+    !isLoading &&
+    (!multipleEntityMode || (forkBranchQueries?.length === 1 && viewMode === 'line'));
+  const showMultipleLineCharts =
+    lensAttributes &&
+    !error &&
+    !isLoading &&
+    multipleEntityMode &&
+    viewMode === 'multiple-line' &&
+    forkBranchQueries &&
+    forkBranchQueries.length > 0;
+
+  const showBurstDetectionHistogram =
+    !error &&
+    !isLoading &&
+    multipleEntityMode &&
+    viewMode === 'burst-detection' &&
+    forkBranchQueries &&
+    forkBranchQueries.length > 0 &&
+    burstDetectionHistogramData.length > 0;
+
+  const renderChartContent = () => {
+    if (showHeatmap) {
+      return (
+        <ChangePointForkHeatmap
+          results={heatmapResults}
+          forkBranches={forkBranchQueries ?? []}
+          selectedEntityIndices={selectedEntityIndices}
+          onSelectEntity={setSelectedEntityIndices}
+          timeRange={fetchParams.timeRange}
+          charts={charts}
+          renderEntityDetailChart={(entityIndex) => {
+            const attrs = entityAttributesMap[entityIndex];
+            if (!attrs) return null;
+            return (
+              <div
+                css={css({
+                  minHeight: 200,
+                  height: '100%',
+                  position: 'relative',
+                  '& > div': { height: '100%', position: 'absolute', width: '100%' },
+                })}
+                data-test-subj="changePointEntityDetailChart"
+              >
+                <lens.EmbeddableComponent
+                  abortController={fetchParams.abortController}
+                  attributes={attrs}
+                  executionContext={{ description: 'Discover change point entity detail' }}
+                  id={`discover-change-point-entity-${entityIndex}`}
+                  lastReloadRequestTime={fetchParams.lastReloadRequestTime}
+                  noPadding={true}
+                  onBrushEnd={handleBrushEnd}
+                  onFilter={onFilter}
+                  searchSessionId={fetchParams.searchSessionId}
+                  syncCursor={true}
+                  syncTooltips={true}
+                  timeRange={fetchParams.timeRange}
+                  viewMode="view"
+                />
+              </div>
+            );
+          }}
+        />
+      );
+    }
+    if (showLineChart) {
+      return (
+        <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
+          <EuiFlexItem grow css={css({ minHeight: 0 })}>
+            <div css={chartCss} data-test-subj="changePointExperienceLensLineChart">
+              <lens.EmbeddableComponent
+                abortController={fetchParams.abortController}
+                attributes={lensAttributes}
+                executionContext={{ description: 'Discover change point chart' }}
+                id="discover-change-point-lens"
+                lastReloadRequestTime={fetchParams.lastReloadRequestTime}
+                noPadding={true}
+                onBrushEnd={handleBrushEnd}
+                onFilter={onFilter}
+                searchSessionId={fetchParams.searchSessionId}
+                timeRange={fetchParams.timeRange}
+                viewMode="view"
+              />
+            </div>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    }
+    if (showMultipleLineCharts) {
+      return (
+        <>
+          <EuiSpacer size="xs" />
+          <EuiFlexGrid columns={3} css={css({ flex: 1, minHeight: 0 })}>
+            {forkBranchQueries!.map((branch, entityIdx) => {
+              const attrs = entityAttributesMap[entityIdx];
+              if (!attrs) return null;
+              const entityLabel = branch.branchLabel;
+              return (
+                <EuiFlexItem
+                  key={entityLabel}
+                  css={css({
+                    minHeight: 220,
+                    minWidth: 0,
+                  })}
+                >
+                  <EuiPanel
+                    paddingSize="xs"
+                    hasBorder
+                    hasShadow={false}
+                    css={css({
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      overflow: 'hidden',
+                    })}
+                    data-test-subj={`changePointMultipleLineChart-${entityLabel}`}
+                  >
+                    <EuiFlexGroup
+                      direction="column"
+                      gutterSize="xs"
+                      css={css({ flex: 1, minHeight: 0 })}
+                    >
+                      <EuiFlexItem grow={false}>
+                        <EuiText
+                          size="xs"
+                          css={css({
+                            fontWeight: 600,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          })}
+                          title={entityLabel}
+                        >
+                          {entityLabel}
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow
+                        css={css({
+                          minHeight: 0,
+                          overflow: 'hidden',
+                        })}
+                      >
+                        <div
+                          css={css({
+                            minHeight: 200,
+                            height: '100%',
+                            position: 'relative',
+                            '& > div': {
+                              height: '100%',
+                              position: 'absolute',
+                              width: '100%',
+                            },
+                          })}
+                        >
+                          <lens.EmbeddableComponent
+                            abortController={fetchParams.abortController}
+                            attributes={attrs}
+                            executionContext={{ description: 'Discover change point entity chart' }}
+                            id={`discover-change-point-multiple-entity-${entityLabel}`}
+                            lastReloadRequestTime={fetchParams.lastReloadRequestTime}
+                            noPadding={true}
+                            onBrushEnd={handleBrushEnd}
+                            onFilter={onFilter}
+                            searchSessionId={fetchParams.searchSessionId}
+                            syncCursor={true}
+                            syncTooltips={true}
+                            timeRange={fetchParams.timeRange}
+                            viewMode="view"
+                          />
+                        </div>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiPanel>
+                </EuiFlexItem>
+              );
+            })}
+          </EuiFlexGrid>
+        </>
+      );
+    }
+    if (showBurstDetectionHistogram) {
+      return (
+        <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
+          <EuiFlexItem grow css={css({ minHeight: 0 })}>
+            <div css={chartCss} data-test-subj="changePointBurstHistogramContainer">
+              <ChangePointBurstHistogram data={burstDetectionHistogramData} charts={charts} />
+            </div>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    }
+    return (
+      <EuiFlexGroup
+        alignItems="center"
+        css={css({ minHeight: 350, height: '100%' })}
+        justifyContent="center"
+      >
+        <EuiFlexItem grow={false}>
+          <EuiText color="subdued" size="s">
+            <FormattedMessage
+              id="discover.contextAwareness.changePointExperience.chartNotAvailableMessage"
+              defaultMessage="Chart not available for this query"
+            />
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
+
+  return (
+    <div
+      css={[
+        histogramCss,
+        css({
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+          paddingLeft: euiTheme.size.m,
+          paddingRight: euiTheme.size.m,
+        }),
+      ]}
+      data-test-subj="changePointExperienceView"
+    >
+      {chartToolbarCss ? (
+        <div css={chartToolbarCss} className="eui-xScroll">
+          <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
+            <EuiFlexItem grow={false}>{renderToggleActions?.()}</EuiFlexItem>
+            {multipleEntityMode && (
+              <EuiFlexItem grow={false}>
+                <EuiSelect
+                  compressed
+                  value={viewMode}
+                  onChange={(e) =>
+                    setViewMode(
+                      e.target.value as 'heatmap' | 'line' | 'multiple-line' | 'burst-detection'
+                    )
+                  }
+                  aria-label={i18n.translate(
+                    'discover.contextAwareness.changePointExperience.viewModeLabel',
+                    { defaultMessage: 'Chart view mode' }
+                  )}
+                  options={[
+                    {
+                      value: 'heatmap',
+                      text: i18n.translate(
+                        'discover.contextAwareness.changePointExperience.viewHeatmap',
+                        { defaultMessage: 'Heatmap' }
+                      ),
+                    },
+                    ...(forkBranchQueries && forkBranchQueries.length === 1
+                      ? [
+                          {
+                            value: 'line' as const,
+                            text: i18n.translate(
+                              'discover.contextAwareness.changePointExperience.viewLineChart',
+                              { defaultMessage: 'Line chart' }
+                            ),
+                          },
+                        ]
+                      : []),
+                    {
+                      value: 'multiple-line',
+                      text: i18n.translate(
+                        'discover.contextAwareness.changePointExperience.viewMultipleLineCharts',
+                        { defaultMessage: 'Multiple line charts' }
+                      ),
+                    },
+                    {
+                      value: 'burst-detection',
+                      text: i18n.translate(
+                        'discover.contextAwareness.changePointExperience.viewBurstDetection',
+                        { defaultMessage: 'Burst Detection Histogram' }
+                      ),
+                    },
+                  ]}
+                  data-test-subj="changePointViewModeSelect"
+                />
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </div>
+      ) : null}
+      <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
+        <EuiFlexItem grow css={css({ minHeight: 0, overflowY: 'auto' })}>
+          {isLoading ? (
+            <EuiFlexGroup
+              alignItems="center"
+              css={css({ minHeight: 350, height: '100%' })}
+              justifyContent="center"
+            >
+              <EuiFlexItem grow={false}>
+                <EuiLoadingChart size="l" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : null}
+          {error ? (
+            <EuiFlexGroup
+              alignItems="center"
+              css={css({ minHeight: 350, height: '100%' })}
+              justifyContent="center"
+            >
+              <EuiFlexItem grow={false}>
+                <EuiText color="subdued" size="s">
+                  {error}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : null}
+          {renderChartContent()}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
@@ -10,6 +10,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { EuiFlexGroup, EuiFlexItem, EuiLoadingChart, EuiText, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
@@ -35,12 +36,18 @@ import {
   buildChangePointLensAttributesByRecordId,
   deriveEntityAttributes,
   formatChangePointAnnotationLabel,
-  getBurstDetectionHistogram,
+  getBestIntervalFromResults,
   getChangePointColumnIdsFromColumns,
   getChangePointResultsFromTable,
+  getForkColumnMetaForChangePointTable,
   getTimeColumnId,
   getValueColumnId,
 } from './helpers';
+import {
+  applyBurstBarChartAggregateOnlyToLensAttributes,
+  buildChangePointBurstBarAggregateEsqlUnsplit,
+  resolveEsqlResultColumnId,
+} from './change_point_lens_esql';
 import { CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID, FORK_COLUMN_ID } from './constants';
 import type { ChangePointResult, ChangePointExperienceViewProps, DataLayerLike } from './types';
 
@@ -66,6 +73,9 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
   const [lensAttributes, setLensAttributes] = useState<TypedLensByValueInput['attributes'] | null>(
     null
   );
+  const [burstLensAttributes, setBurstLensAttributes] = useState<
+    TypedLensByValueInput['attributes'] | null
+  >(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const columns = useMemo(
@@ -141,16 +151,6 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
       forkBranchLabels
     );
   }, [fetchParams.table, multipleEntityMode, forkBranchLabels, colsToUse, changePointColumnIds]);
-
-  const entityLabels = useMemo(
-    () => forkBranchLabels?.map((b) => b.branchLabel) ?? [],
-    [forkBranchLabels]
-  );
-
-  const burstDetectionHistogramData = useMemo(() => {
-    if (!multipleEntityMode || !forkBranchLabels?.length || heatmapResults.length === 0) return [];
-    return getBurstDetectionHistogram(heatmapResults, entityLabels, fetchParams.timeRange);
-  }, [heatmapResults, forkBranchLabels, multipleEntityMode, entityLabels, fetchParams.timeRange]);
 
   const entityAttributesMap = useMemo(() => {
     if (!lensAttributes || !multipleEntityMode || !forkBranchLabels) return {};
@@ -243,6 +243,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         !fetchParams.dataView
       ) {
         setLensAttributes(null);
+        setBurstLensAttributes(null);
         setIsLoading(false);
         return;
       }
@@ -252,6 +253,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
 
       if (!effectiveSourceQuery && !isForkMode) {
         setLensAttributes(null);
+        setBurstLensAttributes(null);
         setError('Could not derive source query for change point');
         setIsLoading(false);
         return;
@@ -259,6 +261,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
 
       if (!isForkMode && !sourceColumns.length) {
         setLensAttributes(null);
+        setBurstLensAttributes(null);
         setIsLoading(false);
         return;
       }
@@ -269,6 +272,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         const timeRange = fetchParams.timeRange;
 
         let attributes: TypedLensByValueInput['attributes'];
+        let burstAttrs: TypedLensByValueInput['attributes'] | null = null;
 
         if (isForkMode && forkBranchLabels) {
           const forkTable = fetchParams.table;
@@ -340,6 +344,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             : [];
           if (!validEntities.length) {
             setLensAttributes(null);
+            setBurstLensAttributes(null);
             setError('Could not get columns for fork branches');
             setIsLoading(false);
             return;
@@ -362,6 +367,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
           if (cancelled) return;
           if (!suggestions?.length) {
             setLensAttributes(null);
+            setBurstLensAttributes(null);
             setError('No XY chart suggestion for fork source data');
             setIsLoading(false);
             return;
@@ -448,9 +454,85 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             suggestion: forkSuggestion,
             dataView: fetchParams.dataView,
           }) as TypedLensByValueInput['attributes'];
+
+          const fullEsqlCandidate =
+            isOfAggregateQueryType(fetchParams.query) &&
+            (fetchParams.query as { esql?: string }).esql?.trim();
+          const fullEsqlForBurst = typeof fullEsqlCandidate === 'string' ? fullEsqlCandidate : '';
+          if (
+            fullEsqlForBurst &&
+            forkTimeColumnId &&
+            forkPvalueColumnId &&
+            forkTable?.columns?.length &&
+            !cancelled
+          ) {
+            const forkMeta = getForkColumnMetaForChangePointTable(
+              forkTable,
+              FORK_COLUMN_ID,
+              forkBranchLabels
+            );
+            const aggInterval = getBestIntervalFromResults(changePointResults);
+            const burstEsql = buildChangePointBurstBarAggregateEsqlUnsplit({
+              changePointQueryEsql: fullEsqlForBurst,
+              timeColumnId: forkTimeColumnId,
+              pvalueColumnId: forkPvalueColumnId,
+              interval: aggInterval,
+              meta: forkMeta,
+              forkBranches: forkBranchLabels,
+            });
+            const absoluteTimeRange = timeRange
+              ? { from: timeRange.from, to: timeRange.to }
+              : data.query.timefilter.timefilter.getAbsoluteTime();
+
+            if (burstEsql && !cancelled) {
+              const burstColumns = await getESQLQueryColumns({
+                esqlQuery: burstEsql,
+                search: data.search.search,
+                signal: fetchParams.abortController?.signal,
+                timeRange: absoluteTimeRange,
+              });
+              if (!cancelled && burstColumns?.length) {
+                const burstContext = {
+                  dataViewSpec,
+                  fieldName: '',
+                  textBasedColumns: burstColumns,
+                  query: { esql: burstEsql },
+                };
+                const burstSuggestions = stateHelper.suggestions(
+                  burstContext,
+                  fetchParams.dataView,
+                  [],
+                  ChartType.XY,
+                  undefined
+                );
+                if (burstSuggestions?.length) {
+                  const burstAttrsRaw = getLensAttributesFromSuggestion({
+                    filters: fetchParams.filters ?? [],
+                    query: { esql: burstEsql },
+                    suggestion: burstSuggestions[0],
+                    dataView: fetchParams.dataView,
+                  }) as TypedLensByValueInput['attributes'];
+                  const xId = resolveEsqlResultColumnId(burstColumns, 'cp_tb');
+                  const yId = resolveEsqlResultColumnId(burstColumns, 'cp_cnt');
+                  burstAttrs = applyBurstBarChartAggregateOnlyToLensAttributes(
+                    burstAttrsRaw,
+                    xId,
+                    yId,
+                    {
+                      yTitle: i18n.translate(
+                        'discover.contextAwareness.changePointBurstHistogram.yAxisTitle',
+                        { defaultMessage: 'Number of entities' }
+                      ),
+                    }
+                  );
+                }
+              }
+            }
+          }
         } else {
           if (!sourceQuery) {
             setLensAttributes(null);
+            setBurstLensAttributes(null);
             setIsLoading(false);
             return;
           }
@@ -473,6 +555,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
           if (cancelled) return;
           if (!suggestions?.length) {
             setLensAttributes(null);
+            setBurstLensAttributes(null);
             setError('No XY chart suggestion for source data');
             setIsLoading(false);
             return;
@@ -622,11 +705,13 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
           }
         }
 
+        setBurstLensAttributes(burstAttrs);
         setLensAttributes(attributes);
       } catch (e) {
         if (!cancelled) {
           setError(e instanceof Error ? e.message : 'Failed to load chart');
           setLensAttributes(null);
+          setBurstLensAttributes(null);
         }
       } finally {
         if (!cancelled) setIsLoading(false);
@@ -708,7 +793,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
     viewMode === 'burst-detection' &&
     forkBranchLabels &&
     forkBranchLabels.length > 0 &&
-    burstDetectionHistogramData.length > 0;
+    Boolean(burstLensAttributes);
 
   const renderChartContent = () => {
     if (showHeatmap) {
@@ -769,7 +854,16 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
           <EuiFlexItem grow css={css({ minHeight: 0 })}>
             <div css={chartCss} data-test-subj="changePointBurstHistogramContainer">
-              <ChangePointBurstHistogram data={burstDetectionHistogramData} charts={charts} />
+              <ChangePointBurstHistogram
+                lens={lens}
+                attributes={burstLensAttributes}
+                abortController={fetchParams.abortController}
+                lastReloadRequestTime={fetchParams.lastReloadRequestTime}
+                searchSessionId={fetchParams.searchSessionId}
+                timeRange={fetchParams.timeRange}
+                onBrushEnd={handleBrushEnd}
+                onFilter={onFilter}
+              />
             </div>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_experience_view.tsx
@@ -9,36 +9,34 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
-import {
-  EuiFlexGrid,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLoadingChart,
-  EuiPanel,
-  EuiSelect,
-  EuiSpacer,
-  EuiText,
-  useEuiTheme,
-} from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingChart, EuiText, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
 import { ChartType, getLensAttributesFromSuggestion } from '@kbn/visualization-utils';
 import {
   getSourceQueryBeforeChangePoint,
-  getSourceQueriesFromForkWithChangePoint,
-  getChangePointOutputColumnNames,
+  getForkBranchLabels,
+  getTemplateSourceQueryFromForkWithChangePoint,
   getESQLQueryColumns,
+  replaceEntityValueInSourceQuery,
 } from '@kbn/esql-utils';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { ChangePointBurstHistogram } from './change_point_burst_histogram';
-import { ChangePointForkHeatmap } from './change_point_fork_heatmap';
+import { ChangePointHeatmap } from './change_point_heatmap';
+import {
+  ChangePointLensEmbeddable,
+  changePointLensNestedChartWrapperCss,
+} from './change_point_lens_embeddable';
+import { ChangePointMultipleLineCharts } from './change_point_multiple_line_charts';
+import { ViewModeSelection, type ChangePointViewMode } from './view_mode_selection';
 import {
   applyLineChartStyleToDataLayers,
+  buildChangePointLensAttributesByRecordId,
   deriveEntityAttributes,
   formatChangePointAnnotationLabel,
   getBurstDetectionHistogram,
+  getChangePointColumnIdsFromColumns,
   getChangePointResultsFromTable,
   getTimeColumnId,
   getValueColumnId,
@@ -60,6 +58,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
   services,
   onBrushEnd,
   onFilter,
+  changePointLensContext$,
 }) => {
   const { data, lens } = services;
   const { charts } = useDiscoverServices();
@@ -75,54 +74,59 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
     [fetchParams.columns, fetchParams.columnsMap]
   );
 
-  // The bridge between the ES|QL CHANGE_POINT output and the table columns used for charts and heatmaps
-  const changePointColumnNames = useMemo(() => {
-    const query = fetchParams.query as { esql?: string } | undefined;
-    return query?.esql ? getChangePointOutputColumnNames(query.esql) : undefined;
-  }, [fetchParams.query]);
+  const colsToUse = useMemo(
+    () => (fetchParams.table?.columns?.length ? fetchParams.table.columns : columns),
+    [fetchParams.table?.columns, columns]
+  );
+
+  const changePointColumnIds = useMemo(
+    () => getChangePointColumnIdsFromColumns(colsToUse),
+    [colsToUse]
+  );
 
   const sourceQuery = useMemo(() => {
     const query = fetchParams.query as { esql?: string } | undefined;
     return query?.esql ? getSourceQueryBeforeChangePoint(query.esql) : undefined;
   }, [fetchParams.query]);
 
-  // The array of source queries for each fork branch
-  const forkBranchQueries = useMemo(() => {
+  const forkBranchLabels = useMemo(() => {
     const query = fetchParams.query as { esql?: string } | undefined;
-    return query?.esql ? getSourceQueriesFromForkWithChangePoint(query.esql) : undefined;
+    return query?.esql ? getForkBranchLabels(query.esql) : undefined;
   }, [fetchParams.query]);
 
-  const multipleEntityMode = Boolean(forkBranchQueries?.length);
+  const templateSourceQuery = useMemo(() => {
+    const query = fetchParams.query as { esql?: string } | undefined;
+    return query?.esql ? getTemplateSourceQueryFromForkWithChangePoint(query.esql) : undefined;
+  }, [fetchParams.query]);
 
-  const [viewMode, setViewMode] = useState<
-    'heatmap' | 'line' | 'multiple-line' | 'burst-detection'
-  >('multiple-line');
+  const multipleEntityMode = Boolean(forkBranchLabels?.length);
+
+  const [viewMode, setViewMode] = useState<ChangePointViewMode>('multiple-line');
   const [selectedEntityIndices, setSelectedEntityIndices] = useState<number[]>([]);
 
   useEffect(() => {
-    if (forkBranchQueries && selectedEntityIndices.length > 0) {
-      const valid = selectedEntityIndices.filter((i) => i < forkBranchQueries.length);
+    if (forkBranchLabels && selectedEntityIndices.length > 0) {
+      const valid = selectedEntityIndices.filter((i) => i < forkBranchLabels.length);
       if (valid.length !== selectedEntityIndices.length) {
         setSelectedEntityIndices(valid);
       }
     }
-  }, [selectedEntityIndices, forkBranchQueries]);
+  }, [selectedEntityIndices, forkBranchLabels]);
 
   const sourceColumns = useMemo(() => {
-    if (!changePointColumnNames) return columns;
-    return columns.filter(
-      (c) =>
-        c.id !== changePointColumnNames.typeColumn && c.id !== changePointColumnNames.pvalueColumn
-    );
-  }, [columns, changePointColumnNames]);
+    const { typeColumnId, pvalueColumnId } = changePointColumnIds;
+    if (!typeColumnId && !pvalueColumnId) return columns;
+    return columns.filter((c) => {
+      const id = c.id ?? c.name;
+      return id !== typeColumnId && id !== pvalueColumnId;
+    });
+  }, [columns, changePointColumnIds]);
 
   const heatmapResults = useMemo((): ChangePointResult[] => {
     const table = fetchParams.table;
-    if (!table?.rows?.length || !multipleEntityMode || !forkBranchQueries?.length) return [];
-    const colsToUse = table.columns?.length ? table.columns : columns;
+    if (!table?.rows?.length || !multipleEntityMode || !forkBranchLabels?.length) return [];
     const timeColumnId = getTimeColumnId(colsToUse);
-    const typeColumnId = changePointColumnNames?.typeColumn;
-    const pvalueColumnId = changePointColumnNames?.pvalueColumn;
+    const { typeColumnId, pvalueColumnId } = changePointColumnIds;
     const valueColumnId = timeColumnId
       ? getValueColumnId(colsToUse, timeColumnId, typeColumnId, pvalueColumnId)
       : undefined;
@@ -134,22 +138,22 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
       pvalueColumnId,
       valueColumnId,
       FORK_COLUMN_ID,
-      forkBranchQueries
+      forkBranchLabels
     );
-  }, [fetchParams.table, multipleEntityMode, forkBranchQueries, columns, changePointColumnNames]);
+  }, [fetchParams.table, multipleEntityMode, forkBranchLabels, colsToUse, changePointColumnIds]);
 
   const entityLabels = useMemo(
-    () => forkBranchQueries?.map((b) => b.branchLabel) ?? [],
-    [forkBranchQueries]
+    () => forkBranchLabels?.map((b) => b.branchLabel) ?? [],
+    [forkBranchLabels]
   );
 
   const burstDetectionHistogramData = useMemo(() => {
-    if (!multipleEntityMode || !forkBranchQueries?.length || heatmapResults.length === 0) return [];
+    if (!multipleEntityMode || !forkBranchLabels?.length || heatmapResults.length === 0) return [];
     return getBurstDetectionHistogram(heatmapResults, entityLabels, fetchParams.timeRange);
-  }, [heatmapResults, forkBranchQueries, multipleEntityMode, entityLabels, fetchParams.timeRange]);
+  }, [heatmapResults, forkBranchLabels, multipleEntityMode, entityLabels, fetchParams.timeRange]);
 
   const entityAttributesMap = useMemo(() => {
-    if (!lensAttributes || !multipleEntityMode || !forkBranchQueries) return {};
+    if (!lensAttributes || !multipleEntityMode || !forkBranchLabels) return {};
     const dataViewId = fetchParams.dataView?.id ?? '';
     const forkLineColors = [
       euiTheme.colors.borderBaseProminent,
@@ -159,15 +163,15 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
       euiTheme.colors.warning,
     ];
     const map: Record<number, TypedLensByValueInput['attributes']> = {};
-    for (let i = 0; i < forkBranchQueries.length; i++) {
+    for (let i = 0; i < forkBranchLabels.length; i++) {
       const entityResults = heatmapResults.filter(
-        (r) => r.forkIndex === i || r.forkIndex === forkBranchQueries[i].branchIndex
+        (r) => r.forkIndex === i || r.forkIndex === forkBranchLabels[i].branchIndex
       );
       const attrs = deriveEntityAttributes(
         lensAttributes,
         i,
         entityResults,
-        forkBranchQueries[i].branchLabel,
+        forkBranchLabels[i].branchLabel,
         dataViewId,
         forkLineColors
       );
@@ -177,11 +181,55 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
   }, [
     lensAttributes,
     multipleEntityMode,
-    forkBranchQueries,
+    forkBranchLabels,
     heatmapResults,
     fetchParams.dataView?.id,
     euiTheme.colors,
   ]);
+
+  const changePointDocLensContextValue = useMemo(() => {
+    const lensAttributesByRecordId = buildChangePointLensAttributesByRecordId(
+      fetchParams.table,
+      colsToUse,
+      changePointColumnIds,
+      forkBranchLabels,
+      entityAttributesMap,
+      lensAttributes,
+      multipleEntityMode
+    );
+    return {
+      lensAttributesByRecordId,
+      fetchSlice: {
+        abortController: fetchParams.abortController,
+        lastReloadRequestTime: fetchParams.lastReloadRequestTime,
+        searchSessionId: fetchParams.searchSessionId,
+        timeRange: fetchParams.timeRange,
+      },
+    };
+  }, [
+    fetchParams.table,
+    fetchParams.abortController,
+    fetchParams.lastReloadRequestTime,
+    fetchParams.searchSessionId,
+    fetchParams.timeRange,
+    colsToUse,
+    changePointColumnIds,
+    forkBranchLabels,
+    entityAttributesMap,
+    lensAttributes,
+    multipleEntityMode,
+  ]);
+
+  useEffect(() => {
+    if (!isComponentVisible) {
+      changePointLensContext$.next(undefined);
+      return undefined;
+    }
+    changePointLensContext$.next(changePointDocLensContextValue);
+    return () => {
+      changePointLensContext$.next(undefined);
+    };
+  }, [changePointLensContext$, isComponentVisible, changePointDocLensContextValue]);
 
   useEffect(() => {
     let cancelled = false;
@@ -199,9 +247,8 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         return;
       }
 
-      const forkBranches = forkBranchQueries;
-      const isForkMode = Boolean(forkBranches?.length);
-      const effectiveSourceQuery = isForkMode ? forkBranches?.[0]?.sourceQuery : sourceQuery;
+      const isForkMode = Boolean(forkBranchLabels?.length);
+      const effectiveSourceQuery = isForkMode ? templateSourceQuery : sourceQuery;
 
       if (!effectiveSourceQuery && !isForkMode) {
         setLensAttributes(null);
@@ -223,38 +270,87 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
 
         let attributes: TypedLensByValueInput['attributes'];
 
-        if (isForkMode && forkBranches) {
-          const branchColumns = await Promise.all(
-            forkBranches.map((branch) =>
-              getESQLQueryColumns({
-                esqlQuery: branch.sourceQuery,
-                search: data.search.search,
-                signal: fetchParams.abortController?.signal,
-                timeRange: timeRange
-                  ? { from: timeRange.from, to: timeRange.to }
-                  : data.query.timefilter.timefilter.getAbsoluteTime(),
-              })
-            )
-          );
+        if (isForkMode && forkBranchLabels) {
+          const forkTable = fetchParams.table;
+          const forkColsToUse = forkTable?.columns?.length ? forkTable.columns : columns;
+          const forkTimeColumnId = getTimeColumnId(forkColsToUse);
+          const forkChangePointIds = getChangePointColumnIdsFromColumns(forkColsToUse);
+          const forkTypeColumnId = forkChangePointIds.typeColumnId;
+          const forkPvalueColumnId = forkChangePointIds.pvalueColumnId;
+          const forkValueColumnId = forkTimeColumnId
+            ? getValueColumnId(
+                forkColsToUse,
+                forkTimeColumnId,
+                forkTypeColumnId,
+                forkPvalueColumnId
+              )
+            : undefined;
+
+          const changePointResults =
+            forkTable?.rows?.length && forkTimeColumnId && forkValueColumnId
+              ? getChangePointResultsFromTable(
+                  forkTable,
+                  forkTimeColumnId,
+                  forkTypeColumnId,
+                  forkPvalueColumnId,
+                  forkValueColumnId,
+                  FORK_COLUMN_ID,
+                  forkBranchLabels
+                )
+              : [];
+
+          const uniqueForkIndices = [
+            ...new Set(
+              changePointResults.map((r) => r.forkIndex).filter((i): i is number => i !== undefined)
+            ),
+          ].sort((a, b) => a - b);
+
+          const entitiesToShow =
+            uniqueForkIndices.length > 0 && templateSourceQuery
+              ? uniqueForkIndices.map((i) => ({
+                  branchIndex: i,
+                  branchLabel: forkBranchLabels[i].branchLabel,
+                  sourceQuery: replaceEntityValueInSourceQuery(
+                    templateSourceQuery,
+                    forkBranchLabels[i].branchLabel
+                  ),
+                }))
+              : forkBranchLabels.map((b) => ({
+                  branchIndex: b.branchIndex,
+                  branchLabel: b.branchLabel,
+                  sourceQuery: replaceEntityValueInSourceQuery(
+                    templateSourceQuery ?? '',
+                    b.branchLabel
+                  ),
+                }));
+
+          const templateColumns = await getESQLQueryColumns({
+            esqlQuery: templateSourceQuery!,
+            search: data.search.search,
+            signal: fetchParams.abortController?.signal,
+            timeRange: timeRange
+              ? { from: timeRange.from, to: timeRange.to }
+              : data.query.timefilter.timefilter.getAbsoluteTime(),
+          });
 
           if (cancelled) return;
 
-          const validBranches = forkBranches
-            .map((branch, i) => ({ branch, cols: branchColumns[i] }))
-            .filter((b) => b.cols?.length);
-          if (!validBranches.length) {
+          const validEntities = templateColumns?.length
+            ? entitiesToShow.map((entity) => ({ entity, cols: templateColumns }))
+            : [];
+          if (!validEntities.length) {
             setLensAttributes(null);
             setError('Could not get columns for fork branches');
             setIsLoading(false);
             return;
           }
 
-          const firstBranch = validBranches[0];
+          const firstEntity = validEntities[0];
           const context = {
             dataViewSpec,
             fieldName: '',
-            textBasedColumns: firstBranch.cols,
-            query: { esql: firstBranch.branch.sourceQuery },
+            textBasedColumns: firstEntity.cols,
+            query: { esql: firstEntity.entity.sourceQuery },
           };
           const suggestions = stateHelper.suggestions(
             context,
@@ -286,8 +382,8 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             euiTheme.colors.warning,
           ];
 
-          validBranches.forEach(({ branch, cols: branchCols }) => {
-            const layerId = `fork-branch-${branch.branchIndex}`;
+          validEntities.forEach(({ entity, cols: branchCols }) => {
+            const layerId = `fork-branch-${entity.branchIndex}`;
             const timeCol = branchCols.find(
               (c) =>
                 c.meta?.type === 'date' ||
@@ -298,7 +394,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
               branchCols.find((c) => c.id !== timeCol?.id);
             if (!timeCol || !valueCol) return;
 
-            const entityLabel = branch.branchLabel;
+            const entityLabel = entity.branchLabel;
             const valueColumnId = `${layerId}-${valueCol.id}`;
             const textBasedColumns = branchCols.map((c) => {
               const isValueCol = c.id === valueCol.id;
@@ -312,11 +408,11 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             });
             datasourceLayers[layerId] = {
               index: fetchParams.dataView.id ?? dataViewSpec.id ?? '',
-              query: { esql: branch.sourceQuery },
+              query: { esql: entity.sourceQuery },
               columns: textBasedColumns,
               timeField: dataViewSpec.timeFieldName,
             };
-            const color = forkLineColors[branch.branchIndex % forkLineColors.length];
+            const color = forkLineColors[entity.branchIndex % forkLineColors.length];
             visDataLayers.push({
               layerId,
               layerType: 'data',
@@ -412,9 +508,8 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         }
 
         const table = fetchParams.table;
-        const timeColumnId = changePointColumnNames ? getTimeColumnId(columns) : undefined;
-        const typeColumnId = changePointColumnNames?.typeColumn;
-        const pvalueColumnId = changePointColumnNames?.pvalueColumn;
+        const timeColumnId = getTimeColumnId(columns);
+        const { typeColumnId, pvalueColumnId } = changePointColumnIds;
         const valueColumnId = timeColumnId
           ? getValueColumnId(columns, timeColumnId, typeColumnId, pvalueColumnId)
           : undefined;
@@ -431,7 +526,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             pvalueColumnId,
             valueColumnId,
             forkColumnId,
-            forkBranches
+            forkBranchLabels
           );
           // Add change point annotations over the line chart (like AIOps)
           if (results.length > 0) {
@@ -446,8 +541,8 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             let annotationLayers: DataLayerLike[] = [];
 
             const hasForkIndex = results.some((r) => r.forkIndex !== undefined);
-            if (isForkMode && forkBranches && hasForkIndex) {
-              forkBranches.forEach((branch, branchIdx) => {
+            if (isForkMode && forkBranchLabels && hasForkIndex) {
+              forkBranchLabels.forEach((branch, branchIdx) => {
                 const branchResults = results.filter(
                   (r) => r.forkIndex === branch.branchIndex || r.forkIndex === branchIdx
                 );
@@ -552,9 +647,11 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
     fetchParams.abortController,
     sourceQuery,
     sourceColumns,
-    forkBranchQueries,
+    forkBranchLabels,
+    templateSourceQuery,
     columns,
-    changePointColumnNames,
+    colsToUse,
+    changePointColumnIds,
     lens,
     data.search,
     data.query.timefilter.timefilter,
@@ -596,35 +693,29 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
 
   const showHeatmap =
     lensAttributes && !error && !isLoading && multipleEntityMode && viewMode === 'heatmap';
-  const showLineChart =
+  const showLineCharts =
     lensAttributes &&
     !error &&
     !isLoading &&
-    (!multipleEntityMode || (forkBranchQueries?.length === 1 && viewMode === 'line'));
-  const showMultipleLineCharts =
-    lensAttributes &&
-    !error &&
-    !isLoading &&
-    multipleEntityMode &&
     viewMode === 'multiple-line' &&
-    forkBranchQueries &&
-    forkBranchQueries.length > 0;
+    ((!multipleEntityMode && lensAttributes) ||
+      (multipleEntityMode && forkBranchLabels && forkBranchLabels.length > 0));
 
   const showBurstDetectionHistogram =
     !error &&
     !isLoading &&
     multipleEntityMode &&
     viewMode === 'burst-detection' &&
-    forkBranchQueries &&
-    forkBranchQueries.length > 0 &&
+    forkBranchLabels &&
+    forkBranchLabels.length > 0 &&
     burstDetectionHistogramData.length > 0;
 
   const renderChartContent = () => {
     if (showHeatmap) {
       return (
-        <ChangePointForkHeatmap
+        <ChangePointHeatmap
           results={heatmapResults}
-          forkBranches={forkBranchQueries ?? []}
+          forkBranches={forkBranchLabels ?? []}
           selectedEntityIndices={selectedEntityIndices}
           onSelectEntity={setSelectedEntityIndices}
           timeRange={fetchParams.timeRange}
@@ -633,150 +724,44 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
             const attrs = entityAttributesMap[entityIndex];
             if (!attrs) return null;
             return (
-              <div
-                css={css({
-                  minHeight: 200,
-                  height: '100%',
-                  position: 'relative',
-                  '& > div': { height: '100%', position: 'absolute', width: '100%' },
-                })}
-                data-test-subj="changePointEntityDetailChart"
-              >
-                <lens.EmbeddableComponent
-                  abortController={fetchParams.abortController}
-                  attributes={attrs}
-                  executionContext={{ description: 'Discover change point entity detail' }}
-                  id={`discover-change-point-entity-${entityIndex}`}
-                  lastReloadRequestTime={fetchParams.lastReloadRequestTime}
-                  noPadding={true}
-                  onBrushEnd={handleBrushEnd}
-                  onFilter={onFilter}
-                  searchSessionId={fetchParams.searchSessionId}
-                  syncCursor={true}
-                  syncTooltips={true}
-                  timeRange={fetchParams.timeRange}
-                  viewMode="view"
-                />
-              </div>
+              <ChangePointLensEmbeddable
+                lens={lens}
+                attributes={attrs}
+                executionContextDescription="Discover change point entity detail"
+                id={`discover-change-point-entity-${entityIndex}`}
+                abortController={fetchParams.abortController}
+                lastReloadRequestTime={fetchParams.lastReloadRequestTime}
+                searchSessionId={fetchParams.searchSessionId}
+                timeRange={fetchParams.timeRange}
+                onBrushEnd={handleBrushEnd}
+                onFilter={onFilter}
+                syncCursor={true}
+                syncTooltips={true}
+                wrapperCss={changePointLensNestedChartWrapperCss()}
+                dataTestSubj="changePointEntityDetailChart"
+              />
             );
           }}
         />
       );
     }
-    if (showLineChart) {
+    if (showLineCharts) {
       return (
-        <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
-          <EuiFlexItem grow css={css({ minHeight: 0 })}>
-            <div css={chartCss} data-test-subj="changePointExperienceLensLineChart">
-              <lens.EmbeddableComponent
-                abortController={fetchParams.abortController}
-                attributes={lensAttributes}
-                executionContext={{ description: 'Discover change point chart' }}
-                id="discover-change-point-lens"
-                lastReloadRequestTime={fetchParams.lastReloadRequestTime}
-                noPadding={true}
-                onBrushEnd={handleBrushEnd}
-                onFilter={onFilter}
-                searchSessionId={fetchParams.searchSessionId}
-                timeRange={fetchParams.timeRange}
-                viewMode="view"
-              />
-            </div>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      );
-    }
-    if (showMultipleLineCharts) {
-      return (
-        <>
-          <EuiSpacer size="xs" />
-          <EuiFlexGrid columns={3} css={css({ flex: 1, minHeight: 0 })}>
-            {forkBranchQueries!.map((branch, entityIdx) => {
-              const attrs = entityAttributesMap[entityIdx];
-              if (!attrs) return null;
-              const entityLabel = branch.branchLabel;
-              return (
-                <EuiFlexItem
-                  key={entityLabel}
-                  css={css({
-                    minHeight: 220,
-                    minWidth: 0,
-                  })}
-                >
-                  <EuiPanel
-                    paddingSize="xs"
-                    hasBorder
-                    hasShadow={false}
-                    css={css({
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      overflow: 'hidden',
-                    })}
-                    data-test-subj={`changePointMultipleLineChart-${entityLabel}`}
-                  >
-                    <EuiFlexGroup
-                      direction="column"
-                      gutterSize="xs"
-                      css={css({ flex: 1, minHeight: 0 })}
-                    >
-                      <EuiFlexItem grow={false}>
-                        <EuiText
-                          size="xs"
-                          css={css({
-                            fontWeight: 600,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                          })}
-                          title={entityLabel}
-                        >
-                          {entityLabel}
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow
-                        css={css({
-                          minHeight: 0,
-                          overflow: 'hidden',
-                        })}
-                      >
-                        <div
-                          css={css({
-                            minHeight: 200,
-                            height: '100%',
-                            position: 'relative',
-                            '& > div': {
-                              height: '100%',
-                              position: 'absolute',
-                              width: '100%',
-                            },
-                          })}
-                        >
-                          <lens.EmbeddableComponent
-                            abortController={fetchParams.abortController}
-                            attributes={attrs}
-                            executionContext={{ description: 'Discover change point entity chart' }}
-                            id={`discover-change-point-multiple-entity-${entityLabel}`}
-                            lastReloadRequestTime={fetchParams.lastReloadRequestTime}
-                            noPadding={true}
-                            onBrushEnd={handleBrushEnd}
-                            onFilter={onFilter}
-                            searchSessionId={fetchParams.searchSessionId}
-                            syncCursor={true}
-                            syncTooltips={true}
-                            timeRange={fetchParams.timeRange}
-                            viewMode="view"
-                          />
-                        </div>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiPanel>
-                </EuiFlexItem>
-              );
-            })}
-          </EuiFlexGrid>
-        </>
+        <ChangePointMultipleLineCharts
+          lens={lens}
+          multipleEntityMode={multipleEntityMode}
+          forkBranchLabels={forkBranchLabels}
+          entityAttributesMap={entityAttributesMap}
+          lensAttributes={lensAttributes}
+          fetchSlice={{
+            abortController: fetchParams.abortController,
+            lastReloadRequestTime: fetchParams.lastReloadRequestTime,
+            searchSessionId: fetchParams.searchSessionId,
+            timeRange: fetchParams.timeRange,
+          }}
+          onBrushEnd={handleBrushEnd}
+          onFilter={onFilter}
+        />
       );
     }
     if (showBurstDetectionHistogram) {
@@ -827,58 +812,7 @@ export const ChangePointExperienceView: React.FC<ChangePointExperienceViewProps>
         <div css={chartToolbarCss} className="eui-xScroll">
           <EuiFlexGroup alignItems="center" gutterSize="s" wrap>
             <EuiFlexItem grow={false}>{renderToggleActions?.()}</EuiFlexItem>
-            {multipleEntityMode && (
-              <EuiFlexItem grow={false}>
-                <EuiSelect
-                  compressed
-                  value={viewMode}
-                  onChange={(e) =>
-                    setViewMode(
-                      e.target.value as 'heatmap' | 'line' | 'multiple-line' | 'burst-detection'
-                    )
-                  }
-                  aria-label={i18n.translate(
-                    'discover.contextAwareness.changePointExperience.viewModeLabel',
-                    { defaultMessage: 'Chart view mode' }
-                  )}
-                  options={[
-                    {
-                      value: 'heatmap',
-                      text: i18n.translate(
-                        'discover.contextAwareness.changePointExperience.viewHeatmap',
-                        { defaultMessage: 'Heatmap' }
-                      ),
-                    },
-                    ...(forkBranchQueries && forkBranchQueries.length === 1
-                      ? [
-                          {
-                            value: 'line' as const,
-                            text: i18n.translate(
-                              'discover.contextAwareness.changePointExperience.viewLineChart',
-                              { defaultMessage: 'Line chart' }
-                            ),
-                          },
-                        ]
-                      : []),
-                    {
-                      value: 'multiple-line',
-                      text: i18n.translate(
-                        'discover.contextAwareness.changePointExperience.viewMultipleLineCharts',
-                        { defaultMessage: 'Multiple line charts' }
-                      ),
-                    },
-                    {
-                      value: 'burst-detection',
-                      text: i18n.translate(
-                        'discover.contextAwareness.changePointExperience.viewBurstDetection',
-                        { defaultMessage: 'Burst Detection Histogram' }
-                      ),
-                    },
-                  ]}
-                  data-test-subj="changePointViewModeSelect"
-                />
-              </EuiFlexItem>
-            )}
+            {multipleEntityMode && <ViewModeSelection value={viewMode} onChange={setViewMode} />}
           </EuiFlexGroup>
         </div>
       ) : null}

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_fork_heatmap.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_fork_heatmap.tsx
@@ -1,0 +1,454 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme, useEuiFontSize } from '@elastic/eui';
+import type {
+  ElementClickListener,
+  HeatmapElementEvent,
+  HeatmapSpec,
+  PartialTheme,
+  TooltipProps,
+} from '@elastic/charts';
+import { Chart, Heatmap, ScaleType, Settings, Tooltip } from '@elastic/charts';
+import { i18n } from '@kbn/i18n';
+import type { TimeRange } from '@kbn/es-query';
+import type { ForkBranchSourceQuery } from '@kbn/esql-utils';
+import type { ChangePointResult, ChangePointForkHeatmapProps } from './types';
+import {
+  getBestIntervalFromResults,
+  getBucketsFromResults,
+  getTimeBucket,
+  getTimeBucketsForRange,
+} from './helpers';
+import { MAX_ENTITY_LABEL_LENGTH, MAX_SELECTED_ENTITIES, Y_AXIS_LABEL_WIDTH } from './constants';
+
+/** Truncate label with ellipsis when exceeding max length. */
+function truncateEntityLabel(label: string): string {
+  if (label.length <= MAX_ENTITY_LABEL_LENGTH) return label;
+  return `${label.slice(0, MAX_ENTITY_LABEL_LENGTH - 3)}...`;
+}
+
+/** Sentinel value for empty cells - uses the "no data" color band (1.0–2.0). */
+const EMPTY_CELL_VALUE = 1.5;
+
+/** P-value significance categories with discrete colors. */
+export const PVALUE_LEGEND_ITEMS = [
+  { label: 'Highly Significant (p < 0.01)', color: '#BD271E', min: 0, max: 0.01 },
+  { label: 'Moderate (0.01 ≤ p < 0.05)', color: '#E7664C', min: 0.01, max: 0.05 },
+  { label: 'Slight (0.05 ≤ p < 0.10)', color: '#F5D371', min: 0.05, max: 0.1 },
+  { label: 'Not Significant (p ≥ 0.10)', color: '#D3D3D3', min: 0.1, max: 1 },
+] as const;
+
+interface HeatmapDatum {
+  x: string;
+  y: string;
+  value: number;
+  entityIndex: number;
+}
+
+/**
+ * Build heatmap data and metadata for Elastic Charts.
+ * When timeRange is provided, columns span the full date range at the best interval derived from results.
+ */
+function buildHeatmapData(
+  results: ChangePointResult[],
+  forkBranches: ForkBranchSourceQuery[],
+  timeRange?: TimeRange
+): {
+  entityIndicesWithChangePoints: number[];
+  timeBuckets: Array<{ key: string; label: string }>;
+  data: HeatmapDatum[];
+} {
+  const allEntityLabels = forkBranches.map((b) => b.branchLabel);
+  const validResults = results.filter((r) => {
+    if (r.forkIndex === undefined || r.forkIndex < 0 || r.forkIndex >= allEntityLabels.length)
+      return false;
+    if (r.pvalue == null) return false;
+    return true;
+  });
+
+  const resultsWithPvalue = results.filter((r) => r.pvalue != null && r.timestamp);
+  const useFallback =
+    validResults.length === 0 && resultsWithPvalue.length > 0 && allEntityLabels.length === 1;
+  const resultsToUse = useFallback ? resultsWithPvalue : validResults;
+
+  const interval = getBestIntervalFromResults(resultsToUse);
+  const timeBuckets =
+    timeRange?.from && timeRange?.to
+      ? getTimeBucketsForRange(timeRange, interval)
+      : getBucketsFromResults(resultsToUse, interval);
+
+  const grid = new Map<string, number>();
+  for (const r of resultsToUse) {
+    if (r.pvalue == null) continue;
+    const fi = useFallback ? 0 : r.forkIndex ?? 0;
+    const { key } = getTimeBucket(r.timestamp, interval);
+    const cellKey = `${fi}-${key}`;
+    const existing = grid.get(cellKey);
+    const pval = r.pvalue;
+    if (existing == null || pval < existing) {
+      grid.set(cellKey, pval);
+    }
+  }
+
+  const entityIndicesWithChangePoints = [
+    ...new Set(
+      [...grid.keys()]
+        .map((k) => {
+          const dashIdx = k.indexOf('-');
+          return dashIdx >= 0 ? parseInt(k.slice(0, dashIdx), 10) : -1;
+        })
+        .filter((i) => i >= 0 && i < forkBranches.length)
+    ),
+  ].sort((a, b) => a - b);
+
+  const data: HeatmapDatum[] = [];
+  for (const entityIdx of entityIndicesWithChangePoints) {
+    const yLabel = forkBranches[entityIdx]?.branchLabel ?? '';
+    for (const { key } of timeBuckets) {
+      const pvalue = grid.get(`${entityIdx}-${key}`);
+      data.push({
+        x: key,
+        y: yLabel,
+        value: pvalue != null ? pvalue : EMPTY_CELL_VALUE,
+        entityIndex: entityIdx,
+      });
+    }
+  }
+
+  return { entityIndicesWithChangePoints, timeBuckets, data };
+}
+
+/** Custom tooltip for p-value heatmap cells; shows full entity name on hover. */
+interface TooltipTheme {
+  backgroundColor: string;
+  color: string;
+}
+
+const createChangePointHeatmapTooltip =
+  (tooltipTheme: TooltipTheme): NonNullable<TooltipProps['customTooltip']> =>
+  ({ values }) => {
+    if (values.length === 0) return null;
+    const entityLabel = values.length >= 2 ? String(values[1]?.value ?? '') : '';
+    const cellOrFirst = values.length >= 3 ? values[2] : values[0];
+    const rawVal = (cellOrFirst as { value?: unknown })?.value;
+    const isEmpty = rawVal === EMPTY_CELL_VALUE;
+    const pvalueLabel = i18n.translate('discover.contextAwareness.changePointHeatmap.pvalueLabel', {
+      defaultMessage: 'p-value',
+    });
+    const pvalueDisplay = isEmpty
+      ? i18n.translate('discover.contextAwareness.changePointHeatmap.noData', {
+          defaultMessage: 'No change point',
+        })
+      : String(rawVal);
+    const entityLabelTitle = i18n.translate(
+      'discover.contextAwareness.changePointHeatmap.entityLabel',
+      { defaultMessage: 'Entity' }
+    );
+    return (
+      <div
+        style={{
+          padding: 8,
+          backgroundColor: tooltipTheme.backgroundColor,
+          color: tooltipTheme.color,
+          borderRadius: 4,
+        }}
+      >
+        {entityLabel ? (
+          <div style={{ display: 'flex', gap: 8, marginBottom: 4 }}>
+            <span>{entityLabelTitle}:</span>
+            <span>{entityLabel}</span>
+          </div>
+        ) : null}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <span>{pvalueLabel}:</span>
+          <span>{pvalueDisplay}</span>
+        </div>
+      </div>
+    );
+  };
+
+export const ChangePointForkHeatmap: React.FC<ChangePointForkHeatmapProps> = ({
+  results,
+  forkBranches,
+  selectedEntityIndices,
+  onSelectEntity,
+  renderEntityDetailChart,
+  timeRange,
+  charts,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const baseTheme = charts.theme.useChartsBaseTheme();
+  const euiFontSizeXS = useEuiFontSize('xs', { unit: 'px' }).fontSize as string;
+
+  const toggleEntitySelection = useCallback(
+    (entityIdx: number) => {
+      const isSelected = selectedEntityIndices.includes(entityIdx);
+      if (isSelected) {
+        onSelectEntity(selectedEntityIndices.filter((i) => i !== entityIdx));
+      } else if (selectedEntityIndices.length < MAX_SELECTED_ENTITIES) {
+        onSelectEntity([...selectedEntityIndices, entityIdx].sort((a, b) => a - b));
+      }
+    },
+    [selectedEntityIndices, onSelectEntity]
+  );
+
+  const { entityIndicesWithChangePoints, timeBuckets, data } = useMemo(
+    () => buildHeatmapData(results, forkBranches, timeRange),
+    [results, forkBranches, timeRange]
+  );
+
+  const highlightedData: HeatmapSpec['highlightedData'] = useMemo(() => {
+    if (selectedEntityIndices.length === 0) return undefined;
+    const selectedLabels = selectedEntityIndices
+      .map((i) => forkBranches[i]?.branchLabel)
+      .filter(Boolean);
+    if (selectedLabels.length === 0) return undefined;
+    return {
+      x: timeBuckets.map((t) => t.key),
+      y: selectedLabels,
+    };
+  }, [selectedEntityIndices, forkBranches, timeBuckets]);
+
+  const onElementClick = useCallback(
+    (events: HeatmapElementEvent[]) => {
+      if (events.length === 0) return;
+      const event = events[0];
+      const cell = event[0];
+      const datum = cell.datum as unknown as HeatmapDatum;
+      const entityIdx =
+        datum.entityIndex ?? forkBranches.findIndex((b) => b.branchLabel === datum.y);
+      if (entityIdx >= 0) {
+        toggleEntitySelection(entityIdx);
+      }
+    },
+    [toggleEntitySelection, forkBranches]
+  ) as ElementClickListener;
+
+  const themeOverrides = useMemo<PartialTheme>(
+    () => ({
+      background: {
+        color: euiTheme.colors.backgroundBasePlain,
+      },
+      heatmap: {
+        grid: {
+          stroke: {
+            width: 1,
+            color: euiTheme.border.color,
+          },
+        },
+        cell: {
+          maxWidth: 'fill',
+          maxHeight: 'fill',
+          label: {
+            visible: false,
+          },
+          border: {
+            stroke: euiTheme.colors.borderBasePlain,
+            strokeWidth: 0,
+          },
+        },
+        yAxisLabel: {
+          visible: true,
+          width: Y_AXIS_LABEL_WIDTH,
+          textColor: euiTheme.colors.textSubdued,
+          fontSize: parseInt(euiFontSizeXS, 10),
+        },
+        xAxisLabel: {
+          visible: true,
+          textColor: euiTheme.colors.textSubdued,
+          fontSize: parseInt(euiFontSizeXS, 10),
+        },
+      },
+    }),
+    [euiTheme, euiFontSizeXS]
+  );
+
+  const tooltipOptions = useMemo<TooltipProps>(
+    () => ({
+      placement: 'auto',
+      fallbackPlacements: ['left'],
+      boundary: 'chart',
+      customTooltip: createChangePointHeatmapTooltip({
+        backgroundColor: euiTheme.colors.darkestShade,
+        color: euiTheme.colors.emptyShade,
+      }),
+    }),
+    [euiTheme.colors.darkestShade, euiTheme.colors.emptyShade]
+  );
+
+  if (entityIndicesWithChangePoints.length === 0 || timeBuckets.length === 0) {
+    return null;
+  }
+
+  const chartHeight = Math.max(120, entityIndicesWithChangePoints.length * 28 + 60);
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup
+          justifyContent="flexEnd"
+          alignItems="center"
+          gutterSize="xs"
+          wrap
+          data-test-subj="changePointHeatmapLegend"
+        >
+          {PVALUE_LEGEND_ITEMS.map((item, idx) => (
+            <EuiFlexItem key={idx} grow={false}>
+              <EuiFlexGroup alignItems="center" gutterSize="xs">
+                <div
+                  css={css({
+                    width: 12,
+                    height: 12,
+                    borderRadius: 2,
+                    backgroundColor: item.color,
+                  })}
+                />
+                <EuiText size="xs">{item.label}</EuiText>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          ))}
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup alignItems="center" gutterSize="xs">
+              <div
+                css={css({
+                  width: 12,
+                  height: 12,
+                  borderRadius: 2,
+                  backgroundColor: euiTheme.colors.backgroundBasePlain,
+                  border: `1px solid ${euiTheme.border.color}`,
+                })}
+              />
+              <EuiText size="xs">
+                {i18n.translate('discover.contextAwareness.changePointHeatmap.noDataLegend', {
+                  defaultMessage: 'No change point',
+                })}
+              </EuiText>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <div
+          css={css({
+            overflowX: 'auto',
+            padding: euiTheme.size.s,
+            backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+            borderRadius: euiTheme.border.radius.medium,
+          })}
+          data-test-subj="changePointForkHeatmap"
+        >
+          <Chart size={{ height: chartHeight }}>
+            <Tooltip {...tooltipOptions} />
+            <Settings
+              theme={themeOverrides}
+              baseTheme={baseTheme}
+              onElementClick={onElementClick}
+              showLegend={false}
+              locale={i18n.getLocale()}
+            />
+            <Heatmap
+              id="change-point-heatmap"
+              timeZone="UTC"
+              colorScale={{
+                type: 'bands',
+                bands: [
+                  { start: 0, end: 0.01, color: PVALUE_LEGEND_ITEMS[0].color },
+                  { start: 0.01, end: 0.05, color: PVALUE_LEGEND_ITEMS[1].color },
+                  { start: 0.05, end: 0.1, color: PVALUE_LEGEND_ITEMS[2].color },
+                  { start: 0.1, end: 1, color: PVALUE_LEGEND_ITEMS[3].color },
+                  {
+                    start: 1,
+                    end: 2,
+                    color: euiTheme.colors.backgroundBasePlain,
+                    label: i18n.translate('discover.contextAwareness.changePointHeatmap.noData', {
+                      defaultMessage: 'No change point',
+                    }),
+                  },
+                ],
+              }}
+              data={data}
+              xAccessor="x"
+              yAccessor="y"
+              valueAccessor="value"
+              valueFormatter={(v) =>
+                v === EMPTY_CELL_VALUE ? '—' : v < 0.01 ? v.toExponential(1) : v.toFixed(2)
+              }
+              xScale={{ type: ScaleType.Ordinal }}
+              xSortPredicate="dataIndex"
+              ySortPredicate="dataIndex"
+              highlightedData={highlightedData}
+              xAxisTitle=""
+              xAxisLabelName=""
+              xAxisLabelFormatter={(v) => {
+                const bucket = timeBuckets.find((t) => t.key === v);
+                return bucket?.label ?? String(v);
+              }}
+              yAxisTitle=""
+              yAxisLabelName=""
+              yAxisLabelFormatter={(v) => truncateEntityLabel(String(v))}
+            />
+          </Chart>
+        </div>
+      </EuiFlexItem>
+      {selectedEntityIndices.length > 0 ? (
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup wrap gutterSize="m" css={css({ alignContent: 'flex-start' })}>
+            {selectedEntityIndices.map((entityIdx) => (
+              <EuiFlexItem
+                key={entityIdx}
+                css={css({
+                  minHeight: 200,
+                  width: '33.333%',
+                  minWidth: 280,
+                  maxWidth: 400,
+                })}
+              >
+                <div
+                  css={css({
+                    height: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: euiTheme.size.xs,
+                  })}
+                >
+                  <EuiText
+                    size="xs"
+                    css={css({
+                      fontWeight: 600,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    })}
+                    title={forkBranches[entityIdx]?.branchLabel ?? ''}
+                  >
+                    {truncateEntityLabel(forkBranches[entityIdx]?.branchLabel ?? '')}
+                  </EuiText>
+                  <div
+                    css={css({
+                      flex: 1,
+                      minHeight: 180,
+                      position: 'relative',
+                      '& > div': { height: '100%', position: 'absolute', width: '100%' },
+                    })}
+                    data-test-subj={`changePointEntityDetailChart-${entityIdx}`}
+                  >
+                    {renderEntityDetailChart(entityIdx)}
+                  </div>
+                </div>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      ) : null}
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_heatmap.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_heatmap.tsx
@@ -20,8 +20,8 @@ import type {
 import { Chart, Heatmap, ScaleType, Settings, Tooltip } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
 import type { TimeRange } from '@kbn/es-query';
-import type { ForkBranchSourceQuery } from '@kbn/esql-utils';
-import type { ChangePointResult, ChangePointForkHeatmapProps } from './types';
+import type { ForkBranchLabel } from '@kbn/esql-utils';
+import type { ChangePointResult, ChangePointHeatmapProps } from './types';
 import {
   getBestIntervalFromResults,
   getBucketsFromResults,
@@ -60,7 +60,7 @@ interface HeatmapDatum {
  */
 function buildHeatmapData(
   results: ChangePointResult[],
-  forkBranches: ForkBranchSourceQuery[],
+  forkBranches: ForkBranchLabel[],
   timeRange?: TimeRange
 ): {
   entityIndicesWithChangePoints: number[];
@@ -176,7 +176,7 @@ const createChangePointHeatmapTooltip =
     );
   };
 
-export const ChangePointForkHeatmap: React.FC<ChangePointForkHeatmapProps> = ({
+export const ChangePointHeatmap: React.FC<ChangePointHeatmapProps> = ({
   results,
   forkBranches,
   selectedEntityIndices,

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_lens_embeddable.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_lens_embeddable.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css, type SerializedStyles } from '@emotion/react';
+import type { UseEuiThemeReturn } from '@elastic/eui';
+import type { TimeRange } from '@kbn/es-query';
+import type {
+  LensEmbeddableInput,
+  LensPublicStart,
+  TypedLensByValueInput,
+} from '@kbn/lens-plugin/public';
+import React from 'react';
+
+/** Shared fetch / reload inputs passed from Discover chart section or doc viewer tab. */
+export interface ChangePointLensFetchSlice {
+  abortController?: AbortController;
+  lastReloadRequestTime?: number;
+  searchSessionId?: string;
+  timeRange?: TimeRange;
+}
+
+export interface ChangePointLensEmbeddableProps extends ChangePointLensFetchSlice {
+  lens: LensPublicStart;
+  attributes: TypedLensByValueInput['attributes'];
+  id: string;
+  executionContextDescription: string;
+  onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
+  onFilter?: LensEmbeddableInput['onFilter'];
+  syncCursor?: boolean;
+  syncTooltips?: boolean;
+  /** Emotion styles for the outer div that positions the Lens embeddable */
+  wrapperCss: SerializedStyles;
+  dataTestSubj?: string;
+}
+
+/**
+ * Lens line chart used for Discover change point experience (multiple-line, heatmap detail)
+ * and the change point document viewer tab.
+ */
+export const ChangePointLensEmbeddable: React.FC<ChangePointLensEmbeddableProps> = ({
+  lens,
+  attributes,
+  abortController,
+  id,
+  executionContextDescription,
+  lastReloadRequestTime,
+  searchSessionId,
+  timeRange,
+  onBrushEnd,
+  onFilter,
+  syncCursor,
+  syncTooltips,
+  wrapperCss,
+  dataTestSubj,
+}) => {
+  const { EmbeddableComponent } = lens;
+  return (
+    <div css={wrapperCss} data-test-subj={dataTestSubj}>
+      <EmbeddableComponent
+        abortController={abortController}
+        attributes={attributes}
+        executionContext={{ description: executionContextDescription }}
+        id={id}
+        lastReloadRequestTime={lastReloadRequestTime}
+        noPadding={true}
+        onBrushEnd={onBrushEnd}
+        onFilter={onFilter}
+        searchSessionId={searchSessionId}
+        syncCursor={syncCursor}
+        syncTooltips={syncTooltips}
+        timeRange={timeRange}
+        viewMode="view"
+      />
+    </div>
+  );
+};
+
+/** Main chart area in the change point experience (full-width line chart). */
+export const changePointExperienceLensWrapperCss = (euiTheme: UseEuiThemeReturn['euiTheme']) =>
+  css({
+    flex: 1,
+    marginBlock: euiTheme.size.xs,
+    minHeight: 350,
+    position: 'relative',
+    '& > div': {
+      height: '100%',
+      position: 'absolute',
+      width: '100%',
+    },
+  });
+
+/** Nested chart cell (multi-entity grid or heatmap entity detail). */
+export const changePointLensNestedChartWrapperCss = () =>
+  css({
+    minHeight: 200,
+    height: '100%',
+    position: 'relative',
+    '& > div': {
+      height: '100%',
+      position: 'absolute',
+      width: '100%',
+    },
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_lens_esql.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_lens_esql.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DatatableColumn } from '@kbn/expressions-plugin/common';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import type { ForkBranchLabel } from '@kbn/esql-utils';
+import type { ForkColumnMetaForChangePoint } from './helpers';
+import type { DataLayerLike, TimeInterval } from './types';
+
+const CP_ENTITY = 'cp_entity';
+
+export function quoteEsqlIdentifier(id: string): string {
+  if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {
+    return id;
+  }
+  return `\`${id.replace(/`/g, '``')}\``;
+}
+
+export function escapeEsqlDoubleQuotedString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function timeIntervalToDateTruncUnit(interval: TimeInterval): string {
+  const map: Record<TimeInterval, string> = {
+    minute: '1 minute',
+    hour: '1 hour',
+    day: '1 day',
+    month: '1 month',
+  };
+  return map[interval];
+}
+
+export function resolveEsqlResultColumnId(
+  cols: DatatableColumn[] | undefined,
+  alias: string
+): string {
+  if (!cols?.length) {
+    return alias;
+  }
+  const hit = cols.find((c) => c.id === alias || c.name === alias);
+  return hit?.id ?? hit?.name ?? alias;
+}
+
+export function buildChangePointEntityEvalPipeline(
+  meta: ForkColumnMetaForChangePoint,
+  forkBranches: ForkBranchLabel[]
+): string | null {
+  if (meta.entityColumnByBranchLabel) {
+    const col = quoteEsqlIdentifier(meta.entityColumnByBranchLabel);
+    return `| EVAL ${CP_ENTITY} = ${col}\n`;
+  }
+  if (!meta.hasForkColumn || !meta.effectiveForkColumnId) {
+    return null;
+  }
+  const forkQ = quoteEsqlIdentifier(meta.effectiveForkColumnId);
+  if (forkBranches.length === 0) {
+    return null;
+  }
+  const caseBranches = forkBranches.flatMap((b) => [
+    `cp_fork_idx == ${b.branchIndex}`,
+    `"${escapeEsqlDoubleQuotedString(b.branchLabel)}"`,
+  ]);
+  return (
+    `| EVAL cp_fork_idx = case(${forkQ} > 0, ${forkQ} - 1, ${forkQ})\n` +
+    `| EVAL ${CP_ENTITY} = case(${caseBranches.join(', ')}, TO_STRING(cp_fork_idx))\n`
+  );
+}
+
+/** One row per (time bucket, entity) with min p-value; base for burst count-by-bucket. */
+export function buildChangePointHeatmapAggregateEsql(params: {
+  changePointQueryEsql: string;
+  timeColumnId: string;
+  pvalueColumnId: string;
+  interval: TimeInterval;
+  meta: ForkColumnMetaForChangePoint;
+  forkBranches: ForkBranchLabel[];
+}): string | null {
+  const { changePointQueryEsql, timeColumnId, pvalueColumnId, interval, meta, forkBranches } =
+    params;
+  const inner = changePointQueryEsql.trim();
+  if (!inner || !pvalueColumnId) {
+    return null;
+  }
+
+  const entityPipeline = buildChangePointEntityEvalPipeline(meta, forkBranches);
+  if (!entityPipeline) {
+    return null;
+  }
+
+  const tTime = quoteEsqlIdentifier(timeColumnId);
+  const tPval = quoteEsqlIdentifier(pvalueColumnId);
+  const trunc = timeIntervalToDateTruncUnit(interval);
+
+  return (
+    `FROM (${inner})\n` +
+    `| WHERE ${tPval} IS NOT NULL\n` +
+    `| EVAL cp_tb = DATE_TRUNC(${trunc}, ${tTime})\n` +
+    `${entityPipeline}` +
+    `| STATS cp_pvalue = MIN(${tPval}) BY cp_tb, ${CP_ENTITY}`
+  );
+}
+
+/**
+ * Single series per time bucket: count of distinct entities (rows) with a change point in that bucket,
+ * after collapsing to one row per (bucket, entity).
+ */
+export function buildChangePointBurstBarAggregateEsqlUnsplit(params: {
+  changePointQueryEsql: string;
+  timeColumnId: string;
+  pvalueColumnId: string;
+  interval: TimeInterval;
+  meta: ForkColumnMetaForChangePoint;
+  forkBranches: ForkBranchLabel[];
+}): string | null {
+  const base = buildChangePointHeatmapAggregateEsql(params);
+  if (!base) {
+    return null;
+  }
+  return `${base}\n| STATS cp_cnt = COUNT(*) BY cp_tb\n| KEEP cp_tb, cp_cnt`;
+}
+
+const BURST_Y_WHOLE_NUMBER_FORMAT = {
+  id: 'number',
+  params: { decimals: 0 },
+} as const;
+
+/** Keep only one text-based datasource layer (matches a single XY data layer). */
+function pruneBurstTextBasedDatasourceLayers(
+  attributes: TypedLensByValueInput['attributes'],
+  keepLayerId: string
+): TypedLensByValueInput['attributes'] {
+  const textBased = attributes.state.datasourceStates?.textBased as
+    | { layers?: Record<string, unknown>; [key: string]: unknown }
+    | undefined;
+  const layer = textBased?.layers?.[keepLayerId];
+  if (!textBased?.layers || !layer) {
+    return attributes;
+  }
+  return {
+    ...attributes,
+    state: {
+      ...attributes.state,
+      datasourceStates: {
+        ...attributes.state.datasourceStates,
+        textBased: {
+          ...textBased,
+          layers: { [keepLayerId]: layer },
+        },
+      },
+    } as unknown as TypedLensByValueInput['attributes']['state'],
+  };
+}
+
+function withBurstYMetricWholeNumberFormat(
+  attributes: TypedLensByValueInput['attributes'],
+  yColumnId: string,
+  textBasedDataLayerIds: ReadonlySet<string>
+): TypedLensByValueInput['attributes'] {
+  const textBased = attributes.state.datasourceStates?.textBased as
+    | {
+        layers?: Record<
+          string,
+          {
+            columns?: Array<{
+              columnId: string;
+              params?: Record<string, unknown>;
+              [key: string]: unknown;
+            }>;
+            [key: string]: unknown;
+          }
+        >;
+        [key: string]: unknown;
+      }
+    | undefined;
+
+  if (!textBased?.layers) {
+    return attributes;
+  }
+
+  const newTextBasedLayers: NonNullable<typeof textBased.layers> = {};
+  for (const [layerId, layer] of Object.entries(textBased.layers)) {
+    if (!textBasedDataLayerIds.has(layerId)) {
+      newTextBasedLayers[layerId] = layer;
+      continue;
+    }
+    newTextBasedLayers[layerId] = {
+      ...layer,
+      columns: (layer.columns ?? []).map((col) =>
+        col.columnId === yColumnId
+          ? {
+              ...col,
+              params: {
+                ...(col.params ?? {}),
+                format: BURST_Y_WHOLE_NUMBER_FORMAT,
+              },
+            }
+          : col
+      ),
+    };
+  }
+
+  return {
+    ...attributes,
+    state: {
+      ...attributes.state,
+      datasourceStates: {
+        ...attributes.state.datasourceStates,
+        textBased: {
+          ...textBased,
+          layers: newTextBasedLayers,
+        },
+      },
+    } as unknown as TypedLensByValueInput['attributes']['state'],
+  };
+}
+
+/** Vertical bar chart without breakdown (total count per time bucket). */
+export function applyBurstBarChartAggregateOnlyToLensAttributes(
+  attributes: TypedLensByValueInput['attributes'],
+  xColumnId: string,
+  yColumnId: string,
+  options?: { yTitle?: string }
+): TypedLensByValueInput['attributes'] {
+  const vis = attributes.state.visualization as {
+    layers?: DataLayerLike[];
+    preferredSeriesType?: string;
+    yTitle?: string;
+    [key: string]: unknown;
+  };
+  if (!vis?.layers?.length) {
+    return attributes;
+  }
+
+  const isDataLayer = (layer: DataLayerLike) => !layer.layerType || layer.layerType === 'data';
+  const dataLayers = vis.layers.filter(isDataLayer);
+  const nonDataLayers = vis.layers.filter((layer) => !isDataLayer(layer));
+  const primaryData = dataLayers[0] as DataLayerLike & { layerId?: string };
+  if (!primaryData?.layerId || typeof primaryData.layerId !== 'string') {
+    return attributes;
+  }
+
+  const { yConfig: _omitYConfig, ...primaryWithoutYConfig } = primaryData;
+
+  const newLayers: DataLayerLike[] = [
+    {
+      ...primaryWithoutYConfig,
+      layerType: 'data',
+      seriesType: 'bar',
+      xAccessor: xColumnId,
+      accessors: [yColumnId],
+      splitAccessors: undefined,
+    },
+    ...nonDataLayers,
+  ];
+
+  const textBasedDataLayerIds = new Set([primaryData.layerId]);
+
+  let next: TypedLensByValueInput['attributes'] = {
+    ...attributes,
+    state: {
+      ...attributes.state,
+      visualization: {
+        ...vis,
+        preferredSeriesType: 'bar',
+        layers: newLayers,
+        yLeftExtent: { mode: 'full', niceValues: false },
+        ...(options?.yTitle !== undefined ? { yTitle: options.yTitle } : {}),
+      },
+    } as TypedLensByValueInput['attributes']['state'],
+  };
+
+  next = pruneBurstTextBasedDatasourceLayers(next, primaryData.layerId);
+  return withBurstYMetricWholeNumberFormat(next, yColumnId, textBasedDataLayerIds);
+}

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_multiple_line_charts.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_multiple_line_charts.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { css } from '@emotion/react';
+import {
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import type { ForkBranchLabel } from '@kbn/esql-utils';
+import type {
+  LensEmbeddableInput,
+  LensPublicStart,
+  TypedLensByValueInput,
+} from '@kbn/lens-plugin/public';
+import React from 'react';
+import {
+  ChangePointLensEmbeddable,
+  changePointExperienceLensWrapperCss,
+  changePointLensNestedChartWrapperCss,
+  type ChangePointLensFetchSlice,
+} from './change_point_lens_embeddable';
+
+export interface ChangePointMultipleLineChartsProps {
+  lens: LensPublicStart;
+  multipleEntityMode: boolean;
+  forkBranchLabels: ForkBranchLabel[] | undefined;
+  /** Per-entity Lens attributes when multipleEntityMode */
+  entityAttributesMap: Record<number, TypedLensByValueInput['attributes']>;
+  /** Single-chart Lens attributes when not in multiple-entity mode (unused when multipleEntityMode) */
+  lensAttributes: TypedLensByValueInput['attributes'] | null;
+  fetchSlice: ChangePointLensFetchSlice;
+  onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
+  onFilter?: LensEmbeddableInput['onFilter'];
+}
+
+/**
+ * Multiple-line (and single line) Lens views for the change point chart section.
+ */
+export const ChangePointMultipleLineCharts: React.FC<ChangePointMultipleLineChartsProps> = ({
+  lens,
+  multipleEntityMode,
+  forkBranchLabels,
+  entityAttributesMap,
+  lensAttributes,
+  fetchSlice,
+  onBrushEnd,
+  onFilter,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const chartCss = changePointExperienceLensWrapperCss(euiTheme);
+  const nestedChartCss = changePointLensNestedChartWrapperCss();
+
+  const isSingleChart = !multipleEntityMode || (forkBranchLabels?.length ?? 0) === 1;
+  const chartEntities = forkBranchLabels ?? [];
+  const gridColumns = isSingleChart ? 1 : 3;
+
+  if (isSingleChart) {
+    const attrs = multipleEntityMode ? entityAttributesMap[0] : lensAttributes;
+    const entityLabel = chartEntities[0]?.branchLabel;
+    if (!attrs) {
+      return null;
+    }
+    return (
+      <EuiFlexGroup direction="column" gutterSize="none" css={css({ flex: 1, minHeight: 0 })}>
+        <EuiFlexItem grow css={css({ minHeight: 0 })}>
+          <ChangePointLensEmbeddable
+            lens={lens}
+            attributes={attrs}
+            executionContextDescription="Discover change point chart"
+            id={
+              entityLabel
+                ? `discover-change-point-entity-${entityLabel}`
+                : 'discover-change-point-lens'
+            }
+            {...fetchSlice}
+            onBrushEnd={onBrushEnd}
+            onFilter={onFilter}
+            syncCursor={true}
+            syncTooltips={true}
+            wrapperCss={chartCss}
+            dataTestSubj="changePointExperienceLensLineChart"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  return (
+    <>
+      <EuiSpacer size="xs" />
+      <EuiFlexGrid columns={gridColumns} css={css({ flex: 1, minHeight: 0 })}>
+        {chartEntities.map((branch, entityIdx) => {
+          const attrs = entityAttributesMap[entityIdx];
+          if (!attrs) return null;
+          const entityLabel = branch.branchLabel;
+          return (
+            <EuiFlexItem
+              key={entityLabel}
+              css={css({
+                minHeight: 220,
+                minWidth: 0,
+              })}
+            >
+              <EuiPanel
+                paddingSize="xs"
+                hasBorder
+                hasShadow={false}
+                css={css({
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  overflow: 'hidden',
+                })}
+                data-test-subj={`changePointLineChart-${entityLabel}`}
+              >
+                <EuiFlexGroup
+                  direction="column"
+                  gutterSize="xs"
+                  css={css({ flex: 1, minHeight: 0 })}
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiText
+                      size="xs"
+                      css={css({
+                        fontWeight: 600,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      })}
+                      title={entityLabel}
+                    >
+                      {entityLabel}
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow
+                    css={css({
+                      minHeight: 0,
+                      overflow: 'hidden',
+                    })}
+                  >
+                    <ChangePointLensEmbeddable
+                      lens={lens}
+                      attributes={attrs}
+                      executionContextDescription="Discover change point entity chart"
+                      id={`discover-change-point-multiple-entity-${entityLabel}`}
+                      {...fetchSlice}
+                      onBrushEnd={onBrushEnd}
+                      onFilter={onFilter}
+                      syncCursor={true}
+                      syncTooltips={true}
+                      wrapperCss={nestedChartCss}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            </EuiFlexItem>
+          );
+        })}
+      </EuiFlexGrid>
+    </>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_pvalue_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_pvalue_cell.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { FC } from 'react';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
+
+/** Impact level from p-value: lower p-value = more extreme change */
+export type PvalueImpactLevel = 'extreme' | 'high' | 'medium' | 'low' | 'minimal';
+
+const PVALUE_THRESHOLDS: Array<{ max: number; level: PvalueImpactLevel }> = [
+  { max: 0.001, level: 'extreme' },
+  { max: 0.01, level: 'high' },
+  { max: 0.05, level: 'medium' },
+  { max: 0.1, level: 'low' },
+  { max: 1, level: 'minimal' },
+];
+
+function getImpactLevel(pvalue: number): PvalueImpactLevel {
+  for (const { max, level } of PVALUE_THRESHOLDS) {
+    if (pvalue < max) return level;
+  }
+  return 'minimal';
+}
+
+const IMPACT_LEVEL_COLORS: Record<PvalueImpactLevel, string> = {
+  extreme: 'danger',
+  high: 'warning',
+  medium: 'primary',
+  low: 'default',
+  minimal: 'hollow',
+};
+
+const IMPACT_LEVEL_LABELS: Record<PvalueImpactLevel, string> = {
+  extreme: i18n.translate('discover.contextAwareness.changePointPvalueCell.impactVeryHigh', {
+    defaultMessage: 'extreme',
+  }),
+  high: i18n.translate('discover.contextAwareness.changePointPvalueCell.impactHigh', {
+    defaultMessage: 'high',
+  }),
+  medium: i18n.translate('discover.contextAwareness.changePointPvalueCell.impactMedium', {
+    defaultMessage: 'medium',
+  }),
+  low: i18n.translate('discover.contextAwareness.changePointPvalueCell.impactLow', {
+    defaultMessage: 'low',
+  }),
+  minimal: i18n.translate('discover.contextAwareness.changePointPvalueCell.impactMinimal', {
+    defaultMessage: 'minimal',
+  }),
+};
+
+function formatPvalue(value: number): string {
+  if (value === 0) return '0';
+  if (value >= 0.01 && value < 1) return value.toFixed(4);
+  return value.toExponential(2);
+}
+
+export interface ChangePointPvalueCellContext {
+  pvalueColumnId: string;
+}
+
+interface ChangePointPvalueCellProps extends DataGridCellValueElementProps {
+  context: ChangePointPvalueCellContext;
+}
+
+export const ChangePointPvalueCell: FC<ChangePointPvalueCellProps> = ({
+  row,
+  columnId,
+  context,
+}) => {
+  const raw = row.flattened?.[columnId] ?? row.flattened?.[context.pvalueColumnId];
+  const pvalue = typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+
+  if (pvalue === null || pvalue === undefined) {
+    return '(null)';
+  }
+
+  const level = getImpactLevel(pvalue);
+  const color = IMPACT_LEVEL_COLORS[level];
+  const label = IMPACT_LEVEL_LABELS[level];
+
+  return (
+    <EuiFlexGroup
+      gutterSize="s"
+      alignItems="center"
+      wrap={false}
+      responsive={false}
+      direction="column"
+    >
+      <EuiFlexItem grow={false}>
+        <EuiBadge color={color} title={String(pvalue)}>
+          {label}
+        </EuiBadge>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>{formatPvalue(pvalue)}</EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_pvalue_column_header.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/change_point_pvalue_column_header.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiIconTip, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const TOOLTIP_TITLE = i18n.translate(
+  'discover.contextAwareness.changePointPvalueColumnHeader.tooltipTitle',
+  { defaultMessage: 'P-value' }
+);
+
+const TOOLTIP_CONTENT = i18n.translate(
+  'discover.contextAwareness.changePointPvalueColumnHeader.tooltipContent',
+  {
+    defaultMessage:
+      'Statistical significance of the change point. Lower values indicate a more extreme change. The impact badge reflects this (e.g. very high for p < 0.001).',
+  }
+);
+
+interface ChangePointPvalueColumnHeaderProps {
+  columnDisplayName?: string;
+  headerRowHeight?: number;
+}
+
+export const ChangePointPvalueColumnHeader: React.FC<ChangePointPvalueColumnHeaderProps> = ({
+  columnDisplayName,
+  headerRowHeight = 1,
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 0,
+        overflow: 'hidden',
+        width: '100%',
+      }}
+    >
+      <span css={{ marginRight: euiTheme.size.xs }}>
+        <EuiIconTip
+          data-test-subj="change-point-pvalue-header-icon"
+          type="info"
+          content={TOOLTIP_CONTENT}
+          title={TOOLTIP_TITLE}
+        />
+      </span>
+      <span css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {columnDisplayName ?? 'pvalue'}
+      </span>
+    </div>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/constants.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/constants.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID = 'discover-change-point-tooltip-annotations';
+
+export const DEFAULT_PVALUE_WHEN_MISSING = 0.05;
+
+export const FORK_COLUMN_ID = '_fork';
+
+export const MS_PER_HOUR = 60 * 60 * 1000;
+export const MS_PER_DAY = 24 * MS_PER_HOUR;
+export const MS_PER_MONTH = 30 * MS_PER_DAY;
+
+export const MAX_SELECTED_ENTITIES = 6;
+/** Max character length for entity labels in the y-axis; longer labels are truncated with ellipsis. */
+export const MAX_ENTITY_LABEL_LENGTH = 25;
+/** Y-axis label width (px), matching ML anomaly swimlane. */
+export const Y_AXIS_LABEL_WIDTH = 170;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import {
+  buildChangePointLensAttributesByRecordId,
+  mapForkIndexToEntityChartKey,
+  rowIsQualifyingChangePointForDocChart,
+} from './helpers';
+
+const mockLensAttrs = {
+  title: 't',
+  visualizationType: 'lnsXY',
+} as unknown as TypedLensByValueInput['attributes'];
+
+describe('change_point helpers (doc tab bridge)', () => {
+  describe('mapForkIndexToEntityChartKey', () => {
+    it('returns fork index when in range', () => {
+      expect(
+        mapForkIndexToEntityChartKey(1, [
+          { branchLabel: 'a', branchIndex: 0 },
+          { branchLabel: 'b', branchIndex: 1 },
+        ])
+      ).toBe(1);
+    });
+
+    it('maps branchIndex to array index when fork value uses branchIndex', () => {
+      expect(
+        mapForkIndexToEntityChartKey(5, [
+          { branchLabel: 'a', branchIndex: 0 },
+          { branchLabel: 'b', branchIndex: 5 },
+        ])
+      ).toBe(1);
+    });
+  });
+
+  describe('rowIsQualifyingChangePointForDocChart', () => {
+    const table = {
+      type: 'datatable' as const,
+      columns: [
+        { id: '@timestamp', name: '@timestamp', meta: { type: 'date' } },
+        { id: 'type', name: 'type', meta: { type: 'string' } },
+        { id: 'pvalue', name: 'pvalue', meta: { type: 'number' } },
+      ],
+      rows: [
+        { '@timestamp': '2024-01-01T00:00:00.000Z', type: 'change_point', pvalue: 0.01 },
+        { '@timestamp': '2024-01-02T00:00:00.000Z', type: null, pvalue: 0.02 },
+        { '@timestamp': '2024-01-03T00:00:00.000Z', type: 'change_point', pvalue: null },
+      ],
+    };
+
+    it('returns true only when time, type, and p-value are all present', () => {
+      expect(
+        rowIsQualifyingChangePointForDocChart(
+          table.rows[0] as Record<string, unknown>,
+          table,
+          '@timestamp',
+          'type',
+          'pvalue'
+        )
+      ).toBe(true);
+      expect(
+        rowIsQualifyingChangePointForDocChart(
+          table.rows[1] as Record<string, unknown>,
+          table,
+          '@timestamp',
+          'type',
+          'pvalue'
+        )
+      ).toBe(false);
+      expect(
+        rowIsQualifyingChangePointForDocChart(
+          table.rows[2] as Record<string, unknown>,
+          table,
+          '@timestamp',
+          'type',
+          'pvalue'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('buildChangePointLensAttributesByRecordId', () => {
+    it('maps only qualifying change-point rows in single-entity mode', () => {
+      const table = {
+        type: 'datatable' as const,
+        columns: [
+          { id: '@timestamp', name: '@timestamp', meta: { type: 'date' } },
+          { id: 'type', name: 'type', meta: { type: 'string' } },
+          { id: 'pvalue', name: 'pvalue', meta: { type: 'number' } },
+        ],
+        rows: [
+          { '@timestamp': '2024-01-01T00:00:00.000Z', type: 'change_point', pvalue: 0.01 },
+          { '@timestamp': '2024-01-02T00:00:00.000Z', type: null, pvalue: 0.02 },
+        ],
+      };
+      const out = buildChangePointLensAttributesByRecordId(
+        table,
+        table.columns,
+        { typeColumnId: 'type', pvalueColumnId: 'pvalue' },
+        undefined,
+        {},
+        mockLensAttrs,
+        false
+      );
+      expect(out['0']).toBe(mockLensAttrs);
+      expect(out['1']).toBeUndefined();
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.ts
@@ -1,0 +1,653 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common';
+import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import { getChangePointOutputColumnNames } from '@kbn/esql-utils';
+import type { TimeRange } from '@kbn/es-query';
+import dateMath from '@kbn/datemath';
+import type {
+  BurstDetectionHistogramBucket,
+  ChangePointResult,
+  DataLayerLike,
+  RecordLike,
+  TimeInterval,
+} from './types';
+import {
+  CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID,
+  DEFAULT_PVALUE_WHEN_MISSING,
+  MS_PER_HOUR,
+  MS_PER_DAY,
+  MS_PER_MONTH,
+} from './constants';
+
+function getTimeBucketKey(ts: string, interval: TimeInterval): string {
+  try {
+    const d = new Date(ts);
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const day = d.getDate();
+    const h = d.getHours();
+    const min = d.getMinutes();
+    if (interval === 'month') return `${y}-${String(m + 1).padStart(2, '0')}`;
+    if (interval === 'day')
+      return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    if (interval === 'hour')
+      return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
+        h
+      ).padStart(2, '0')}`;
+    return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
+      h
+    ).padStart(2, '0')}-${String(min).padStart(2, '0')}`;
+  } catch {
+    return ts.slice(0, 16);
+  }
+}
+
+/** Get a time bucket size ('minute' | 'hour' | 'day' | 'month') based on the time span of the change point results. */
+export function getBestIntervalFromResults(results: ChangePointResult[]): TimeInterval {
+  const timestamps = results
+    .filter((r) => r.timestamp)
+    .map((r) => new Date(r.timestamp).getTime())
+    .filter((t) => !Number.isNaN(t));
+  if (timestamps.length < 2) return 'month';
+  const minTs = Math.min(...timestamps);
+  const maxTs = Math.max(...timestamps);
+  const spanMs = maxTs - minTs;
+  if (spanMs <= 2 * MS_PER_HOUR) return 'minute';
+  if (spanMs <= 2 * MS_PER_DAY) return 'hour';
+  if (spanMs <= 2 * MS_PER_MONTH) return 'day';
+  return 'month';
+}
+
+/** Get time bucket key and label based on interval. */
+export function getTimeBucket(ts: string, interval: TimeInterval): { key: string; label: string } {
+  try {
+    const d = new Date(ts);
+    const y = d.getFullYear();
+    const m = d.getMonth();
+    const day = d.getDate();
+    const h = d.getHours();
+    const min = d.getMinutes();
+    if (interval === 'month') {
+      const key = `${y}-${String(m + 1).padStart(2, '0')}`;
+      const label = d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+      return { key, label };
+    }
+    if (interval === 'day') {
+      const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+      const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+      return { key, label };
+    }
+    if (interval === 'hour') {
+      const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
+        h
+      ).padStart(2, '0')}`;
+      const label = d.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+      });
+      return { key, label };
+    }
+    const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
+      h
+    ).padStart(2, '0')}-${String(min).padStart(2, '0')}`;
+    const label = d.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    return { key, label };
+  } catch {
+    return { key: ts, label: ts.slice(0, 16) };
+  }
+}
+
+/** Generate time buckets for the full date range at the given interval. */
+export function getTimeBucketsForRange(
+  timeRange: TimeRange,
+  interval: TimeInterval
+): Array<{ key: string; label: string }> {
+  const fromMoment = dateMath.parse(timeRange.from);
+  const toMoment = dateMath.parse(timeRange.to, { roundUp: true });
+  if (!fromMoment?.isValid() || !toMoment?.isValid() || fromMoment.isAfter(toMoment)) return [];
+
+  const buckets: Array<{ key: string; label: string }> = [];
+  const current = fromMoment.clone();
+
+  while (current.isSameOrBefore(toMoment)) {
+    const d = current.toDate();
+    const ts = d.toISOString();
+    const { key, label } = getTimeBucket(ts, interval);
+    if (buckets.length === 0 || buckets[buckets.length - 1].key !== key) {
+      buckets.push({ key, label });
+    }
+    switch (interval) {
+      case 'month':
+        current.add(1, 'month');
+        break;
+      case 'day':
+        current.add(1, 'day');
+        break;
+      case 'hour':
+        current.add(1, 'hour');
+        break;
+      case 'minute':
+        current.add(1, 'minute');
+        break;
+    }
+  }
+
+  return buckets;
+}
+
+/** Get unique time buckets from results at the given interval, sorted by key. */
+export function getBucketsFromResults(
+  results: ChangePointResult[],
+  interval: TimeInterval
+): Array<{ key: string; label: string }> {
+  const bucketMap = new Map<string, { key: string; label: string }>();
+  for (const r of results) {
+    if (!r.timestamp) continue;
+    const { key, label } = getTimeBucket(r.timestamp, interval);
+    bucketMap.set(key, { key, label });
+  }
+  return [...bucketMap.values()].sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Build burst detection histogram: X = time bucket (timeline), Y = entities with change point (stacked by entity).
+ * Returns one row per (timeBucket, entity) with y=1 when entity had a change point in that bucket.
+ */
+export function getBurstDetectionHistogram(
+  results: ChangePointResult[],
+  entityLabels: string[],
+  timeRange?: { from: string; to: string }
+): BurstDetectionHistogramBucket[] {
+  const validResults = results.filter((r) => r.forkIndex !== undefined && r.timestamp);
+  if (validResults.length === 0 || entityLabels.length === 0) return [];
+
+  const interval = getBestIntervalFromResults(validResults);
+  const bucketToTimestamp = new Map<string, number>();
+  const bucketToEntities = new Map<string, Set<number>>();
+
+  const addToBucket = (key: string, ts: string, entityIdx: number) => {
+    const d = new Date(ts);
+    const ms = d.getTime();
+    if (!bucketToTimestamp.has(key)) bucketToTimestamp.set(key, ms);
+    let set = bucketToEntities.get(key);
+    if (!set) {
+      set = new Set();
+      bucketToEntities.set(key, set);
+    }
+    set.add(entityIdx);
+  };
+
+  for (const r of validResults) {
+    const key = getTimeBucketKey(r.timestamp!, interval);
+    addToBucket(key, r.timestamp!, r.forkIndex!);
+  }
+
+  if (timeRange?.from && timeRange?.to) {
+    const fromMoment = dateMath.parse(timeRange.from);
+    const toMoment = dateMath.parse(timeRange.to, { roundUp: true });
+    if (fromMoment?.isValid() && toMoment?.isValid()) {
+      const current = fromMoment.clone();
+      while (current.isSameOrBefore(toMoment)) {
+        const ts = current.toDate().toISOString();
+        const key = getTimeBucketKey(ts, interval);
+        if (!bucketToTimestamp.has(key)) {
+          bucketToTimestamp.set(key, current.valueOf());
+          bucketToEntities.set(key, new Set());
+        }
+        switch (interval) {
+          case 'month':
+            current.add(1, 'month');
+            break;
+          case 'day':
+            current.add(1, 'day');
+            break;
+          case 'hour':
+            current.add(1, 'hour');
+            break;
+          case 'minute':
+            current.add(1, 'minute');
+            break;
+        }
+      }
+    }
+  }
+
+  const keys = [...bucketToTimestamp.keys()].sort();
+  const data: BurstDetectionHistogramBucket[] = [];
+  for (const key of keys) {
+    const ts = bucketToTimestamp.get(key)!;
+    const entities = bucketToEntities.get(key) ?? new Set();
+    for (const entityIdx of entities) {
+      const label = entityLabels[entityIdx] ?? `Entity ${entityIdx}`;
+      data.push({ x: ts, g: label, y: 1 });
+    }
+  }
+  return data;
+}
+
+/** Format annotation tooltip label: type, optional p-value, optional entity. */
+export function formatChangePointAnnotationLabel(
+  type: string | undefined,
+  pvalue: number | null | undefined,
+  entity?: string
+): string {
+  const typeLabel = type ?? 'Change point';
+  const parts: string[] = [];
+  if (entity) parts.push(entity);
+  if (pvalue != null && !Number.isNaN(pvalue)) {
+    const pvalStr = pvalue < 0.01 ? pvalue.toExponential(2) : pvalue.toFixed(4);
+    parts.push(`p-value: ${pvalStr}`);
+  }
+  if (parts.length === 0) return typeLabel;
+  return `${typeLabel} (${parts.join(', ')})`;
+}
+
+/**
+ * Apply line chart styling to source data layers (line series, subdued color).
+ */
+export function applyLineChartStyleToDataLayers(
+  layers: DataLayerLike[],
+  sourceLineColor: string
+): DataLayerLike[] {
+  return layers.map((layer) => {
+    if (layer.layerType !== 'data' || !layer.accessors?.length) return layer;
+    const yConfig = layer.accessors.map((forAccessor) => ({
+      forAccessor,
+      color: sourceLineColor,
+    }));
+    return { ...layer, seriesType: 'line', yConfig };
+  });
+}
+
+/**
+ * Derive per-entity Lens attributes from full fork chart attributes.
+ * Keeps only the data layer and annotation layer for the entity. Prefers
+ * extracting the annotation layer from the full chart; falls back to building
+ * from entityResults if not found.
+ */
+export function deriveEntityAttributes(
+  fullAttributes: TypedLensByValueInput['attributes'],
+  entityIndex: number,
+  entityResults: ChangePointResult[],
+  entityLabel: string,
+  dataViewId: string,
+  forkLineColors: string[]
+): TypedLensByValueInput['attributes'] | null {
+  const dataLayerId = `fork-branch-${entityIndex}`;
+  const annotationLayerId = `${CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID}-branch-${entityIndex}`;
+  const textBased = fullAttributes.state?.datasourceStates?.textBased as
+    | { layers?: Record<string, unknown> }
+    | undefined;
+  const dsLayers = textBased?.layers;
+  const visLayers =
+    (fullAttributes.state?.visualization as { layers?: DataLayerLike[] })?.layers ?? [];
+  if (!dsLayers?.[dataLayerId]) return null;
+  const dataLayer = visLayers.find((l) => l.layerId === dataLayerId);
+  if (!dataLayer) return null;
+
+  const entityLayers: DataLayerLike[] = [dataLayer];
+  let annotationLayer = visLayers.find(
+    (l: DataLayerLike) => l.layerId === annotationLayerId && l.layerType === 'annotations'
+  ) as DataLayerLike | undefined;
+
+  if (!annotationLayer && entityResults.length > 0) {
+    const color = forkLineColors[entityIndex % forkLineColors.length] ?? forkLineColors[0];
+    const dataLayerIndex = (dsLayers[dataLayerId] as { index?: string })?.index;
+    const effectiveIndexPatternId = dataLayerIndex ?? dataViewId;
+    const annotations = entityResults.map((r, idx) => {
+      const timestamp = (() => {
+        try {
+          return new Date(r.timestamp).toISOString();
+        } catch {
+          return r.timestamp;
+        }
+      })();
+      return {
+        id: `change-point-annotation-b${entityIndex}-${idx}`,
+        type: 'manual' as const,
+        icon: 'triangle' as const,
+        textVisibility: true,
+        label: formatChangePointAnnotationLabel(r.type, r.pvalue ?? null),
+        key: { type: 'point_in_time' as const, timestamp },
+        isHidden: false,
+        color,
+        lineStyle: 'solid' as const,
+        lineWidth: 1,
+        outside: false,
+      };
+    });
+    annotationLayer = {
+      layerId: annotationLayerId,
+      layerType: 'annotations' as const,
+      indexPatternId: effectiveIndexPatternId,
+      annotations,
+      ignoreGlobalFilters: true,
+    } as DataLayerLike;
+  }
+
+  if (annotationLayer) {
+    // Strip entity from annotation labels (redundant in per-entity mini charts)
+    const entitySuffix = ` (${entityLabel})`;
+    const entityInParens = ` (${entityLabel}, `;
+    const entityComma = `, ${entityLabel})`;
+    const annotations = (annotationLayer.annotations ?? []) as Array<{ label?: string }>;
+    annotationLayer = {
+      ...annotationLayer,
+      annotations: annotations.map((a) => {
+        let label = a.label ?? '';
+        if (label.endsWith(entitySuffix)) {
+          label = label.slice(0, -entitySuffix.length);
+        } else if (label.includes(entityInParens)) {
+          label = label.replace(entityInParens, ' (');
+        } else if (label.includes(entityComma)) {
+          label = label.replace(entityComma, ')');
+        }
+        return { ...a, label };
+      }),
+    } as DataLayerLike;
+    entityLayers.push(annotationLayer);
+  }
+
+  // Use metric field name in tooltip instead of entity (redundant in per-entity mini charts)
+  const dsLayer = dsLayers[dataLayerId] as {
+    columns?: Array<{
+      columnId?: string;
+      fieldName?: string;
+      label?: string;
+      customLabel?: boolean;
+    }>;
+  };
+  const valueAccessors = new Set(dataLayer.accessors ?? []);
+  const dsLayerWithMetricLabel = dsLayer?.columns
+    ? {
+        ...dsLayer,
+        columns: dsLayer.columns.map((col) =>
+          valueAccessors.has(col.columnId ?? '')
+            ? { ...col, customLabel: false, label: col.fieldName ?? col.label }
+            : col
+        ),
+      }
+    : dsLayer;
+
+  return {
+    ...fullAttributes,
+    state: {
+      ...fullAttributes.state,
+      datasourceStates: {
+        ...fullAttributes.state?.datasourceStates,
+        textBased: {
+          ...textBased,
+          layers: { [dataLayerId]: dsLayerWithMetricLabel },
+        },
+      },
+      visualization: {
+        ...(fullAttributes.state?.visualization as object),
+        layers: entityLayers,
+      },
+    } as TypedLensByValueInput['attributes']['state'],
+  };
+}
+
+/**
+ * Build change point results from doc viewer records (e.g. textBasedHits).
+ * Uses columns + columnsMeta to resolve time/type/pvalue/value column ids.
+ * Includes every record (one result per record) so indices align with the hit list.
+ * Rows without a p-value are included as long as they have a timestamp, so before/after
+ * values can be taken from adjacent rows that may not be change points.
+ */
+export function getChangePointResultsFromRecords(
+  records: RecordLike[],
+  columns: string[],
+  columnsMeta: Record<string, { type?: string }> | undefined,
+  query: { esql?: string }
+): { results: ChangePointResult[]; metricLabel: string } {
+  const columnNames = getChangePointOutputColumnNames(query?.esql);
+  const typeColumnId =
+    columnNames && columns.includes(columnNames.typeColumn) ? columnNames.typeColumn : undefined;
+  const pvalueColumnId =
+    columnNames && columns.includes(columnNames.pvalueColumn)
+      ? columnNames.pvalueColumn
+      : undefined;
+  const timeColumnId =
+    columns.find(
+      (id) =>
+        columnsMeta?.[id]?.type === 'date' ||
+        (typeof columnsMeta?.[id]?.type === 'string' &&
+          String(columnsMeta?.[id]?.type).startsWith('date'))
+    ) ?? columns[0];
+  let valueColumnId = columns.find(
+    (id) =>
+      id !== timeColumnId &&
+      id !== typeColumnId &&
+      id !== pvalueColumnId &&
+      columnsMeta?.[id]?.type === 'number'
+  );
+  if (!valueColumnId) {
+    valueColumnId = columns.find(
+      (id) => id !== timeColumnId && id !== typeColumnId && id !== pvalueColumnId
+    );
+  }
+  const metricLabel = valueColumnId ?? '';
+
+  if (!timeColumnId) {
+    return { results: [], metricLabel };
+  }
+
+  const skipColumnIds = new Set([timeColumnId, typeColumnId, pvalueColumnId].filter(Boolean));
+
+  const results: ChangePointResult[] = [];
+  for (const rec of records) {
+    const row = rec.flattened ?? {};
+    const ts = row[timeColumnId];
+    const timestamp = timestampToIso(ts) ?? '';
+    const typeVal = typeColumnId ? row[typeColumnId] : undefined;
+    const pval = pvalueColumnId != null ? row[pvalueColumnId] : undefined;
+    let rawVal = valueColumnId != null ? row[valueColumnId] : undefined;
+    if (rawVal === undefined && row && typeof row === 'object') {
+      for (const k of Object.keys(row)) {
+        if (skipColumnIds.has(k)) continue;
+        const v = row[k];
+        if (v != null && (typeof v === 'number' || !Number.isNaN(Number(v)))) {
+          rawVal = v;
+          break;
+        }
+      }
+    }
+    const value =
+      rawVal != null && (typeof rawVal === 'number' || !Number.isNaN(Number(rawVal)))
+        ? Number(rawVal)
+        : undefined;
+    results.push({
+      timestamp,
+      type: typeVal != null ? String(typeVal) : undefined,
+      pvalue: pval != null && pval !== '' ? Number(pval) : undefined,
+      value,
+    });
+  }
+  return { results, metricLabel };
+}
+
+/** Read cell value from a row; rows may be keyed by column id, column name, or raw keys; or arrays by index. */
+export function getRowValue(
+  row: Record<string, unknown> | unknown[],
+  columnId: string,
+  table: Datatable
+): unknown {
+  const col = table.columns.find((c) => c.id === columnId || c.name === columnId);
+  if (!col) return undefined;
+  if (Array.isArray(row)) {
+    const idx = table.columns.findIndex((c) => c.id === columnId || c.name === columnId);
+    return idx >= 0 ? row[idx] : undefined;
+  }
+  let val = (row as Record<string, unknown>)[col.id] ?? (row as Record<string, unknown>)[col.name];
+  if (val === undefined && row && typeof row === 'object' && !Array.isArray(row)) {
+    const target = (col.name ?? col.id ?? '').toLowerCase();
+    const targetNorm = target.replace(/_/g, '');
+    const key = Object.keys(row as Record<string, unknown>).find(
+      (k) =>
+        k.toLowerCase() === target ||
+        k.toLowerCase().replace(/_/g, '') === targetNorm ||
+        (targetNorm === 'fork' && k.toLowerCase().includes('fork'))
+    );
+    if (key) val = (row as Record<string, unknown>)[key];
+  }
+  return val;
+}
+
+/** ES|QL date columns may use meta.type 'date' or 'date_nanos'; columns may have id or name. */
+export function getTimeColumnId(columns: DatatableColumn[]): string | undefined {
+  const dateCol = columns.find(
+    (c) =>
+      c.meta?.type === 'date' ||
+      (typeof c.meta?.type === 'string' && c.meta.type.startsWith('date')) ||
+      (c as { type?: string }).type === 'date'
+  );
+  if (dateCol) return dateCol.id ?? dateCol.name;
+  if (columns.length > 0) return columns[0].id ?? columns[0].name;
+  return undefined;
+}
+
+/** Find a column whose values match fork branch labels (e.g. provider matching entity URLs). */
+function findEntityColumnMatchingBranchLabels(
+  table: Datatable,
+  forkBranches: Array<{ branchLabel: string }>
+): string | undefined {
+  const labels = new Set(forkBranches.map((b) => b.branchLabel));
+  let bestColId: string | undefined;
+  let bestMatchCount = 0;
+  for (const col of table.columns) {
+    const colId = col.id ?? col.name;
+    if (!colId) continue;
+    let matchCount = 0;
+    for (const row of table.rows) {
+      const val = getRowValue(row as Record<string, unknown>, colId, table);
+      if (val != null && labels.has(String(val))) matchCount++;
+    }
+    if (matchCount > bestMatchCount) {
+      bestMatchCount = matchCount;
+      bestColId = colId;
+    }
+  }
+  return bestColId;
+}
+
+/**
+ * Build change point results from the query result table (time, type, pvalue, value columns).
+ * Excludes rows where pvalue is null when the pvalue column is present.
+ * When forkColumnId is provided (e.g. _fork), includes forkIndex for each result.
+ * When _fork is missing but forkBranches provided, matches column values to branchLabel for entity.
+ * Table rows may be objects keyed by column id/name or arrays by column index.
+ */
+export function getChangePointResultsFromTable(
+  table: Datatable,
+  timeColumnId: string,
+  typeColumnId: string | undefined,
+  pvalueColumnId: string | undefined,
+  valueColumnId: string | undefined,
+  forkColumnId?: string,
+  forkBranches?: Array<{ branchLabel: string }>
+): ChangePointResult[] {
+  const hasTimeColumn = table.columns.some((c) => (c.id ?? c.name) === timeColumnId);
+  if (!hasTimeColumn) return [];
+
+  const forkCol = forkColumnId
+    ? table.columns.find(
+        (c) =>
+          c.id === forkColumnId ||
+          c.name === forkColumnId ||
+          c.id === '_fork' ||
+          c.name === '_fork' ||
+          (typeof c.name === 'string' && c.name.toLowerCase().includes('fork'))
+      )
+    : undefined;
+  const hasForkColumn = Boolean(forkCol);
+  const effectiveForkColumnId = forkCol?.id ?? forkCol?.name ?? forkColumnId;
+
+  const entityColumnByBranchLabel =
+    !hasForkColumn && forkBranches?.length
+      ? findEntityColumnMatchingBranchLabels(table, forkBranches)
+      : undefined;
+
+  const results: ChangePointResult[] = [];
+  for (const row of table.rows) {
+    const rowRecord = row as Record<string, unknown> | unknown[];
+    const ts = getRowValue(rowRecord, timeColumnId, table);
+    const timestamp = timestampToIso(ts);
+    if (!timestamp) continue;
+    if (pvalueColumnId) {
+      const pval = getRowValue(rowRecord, pvalueColumnId, table);
+      if (pval === null || pval === undefined) continue;
+    }
+
+    const typeVal = typeColumnId ? getRowValue(rowRecord, typeColumnId, table) : undefined;
+    const pval = pvalueColumnId ? getRowValue(rowRecord, pvalueColumnId, table) : undefined;
+    const val = valueColumnId ? getRowValue(rowRecord, valueColumnId, table) : undefined;
+    let forkIndex: number | undefined;
+    if (hasForkColumn && effectiveForkColumnId) {
+      const forkVal = getRowValue(rowRecord, effectiveForkColumnId, table);
+      if (typeof forkVal === 'number' && Number.isInteger(forkVal)) {
+        forkIndex = forkVal > 0 ? forkVal - 1 : forkVal;
+      } else if (typeof forkVal === 'string') {
+        const match = forkVal.match(/^fork(\d+)$/i);
+        if (match) forkIndex = parseInt(match[1], 10) - 1;
+      }
+    } else if (entityColumnByBranchLabel) {
+      const entityVal = getRowValue(rowRecord, entityColumnByBranchLabel, table);
+      const idx =
+        entityVal != null && forkBranches
+          ? forkBranches.findIndex(
+              (b) =>
+                String(entityVal) === b.branchLabel || String(entityVal) === String(b.branchLabel)
+            )
+          : -1;
+      if (idx >= 0) forkIndex = idx;
+    }
+    const pvalueNum = pval != null ? Number(pval) : undefined;
+    results.push({
+      timestamp,
+      type: typeVal != null ? String(typeVal) : undefined,
+      pvalue: pvalueNum ?? (val != null ? DEFAULT_PVALUE_WHEN_MISSING : undefined),
+      value: val != null && typeof val === 'number' ? val : undefined,
+      forkIndex,
+    });
+  }
+  return results;
+}
+
+/** First numeric column that is not time, type, or pvalue (the metric value column). */
+export function getValueColumnId(
+  columns: DatatableColumn[],
+  timeColumnId: string,
+  typeColumnId: string | undefined,
+  pvalueColumnId: string | undefined
+): string | undefined {
+  const col = columns.find((c) => {
+    const id = c.id ?? c.name;
+    if (!id) return false;
+    if (id === timeColumnId || id === typeColumnId || id === pvalueColumnId) return false;
+    return c.meta?.type === 'number' || (c as { type?: string }).type === 'double';
+  });
+  return col?.id ?? col?.name;
+}
+
+/** Normalize timestamps to ISO strings, while safely handling invalid or unsupported types. */
+export function timestampToIso(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return new Date(value).toISOString();
+  return undefined;
+}

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/helpers.ts
@@ -9,7 +9,8 @@
 
 import type { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { TypedLensByValueInput } from '@kbn/lens-plugin/public';
-import { getChangePointOutputColumnNames } from '@kbn/esql-utils';
+import { getChangePointEntityFieldName, getChangePointOutputColumnNames } from '@kbn/esql-utils';
+import type { ForkBranchLabel } from '@kbn/esql-utils';
 import type { TimeRange } from '@kbn/es-query';
 import dateMath from '@kbn/datemath';
 import type {
@@ -22,29 +23,39 @@ import type {
 import {
   CHANGE_POINT_TOOLTIP_ANNOTATION_LAYER_ID,
   DEFAULT_PVALUE_WHEN_MISSING,
+  FORK_COLUMN_ID,
   MS_PER_HOUR,
   MS_PER_DAY,
   MS_PER_MONTH,
 } from './constants';
 
+/** Advance a moment by one unit of the given interval. */
+function advanceMomentByInterval(
+  current: { add: (amount: number, unit: 'month' | 'day' | 'hour' | 'minute') => unknown },
+  interval: TimeInterval
+): void {
+  const unitMap: Record<TimeInterval, 'month' | 'day' | 'hour' | 'minute'> = {
+    month: 'month',
+    day: 'day',
+    hour: 'hour',
+    minute: 'minute',
+  };
+  current.add(1, unitMap[interval]);
+}
+
 function getTimeBucketKey(ts: string, interval: TimeInterval): string {
   try {
     const d = new Date(ts);
-    const y = d.getFullYear();
-    const m = d.getMonth();
-    const day = d.getDate();
-    const h = d.getHours();
-    const min = d.getMinutes();
-    if (interval === 'month') return `${y}-${String(m + 1).padStart(2, '0')}`;
-    if (interval === 'day')
-      return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-    if (interval === 'hour')
-      return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
-        h
-      ).padStart(2, '0')}`;
-    return `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
-      h
-    ).padStart(2, '0')}-${String(min).padStart(2, '0')}`;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const parts = [
+      d.getFullYear(),
+      pad(d.getMonth() + 1),
+      pad(d.getDate()),
+      pad(d.getHours()),
+      pad(d.getMinutes()),
+    ];
+    const len: Record<TimeInterval, number> = { month: 2, day: 3, hour: 4, minute: 5 };
+    return parts.slice(0, len[interval]).join('-');
   } catch {
     return ts.slice(0, 16);
   }
@@ -66,45 +77,19 @@ export function getBestIntervalFromResults(results: ChangePointResult[]): TimeIn
   return 'month';
 }
 
+const TIME_BUCKET_LABEL_OPTIONS: Record<TimeInterval, Intl.DateTimeFormatOptions> = {
+  month: { month: 'short', year: '2-digit' },
+  day: { month: 'short', day: 'numeric' },
+  hour: { month: 'short', day: 'numeric', hour: '2-digit' },
+  minute: { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' },
+};
+
 /** Get time bucket key and label based on interval. */
 export function getTimeBucket(ts: string, interval: TimeInterval): { key: string; label: string } {
   try {
     const d = new Date(ts);
-    const y = d.getFullYear();
-    const m = d.getMonth();
-    const day = d.getDate();
-    const h = d.getHours();
-    const min = d.getMinutes();
-    if (interval === 'month') {
-      const key = `${y}-${String(m + 1).padStart(2, '0')}`;
-      const label = d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
-      return { key, label };
-    }
-    if (interval === 'day') {
-      const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-      const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-      return { key, label };
-    }
-    if (interval === 'hour') {
-      const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
-        h
-      ).padStart(2, '0')}`;
-      const label = d.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-      });
-      return { key, label };
-    }
-    const key = `${y}-${String(m + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}-${String(
-      h
-    ).padStart(2, '0')}-${String(min).padStart(2, '0')}`;
-    const label = d.toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    const key = getTimeBucketKey(ts, interval);
+    const label = d.toLocaleDateString(undefined, TIME_BUCKET_LABEL_OPTIONS[interval]);
     return { key, label };
   } catch {
     return { key: ts, label: ts.slice(0, 16) };
@@ -130,20 +115,7 @@ export function getTimeBucketsForRange(
     if (buckets.length === 0 || buckets[buckets.length - 1].key !== key) {
       buckets.push({ key, label });
     }
-    switch (interval) {
-      case 'month':
-        current.add(1, 'month');
-        break;
-      case 'day':
-        current.add(1, 'day');
-        break;
-      case 'hour':
-        current.add(1, 'hour');
-        break;
-      case 'minute':
-        current.add(1, 'minute');
-        break;
-    }
+    advanceMomentByInterval(current, interval);
   }
 
   return buckets;
@@ -208,20 +180,7 @@ export function getBurstDetectionHistogram(
           bucketToTimestamp.set(key, current.valueOf());
           bucketToEntities.set(key, new Set());
         }
-        switch (interval) {
-          case 'month':
-            current.add(1, 'month');
-            break;
-          case 'day':
-            current.add(1, 'day');
-            break;
-          case 'hour':
-            current.add(1, 'hour');
-            break;
-          case 'minute':
-            current.add(1, 'minute');
-            break;
-        }
+        advanceMomentByInterval(current, interval);
       }
     }
   }
@@ -508,6 +467,36 @@ export function getRowValue(
   return val;
 }
 
+function getColumnId(col: DatatableColumn | undefined): string | undefined {
+  return col?.id ?? col?.name;
+}
+
+/** Known column names for CHANGE_POINT output (defaults and common AS renames). */
+const CHANGE_POINT_TYPE_COLUMN_NAMES = ['type', 'change_type', 'changeType'];
+const CHANGE_POINT_PVALUE_COLUMN_NAMES = ['pvalue', 'p_value', 'pValue'];
+
+/**
+ * Resolves type and pvalue column IDs from table columns by matching known CHANGE_POINT output names.
+ * Uses fetchParams columns; no query parsing needed.
+ */
+export function getChangePointColumnIdsFromColumns(columns: DatatableColumn[]): {
+  typeColumnId?: string;
+  pvalueColumnId?: string;
+} {
+  const typeCol = columns.find((c) => {
+    const id = (c.id ?? c.name ?? '').toLowerCase();
+    return CHANGE_POINT_TYPE_COLUMN_NAMES.some((n) => id === n.toLowerCase());
+  });
+  const pvalueCol = columns.find((c) => {
+    const id = (c.id ?? c.name ?? '').toLowerCase();
+    return CHANGE_POINT_PVALUE_COLUMN_NAMES.some((n) => id === n.toLowerCase());
+  });
+  return {
+    typeColumnId: getColumnId(typeCol),
+    pvalueColumnId: getColumnId(pvalueCol),
+  };
+}
+
 /** ES|QL date columns may use meta.type 'date' or 'date_nanos'; columns may have id or name. */
 export function getTimeColumnId(columns: DatatableColumn[]): string | undefined {
   const dateCol = columns.find(
@@ -516,9 +505,51 @@ export function getTimeColumnId(columns: DatatableColumn[]): string | undefined 
       (typeof c.meta?.type === 'string' && c.meta.type.startsWith('date')) ||
       (c as { type?: string }).type === 'date'
   );
-  if (dateCol) return dateCol.id ?? dateCol.name;
-  if (columns.length > 0) return columns[0].id ?? columns[0].name;
+  if (dateCol) return getColumnId(dateCol);
+  if (columns.length > 0) return getColumnId(columns[0]);
   return undefined;
+}
+
+/**
+ * Derives entities from the ES|QL query and change point result table.
+ * Uses the query to find the entity field name (e.g. the BY field that is not the time dimension),
+ * then extracts unique values from the table for that column.
+ * @param esql - The full ES|QL query string
+ * @param table - The change point result datatable
+ * @returns Array of { branchIndex, branchLabel } for each entity, or undefined when no entity field
+ */
+export function getEntitiesFromChangePointData(
+  esql: string | undefined,
+  table: Datatable
+): ForkBranchLabel[] | undefined {
+  if (!esql || !table?.rows?.length) return undefined;
+
+  const entityFieldName = getChangePointEntityFieldName(esql);
+  if (!entityFieldName) return undefined;
+
+  const entityCol = table.columns.find((c) => (c.id ?? c.name) === entityFieldName);
+  const entityColumnId = getColumnId(entityCol);
+  if (!entityColumnId) return undefined;
+
+  const seen = new Map<string, number>();
+  const order: string[] = [];
+  for (const row of table.rows) {
+    const val = getRowValue(row as Record<string, unknown> | unknown[], entityColumnId, table);
+    if (val != null && val !== '') {
+      const str = String(val);
+      if (!seen.has(str)) {
+        seen.set(str, order.length);
+        order.push(str);
+      }
+    }
+  }
+
+  if (order.length === 0) return undefined;
+
+  return order.map((branchLabel, branchIndex) => ({
+    branchIndex,
+    branchLabel,
+  }));
 }
 
 /** Find a column whose values match fork branch labels (e.g. provider matching entity URLs). */
@@ -530,7 +561,7 @@ function findEntityColumnMatchingBranchLabels(
   let bestColId: string | undefined;
   let bestMatchCount = 0;
   for (const col of table.columns) {
-    const colId = col.id ?? col.name;
+    const colId = getColumnId(col);
     if (!colId) continue;
     let matchCount = 0;
     for (const row of table.rows) {
@@ -543,6 +574,185 @@ function findEntityColumnMatchingBranchLabels(
     }
   }
   return bestColId;
+}
+
+export interface ForkColumnMetaForChangePoint {
+  hasForkColumn: boolean;
+  effectiveForkColumnId: string | undefined;
+  entityColumnByBranchLabel: string | undefined;
+}
+
+export function getForkColumnMetaForChangePointTable(
+  table: Datatable,
+  forkColumnId?: string,
+  forkBranches?: Array<{ branchLabel: string }>
+): ForkColumnMetaForChangePoint {
+  const forkCol = forkColumnId
+    ? table.columns.find(
+        (c) =>
+          c.id === forkColumnId ||
+          c.name === forkColumnId ||
+          c.id === '_fork' ||
+          c.name === '_fork' ||
+          (typeof c.name === 'string' && c.name.toLowerCase().includes('fork'))
+      )
+    : undefined;
+  const hasForkColumn = Boolean(forkCol);
+  const effectiveForkColumnId = forkCol?.id ?? forkCol?.name ?? forkColumnId;
+  const entityColumnByBranchLabel =
+    !hasForkColumn && forkBranches?.length
+      ? findEntityColumnMatchingBranchLabels(table, forkBranches)
+      : undefined;
+  return { hasForkColumn, effectiveForkColumnId, entityColumnByBranchLabel };
+}
+
+export function resolveForkIndexForChangePointRow(
+  rowRecord: Record<string, unknown> | unknown[],
+  table: Datatable,
+  meta: ForkColumnMetaForChangePoint,
+  forkBranches?: Array<{ branchLabel: string }>
+): number | undefined {
+  let forkIndex: number | undefined;
+  if (meta.hasForkColumn && meta.effectiveForkColumnId) {
+    const forkVal = getRowValue(rowRecord, meta.effectiveForkColumnId, table);
+    if (typeof forkVal === 'number' && Number.isInteger(forkVal)) {
+      forkIndex = forkVal > 0 ? forkVal - 1 : forkVal;
+    } else if (typeof forkVal === 'string') {
+      const match = forkVal.match(/^fork(\d+)$/i);
+      if (match) forkIndex = parseInt(match[1], 10) - 1;
+    }
+  } else if (meta.entityColumnByBranchLabel) {
+    const entityVal = getRowValue(rowRecord, meta.entityColumnByBranchLabel, table);
+    const idx =
+      entityVal != null && forkBranches
+        ? forkBranches.findIndex(
+            (b) =>
+              String(entityVal) === b.branchLabel || String(entityVal) === String(b.branchLabel)
+          )
+        : -1;
+    if (idx >= 0) forkIndex = idx;
+  }
+  return forkIndex;
+}
+
+/** Map _fork / entity value to entityAttributesMap key (array index in forkBranchLabels). */
+export function mapForkIndexToEntityChartKey(
+  forkIndex: number | undefined,
+  forkBranchLabels: ForkBranchLabel[]
+): number | undefined {
+  if (forkIndex == null || forkBranchLabels.length === 0) return undefined;
+  if (forkIndex >= 0 && forkIndex < forkBranchLabels.length) {
+    return forkIndex;
+  }
+  const byBranchIndex = forkBranchLabels.findIndex((b) => b.branchIndex === forkIndex);
+  return byBranchIndex >= 0 ? byBranchIndex : undefined;
+}
+
+/**
+ * Document flyout chart only for rows that look like real CHANGE_POINT hits:
+ * valid time, non-null p-value, and non-null type (when those columns exist).
+ */
+export function rowIsQualifyingChangePointForDocChart(
+  rowRecord: Record<string, unknown> | unknown[],
+  table: Datatable,
+  timeColumnId: string | undefined,
+  typeColumnId: string | undefined,
+  pvalueColumnId: string | undefined
+): boolean {
+  if (!timeColumnId) return false;
+  const ts = getRowValue(rowRecord, timeColumnId, table);
+  if (!timestampToIso(ts)) return false;
+  if (!pvalueColumnId) return false;
+  const pval = getRowValue(rowRecord, pvalueColumnId, table);
+  if (pval === null || pval === undefined) return false;
+  if (!typeColumnId) return false;
+  const typeVal = getRowValue(rowRecord, typeColumnId, table);
+  if (typeVal === null || typeVal === undefined) return false;
+  return true;
+}
+
+/**
+ * Maps each ES|QL table row index to the same per-entity Lens attributes used in the
+ * multiple-line chart ({@link DataTableRecord.id} is String(rowIndex) in fetch_esql).
+ * Only rows that pass {@link rowIsQualifyingChangePointForDocChart} get an entry.
+ */
+export function buildChangePointLensAttributesByRecordId(
+  table: Datatable | undefined,
+  colsToUse: DatatableColumn[],
+  changePointColumnIds: { typeColumnId?: string; pvalueColumnId?: string },
+  forkBranchLabels: ForkBranchLabel[] | undefined,
+  entityAttributesMap: Record<number, TypedLensByValueInput['attributes']>,
+  lensAttributes: TypedLensByValueInput['attributes'] | null,
+  multipleEntityMode: boolean
+): Record<string, TypedLensByValueInput['attributes']> {
+  const out: Record<string, TypedLensByValueInput['attributes']> = {};
+  if (!table?.rows?.length || !lensAttributes) {
+    return out;
+  }
+
+  const timeColumnId = getTimeColumnId(colsToUse);
+  const { typeColumnId, pvalueColumnId } = changePointColumnIds;
+
+  if (!multipleEntityMode) {
+    for (let i = 0; i < table.rows.length; i++) {
+      const rowRecord = table.rows[i] as Record<string, unknown> | unknown[];
+      if (
+        rowIsQualifyingChangePointForDocChart(
+          rowRecord,
+          table,
+          timeColumnId,
+          typeColumnId,
+          pvalueColumnId
+        )
+      ) {
+        out[String(i)] = lensAttributes;
+      }
+    }
+    return out;
+  }
+
+  if (!forkBranchLabels?.length) {
+    return out;
+  }
+
+  const valueColumnId = timeColumnId
+    ? getValueColumnId(colsToUse, timeColumnId, typeColumnId, pvalueColumnId)
+    : undefined;
+  if (!timeColumnId || !valueColumnId) {
+    return out;
+  }
+
+  const forkMeta = getForkColumnMetaForChangePointTable(table, FORK_COLUMN_ID, forkBranchLabels);
+
+  table.rows.forEach((row, rowIndex) => {
+    const rowRecord = row as Record<string, unknown> | unknown[];
+    if (
+      !rowIsQualifyingChangePointForDocChart(
+        rowRecord,
+        table,
+        timeColumnId,
+        typeColumnId,
+        pvalueColumnId
+      )
+    ) {
+      return;
+    }
+
+    const forkIndex = resolveForkIndexForChangePointRow(
+      rowRecord,
+      table,
+      forkMeta,
+      forkBranchLabels
+    );
+    const entityKey = mapForkIndexToEntityChartKey(forkIndex, forkBranchLabels);
+    if (entityKey == null) return;
+    const attrs = entityAttributesMap[entityKey];
+    if (attrs) {
+      out[String(rowIndex)] = attrs;
+    }
+  });
+
+  return out;
 }
 
 /**
@@ -564,23 +774,7 @@ export function getChangePointResultsFromTable(
   const hasTimeColumn = table.columns.some((c) => (c.id ?? c.name) === timeColumnId);
   if (!hasTimeColumn) return [];
 
-  const forkCol = forkColumnId
-    ? table.columns.find(
-        (c) =>
-          c.id === forkColumnId ||
-          c.name === forkColumnId ||
-          c.id === '_fork' ||
-          c.name === '_fork' ||
-          (typeof c.name === 'string' && c.name.toLowerCase().includes('fork'))
-      )
-    : undefined;
-  const hasForkColumn = Boolean(forkCol);
-  const effectiveForkColumnId = forkCol?.id ?? forkCol?.name ?? forkColumnId;
-
-  const entityColumnByBranchLabel =
-    !hasForkColumn && forkBranches?.length
-      ? findEntityColumnMatchingBranchLabels(table, forkBranches)
-      : undefined;
+  const forkMeta = getForkColumnMetaForChangePointTable(table, forkColumnId, forkBranches);
 
   const results: ChangePointResult[] = [];
   for (const row of table.rows) {
@@ -596,26 +790,7 @@ export function getChangePointResultsFromTable(
     const typeVal = typeColumnId ? getRowValue(rowRecord, typeColumnId, table) : undefined;
     const pval = pvalueColumnId ? getRowValue(rowRecord, pvalueColumnId, table) : undefined;
     const val = valueColumnId ? getRowValue(rowRecord, valueColumnId, table) : undefined;
-    let forkIndex: number | undefined;
-    if (hasForkColumn && effectiveForkColumnId) {
-      const forkVal = getRowValue(rowRecord, effectiveForkColumnId, table);
-      if (typeof forkVal === 'number' && Number.isInteger(forkVal)) {
-        forkIndex = forkVal > 0 ? forkVal - 1 : forkVal;
-      } else if (typeof forkVal === 'string') {
-        const match = forkVal.match(/^fork(\d+)$/i);
-        if (match) forkIndex = parseInt(match[1], 10) - 1;
-      }
-    } else if (entityColumnByBranchLabel) {
-      const entityVal = getRowValue(rowRecord, entityColumnByBranchLabel, table);
-      const idx =
-        entityVal != null && forkBranches
-          ? forkBranches.findIndex(
-              (b) =>
-                String(entityVal) === b.branchLabel || String(entityVal) === String(b.branchLabel)
-            )
-          : -1;
-      if (idx >= 0) forkIndex = idx;
-    }
+    const forkIndex = resolveForkIndexForChangePointRow(rowRecord, table, forkMeta, forkBranches);
     const pvalueNum = pval != null ? Number(pval) : undefined;
     results.push({
       timestamp,
@@ -636,12 +811,12 @@ export function getValueColumnId(
   pvalueColumnId: string | undefined
 ): string | undefined {
   const col = columns.find((c) => {
-    const id = c.id ?? c.name;
+    const id = getColumnId(c);
     if (!id) return false;
     if (id === timeColumnId || id === typeColumnId || id === pvalueColumnId) return false;
     return c.meta?.type === 'number' || (c as { type?: string }).type === 'double';
   });
-  return col?.id ?? col?.name;
+  return getColumnId(col);
 }
 
 /** Normalize timestamps to ISO strings, while safely handling invalid or unsupported types. */

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createChangePointDataSourceProfileProvider } from './profile';
+export type { ChangePointPvalueCellContext } from './change_point_pvalue_cell';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/index.ts
@@ -8,4 +8,13 @@
  */
 
 export { createChangePointDataSourceProfileProvider } from './profile';
+export type { ChangePointDataSourceResolvedContext } from './profile';
+export {
+  CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
+  isChangePointDataSourceContext,
+} from './change_point_context';
+export type {
+  ChangePointLensDataSourceContext,
+  ChangePointLensDocContext,
+} from './change_point_context';
 export type { ChangePointPvalueCellContext } from './change_point_pvalue_cell';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { isOfAggregateQueryType } from '@kbn/es-query';
+import { hasChangePointCommand, getChangePointOutputColumnNames } from '@kbn/esql-utils';
+import type {
+  DataGridCellValueElementProps,
+  CustomGridColumnsConfiguration,
+  CustomGridColumnProps,
+} from '@kbn/unified-data-table';
+import { DataSourceType, isDataSourceType } from '../../../../../common/data_sources';
+import type { DataSourceProfileProvider } from '../../../profiles';
+import { DataSourceCategory } from '../../../profiles';
+import { ChangePointPvalueCell } from './change_point_pvalue_cell';
+import { ChangePointPvalueColumnHeader } from './change_point_pvalue_column_header';
+import { ChangePointExperienceView } from './change_point_experience_view';
+import type { ChangePointExperienceViewProps } from './types';
+import type { ChangePointPvalueCellContext } from './change_point_pvalue_cell';
+
+const CHANGE_POINT_DATA_SOURCE_PROFILE_ID = 'change-point-data-source-profile';
+
+const CHANGE_POINT_CHART_LOCAL_STORAGE_KEY = 'discover:changePointExperience';
+
+export const createChangePointDataSourceProfileProvider =
+  (): DataSourceProfileProvider<ChangePointPvalueCellContext> => ({
+    profileId: CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
+    profile: {
+      getChartSectionConfiguration: (prev) => (params) => ({
+        ...prev(params),
+        renderChartSection: (props) =>
+          React.createElement(ChangePointExperienceView, {
+            ...props,
+            actions: params.actions,
+          } as ChangePointExperienceViewProps),
+        replaceDefaultChart: true as const,
+        localStorageKeyPrefix: CHANGE_POINT_CHART_LOCAL_STORAGE_KEY,
+        defaultTopPanelHeight: 'max-content',
+      }),
+      getColumnsConfiguration:
+        (prev, { context }) =>
+        (): CustomGridColumnsConfiguration => {
+          const base = prev ? prev() : {};
+          const { pvalueColumnId } = context ?? {};
+          if (!pvalueColumnId) return base;
+          return {
+            ...base,
+            [pvalueColumnId]: ({ column, headerRowHeight }: CustomGridColumnProps) => ({
+              ...column,
+              display: React.createElement(ChangePointPvalueColumnHeader, {
+                columnDisplayName: column.displayAsText,
+                headerRowHeight,
+              }),
+            }),
+          };
+        },
+      getCellRenderers:
+        (prev, { context }) =>
+        (params) => {
+          const { pvalueColumnId } = context;
+          if (!pvalueColumnId) {
+            return prev(params);
+          }
+          const pvalueRenderer = (props: DataGridCellValueElementProps) =>
+            React.createElement(ChangePointPvalueCell, { ...props, context });
+          return {
+            ...prev(params),
+            [pvalueColumnId]: pvalueRenderer,
+          };
+        },
+    },
+    resolve: (params) => {
+      if (!isDataSourceType(params.dataSource, DataSourceType.Esql)) {
+        return { isMatch: false };
+      }
+
+      const query = params.query;
+      if (!isOfAggregateQueryType(query) || !query.esql) {
+        return { isMatch: false };
+      }
+
+      if (!hasChangePointCommand(query.esql)) {
+        return { isMatch: false };
+      }
+
+      const columnNames = getChangePointOutputColumnNames(query.esql);
+      const pvalueColumnId = columnNames?.pvalueColumn ?? 'pvalue';
+
+      return {
+        isMatch: true,
+        context: {
+          category: DataSourceCategory.Default,
+          pvalueColumnId,
+        },
+      };
+    },
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/profile.ts
@@ -15,34 +15,44 @@ import type {
   CustomGridColumnsConfiguration,
   CustomGridColumnProps,
 } from '@kbn/unified-data-table';
+import { BehaviorSubject } from 'rxjs';
 import { DataSourceType, isDataSourceType } from '../../../../../common/data_sources';
 import type { DataSourceProfileProvider } from '../../../profiles';
 import { DataSourceCategory } from '../../../profiles';
 import { ChangePointPvalueCell } from './change_point_pvalue_cell';
 import { ChangePointPvalueColumnHeader } from './change_point_pvalue_column_header';
+import {
+  CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
+  type ChangePointLensDataSourceContext,
+  type ChangePointLensDocContext,
+} from './change_point_context';
 import { ChangePointExperienceView } from './change_point_experience_view';
 import type { ChangePointExperienceViewProps } from './types';
 import type { ChangePointPvalueCellContext } from './change_point_pvalue_cell';
 
-const CHANGE_POINT_DATA_SOURCE_PROFILE_ID = 'change-point-data-source-profile';
-
 const CHANGE_POINT_CHART_LOCAL_STORAGE_KEY = 'discover:changePointExperience';
 
+export type ChangePointDataSourceResolvedContext = ChangePointPvalueCellContext &
+  ChangePointLensDataSourceContext;
+
 export const createChangePointDataSourceProfileProvider =
-  (): DataSourceProfileProvider<ChangePointPvalueCellContext> => ({
+  (): DataSourceProfileProvider<ChangePointDataSourceResolvedContext> => ({
     profileId: CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
     profile: {
-      getChartSectionConfiguration: (prev) => (params) => ({
-        ...prev(params),
-        renderChartSection: (props) =>
-          React.createElement(ChangePointExperienceView, {
-            ...props,
-            actions: params.actions,
-          } as ChangePointExperienceViewProps),
-        replaceDefaultChart: true as const,
-        localStorageKeyPrefix: CHANGE_POINT_CHART_LOCAL_STORAGE_KEY,
-        defaultTopPanelHeight: 'max-content',
-      }),
+      getChartSectionConfiguration:
+        (prev, { context }) =>
+        (params) => ({
+          ...prev(params),
+          renderChartSection: (props) =>
+            React.createElement(ChangePointExperienceView, {
+              ...props,
+              actions: params.actions,
+              changePointLensContext$: context.changePointLensContext$,
+            } as ChangePointExperienceViewProps),
+          replaceDefaultChart: true as const,
+          localStorageKeyPrefix: CHANGE_POINT_CHART_LOCAL_STORAGE_KEY,
+          defaultTopPanelHeight: 'max-content',
+        }),
       getColumnsConfiguration:
         (prev, { context }) =>
         (): CustomGridColumnsConfiguration => {
@@ -97,6 +107,9 @@ export const createChangePointDataSourceProfileProvider =
         context: {
           category: DataSourceCategory.Default,
           pvalueColumnId,
+          changePointLensContext$: new BehaviorSubject<ChangePointLensDocContext | undefined>(
+            undefined
+          ),
         },
       };
     },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
+import type { RestorableStateProviderProps } from '@kbn/restorable-state';
+import type { ChartSectionProps } from '@kbn/unified-histogram/types';
+import type { TimeRange } from '@kbn/es-query';
+import type { ForkBranchSourceQuery } from '@kbn/esql-utils';
+import type { ChartSectionConfigurationExtensionParams } from '../../../types';
+
+export type TimeInterval = 'month' | 'day' | 'hour' | 'minute';
+
+/** Bucket for burst histogram: x = timestamp (ms), g = entity label, y = 1 per entity in bucket (stacked). */
+export interface BurstDetectionHistogramBucket {
+  x: number;
+  g: string;
+  y: number;
+}
+
+export interface ChangePointBurstHistogramProps {
+  data: BurstDetectionHistogramBucket[];
+  charts: ChartsPluginStart;
+}
+
+/** Props for the change point experience view; matches ChartSectionConfiguration's renderChartSection (default T = object). */
+export type ChangePointExperienceViewProps = ChartSectionProps &
+  RestorableStateProviderProps<object> & {
+    actions?: ChartSectionConfigurationExtensionParams['actions'];
+  };
+
+export interface ChangePointForkHeatmapProps {
+  results: ChangePointResult[];
+  forkBranches: ForkBranchSourceQuery[];
+  selectedEntityIndices: number[];
+  onSelectEntity: (indices: number[]) => void;
+  renderEntityDetailChart: (entityIndex: number) => React.ReactNode;
+  /** When provided, columns span the full date range at the best interval derived from results. */
+  timeRange?: TimeRange;
+  charts: ChartsPluginStart;
+}
+
+/** A single change point result from the ES|QL CHANGE_POINT output. */
+export interface ChangePointResult {
+  timestamp: string;
+  type?: string;
+  pvalue?: number | null;
+  value?: number;
+  /** Branch index when CHANGE_POINT is inside FORK (_fork column value). */
+  forkIndex?: number;
+}
+
+export interface DataLayerLike {
+  layerType?: string;
+  accessors?: string[];
+  yConfig?: Array<{ forAccessor: string; color?: string }>;
+  [key: string]: unknown;
+}
+
+/** Record-like row with id and optional flattened fields (e.g. from DataTableRecord). */
+export interface RecordLike {
+  id: string;
+  flattened?: Record<string, unknown>;
+}

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
@@ -11,8 +11,10 @@ import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { RestorableStateProviderProps } from '@kbn/restorable-state';
 import type { ChartSectionProps } from '@kbn/unified-histogram/types';
 import type { TimeRange } from '@kbn/es-query';
-import type { ForkBranchSourceQuery } from '@kbn/esql-utils';
+import type { ForkBranchLabel } from '@kbn/esql-utils';
+import type { BehaviorSubject } from 'rxjs';
 import type { ChartSectionConfigurationExtensionParams } from '../../../types';
+import type { ChangePointLensDocContext } from './change_point_context';
 
 export type TimeInterval = 'month' | 'day' | 'hour' | 'minute';
 
@@ -32,11 +34,13 @@ export interface ChangePointBurstHistogramProps {
 export type ChangePointExperienceViewProps = ChartSectionProps &
   RestorableStateProviderProps<object> & {
     actions?: ChartSectionConfigurationExtensionParams['actions'];
+    /** Bridges per-row Lens attributes to the change point document tab (see change_point_context). */
+    changePointLensContext$: BehaviorSubject<ChangePointLensDocContext | undefined>;
   };
 
-export interface ChangePointForkHeatmapProps {
+export interface ChangePointHeatmapProps {
   results: ChangePointResult[];
-  forkBranches: ForkBranchSourceQuery[];
+  forkBranches: ForkBranchLabel[];
   selectedEntityIndices: number[];
   onSelectEntity: (indices: number[]) => void;
   renderEntityDetailChart: (entityIndex: number) => React.ReactNode;

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/types.ts
@@ -7,6 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type {
+  LensEmbeddableInput,
+  LensPublicStart,
+  TypedLensByValueInput,
+} from '@kbn/lens-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { RestorableStateProviderProps } from '@kbn/restorable-state';
 import type { ChartSectionProps } from '@kbn/unified-histogram/types';
@@ -26,8 +31,14 @@ export interface BurstDetectionHistogramBucket {
 }
 
 export interface ChangePointBurstHistogramProps {
-  data: BurstDetectionHistogramBucket[];
-  charts: ChartsPluginStart;
+  lens: LensPublicStart;
+  attributes: TypedLensByValueInput['attributes'] | null;
+  abortController?: AbortController;
+  lastReloadRequestTime?: number;
+  searchSessionId?: string;
+  timeRange?: TimeRange;
+  onBrushEnd?: LensEmbeddableInput['onBrushEnd'];
+  onFilter?: LensEmbeddableInput['onFilter'];
 }
 
 /** Props for the change point experience view; matches ChartSectionConfiguration's renderChartSection (default T = object). */

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/view_mode_selection.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_data_source_profile/view_mode_selection.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiFlexItem, EuiSelect } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export type ChangePointViewMode = 'heatmap' | 'multiple-line' | 'burst-detection';
+
+export interface ViewModeSelectionProps {
+  value: ChangePointViewMode;
+  onChange: (value: ChangePointViewMode) => void;
+}
+
+export const ViewModeSelection: React.FC<ViewModeSelectionProps> = ({ value, onChange }) => (
+  <EuiFlexItem grow={false}>
+    <EuiSelect
+      compressed
+      value={value}
+      onChange={(e) => onChange(e.target.value as ChangePointViewMode)}
+      aria-label={i18n.translate('discover.contextAwareness.changePointExperience.viewModeLabel', {
+        defaultMessage: 'Chart view mode',
+      })}
+      options={[
+        {
+          value: 'heatmap',
+          text: i18n.translate('discover.contextAwareness.changePointExperience.viewHeatmap', {
+            defaultMessage: 'Heatmap',
+          }),
+        },
+        {
+          value: 'multiple-line',
+          text: i18n.translate(
+            'discover.contextAwareness.changePointExperience.viewMultipleLineCharts',
+            { defaultMessage: 'Multiple line charts' }
+          ),
+        },
+        {
+          value: 'burst-detection',
+          text: i18n.translate(
+            'discover.contextAwareness.changePointExperience.viewBurstDetection',
+            { defaultMessage: 'Burst Detection Histogram' }
+          ),
+        },
+      ]}
+      data-test-subj="changePointViewModeSelect"
+    />
+  </EuiFlexItem>
+);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_document_profile/change_point_tab.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_document_profile/change_point_tab.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { EuiText, useEuiTheme } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { BehaviorSubject } from 'rxjs';
+import useObservable from 'react-use/lib/useObservable';
+import type { DocViewActions, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import {
+  ChangePointLensEmbeddable,
+  changePointExperienceLensWrapperCss,
+} from '../change_point_data_source_profile/change_point_lens_embeddable';
+import type { ChangePointLensDocContext } from '../change_point_data_source_profile/change_point_context';
+
+export interface ChangePointTabProps extends DocViewRenderProps {
+  docViewActions?: DocViewActions;
+  changePointLensContext$: BehaviorSubject<ChangePointLensDocContext | undefined>;
+}
+
+export const ChangePointTab: React.FC<ChangePointTabProps> = ({ hit, changePointLensContext$ }) => {
+  const { lens, data } = useDiscoverServices();
+  const { euiTheme } = useEuiTheme();
+  const chartWrapperCss = useMemo(() => changePointExperienceLensWrapperCss(euiTheme), [euiTheme]);
+
+  const lensDocContext = useObservable(changePointLensContext$, changePointLensContext$.getValue());
+
+  const changePointLensAttributes = lensDocContext?.lensAttributesByRecordId[hit.id];
+  const fetchSlice = lensDocContext?.fetchSlice;
+
+  const handleBrushEnd = useCallback(
+    (event: { preventDefault: () => void; range?: number[] }) => {
+      event.preventDefault();
+      if (event.range?.length && event.range.length >= 2) {
+        const [min, max] = event.range;
+        data.query.timefilter.timefilter.setTime({
+          from: new Date(min).toISOString(),
+          to: new Date(max).toISOString(),
+          mode: 'absolute',
+        });
+      }
+    },
+    [data.query.timefilter.timefilter]
+  );
+
+  if (changePointLensAttributes && fetchSlice) {
+    return (
+      <ChangePointLensEmbeddable
+        lens={lens}
+        attributes={changePointLensAttributes}
+        executionContextDescription="Discover change point document tab chart"
+        id={`discover-change-point-doc-tab-lens-${hit.id}`}
+        abortController={fetchSlice.abortController}
+        lastReloadRequestTime={fetchSlice.lastReloadRequestTime}
+        searchSessionId={fetchSlice.searchSessionId}
+        timeRange={fetchSlice.timeRange}
+        onBrushEnd={handleBrushEnd}
+        syncCursor={false}
+        syncTooltips={false}
+        wrapperCss={chartWrapperCss}
+        dataTestSubj="changePointDocTabLensChart"
+      />
+    );
+  }
+
+  return (
+    <EuiText size="s" color="subdued">
+      <FormattedMessage
+        id="discover.contextAwareness.changePointTab.placeholder"
+        defaultMessage="Change point chart for this row is not available yet. Ensure the chart section is visible and results have finished loading."
+      />
+    </EuiText>
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_document_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/change_point_document_profile/profile.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import React from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { i18n } from '@kbn/i18n';
+import type { DocumentProfileProvider } from '../../../profiles';
+import { DocumentType } from '../../../profiles';
+import type { DocViewerExtensionParams } from '../../../types';
+import {
+  CHANGE_POINT_DATA_SOURCE_PROFILE_ID,
+  isChangePointDataSourceContext,
+  type ChangePointLensDocContext,
+} from '../change_point_data_source_profile/change_point_context';
+import { ChangePointTab } from './change_point_tab';
+
+export interface ChangePointDocumentProfileContext {
+  changePointLensContext$: BehaviorSubject<ChangePointLensDocContext | undefined>;
+}
+
+export const createChangePointDocumentProfileProvider =
+  (): DocumentProfileProvider<ChangePointDocumentProfileContext> => ({
+    profileId: 'change-point-document-profile',
+    profile: {
+      getDocViewer:
+        (prev, { context }) =>
+        (params: DocViewerExtensionParams) => {
+          const prevDocViewer = prev(params);
+          return {
+            ...prevDocViewer,
+            docViewsRegistry: (registry: DocViewsRegistry) => {
+              registry.add({
+                id: 'doc_view_change_point_details',
+                title: i18n.translate('discover.contextAwareness.changePointDocView.tabTitle', {
+                  defaultMessage: 'Change point',
+                }),
+                order: 5,
+                render: (props) => (
+                  <ChangePointTab
+                    docViewActions={params.actions}
+                    changePointLensContext$={context.changePointLensContext$}
+                    {...props}
+                  />
+                ),
+              });
+              return prevDocViewer.docViewsRegistry(registry);
+            },
+          };
+        },
+    },
+    resolve: ({ dataSourceContext }) => {
+      if (dataSourceContext.profileId !== CHANGE_POINT_DATA_SOURCE_PROFILE_ID) {
+        return { isMatch: false };
+      }
+      return {
+        isMatch: true,
+        context: {
+          type: DocumentType.Default,
+          changePointLensContext$: isChangePointDataSourceContext(dataSourceContext)
+            ? dataSourceContext.changePointLensContext$
+            : new BehaviorSubject<ChangePointLensDocContext | undefined>(undefined),
+        },
+      };
+    },
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -15,6 +15,7 @@ import type {
   RootProfileService,
 } from '../profiles';
 import { createClassicNavRootProfileProvider } from './common/classic_nav_root_profile';
+import { createChangePointDataSourceProfileProvider } from './common/change_point_data_source_profile';
 import { createDeprecationLogsDataSourceProfileProvider } from './common/deprecation_logs_data_source_profile';
 import { createPatternsDataSourceProfileProvider } from './common/patterns_data_source_profile';
 import { registerEnabledProfileProviders } from './register_enabled_profile_providers';
@@ -120,6 +121,7 @@ const createRootProfileProviders = (providerServices: ProfileProviderServices) =
 const createDataSourceProfileProviders = (providerServices: ProfileProviderServices) => [
   createExampleDataSourceProfileProvider(),
   createPatternsDataSourceProfileProvider(providerServices),
+  createChangePointDataSourceProfileProvider(),
   createDeprecationLogsDataSourceProfileProvider(),
   ...createObservabilityLogsDataSourceProfileProviders(providerServices),
   ...createObservabilityTracesDataSourceProfileProviders(providerServices),

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -35,6 +35,7 @@ import type {
 } from './profile_provider_services';
 import { createSecurityRootProfileProvider } from './security/security_root_profile';
 import { createMetricsDataSourceProfileProvider } from './common/metrics_data_source_profile';
+import { createChangePointDocumentProfileProvider } from './common/change_point_document_profile/profile';
 
 /**
  * Register profile providers for root, data source, and document contexts to the profile profile services
@@ -135,6 +136,7 @@ const createDataSourceProfileProviders = (providerServices: ProfileProviderServi
  */
 const createDocumentProfileProviders = (providerServices: ProfileProviderServices) => [
   createExampleDocumentProfileProvider(),
+  createChangePointDocumentProfileProvider(),
   ...createSecurityDocumentProfileProviders(providerServices),
   ...createObservabilityDocumentProfileProviders(providerServices),
 ];

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -42,6 +42,7 @@
     "@kbn/lens-plugin",
     "@kbn/es-query",
     "@kbn/utility-types",
+    "@kbn/visualization-utils",
     "@kbn/i18n",
     "@kbn/std",
     "@kbn/core-ui-settings-browser",

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -26,6 +26,7 @@ import {
   isDOMNode,
   EuiSpacer,
 } from '@elastic/eui';
+import type { AggregateQuery, Query } from '@kbn/es-query';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import type { ToastsStart } from '@kbn/core-notifications-browser';
@@ -52,6 +53,7 @@ export interface UnifiedDocViewerFlyoutProps
   };
   docViewsRegistry?: DocViewRenderProps['docViewsRegistry'];
   isEsqlQuery: boolean;
+  query?: Query | AggregateQuery;
   columns: string[];
   columnsMeta?: DataTableColumnsMeta;
   hit: DataTableRecord;
@@ -96,6 +98,7 @@ export function UnifiedDocViewerFlyout({
   isEsqlQuery,
   columns,
   columnsMeta,
+  query,
   hit,
   hits,
   dataView,
@@ -229,6 +232,7 @@ export function UnifiedDocViewerFlyout({
         ? euiTheme.base + PROJECT_VIEW_MARGIN_BOTTOM
         : euiTheme.base,
       hideFilteringOnComputedColumns,
+      query,
     }),
     [
       actualHit,
@@ -244,6 +248,7 @@ export function UnifiedDocViewerFlyout({
       isProjectStyle,
       euiTheme.base,
       hideFilteringOnComputedColumns,
+      query,
     ]
   );
 


### PR DESCRIPTION
## Summary

NOTE: This is a work in progress but everything in the branch works. Feel free to test.

Replaces Discover's chart with custom chart(s) that effectively show change points:

1. Single line chart when BY is not used. Source data is the line and the change point is shown as an annotation.

<img width="1716" height="935" alt="image" src="https://github.com/user-attachments/assets/e7cf4060-99f1-4090-98f0-2e1dd15d54db" />

2. Low and medium cardinality: Multiple single line charts. 

https://github.com/user-attachments/assets/03d7323f-4ee2-4466-830f-3b9e6e90ec1a

3. Medium (non-null) cardinality: heatmap-style per-split swimlanes (think something similar to the swimlanes we have for anomaly detection)

https://github.com/user-attachments/assets/f335fac9-6bc0-45fd-907e-ba9b2c386bb7

4. High (non-null) cardinality: Histogram of Change-Point Times (Burst Detection) 
    - Answers the question - Did many entities shift at the same time? When were the big events?
    - X-axis: timeline (hour/day/week)
    - Y-axis: number of entities that had a change point in that time bucket
    - Due to the limitations of using the FORK command (limit 8 forks), it was difficult to come up with a useful demo for this histogram but it will look something like this (created with mock data):
    
    
   <img width="1711" height="983" alt="image" src="https://github.com/user-attachments/assets/b4f8296f-6628-4868-a7d9-6cd4f072d235" />

    
### Dependencies
CHANGE BY is being worked on now - testing for this was done using the FORK command with CHANGE_POINT to simulate the behavior.

### NOTE
Keep in mind this is a POC and a WIP and there are improvements to be made - including code clean up, and improving each view with things like quick filters, combining views when drilling in, etc. 

Possible improvements planned:

- move change point code into package
- add suggested command (e.g. adding the command for removing nulls in table) when using CHANGE_POINT in ES|QL editor
- actions on charts so user can open flyout and see the additional background fetch that is happening to populate line charts (change points are added as annotations)
- only show mini charts with results
- heatmap improvements to ensure x-axis labels are always readable

## TESTING

For a non-split change point output, try this command:
```
FROM gallery-*
| STATS avg_bytes = AVG(bytes) BY time = BUCKET(`@timestamp`, 1h)
   | CHANGE_POINT avg_bytes ON time
   ```

For now, to simulate the BY command, you'll need to use FORK in conjunction with CHANGE_POINT
Something like this:

```
FROM gallery-*
| FORK 
  ( WHERE referer == "http://domainsigma.com/whois/galleryjasminewhite.co" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | EVAL provider = "http://domainsigma.com/whois/galleryjasminewhite.co" | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
  ( WHERE referer == "http://www.galleryjasminewhite.com/wp-content/themes/mandalay/js/jquery.js" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | EVAL provider = "http://www.galleryjasminewhite.com/wp-content/themes/mandalay/js/jquery.js" | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
  ( WHERE referer == "https://www.google.com/" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | EVAL provider = "https://www.google.com/" | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
  ( WHERE referer == "http://www.galleryjasminewhite.com/artists/laure-pink-2/" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | EVAL provider = "http://www.galleryjasminewhite.com/artists/laure-pink-2/" | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
   ( WHERE referer == "http://www.google.com/blank.html" | STATS avg_bytes = AVG(bytes) BY bucket = BUCKET(@timestamp, 1 day) | EVAL provider = "http://www.google.com/blank.html" | SORT bucket | CHANGE_POINT avg_bytes ON bucket )
| WHERE type IS NOT NULL
| KEEP provider, bucket, avg_bytes, type, pvalue
| SORT provider, bucket
```


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




