### PR TITLE
[Entity Store] Scout: resume two IDP tests

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/logs_extraction.spec.ts
@@ -413,7 +413,7 @@ apiTest.describe('Entity Store Main logs extraction', { tag: ENTITY_STORE_TAGS }
     });
   });
 
-  apiTest.skip(
+  apiTest(
     'Should apply user postAggFilter: IDP asset/iam paths and entity.id-after-LOOKUP; omit when no keep branch',
     async ({ apiClient, esClient }) => {
       const from = '2026-03-01T10:00:00Z';
@@ -545,7 +545,7 @@ apiTest.describe('Entity Store Main logs extraction', { tag: ENTITY_STORE_TAGS }
     }
   );
 
-  apiTest.skip(
+  apiTest(
     'Should only enrich (update) existing entities when entity already exists for both IDP and non-IDP, no new entity creation',
     async ({ apiClient, esClient }) => {
       const from = '2026-03-02T10:00:00Z';


### PR DESCRIPTION
## Summary

Resume 2 Scout tests:
- `'Should apply user postAggFilter: IDP asset/iam paths and entity.id-after-LOOKUP; omit when no keep branch'`
- `'Should only enrich (update) existing entities when entity already exists for both IDP and non-IDP, no new entity creation'`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
