### PR TITLE
[PoC] [Agent Builder] pass runAgent to getSmlData

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/create_services.ts
@@ -117,6 +117,7 @@ export class ServiceManager {
     const sml = this.services.sml.start({
       logger: logger.get('sml'),
       securityAuthz: securityPlugin?.authz,
+      getRunAgent: () => getRunner().runAgent,
     });
 
     const tools = this.services.tools.start({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
@@ -13,6 +13,7 @@ import type {
 } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { RunAgentFn } from '@kbn/agent-builder-server';
 import type { SmlTypeRegistry } from './sml_type_registry';
 import type { SmlIndexAction, SmlContext } from './types';
 import { createSmlStorage, smlIndexName } from './sml_storage';
@@ -21,6 +22,7 @@ import { isNotFoundError } from './sml_service';
 export interface SmlIndexerDeps {
   registry: SmlTypeRegistry;
   logger: Logger;
+  getRunAgent?: () => RunAgentFn;
 }
 
 export interface SmlIndexer {
@@ -39,17 +41,19 @@ export interface SmlIndexer {
   }) => Promise<void>;
 }
 
-export const createSmlIndexer = ({ registry, logger }: SmlIndexerDeps): SmlIndexer => {
-  return new SmlIndexerImpl({ registry, logger });
+export const createSmlIndexer = ({ registry, logger, getRunAgent }: SmlIndexerDeps): SmlIndexer => {
+  return new SmlIndexerImpl({ registry, logger, getRunAgent });
 };
 
 class SmlIndexerImpl implements SmlIndexer {
   private readonly registry: SmlTypeRegistry;
   private readonly logger: Logger;
+  private readonly getRunAgent?: () => RunAgentFn;
 
-  constructor({ registry, logger }: SmlIndexerDeps) {
+  constructor({ registry, logger, getRunAgent }: SmlIndexerDeps) {
     this.registry = registry;
     this.logger = logger;
+    this.getRunAgent = getRunAgent;
   }
 
   async indexAttachment({
@@ -99,6 +103,7 @@ class SmlIndexerImpl implements SmlIndexer {
       savedObjectsClient,
       logger: contextLogger,
       request,
+      runAgent: this.getRunAgent?.(),
     };
 
     this.logger.info(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_service.ts
@@ -10,6 +10,7 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { AuthorizationServiceSetup } from '@kbn/security-plugin-types-server';
+import type { RunAgentFn } from '@kbn/agent-builder-server';
 import type { SmlService, SmlSearchResult, SmlDocument, SmlTypeDefinition } from './types';
 import { createSmlTypeRegistry, type SmlTypeRegistry } from './sml_type_registry';
 import { createSmlIndexer, type SmlIndexer } from './sml_indexer';
@@ -28,6 +29,7 @@ export interface SmlServiceSetup {
 export interface SmlServiceStartDeps {
   logger: Logger;
   securityAuthz?: AuthorizationServiceSetup;
+  getRunAgent?: () => RunAgentFn;
 }
 
 export interface SmlServiceInstance {
@@ -58,14 +60,18 @@ class SmlServiceImpl implements SmlServiceInstance {
     };
   }
 
-  start({ logger, securityAuthz }: SmlServiceStartDeps): SmlService {
+  start({ logger, securityAuthz, getRunAgent }: SmlServiceStartDeps): SmlService {
     this.securityAuthz = securityAuthz;
     if (!securityAuthz) {
       logger.warn(
         'SML service started without security authorization — permission checks are disabled (open access)'
       );
     }
-    this.indexer = createSmlIndexer({ registry: this.registry, logger: logger.get('indexer') });
+    this.indexer = createSmlIndexer({
+      registry: this.registry,
+      logger: logger.get('indexer'),
+      getRunAgent,
+    });
     this.crawler = new SmlCrawlerImpl({
       indexer: this.indexer,
       logger: logger.get('crawler'),

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
@@ -13,6 +13,7 @@ import type {
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { AttachmentInput } from '@kbn/agent-builder-common/attachments';
+import type { RunAgentFn } from '@kbn/agent-builder-server';
 
 /**
  * A single SML chunk to be indexed.
@@ -44,6 +45,8 @@ export interface SmlContext {
   logger: Logger;
   /** The current user's request, when available. Absent during background crawler runs. */
   request?: KibanaRequest;
+  /** Execute an agent by ID. Available when the runner has been initialized. */
+  runAgent?: RunAgentFn;
 }
 
 /**


### PR DESCRIPTION
## Summary

Passes runAgent to getSmlData to make it easier to create more complex sml entity extraction that uses agents under the hood.
