### PR TITLE
[Entity Store] Remove redundant installSharedElasticsearchAssets() call

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/asset_manager/asset_manager_client.ts
@@ -340,16 +340,9 @@ export class AssetManagerClient {
       }
 
       this.logger.get(type).debug(`Installing assets for entity type: ${type}`);
-      await Promise.all([
-        this.engineDescriptorClient.init(type),
-        // Install all shared assets (component templates for ALL types, index templates, pipeline)
-        // before creating indices, to ensure complete mappings.
-        installSharedElasticsearchAssets({
-          esClient: this.esClient,
-          logger: this.logger,
-          namespace: this.namespace,
-        }),
-      ]);
+      // Those 3 operations have to happen in order: 1. Init engine; 2. Install
+      // Indices & Data Streams; 3. Update engine.
+      await this.engineDescriptorClient.init(type);
       await installIndicesAndDataStreams(this.esClient, this.namespace, this.logger);
       await this.engineDescriptorClient.update(type, { status: ENGINE_STATUS.STARTED });
       this.logger.debug(`Installed definition: ${type}`);


### PR DESCRIPTION
## Summary

Drops a redundant call. All Scout tests still pass.

cc: @chennn1990 

