### PR TITLE
[Lens as code] Ensure `unassigned_color` transformation

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/tagcloud.test.ts
@@ -91,7 +91,7 @@ describe('Tagcloud Schema', () => {
                 color: { type: 'from_palette', palette: 'default', index: 0 },
               },
             ],
-            unassignedColor: { type: 'color_code', value: '#cccccc' },
+            unassigned_color: { type: 'color_code', value: '#cccccc' },
           },
         },
       };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.test.ts
@@ -238,7 +238,7 @@ describe('Color Schema', () => {
             color: { type: 'color_code', value: 'red' },
           },
         ],
-        unassignedColor: { type: 'color_code', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);
@@ -271,7 +271,7 @@ describe('Color Schema', () => {
             color: { type: 'from_palette', palette: 'default', index: 0 },
           },
         ],
-        unassignedColor: { type: 'color_code', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);
@@ -354,7 +354,7 @@ describe('Color Schema', () => {
             palette: 'default',
           },
         ],
-        unassignedColor: { type: 'color_code', value: 'green' },
+        unassigned_color: { type: 'color_code', value: 'green' },
       };
 
       const validated = allColoringTypeSchema.validate(input);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/color.ts
@@ -244,7 +244,7 @@ const categoricalColorMappingSchema = schema.object(
       }),
       { maxSize: 1000 }
     ),
-    unassignedColor: schema.maybe(colorDefSchema),
+    unassigned_color: schema.maybe(colorDefSchema),
   },
   { meta: { id: 'categoricalColorMapping', title: 'Categorical Color Mapping' } }
 );
@@ -269,7 +269,7 @@ const gradientColorMappingSchema = schema.object(
       )
     ),
     gradient: schema.maybe(schema.arrayOf(colorDefSchema, { maxSize: 3 })),
-    unassignedColor: schema.maybe(colorDefSchema),
+    unassigned_color: schema.maybe(colorDefSchema),
   },
   { meta: { id: 'gradientColorMapping', title: 'Gradient Color Mapping' } }
 );

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.test.ts
@@ -828,7 +828,7 @@ describe('Color util transforms', () => {
             color: { type: 'color_code', value: '#ff0000' },
           },
         ],
-        unassignedColor: { type: 'color_code', value: '#00ff00' },
+        unassigned_color: { type: 'color_code', value: '#00ff00' },
       };
 
       const lensState = fromColorMappingAPIToLensState(originalColorMapping);
@@ -884,7 +884,7 @@ describe('Color util transforms', () => {
           { type: 'from_palette', index: 2, palette: 'no_default' },
         ],
         sort: 'asc',
-        unassignedColor: { type: 'from_palette', palette: SEMANTIC_PALETTE, index: 2 },
+        unassigned_color: { type: 'from_palette', palette: SEMANTIC_PALETTE, index: 2 },
       };
 
       const lensState = fromColorMappingAPIToLensState(originalColorMapping);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
@@ -296,7 +296,7 @@ export function fromColorMappingLensStateToAPI(
     return;
   }
 
-  const unassignedColorDef = fromUnassignedColorLensStateToAPI(
+  const unassignedColorAPI = fromUnassignedColorLensStateToAPI(
     colorMapping.specialAssignments[0]?.color
   );
   if (isLensStateCategoricalConfigColorMapping(colorMapping)) {
@@ -309,7 +309,7 @@ export function fromColorMappingLensStateToAPI(
           color: fromColorLensStateToAPI(color),
         };
       }),
-      ...unassignedColorDef,
+      ...unassignedColorAPI,
     };
   }
 
@@ -327,7 +327,7 @@ export function fromColorMappingLensStateToAPI(
     }),
     sort: (colorMapping.colorMode as ColorMapping.GradientColorMode).sort,
     gradient: colorMode.steps.map((color) => fromColorLensStateToAPI(color)),
-    ...unassignedColorDef,
+    ...unassignedColorAPI,
   };
 }
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/coloring/coloring.ts
@@ -274,12 +274,11 @@ function isLensStateCategoricalConfigColorMapping(
 
 function fromUnassignedColorLensStateToAPI(
   color: ColorMapping.CategoricalColor | ColorMapping.ColorCode | ColorMapping.LoopColor | undefined
-): { unassignedColor: Extract<ColorMappingColorDefType, { type: 'color_code' }> } | {} {
+): { unassigned_color: Extract<ColorMappingColorDefType, { type: 'color_code' }> } | {} {
   if (!color || color.type === 'loop') {
     return {};
   }
-  const unassignedColor = fromColorLensStateToAPI(color);
-  return { unassignedColor };
+  return { unassigned_color: fromColorLensStateToAPI(color) };
 }
 
 export function fromColorMappingLensStateToAPI(
@@ -297,7 +296,7 @@ export function fromColorMappingLensStateToAPI(
     return;
   }
 
-  const unassignedColor = fromUnassignedColorLensStateToAPI(
+  const unassignedColorDef = fromUnassignedColorLensStateToAPI(
     colorMapping.specialAssignments[0]?.color
   );
   if (isLensStateCategoricalConfigColorMapping(colorMapping)) {
@@ -310,7 +309,7 @@ export function fromColorMappingLensStateToAPI(
           color: fromColorLensStateToAPI(color),
         };
       }),
-      ...unassignedColor,
+      ...unassignedColorDef,
     };
   }
 
@@ -328,7 +327,7 @@ export function fromColorMappingLensStateToAPI(
     }),
     sort: (colorMapping.colorMode as ColorMapping.GradientColorMode).sort,
     gradient: colorMode.steps.map((color) => fromColorLensStateToAPI(color)),
-    ...unassignedColor,
+    ...unassignedColorDef,
   };
 }
 
@@ -411,8 +410,8 @@ export function fromColorMappingAPIToLensState(
           type: 'other',
         },
       ],
-      color: colorMapping.unassignedColor
-        ? fromColorDefAPIToLensState(colorMapping.unassignedColor)
+      color: colorMapping.unassigned_color
+        ? fromColorDefAPIToLensState(colorMapping.unassigned_color)
         : { type: 'loop' },
       touched: false,
     },


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/257034.

Updates API payload properties `unassigned_color` to follow the snake_case convention.

This `jq` command is able to identify camelCase properties in the OAS docs:

```
jq -r '.. | objects | select(has("properties")) | .properties | to_entries[] | select(.key | test("[a-z][A-Z]")) | .key' oas_docs/bundle.json | sort -u
```

It identifies `unassignedColor` without this PR. No other camelCase properties are left with this PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk, API has not been released.