### PR TITLE
[One Workflow] security audit logging for workflow management APIs

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/cancel_execution.ts
@@ -14,6 +14,7 @@ import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_CANCEL_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerCancelExecutionRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -45,8 +46,13 @@ export function registerCancelExecutionRoute({ router, api, spaces }: RouteDepen
           const { executionId } = request.params;
           const spaceId = spaces.getSpaceId(request);
           await api.cancelWorkflowExecution(executionId, spaceId);
+          await WorkflowManagementAuditLog.logExecutionCanceled(context, { executionId });
           return response.ok();
         } catch (error) {
+          await WorkflowManagementAuditLog.logExecutionCancelFailed(context, {
+            executionId: request.params.executionId,
+            error,
+          });
           return handleRouteError(response, error, { checkNotFound: true });
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/executions.test.ts
@@ -27,6 +27,17 @@ describe('Execution Routes', () => {
         type: 'enterprise',
       },
     }),
+    core: Promise.resolve({
+      security: {
+        audit: {
+          logger: {
+            enabled: false,
+            log: jest.fn(),
+            includeSavedObjectNames: false,
+          },
+        },
+      },
+    }),
   };
 
   const mockResponse = {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/resume_execution.ts
@@ -15,6 +15,7 @@ import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTION_RESUME_SECURITY } from '../utils/route_security';
 import { executionIdParamSchema } from '../utils/schemas';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerResumeExecutionRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned
@@ -54,6 +55,8 @@ export function registerResumeExecutionRoute({ router, api, spaces }: RouteDepen
 
           await api.resumeWorkflowExecution(executionId, spaceId, input, request);
 
+          await WorkflowManagementAuditLog.logExecutionResumed(context, { executionId });
+
           return response.ok({
             body: {
               success: true,
@@ -62,6 +65,10 @@ export function registerResumeExecutionRoute({ router, api, spaces }: RouteDepen
             },
           });
         } catch (error) {
+          await WorkflowManagementAuditLog.logExecutionResumeFailed(context, {
+            executionId: request.params.executionId,
+            error,
+          });
           return handleRouteError(response, error, { checkNotFound: true });
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
@@ -16,6 +16,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerRunWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
@@ -102,8 +103,16 @@ export function registerRunWorkflowRoute({ router, api, logger, spaces }: RouteD
             undefined,
             metadata
           );
+          await WorkflowManagementAuditLog.logWorkflowRun(context, {
+            workflowId: id,
+            executionId: workflowExecutionId,
+          });
           return response.ok({ body: { workflowExecutionId } });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowRunFailed(context, {
+            workflowId: request.params.id,
+            error,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/run_workflow.ts
@@ -16,8 +16,8 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerRunWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerTestStepRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_step.ts
@@ -13,6 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerTestStepRoute({ router, api, spaces }: RouteDependencies) {
@@ -62,8 +63,14 @@ export function registerTestStepRoute({ router, api, spaces }: RouteDependencies
             spaceId,
             request
           );
+          await WorkflowManagementAuditLog.logWorkflowStepTest(context, {
+            stepId: request.body.stepId,
+            workflowExecutionId,
+            workflowId: request.body.workflowId,
+          });
           return response.ok({ body: { workflowExecutionId } });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowStepTestFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
@@ -14,8 +14,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerTestWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/executions/test_workflow.ts
@@ -14,6 +14,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_EXECUTE_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerTestWorkflowRoute({ router, api, logger, spaces }: RouteDependencies) {
@@ -84,8 +85,14 @@ export function registerTestWorkflowRoute({ router, api, logger, spaces }: Route
             request,
           });
 
+          await WorkflowManagementAuditLog.logWorkflowTest(context, {
+            workflowExecutionId,
+            workflowId,
+          });
+
           return response.ok({ body: { workflowExecutionId } });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowTestFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -91,6 +91,19 @@ describe('WorkflowManagementAuditLog', () => {
       );
     });
 
+    it('logBulkWorkflowCreateResults', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logBulkWorkflowCreateResults(context, {
+        created: [{ id: 'new-1' }, { id: 'new-2' }],
+        failed: [{ index: 0, id: 'bad', error: 'nope' }],
+      });
+      expect(log).toHaveBeenCalledTimes(3);
+      expect(log.mock.calls[0][0].message).toContain('bulk import');
+      expect(log.mock.calls[0][0].message).toContain('[id=new-1]');
+      expect(log.mock.calls[1][0].message).toContain('[id=new-2]');
+      expect(log.mock.calls[2][0].error).toEqual({ code: 'bulk_create_row', message: 'nope' });
+    });
+
     it('logWorkflowUpdated and logWorkflowUpdateFailed', async () => {
       const { context, log } = createAuditContext();
       await WorkflowManagementAuditLog.logWorkflowUpdated(context, { id: 'u-1' });

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -117,17 +117,18 @@ describe('WorkflowManagementAuditLog', () => {
       expect(l2.mock.calls[0][0].event.outcome).toBe('failure');
     });
 
-    it('logBulkWorkflowDeleteSummary and logBulkWorkflowDeleteFailed', async () => {
+    it('logBulkWorkflowDeleteResults and logBulkWorkflowDeleteFailed', async () => {
       const { context, log } = createAuditContext();
-      await WorkflowManagementAuditLog.logBulkWorkflowDeleteSummary(context, {
-        total: 10,
-        deleted: 8,
-        failureCount: 2,
+      await WorkflowManagementAuditLog.logBulkWorkflowDeleteResults(context, {
+        successfulIds: ['w1', 'w2'],
+        failures: [{ id: 'w3', error: 'es error' }],
       });
-      expect(log.mock.calls[0][0].message).toContain('requested 10');
-      expect(log.mock.calls[0][0].message).toContain('deleted 8');
-      expect(log.mock.calls[0][0].message).toContain('failed 2');
-      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.BULK_DELETE);
+      expect(log).toHaveBeenCalledTimes(3);
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.DELETE);
+      expect(log.mock.calls[0][0].message).toContain('[id=w1]');
+      expect(log.mock.calls[1][0].message).toContain('[id=w2]');
+      expect(log.mock.calls[2][0].event.outcome).toBe('failure');
+      expect(log.mock.calls[2][0].message).toContain('[id=w3]');
 
       const { context: c2, log: l2 } = createAuditContext();
       await WorkflowManagementAuditLog.logBulkWorkflowDeleteFailed(c2, err);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -110,11 +110,30 @@ describe('WorkflowManagementAuditLog', () => {
       const { context, log } = createAuditContext();
       await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id: 'd-1' });
       expect(log.mock.calls[0][0].event.type).toEqual(['deletion']);
+      expect(log.mock.calls[0][0].message).toBe('User deleted workflow [id=d-1]');
+
+      const { context: cBulk, log: lBulk } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowDeleted(cBulk, {
+        id: 'd-2',
+        viaBulkDelete: true,
+      });
+      expect(lBulk.mock.calls[0][0].message).toContain('via bulk delete');
+      expect(lBulk.mock.calls[0][0].message).toContain('[id=d-2]');
 
       const { context: c2, log: l2 } = createAuditContext();
       await WorkflowManagementAuditLog.logWorkflowDeleteFailed(c2, { id: 'd-1', error: err });
       expect(l2.mock.calls[0][0].event.type).toEqual(['deletion']);
       expect(l2.mock.calls[0][0].event.outcome).toBe('failure');
+      expect(l2.mock.calls[0][0].message).toContain('User failed to delete workflow [id=d-1]');
+      expect(l2.mock.calls[0][0].message).not.toContain('bulk delete');
+
+      const { context: c3, log: l3 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowDeleteFailed(c3, {
+        id: 'd-2',
+        error: err,
+        viaBulkDelete: true,
+      });
+      expect(l3.mock.calls[0][0].message).toContain('via bulk delete');
     });
 
     it('logBulkWorkflowDeleteResults and logBulkWorkflowDeleteFailed', async () => {
@@ -125,9 +144,12 @@ describe('WorkflowManagementAuditLog', () => {
       });
       expect(log).toHaveBeenCalledTimes(3);
       expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.DELETE);
+      expect(log.mock.calls[0][0].message).toContain('via bulk delete');
       expect(log.mock.calls[0][0].message).toContain('[id=w1]');
+      expect(log.mock.calls[1][0].message).toContain('via bulk delete');
       expect(log.mock.calls[1][0].message).toContain('[id=w2]');
       expect(log.mock.calls[2][0].event.outcome).toBe('failure');
+      expect(log.mock.calls[2][0].message).toContain('via bulk delete');
       expect(log.mock.calls[2][0].message).toContain('[id=w3]');
 
       const { context: c2, log: l2 } = createAuditContext();

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -104,7 +104,7 @@ describe('WorkflowManagementAuditLog', () => {
       expect(log.mock.calls[0][0]).toEqual(
         expect.objectContaining({
           message: expect.stringContaining('[index=2]'),
-          error: { code: 'bulk_create_row', message: 'invalid yaml' },
+          error: { code: 'Unknown', message: 'invalid yaml' },
           event: expect.objectContaining({
             action: WorkflowManagementAuditActions.CREATE,
             outcome: 'failure',
@@ -123,7 +123,7 @@ describe('WorkflowManagementAuditLog', () => {
       expect(log.mock.calls[0][0].message).toContain('bulk import');
       expect(log.mock.calls[0][0].message).toContain('[id=new-1]');
       expect(log.mock.calls[1][0].message).toContain('[id=new-2]');
-      expect(log.mock.calls[2][0].error).toEqual({ code: 'bulk_create_row', message: 'nope' });
+      expect(log.mock.calls[2][0].error).toEqual({ code: 'Unknown', message: 'nope' });
     });
 
     it('logWorkflowUpdated and logWorkflowUpdateFailed', async () => {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -1,0 +1,275 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  WorkflowManagementAuditActions,
+  WorkflowManagementAuditLog,
+} from './workflow_audit_logging';
+import type { WorkflowsRequestHandlerContext } from '../../../types';
+
+function createAuditContext() {
+  const log = jest.fn();
+  const context = {
+    core: Promise.resolve({
+      security: {
+        audit: {
+          logger: {
+            enabled: true,
+            log,
+            includeSavedObjectNames: false,
+          },
+        },
+      },
+    }),
+  } as unknown as WorkflowsRequestHandlerContext;
+  return { context, log };
+}
+
+describe('WorkflowManagementAuditLog', () => {
+  describe('when delegating to core security audit logger', () => {
+    const err = new Error('boom');
+
+    it('logWorkflowCreated (single)', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCreated(context, { id: 'w-1' });
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          message: 'User created workflow [id=w-1]',
+          event: expect.objectContaining({
+            action: WorkflowManagementAuditActions.CREATE,
+            outcome: 'success',
+            type: ['creation'],
+            category: ['database'],
+          }),
+        })
+      );
+    });
+
+    it('logWorkflowCreated (bulk import)', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCreated(context, {
+        id: 'w-2',
+        viaBulkImport: true,
+      });
+      expect(log.mock.calls[0][0].message).toContain('bulk import');
+      expect(log.mock.calls[0][0].message).toContain('[id=w-2]');
+    });
+
+    it('logWorkflowCreateFailed (single vs bulk message)', async () => {
+      const { context: c1, log: l1 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCreateFailed(c1, err);
+      expect(l1.mock.calls[0][0].message).toBe('User failed to create a workflow');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCreateFailed(c2, err, { bulkOperation: true });
+      expect(l2.mock.calls[0][0].message).toBe('User failed bulk workflow create');
+    });
+
+    it('logBulkCreateRowFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logBulkCreateRowFailed(context, {
+        index: 2,
+        id: 'bad',
+        error: 'invalid yaml',
+      });
+      expect(log.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('[index=2]'),
+          error: { code: 'bulk_create_row', message: 'invalid yaml' },
+          event: expect.objectContaining({
+            action: WorkflowManagementAuditActions.CREATE,
+            outcome: 'failure',
+          }),
+        })
+      );
+    });
+
+    it('logWorkflowUpdated and logWorkflowUpdateFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowUpdated(context, { id: 'u-1' });
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.UPDATE);
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowUpdateFailed(c2, { id: 'u-1', error: err });
+      expect(l2.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('[id=u-1]'),
+          error: { code: 'Error', message: 'boom' },
+        })
+      );
+    });
+
+    it('logWorkflowDeleted and logWorkflowDeleteFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id: 'd-1' });
+      expect(log.mock.calls[0][0].event.type).toEqual(['deletion']);
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowDeleteFailed(c2, { id: 'd-1', error: err });
+      expect(l2.mock.calls[0][0].event.type).toEqual(['deletion']);
+      expect(l2.mock.calls[0][0].event.outcome).toBe('failure');
+    });
+
+    it('logBulkWorkflowDeleteSummary and logBulkWorkflowDeleteFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logBulkWorkflowDeleteSummary(context, {
+        total: 10,
+        deleted: 8,
+        failureCount: 2,
+      });
+      expect(log.mock.calls[0][0].message).toContain('requested 10');
+      expect(log.mock.calls[0][0].message).toContain('deleted 8');
+      expect(log.mock.calls[0][0].message).toContain('failed 2');
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.BULK_DELETE);
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logBulkWorkflowDeleteFailed(c2, err);
+      expect(l2.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.BULK_DELETE);
+    });
+
+    it('logWorkflowCloned and logWorkflowCloneFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCloned(context, { sourceId: 'a', newId: 'b' });
+      expect(log.mock.calls[0][0].message).toContain('sourceId=a');
+      expect(log.mock.calls[0][0].message).toContain('[id=b]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowCloneFailed(c2, { sourceId: 'a', error: err });
+      expect(l2.mock.calls[0][0].event.type).toEqual(['creation']);
+    });
+
+    it('logWorkflowExported, logWorkflowsExported, and logWorkflowExportFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowExported(context, { id: 'exp-1' });
+      expect(log.mock.calls[0][0].event.type).toEqual(['access']);
+
+      const { context: cBatch, log: lBatch } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowsExported(cBatch, { ids: ['a', 'b'] });
+      expect(lBatch).toHaveBeenCalledTimes(2);
+      expect(lBatch.mock.calls[0][0].message).toContain('[id=a]');
+      expect(lBatch.mock.calls[1][0].message).toContain('[id=b]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowExportFailed(c2, err);
+      expect(l2.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.EXPORT);
+    });
+
+    it('logWorkflowAccessed and logWorkflowAccessFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowAccessed(context, { id: 'g-1' });
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.GET);
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowAccessFailed(c2, { id: 'g-1', error: err });
+      expect(l2.mock.calls[0][0].event.type).toEqual(['access']);
+    });
+
+    it('logWorkflowMget and logWorkflowMgetFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowMget(context, {
+        requestedCount: 5,
+        returnedCount: 3,
+      });
+      expect(log.mock.calls[0][0].message).toContain('requested 5');
+      expect(log.mock.calls[0][0].message).toContain('returned 3');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowMgetFailed(c2, err);
+      expect(l2.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.MGET);
+    });
+
+    it('logWorkflowRun and logWorkflowRunFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowRun(context, {
+        workflowId: 'wf',
+        executionId: 'ex',
+      });
+      expect(log.mock.calls[0][0].message).toContain('[id=wf]');
+      expect(log.mock.calls[0][0].message).toContain('[executionId=ex]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowRunFailed(c2, { workflowId: 'wf', error: err });
+      expect(l2.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.RUN);
+    });
+
+    it('logWorkflowTest with and without workflowId', async () => {
+      const { context: c1, log: l1 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowTest(c1, {
+        workflowExecutionId: 'e1',
+        workflowId: 'w',
+      });
+      expect(l1.mock.calls[0][0].message).toContain('[workflowId=w]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowTest(c2, { workflowExecutionId: 'e2' });
+      expect(l2.mock.calls[0][0].message).toContain('[draft yaml]');
+    });
+
+    it('logWorkflowTestFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowTestFailed(context, err);
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.TEST);
+    });
+
+    it('logWorkflowStepTest with and without workflowId', async () => {
+      const { context: c1, log: l1 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowStepTest(c1, {
+        stepId: 's1',
+        workflowExecutionId: 'e1',
+        workflowId: 'w',
+      });
+      expect(l1.mock.calls[0][0].message).toContain('[stepId=s1]');
+      expect(l1.mock.calls[0][0].message).toContain('[workflowId=w]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowStepTest(c2, {
+        stepId: 's2',
+        workflowExecutionId: 'e2',
+      });
+      expect(l2.mock.calls[0][0].message).toContain('[draft yaml]');
+    });
+
+    it('logWorkflowStepTestFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logWorkflowStepTestFailed(context, err);
+      expect(log.mock.calls[0][0].event.action).toBe(WorkflowManagementAuditActions.TEST_STEP);
+    });
+
+    it('logExecutionCanceled and logExecutionCancelFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logExecutionCanceled(context, { executionId: 'x-1' });
+      expect(log.mock.calls[0][0].message).toContain('[executionId=x-1]');
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logExecutionCancelFailed(c2, {
+        executionId: 'x-1',
+        error: err,
+      });
+      expect(l2.mock.calls[0][0].event.action).toBe(
+        WorkflowManagementAuditActions.CANCEL_EXECUTION
+      );
+    });
+
+    it('logExecutionResumed and logExecutionResumeFailed', async () => {
+      const { context, log } = createAuditContext();
+      await WorkflowManagementAuditLog.logExecutionResumed(context, { executionId: 'r-1' });
+      expect(log.mock.calls[0][0].event.action).toBe(
+        WorkflowManagementAuditActions.RESUME_EXECUTION
+      );
+
+      const { context: c2, log: l2 } = createAuditContext();
+      await WorkflowManagementAuditLog.logExecutionResumeFailed(c2, {
+        executionId: 'r-1',
+        error: err,
+      });
+      expect(l2.mock.calls[0][0].event.outcome).toBe('failure');
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.test.ts
@@ -35,6 +35,28 @@ describe('WorkflowManagementAuditLog', () => {
   describe('when delegating to core security audit logger', () => {
     const err = new Error('boom');
 
+    it('does not throw when audit log fails (success path remains safe for callers)', async () => {
+      const context = {
+        core: Promise.resolve({
+          security: {
+            audit: {
+              logger: {
+                enabled: true,
+                log: () => {
+                  throw new Error('audit sink failed');
+                },
+                includeSavedObjectNames: false,
+              },
+            },
+          },
+        }),
+      } as unknown as WorkflowsRequestHandlerContext;
+
+      await expect(
+        WorkflowManagementAuditLog.logWorkflowCreated(context, { id: 'w-1' })
+      ).resolves.toBeUndefined();
+    });
+
     it('logWorkflowCreated (single)', async () => {
       const { context, log } = createAuditContext();
       await WorkflowManagementAuditLog.logWorkflowCreated(context, { id: 'w-1' });

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -180,19 +180,25 @@ export class WorkflowManagementAuditLog {
     );
   }
 
-  static async logBulkWorkflowDeleteSummary(
+  /**
+   * One `workflow_delete` audit event per successfully removed id and per failed id (bulk API).
+   */
+  static async logBulkWorkflowDeleteResults(
     context: WorkflowsRequestHandlerContext,
-    params: { total: number; deleted: number; failureCount: number }
+    params: {
+      successfulIds: readonly string[];
+      failures: ReadonlyArray<{ id: string; error: string }>;
+    }
   ): Promise<void> {
-    const { total, deleted, failureCount } = params;
-    await writeAudit(
-      context,
-      successEvent(
-        WorkflowManagementAuditActions.BULK_DELETE,
-        'deletion',
-        `User bulk deleted workflows: requested ${total}, deleted ${deleted}, failed ${failureCount}`
-      )
-    );
+    for (const id of params.successfulIds) {
+      await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id });
+    }
+    for (const f of params.failures) {
+      await WorkflowManagementAuditLog.logWorkflowDeleteFailed(context, {
+        id: f.id,
+        error: new Error(f.error),
+      });
+    }
   }
 
   static async logBulkWorkflowDeleteFailed(

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -69,8 +69,14 @@ async function writeAudit(
   context: WorkflowsRequestHandlerContext,
   event: AuditEvent
 ): Promise<void> {
-  const coreContext = await context.core;
-  coreContext.security.audit.logger.log(event);
+  try {
+    const coreContext = await context.core;
+    await Promise.resolve(coreContext.security.audit.logger.log(event));
+  } catch {
+    // Best-effort only: never let audit affect the HTTP response. There is no request-scoped or
+    // module-level Kibana Logger here (core context does not expose one); optional debug on failure
+    // would require plugin-injected configuration, which we avoid for this helper.
+  }
 }
 
 /** Facade for workflow management audit events (uses `context.core.security.audit.logger`). */

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -1,0 +1,482 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AuditEvent } from '@kbn/security-plugin-types-server';
+import type { WorkflowsRequestHandlerContext } from '../../../types';
+
+/** Stable action names for xpack.security.audit.ignore_filters */
+export const WorkflowManagementAuditActions = {
+  CREATE: 'workflow_create',
+  UPDATE: 'workflow_update',
+  DELETE: 'workflow_delete',
+  BULK_DELETE: 'workflow_bulk_delete',
+  CLONE: 'workflow_clone',
+  EXPORT: 'workflow_export',
+  MGET: 'workflow_mget',
+  GET: 'workflow_get',
+  RUN: 'workflow_run',
+  TEST: 'workflow_test',
+  TEST_STEP: 'workflow_test_step',
+  CANCEL_EXECUTION: 'workflow_execution_cancel',
+  RESUME_EXECUTION: 'workflow_execution_resume',
+} as const;
+
+function failureEvent(
+  action: string,
+  message: string,
+  error: unknown,
+  eventType: 'access' | 'change' | 'creation' | 'deletion' = 'change'
+): AuditEvent {
+  const err = error instanceof Error ? error : new Error(String(error));
+  return {
+    message,
+    event: {
+      action,
+      category: ['database'],
+      type: [eventType],
+      outcome: 'failure',
+    },
+    error: {
+      code: err.name,
+      message: err.message,
+    },
+  };
+}
+
+function successEvent(
+  action: string,
+  eventType: 'access' | 'change' | 'creation' | 'deletion',
+  message: string
+): AuditEvent {
+  return {
+    message,
+    event: {
+      action,
+      category: ['database'],
+      type: [eventType],
+      outcome: 'success',
+    },
+  };
+}
+
+async function writeAudit(
+  context: WorkflowsRequestHandlerContext,
+  event: AuditEvent
+): Promise<void> {
+  const coreContext = await context.core;
+  coreContext.security.audit.logger.log(event);
+}
+
+/** Facade for workflow management audit events (uses `context.core.security.audit.logger`). */
+export class WorkflowManagementAuditLog {
+  static async logWorkflowCreated(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string; viaBulkImport?: boolean }
+  ): Promise<void> {
+    const { id, viaBulkImport } = params;
+    const message = viaBulkImport
+      ? `User created workflow via bulk import [id=${id}]`
+      : `User created workflow [id=${id}]`;
+    await writeAudit(
+      context,
+      successEvent(WorkflowManagementAuditActions.CREATE, 'creation', message)
+    );
+  }
+
+  static async logWorkflowCreateFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown,
+    options: { bulkOperation?: boolean } = {}
+  ): Promise<void> {
+    const message = options.bulkOperation
+      ? 'User failed bulk workflow create'
+      : 'User failed to create a workflow';
+    await writeAudit(
+      context,
+      failureEvent(WorkflowManagementAuditActions.CREATE, message, error, 'creation')
+    );
+  }
+
+  static async logBulkCreateRowFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { index: number; id: string; error: string }
+  ): Promise<void> {
+    const { index, id, error: errorMessage } = params;
+    await writeAudit(context, {
+      message: `User failed to create workflow via bulk import [index=${index}] [id=${id}]: ${errorMessage}`,
+      event: {
+        action: WorkflowManagementAuditActions.CREATE,
+        category: ['database'],
+        type: ['creation'],
+        outcome: 'failure',
+      },
+      error: {
+        code: 'bulk_create_row',
+        message: errorMessage,
+      },
+    });
+  }
+
+  static async logWorkflowUpdated(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.UPDATE,
+        'change',
+        `User updated workflow [id=${params.id}]`
+      )
+    );
+  }
+
+  static async logWorkflowUpdateFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.UPDATE,
+        `User failed to update workflow [id=${params.id}]`,
+        params.error
+      )
+    );
+  }
+
+  static async logWorkflowDeleted(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.DELETE,
+        'deletion',
+        `User deleted workflow [id=${params.id}]`
+      )
+    );
+  }
+
+  static async logWorkflowDeleteFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.DELETE,
+        `User failed to delete workflow [id=${params.id}]`,
+        params.error,
+        'deletion'
+      )
+    );
+  }
+
+  static async logBulkWorkflowDeleteSummary(
+    context: WorkflowsRequestHandlerContext,
+    params: { total: number; deleted: number; failureCount: number }
+  ): Promise<void> {
+    const { total, deleted, failureCount } = params;
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.BULK_DELETE,
+        'deletion',
+        `User bulk deleted workflows: requested ${total}, deleted ${deleted}, failed ${failureCount}`
+      )
+    );
+  }
+
+  static async logBulkWorkflowDeleteFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.BULK_DELETE,
+        'User failed bulk workflow delete',
+        error,
+        'deletion'
+      )
+    );
+  }
+
+  static async logWorkflowCloned(
+    context: WorkflowsRequestHandlerContext,
+    params: { sourceId: string; newId: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.CLONE,
+        'creation',
+        `User cloned workflow [sourceId=${params.sourceId}] to [id=${params.newId}]`
+      )
+    );
+  }
+
+  static async logWorkflowCloneFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { sourceId: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.CLONE,
+        `User failed to clone workflow [id=${params.sourceId}]`,
+        params.error,
+        'creation'
+      )
+    );
+  }
+
+  /** One audit event per exported workflow id (bulk export). */
+  static async logWorkflowsExported(
+    context: WorkflowsRequestHandlerContext,
+    params: { ids: readonly string[] }
+  ): Promise<void> {
+    for (const id of params.ids) {
+      await writeAudit(
+        context,
+        successEvent(
+          WorkflowManagementAuditActions.EXPORT,
+          'access',
+          `User exported workflow [id=${id}]`
+        )
+      );
+    }
+  }
+
+  static async logWorkflowExported(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string }
+  ): Promise<void> {
+    await WorkflowManagementAuditLog.logWorkflowsExported(context, { ids: [params.id] });
+  }
+
+  static async logWorkflowExportFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.EXPORT,
+        'User failed to export workflows',
+        error,
+        'access'
+      )
+    );
+  }
+
+  static async logWorkflowAccessed(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.GET,
+        'access',
+        `User accessed workflow [id=${params.id}]`
+      )
+    );
+  }
+
+  static async logWorkflowAccessFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { id: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.GET,
+        `User failed to read workflow [id=${params.id}]`,
+        params.error,
+        'access'
+      )
+    );
+  }
+
+  static async logWorkflowMget(
+    context: WorkflowsRequestHandlerContext,
+    params: { requestedCount: number; returnedCount: number }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.MGET,
+        'access',
+        `User requested workflows by ids: requested ${params.requestedCount}, returned ${params.returnedCount}`
+      )
+    );
+  }
+
+  static async logWorkflowMgetFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.MGET,
+        'User failed workflows mget',
+        error,
+        'access'
+      )
+    );
+  }
+
+  static async logWorkflowRun(
+    context: WorkflowsRequestHandlerContext,
+    params: { workflowId: string; executionId: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.RUN,
+        'change',
+        `User ran workflow [id=${params.workflowId}] [executionId=${params.executionId}]`
+      )
+    );
+  }
+
+  static async logWorkflowRunFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { workflowId: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.RUN,
+        `User failed to run workflow [id=${params.workflowId}]`,
+        params.error
+      )
+    );
+  }
+
+  static async logWorkflowTest(
+    context: WorkflowsRequestHandlerContext,
+    params: { workflowExecutionId: string; workflowId?: string }
+  ): Promise<void> {
+    const workflowRef =
+      params.workflowId !== undefined ? `[workflowId=${params.workflowId}]` : '[draft yaml]';
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.TEST,
+        'change',
+        `User tested workflow ${workflowRef} [executionId=${params.workflowExecutionId}]`
+      )
+    );
+  }
+
+  static async logWorkflowTestFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(WorkflowManagementAuditActions.TEST, 'User failed workflow test', error)
+    );
+  }
+
+  static async logWorkflowStepTest(
+    context: WorkflowsRequestHandlerContext,
+    params: {
+      stepId: string;
+      workflowExecutionId: string;
+      workflowId?: string;
+    }
+  ): Promise<void> {
+    const wfPart =
+      params.workflowId !== undefined ? `[workflowId=${params.workflowId}]` : '[draft yaml]';
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.TEST_STEP,
+        'change',
+        `User tested workflow step [stepId=${params.stepId}] ${wfPart} [executionId=${params.workflowExecutionId}]`
+      )
+    );
+  }
+
+  static async logWorkflowStepTestFailed(
+    context: WorkflowsRequestHandlerContext,
+    error: unknown
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.TEST_STEP,
+        'User failed workflow step test',
+        error
+      )
+    );
+  }
+
+  static async logExecutionCanceled(
+    context: WorkflowsRequestHandlerContext,
+    params: { executionId: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.CANCEL_EXECUTION,
+        'change',
+        `User canceled workflow execution [executionId=${params.executionId}]`
+      )
+    );
+  }
+
+  static async logExecutionCancelFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { executionId: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.CANCEL_EXECUTION,
+        `User failed to cancel workflow execution [executionId=${params.executionId}]`,
+        params.error
+      )
+    );
+  }
+
+  static async logExecutionResumed(
+    context: WorkflowsRequestHandlerContext,
+    params: { executionId: string }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      successEvent(
+        WorkflowManagementAuditActions.RESUME_EXECUTION,
+        'change',
+        `User resumed workflow execution [executionId=${params.executionId}]`
+      )
+    );
+  }
+
+  static async logExecutionResumeFailed(
+    context: WorkflowsRequestHandlerContext,
+    params: { executionId: string; error: unknown }
+  ): Promise<void> {
+    await writeAudit(
+      context,
+      failureEvent(
+        WorkflowManagementAuditActions.RESUME_EXECUTION,
+        `User failed to resume workflow execution [executionId=${params.executionId}]`,
+        params.error
+      )
+    );
+  }
+}

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -123,6 +123,31 @@ export class WorkflowManagementAuditLog {
     });
   }
 
+  /**
+   * One `workflow_create` audit per created workflow and per failed bulk row (bulk POST /api/workflows).
+   */
+  static async logBulkWorkflowCreateResults(
+    context: WorkflowsRequestHandlerContext,
+    params: {
+      created: ReadonlyArray<{ id: string }>;
+      failed: ReadonlyArray<{ index: number; id: string; error: string }>;
+    }
+  ): Promise<void> {
+    for (const workflow of params.created) {
+      await WorkflowManagementAuditLog.logWorkflowCreated(context, {
+        id: workflow.id,
+        viaBulkImport: true,
+      });
+    }
+    for (const row of params.failed) {
+      await WorkflowManagementAuditLog.logBulkCreateRowFailed(context, {
+        index: row.index,
+        id: row.id,
+        error: row.error,
+      });
+    }
+  }
+
   static async logWorkflowUpdated(
     context: WorkflowsRequestHandlerContext,
     params: { id: string }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -27,42 +27,36 @@ export const WorkflowManagementAuditActions = {
   RESUME_EXECUTION: 'workflow_execution_resume',
 } as const;
 
-function failureEvent(
-  action: string,
-  message: string,
-  error: unknown,
-  eventType: 'access' | 'change' | 'creation' | 'deletion' = 'change'
-): AuditEvent {
-  const err = error instanceof Error ? error : new Error(String(error));
-  return {
-    message,
-    event: {
-      action,
-      category: ['database'],
-      type: [eventType],
-      outcome: 'failure',
-    },
-    error: {
-      code: err.name,
-      message: err.message,
-    },
-  };
-}
+type WorkflowAuditEventType = 'access' | 'change' | 'creation' | 'deletion';
 
-function successEvent(
+/**
+ * Builds a workflow-management audit event (success vs failure from presence of `error`).
+ * Non-`Error` values use ECS error code `Unknown` and `String(error)` as the message.
+ */
+function createEvent(
   action: string,
-  eventType: 'access' | 'change' | 'creation' | 'deletion',
-  message: string
+  eventType: WorkflowAuditEventType,
+  message: string,
+  error?: unknown
 ): AuditEvent {
-  return {
+  const event: AuditEvent = {
     message,
     event: {
       action,
       category: ['database'],
       type: [eventType],
-      outcome: 'success',
+      outcome: error !== undefined ? 'failure' : 'success',
     },
   };
+
+  if (error !== undefined) {
+    event.error =
+      error instanceof Error
+        ? { code: error.name, message: error.message }
+        : { code: 'Unknown', message: String(error) };
+  }
+
+  return event;
 }
 
 async function writeAudit(
@@ -73,9 +67,7 @@ async function writeAudit(
     const coreContext = await context.core;
     await Promise.resolve(coreContext.security.audit.logger.log(event));
   } catch {
-    // Best-effort only: never let audit affect the HTTP response. There is no request-scoped or
-    // module-level Kibana Logger here (core context does not expose one); optional debug on failure
-    // would require plugin-injected configuration, which we avoid for this helper.
+    // Best-effort only: never let audit affect the HTTP response.
   }
 }
 
@@ -91,7 +83,7 @@ export class WorkflowManagementAuditLog {
       : `User created workflow [id=${id}]`;
     await writeAudit(
       context,
-      successEvent(WorkflowManagementAuditActions.CREATE, 'creation', message)
+      createEvent(WorkflowManagementAuditActions.CREATE, 'creation', message)
     );
   }
 
@@ -105,7 +97,7 @@ export class WorkflowManagementAuditLog {
       : 'User failed to create a workflow';
     await writeAudit(
       context,
-      failureEvent(WorkflowManagementAuditActions.CREATE, message, error, 'creation')
+      createEvent(WorkflowManagementAuditActions.CREATE, 'creation', message, error)
     );
   }
 
@@ -114,19 +106,15 @@ export class WorkflowManagementAuditLog {
     params: { index: number; id: string; error: string }
   ): Promise<void> {
     const { index, id, error: errorMessage } = params;
-    await writeAudit(context, {
-      message: `User failed to create workflow via bulk import [index=${index}] [id=${id}]: ${errorMessage}`,
-      event: {
-        action: WorkflowManagementAuditActions.CREATE,
-        category: ['database'],
-        type: ['creation'],
-        outcome: 'failure',
-      },
-      error: {
-        code: 'bulk_create_row',
-        message: errorMessage,
-      },
-    });
+    await writeAudit(
+      context,
+      createEvent(
+        WorkflowManagementAuditActions.CREATE,
+        'creation',
+        `User failed to create workflow via bulk import [index=${index}] [id=${id}]: ${errorMessage}`,
+        errorMessage
+      )
+    );
   }
 
   /**
@@ -160,7 +148,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.UPDATE,
         'change',
         `User updated workflow [id=${params.id}]`
@@ -174,8 +162,9 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.UPDATE,
+        'change',
         `User failed to update workflow [id=${params.id}]`,
         params.error
       )
@@ -192,7 +181,7 @@ export class WorkflowManagementAuditLog {
       : `User deleted workflow [id=${id}]`;
     await writeAudit(
       context,
-      successEvent(WorkflowManagementAuditActions.DELETE, 'deletion', message)
+      createEvent(WorkflowManagementAuditActions.DELETE, 'deletion', message)
     );
   }
 
@@ -206,7 +195,7 @@ export class WorkflowManagementAuditLog {
       : `User failed to delete workflow [id=${id}]`;
     await writeAudit(
       context,
-      failureEvent(WorkflowManagementAuditActions.DELETE, message, error, 'deletion')
+      createEvent(WorkflowManagementAuditActions.DELETE, 'deletion', message, error)
     );
   }
 
@@ -238,11 +227,11 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.BULK_DELETE,
+        'deletion',
         'User failed bulk workflow delete',
-        error,
-        'deletion'
+        error
       )
     );
   }
@@ -253,7 +242,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.CLONE,
         'creation',
         `User cloned workflow [sourceId=${params.sourceId}] to [id=${params.newId}]`
@@ -267,11 +256,11 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.CLONE,
+        'creation',
         `User failed to clone workflow [id=${params.sourceId}]`,
-        params.error,
-        'creation'
+        params.error
       )
     );
   }
@@ -284,7 +273,7 @@ export class WorkflowManagementAuditLog {
     for (const id of params.ids) {
       await writeAudit(
         context,
-        successEvent(
+        createEvent(
           WorkflowManagementAuditActions.EXPORT,
           'access',
           `User exported workflow [id=${id}]`
@@ -306,11 +295,11 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.EXPORT,
+        'access',
         'User failed to export workflows',
-        error,
-        'access'
+        error
       )
     );
   }
@@ -321,7 +310,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.GET,
         'access',
         `User accessed workflow [id=${params.id}]`
@@ -335,11 +324,11 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.GET,
+        'access',
         `User failed to read workflow [id=${params.id}]`,
-        params.error,
-        'access'
+        params.error
       )
     );
   }
@@ -350,7 +339,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.MGET,
         'access',
         `User requested workflows by ids: requested ${params.requestedCount}, returned ${params.returnedCount}`
@@ -364,11 +353,11 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.MGET,
+        'access',
         'User failed workflows mget',
-        error,
-        'access'
+        error
       )
     );
   }
@@ -379,7 +368,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.RUN,
         'change',
         `User ran workflow [id=${params.workflowId}] [executionId=${params.executionId}]`
@@ -393,8 +382,9 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.RUN,
+        'change',
         `User failed to run workflow [id=${params.workflowId}]`,
         params.error
       )
@@ -409,7 +399,7 @@ export class WorkflowManagementAuditLog {
       params.workflowId !== undefined ? `[workflowId=${params.workflowId}]` : '[draft yaml]';
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.TEST,
         'change',
         `User tested workflow ${workflowRef} [executionId=${params.workflowExecutionId}]`
@@ -423,7 +413,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(WorkflowManagementAuditActions.TEST, 'User failed workflow test', error)
+      createEvent(WorkflowManagementAuditActions.TEST, 'change', 'User failed workflow test', error)
     );
   }
 
@@ -439,7 +429,7 @@ export class WorkflowManagementAuditLog {
       params.workflowId !== undefined ? `[workflowId=${params.workflowId}]` : '[draft yaml]';
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.TEST_STEP,
         'change',
         `User tested workflow step [stepId=${params.stepId}] ${wfPart} [executionId=${params.workflowExecutionId}]`
@@ -453,8 +443,9 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.TEST_STEP,
+        'change',
         'User failed workflow step test',
         error
       )
@@ -467,7 +458,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.CANCEL_EXECUTION,
         'change',
         `User canceled workflow execution [executionId=${params.executionId}]`
@@ -481,8 +472,9 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.CANCEL_EXECUTION,
+        'change',
         `User failed to cancel workflow execution [executionId=${params.executionId}]`,
         params.error
       )
@@ -495,7 +487,7 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      successEvent(
+      createEvent(
         WorkflowManagementAuditActions.RESUME_EXECUTION,
         'change',
         `User resumed workflow execution [executionId=${params.executionId}]`
@@ -509,8 +501,9 @@ export class WorkflowManagementAuditLog {
   ): Promise<void> {
     await writeAudit(
       context,
-      failureEvent(
+      createEvent(
         WorkflowManagementAuditActions.RESUME_EXECUTION,
+        'change',
         `User failed to resume workflow execution [executionId=${params.executionId}]`,
         params.error
       )

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/utils/workflow_audit_logging.ts
@@ -153,30 +153,29 @@ export class WorkflowManagementAuditLog {
 
   static async logWorkflowDeleted(
     context: WorkflowsRequestHandlerContext,
-    params: { id: string }
+    params: { id: string; viaBulkDelete?: boolean }
   ): Promise<void> {
+    const { id, viaBulkDelete } = params;
+    const message = viaBulkDelete
+      ? `User deleted workflow via bulk delete [id=${id}]`
+      : `User deleted workflow [id=${id}]`;
     await writeAudit(
       context,
-      successEvent(
-        WorkflowManagementAuditActions.DELETE,
-        'deletion',
-        `User deleted workflow [id=${params.id}]`
-      )
+      successEvent(WorkflowManagementAuditActions.DELETE, 'deletion', message)
     );
   }
 
   static async logWorkflowDeleteFailed(
     context: WorkflowsRequestHandlerContext,
-    params: { id: string; error: unknown }
+    params: { id: string; error: unknown; viaBulkDelete?: boolean }
   ): Promise<void> {
+    const { id, error, viaBulkDelete } = params;
+    const message = viaBulkDelete
+      ? `User failed to delete workflow via bulk delete [id=${id}]`
+      : `User failed to delete workflow [id=${id}]`;
     await writeAudit(
       context,
-      failureEvent(
-        WorkflowManagementAuditActions.DELETE,
-        `User failed to delete workflow [id=${params.id}]`,
-        params.error,
-        'deletion'
-      )
+      failureEvent(WorkflowManagementAuditActions.DELETE, message, error, 'deletion')
     );
   }
 
@@ -191,12 +190,13 @@ export class WorkflowManagementAuditLog {
     }
   ): Promise<void> {
     for (const id of params.successfulIds) {
-      await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id });
+      await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id, viaBulkDelete: true });
     }
     for (const f of params.failures) {
       await WorkflowManagementAuditLog.logWorkflowDeleteFailed(context, {
         id: f.id,
         error: new Error(f.error),
+        viaBulkDelete: true,
       });
     }
   }

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
@@ -56,19 +56,10 @@ export function registerBulkCreateWorkflowsRoute({ router, api, spaces }: RouteD
           const result = await api.bulkCreateWorkflows(request.body.workflows, spaceId, request, {
             overwrite,
           });
-          for (const createdWorkflow of result.created) {
-            await WorkflowManagementAuditLog.logWorkflowCreated(context, {
-              id: createdWorkflow.id,
-              viaBulkImport: true,
-            });
-          }
-          for (const row of result.failed) {
-            await WorkflowManagementAuditLog.logBulkCreateRowFailed(context, {
-              index: row.index,
-              id: row.id,
-              error: row.error,
-            });
-          }
+          await WorkflowManagementAuditLog.logBulkWorkflowCreateResults(context, {
+            created: result.created,
+            failed: result.failed,
+          });
           return response.ok({ body: result });
         } catch (error) {
           await WorkflowManagementAuditLog.logWorkflowCreateFailed(context, error, {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
@@ -14,8 +14,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_BULK_CREATE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerBulkCreateWorkflowsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_create_workflows.ts
@@ -14,6 +14,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_BULK_CREATE_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerBulkCreateWorkflowsRoute({ router, api, spaces }: RouteDependencies) {
@@ -55,8 +56,24 @@ export function registerBulkCreateWorkflowsRoute({ router, api, spaces }: RouteD
           const result = await api.bulkCreateWorkflows(request.body.workflows, spaceId, request, {
             overwrite,
           });
+          for (const createdWorkflow of result.created) {
+            await WorkflowManagementAuditLog.logWorkflowCreated(context, {
+              id: createdWorkflow.id,
+              viaBulkImport: true,
+            });
+          }
+          for (const row of result.failed) {
+            await WorkflowManagementAuditLog.logBulkCreateRowFailed(context, {
+              index: row.index,
+              id: row.id,
+              error: row.error,
+            });
+          }
           return response.ok({ body: result });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowCreateFailed(context, error, {
+            bulkOperation: true,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
@@ -13,6 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 const MAX_BULK_DELETE_BATCH_SIZE = 1000;
@@ -55,8 +56,14 @@ export function registerBulkDeleteWorkflowsRoute({ router, api, spaces }: RouteD
           const { ids } = request.body;
           const spaceId = spaces.getSpaceId(request);
           const result = await api.deleteWorkflows(ids, spaceId, request);
+          await WorkflowManagementAuditLog.logBulkWorkflowDeleteSummary(context, {
+            total: result.total,
+            deleted: result.deleted,
+            failureCount: result.failures.length,
+          });
           return response.ok({ body: result });
         } catch (error) {
+          await WorkflowManagementAuditLog.logBulkWorkflowDeleteFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 const MAX_BULK_DELETE_BATCH_SIZE = 1000;
 

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/bulk_delete_workflows.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 const MAX_BULK_DELETE_BATCH_SIZE = 1000;
 
@@ -56,12 +56,12 @@ export function registerBulkDeleteWorkflowsRoute({ router, api, spaces }: RouteD
           const { ids } = request.body;
           const spaceId = spaces.getSpaceId(request);
           const result = await api.deleteWorkflows(ids, spaceId, request);
-          await WorkflowManagementAuditLog.logBulkWorkflowDeleteSummary(context, {
-            total: result.total,
-            deleted: result.deleted,
-            failureCount: result.failures.length,
+          const { successfulIds = [], ...responseBody } = result;
+          await WorkflowManagementAuditLog.logBulkWorkflowDeleteResults(context, {
+            successfulIds,
+            failures: result.failures,
           });
-          return response.ok({ body: result });
+          return response.ok({ body: responseBody });
         } catch (error) {
           await WorkflowManagementAuditLog.logBulkWorkflowDeleteFailed(context, error);
           return handleRouteError(response, error);

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
@@ -13,6 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerCloneWorkflowRoute({ router, api, spaces }: RouteDependencies) {
@@ -49,8 +50,16 @@ export function registerCloneWorkflowRoute({ router, api, spaces }: RouteDepende
             return response.notFound();
           }
           const createdWorkflow = await api.cloneWorkflow(workflow, spaceId, request);
+          await WorkflowManagementAuditLog.logWorkflowCloned(context, {
+            sourceId: id,
+            newId: createdWorkflow.id,
+          });
           return response.ok({ body: createdWorkflow });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowCloneFailed(context, {
+            sourceId: request.params.id,
+            error,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/clone_workflow.ts
@@ -13,8 +13,8 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerCloneWorkflowRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
@@ -13,6 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerCreateWorkflowRoute({ router, api, spaces }: RouteDependencies) {
@@ -45,8 +46,12 @@ export function registerCreateWorkflowRoute({ router, api, spaces }: RouteDepend
         try {
           const spaceId = spaces.getSpaceId(request);
           const createdWorkflow = await api.createWorkflow(request.body, spaceId, request);
+          await WorkflowManagementAuditLog.logWorkflowCreated(context, {
+            id: createdWorkflow.id,
+          });
           return response.ok({ body: createdWorkflow });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowCreateFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/create_workflow.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_CREATE_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerCreateWorkflowRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
@@ -13,6 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerDeleteWorkflowRoute({ router, api, spaces }: RouteDependencies) {
@@ -45,8 +46,13 @@ export function registerDeleteWorkflowRoute({ router, api, spaces }: RouteDepend
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);
           await api.deleteWorkflows([id], spaceId, request);
+          await WorkflowManagementAuditLog.logWorkflowDeleted(context, { id });
           return response.ok();
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowDeleteFailed(context, {
+            id: request.params.id,
+            error,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/delete_workflow.ts
@@ -13,8 +13,8 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_DELETE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerDeleteWorkflowRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/export_workflows.ts
@@ -17,6 +17,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerExportWorkflowsRoute({ router, api, logger, spaces }: RouteDependencies) {
   router.versioned
@@ -85,6 +86,10 @@ export function registerExportWorkflowsRoute({ router, api, logger, spaces }: Ro
           const filename = `workflows_export_${timestamp}.zip`;
           const zipBuffer = await generateWorkflowsArchive(entries);
 
+          await WorkflowManagementAuditLog.logWorkflowsExported(context, {
+            ids: entries.map((e) => e.id),
+          });
+
           return response.ok({
             body: zipBuffer,
             headers: {
@@ -93,6 +98,7 @@ export function registerExportWorkflowsRoute({ router, api, logger, spaces }: Ro
             },
           });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowExportFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
@@ -13,8 +13,8 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerGetWorkflowRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/get_workflow.ts
@@ -13,6 +13,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerGetWorkflowRoute({ router, api, spaces }: RouteDependencies) {
@@ -48,8 +49,13 @@ export function registerGetWorkflowRoute({ router, api, spaces }: RouteDependenc
           if (!workflow) {
             return response.notFound({ body: { message: 'Workflow not found' } });
           }
+          await WorkflowManagementAuditLog.logWorkflowAccessed(context, { id });
           return response.ok({ body: workflow });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowAccessFailed(context, {
+            id: request.params.id,
+            error,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
@@ -13,8 +13,8 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerMgetWorkflowsRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/mget_workflows.ts
@@ -13,6 +13,7 @@ import type { RouteDependencies } from '../types';
 import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_READ_SECURITY } from '../utils/route_security';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerMgetWorkflowsRoute({ router, api, spaces }: RouteDependencies) {
@@ -65,8 +66,13 @@ export function registerMgetWorkflowsRoute({ router, api, spaces }: RouteDepende
           const spaceId = spaces.getSpaceId(request);
           const { ids, source } = request.body;
           const workflows = await api.getWorkflowsSourceByIds(ids, spaceId, source);
+          await WorkflowManagementAuditLog.logWorkflowMget(context, {
+            requestedCount: ids.length,
+            returnedCount: workflows.length,
+          });
           return response.ok({ body: workflows });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowMgetFailed(context, error);
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
@@ -14,8 +14,8 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_UPDATE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
-import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 
 export function registerUpdateWorkflowRoute({ router, api, spaces }: RouteDependencies) {
   router.versioned

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/update_workflow.ts
@@ -14,6 +14,7 @@ import { API_VERSION, AVAILABILITY, OAS_TAG } from '../utils/route_constants';
 import { handleRouteError } from '../utils/route_error_handlers';
 import { WORKFLOW_UPDATE_SECURITY } from '../utils/route_security';
 import { idParamSchema } from '../utils/schemas';
+import { WorkflowManagementAuditLog } from '../utils/workflow_audit_logging';
 import { withLicenseCheck } from '../utils/with_license_check';
 
 export function registerUpdateWorkflowRoute({ router, api, spaces }: RouteDependencies) {
@@ -48,8 +49,13 @@ export function registerUpdateWorkflowRoute({ router, api, spaces }: RouteDepend
           const { id } = request.params;
           const spaceId = spaces.getSpaceId(request);
           const updated = await api.updateWorkflow(id, request.body, spaceId, request);
+          await WorkflowManagementAuditLog.logWorkflowUpdated(context, { id });
           return response.ok({ body: updated });
         } catch (error) {
+          await WorkflowManagementAuditLog.logWorkflowUpdateFailed(context, {
+            id: request.params.id,
+            error,
+          });
           return handleRouteError(response, error);
         }
       })

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
@@ -33,6 +33,17 @@ const createLicensingContext = () => ({
       type: 'enterprise',
     },
   }),
+  core: Promise.resolve({
+    security: {
+      audit: {
+        logger: {
+          enabled: false,
+          log: jest.fn(),
+          includeSavedObjectNames: false,
+        },
+      },
+    },
+  }),
 });
 
 describe('Workflow routes', () => {

--- a/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/routes/workflows/workflows.test.ts
@@ -342,8 +342,13 @@ describe('Workflow routes', () => {
     });
 
     it('should call api.deleteWorkflows with ids, space id, and request', async () => {
-      const bodyResult = { total: 2, deleted: 2, failures: [] };
-      mockApi.deleteWorkflows.mockResolvedValue(bodyResult);
+      const apiResult = {
+        total: 2,
+        deleted: 2,
+        failures: [] as Array<{ id: string; error: string }>,
+        successfulIds: ['a', 'b'],
+      };
+      mockApi.deleteWorkflows.mockResolvedValue(apiResult);
       const request = httpServerMock.createKibanaRequest({ body: { ids: ['a', 'b'] } });
       const response = mockResponse();
       const context = createLicensingContext() as any;
@@ -351,7 +356,9 @@ describe('Workflow routes', () => {
       await routeHandlers[key].handler(context, request, response);
 
       expect(mockApi.deleteWorkflows).toHaveBeenCalledWith(['a', 'b'], 'default-space', request);
-      expect(response.ok).toHaveBeenCalledWith({ body: bodyResult });
+      expect(response.ok).toHaveBeenCalledWith({
+        body: { total: 2, deleted: 2, failures: [] },
+      });
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_api.ts
@@ -61,6 +61,11 @@ export interface DeleteWorkflowsResponse {
     id: string;
     error: string;
   }>;
+  /**
+   * Workflow ids successfully soft-deleted in Elasticsearch. Used server-side for audit logging;
+   * bulk delete route omits this field from the HTTP JSON body so the public API shape is unchanged.
+   */
+  successfulIds?: string[];
 }
 
 export interface GetWorkflowExecutionLogsParams {

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.test.ts
@@ -1932,6 +1932,7 @@ steps:
         total: 1,
         deleted: 1,
         failures: [],
+        successfulIds: ['test-workflow-id'],
       });
 
       expect(mockEsClient.search).toHaveBeenCalledWith(
@@ -1970,6 +1971,7 @@ steps:
         total: 1,
         deleted: 1,
         failures: [],
+        successfulIds: [],
       });
     });
 
@@ -2017,6 +2019,7 @@ steps:
         total: 2,
         deleted: 1,
         failures: [{ id: 'workflow-2', error: 'Database error' }],
+        successfulIds: ['workflow-1'],
       });
     });
   });

--- a/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
+++ b/src/platform/plugins/shared/workflows_management/server/api/workflows_management_service.ts
@@ -707,6 +707,7 @@ export class WorkflowsService {
 
     const now = new Date();
     const failures: Array<{ id: string; error: string }> = [];
+    const successfulIds: string[] = [];
     const client = this.workflowStorage.getClient();
 
     // Bulk fetch all workflows in a single search call
@@ -741,7 +742,6 @@ export class WorkflowsService {
         });
 
         // Process bulk response to track successes and failures
-        const successfulIds: string[] = [];
         bulkResponse.items.forEach((item) => {
           const operation = item.index;
           if (operation?.error) {
@@ -788,6 +788,7 @@ export class WorkflowsService {
       total: ids.length,
       deleted: ids.length - failures.length,
       failures,
+      successfulIds,
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds **custom Kibana security audit events** for `workflows_management` public HTTP routes via `WorkflowManagementAuditLog` and `context.core.security.audit.logger`.
- Stable **`event.action`** values live in `WorkflowManagementAuditActions` for `xpack.security.audit.ignore_filters`.
- **Bulk delete:** one **`workflow_delete`** event per successfully removed workflow id and per failed id; **`workflow_bulk_delete`** only when the bulk delete **handler throws** before per-id logging. **`successfulIds`** is returned server-side for audit and **stripped** from the HTTP JSON body (`{ total, deleted, failures }` unchanged).
- **Bulk create / export:** multiple events per request (per created id, per failed row, per exported id).
- **Tests:** `workflow_audit_logging.test.ts` + route context mocks.

## Audit event catalog

### Common properties (all rows below)

| Property | Value |
|----------|--------|
| `event.category` | `database` |
| `event.type` | See per-action column (ECS-style: `creation`, `change`, `deletion`, `access`) |
| `event.outcome` | `success` or `failure` |
| `message` | Human-readable string; workflow/execution ids appear as `[id=…]`, `[executionId=…]`, etc. |
| `error` | On **failure**: `error.code` (exception name or `bulk_create_row`), `error.message` |

Kibana’s scoped audit logger also attaches **user**, **kibana.space_id**, **kibana.session_id**, **trace.id**, **client.ip**, and related HTTP metadata (not set in our event payload).

---

### By `event.action`

| `event.action` | `event.type` | One-line description |
|----------------|--------------|----------------------|
| **`workflow_create`** | `creation` | User created a workflow (single POST or one row of bulk import). |
| **`workflow_create`** | `creation` | User’s bulk import row failed validation/ES (`outcome: failure`, `error.code: bulk_create_row`). |
| **`workflow_create`** | `creation` | User failed to create a workflow or the whole bulk-create request threw (`outcome: failure`). |
| **`workflow_update`** | `change` | User updated a workflow by id. |
| **`workflow_update`** | `change` | User failed to update a workflow (`outcome: failure`). |
| **`workflow_delete`** | `deletion` | User deleted a workflow (single delete or one id from bulk delete). |
| **`workflow_delete`** | `deletion` | User failed to delete a workflow / one bulk-delete row failed (`outcome: failure`). |
| **`workflow_bulk_delete`** | `deletion` | Bulk delete route failed with an exception before per-id results (`outcome: failure`). |
| **`workflow_clone`** | `creation` | User cloned a workflow (source id → new id). |
| **`workflow_clone`** | `creation` | User failed to clone a workflow (`outcome: failure`). |
| **`workflow_export`** | `access` | User exported one workflow id as part of a ZIP export (one event per id). |
| **`workflow_export`** | `access` | User failed the export request (`outcome: failure`). |
| **`workflow_get`** | `access` | User read a single workflow by id (success only when found). |
| **`workflow_get`** | `access` | User failed to read a workflow (`outcome: failure`). |
| **`workflow_mget`** | `access` | User requested multiple workflows by ids (one summary: requested vs returned count). |
| **`workflow_mget`** | `access` | User failed the mget request (`outcome: failure`). |
| **`workflow_run`** | `change` | User started a workflow run (includes `executionId` in `message`). |
| **`workflow_run`** | `change` | User failed to run a workflow (`outcome: failure`). |
| **`workflow_test`** | `change` | User ran workflow test mode (`message`: saved `workflowId` or `[draft yaml]`, plus `executionId`). |
| **`workflow_test`** | `change` | User failed workflow test (`outcome: failure`). |
| **`workflow_test_step`** | `change` | User ran step test (`message`: `stepId`, optional `workflowId` or draft, `executionId`). |
| **`workflow_test_step`** | `change` | User failed step test (`outcome: failure`). |
| **`workflow_execution_cancel`** | `change` | User canceled a workflow execution. |
| **`workflow_execution_cancel`** | `change` | User failed to cancel execution (`outcome: failure`). |
| **`workflow_execution_resume`** | `change` | User resumed a workflow execution. |
| **`workflow_execution_resume`** | `change` | User failed to resume execution (`outcome: failure`). |

---

## How to test locally

1. Enable audit logging in `kibana.yml` / `kibana.dev.yml` (appropriate license). Use a file or console appender with JSON layout. **Avoid** `ignore_filters` that drop `event.category: database` if you need to see these events.
2. Run Kibana, perform workflow actions (UI or API), grep audit log for `workflow_` actions.

```yaml
xpack.security.audit.enabled: true
xpack.security.audit.appender.type: file
xpack.security.audit.appender.fileName: /tmp/kibana-audit.log
xpack.security.audit.appender.layout.type: json
```

```bash
yarn test:jest --config src/platform/plugins/shared/workflows_management/server/jest.config.js workflow_audit_logging.test.ts
```

## Notes

- Does not emit an audit line for every step of ongoing **execution** (volume); focuses on management APIs and explicit run/test/cancel/resume.
- `event.category: database` matches Kibana/ECS usage for persisted-entity operations (similar to other features).
