### PR TITLE
[SharedUX] Get spaces callout on each solution nav

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -156,7 +156,7 @@ pageLoadAssetSize:
   searchHomepage: 9005
   searchIndices: 9991
   searchInferenceEndpoints: 9400
-  searchNavigation: 7404
+  searchNavigation: 8308
   searchNotebooks: 18826
   searchPlayground: 12122
   searchprofiler: 6509

--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
@@ -84,6 +84,10 @@ export type SolutionNavProps = Omit<EuiSideNavProps<{}>, 'children' | 'items' | 
    * Hidden when the nav is collapsed.
    */
   footer?: React.ReactNode;
+  /**
+   * Whether the nav has pinned bottom items.
+   */
+  hasPinnedBottomNavItems?: boolean;
 };
 
 const FLYOUT_SIZE = 248;
@@ -115,6 +119,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
   onCollapse,
   canBeCollapsed = true,
   footer,
+  hasPinnedBottomNavItems = false,
   ...rest
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -258,7 +263,16 @@ export const SolutionNav: FC<SolutionNavProps> = ({
 
   const footerContent = footer && (
     <div css={styles.solutionNavFooter} data-test-subj="solutionNavFooter">
-      <EuiHorizontalRule margin="m" />
+      <EuiHorizontalRule
+        margin="m"
+        css={
+          hasPinnedBottomNavItems
+            ? css`
+                margin-block-start: ${euiTheme.size.xs};
+              `
+            : undefined
+        }
+      />
       {footer}
     </div>
   );

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/page_template/page_template.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/page_template/page_template.test.tsx
@@ -15,6 +15,8 @@ import { getKibanaPageTemplateKibanaDependenciesMock as getPageTemplateServices 
 import { createLazyObservabilityPageTemplate } from './lazy_page_template';
 import { ObservabilityPageTemplate } from './page_template';
 import { createNavigationRegistry } from './helpers/navigation_registry';
+import { applicationServiceMock, notificationServiceMock } from '@kbn/core/public/mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -22,6 +24,24 @@ jest.mock('react-router-dom', () => ({
     pathname: '/test-path',
   }),
 }));
+
+const mockNotifications = notificationServiceMock.createStartContract();
+const mockApplication = applicationServiceMock.createStartContract();
+const mockSpaces = spacesPluginMock.createStartContract();
+
+jest.mock('@kbn/kibana-react-plugin/public', () => {
+  const original = jest.requireActual('@kbn/kibana-react-plugin/public');
+  return {
+    ...original,
+    useKibana: () => ({
+      services: {
+        notifications: mockNotifications,
+        application: mockApplication,
+        spaces: mockSpaces,
+      },
+    }),
+  };
+});
 
 const navigationRegistry = createNavigationRegistry();
 
@@ -114,5 +134,70 @@ describe('Page template', () => {
     expect(container).toHaveTextContent('Section A Url B');
     expect(container).toHaveTextContent('Section B Url A');
     expect(container).toHaveTextContent('Section B Url B');
+  });
+
+  describe('solution view switch callout', () => {
+    const templateProps = {
+      currentAppId$: of('Test app ID'),
+      getUrlForApp: () => '/test-url',
+      navigateToApp: async () => {},
+      navigationSections$: navigationRegistry.sections$,
+      getPageTemplateServices,
+    };
+
+    const MockSolutionViewSwitchCallout = () => <div data-test-subj="solutionViewSwitchCallout" />;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockNotifications.tours.isEnabled.mockReturnValue(true);
+      mockApplication.capabilities = {
+        ...mockApplication.capabilities,
+        spaces: { manage: true },
+      };
+      mockSpaces.ui.components.getSolutionViewSwitchCallout = MockSolutionViewSwitchCallout;
+    });
+
+    it('renders SolutionViewSwitchCallout when all conditions are met', () => {
+      const { getByTestId } = render(
+        <I18nProvider>
+          <ObservabilityPageTemplate {...templateProps}>
+            <div>Test</div>
+          </ObservabilityPageTemplate>
+        </I18nProvider>
+      );
+
+      expect(getByTestId('solutionViewSwitchCallout')).toBeInTheDocument();
+    });
+
+    it('does not render SolutionViewSwitchCallout when announcements are disabled', () => {
+      mockNotifications.tours.isEnabled.mockReturnValue(false);
+
+      const { queryByTestId } = render(
+        <I18nProvider>
+          <ObservabilityPageTemplate {...templateProps}>
+            <div>Test</div>
+          </ObservabilityPageTemplate>
+        </I18nProvider>
+      );
+
+      expect(queryByTestId('solutionViewSwitchCallout')).not.toBeInTheDocument();
+    });
+
+    it('does not render SolutionViewSwitchCallout when canManageSpaces is false', () => {
+      mockApplication.capabilities = {
+        ...mockApplication.capabilities,
+        spaces: { manage: false },
+      };
+
+      const { queryByTestId } = render(
+        <I18nProvider>
+          <ObservabilityPageTemplate {...templateProps}>
+            <div>Test</div>
+          </ObservabilityPageTemplate>
+        </I18nProvider>
+      );
+
+      expect(queryByTestId('solutionViewSwitchCallout')).not.toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/page_template/page_template.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/page_template/page_template.tsx
@@ -24,6 +24,7 @@ import type {
   KibanaPageTemplateKibanaDependencies,
 } from '@kbn/shared-ux-page-kibana-template';
 
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { NavNameWithBadge, hideBadge } from './nav_name_with_badge';
 import { NavNameWithBetaBadge } from './nav_name_with_beta_badge';
 
@@ -111,7 +112,16 @@ export function ObservabilityPageTemplate({
   const currentAppId = useObservable(currentAppId$, undefined);
   const { pathname: currentPath } = useLocation();
 
-  const { services } = useKibana();
+  const { services } = useKibana<{ spaces?: SpacesPluginStart }>();
+
+  const areAnnouncementsEnabled = services.notifications?.tours.isEnabled();
+  const canManageSpaces = services.application?.capabilities.spaces?.manage;
+
+  const SolutionViewSwitchCallout = services.spaces?.ui?.components?.getSolutionViewSwitchCallout;
+  const solutionNavFooter =
+    areAnnouncementsEnabled && canManageSpaces && SolutionViewSwitchCallout ? (
+      <SolutionViewSwitchCallout currentSolution="oblt" />
+    ) : undefined;
 
   const sideNavItems = useMemo<Array<EuiSideNavItemType<unknown>>>(
     () =>
@@ -196,6 +206,7 @@ export function ObservabilityPageTemplate({
                 icon: 'logoObservability',
                 items: sideNavItems,
                 name: sideNavTitle,
+                footer: solutionNavFooter,
               }
             : undefined
         }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
 import type { ApplicationStart, Capabilities } from '@kbn/core/public';
+import { notificationServiceMock } from '@kbn/core/public/mocks';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
@@ -18,6 +19,7 @@ import { searchNavigationMock } from '@kbn/search-navigation/public/mocks';
 import { securityMock } from '@kbn/security-plugin/public/mocks';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import { uiActionsPluginMock } from '@kbn/ui-actions-plugin/public/mocks';
 
 import { mockHistory } from '../react_router/state.mock';
@@ -62,6 +64,7 @@ export const mockKibanaValues = {
   } as unknown as LensPublicStart,
   ml: mlPluginMock.createStartContract(),
   navigateToUrl: jest.fn(),
+  notifications: notificationServiceMock.createStartContract(),
   productFeatures: {
     hasDocumentLevelSecurityEnabled: true,
     hasIncrementalSyncEnabled: true,
@@ -75,6 +78,7 @@ export const mockKibanaValues = {
   setChromeIsVisible: jest.fn(),
   setDocTitle: jest.fn(),
   share: sharePluginMock.createStartContract(),
+  spaces: spacesPluginMock.createStartContract(),
   uiActions: uiActionsPluginMock.createStartContract(),
   uiSettings: uiSettingsServiceMock.createStartContract(),
   updateSideNavDefinition: jest.fn(),

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.tsx
@@ -72,6 +72,7 @@ export const renderApp = (
     fleet,
     uiActions,
     searchNavigation,
+    spaces,
   } = plugins;
 
   const productFeatures = features ?? { ...DEFAULT_PRODUCT_FEATURES };
@@ -106,6 +107,7 @@ export const renderApp = (
     lens,
     ml,
     navigateToUrl,
+    notifications,
     productFeatures,
     renderHeaderActions: (HeaderActions) =>
       params.setHeaderActionMenu(
@@ -117,6 +119,7 @@ export const renderApp = (
     setChromeIsVisible: chrome.setIsVisible,
     setDocTitle: chrome.docTitle.change,
     share,
+    spaces,
     uiActions,
     uiSettings,
     updateSideNavDefinition,

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -21,6 +21,7 @@ import type {
   IUiSettingsClient,
   ChromeStart,
   SecurityServiceStart,
+  NotificationsStart,
 } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 
@@ -34,6 +35,7 @@ import { ELASTICSEARCH_URL_PLACEHOLDER } from '@kbn/search-shared-ui';
 import type { AuthenticatedUser, SecurityPluginStart } from '@kbn/security-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 
 import type { ClientConfigType, ProductFeatures } from '../../../../common/types';
@@ -67,6 +69,7 @@ export interface KibanaLogicProps {
   lens?: LensPublicStart;
   ml?: MlPluginStart;
   navigateToUrl: RequiredFieldsOnly<ApplicationStart['navigateToUrl']>;
+  notifications: NotificationsStart;
   productFeatures: ProductFeatures;
   renderHeaderActions(HeaderActions?: FC): void;
   searchNavigation: SearchNavigationPluginStart;
@@ -75,6 +78,7 @@ export interface KibanaLogicProps {
   setChromeIsVisible(isVisible: boolean): void;
   setDocTitle(title: string): void;
   share?: SharePluginStart;
+  spaces?: SpacesPluginStart;
   uiActions: UiActionsStart;
   uiSettings?: IUiSettingsClient;
   updateSideNavDefinition: UpdateSideNavDefinitionFn;
@@ -103,6 +107,7 @@ export interface KibanaValues {
   lens: LensPublicStart | null;
   ml: MlPluginStart | null;
   navigateToUrl(path: string, options?: CreateHrefOptions): Promise<void>;
+  notifications: NotificationsStart;
   productFeatures: ProductFeatures;
   renderHeaderActions(HeaderActions?: FC): void;
   security: SecurityPluginStart | null;
@@ -111,6 +116,7 @@ export interface KibanaValues {
   setChromeIsVisible(isVisible: boolean): void;
   setDocTitle(title: string): void;
   share: SharePluginStart | null;
+  spaces: SpacesPluginStart | null;
   uiActions: UiActionsStart | null;
   uiSettings: IUiSettingsClient | null;
   updateSideNavDefinition: UpdateSideNavDefinitionFn;
@@ -149,6 +155,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
       },
       {},
     ],
+    notifications: [props.notifications, {}],
     productFeatures: [props.productFeatures, {}],
     renderHeaderActions: [props.renderHeaderActions, {}],
     searchNavigation: [props.searchNavigation, {}],
@@ -157,6 +164,7 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
     setChromeIsVisible: [props.setChromeIsVisible, {}],
     setDocTitle: [props.setDocTitle, {}],
     share: [props.share || null, {}],
+    spaces: [props.spaces || null, {}],
     uiActions: [props.uiActions, {}],
     uiSettings: [props.uiSettings, {}],
     updateSideNavDefinition: [props.updateSideNavDefinition, {}],

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.test.tsx
@@ -9,16 +9,19 @@ import { setMockValues } from '../../__mocks__/kea_logic';
 
 import React from 'react';
 
+import { render } from '@testing-library/react';
 import { shallow } from 'enzyme';
 
 import { EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
+import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { FlashMessages } from '../flash_messages';
 import { Loading } from '../loading';
 
+import type { PageTemplateProps } from './page_template';
 import { EnterpriseSearchPageTemplateWrapper } from './page_template';
 
 describe('EnterpriseSearchPageTemplateWrapper', () => {
@@ -294,6 +297,83 @@ describe('EnterpriseSearchPageTemplateWrapper', () => {
       );
 
       expect(wrapper.find(consolePlugin.EmbeddableConsole).exists()).toBe(false);
+    });
+  });
+
+  describe('solution nav footer', () => {
+    const MockFooter = () => <div data-test-subj="mockSolutionNavFooter">footer</div>;
+
+    const renderTemplate = (props: Partial<PageTemplateProps> = {}) =>
+      render(
+        <I18nProvider>
+          <EnterpriseSearchPageTemplateWrapper {...props} />
+        </I18nProvider>
+      );
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('merges SolutionViewSwitchCallout into solutionNav when available', () => {
+      setMockValues({
+        capabilities: { spaces: { manage: true } },
+        notifications: {
+          tours: { isEnabled: () => true },
+        },
+        spaces: {
+          ui: {
+            components: {
+              getSolutionViewSwitchCallout: MockFooter,
+            },
+          },
+        },
+      });
+
+      const { getByTestId } = renderTemplate({
+        solutionNav: { items: [], name: 'Elasticsearch' },
+      });
+
+      expect(getByTestId('mockSolutionNavFooter')).toBeInTheDocument();
+    });
+
+    it('does not set footer when announcements are disabled', () => {
+      setMockValues({
+        notifications: {
+          tours: { isEnabled: () => false },
+        },
+        spaces: {
+          ui: {
+            components: {
+              getSolutionViewSwitchCallout: MockFooter,
+            },
+          },
+        },
+      });
+
+      const { queryByTestId } = renderTemplate({
+        solutionNav: { items: [], name: 'Elasticsearch' },
+      });
+
+      expect(queryByTestId('mockSolutionNavFooter')).not.toBeInTheDocument();
+    });
+
+    it('does not set footer when canManageSpaces is false', () => {
+      setMockValues({
+        capabilities: { spaces: { manage: false } },
+        spaces: {
+          ui: {
+            components: {
+              getSolutionViewSwitchCallout: MockFooter,
+            },
+          },
+        },
+      });
+
+      const { queryByTestId } = renderTemplate({
+        solutionNav: { items: [], name: 'Elasticsearch' },
+      });
+
+      expect(queryByTestId('mockSolutionNavFooter')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -67,12 +67,19 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
   ...pageTemplateProps
 }) => {
   const { readOnlyMode } = useValues(HttpLogic);
-  const { renderHeaderActions, consolePlugin } = useValues(KibanaLogic);
+  const { renderHeaderActions, consolePlugin, capabilities, notifications, spaces } =
+    useValues(KibanaLogic);
 
   const hasCustomEmptyState = !!emptyState;
   const showCustomEmptyState = hasCustomEmptyState && isEmptyState;
 
   const navIcon = solutionNavIcon ?? 'logoElasticsearch';
+
+  const SolutionViewSwitchCallout = spaces?.ui?.components?.getSolutionViewSwitchCallout;
+  const solutionNavFooter =
+    notifications.tours.isEnabled() && capabilities.spaces?.manage && SolutionViewSwitchCallout ? (
+      <SolutionViewSwitchCallout currentSolution="es" />
+    ) : undefined;
 
   useLayoutEffect(() => {
     if (useEndpointHeaderActions) {
@@ -94,7 +101,11 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
         ),
       }}
       isEmptyState={isEmptyState && !isLoading}
-      solutionNav={solutionNav && solutionNav.items ? { icon: navIcon, ...solutionNav } : undefined}
+      solutionNav={
+        solutionNav && solutionNav.items
+          ? { icon: navIcon, ...solutionNav, footer: solutionNavFooter }
+          : undefined
+      }
     >
       {setPageChrome}
       {readOnlyMode && (

--- a/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
@@ -35,6 +35,7 @@ import type { SearchPlaygroundPluginStart } from '@kbn/search-playground/public'
 import { ELASTICSEARCH_URL_PLACEHOLDER } from '@kbn/search-shared-ui';
 import type { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
 
 import {
@@ -88,6 +89,7 @@ export interface PluginsStart {
   searchPlayground?: SearchPlaygroundPluginStart;
   security?: SecurityPluginStart;
   share?: SharePluginStart;
+  spaces?: SpacesPluginStart;
   uiActions: UiActionsStart;
 }
 

--- a/x-pack/solutions/search/plugins/search_navigation/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_navigation/kibana.jsonc
@@ -14,7 +14,8 @@
     ],
     "requiredPlugins": [],
     "optionalPlugins": [
-      "serverless"
+      "serverless",
+      "spaces"
     ],
     "requiredBundles": []
   }

--- a/x-pack/solutions/search/plugins/search_navigation/moon.yml
+++ b/x-pack/solutions/search/plugins/search_navigation/moon.yml
@@ -25,6 +25,7 @@ dependsOn:
   - '@kbn/serverless'
   - '@kbn/core-plugins-browser'
   - '@kbn/deeplinks-search'
+  - '@kbn/spaces-plugin'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.test.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.test.ts
@@ -11,6 +11,10 @@ import type { ChromeNavLink } from '@kbn/core-chrome-browser';
 import { classicNavigationFactory } from './classic_navigation';
 import type { ClassicNavItem } from './types';
 
+jest.mock('./solution_navigation_footer', () => ({
+  getSolutionNavFooter: () => undefined,
+}));
+
 describe('classicNavigationFactory', function () {
   const mockedNavLinks: Array<Partial<ChromeNavLink>> = [
     {

--- a/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/classic_navigation.ts
@@ -11,8 +11,10 @@ import type { CoreStart, ScopedHistory } from '@kbn/core/public';
 import type { ChromeNavLink, EuiSideNavItemTypeEnhanced } from '@kbn/core-chrome-browser';
 import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
 
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { ClassicNavItem, ClassicNavItemDeepLink } from './types';
 import { stripTrailingSlash } from './utils';
+import { getSolutionNavFooter } from './solution_navigation_footer';
 
 type DeepLinksMap = Record<string, ChromeNavLink | undefined>;
 type SolutionNavItems = SolutionNavProps['items'];
@@ -20,7 +22,8 @@ type SolutionNavItems = SolutionNavProps['items'];
 export const classicNavigationFactory = (
   classicItems: ClassicNavItem[],
   core: CoreStart,
-  history: ScopedHistory<unknown>
+  history: ScopedHistory<unknown>,
+  spaces?: SpacesPluginStart
 ): SolutionNavProps | undefined => {
   const navLinks = core.chrome.navLinks.getAll();
   const deepLinks = navLinks.reduce((links: DeepLinksMap, link: ChromeNavLink) => {
@@ -36,6 +39,11 @@ export const classicNavigationFactory = (
     deepLinks,
     currentLocation
   );
+  const footer = getSolutionNavFooter({
+    application: core.application,
+    notifications: core.notifications,
+    spaces,
+  });
 
   return {
     items,
@@ -43,6 +51,7 @@ export const classicNavigationFactory = (
     name: i18n.translate('xpack.searchNavigation.classicNav.name', {
       defaultMessage: 'Elasticsearch',
     }),
+    footer,
   };
 };
 

--- a/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/plugin.ts
@@ -95,7 +95,12 @@ export class SearchNavigationPlugin
   private useClassicNavigation(history: ScopedHistory<unknown>) {
     if (this.coreStart === undefined || this.currentChromeStyle !== 'classic') return undefined;
 
-    return classicNavigationFactory(this.baseClassicNavItems, this.coreStart, history);
+    return classicNavigationFactory(
+      this.baseClassicNavItems,
+      this.coreStart,
+      history,
+      this.pluginsStart?.spaces
+    );
   }
 
   private getBaseClassicNavItems(): ClassicNavItem[] {

--- a/x-pack/solutions/search/plugins/search_navigation/public/solution_navigation_footer.test.tsx
+++ b/x-pack/solutions/search/plugins/search_navigation/public/solution_navigation_footer.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { applicationServiceMock, notificationServiceMock } from '@kbn/core/public/mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
+import type { ApplicationStart } from '@kbn/core/public';
+import { getSolutionNavFooter } from './solution_navigation_footer';
+
+describe('SolutionNavigationFooter', () => {
+  describe('getSolutionNavFooter', () => {
+    const MockSolutionViewSwitchCallout = () => <div data-test-subj="solutionViewSwitchCallout" />;
+    const mockNotifications = notificationServiceMock.createStartContract();
+    const mockApplication: ApplicationStart = applicationServiceMock.createStartContract();
+    const mockSpaces = spacesPluginMock.createStartContract();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockNotifications.tours.isEnabled.mockReturnValue(true);
+      mockApplication.capabilities = {
+        ...mockApplication.capabilities,
+        spaces: { manage: true },
+      };
+      mockSpaces.ui.components.getSolutionViewSwitchCallout = MockSolutionViewSwitchCallout;
+    });
+
+    it('returns a React element when all conditions are met', () => {
+      const footer = getSolutionNavFooter({
+        application: mockApplication,
+        notifications: mockNotifications,
+        spaces: mockSpaces,
+      });
+      expect(React.isValidElement(footer)).toBe(true);
+    });
+
+    it('returns undefined when announcements are disabled', () => {
+      mockNotifications.tours.isEnabled.mockReturnValue(false);
+      const footer = getSolutionNavFooter({
+        application: mockApplication,
+        notifications: mockNotifications,
+        spaces: mockSpaces,
+      });
+      expect(footer).toBeUndefined();
+    });
+
+    it('returns undefined when canManageSpaces is false', () => {
+      mockApplication.capabilities = {
+        ...mockApplication.capabilities,
+        spaces: { manage: false },
+      };
+      const footer = getSolutionNavFooter({
+        application: mockApplication,
+        notifications: mockNotifications,
+        spaces: mockSpaces,
+      });
+      expect(footer).toBeUndefined();
+    });
+
+    it('returns undefined when spaces plugin is not available', () => {
+      const footer = getSolutionNavFooter({
+        application: mockApplication,
+        notifications: mockNotifications,
+      });
+      expect(footer).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_navigation/public/solution_navigation_footer.tsx
+++ b/x-pack/solutions/search/plugins/search_navigation/public/solution_navigation_footer.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import type { NotificationsStart } from '@kbn/core/public';
+import type { ApplicationStart } from '@kbn/core/public';
+import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
+
+interface GetSolutionNavFooterParams {
+  application: ApplicationStart;
+  notifications: NotificationsStart;
+  spaces?: SpacesPluginStart | null;
+}
+
+export const getSolutionNavFooter = ({
+  application,
+  notifications,
+  spaces,
+}: GetSolutionNavFooterParams): SolutionNavProps['footer'] | undefined => {
+  const areAnnouncementsEnabled = notifications.tours.isEnabled();
+  const canManageSpaces = application.capabilities.spaces?.manage === true;
+
+  const SolutionViewSwitchCallout = spaces?.ui?.components?.getSolutionViewSwitchCallout;
+
+  if (!areAnnouncementsEnabled || !canManageSpaces || !SolutionViewSwitchCallout) {
+    return undefined;
+  }
+
+  return <SolutionViewSwitchCallout currentSolution="es" />;
+};

--- a/x-pack/solutions/search/plugins/search_navigation/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_navigation/public/types.ts
@@ -10,6 +10,7 @@ import type { AppDeepLinkId, ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 import type { ScopedHistory } from '@kbn/core/public';
 import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNavigationPluginSetup {}
@@ -34,6 +35,7 @@ export interface AppPluginSetupDependencies {
 
 export interface AppPluginStartDependencies {
   serverless?: ServerlessPluginStart;
+  spaces?: SpacesPluginStart;
 }
 
 export interface ClassicNavItemDeepLink {

--- a/x-pack/solutions/search/plugins/search_navigation/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_navigation/tsconfig.json
@@ -16,6 +16,7 @@
     "@kbn/serverless",
     "@kbn/core-plugins-browser",
     "@kbn/deeplinks-search",
+    "@kbn/spaces-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_security_solution_navigation.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_security_solution_navigation.test.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { render, renderHook } from '@testing-library/react';
 import { of } from 'rxjs';
 import { useSecuritySolutionNavigation } from './use_security_solution_navigation';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
+import { applicationServiceMock, notificationServiceMock } from '@kbn/core/public/mocks';
 
 const mockUseBreadcrumbsNav = jest.fn();
 jest.mock('../breadcrumbs', () => ({
@@ -21,10 +23,15 @@ jest.mock('../security_side_nav', () => ({
 }));
 
 const mockGetChromeStyle$ = jest.fn().mockReturnValue(of('classic'));
+
+const mockServices: Record<string, unknown> = {
+  chrome: { getChromeStyle$: () => mockGetChromeStyle$() },
+};
+
 jest.mock('../../../lib/kibana/kibana_react', () => {
   return {
     useKibana: () => ({
-      services: { chrome: { getChromeStyle$: () => mockGetChromeStyle$() } },
+      services: mockServices,
     }),
   };
 });
@@ -82,6 +89,51 @@ describe('Security Solution Navigation', () => {
     it('should initialize breadcrumbs', () => {
       renderHook(useSecuritySolutionNavigation);
       expect(mockUseBreadcrumbsNav).toHaveBeenCalled();
+    });
+
+    describe('solution view switch callout', () => {
+      const mockNotifications = notificationServiceMock.createStartContract();
+      const mockApplication = applicationServiceMock.createStartContract();
+      const mockSpaces = spacesPluginMock.createStartContract();
+
+      beforeEach(() => {
+        mockNotifications.tours.isEnabled.mockReturnValue(true);
+        mockApplication.capabilities = {
+          ...mockApplication.capabilities,
+          spaces: { manage: true },
+        };
+        Object.assign(mockServices, {
+          chrome: { getChromeStyle$: () => mockGetChromeStyle$() },
+          notifications: mockNotifications,
+          application: mockApplication,
+          spaces: mockSpaces,
+        });
+      });
+
+      it('includes footer with SolutionViewSwitchCallout when all conditions are met', () => {
+        const { result } = renderHook(useSecuritySolutionNavigation);
+        expect(result.current?.footer).toBeDefined();
+        expect(result.current?.hasPinnedBottomNavItems).toBe(true);
+      });
+
+      it('does not include footer when announcements are disabled', () => {
+        mockNotifications.tours.isEnabled.mockReturnValue(false);
+
+        const { result } = renderHook(useSecuritySolutionNavigation);
+        expect(result.current?.footer).toBeUndefined();
+        expect(result.current?.hasPinnedBottomNavItems).toBeUndefined();
+      });
+
+      it('does not include footer when canManageSpaces is false', () => {
+        mockApplication.capabilities = {
+          ...mockApplication.capabilities,
+          spaces: { manage: false },
+        };
+
+        const { result } = renderHook(useSecuritySolutionNavigation);
+        expect(result.current?.footer).toBeUndefined();
+        expect(result.current?.hasPinnedBottomNavItems).toBeUndefined();
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_security_solution_navigation.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/navigation/use_security_solution_navigation/use_security_solution_navigation.tsx
@@ -24,7 +24,7 @@ const translatedNavTitle = i18n.translate('xpack.securitySolution.navigation.mai
 });
 
 export const useSecuritySolutionNavigation = (): KibanaPageTemplateProps['solutionNav'] | null => {
-  const { chrome } = useKibana().services;
+  const { chrome, notifications, application, spaces } = useKibana().services;
   const chromeStyle$ = useMemo(() => chrome.getChromeStyle$(), [chrome]);
   const chromeStyle = useObservable(chromeStyle$, undefined);
 
@@ -39,11 +39,22 @@ export const useSecuritySolutionNavigation = (): KibanaPageTemplateProps['soluti
     return null;
   }
 
+  const areAnnouncementsEnabled = notifications?.tours.isEnabled();
+  const canManageSpaces = application?.capabilities.spaces?.manage;
+
+  const SolutionViewSwitchCallout = spaces?.ui?.components?.getSolutionViewSwitchCallout;
+  const solutionNavFooter =
+    areAnnouncementsEnabled && canManageSpaces && SolutionViewSwitchCallout ? (
+      <SolutionViewSwitchCallout currentSolution="security" />
+    ) : undefined;
+
   return {
     canBeCollapsed: true,
     name: translatedNavTitle,
     icon: 'logoSecurity',
     children: <SecuritySideNav />,
     closeFlyoutButtonPosition: 'inside',
+    footer: solutionNavFooter,
+    ...(solutionNavFooter ? { hasPinnedBottomNavItems: true } : {}),
   };
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/256675

Related PRs:
- [[SharedUX] Add solution view switch callout to spaces plugin](https://github.com/elastic/kibana/pull/258093)
- [[SharedUX] Add notification and tour to spaces dropdown](https://github.com/elastic/kibana/pull/258864)

Will merge only after:

- [x]  [[SharedUX] Preserve feature visibility on solution change](https://github.com/elastic/kibana/pull/259316)

## Summary

As part of [[Epic]: Solution side nav Encouragement callout](https://github.com/elastic/kibana-team/issues/2873) we are now prompting users to switch to solution views directly from a callout + modal placed on each solution nav. 

This PR is the last step to achieve that by getting the `SolutionViewSwitchCallout` component from spaces UI api into all 3 solution navs (Obs, Search and Security). Callout will only show for users who can manage spaces and who have `hideAnnouncements` UI setting configured to `false`(default).

## Testing

<details>
<summary>Observability</summary>

<img width="479" height="1090" alt="Screenshot 2026-03-26 at 11 38 18" src="https://github.com/user-attachments/assets/9470492e-c14e-44de-a776-d025a987ad11" />

</details>

<details>
<summary>Search</summary>

<img width="432" height="1092" alt="Screenshot 2026-03-26 at 11 38 42" src="https://github.com/user-attachments/assets/5ec41452-d140-47a8-ad1f-9a6064f103eb" />

</details>

<details>
<summary>Security</summary>

<img width="372" height="1091" alt="Screenshot 2026-03-26 at 11 42 44" src="https://github.com/user-attachments/assets/d6bb8b27-249a-484c-8723-a81b4b16ff55" />

</details>

Entire flow: 

https://github.com/user-attachments/assets/76d0a8ac-66da-4744-b348-4e03ebedf3fa
