### PR TITLE
Increase `Check saved objects changes` CI step timeout

### DIFF
--- a/.buildkite/pipelines/pull_request/check_saved_objects.yml
+++ b/.buildkite/pipelines/pull_request/check_saved_objects.yml
@@ -8,7 +8,7 @@ steps:
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:
       - build
-    timeout_in_minutes: 10
+    timeout_in_minutes: 12
     soft_fail: true # Can be removed when we are confident that this check is not too disruptive
     retry:
       automatic:


### PR DESCRIPTION
## Summary

Recent executions are very close to the current timeout, and some of them are simply failing.