### PR TITLE
[Agent Builder] Keep canvas previews in sync with latest attachment versions

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_context.tsx
@@ -12,6 +12,7 @@ interface CanvasState {
   attachment: UnknownAttachment;
   isSidebar: boolean;
   version?: number;
+  followsLatestVersion: boolean;
 }
 
 export const getAttachmentPreviewKey = (attachmentId: string, version?: number) =>
@@ -20,8 +21,14 @@ export const getAttachmentPreviewKey = (attachmentId: string, version?: number) 
 interface CanvasContextValue {
   canvasState: CanvasState | null;
   previewedAttachmentKey: string | null;
-  openCanvas: (attachment: UnknownAttachment, isSidebar: boolean, version?: number) => void;
+  openCanvas: (
+    attachment: UnknownAttachment,
+    isSidebar: boolean,
+    version?: number,
+    followsLatestVersion?: boolean
+  ) => void;
   closeCanvas: () => void;
+  syncCanvasToVersion: (version: number, attachment: UnknownAttachment) => void;
   setCanvasAttachmentOrigin: (origin: string) => void;
   setPreviewedAttachmentKey: (attachmentKey: string | null) => void;
 }
@@ -37,8 +44,13 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
   const [previewedAttachmentKey, setPreviewedAttachmentKey] = useState<string | null>(null);
 
   const openCanvas = useCallback(
-    (attachment: UnknownAttachment, isSidebar: boolean, version?: number) => {
-      setCanvasState({ attachment, isSidebar, version });
+    (
+      attachment: UnknownAttachment,
+      isSidebar: boolean,
+      version?: number,
+      followsLatestVersion = false
+    ) => {
+      setCanvasState({ attachment, isSidebar, version, followsLatestVersion });
       setPreviewedAttachmentKey(getAttachmentPreviewKey(attachment.id, version));
     },
     []
@@ -46,16 +58,27 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
 
   const closeCanvas = useCallback(() => {
     if (canvasState) {
-      const canvasPreviewKey = getAttachmentPreviewKey(
-        canvasState.attachment.id,
-        canvasState.version
-      );
-      if (previewedAttachmentKey === canvasPreviewKey) {
+      const attachmentPreviewKeyPrefix = `${canvasState.attachment.id}:`;
+      if (previewedAttachmentKey?.startsWith(attachmentPreviewKeyPrefix)) {
         setPreviewedAttachmentKey(null);
       }
     }
     setCanvasState(null);
   }, [canvasState, previewedAttachmentKey]);
+
+  const syncCanvasToVersion = useCallback((version: number, attachment: UnknownAttachment) => {
+    setCanvasState((prev) => {
+      if (!prev || prev.attachment.id !== attachment.id || !prev.followsLatestVersion) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        version,
+        attachment,
+      };
+    });
+  }, []);
 
   const setCanvasAttachmentOrigin = useCallback((origin: string) => {
     setCanvasState((prev) => {
@@ -72,11 +95,19 @@ export const CanvasProvider: React.FC<CanvasProviderProps> = ({ children }) => {
       canvasState,
       openCanvas,
       closeCanvas,
+      syncCanvasToVersion,
       setCanvasAttachmentOrigin,
       previewedAttachmentKey,
       setPreviewedAttachmentKey,
     }),
-    [canvasState, previewedAttachmentKey, openCanvas, closeCanvas, setCanvasAttachmentOrigin]
+    [
+      canvasState,
+      previewedAttachmentKey,
+      openCanvas,
+      closeCanvas,
+      syncCanvasToVersion,
+      setCanvasAttachmentOrigin,
+    ]
   );
 
   return <CanvasContext.Provider value={value}>{children}</CanvasContext.Provider>;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.test.tsx
@@ -6,18 +6,25 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { CanvasFlyout } from './canvas_flyout';
 
 const mockCloseCanvas = jest.fn();
+const mockSyncCanvasToVersion = jest.fn();
+const mockSetPreviewedAttachmentKey = jest.fn();
 let mockConversationId = 'conversation-1';
+let mockCanvasState: any = null;
+let mockConversation: any = null;
 
 jest.mock('./canvas_context', () => ({
+  getAttachmentPreviewKey: (attachmentId: string, version?: number) =>
+    `${attachmentId}:${version ?? 'latest'}`,
   useCanvasContext: () => ({
-    canvasState: null,
+    canvasState: mockCanvasState,
     closeCanvas: mockCloseCanvas,
+    syncCanvasToVersion: mockSyncCanvasToVersion,
     setCanvasAttachmentOrigin: jest.fn(),
-    updateCanvasAttachment: jest.fn(),
+    setPreviewedAttachmentKey: mockSetPreviewedAttachmentKey,
   }),
 }));
 
@@ -33,7 +40,7 @@ jest.mock('../../../../../context/conversation/conversation_context', () => ({
 
 jest.mock('../../../../../hooks/use_conversation', () => ({
   useConversation: () => ({
-    conversation: null,
+    conversation: mockConversation,
   }),
 }));
 
@@ -57,7 +64,19 @@ const mockAttachmentsService = {
 describe('CanvasFlyout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSyncCanvasToVersion.mockImplementation((version: number, attachment: any) => {
+      if (!mockCanvasState) {
+        return;
+      }
+      mockCanvasState = {
+        ...mockCanvasState,
+        version,
+        attachment,
+      };
+    });
     mockConversationId = 'conversation-1';
+    mockCanvasState = null;
+    mockConversation = null;
   });
 
   it('closes canvas when conversation ID changes', () => {
@@ -78,5 +97,58 @@ describe('CanvasFlyout', () => {
     rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
 
     expect(mockCloseCanvas).not.toHaveBeenCalled();
+  });
+
+  it('refreshes canvas content when following the latest attachment version', () => {
+    mockCanvasState = {
+      attachment: {
+        id: 'attachment-1',
+        type: 'test_attachment',
+        data: { title: 'Version 1' },
+      },
+      isSidebar: false,
+      version: 1,
+      followsLatestVersion: true,
+    };
+    mockConversation = {
+      attachments: [
+        {
+          id: 'attachment-1',
+          type: 'test_attachment',
+          current_version: 1,
+          versions: [{ version: 1, data: { title: 'Version 1' } }],
+        },
+      ],
+    };
+    mockAttachmentsService.getAttachmentUiDefinition.mockReturnValue({
+      getLabel: (attachment: { data: { title: string } }) => attachment.data.title,
+      renderCanvasContent: ({ attachment }: { attachment: { data: { title: string } } }) => (
+        <div>{attachment.data.title}</div>
+      ),
+    });
+
+    const { rerender } = render(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(screen.getByText('Version 1')).toBeInTheDocument();
+
+    mockConversation = {
+      attachments: [
+        {
+          id: 'attachment-1',
+          type: 'test_attachment',
+          current_version: 2,
+          versions: [
+            { version: 1, data: { title: 'Version 1' } },
+            { version: 2, data: { title: 'Version 2' } },
+          ],
+        },
+      ],
+    };
+
+    rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+    rerender(<CanvasFlyout attachmentsService={mockAttachmentsService} />);
+
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+    expect(mockSetPreviewedAttachmentKey).toHaveBeenLastCalledWith('attachment-1:2');
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/canvas_flyout.tsx
@@ -5,18 +5,20 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { EuiFlyout, EuiFlyoutBody, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+import { getLatestVersion } from '@kbn/agent-builder-common/attachments';
 import type { ActionButton } from '@kbn/agent-builder-browser/attachments';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationId } from '../../../../../context/conversation/use_conversation_id';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { usePersistedConversationId } from '../../../../../hooks/use_persisted_conversation_id';
 import { useAgentBuilderServices } from '../../../../../hooks/use_agent_builder_service';
+import { useConversation } from '../../../../../hooks/use_conversation';
 import { AttachmentHeader } from './attachment_header';
-import { useCanvasContext } from './canvas_context';
+import { getAttachmentPreviewKey, useCanvasContext } from './canvas_context';
 
 const FLYOUT_ARIA_LABEL = i18n.translate('xpack.agentBuilder.canvasFlyout.ariaLabel', {
   defaultMessage: 'Attachment preview',
@@ -33,8 +35,15 @@ interface CanvasFlyoutProps {
  */
 export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }) => {
   const { euiTheme } = useEuiTheme();
-  const { canvasState, closeCanvas, setCanvasAttachmentOrigin } = useCanvasContext();
+  const {
+    canvasState,
+    closeCanvas,
+    setCanvasAttachmentOrigin,
+    syncCanvasToVersion,
+    setPreviewedAttachmentKey,
+  } = useCanvasContext();
   const conversationId = useConversationId();
+  const { conversation } = useConversation();
   const { conversationActions } = useConversationContext();
   const { openSidebarConversation: openSidebarConversationInternal } = useAgentBuilderServices();
   const { updatePersistedConversationId } = usePersistedConversationId({});
@@ -56,6 +65,32 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
       prevConversationIdRef.current = conversationId;
     }
   }, [conversationId, closeCanvas]);
+
+  useLayoutEffect(() => {
+    if (!canvasState?.followsLatestVersion) {
+      return;
+    }
+
+    const versionedAttachment = conversation?.attachments?.find(
+      (attachment) => attachment.id === canvasState.attachment.id
+    );
+    const latestVersion = versionedAttachment ? getLatestVersion(versionedAttachment) : undefined;
+
+    if (!versionedAttachment || !latestVersion || latestVersion.version === canvasState.version) {
+      return;
+    }
+
+    syncCanvasToVersion(latestVersion.version, {
+      id: versionedAttachment.id,
+      type: versionedAttachment.type,
+      data: latestVersion.data,
+      hidden: versionedAttachment.hidden,
+      origin: versionedAttachment.origin,
+    });
+    setPreviewedAttachmentKey(
+      getAttachmentPreviewKey(versionedAttachment.id, latestVersion.version)
+    );
+  }, [canvasState, conversation?.attachments, syncCanvasToVersion, setPreviewedAttachmentKey]);
 
   const updateOrigin = useCallback(
     async (origin: string) => {
@@ -79,7 +114,6 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
       conversationActions,
     ]
   );
-
   const uiDefinition = canvasState
     ? attachmentsService.getAttachmentUiDefinition(canvasState.attachment.type)
     : null;
@@ -114,7 +148,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
     return null;
   }
 
-  const { attachment, isSidebar } = canvasState;
+  const { attachment, version, isSidebar } = canvasState;
   const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
 
   const flyoutStyles = !isSidebar
@@ -153,7 +187,7 @@ export const CanvasFlyout: React.FC<CanvasFlyoutProps> = ({ attachmentsService }
         previewBadgeState="preview_available"
       />
       <EuiFlyoutBody css={flyoutBodyStyles}>
-        <React.Fragment key={`${attachment.id}:${canvasState.version ?? 'latest'}`}>
+        <React.Fragment key={`${attachment.id}:${version ?? 'latest'}`}>
           {uiDefinition.renderCanvasContent(
             {
               attachment,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -27,6 +27,8 @@ interface InlineAttachmentWithActionsProps {
   screenContext?: ScreenContextAttachmentData;
   /** Version number of the attachment being rendered, used for canvas preview comparison */
   version?: number;
+  /** Whether this inline render is showing the latest available attachment version */
+  isLatestVersion?: boolean;
   /**
    * Shared preview state for header actions/badges.
    */
@@ -43,6 +45,7 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   conversationId,
   screenContext,
   version,
+  isLatestVersion = false,
   previewBadgeState,
 }) => {
   const {
@@ -55,8 +58,8 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   const { updatePersistedConversationId } = usePersistedConversationId({});
 
   const openCanvas = useCallback(() => {
-    openCanvasContext(attachment, isSidebar, version);
-  }, [openCanvasContext, attachment, isSidebar, version]);
+    openCanvasContext(attachment, isSidebar, version, isLatestVersion);
+  }, [openCanvasContext, attachment, isSidebar, version, isLatestVersion]);
 
   const updateOrigin = useCallback(
     async (origin: string) => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/markdown_plugins/render_attachment_plugin.tsx
@@ -157,6 +157,7 @@ export const createRenderAttachmentRenderer = ({
         isSidebar={isSidebar}
         screenContext={screenContext}
         version={versionToUse}
+        isLatestVersion={versionToUse === attachment.current_version}
       />
     );
   };


### PR DESCRIPTION
## Summary

Keeps attachment canvas previews synced when the canvas was opened from the latest available attachment version - when the new version arrives, canvas is updated. If the user previews not the latest version, it is not automatically synced.


https://github.com/user-attachments/assets/6b489414-f21d-448d-a25a-87d1b3464a42






### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



