### PR TITLE
[8.19] Assign CODEOWNERS to FTR test files missing ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1157,6 +1157,58 @@ src/platform/plugins/shared/discover/public/context_awareness/profile_providers/
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_data_source_profile @elastic/obs-presentation-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/traces_document_profile @elastic/obs-presentation-team
 /src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security @elastic/kibana-data-discovery @elastic/security-threat-hunting-investigations
+/src/platform/test/api_integration/apis/data_view_field_editor/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/apis/data_views/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/apis/kql_telemetry/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/apis/saved_queries/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/apis/scripts/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/apis/search/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/fixtures/es_archiver/index_patterns/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/fixtures/kbn_archiver/index_patterns/ @elastic/kibana-data-discovery
+/src/platform/test/api_integration/fixtures/kbn_archiver/management/saved_objects/relationships.json @elastic/kibana-core @elastic/kibana-data-discovery
+/src/platform/test/examples/data_view_field_editor_example/ @elastic/kibana-data-discovery
+/src/platform/test/examples/discover_customization_examples/ @elastic/kibana-data-discovery
+/src/platform/test/examples/field_formats/ @elastic/kibana-data-discovery
+/src/platform/test/examples/partial_results/ @elastic/kibana-data-discovery
+/src/platform/test/examples/search/ @elastic/kibana-data-discovery
+/src/platform/test/examples/unified_field_list_examples/ @elastic/kibana-data-discovery
+/src/platform/test/functional/apps/context/ @elastic/kibana-data-discovery
+/src/platform/test/functional/apps/discover/ @elastic/kibana-data-discovery
+/src/platform/test/functional/firefox/discover.config.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/alias/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/date_n* @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/discover/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/hamlet/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/huge_fields/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/index_pattern_without_timefield/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/large_fields/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/message_with_newline/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/es_archiver/unmapped_fields/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/date_* @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/discover/ @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/discover.json @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/index_pattern_without_timefield.json @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/invalid_scripted_field.json @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/management.json @elastic/kibana-management @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/message_with_newline.json @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/testlargestring.json @elastic/kibana-data-discovery
+/src/platform/test/functional/fixtures/kbn_archiver/unmapped_fields.json @elastic/kibana-data-discovery
+/src/platform/test/functional/page_objects/context_page.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/page_objects/discover_page.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/page_objects/unified_field_list.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/services/data_grid.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/services/data_views.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/services/field_editor.ts @elastic/kibana-data-discovery
+/src/platform/test/functional/services/doc_table.ts @elastic/kibana-data-discovery
+/src/platform/test/plugin_functional/test_suites/data_plugin/ @elastic/kibana-data-discovery
+/src/platform/test/accessibility/apps/discover.ts @elastic/kibana-data-discovery
+/x-pack/platform/test/functional/apps/data_views/ @elastic/kibana-data-discovery
+/x-pack/platform/test/functional/apps/discover/ @elastic/kibana-data-discovery
+/x-pack/platform/test/functional/apps/saved_query_management/ @elastic/kibana-data-discovery
+/x-pack/platform/test/api_integration/apis/search/ @elastic/kibana-data-discovery
+/x-pack/platform/test/examples/search_examples/ @elastic/kibana-data-discovery
+/x-pack/platform/test/functional_with_es_ssl/apps/discover_ml/discover/ @elastic/kibana-data-discovery
+/x-pack/platform/test/accessibility/apps/group3/search_sessions.ts @elastic/kibana-data-discovery
 
 # Platform Docs
 /x-pack/platform/test/screenshot_creation @elastic/platform-docs
@@ -1184,6 +1236,26 @@ src/platform/plugins/shared/discover/public/context_awareness/profile_providers/
 /src/plugins/visualize/ @elastic/kibana-visualizations
 /x-pack/platform/test/functional/apps/lens @elastic/kibana-visualizations
 /x-pack/platform/test/functional/apps/graph @elastic/kibana-visualizations
+/src/platform/test/functional/apps/visualize/ @elastic/kibana-visualizations
+/src/platform/test/api_integration/apis/event_annotations/ @elastic/kibana-visualizations
+/src/platform/test/api_integration/fixtures/kbn_archiver/event_annotations/ @elastic/kibana-visualizations
+/src/platform/test/examples/expressions_explorer/ @elastic/kibana-visualizations
+/src/platform/test/functional/fixtures/kbn_archiver/managed_content.json @elastic/kibana-visualizations
+/src/platform/test/functional/fixtures/kbn_archiver/visualize.json @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/annotation_library_editor_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/legacy/data_table_vis.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/tag_cloud_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/time_to_visualize_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/timelion_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/vega_chart_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/visual_builder_page.ts @elastic/kibana-visualizations
+/src/platform/test/functional/page_objects/visualize_*.ts @elastic/kibana-visualizations
+/src/platform/test/functional/services/visualizations/ @elastic/kibana-visualizations
+/src/platform/test/functional/services/renderable.ts @elastic/kibana-visualizations
+/src/platform/test/functional/apps/getting_started/ @elastic/kibana-visualizations
+/src/platform/test/functional/firefox/visualize.config.ts @elastic/kibana-visualizations
+/src/platform/test/plugin_functional/test_suites/custom_visualizations/ @elastic/kibana-visualizations
+/src/platform/test/accessibility/apps/visualize.ts @elastic/kibana-visualizations
 
 # ES|QL
 /src/platform/test/api_integration/apis/esql/*.ts @elastic/kibana-esql
@@ -1250,6 +1322,12 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/functional/page_objects/index.ts @elastic/observability-ui
 /x-pack/solutions/observability/test/functional/services/index.ts @elastic/observability-ui
 /x-pack/solutions/observability/test/functional_with_es_ssl/apps/index.ts @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/advanced_settings.ts @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/ @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/logs_essentials_only/ @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/onboarding/ @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/streams/ @elastic/observability-ui
+/x-pack/solutions/observability/test/serverless/api_integration/configs/configs.logs_essentials.ts @elastic/observability-ui
 
 ### Observability Plugins
 
@@ -1330,6 +1408,9 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/plugins/infra/server/services/rules @elastic/obs-presentation-team @elastic/obs-exploration-team
 /x-pack/solutions/observability/test/common/utils/synthtrace @elastic/obs-presentation-team @elastic/obs-exploration-team
 /src/platform/test/functional/services/synthtrace/logs_synthtrace_es_client.ts @elastic/obs-presentation-team @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/functional/page_objects/observability_logs_explorer.ts @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/functional/services/logs_ui/ @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/common/utils/server_route_repository/ @elastic/obs-presentation-team
 
 ## Streams parts owned by Logs UX
 /x-pack/platform/plugins/shared/streams_app/public/components/data_management @elastic/obs-onboarding-team
@@ -1435,6 +1516,12 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /src/platform/test/functional/apps/discover/observability/logs @elastic/obs-exploration-team
 /x-pack/solutions/observability/plugins/observability/public/pages/landing @elastic/obs-onboarding-team
 /x-pack/solutions/observability/test/functional/config.firefox.ts @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/serverless/functional/test_suites/discover/logs/ @elastic/obs-exploration-team
+/src/platform/test/functional/apps/discover/observability/ @elastic/obs-exploration-team
+/x-pack/solutions/observability/test/serverless/functional/configs/ @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/ @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/serverless/api_integration/configs/index.feature_flags.ts @elastic/obs-onboarding-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/dataset_quality_api_integration/ @elastic/obs-onboarding-team
 
 # Observability-ui
 /x-pack/solutions/observability/test/functional_solution_sidenav/ @elastic/observability-ui
@@ -1451,6 +1538,18 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/streams @elastic/streams-program-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.index.ts @elastic/streams-program-team
 /x-pack/solutions/observability/test/api_integration_deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts @elastic/streams-program-team
+/x-pack/platform/test/functional/fixtures/kbn_archives/streams/ @elastic/streams-program-team
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/cases/ @elastic/kibana-cases
+/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/ @elastic/kibana-cases
+/x-pack/solutions/observability/test/serverless/functional/test_suites/rules/ @elastic/response-ops
+/x-pack/solutions/observability/test/serverless/functional/test_suites/screenshot_creation/ @elastic/response-ops
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/fleet/ @elastic/fleet
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/synthetics/ @elastic/obs-ux-management-team
+/x-pack/solutions/observability/test/serverless/api_integration/configs/config.feature_flags.ts @elastic/kibana-security
+/x-pack/solutions/observability/test/serverless/api_integration/test_suites/platform_security/ @elastic/kibana-security
+/x-pack/solutions/observability/test/serverless/functional/test_suites/role_management/ @elastic/kibana-security
+/x-pack/solutions/observability/test/serverless/functional/test_suites/ml/ @elastic/ml-ui
+/x-pack/solutions/observability/test/serverless/functional/test_suites/navigation.ts @elastic/obs-presentation-team
 
 ### END Observability Plugins
 
@@ -1492,6 +1591,15 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/fixtures/es_archives/maps/ @elastic/kibana-presentation
 /x-pack/platform/plugins/shared/stack_alerts/server/rule_types/geo_containment @elastic/kibana-presentation
 /x-pack/platform/plugins/shared/stack_alerts/public/rule_types/geo_containment @elastic/kibana-presentation
+/src/platform/test/functional/apps/dashboard/ @elastic/kibana-presentation
+/src/platform/test/functional/apps/dashboard_elements/ @elastic/kibana-presentation
+/src/platform/test/functional/services/dashboard/ @elastic/kibana-presentation
+/src/platform/test/functional/services/inspector.ts @elastic/kibana-presentation
+/src/platform/test/functional/page_objects/unified_search_page.ts @elastic/kibana-presentation
+/src/platform/test/functional/screenshots/baseline/ @elastic/kibana-presentation
+/src/platform/test/functional/fixtures/kbn_archiver/canvas/ @elastic/kibana-presentation
+/src/platform/test/functional/fixtures/kbn_archiver/dashboard/ @elastic/kibana-presentation
+/src/platform/test/plugin_functional/test_suites/panel_actions/ @elastic/kibana-presentation
 
 
 # Machine Learning
@@ -1511,6 +1619,7 @@ x-pack/solutions/observability/plugins/observability/server/lib/esql_extensions 
 /x-pack/platform/test/screenshot_creation/apps/ml_docs @elastic/ml-ui
 /x-pack/test_serverless/**/test_suites/**/ml/ @elastic/ml-ui
 /x-pack/test_serverless/**/test_suites/common/management/transforms/ @elastic/ml-ui
+/src/platform/test/examples/response_stream/ @elastic/ml-ui
 
 # Security Machine Learning
 x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security_* @elastic/security-ml
@@ -1672,6 +1781,43 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/serverless/functional/services/ @elastic/appex-qa # temporarily due to SKA tests relocation
 /x-pack/platform/test/serverless/functional/config* @elastic/appex-qa
 /x-pack/platform/test/serverless/functional/ftr_provider_context.d.ts @elastic/appex-qa
+/src/platform/test/accessibility/ @elastic/appex-qa
+/src/platform/test/api_integration/config.js @elastic/appex-qa
+/src/platform/test/api_integration/ftr_provider_context.d.ts @elastic/appex-qa
+/src/platform/test/api_integration/jest.config.js @elastic/appex-qa
+/src/platform/test/api_integration/apis/index.ts @elastic/appex-qa
+/src/platform/test/api_integration/services/index.ts @elastic/appex-qa
+/src/platform/test/common/config.js @elastic/appex-qa
+/src/platform/test/common/fixtures/plugins/coverage/public/ @elastic/appex-qa
+/src/platform/test/common/services/index.ts @elastic/appex-qa
+/src/platform/test/examples/README.md @elastic/appex-qa
+/src/platform/test/examples/config.js @elastic/appex-qa
+/src/platform/test/functional/README.md @elastic/appex-qa
+/src/platform/test/functional/config.* @elastic/appex-qa
+/src/platform/test/functional/ftr_provider_context.ts @elastic/appex-qa
+/src/platform/test/functional/jest.config.js @elastic/appex-qa
+/src/platform/test/functional/firefox/config.base.ts @elastic/appex-qa
+/src/platform/test/functional/fixtures/es_archiver/README.md @elastic/appex-qa
+/src/platform/test/functional/page_objects/common_page.ts @elastic/appex-qa
+/src/platform/test/functional/page_objects/error_page.ts @elastic/appex-qa
+/src/platform/test/functional/page_objects/header_page.ts @elastic/appex-qa
+/src/platform/test/functional/page_objects/index.ts @elastic/appex-qa
+/src/platform/test/functional/page_objects/time_picker.ts @elastic/appex-qa
+/src/platform/test/functional/services/combo_box.ts @elastic/appex-qa
+/src/platform/test/functional/services/embedding.ts @elastic/appex-qa
+/src/platform/test/functional/services/filter_bar.ts @elastic/appex-qa
+/src/platform/test/functional/services/flyout.ts @elastic/appex-qa
+/src/platform/test/functional/services/global_nav.ts @elastic/appex-qa
+/src/platform/test/functional/services/index.ts @elastic/appex-qa
+/src/platform/test/functional/services/listing_table.ts @elastic/appex-qa
+/src/platform/test/functional/services/menu_toggle.ts @elastic/appex-qa
+/src/platform/test/functional/services/query_bar.ts @elastic/appex-qa
+/src/platform/test/functional/services/remote_es/remote_es.ts @elastic/appex-qa
+/src/platform/test/functional/services/supertest.ts @elastic/appex-qa
+/src/platform/test/harden/ @elastic/appex-qa
+/src/platform/test/plugin_functional/README.md @elastic/appex-qa
+/src/platform/test/plugin_functional/config.ts @elastic/appex-qa
+/src/platform/test/plugin_functional/services/index.ts @elastic/appex-qa
 
 # Core
 /x-pack/platform/test/fixtures/es_archives/lists @elastic/kibana-core
@@ -1716,6 +1862,8 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /src/platform/test/functional/page_objects/home_page.ts @elastic/appex-sharedux
 /src/platform/test/functional/page_objects/export_page.ts @elastic/appex-sharedux
 /src/platform/test/functional/page_objects/solution_navigation.ts @elastic/appex-sharedux
+/src/platform/test/functional/services/monaco_editor.ts @elastic/appex-sharedux
+/src/platform/test/examples/bfetch_explorer/ @elastic/appex-sharedux
 /src/platform/test/functional/fixtures/es_archiver/deprecations_service @elastic/kibana-core
 /src/platform/test/health_gateway @elastic/kibana-core
 /src/platform/test/api_integration/apis/saved_objects* @elastic/kibana-core
@@ -1763,6 +1911,16 @@ x-pack/platform/plugins/shared/ml/server/models/data_recognizer/modules/security
 /x-pack/platform/test/serverless/api_integration/test_suites/core/ @elastic/kibana-core
 /x-pack/platform/test/serverless/api_integration/test_suites/telemetry/ @elastic/kibana-core
 /x-pack/platform/test/fixtures/es_archives/cases/migrations/8.8.0 @elastic/kibana-cases
+/src/platform/test/analytics/ @elastic/kibana-core
+/src/platform/test/api_integration/fixtures/import.ndjson @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/application_links/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/core/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/core_plugins/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/saved_objects_hidden_type/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/saved_objects_management/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/telemetry/ @elastic/kibana-core
+/src/platform/test/plugin_functional/test_suites/usage_collection/ @elastic/kibana-core
+/src/platform/test/tsconfig.json @elastic/kibana-core
 
 #CC# /src/core/server/csp/ @elastic/kibana-core
 #CC# /src/plugins/saved_objects/ @elastic/kibana-core
@@ -1810,6 +1968,15 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /x-pack/platform/test/functional/page_objects/account_settings_page.ts @elastic/kibana-security
 /x-pack/platform/test/functional/apps/user_profiles @elastic/kibana-security
 /x-pack/platform//test/ftr_apis/security_and_spaces @elastic/kibana-security
+/x-pack/platform/test/ftr_apis/security_and_spaces/ @elastic/kibana-security
+/x-pack/platform/test/functional/apps/api_keys/ @elastic/kibana-security
+/src/platform/test/functional/page_objects/login_page.ts @elastic/kibana-security
+/src/platform/test/functional/page_objects/space_settings.ts @elastic/kibana-security
+/src/platform/test/interactive_setup_api_integration/ @elastic/kibana-security
+/src/platform/test/interactive_setup_functional/ @elastic/kibana-security
+/src/platform/test/plugin_functional/snapshots/baseline/hardening/ @elastic/kibana-security
+/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts @elastic/kibana-security
+/src/platform/test/plugin_functional/test_suites/hardening/ @elastic/kibana-security
 
 /.github/codeql @elastic/kibana-security
 /src/dev/eslint/security_eslint_rule_tests.ts @elastic/kibana-security
@@ -1899,6 +2066,7 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 /x-pack/platform/test/fixtures/es_archives/alerting/8_2_0 @elastic/response-ops
 /x-pack/platform/test/fixtures/es_archives/cases/signals/default @elastic/kibana-cases
 /x-pack/platform/test/fixtures/es_archives/cases/signals/hosts_users @elastic/kibana-cases
+/x-pack/platform/test/fixtures/es_archives/alerts_legacy/ @elastic/response-ops
 
 # Enterprise Search
 # search
@@ -1989,6 +2157,17 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/platform/test/accessibility/apps/group3/rollup_jobs.ts @elastic/kibana-management
 /x-pack/platform/test/accessibility/apps/group3/upgrade_assistant.ts @elastic/kibana-core
 /x-pack/platform/test/accessibility/apps/group3/watcher.ts @elastic/kibana-management
+/src/platform/test/api_integration/apis/console/ @elastic/kibana-management
+/src/platform/test/functional/apps/console/ @elastic/kibana-management
+/src/platform/test/functional/apps/management/ @elastic/kibana-management
+/src/platform/test/functional/apps/saved_objects_management/ @elastic/kibana-management
+/src/platform/test/functional/firefox/console.config.ts @elastic/kibana-management
+/src/platform/test/functional/page_objects/console_page.ts @elastic/kibana-management
+/src/platform/test/functional/page_objects/embedded_console.ts @elastic/kibana-management
+/src/platform/test/functional/page_objects/management/ @elastic/kibana-management
+/src/platform/test/plugin_functional/test_suites/management/ @elastic/kibana-management
+/src/platform/test/accessibility/apps/console.ts @elastic/kibana-management
+/src/platform/test/accessibility/apps/management.ts @elastic/kibana-management
 
 #CC# /x-pack/plugins/cross_cluster_replication/ @elastic/kibana-management
 
@@ -2010,6 +2189,10 @@ x-pack/platform/test/functional/page_objects/search_profiler_page.ts @elastic/se
 /x-pack/solutions/security/test/serverless/ @elastic/security-solution
 /x-pack/solutions/security/test/serverless/functional/configs/config.ts @elastic/security-solution @elastic/appex-qa
 /x-pack/solutions/security/test/serverless/functional/configs/config.feature_flags.ts @elastic/security-solution
+/x-pack/solutions/security/test/common/utils/detections_response/spaces.ts @elastic/security-detections-response
+/x-pack/solutions/security/test/fixtures/es_archives/auditbeat/default/ @elastic/security-solution
+/x-pack/solutions/security/test/fixtures/es_archives/auditbeat/hosts/ @elastic/security-entity-analytics
+/x-pack/solutions/security/test/fixtures/es_archives/entity/user_risk/ @elastic/security-entity-analytics
 
 #CC# /x-pack/solutions/security/plugins/security_solution/ @elastic/security-solution
 /x-pack/platform/test/fixtures/es_archives/cases/signals/duplicate_ids @elastic/kibana-cases


### PR DESCRIPTION
The "verify test ownership" quick check soon to be introduced in https://github.com/elastic/kibana/pull/259699 shows that 900 FTR test files on the 8.19 branch are missing a CODEOWNERS entry (this branch wasn't previously covered by the check).

This PR adds CODEOWNERS entries for all unowned test files across. `main` is used as the source of truth to assign ownership. When ownership can't be determined from `main` we fall back to tracing the file’s history (commits, renames, and the PR that introduced or last moved it), plus author/team labels on that PR.