### PR TITLE
[Inference] Only save explicitly saved inference endpoint lists

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { useModelSettingsForm } from './use_model_settings_form';
 import { useRegisteredFeatures } from '../../hooks/use_registered_features';
 import { useInferenceSettings, useSaveInferenceSettings } from '../../hooks/use_inference_settings';
@@ -142,10 +143,7 @@ describe('useModelSettingsForm', () => {
     });
 
     expect(mockSaveSettings).toHaveBeenCalledWith({
-      features: expect.arrayContaining([
-        { feature_id: 'child_1', endpoints: [{ id: 'ep-1' }, { id: 'ep-2' }] },
-        { feature_id: 'child_2', endpoints: [{ id: 'endpoint-c' }] },
-      ]),
+      features: [{ feature_id: 'child_1', endpoints: [{ id: 'ep-1' }, { id: 'ep-2' }] }],
     });
   });
 
@@ -163,6 +161,7 @@ describe('useModelSettingsForm', () => {
     expect(result.current.assignments.child_1).toEqual(['endpoint-a', 'endpoint-b']);
     expect(result.current.assignments.child_2).toEqual(['endpoint-c']);
     expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(mockSaveSettings).toHaveBeenCalledWith({ features: [] });
   });
 
   it('resetSection does nothing for unknown section', () => {
@@ -175,7 +174,7 @@ describe('useModelSettingsForm', () => {
     expect(mockSaveSettings).not.toHaveBeenCalled();
   });
 
-  it('falls back to parent recommendedEndpoints when child has none', () => {
+  it('falls back to Kibana default endpoint when child and parent have no recommendations', () => {
     const childWithNoRecommended: InferenceFeatureConfig = {
       ...childFeature2,
       recommendedEndpoints: [],
@@ -187,7 +186,9 @@ describe('useModelSettingsForm', () => {
 
     const { result } = renderHook(() => useModelSettingsForm());
 
-    expect(result.current.assignments.child_2).toEqual([]);
+    expect(result.current.assignments.child_2).toEqual([
+      defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION,
+    ]);
   });
 
   it('falls back to parent recommendedEndpoints when parent has them and child has none', () => {
@@ -233,6 +234,30 @@ describe('useModelSettingsForm', () => {
     });
 
     expect(result.current.assignments.child_2).toEqual(['parent-ep']);
+  });
+
+  it('save excludes features matching Kibana default endpoint from payload', () => {
+    const childWithNoRecommended: InferenceFeatureConfig = {
+      ...childFeature2,
+      recommendedEndpoints: [],
+    };
+    mockUseRegisteredFeatures.mockReturnValue({
+      features: [parentFeature, childFeature1, childWithNoRecommended],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useModelSettingsForm());
+
+    act(() => {
+      result.current.updateEndpoints('child_1', ['ep-1']);
+    });
+    act(() => {
+      result.current.save();
+    });
+
+    expect(mockSaveSettings).toHaveBeenCalledWith({
+      features: [{ feature_id: 'child_1', endpoints: [{ id: 'ep-1' }] }],
+    });
   });
 
   it('isLoading is true when any dependency is loading', () => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/use_model_settings_form.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { defaultInferenceEndpoints } from '@kbn/inference-common';
 import { useInferenceSettings, useSaveInferenceSettings } from '../../hooks/use_inference_settings';
 import { useRegisteredFeatures } from '../../hooks/use_registered_features';
 import type { InferenceFeatureResponse } from '../../../common/types';
@@ -30,18 +31,48 @@ export interface ModelSettingsForm {
 const getEffectiveEndpoints = (
   feature: { recommendedEndpoints: string[]; parentFeatureId?: string },
   recommendedEndpointsById: Map<string, string[]>
-): string[] =>
-  feature.recommendedEndpoints.length > 0
-    ? feature.recommendedEndpoints
-    : feature.parentFeatureId
-    ? recommendedEndpointsById.get(feature.parentFeatureId) ?? []
-    : [];
+): string[] => {
+  if (feature.recommendedEndpoints.length > 0) {
+    return feature.recommendedEndpoints;
+  }
+  if (feature.parentFeatureId) {
+    const parentEndpoints = recommendedEndpointsById.get(feature.parentFeatureId) ?? [];
+    if (parentEndpoints.length > 0) {
+      return parentEndpoints;
+    }
+  }
+  return [defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION];
+};
 
 const toApiFormat = (assignments: Assignments) =>
   Object.entries(assignments).map(([featureId, ids]) => ({
     feature_id: featureId,
     endpoints: ids.map((id) => ({ id })),
   }));
+
+const arraysEqual = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((v, i) => v === b[i]);
+
+/**
+ * Returns only the assignments that differ from the recommended defaults.
+ * Features whose endpoints match the defaults are omitted so the server-side
+ * fallback chain (recommendedEndpoints → parent) stays in effect.
+ */
+const getChangedAssignments = (
+  assignments: Assignments,
+  registeredFeatures: InferenceFeatureResponse[],
+  recommendedEndpointsById: Map<string, string[]>
+): Assignments => {
+  const featureById = new Map(registeredFeatures.map((f) => [f.featureId, f]));
+  return Object.fromEntries(
+    Object.entries(assignments).filter(([featureId, ids]) => {
+      const feature = featureById.get(featureId);
+      if (!feature) return true;
+      const defaults = getEffectiveEndpoints(feature, recommendedEndpointsById);
+      return !arraysEqual(ids, defaults);
+    })
+  );
+};
 
 export const useModelSettingsForm = (): ModelSettingsForm => {
   const { features: registeredFeatures, isLoading: isFeaturesLoading } = useRegisteredFeatures();
@@ -114,8 +145,13 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
   }, []);
 
   const save = useCallback(() => {
-    saveSettings({ features: toApiFormat(assignments) });
-  }, [saveSettings, assignments]);
+    const changed = getChangedAssignments(
+      assignments,
+      registeredFeatures,
+      recommendedEndpointsById
+    );
+    saveSettings({ features: toApiFormat(changed) });
+  }, [saveSettings, assignments, registeredFeatures, recommendedEndpointsById]);
 
   const resetSection = useCallback(
     (sectionId: string) => {
@@ -130,9 +166,10 @@ export const useModelSettingsForm = (): ModelSettingsForm => {
       );
       const updated = { ...assignments, ...resetEntries };
       setAssignments(updated);
-      saveSettings({ features: toApiFormat(updated) });
+      const changed = getChangedAssignments(updated, registeredFeatures, recommendedEndpointsById);
+      saveSettings({ features: toApiFormat(changed) });
     },
-    [assignments, sections, saveSettings, recommendedEndpointsById]
+    [assignments, sections, saveSettings, recommendedEndpointsById, registeredFeatures]
   );
 
   return {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.test.ts
@@ -7,7 +7,11 @@
 
 import type { ISavedObjectsRepository, Logger, SavedObject } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
-import { type InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
+import {
+  type InferenceConnector,
+  InferenceConnectorType,
+  defaultInferenceEndpoints,
+} from '@kbn/inference-common';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { InferenceFeatureConfig } from './types';
 import type { InferenceSettingsAttributes } from '../common/types';
@@ -97,17 +101,18 @@ describe('getForFeature', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('not registered'));
   });
 
-  it('returns empty endpoints for features with no SO and no recommendations', async () => {
+  it('falls back to Kibana default endpoint when no SO and no recommendations', async () => {
+    const defaultEp = defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION;
     registry.register(createValidFeature({ featureId: 'f1', taskType: 'chat_completion' }));
     const result = await getForFeature(
       registry,
       createSoClient(),
-      createGetConnectorById([]),
+      createGetConnectorById([defaultEp]),
       'f1',
       logger
     );
     expect(result).toEqual({
-      endpoints: [],
+      endpoints: [createConnector(defaultEp)],
       warnings: [],
       soEntryFound: false,
     });
@@ -389,6 +394,28 @@ describe('getForFeature', () => {
       getForFeature(registry, createSoClient(), createGetConnectorById(['gp_ep']), 'child', logger)
     ).resolves.toEqual({
       endpoints: [createConnector('gp_ep')],
+      warnings: [],
+      soEntryFound: false,
+    });
+  });
+
+  it('prefers recommendedEndpoints over Kibana default endpoint', async () => {
+    registry.register(
+      createValidFeature({
+        featureId: 'f1',
+        recommendedEndpoints: ['rec1'],
+      })
+    );
+    await expect(
+      getForFeature(
+        registry,
+        createSoClient(),
+        createGetConnectorById(['rec1', defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION]),
+        'f1',
+        logger
+      )
+    ).resolves.toEqual({
+      endpoints: [createConnector('rec1')],
       warnings: [],
       soEntryFound: false,
     });

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/inference_endpoints.ts
@@ -8,7 +8,7 @@
 import type { ISavedObjectsRepository, Logger } from '@kbn/core/server';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import type { InferenceConnector } from '@kbn/inference-common';
+import { type InferenceConnector, defaultInferenceEndpoints } from '@kbn/inference-common';
 import { INFERENCE_SETTINGS_SO_TYPE, INFERENCE_SETTINGS_ID } from '../common/constants';
 import type { InferenceSettingsAttributes } from '../common/types';
 import type { InferenceFeatureRegistry } from './inference_feature_registry';
@@ -177,7 +177,9 @@ const resolveEndpointIds = async (
   }
 
   return {
-    ids: recEntry?.recommendedEndpoints ?? [],
+    ids: recEntry?.recommendedEndpoints ?? [
+      defaultInferenceEndpoints.KIBANA_DEFAULT_CHAT_COMPLETION,
+    ],
     warnings: [],
     soEntryFound: false,
   };


### PR DESCRIPTION


## Summary

Only save changed inference endpoint assignments.

- Filter out assignments matching recommended defaults before saving to the inference settings saved object, so the server-side fallback chain (recommendedEndpoints => parent.recommendedEndpoints) stays active for unchanged features.
- Fall back to the Kibana default chat completion endpoint when a feature has no recommended endpoints and no parent with recommendations, instead of showing an empty list.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
