### PR TITLE
filter out cypress svl tests to only run against main

### DIFF
--- a/.buildkite/pipeline-utils/buildkite/utils.test.ts
+++ b/.buildkite/pipeline-utils/buildkite/utils.test.ts
@@ -124,9 +124,12 @@ describe('getPipeline', () => {
     const pipelineSource = fs.readFileSync(pullRequestPipeline, 'utf8');
     const cancelablePipelines = [
       ...new Set(
-        [...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs)].map(
-          ([, filename]) => path.resolve(repoRoot, filename)
-        )
+        [
+          ...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs),
+          ...pipelineSource.matchAll(
+            /getPipeline\(\s*'([^']+\.yml)'\s*,\s*\{\s*\.\.\.cancelable,\s*gateServerlessStepsToMainPrBase:\s*true\s*\}\s*\)/gs
+          ),
+        ].map(([, filename]) => path.resolve(repoRoot, filename))
       ),
     ];
 
@@ -148,9 +151,12 @@ describe('getPipeline', () => {
     // Collect all cancelable pipeline files
     const cancelablePipelines = [
       ...new Set(
-        [...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs)].map(
-          ([, filename]) => path.resolve(repoRoot, filename)
-        )
+        [
+          ...pipelineSource.matchAll(/getPipeline\(\s*'([^']+\.yml)'\s*,\s*cancelable\s*\)/gs),
+          ...pipelineSource.matchAll(
+            /getPipeline\(\s*'([^']+\.yml)'\s*,\s*\{\s*\.\.\.cancelable,\s*gateServerlessStepsToMainPrBase:\s*true\s*\}\s*\)/gs
+          ),
+        ].map(([, filename]) => path.resolve(repoRoot, filename))
       ),
     ];
 

--- a/.buildkite/pipeline-utils/buildkite/utils.ts
+++ b/.buildkite/pipeline-utils/buildkite/utils.ts
@@ -9,16 +9,20 @@
 
 import { execFileSync } from 'child_process';
 import fs from 'fs';
-import { load as loadYaml } from 'js-yaml';
+import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
 
 export function emitPipeline(pipelineSteps: string[]) {
   const pipelineStr = [...new Set(pipelineSteps)].join('\n');
   console.log(pipelineStr);
 }
 
+const SERVERLESS_CYPRESS_PR_IF = 'build.pull_request.base_branch == "main"';
+
 export interface GetPipelineOptions {
   removeSteps?: boolean;
   cancelOnGateFailure?: boolean;
+  /** If set, command steps whose `key` contains `serverless` get `if` so they run only when the PR targets `main`. */
+  gateServerlessStepsToMainPrBase?: boolean;
 }
 
 function isObj(x: unknown): x is Record<string, unknown> {
@@ -104,16 +108,50 @@ function registerCancelOnGateFailureMetadata(keys: string[]) {
   }
 }
 
+function isServerlessKeyedStep(step: Record<string, unknown>): boolean {
+  return typeof step.key === 'string' && /serverless/i.test(step.key);
+}
+
+function applyGateServerlessStepsToMainPrBase(filename: string, doc: unknown): void {
+  const steps = getSteps(filename, doc);
+
+  const walk = (stepList: unknown[]) => {
+    for (const step of stepList) {
+      if (!isObj(step)) {
+        continue;
+      }
+
+      if (typeof step.group === 'string' && Array.isArray(step.steps)) {
+        walk(step.steps as unknown[]);
+        continue;
+      }
+
+      if (isCommandStep(step) && isServerlessKeyedStep(step) && step.if === undefined) {
+        step.if = SERVERLESS_CYPRESS_PR_IF;
+      }
+    }
+  };
+
+  walk(steps);
+}
+
 export const getPipeline = (filename: string, options?: boolean | GetPipelineOptions) => {
   const opts: GetPipelineOptions =
     typeof options === 'boolean' ? { removeSteps: options } : { removeSteps: true, ...options };
 
   const str = fs.readFileSync(filename).toString();
 
-  if (opts.cancelOnGateFailure) {
+  if (opts.cancelOnGateFailure || opts.gateServerlessStepsToMainPrBase) {
     const doc = loadYaml(str);
-    const keys = extractStepKeys(filename, doc);
-    registerCancelOnGateFailureMetadata(keys);
+    if (opts.gateServerlessStepsToMainPrBase) {
+      applyGateServerlessStepsToMainPrBase(filename, doc);
+    }
+    if (opts.cancelOnGateFailure) {
+      const keys = extractStepKeys(filename, doc);
+      registerCancelOnGateFailureMetadata(keys);
+    }
+    const outStr = opts.gateServerlessStepsToMainPrBase ? dumpYaml(doc) : str;
+    return opts.removeSteps ? outStr.replace(/^steps:/, '') : outStr;
   }
 
   return opts.removeSteps ? str.replace(/^steps:/, '') : str;

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -299,10 +299,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -320,10 +320,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -363,37 +363,40 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml', cancelable)
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/ai4dsoc.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/automatic_import.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/automatic_import.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/detection_engine.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/detection_engine.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/entity_analytics.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/rule_management.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/rule_management.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -463,7 +466,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml', cancelable)
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/explore.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -530,10 +536,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/investigations.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/investigations.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -549,10 +555,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -570,7 +576,7 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(
         getPipeline(
           '.buildkite/pipelines/pull_request/security_solution/cloud_security_posture.yml',
-          cancelable
+          { ...cancelable, gateServerlessStepsToMainPrBase: true }
         )
       );
     }
@@ -590,7 +596,7 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       pipeline.push(
         getPipeline(
           '.buildkite/pipelines/pull_request/security_solution/cspm_agentless_scout.yml',
-          cancelable
+          { ...cancelable, gateServerlessStepsToMainPrBase: true }
         )
       );
     }
@@ -601,10 +607,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/gen_ai_evals.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 
@@ -629,10 +635,10 @@ const SKIPPABLE_PR_MATCHERS = prConfig.skip_ci_on_only_changed!.map((r) => new R
       ALL_UI_TEST_SUITES
     ) {
       pipeline.push(
-        getPipeline(
-          '.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml',
-          cancelable
-        )
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/asset_inventory.yml', {
+          ...cancelable,
+          gateServerlessStepsToMainPrBase: true,
+        })
       );
     }
 


### PR DESCRIPTION
## Summary

Disabling Cypress Serverless steps for non-`main` branch as Serverless is always released from `main`. We don't need to run the tests against 9.x branches.



