### PR TITLE
[Osquery] Fix history pagination with source filters

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/actions/use_unified_history.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/use_unified_history.ts
@@ -77,7 +77,7 @@ export const useUnifiedHistory = ({
           pageSize,
           ...(nextPage ? { nextPage } : {}),
           ...(kuery ? { kuery } : {}),
-          ...(sourceFilters && sourceFilters.length > 0 && sourceFilters.length < 3
+          ...(sourceFilters && sourceFilters.length > 0
             ? { sourceFilters: sourceFilters.join(',') }
             : {}),
           ...(userIds && userIds.length > 0 ? { userIds: userIds.join(',') } : {}),

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/get_unified_history_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/get_unified_history_route.ts
@@ -157,6 +157,7 @@ export const getUnifiedHistoryRoute = (router: IRouter, osqueryContext: OsqueryA
                 startDate,
                 endDate,
                 sortDirection,
+                activeFilters,
               })
             : undefined;
 
@@ -217,7 +218,6 @@ export const getUnifiedHistoryRoute = (router: IRouter, osqueryContext: OsqueryA
             liveHits,
             osqueryContext,
             spaceId,
-            activeFilters,
             logger,
           });
 

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/process_live_history.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/process_live_history.test.ts
@@ -70,7 +70,7 @@ describe('processLiveHistory', () => {
     expect(result.sortValuesMap.get('a2')).toEqual([2000, 2]);
   });
 
-  it('filters by activeFilters when provided', async () => {
+  it('returns all rows without post-fetch source filtering', async () => {
     const hits = [
       createLiveHit({
         _source: { action_id: 'live-1', alert_ids: [], queries: [{ action_id: 'q1', query: 'x' }] },
@@ -87,12 +87,12 @@ describe('processLiveHistory', () => {
       liveHits: hits,
       osqueryContext: createMockOsqueryContext() as never,
       spaceId: 'default',
-      activeFilters: new Set(['live']),
       logger: {} as never,
     });
 
-    expect(result.liveRows).toHaveLength(1);
+    expect(result.liveRows).toHaveLength(2);
     expect(result.liveRows[0].source).toBe('Live');
+    expect(result.liveRows[1].source).toBe('Rule');
   });
 
   it('enriches single query rows with result counts', async () => {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/process_live_history.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/process_live_history.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Logger } from '@kbn/core/server';
-import type { LiveHistoryRow, SourceFilter } from '../../../common/api/unified_history/types';
+import type { LiveHistoryRow } from '../../../common/api/unified_history/types';
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { getResultCountsForActions } from '../../lib/get_result_counts_for_actions';
 import { mapLiveHitToRow } from './map_live_hit_to_row';
@@ -17,7 +17,6 @@ export interface ProcessLiveHistoryParams {
   liveHits: LiveActionHit[];
   osqueryContext: OsqueryAppContext;
   spaceId: string;
-  activeFilters?: Set<SourceFilter>;
   logger: Logger;
 }
 
@@ -37,7 +36,6 @@ export const processLiveHistory = async ({
   liveHits,
   osqueryContext,
   spaceId,
-  activeFilters,
   logger,
 }: ProcessLiveHistoryParams): Promise<ProcessLiveHistoryResult> => {
   const liveRows: LiveHistoryRow[] = liveHits.map(mapLiveHitToRow);
@@ -61,15 +59,7 @@ export const processLiveHistory = async ({
     }
   }
 
-  const filteredLiveRows = activeFilters
-    ? liveRows.filter((row) => {
-        if (row.source === 'Rule') return activeFilters.has('rule');
-
-        return activeFilters.has('live');
-      })
-    : liveRows;
-
-  return { liveRows: filteredLiveRows, sortValuesMap };
+  return { liveRows, sortValuesMap };
 };
 
 const enrichWithResultCounts = async (

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/query_live_actions_dsl.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/query_live_actions_dsl.test.ts
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
+import type { SourceFilter } from '../../../common/api/unified_history/types';
 import { buildLiveActionsQuery } from './query_live_actions_dsl';
+
+const getFilters = (result: ReturnType<typeof buildLiveActionsQuery>) => {
+  const query = result.body.query as Record<string, unknown>;
+
+  return (query.bool as Record<string, unknown>).filter as unknown[];
+};
 
 describe('buildLiveActionsQuery', () => {
   describe('base structure', () => {
@@ -234,6 +241,61 @@ describe('buildLiveActionsQuery', () => {
       expect(filters).toContainEqual({
         range: { '@timestamp': { gte: 'now-24h', lte: 'now' } },
       });
+    });
+  });
+
+  describe('activeFilters (source type filtering)', () => {
+    test('adds must_not exists alert_ids filter when only "live" is selected', () => {
+      const activeFilters = new Set<SourceFilter>(['live']);
+      const result = buildLiveActionsQuery({ pageSize: 20, spaceId: 'default', activeFilters });
+      const filters = getFilters(result);
+
+      expect(filters).toContainEqual({
+        bool: { must_not: { exists: { field: 'alert_ids' } } },
+      });
+    });
+
+    test('adds exists alert_ids filter when only "rule" is selected', () => {
+      const activeFilters = new Set<SourceFilter>(['rule']);
+      const result = buildLiveActionsQuery({ pageSize: 20, spaceId: 'default', activeFilters });
+      const filters = getFilters(result);
+
+      expect(filters).toContainEqual({ exists: { field: 'alert_ids' } });
+    });
+
+    test('does not add alert_ids filter when both "live" and "rule" are selected', () => {
+      const activeFilters = new Set<SourceFilter>(['live', 'rule']);
+      const result = buildLiveActionsQuery({ pageSize: 20, spaceId: 'default', activeFilters });
+      const filters = getFilters(result);
+
+      const alertIdFilters = filters.filter(
+        (f) =>
+          typeof f === 'object' &&
+          f !== null &&
+          (('exists' in f &&
+            (f as Record<string, unknown>).exists != null &&
+            typeof (f as Record<string, unknown>).exists === 'object' &&
+            'field' in ((f as Record<string, unknown>).exists as Record<string, unknown>) &&
+            ((f as Record<string, unknown>).exists as Record<string, unknown>).field ===
+              'alert_ids') ||
+            JSON.stringify(f).includes('alert_ids'))
+      );
+      expect(alertIdFilters).toHaveLength(0);
+    });
+
+    test('does not add alert_ids filter when activeFilters is undefined', () => {
+      const result = buildLiveActionsQuery({ pageSize: 20, spaceId: 'default' });
+      const filters = getFilters(result);
+
+      expect(filters.some((f) => JSON.stringify(f).includes('alert_ids'))).toBe(false);
+    });
+
+    test('does not add alert_ids filter when activeFilters contains all three sources', () => {
+      const activeFilters = new Set<SourceFilter>(['live', 'rule', 'scheduled']);
+      const result = buildLiveActionsQuery({ pageSize: 20, spaceId: 'default', activeFilters });
+      const filters = getFilters(result);
+
+      expect(filters.some((f) => JSON.stringify(f).includes('alert_ids'))).toBe(false);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/query_live_actions_dsl.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/query_live_actions_dsl.ts
@@ -6,6 +6,7 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
+import type { SourceFilter } from '../../../common/api/unified_history/types';
 
 const SIMPLE_QUERY_STRING_SPECIAL_CHARS = /[+\-|"*()~\\{}[\]:^!/&]/g;
 const escapeSimpleQueryString = (input: string): string =>
@@ -23,6 +24,7 @@ interface LiveActionsQueryOptions {
   startDate?: string;
   endDate?: string;
   sortDirection?: 'asc' | 'desc';
+  activeFilters?: Set<SourceFilter>;
 }
 
 export const buildLiveActionsQuery = ({
@@ -35,6 +37,7 @@ export const buildLiveActionsQuery = ({
   startDate,
   endDate,
   sortDirection = 'desc',
+  activeFilters,
 }: LiveActionsQueryOptions): {
   body: Record<string, unknown>;
 } => {
@@ -79,6 +82,20 @@ export const buildLiveActionsQuery = ({
 
   if (tags && tags.length > 0) {
     filters.push({ terms: { tags } });
+  }
+
+  if (activeFilters) {
+    const wantsLive = activeFilters.has('live');
+    const wantsRule = activeFilters.has('rule');
+
+    if (wantsRule && !wantsLive) {
+      // Rule-only: keep actions that have alert_ids
+      filters.push({ exists: { field: 'alert_ids' } });
+    } else if (wantsLive && !wantsRule) {
+      // Live-only: exclude actions that have alert_ids
+      filters.push({ bool: { must_not: { exists: { field: 'alert_ids' } } } });
+    }
+    // Both live+rule selected (or neither, which shouldn't reach here): no filter needed
   }
 
   return {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/source_filter_pagination.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/unified_history/source_filter_pagination.test.ts
@@ -1,0 +1,374 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Integration-style tests for the source filter + pagination pipeline.
+ *
+ * These compose the real functions (buildLiveActionsQuery, processLiveHistory,
+ * mergeRows, computePaginationCursors) to verify end-to-end behaviour when
+ * source filters are applied — the exact scenario that broke pagination before
+ * the fix (see #259695).
+ *
+ * The ES layer is replaced by a lightweight in-memory stub that honours the
+ * query's `alert_ids` filter and `search_after` cursor so we can assert
+ * correct multi-page traversal.
+ */
+
+import type { LiveActionHit } from './map_live_hit_to_row';
+import type { SourceFilter, UnifiedHistoryRow } from '../../../common/api/unified_history/types';
+import type { SortValues } from './query_live_actions_dsl';
+import { buildLiveActionsQuery } from './query_live_actions_dsl';
+import { processLiveHistory } from './process_live_history';
+import { mergeRows } from './merge_rows';
+import { computePaginationCursors, decodeCursor, encodeCursor } from './cursor_utils';
+
+// ── mock result-count enrichment (not relevant to pagination) ──────────
+jest.mock('../../lib/get_result_counts_for_actions', () => ({
+  getResultCountsForActions: jest.fn().mockResolvedValue(new Map()),
+}));
+
+const mockOsqueryContext = {
+  getStartServices: jest
+    .fn()
+    .mockResolvedValue([{ elasticsearch: { client: { asInternalUser: {} } } }]),
+} as never;
+
+const mockLogger = { warn: jest.fn() } as never;
+
+// ── helpers to build realistic ES hits ─────────────────────────────────
+
+let tsCounter = 1_700_000_000_000; // monotonic timestamp seed
+
+const createHit = (id: string, opts: { alertIds?: string[]; ts?: number } = {}): LiveActionHit => {
+  const ts = opts.ts ?? (tsCounter -= 1000);
+
+  return {
+    _source: {
+      action_id: id,
+      '@timestamp': new Date(ts).toISOString(),
+      space_id: 'default',
+      queries: [{ id: `q-${id}`, query: 'SELECT 1;', agents: ['agent-1'] }],
+      ...(opts.alertIds ? { alert_ids: opts.alertIds } : {}),
+    },
+    fields: { action_id: [id] },
+    sort: [ts, 1],
+  };
+};
+
+/**
+ * In-memory stub that simulates ES `search` by applying the same filters
+ * that `buildLiveActionsQuery` emits. It respects:
+ * - `alert_ids` existence / must_not-existence filters
+ * - `search_after` cursor
+ * - `size`
+ */
+const simulateEsSearch = (
+  allHits: LiveActionHit[],
+  query: ReturnType<typeof buildLiveActionsQuery>
+): LiveActionHit[] => {
+  const body = query.body;
+  const filters = ((body.query as Record<string, unknown>).bool as Record<string, unknown>)
+    .filter as unknown[];
+
+  let hits = [...allHits];
+
+  // apply alert_ids filters
+  for (const filter of filters) {
+    const json = JSON.stringify(filter);
+    if (json.includes('alert_ids')) {
+      if (json.includes('must_not')) {
+        // must_not exists alert_ids → keep only hits WITHOUT alert_ids
+        hits = hits.filter((h) => {
+          const alertIds = (h._source as Record<string, unknown>)?.alert_ids;
+
+          return !alertIds || (Array.isArray(alertIds) && alertIds.length === 0);
+        });
+      } else if (json.includes('"exists"')) {
+        // exists alert_ids → keep only hits WITH alert_ids
+        hits = hits.filter((h) => {
+          const alertIds = (h._source as Record<string, unknown>)?.alert_ids;
+
+          return Array.isArray(alertIds) && alertIds.length > 0;
+        });
+      }
+    }
+  }
+
+  // apply search_after
+  const searchAfter = body.search_after as SortValues | undefined;
+  if (searchAfter) {
+    const afterTs = searchAfter[0] as number;
+    hits = hits.filter((h) => (h.sort![0] as number) < afterTs);
+  }
+
+  // sort desc by timestamp (default)
+  hits.sort((a, b) => (b.sort![0] as number) - (a.sort![0] as number));
+
+  // apply size limit
+  const size = body.size as number;
+
+  return hits.slice(0, size);
+};
+
+// ── pipeline helper: runs one "page fetch" exactly like the route handler ──
+
+interface PageResult {
+  rows: UnifiedHistoryRow[];
+  hasMore: boolean;
+  nextPageToken: string | undefined;
+}
+
+const fetchPage = async (
+  allHits: LiveActionHit[],
+  opts: {
+    pageSize: number;
+    activeFilters?: Set<SourceFilter>;
+    nextPage?: string;
+  }
+): Promise<PageResult> => {
+  const { pageSize, activeFilters, nextPage } = opts;
+  const decoded = decodeCursor(nextPage);
+  const fetchSize = pageSize + 1;
+
+  const query = buildLiveActionsQuery({
+    pageSize: fetchSize,
+    searchAfter: decoded.actionSearchAfter,
+    spaceId: 'default',
+    activeFilters,
+  });
+
+  const liveHits = simulateEsSearch(allHits, query);
+
+  const { liveRows, sortValuesMap } = await processLiveHistory({
+    liveHits,
+    osqueryContext: mockOsqueryContext,
+    spaceId: 'default',
+    logger: mockLogger,
+  });
+
+  const mergeResult = mergeRows<UnifiedHistoryRow>(liveRows, [], pageSize);
+
+  const { nextActionSearchAfter, nextScheduledCursor, nextScheduledOffset } =
+    computePaginationCursors({ mergeResult, sortValuesMap, decoded, scheduledOffset: 0 });
+
+  let nextPageToken: string | undefined;
+  if (mergeResult.hasMore) {
+    nextPageToken = encodeCursor({
+      actionSearchAfter: nextActionSearchAfter,
+      scheduledCursor: nextScheduledCursor,
+      scheduledOffset: nextScheduledOffset,
+    });
+  }
+
+  return { rows: mergeResult.rows, hasMore: mergeResult.hasMore, nextPageToken };
+};
+
+// ── collect ALL pages via cursor traversal ──────────────────────────────
+
+const fetchAllPages = async (
+  allHits: LiveActionHit[],
+  opts: { pageSize: number; activeFilters?: Set<SourceFilter> }
+): Promise<UnifiedHistoryRow[]> => {
+  const collected: UnifiedHistoryRow[] = [];
+  let nextPage: string | undefined;
+
+  for (let safety = 0; safety < 50; safety++) {
+    const page = await fetchPage(allHits, { ...opts, nextPage });
+    collected.push(...page.rows);
+    if (!page.hasMore) break;
+    nextPage = page.nextPageToken;
+  }
+
+  return collected;
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('source filter pagination (integration)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tsCounter = 1_700_000_000_000; // reset so tests are independent
+  });
+
+  // ── data set: 15 Live + 10 Rule = 25 total ──────────────────────────
+
+  const buildMixedHits = () => {
+    const hits: LiveActionHit[] = [];
+    // first 10 = Rule, last 15 = Live
+    for (let i = 0; i < 25; i++) {
+      hits.push(createHit(`action-${i}`, i < 10 ? { alertIds: ['alert-1'] } : {}));
+    }
+
+    return hits; // first 10 = Rule, last 15 = Live
+  };
+
+  describe('without source filters (baseline)', () => {
+    test('returns all 25 rows across multiple pages', async () => {
+      const hits = buildMixedHits();
+      const all = await fetchAllPages(hits, { pageSize: 10 });
+
+      expect(all).toHaveLength(25);
+    });
+
+    test('first page has exactly pageSize rows and hasMore=true', async () => {
+      const hits = buildMixedHits();
+      const page1 = await fetchPage(hits, { pageSize: 10 });
+
+      expect(page1.rows).toHaveLength(10);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextPageToken).toBeDefined();
+    });
+  });
+
+  describe('with "rule" source filter', () => {
+    const ruleFilter = new Set<SourceFilter>(['rule']);
+
+    test('returns only Rule-sourced rows', async () => {
+      const hits = buildMixedHits();
+      const all = await fetchAllPages(hits, { pageSize: 10, activeFilters: ruleFilter });
+
+      expect(all).toHaveLength(10);
+      expect(
+        all.every((r) => r.sourceType === 'live' && 'source' in r && r.source === 'Rule')
+      ).toBe(true);
+    });
+
+    test('pagination works when Rule rows span multiple pages', async () => {
+      const hits = buildMixedHits();
+      const page1 = await fetchPage(hits, { pageSize: 5, activeFilters: ruleFilter });
+
+      expect(page1.rows).toHaveLength(5);
+      expect(page1.hasMore).toBe(true);
+
+      const page2 = await fetchPage(hits, {
+        pageSize: 5,
+        activeFilters: ruleFilter,
+        nextPage: page1.nextPageToken,
+      });
+
+      expect(page2.rows).toHaveLength(5);
+      expect(page2.hasMore).toBe(false);
+
+      // no duplicates between pages
+      const page1Ids = new Set(page1.rows.map((r) => r.id));
+      const hasDuplicates = page2.rows.some((r) => page1Ids.has(r.id));
+      expect(hasDuplicates).toBe(false);
+    });
+  });
+
+  describe('with "live" source filter', () => {
+    const liveFilter = new Set<SourceFilter>(['live']);
+
+    test('returns only Live-sourced rows', async () => {
+      const hits = buildMixedHits();
+      const all = await fetchAllPages(hits, { pageSize: 10, activeFilters: liveFilter });
+
+      expect(all).toHaveLength(15);
+      expect(
+        all.every((r) => r.sourceType === 'live' && 'source' in r && r.source === 'Live')
+      ).toBe(true);
+    });
+
+    test('pagination works when Live rows span multiple pages', async () => {
+      const hits = buildMixedHits();
+
+      const page1 = await fetchPage(hits, { pageSize: 10, activeFilters: liveFilter });
+      expect(page1.rows).toHaveLength(10);
+      expect(page1.hasMore).toBe(true);
+
+      const page2 = await fetchPage(hits, {
+        pageSize: 10,
+        activeFilters: liveFilter,
+        nextPage: page1.nextPageToken,
+      });
+      expect(page2.rows).toHaveLength(5);
+      expect(page2.hasMore).toBe(false);
+    });
+
+    test('no rows are lost or duplicated across pages', async () => {
+      const hits = buildMixedHits();
+      const all = await fetchAllPages(hits, { pageSize: 7, activeFilters: liveFilter });
+      const ids = all.map((r) => r.id);
+
+      // no duplicates
+      expect(new Set(ids).size).toBe(ids.length);
+      // all 15 Live rows collected
+      expect(ids).toHaveLength(15);
+    });
+  });
+
+  describe('with "live" + "rule" source filter (both)', () => {
+    const bothFilter = new Set<SourceFilter>(['live', 'rule']);
+
+    test('returns all live action rows (both Live and Rule)', async () => {
+      const hits = buildMixedHits();
+      const all = await fetchAllPages(hits, { pageSize: 10, activeFilters: bothFilter });
+
+      expect(all).toHaveLength(25);
+    });
+
+    test('pagination works identically to unfiltered for live-only data', async () => {
+      const hits = buildMixedHits();
+      const page1 = await fetchPage(hits, { pageSize: 10, activeFilters: bothFilter });
+
+      expect(page1.rows).toHaveLength(10);
+      expect(page1.hasMore).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('single row matching filter: hasMore is false, one row returned', async () => {
+      const hits = [createHit('only-rule', { alertIds: ['a'] })];
+      const ruleFilter = new Set<SourceFilter>(['rule']);
+      const page = await fetchPage(hits, { pageSize: 10, activeFilters: ruleFilter });
+
+      expect(page.rows).toHaveLength(1);
+      expect(page.hasMore).toBe(false);
+    });
+
+    test('no rows matching filter: empty page, hasMore is false', async () => {
+      // all hits are Rule-sourced, but we filter for Live only
+      const hits = [createHit('r1', { alertIds: ['a'] }), createHit('r2', { alertIds: ['a'] })];
+      const liveFilter = new Set<SourceFilter>(['live']);
+      const page = await fetchPage(hits, { pageSize: 10, activeFilters: liveFilter });
+
+      expect(page.rows).toHaveLength(0);
+      expect(page.hasMore).toBe(false);
+    });
+
+    test('exact pageSize rows matching: hasMore is false', async () => {
+      // exactly 10 Rule hits, pageSize=10
+      const hits = Array.from({ length: 10 }, (_, i) => createHit(`r-${i}`, { alertIds: ['a'] }));
+      const ruleFilter = new Set<SourceFilter>(['rule']);
+      const page = await fetchPage(hits, { pageSize: 10, activeFilters: ruleFilter });
+
+      expect(page.rows).toHaveLength(10);
+      expect(page.hasMore).toBe(false);
+    });
+
+    test('pageSize + 1 rows matching: hasMore is true, exactly pageSize rows returned', async () => {
+      const hits = Array.from({ length: 11 }, (_, i) => createHit(`r-${i}`, { alertIds: ['a'] }));
+      const ruleFilter = new Set<SourceFilter>(['rule']);
+      const page = await fetchPage(hits, { pageSize: 10, activeFilters: ruleFilter });
+
+      expect(page.rows).toHaveLength(10);
+      expect(page.hasMore).toBe(true);
+    });
+
+    test('deeply paginated: cursor traversal reaches all rows without loss', async () => {
+      // 47 Live rows, pageSize 5 → 10 pages (9 full + 1 partial)
+      const hits = Array.from({ length: 47 }, (_, i) => createHit(`live-${i}`));
+      const liveFilter = new Set<SourceFilter>(['live']);
+      const all = await fetchAllPages(hits, { pageSize: 5, activeFilters: liveFilter });
+
+      expect(all).toHaveLength(47);
+      expect(new Set(all.map((r) => r.id)).size).toBe(47);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes pagination and row count mismatch in the Osquery History table when source filters (Live, Rule, Scheduled) are applied.

https://github.com/user-attachments/assets/4436a855-2075-418b-ac5b-02b8c681c76f

Closes #259695

## Problem

When users applied source filters on the History tab, pagination broke in two ways:

1. **Post-fetch filtering caused underfetch**: The server fetched a fixed `pageSize + 1` rows from Elasticsearch without any source-type filter, then discarded non-matching rows in JavaScript (`process_live_history.ts`). If, for example, the user filtered to "Rule" only and half the fetched rows were "Live", those were discarded — leaving fewer than `pageSize` rows. The `hasMore` flag was computed from the reduced set, so it would incorrectly report `false`, hiding subsequent pages even though more matching data existed in ES.

2. **Client silently dropped filters when all 3 sources were selected**: A guard in `use_unified_history.ts` (`sourceFilters.length < 3`) prevented sending the `sourceFilters` parameter when all three sources were checked. The server then treated the request as unfiltered, breaking the semantic contract.

## Solution

### Move source-type filtering into the Elasticsearch query (server)

The `alert_ids` field on Fleet action documents already distinguishes Rule-sourced actions (has `alert_ids`) from Live-sourced actions (no `alert_ids`). The fix adds an ES-level filter in `buildLiveActionsQuery`:

| Active filters | ES filter added |
|---|---|
| `live` only | `must_not: { exists: { field: 'alert_ids' } }` |
| `rule` only | `filter: { exists: { field: 'alert_ids' } }` |
| `live` + `rule` | no additional filter (all live actions match) |
| none | no additional filter |

This ensures ES returns exactly `pageSize + 1` **matching** rows, so the `hasMore` calculation and cursor pagination are always accurate.

### Remove post-fetch source filtering (server)

The redundant JavaScript filter in `processLiveHistory` (lines 64-70) that was the root cause of the underfetch has been removed. The function now returns all rows from ES as-is since ES already handles the filtering.

### Remove `length < 3` client guard (client)

The `sourceFilters.length < 3` condition in `useUnifiedHistory` has been removed. Filters are now always sent to the API when any sources are selected.

## Test plan

- [x] Unit tests for `buildLiveActionsQuery`: verifies `alert_ids` filter is added correctly for each source filter combination (live-only, rule-only, both, none, all-three)
- [x] Unit test for `processLiveHistory`: confirms no post-fetch source filtering occurs
- [x] Integration tests (`source_filter_pagination.test.ts`): 14 tests composing the full pipeline (query build → process → merge → cursor) with an in-memory ES stub, covering:
  - Baseline (no filter): all rows paginate correctly
  - Rule filter: only Rule rows returned, multi-page cursor works
  - Live filter: only Live rows returned, multi-page cursor works, no loss
  - Both filters: equivalent to unfiltered
  - Edge cases: single row, zero matches, exact pageSize boundary, pageSize+1 boundary, deep pagination (47 rows across 10 pages)
- [x] Type check passes
- [x] Full osquery Jest suite passes (847 tests)
- [ ] Manual: navigate to History tab, apply "Rule" filter with >pageSize Rule entries, verify pagination arrows work and all rows are reachable
- [ ] Manual: apply "Live" filter, verify same
- [ ] Manual: select all 3 filters, verify behaviour matches unfiltered view
