### PR TITLE
[Discover] Disallow editing of a managed data view via API

### DIFF
--- a/src/platform/plugins/shared/data_views/common/errors/index.ts
+++ b/src/platform/plugins/shared/data_views/common/errors/index.ts
@@ -10,3 +10,4 @@
 export * from './duplicate_index_pattern';
 export * from './data_view_saved_object_conflict';
 export * from './insufficient_access';
+export * from './managed_data_view';

--- a/src/platform/plugins/shared/data_views/common/errors/managed_data_view.ts
+++ b/src/platform/plugins/shared/data_views/common/errors/managed_data_view.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Error thrown when attempting to modify a managed data view.
+ * @public
+ */
+export class ManagedDataViewError extends Error {
+  /**
+   * constructor
+   * @param savedObjectId - Saved object id of data view for display in error message
+   */
+  constructor(savedObjectId?: string) {
+    super(
+      `Cannot modify managed data view${
+        savedObjectId ? `, id: ${savedObjectId}` : ''
+      }. Duplicate the data view and make changes to the copy instead.`
+    );
+    this.name = 'ManagedDataViewError';
+  }
+}

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.test.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.test.ts
@@ -10,13 +10,27 @@
 import { updateDataView } from './update_data_view';
 import { dataViewsService } from '../../mocks';
 import { getUsageCollection } from './test_utils';
+import { ManagedDataViewError } from '../../../common/errors';
+import type { DataViewLazy } from '../../../common';
 
-describe('get default data view', () => {
-  it('call usageCollection', async () => {
+describe('updateDataView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls usageCollection', async () => {
     const usageCollection = getUsageCollection();
+    dataViewsService.getDataViewLazy.mockImplementation(
+      async () =>
+        ({
+          managed: false,
+          title: 'kibana*',
+        } as unknown as DataViewLazy)
+    );
+
     await updateDataView({
       dataViewsService,
-      counterName: 'GET /path',
+      counterName: 'POST /path',
       usageCollection,
       spec: {
         title: 'kibana*',
@@ -24,6 +38,46 @@ describe('get default data view', () => {
       id: 'abc',
       refreshFields: false,
     });
-    expect(usageCollection.incrementCounter).toBeCalledTimes(1);
+    expect(usageCollection.incrementCounter).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws ManagedDataViewError when data view is managed', async () => {
+    dataViewsService.getDataViewLazy.mockImplementation(
+      async () =>
+        ({
+          managed: true,
+          title: 'managed-pattern*',
+        } as unknown as DataViewLazy)
+    );
+
+    await expect(
+      updateDataView({
+        dataViewsService,
+        counterName: 'POST /path',
+        spec: { title: 'new-title*' },
+        id: 'managed-id',
+        refreshFields: false,
+      })
+    ).rejects.toThrow(ManagedDataViewError);
+
+    expect(dataViewsService.updateSavedObject).not.toHaveBeenCalled();
+  });
+
+  it('allows update when data view is not managed', async () => {
+    const mockDataView = {
+      managed: false,
+      title: 'old-title*',
+    } as unknown as DataViewLazy;
+    dataViewsService.getDataViewLazy.mockImplementation(async () => mockDataView);
+
+    await updateDataView({
+      dataViewsService,
+      counterName: 'POST /path',
+      spec: { title: 'new-title*' },
+      id: 'regular-id',
+      refreshFields: false,
+    });
+
+    expect(dataViewsService.updateSavedObject).toHaveBeenCalledWith(mockDataView);
   });
 });

--- a/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
+++ b/src/platform/plugins/shared/data_views/server/rest_api_routes/public/update_data_view.ts
@@ -16,6 +16,7 @@ import type { DataViewSpec } from '../../../common/types';
 import { handleErrors } from './util/handle_errors';
 import { fieldSpecSchema, runtimeFieldSchema, serializedFieldFormatSchema } from '../../schemas';
 import { dataViewSpecSchema } from '../schema';
+import { ManagedDataViewError } from '../../../common/errors';
 import type {
   DataViewsServerPluginStartDependencies,
   DataViewsServerPluginStart,
@@ -69,6 +70,11 @@ export const updateDataView = async ({
 }: UpdateDataViewArgs) => {
   usageCollection?.incrementCounter({ counterName });
   const dataView = await dataViewsService.getDataViewLazy(id);
+
+  if (dataView.managed) {
+    throw new ManagedDataViewError(id);
+  }
+
   const {
     title,
     timeFieldName,


### PR DESCRIPTION
- Resolves https://github.com/elastic/kibana/issues/259721

## Summary

This logic was implemented in UI but was missing in API code.

<img width="1424" height="371" alt="Screenshot 2026-03-26 at 15 59 23" src="https://github.com/user-attachments/assets/81cdfbd0-d8e5-4190-bd74-f42a1d6e2e1a" />



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



