### PR TITLE
[fleet] skip custom role test for ech

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_fleet_all_integrations_none.spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/test/scout/ui/tests/privileges_fleet_all_integrations_none.spec.ts
@@ -6,16 +6,16 @@
  */
 
 import { expect } from '@kbn/scout/ui';
-import { tags } from '@kbn/scout';
 
 import { test } from '../fixtures';
 import { getFleetAllIntegrationsNoneRole } from '../fixtures/services/privileges';
 
 test.describe(
   'When the user has All privilege for Fleet but None for integrations',
-  { tag: tags.stateful.classic },
+  { tag: '@local-stateful-classic' },
   () => {
     test('Fleet is accessible', async ({ browserAuth, pageObjects }) => {
+      // custom roles are not supported in ECH yet: https://github.com/elastic/appex-qa-team/issues/713
       // Login with custom role: Fleet v2 (all) but Fleet (none) - which means integrations are none
       await browserAuth.loginWithCustomRole(getFleetAllIntegrationsNoneRole());
       const { fleetHome } = pageObjects;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/258970

As soon as we add support for custom roles in ECH, this and other tests can be re-enabled for ECH runs



