### PR TITLE
[Alerting v2] Lower MIN_SCHEDULE_INTERVAL from 1m to 5s

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/constants.ts
@@ -12,4 +12,4 @@ export const MAX_CONSECUTIVE_BREACHES = 1000;
 export const MAX_DURATION = '365d';
 
 /** Minimum allowed interval for schedule.every */
-export const MIN_SCHEDULE_INTERVAL = '1m';
+export const MIN_SCHEDULE_INTERVAL = '5s';

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-schemas/src/rule_data_schema.test.ts
@@ -202,28 +202,19 @@ describe('createRuleDataSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    it('accepts schedule.every of exactly 1m (minimum)', () => {
+    it('accepts schedule.every of exactly 5s (minimum)', () => {
       const result = createRuleDataSchema.safeParse({
         ...validCreateData,
-        schedule: { every: '1m' },
+        schedule: { every: '5s' },
       });
 
       expect(result.success).toBe(true);
     });
 
-    it('rejects schedule.every below 1m (30s)', () => {
+    it('rejects schedule.every below 5s (4s)', () => {
       const result = createRuleDataSchema.safeParse({
         ...validCreateData,
-        schedule: { every: '30s' },
-      });
-
-      expect(result.success).toBe(false);
-    });
-
-    it('rejects schedule.every below 1m via cross-unit (59s)', () => {
-      const result = createRuleDataSchema.safeParse({
-        ...validCreateData,
-        schedule: { every: '59s' },
+        schedule: { every: '4s' },
       });
 
       expect(result.success).toBe(false);
@@ -747,8 +738,8 @@ describe('updateRuleDataSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    it('rejects schedule.every below 1m (30s)', () => {
-      const result = updateRuleDataSchema.safeParse({ schedule: { every: '30s' } });
+    it('rejects schedule.every below 5s (4s)', () => {
+      const result = updateRuleDataSchema.safeParse({ schedule: { every: '4s' } });
       expect(result.success).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #258526, which added a `MIN_SCHEDULE_INTERVAL = '1m'` server-side validation on `schedule.every`. This broke the Scout `episode_lifecycle` tests that create rules with a `5s` schedule interval — the API now rejects those requests, causing the "should track multiple groups independently" test (and others in the suite) to fail.

**Fix:** Lower `MIN_SCHEDULE_INTERVAL` from `'1m'` to `'5s'` in `constants.ts`. Update corresponding unit tests to reflect the new boundary.

**Test removal:** Removes one `createRuleDataSchema` test case ("rejects schedule.every below 1m via cross-unit (59s)") that was meant to validate cross-unit comparison but wasn't doing that for 1m so was an unnecessary test before and after these PR changes. (if the min value had been 2m, you could test failures at 1m and at 95s, and that's cross-unit testing ... but when the value is 1m and the lowest unit we allow is seconds, there's no cross-unit test possible). 

A follow-up issue will be created to discuss whether `5s` is the right long-term minimum or if this should be configurable per environment.

## Test plan

- [x] `rule_data_schema.test.ts` — 95 tests pass
- [x] `validation.test.ts` — 48 tests pass

Made with [Cursor](https://cursor.com)