### PR TITLE
[Streams] Fix failure store retention Scout test race condition

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/retention_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/retention_helpers.ts
@@ -384,6 +384,7 @@ export async function setFailureStoreRetention(
   }
 
   await page.getByTestId('failureStoreModalSaveButton').click();
+  await expect(page.getByRole('dialog')).toBeHidden();
 }
 
 /**
@@ -400,6 +401,7 @@ export async function toggleFailureStore(page: ScoutPage, enabled: boolean): Pro
   await waitForElementToBeEnabled(page, 'enableFailureStoreToggle');
   await page.getByTestId('enableFailureStoreToggle').click();
   await page.getByTestId('failureStoreModalSaveButton').click();
+  await expect(page.getByRole('dialog')).toBeHidden();
 }
 
 /**

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
@@ -5,9 +5,13 @@
  * 2.0.
  */
 
+// TEMPORARY: narrowed to failure_store.spec.ts for flaky test runner validation.
+// Revert this change before merging.
 import { createPlaywrightConfig } from '@kbn/scout';
 
-export default createPlaywrightConfig({
+const config = createPlaywrightConfig({
   testDir: './tests',
   runGlobalSetup: true,
 });
+
+export default { ...config, testMatch: '**/failure_store.spec.ts' };

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/playwright.config.ts
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-// TEMPORARY: narrowed to failure_store.spec.ts for flaky test runner validation.
-// Revert this change before merging.
 import { createPlaywrightConfig } from '@kbn/scout';
 
-const config = createPlaywrightConfig({
+export default createPlaywrightConfig({
   testDir: './tests',
   runGlobalSetup: true,
 });
-
-export default { ...config, testMatch: '**/failure_store.spec.ts' };

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/data_management/data_retention/failure_store.spec.ts
@@ -19,8 +19,7 @@ import {
   verifyRetentionDisplay,
 } from '../../../fixtures/retention_helpers';
 
-// Failing: See https://github.com/elastic/kibana/issues/258662
-test.describe.skip('Stream data retention - updating failure store', () => {
+test.describe('Stream data retention - updating failure store', () => {
   test.beforeAll(async ({ apiServices, logsSynthtraceEsClient, esClient }) => {
     await generateLogsData(logsSynthtraceEsClient)({ index: 'logs-generic-default' });
     await esClient.indices.putDataStreamOptions(


### PR DESCRIPTION
closes: #258662
## Summary

The `setFailureStoreRetention` and `toggleFailureStore` test helpers were clicking the save button without waiting for the modal to close (the save API call to complete). This caused a race condition in the "should persist failure store retention across page reload" test: the page navigation fired before the PUT request finished, cancelling it. The previous test's value (7 days) remained in ES instead of the newly set 21 days.

### Fix
 Added `await expect(page.getByRole('dialog')).toBeHidden()` after clicking save in both `setFailureStoreRetention` and `toggleFailureStore`, and removed the skip annotation.