### PR TITLE
[Security Solution] fixed enhanced security profile header showing for non-alert documents

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -9,6 +9,7 @@
 
 import type { DataTableRecord } from '@kbn/discover-utils';
 import type { ProfileProviderServices } from '../profile_provider_services';
+import { DocumentType } from '../../profiles';
 import { createSecurityDocumentProfileProviders } from './security_profile_providers';
 
 const createRecord = (flattened: DataTableRecord['flattened']): DataTableRecord =>
@@ -28,9 +29,10 @@ const getDocViewerResult = (record: DataTableRecord) => {
     docViewsRegistry: jest.fn((r) => r),
   };
   const prev = jest.fn().mockReturnValue(prevDocViewer);
-  const result = enhancedProvider.profile.getDocViewer!(prev)({ record } as Parameters<
-    ReturnType<typeof enhancedProvider.profile.getDocViewer>
-  >[0]);
+  const getDocViewer = enhancedProvider.profile.getDocViewer!(prev, {
+    context: { type: DocumentType.Default },
+  });
+  const result = getDocViewer({ actions: {}, record } as Parameters<typeof getDocViewer>[0]);
   return { result, prevRenderHeader };
 };
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { ProfileProviderServices } from '../profile_provider_services';
+import { createSecurityDocumentProfileProviders } from './security_profile_providers';
+
+const createRecord = (flattened: DataTableRecord['flattened']): DataTableRecord =>
+  ({
+    id: '1',
+    raw: {},
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
+
+const getDocViewerResult = (record: DataTableRecord) => {
+  const providerServices = {} as ProfileProviderServices;
+  const [enhancedProvider] = createSecurityDocumentProfileProviders(providerServices);
+  const prevRenderHeader = jest.fn();
+  const prevDocViewer = {
+    renderHeader: prevRenderHeader,
+    docViewsRegistry: jest.fn((r) => r),
+  };
+  const prev = jest.fn().mockReturnValue(prevDocViewer);
+  const result = enhancedProvider.profile.getDocViewer!(prev)({ record } as Parameters<
+    ReturnType<typeof enhancedProvider.profile.getDocViewer>
+  >[0]);
+  return { result, prevRenderHeader };
+};
+
+describe('createSecurityDocumentProfileProviders', () => {
+  describe('getDocViewer', () => {
+    it('overrides renderHeader for alert documents', () => {
+      const { result, prevRenderHeader } = getDocViewerResult(
+        createRecord({ 'event.kind': 'signal' })
+      );
+
+      expect(result.renderHeader).toBeDefined();
+      expect(result.renderHeader).not.toBe(prevRenderHeader);
+    });
+
+    it('does not override renderHeader for non-alert documents', () => {
+      const { result, prevRenderHeader } = getDocViewerResult(
+        createRecord({ 'event.kind': 'event' })
+      );
+
+      expect(result.renderHeader).toBe(prevRenderHeader);
+    });
+
+    it('adds the overview tab to the registry for alert documents', () => {
+      const { result } = getDocViewerResult(createRecord({ 'event.kind': 'signal' }));
+      const registry = { add: jest.fn() };
+      result.docViewsRegistry(registry as never);
+
+      expect(registry.add).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'doc_view_alerts_overview' })
+      );
+    });
+
+    it('does not add the overview tab to the registry for non-alert documents', () => {
+      const { result } = getDocViewerResult(createRecord({ 'event.kind': 'event' }));
+      const registry = { add: jest.fn() };
+      result.docViewsRegistry(registry as never);
+
+      expect(registry.add).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -30,13 +30,15 @@ export const createSecurityDocumentProfileProviders = (
 
         return {
           ...prevDocViewer,
-          renderHeader: (props) => (
-            <EnhancedAlertFlyoutHeaderLazy
-              {...props}
-              providerServices={providerServices}
-              fallbackRenderHeader={prevDocViewer.renderHeader}
-            />
-          ),
+          renderHeader: isAlert
+            ? (props) => (
+                <EnhancedAlertFlyoutHeaderLazy
+                  {...props}
+                  providerServices={providerServices}
+                  fallbackRenderHeader={prevDocViewer.renderHeader}
+                />
+              )
+            : prevDocViewer.renderHeader,
           docViewsRegistry: (registry) => {
             if (isAlert) {
               registry.add({


### PR DESCRIPTION
## Summary

A bug was found during a recent PR review. The enhanced security profile header for the document flyout in Discover is showing for alert document (which is correct) but also for non-alert documents, like events or attacks (which is not expected).

This PR makes a small code change to ensure that for now we're only displaying the header for alert document.

### Alert documents

| Before | After |
| ------------- | ------------- |
| <img width="1255" height="832" alt="Screenshot 2026-03-26 at 9 57 38 AM" src="https://github.com/user-attachments/assets/ca0f2c13-f718-4c79-b674-425b0e519327" /> | <img width="1256" height="835" alt="Screenshot 2026-03-26 at 9 51 23 AM" src="https://github.com/user-attachments/assets/5a5715ac-eff3-47d1-ba73-641137107f6a" /> |

### Attack documents

| Before | After |
| ------------- | ------------- |
| <img width="1255" height="831" alt="Screenshot 2026-03-26 at 9 58 12 AM" src="https://github.com/user-attachments/assets/87de509d-7335-42b5-b41b-6f1cd94f0b94" /> | <img width="1255" height="832" alt="Screenshot 2026-03-26 at 9 52 42 AM" src="https://github.com/user-attachments/assets/9db71a02-13b3-4e3a-bacb-a492dd11e505" /> |

### Event documents

| Before | After |
| ------------- | ------------- |
| <img width="1254" height="832" alt="Screenshot 2026-03-26 at 9 57 23 AM" src="https://github.com/user-attachments/assets/475bbd81-d2be-40ec-ac7d-fa5fd8f5a6ef" /> | <img width="1254" height="832" alt="Screenshot 2026-03-26 at 9 53 05 AM" src="https://github.com/user-attachments/assets/8c5cf54e-e3dc-407b-a02c-074069b7b50b" /> |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
