### PR TITLE
[failed-test-reporter] redact test run data

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
@@ -9,13 +9,59 @@
 
 import dedent from 'dedent';
 
-import { createFailureIssue, updateFailureIssue } from './report_failure';
+import {
+  createFailureIssue,
+  redactSensitiveGithubFailureText,
+  updateFailureIssue,
+} from './report_failure';
 
 jest.mock('./github_api');
 const { GithubApi } = jest.requireMock('./github_api');
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe('redactSensitiveGithubFailureText()', () => {
+  it('redacts @elastic.co emails, qa.elastic.cloud hosts, and console.qa.cld.elstc.co', () => {
+    const input = dedent`
+      Error: Failed to parse SAML response value.
+      Most likely the 'fixture-user+alias@elastic.co' user has no access to the cloud deployment.
+      Login to console.qa.cld.elstc.co with the user from '.ftr/role_users.json' file and try to load
+      https://fixture-depl-abc123.kb.eu-west-1.aws.qa.elastic.cloud in the same window.
+    `;
+
+    const out = redactSensitiveGithubFailureText(input);
+
+    expect(out).toContain('<redacted>@elastic.co');
+    expect(out).not.toContain('fixture-user+alias@elastic.co');
+    expect(out).toContain('Login to <redacted> with');
+    expect(out).not.toContain('console.qa.cld.elstc.co');
+    expect(out).toContain('<redacted>.qa.elastic.cloud');
+    expect(out).not.toContain('fixture-depl-abc123');
+  });
+
+  it('redacts bare *.qa.elastic.cloud hostnames without a URL scheme', () => {
+    expect(
+      redactSensitiveGithubFailureText('open fake-sub.kb.eu-west-1.aws.qa.elastic.cloud in browser')
+    ).toBe('open <redacted>.qa.elastic.cloud in browser');
+  });
+
+  it('redacts any *.found.no and *.elastic.co hosts and URLs', () => {
+    expect(
+      redactSensitiveGithubFailureText(
+        'open https://fixture-staging.found.no/ then https://fixture-app.elastic.co/'
+      )
+    ).toBe('open <redacted>.found.no then <redacted>.elastic.co');
+    expect(
+      redactSensitiveGithubFailureText(
+        'Login at fixture-staging.found.no or fixture-app.elastic.co'
+      )
+    ).toBe('Login at <redacted>.found.no or <redacted>.elastic.co');
+    expect(redactSensitiveGithubFailureText('other https://fixture-api.found.no/x')).toBe(
+      'other <redacted>.found.no'
+    );
+  });
 });
 
 describe('createFailureIssue()', () => {

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
@@ -13,6 +13,30 @@ import type { ScoutTestFailureExtended } from './get_scout_failures';
 import type { GithubApi } from './github_api';
 import { getIssueMetadata, updateIssueMetadata } from './issue_metadata';
 
+function redactHostnameSuffix(text: string, suffix: string): string {
+  const escaped = suffix.replace(/\./g, '\\.');
+  return text.replace(
+    new RegExp(
+      `(?:https?:\\/\\/)?[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?\\.${escaped}(?:[^\\s]*)?`,
+      'g'
+    ),
+    () => `<redacted>.${suffix}`
+  );
+}
+
+const REDACT_HOST_SUFFIXES = ['found.no', 'elastic.co', 'qa.elastic.cloud'] as const;
+
+/**
+ * Redacts emails and sensitive hostnames (e.g. *.found.no, *.elastic.co, *.qa.elastic.cloud) from text posted to public GitHub issues.
+ */
+export function redactSensitiveGithubFailureText(text: string): string {
+  let out = text.replace(/\bconsole\.qa\.cld\.elstc\.co\b/g, '<redacted>');
+  for (const suffix of REDACT_HOST_SUFFIXES) {
+    out = redactHostnameSuffix(out, suffix);
+  }
+  return out.replace(/\S+@elastic\.co\b/g, '<redacted>@elastic.co');
+}
+
 function isScoutFailure(failure: TestFailure): failure is ScoutTestFailureExtended {
   return 'id' in failure && 'target' in failure && 'location' in failure;
 }
@@ -52,7 +76,7 @@ function createFTRBody(
   branch: string,
   pipeline: string
 ): string {
-  const failureBody = truncateFailureBody(failure.failure);
+  const failureBody = redactSensitiveGithubFailureText(truncateFailureBody(failure.failure));
 
   const bodyContent = [
     'A test failed on a tracked branch',
@@ -89,7 +113,7 @@ function createScoutBody(
   branch: string,
   pipeline: string
 ): string {
-  const failureBody = truncateFailureBody(failure.failure);
+  const failureBody = redactSensitiveGithubFailureText(truncateFailureBody(failure.failure));
 
   // Create table format for Scout test details
   const scoutDetailsTable = [
@@ -236,7 +260,9 @@ function createScoutComment(
    * ```
    */
 
-  return `${base}\n\nNew error message:\n\`\`\`\n${newErrorMessage}\n\`\`\``;
+  return `${base}\n\nNew error message:\n\`\`\`\n${redactSensitiveGithubFailureText(
+    newErrorMessage
+  )}\n\`\`\``;
 }
 
 async function updateFTRFailureIssue(
@@ -278,8 +304,10 @@ async function updateScoutFailureIssue(
   let newErrorMessage: string | undefined;
   if (failure.errorMessage && previousFailureBody) {
     const currentErrorMsg = truncateFailureBody(failure.errorMessage).trim();
-    if (!previousFailureBody.includes(currentErrorMsg)) {
-      newErrorMessage = currentErrorMsg;
+    const redactedPrevious = redactSensitiveGithubFailureText(previousFailureBody);
+    const redactedCurrent = redactSensitiveGithubFailureText(currentErrorMsg);
+    if (!redactedPrevious.includes(redactedCurrent)) {
+      newErrorMessage = redactedCurrent;
     }
   }
 

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
@@ -304,6 +304,9 @@ async function updateScoutFailureIssue(
   let newErrorMessage: string | undefined;
   if (failure.errorMessage && previousFailureBody) {
     const currentErrorMsg = truncateFailureBody(failure.errorMessage).trim();
+    // Current error.message from CI is raw. The issue's first code block is usually already
+    // redacted (we redact on create), but older issues may still hold raw text. Redacting
+    // previous again is idempotent.
     const redactedPrevious = redactSensitiveGithubFailureText(previousFailureBody);
     const redactedCurrent = redactSensitiveGithubFailureText(currentErrorMsg);
     if (!redactedPrevious.includes(redactedCurrent)) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/appex-qa-team/issues/809

Redact host/email info before adding GH issue comment for failed tests.

Related to https://github.com/elastic/kibana/issues/258015#issuecomment-4128832288





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->