### PR TITLE
Enable OAuth on Salesforce connector

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.test.ts
@@ -28,6 +28,32 @@ describe('SalesforceConnector', () => {
     jest.clearAllMocks();
   });
 
+  describe('auth', () => {
+    it('supports oauth_client_credentials auth', () => {
+      const types = (SalesforceConnector.auth?.types as Array<string | { type: string }>).map((t) =>
+        typeof t === 'string' ? t : t.type
+      );
+      expect(types).toContain('oauth_client_credentials');
+    });
+
+    it('supports oauth_authorization_code with correct Salesforce defaults', () => {
+      const oauthType = (
+        SalesforceConnector.auth?.types as Array<
+          string | { type: string; defaults?: Record<string, unknown> }
+        >
+      ).find((t) => typeof t === 'object' && t.type === 'oauth_authorization_code');
+      expect(oauthType).toBeDefined();
+      expect(oauthType).toMatchObject({
+        type: 'oauth_authorization_code',
+        defaults: {
+          authorizationUrl: 'https://login.salesforce.com/services/oauth2/authorize',
+          tokenUrl: 'https://login.salesforce.com/services/oauth2/token',
+          scope: 'api refresh_token',
+        },
+      });
+    });
+  });
+
   describe('query action', () => {
     it('should run SOQL query', async () => {
       const mockResponse = {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/salesforce/salesforce.ts
@@ -71,6 +71,14 @@ export const SalesforceConnector: ConnectorSpec = {
           },
         },
       },
+      {
+        type: 'oauth_authorization_code',
+        defaults: {
+          authorizationUrl: 'https://login.salesforce.com/services/oauth2/authorize',
+          tokenUrl: 'https://login.salesforce.com/services/oauth2/token',
+          scope: 'api refresh_token',
+        },
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/search-team/issues/13432
Tested as part of https://github.com/elastic/kibana/pull/259549

**Release note:** Enabled OAuth for authorising new (Tech Preview) Connector: Salesforce. Users can now authorise using their own [OAuth app](https://help.salesforce.com/s/articleView?id=platform.ev_relay_create_connected_app.htm&type=5).

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


