### PR TITLE
[Chrome Next] Back button, use breadcrumbs for title fallback

### DIFF
--- a/src/core/packages/application/browser-internal/src/application_service.tsx
+++ b/src/core/packages/application/browser-internal/src/application_service.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { flushSync } from 'react-dom';
 import { BehaviorSubject, firstValueFrom, type Observable, Subject, type Subscription } from 'rxjs';
-import { map, shareReplay, switchMap, takeUntil, distinctUntilChanged, filter, take } from 'rxjs';
+import { map, shareReplay, takeUntil, distinctUntilChanged, filter, take } from 'rxjs';
 import type { History } from 'history';
 import { createBrowserHistory } from 'history';
 
@@ -327,13 +327,6 @@ export class ApplicationService {
       currentLocation$: this.location$!.pipe(takeUntil(this.stop$)),
       currentAppId$: this.currentAppId$.pipe(
         filter((appId) => appId !== undefined),
-        distinctUntilChanged(),
-        takeUntil(this.stop$)
-      ),
-      currentAppTitle$: this.currentAppId$.pipe(
-        filter((appId) => appId !== undefined),
-        distinctUntilChanged(),
-        switchMap((appId) => applications$.pipe(map((apps) => apps.get(appId)?.title))),
         distinctUntilChanged(),
         takeUntil(this.stop$)
       ),

--- a/src/core/packages/application/browser-mocks/src/application_service.mock.ts
+++ b/src/core/packages/application/browser-mocks/src/application_service.mock.ts
@@ -49,7 +49,6 @@ const createStartContractMock = (): jest.Mocked<ApplicationStart> => {
   return lazyObject({
     applications$: new BehaviorSubject<Map<string, PublicAppInfo>>(new Map()),
     currentAppId$: currentAppId$.asObservable(),
-    currentAppTitle$: new BehaviorSubject<string | undefined>(undefined),
     currentLocation$: currentLocation$.asObservable(),
     capabilities: capabilitiesServiceMock.createStartContract().capabilities,
     navigateToApp: jest.fn(),
@@ -93,7 +92,6 @@ const createInternalStartContractMock = (
     applications$: new BehaviorSubject<Map<string, PublicAppInfo>>(new Map()),
     capabilities: capabilitiesServiceMock.createStartContract().capabilities,
     currentAppId$: currentAppId$.asObservable(),
-    currentAppTitle$: new BehaviorSubject<string | undefined>(undefined),
     currentLocation$: currentLocation$.asObservable(),
     currentActionMenu$: new BehaviorSubject<MountPoint | undefined>(undefined),
     getComponent: jest.fn(),

--- a/src/core/packages/application/browser/src/contracts.ts
+++ b/src/core/packages/application/browser/src/contracts.ts
@@ -153,13 +153,6 @@ export interface ApplicationStart {
   currentAppId$: Observable<string | undefined>;
 
   /**
-   * An observable that emits the title of the currently mounted application.
-   * Derived from {@link ApplicationStart.currentAppId$ | currentAppId$} and
-   * {@link ApplicationStart.applications$ | applications$}.
-   */
-  currentAppTitle$: Observable<string | undefined>;
-
-  /**
    * An observable that emits the current path#hash and each subsequent update using the global history instance
    */
   currentLocation$: Observable<string>;

--- a/src/core/packages/chrome/browser-components/src/context.tsx
+++ b/src/core/packages/chrome/browser-components/src/context.tsx
@@ -17,7 +17,7 @@ import type { CustomBrandingStart } from '@kbn/core-custom-branding-browser';
 export interface ChromeComponentsDeps {
   application: Pick<
     InternalApplicationStart,
-    'navigateToUrl' | 'currentAppId$' | 'currentAppTitle$' | 'currentActionMenu$'
+    'navigateToUrl' | 'currentAppId$' | 'currentActionMenu$'
   >;
   http: Pick<HttpStart, 'basePath' | 'getLoadingCount$'>;
   docLinks: DocLinksStart;

--- a/src/core/packages/chrome/browser-components/src/project_next/app_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/app_menu.tsx
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { css } from '@emotion/react';
 import React, { lazy, Suspense } from 'react';
 import { useHasLegacyActionMenu } from '../shared/chrome_hooks';
 import { HeaderActionMenu } from '../shared/header_action_menu';
@@ -17,11 +16,6 @@ const AppMenuComponent = lazy(async () => {
   const { AppMenuComponent: Component } = await import('@kbn/core-chrome-app-menu-components');
   return { default: Component };
 });
-
-const styles = css`
-  margin-left: auto;
-  flex-shrink: 0;
-`;
 
 /**
  * Renders the app menu for the Chrome-Next project header.
@@ -33,20 +27,14 @@ export const ProjectNextAppMenu = React.memo(() => {
 
   if (appMenuConfig) {
     return (
-      <div css={styles}>
-        <Suspense>
-          <AppMenuComponent config={appMenuConfig} />
-        </Suspense>
-      </div>
+      <Suspense>
+        <AppMenuComponent config={appMenuConfig} />
+      </Suspense>
     );
   }
 
   if (hasLegacyActionMenu) {
-    return (
-      <div css={styles}>
-        <HeaderActionMenu />
-      </div>
-    );
+    return <HeaderActionMenu />;
   }
 
   return null;

--- a/src/core/packages/chrome/browser-components/src/project_next/back_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/back_button.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiButtonIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useMemo } from 'react';
+import { useBackButton } from './hooks';
+
+/**
+ * Back control for Chrome-Next project header: links to the first project breadcrumb
+ * when there are ≥2 crumbs and the root has an `href`. Renders nothing otherwise.
+ */
+export const ProjectNextBackButton = React.memo(() => {
+  const back = useBackButton();
+
+  const ariaLabel = useMemo(() => {
+    if (!back) {
+      return '';
+    }
+    if (back.backDestinationLabel) {
+      return i18n.translate('core.ui.chrome.projectNextHeader.backButtonAriaLabelWithDestination', {
+        defaultMessage: 'Back to {destination}',
+        values: { destination: back.backDestinationLabel },
+      });
+    }
+    return i18n.translate('core.ui.chrome.projectNextHeader.backButtonAriaLabel', {
+      defaultMessage: 'Back',
+    });
+  }, [back]);
+
+  if (!back) {
+    return null;
+  }
+
+  return (
+    <EuiButtonIcon
+      iconType="arrowLeft"
+      display="empty"
+      size="s"
+      aria-label={ariaLabel}
+      data-test-subj="chromeProjectNextHeaderBack"
+      href={back.backHref}
+    />
+  );
+});

--- a/src/core/packages/chrome/browser-components/src/project_next/back_button.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/back_button.tsx
@@ -13,8 +13,9 @@ import React, { useMemo } from 'react';
 import { useBackButton } from './hooks';
 
 /**
- * Back control for Chrome-Next project header: links to the first project breadcrumb
- * when there are ≥2 crumbs and the root has an `href`. Renders nothing otherwise.
+ * Back control for Chrome-Next project header: uses explicit `chrome.next.header` `back` when
+ * set; otherwise the last non-last project breadcrumb with an `href` (≥2 crumbs; scanning
+ * right to left). Renders nothing when neither applies.
  */
 export const ProjectNextBackButton = React.memo(() => {
   const back = useBackButton();

--- a/src/core/packages/chrome/browser-components/src/project_next/header.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/header.tsx
@@ -7,46 +7,50 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEuiTheme, type UseEuiTheme } from '@elastic/eui';
+import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
-import { useReportTopBarHeight, useTitle } from './hooks';
-import { ProjectNextAppMenu } from './app_menu';
+import { ProjectNextBackButton } from './back_button';
+import { useReportTopBarHeight } from './hooks';
+import { ProjectNextTitle } from './title';
+import { ProjectNextTrailingActions } from './trailing_actions';
 
-const useStyles = (euiTheme: UseEuiTheme['euiTheme']) =>
-  useMemo(() => {
+const useHeaderStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
     const root = css`
       display: flex;
-      align-items: center;
+      flex-direction: column;
+      min-width: 0;
       padding: ${euiTheme.size.s};
       background: ${euiTheme.colors.backgroundBasePlain};
       border-bottom: ${euiTheme.border.thin};
       margin-bottom: -${euiTheme.border.width.thin};
     `;
 
-    const title = css`
-      font-size: ${euiTheme.size.base};
-      font-weight: ${euiTheme.font.weight.semiBold};
-      line-height: ${euiTheme.size.l};
-      margin: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    const primaryRow = css`
+      display: flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+      min-width: 0;
     `;
 
-    return { root, title };
+    return { root, primaryRow };
   }, [euiTheme]);
+};
 
 export const ProjectNextHeader = React.memo(() => {
-  const title = useTitle();
-  const { euiTheme } = useEuiTheme();
-  const styles = useStyles(euiTheme);
+  const styles = useHeaderStyles();
   const heightRef = useReportTopBarHeight();
 
   return (
     <div ref={heightRef} css={styles.root} data-test-subj="chromeProjectNextHeader">
-      <h1 css={styles.title}>{title}</h1>
-      <ProjectNextAppMenu />
+      <div css={styles.primaryRow}>
+        <ProjectNextBackButton />
+        <ProjectNextTitle />
+        <ProjectNextTrailingActions />
+      </div>
     </div>
   );
 });

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/index.ts
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/index.ts
@@ -9,5 +9,6 @@
 
 export { useAiButton } from './use_ai_button';
 export { useProjectNextAppMenu } from './use_project_next_app_menu';
+export { useBackButton } from './use_back_button';
 export { useReportTopBarHeight } from './use_report_top_bar_height';
 export { useTitle } from './use_title';

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import type { BehaviorSubject } from 'rxjs';
+import type { ChromeBreadcrumb, ChromeNextHeaderConfig } from '@kbn/core-chrome-browser';
+import { createMockChromeComponentsDeps, TestChromeProviders } from '../../test_helpers';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { useBackButton } from './use_back_button';
+
+describe('useBackButton', () => {
+  it('prefers explicit chrome.next.header back over breadcrumbs', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([
+      { text: 'Root', href: '/app/r' },
+      { text: 'Section', href: '/app/section' },
+      { text: 'Current' },
+    ]);
+
+    (chrome.next.header.get$() as BehaviorSubject<ChromeNextHeaderConfig | undefined>).next({
+      title: 'T',
+      back: { href: '/app/explicit', label: 'Explicit' },
+    });
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/explicit',
+      backDestinationLabel: 'Explicit',
+    });
+  });
+
+  it('uses explicit back href without label when label is omitted', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Root', href: '/app/r' }, { text: 'Leaf' }]);
+
+    (chrome.next.header.get$() as BehaviorSubject<ChromeNextHeaderConfig | undefined>).next({
+      title: 'T',
+      back: { href: '/app/only-href' },
+    });
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/only-href',
+      backDestinationLabel: undefined,
+    });
+  });
+
+  it('uses explicit back when there is only one breadcrumb', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Only', href: '/app/one' }]);
+
+    (chrome.next.header.get$() as BehaviorSubject<ChromeNextHeaderConfig | undefined>).next({
+      title: 'T',
+      back: { href: '/app/back' },
+    });
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/back',
+      backDestinationLabel: undefined,
+    });
+  });
+
+  it('returns undefined when there are fewer than two breadcrumbs', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Only', href: '/app/one' }]);
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('uses the only non-last crumb with an href when there are two crumbs', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Root', href: '/app/r' }, { text: 'Leaf' }]);
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/r',
+      backDestinationLabel: 'Root',
+    });
+  });
+
+  it('uses the last non-last crumb with an href when several preceding crumbs have hrefs', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([
+      { text: 'Root', href: '/app/r' },
+      { text: 'Section', href: '/app/section' },
+      { text: 'Current' },
+    ]);
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/section',
+      backDestinationLabel: 'Section',
+    });
+  });
+
+  it('uses the last non-last crumb with an href when the root has no href', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([
+      { text: 'Root' },
+      { text: 'Section', href: '/app/section' },
+      { text: 'Current' },
+    ]);
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      backHref: '/app/section',
+      backDestinationLabel: 'Section',
+    });
+  });
+
+  it('returns undefined when no non-last crumb has an href', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Root' }, { text: 'Leaf' }]);
+
+    const { result } = renderHook(() => useBackButton(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.ts
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.ts
@@ -8,28 +8,46 @@
  */
 
 import { useMemo } from 'react';
-import { useProjectBreadcrumbs } from '../../shared/chrome_hooks';
+import { useNextHeader, useProjectBreadcrumbs } from '../../shared/chrome_hooks';
 import { getBreadcrumbPlainText } from '../../shared/breadcrumb_utils';
 
 export interface BackNavigation {
   backHref: string;
-  /** Plain-text title of the root crumb (for `aria-label` on the back control). */
+  /** Plain-text title of the destination crumb (for `aria-label` on the back control). */
   backDestinationLabel?: string;
 }
 
 /**
- * When there are ≥2 project breadcrumbs, exposes the first crumb's `href` for the back control.
- * Returns `undefined` if the root has no `href` (e.g. popover-only crumb).
+ * Resolution: explicit `chrome.next.header` `back.href` (and optional `back.label`) → else the
+ * last non-last project breadcrumb with a truthy `href` (scanning right to left). Returns
+ * `undefined` if neither applies.
  */
 export function useBackButton(): BackNavigation | undefined {
+  const config = useNextHeader();
   const breadcrumbs = useProjectBreadcrumbs();
 
-  const rootCrumb = breadcrumbs.length >= 2 ? breadcrumbs[0] : undefined;
-  const backHref = rootCrumb?.href;
-  const backDestinationLabel = rootCrumb ? getBreadcrumbPlainText(rootCrumb) : undefined;
-
   return useMemo(() => {
-    if (!backHref) return undefined;
-    return { backHref, backDestinationLabel };
-  }, [backHref, backDestinationLabel]);
+    const explicitHref = config?.back?.href?.trim();
+    if (explicitHref) {
+      return {
+        backHref: explicitHref,
+        backDestinationLabel: config?.back?.label,
+      };
+    }
+
+    if (breadcrumbs.length < 2) {
+      return undefined;
+    }
+    for (let i = breadcrumbs.length - 2; i >= 0; i--) {
+      const crumb = breadcrumbs[i];
+      const href = crumb.href;
+      if (href) {
+        return {
+          backHref: href,
+          backDestinationLabel: getBreadcrumbPlainText(crumb),
+        };
+      }
+    }
+    return undefined;
+  }, [breadcrumbs, config]);
 }

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.ts
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_back_button.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useMemo } from 'react';
+import { useProjectBreadcrumbs } from '../../shared/chrome_hooks';
+import { getBreadcrumbPlainText } from '../../shared/breadcrumb_utils';
+
+export interface BackNavigation {
+  backHref: string;
+  /** Plain-text title of the root crumb (for `aria-label` on the back control). */
+  backDestinationLabel?: string;
+}
+
+/**
+ * When there are ≥2 project breadcrumbs, exposes the first crumb's `href` for the back control.
+ * Returns `undefined` if the root has no `href` (e.g. popover-only crumb).
+ */
+export function useBackButton(): BackNavigation | undefined {
+  const breadcrumbs = useProjectBreadcrumbs();
+
+  const rootCrumb = breadcrumbs.length >= 2 ? breadcrumbs[0] : undefined;
+  const backHref = rootCrumb?.href;
+  const backDestinationLabel = rootCrumb ? getBreadcrumbPlainText(rootCrumb) : undefined;
+
+  return useMemo(() => {
+    if (!backHref) return undefined;
+    return { backHref, backDestinationLabel };
+  }, [backHref, backDestinationLabel]);
+}

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_title.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_title.test.tsx
@@ -8,40 +8,31 @@
  */
 
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { BehaviorSubject } from 'rxjs';
-import type { ChromeNextHeaderConfig } from '@kbn/core-chrome-browser';
+import type { ChromeBreadcrumb, ChromeNextHeaderConfig } from '@kbn/core-chrome-browser';
 import { createMockChromeComponentsDeps, TestChromeProviders } from '../../test_helpers';
 import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
 import { useTitle } from './use_title';
 
 describe('useTitle', () => {
-  it('returns the app title from currentAppTitle$', () => {
-    const deps = createMockChromeComponentsDeps();
-    (deps.application.currentAppTitle$ as BehaviorSubject<string | undefined>).next('Discover');
-
-    const { result } = renderHook(() => useTitle(), {
-      wrapper: ({ children }) => <TestChromeProviders deps={deps}>{children}</TestChromeProviders>,
-    });
-
-    expect(result.current).toBe('Discover');
-  });
-
-  it('returns "Unknown" when no app title is available', () => {
+  it('returns undefined when there is no config title and project breadcrumbs are empty', () => {
     const deps = createMockChromeComponentsDeps();
 
     const { result } = renderHook(() => useTitle(), {
       wrapper: ({ children }) => <TestChromeProviders deps={deps}>{children}</TestChromeProviders>,
     });
 
-    expect(result.current).toBe('Unknown');
+    expect(result.current).toBeUndefined();
   });
 
-  it('prefers chrome.next.header config title over app title', () => {
+  it('prefers chrome.next.header config title over breadcrumbs', () => {
     const deps = createMockChromeComponentsDeps();
-    (deps.application.currentAppTitle$ as BehaviorSubject<string | undefined>).next('Dashboards');
 
     const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'From breadcrumbs' }]);
+
     (chrome.next.header.get$() as BehaviorSubject<ChromeNextHeaderConfig | undefined>).next({
       title: 'My Dashboard',
     });
@@ -57,18 +48,72 @@ describe('useTitle', () => {
     expect(result.current).toBe('My Dashboard');
   });
 
-  it('updates when currentAppTitle$ emits a new value', () => {
+  it('uses a single project breadcrumb string text as title', () => {
     const deps = createMockChromeComponentsDeps();
-    const title$ = deps.application.currentAppTitle$ as BehaviorSubject<string | undefined>;
-    title$.next('Dashboard');
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Section' }]);
 
     const { result } = renderHook(() => useTitle(), {
-      wrapper: ({ children }) => <TestChromeProviders deps={deps}>{children}</TestChromeProviders>,
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
     });
 
-    expect(result.current).toBe('Dashboard');
+    expect(result.current).toBe('Section');
+  });
 
-    act(() => title$.next('Discover'));
-    expect(result.current).toBe('Discover');
+  it('uses the last project breadcrumb text when multiple crumbs', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Root', href: '/app/r' }, { text: 'Leaf' }]);
+
+    const { result } = renderHook(() => useTitle(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toBe('Leaf');
+  });
+
+  it('prefers string text over aria-label when both are present on the chosen crumb', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: 'Visible', 'aria-label': 'Aria title' }]);
+
+    const { result } = renderHook(() => useTitle(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toBe('Visible');
+  });
+
+  it('returns undefined when breadcrumb text is not a plain string', () => {
+    const deps = createMockChromeComponentsDeps();
+
+    const chrome = chromeServiceMock.createStartContract();
+    const breadcrumbs$ = chrome.project.getBreadcrumbs$() as BehaviorSubject<ChromeBreadcrumb[]>;
+    breadcrumbs$.next([{ text: <span>Rich</span> }]);
+
+    const { result } = renderHook(() => useTitle(), {
+      wrapper: ({ children }) => (
+        <TestChromeProviders deps={deps} chrome={chrome}>
+          {children}
+        </TestChromeProviders>
+      ),
+    });
+
+    expect(result.current).toBeUndefined();
   });
 });

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_title.ts
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_title.ts
@@ -7,17 +7,30 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useObservable } from '@kbn/use-observable';
-import { useChromeComponentsDeps } from '../../context';
-import { useNextHeader } from '../../shared/chrome_hooks';
+import { useNextHeader, useProjectBreadcrumbs } from '../../shared/chrome_hooks';
+import { getBreadcrumbPlainText } from '../../shared/breadcrumb_utils';
 
 /**
- * Returns the display title for the Chrome-Next project header.
- * Fallback chain: explicit `config.title` -> current app title -> 'Unknown'.
+ * Returns the display title for the Chrome-Next project header, or `undefined` when none.
+ * Resolution: explicit `config.title` -> project breadcrumb text (last crumb) -> `undefined`.
  */
-export function useTitle(): string {
+export function useTitle(): string | undefined {
   const config = useNextHeader();
-  const { application } = useChromeComponentsDeps();
-  const appTitle = useObservable(application.currentAppTitle$, undefined);
-  return config?.title ?? appTitle ?? 'Unknown';
+  const breadcrumbs = useProjectBreadcrumbs();
+
+  if (config?.title) {
+    return config.title;
+  }
+
+  if (breadcrumbs.length === 0) {
+    return undefined;
+  }
+
+  const crumbForTitle = breadcrumbs[breadcrumbs.length - 1];
+  const plain = getBreadcrumbPlainText(crumbForTitle);
+  if (plain) {
+    return plain;
+  }
+
+  return undefined;
 }

--- a/src/core/packages/chrome/browser-components/src/project_next/title.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/title.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useMemo } from 'react';
+import { useTitle } from './hooks';
+
+const useTitleStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
+    const title = css`
+      flex: 1;
+      min-width: 0;
+      font-size: ${euiTheme.size.base};
+      font-weight: ${euiTheme.font.weight.semiBold};
+      line-height: ${euiTheme.size.l};
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    `;
+
+    return { title };
+  }, [euiTheme]);
+};
+
+/**
+ * Title region for the Chrome-Next project header: renders nothing when
+ * `useTitle()` has no string; otherwise an `h1` with Emotion styles.
+ */
+export const ProjectNextTitle = React.memo(() => {
+  const title = useTitle();
+  const styles = useTitleStyles();
+
+  if (!title) {
+    return null;
+  }
+
+  return <h1 css={styles.title}>{title}</h1>;
+});

--- a/src/core/packages/chrome/browser-components/src/project_next/trailing_actions.test.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/trailing_actions.test.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { BehaviorSubject } from 'rxjs';
+import { chromeServiceMock } from '@kbn/core-chrome-browser-mocks';
+import { createMockChromeComponentsDeps, TestChromeProviders } from '../test_helpers';
+import { ProjectNextTrailingActions } from './trailing_actions';
+
+describe('ProjectNextTrailingActions', () => {
+  it('renders nothing when no app menu, legacy action menu, or AI button', () => {
+    const deps = createMockChromeComponentsDeps();
+
+    const { container } = render(
+      <TestChromeProviders deps={deps}>
+        <ProjectNextTrailingActions />
+      </TestChromeProviders>
+    );
+
+    expect(
+      container.querySelector('[data-test-subj="chromeProjectNextHeaderTrailing"]')
+    ).toBeNull();
+  });
+
+  it('renders the trailing region when the AI button slot is set', () => {
+    const deps = createMockChromeComponentsDeps();
+    const chrome = chromeServiceMock.createStartContract();
+    const aiButton$ = chrome.next.aiButton.get$() as BehaviorSubject<React.ReactNode | undefined>;
+    aiButton$.next(<span data-test-subj="aiButtonTest">AI</span>);
+
+    render(
+      <TestChromeProviders deps={deps} chrome={chrome}>
+        <ProjectNextTrailingActions />
+      </TestChromeProviders>
+    );
+
+    expect(screen.getByTestId('chromeProjectNextHeaderTrailing')).toBeInTheDocument();
+    expect(screen.getByTestId('aiButtonTest')).toBeInTheDocument();
+  });
+});

--- a/src/core/packages/chrome/browser-components/src/project_next/trailing_actions.tsx
+++ b/src/core/packages/chrome/browser-components/src/project_next/trailing_actions.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useMemo } from 'react';
+import { useHasLegacyActionMenu } from '../shared/chrome_hooks';
+import { AiButtonSlot } from './ai_button_slot';
+import { ProjectNextAppMenu } from './app_menu';
+import { useAiButton, useProjectNextAppMenu } from './hooks';
+
+const useTrailingStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return useMemo(() => {
+    const root = css`
+      display: flex;
+      align-items: center;
+      gap: ${euiTheme.size.s};
+      flex-shrink: 0;
+      margin-left: auto;
+    `;
+
+    return { root };
+  }, [euiTheme]);
+};
+
+/**
+ * Trailing region of the Chrome-Next project header (app menu, AI button, future global actions).
+ * Renders nothing when no trailing content is available.
+ */
+export const ProjectNextTrailingActions = React.memo(() => {
+  const appMenuConfig = useProjectNextAppMenu();
+  const hasLegacyActionMenu = useHasLegacyActionMenu();
+  const aiButton = useAiButton();
+  const styles = useTrailingStyles();
+
+  const hasTrailingContent = !!appMenuConfig || hasLegacyActionMenu || !!aiButton;
+
+  if (!hasTrailingContent) {
+    return null;
+  }
+
+  return (
+    <div css={styles.root} data-test-subj="chromeProjectNextHeaderTrailing">
+      <ProjectNextAppMenu />
+      <AiButtonSlot />
+    </div>
+  );
+});

--- a/src/core/packages/chrome/browser-components/src/shared/breadcrumb_utils.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/breadcrumb_utils.ts
@@ -10,6 +10,20 @@
 import classNames from 'classnames';
 import type { ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 
+/**
+ * Returns a plain string for breadcrumb display: prefers `text`, then `aria-label` when strings.
+ * Returns `undefined` for React node `text`.
+ */
+export function getBreadcrumbPlainText(crumb: ChromeBreadcrumb): string | undefined {
+  if (typeof crumb.text === 'string') {
+    return crumb.text;
+  }
+  if (typeof crumb['aria-label'] === 'string') {
+    return crumb['aria-label'];
+  }
+  return undefined;
+}
+
 /** Maps raw ChromeBreadcrumb[] to EUI-compatible breadcrumb props */
 export function prepareBreadcrumbs(breadcrumbs: ChromeBreadcrumb[]) {
   const crumbs = breadcrumbs.length === 0 ? [{ text: 'Kibana' } as ChromeBreadcrumb] : breadcrumbs;

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -55,6 +55,7 @@ export type {
   SidebarAppDefinition,
   SidebarSetup,
   SidebarStart,
+  ChromeNextHeaderBack,
   ChromeNextHeaderConfig,
   ChromeNextHeaderMetadataItem,
   ChromeNextHeaderGlobalActions,

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -61,6 +61,7 @@ export type {
 } from './sidebar';
 
 export type {
+  ChromeNextHeaderBack,
   ChromeNextHeaderConfig,
   ChromeNextHeaderMetadataItem,
   ChromeNextHeaderGlobalActions,

--- a/src/core/packages/chrome/browser/src/next_header.ts
+++ b/src/core/packages/chrome/browser/src/next_header.ts
@@ -54,6 +54,19 @@ export interface ChromeNextHeaderConfig {
    * TODO: Consider strict type independent from `@kbn/core-chrome-app-menu-components`
    */
   appMenu?: AppMenuConfigNext;
+
+  /**
+   * Optional explicit back navigation for the Chrome-Next header back control.
+   * When `href` is set, overrides breadcrumb-derived back destination.
+   */
+  back?: ChromeNextHeaderBack;
+}
+
+/** Explicit back target for {@link ChromeNextHeaderConfig.back}. */
+export interface ChromeNextHeaderBack {
+  href: string;
+  /** Destination name for accessibility (e.g. "Back to {label}"). */
+  label?: string;
 }
 
 export interface ChromeNextHeaderMetadataItem {


### PR DESCRIPTION
## Summary

- back button, ~use root breadcrumb as href~ use last not current breadcrumbs as link 
- for title use the last breadcrumb
- revert `currentAppTitle`, it isn't useful 
- layout improvements

<img width="1624" height="1056" alt="Screenshot 2026-03-26 at 12 30 50" src="https://github.com/user-attachments/assets/c589ef94-0c2b-4b33-91ef-6d40f4339db0" />


