### PR TITLE
[EA]  Migrate Entity Analytics serverless splash screen Cypress test to Scout

### DIFF
--- a/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/entity_analytics_dashboards.ts
+++ b/x-pack/solutions/security/packages/kbn-scout-security/src/playwright/fixtures/test/page_objects/entity_analytics_dashboards.ts
@@ -10,13 +10,14 @@ import type { ScoutPage, Locator } from '@kbn/scout';
 const PAGE_URL = 'security/entity_analytics';
 
 export class EntityAnalyticsDashboardsPage {
-  public entityStoreEnablementPanel: Locator;
-  public entityStoreEnablementButton: Locator;
-  public entityStoreEnablementModal: Locator;
-  public enablementRiskScoreSwitch: Locator;
-  public enablementEntityStoreSwitch: Locator;
-  public entitiesListPanel: Locator;
-  public entityStoreEnablementModalButton: Locator;
+  public readonly entityStoreEnablementPanel: Locator;
+  public readonly entityStoreEnablementButton: Locator;
+  public readonly entityStoreEnablementModal: Locator;
+  public readonly enablementRiskScoreSwitch: Locator;
+  public readonly enablementEntityStoreSwitch: Locator;
+  public readonly entitiesListPanel: Locator;
+  public readonly entityStoreEnablementModalButton: Locator;
+  public readonly paywallDescription: Locator;
 
   constructor(private readonly page: ScoutPage) {
     this.entityStoreEnablementPanel = this.page.testSubj.locator('entityStoreEnablementPanel');
@@ -28,6 +29,7 @@ export class EntityAnalyticsDashboardsPage {
     this.entityStoreEnablementModalButton = this.page.testSubj.locator(
       'entityStoreEnablementModalButton'
     );
+    this.paywallDescription = this.page.testSubj.locator('paywallCardDescription');
   }
 
   async navigate() {

--- a/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/entity_analytics/entity_analytics_serverless_splash_screen.spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/test/scout/ui/parallel_tests/entity_analytics/entity_analytics_serverless_splash_screen.spec.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { spaceTest, tags } from '@kbn/scout-security';
+import { expect } from '@kbn/scout-security/ui';
+
+spaceTest.describe(
+  'Entity Analytics Dashboard paywall in Serverless Essentials',
+  { tag: [...tags.serverless.security.essentials] },
+  () => {
+    spaceTest.beforeEach(async ({ browserAuth, pageObjects }) => {
+      const dashboardPage = pageObjects.entityAnalyticsDashboardsPage;
+      await browserAuth.loginAsPlatformEngineer();
+      await dashboardPage.navigate();
+    });
+
+    spaceTest(
+      'should display a paywall splash screen with Security essentials PLI',
+      async ({ pageObjects }) => {
+        const dashboardPage = pageObjects.entityAnalyticsDashboardsPage;
+
+        await expect(dashboardPage.paywallDescription).toContainText(
+          'Entity risk scoring capability is available in our Security Complete license tier',
+          { timeout: 30000 }
+        );
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Migrates the Entity Analytics serverless splash screen Cypress test to Scout (Playwright). The test verifies that when visiting the Entity Analytics dashboard with the Security Essentials PLI, a paywall splash screen is displayed with the correct upgrade message.