### PR TITLE
[AiButton/O11y] AiButton migration

### DIFF
--- a/src/platform/plugins/shared/workflows_management/moon.yml
+++ b/src/platform/plugins/shared/workflows_management/moon.yml
@@ -84,6 +84,7 @@ dependsOn:
   - '@kbn/securitysolution-rules'
   - '@kbn/alerts-as-data-utils'
   - '@kbn/shared-ux-utility'
+  - '@kbn/shared-ux-ai-components'
   - '@kbn/licensing-types'
   - '@kbn/core-lifecycle-server-mocks'
   - '@kbn/scout'

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -25,6 +25,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import type YAML from 'yaml';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { monaco, YAML_LANG_ID } from '@kbn/monaco';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import { isTriggerType } from '@kbn/workflows';
 import type { z } from '@kbn/zod/v4';
 import { ActionsMenuButton } from './actions_menu_button';
@@ -671,9 +672,10 @@ export const WorkflowYAMLEditor = ({
                     />
                   }
                 >
-                  <EuiButtonEmpty
+                  <AiButton
                     iconType="sparkles"
                     size="xs"
+                    variant="empty"
                     aria-label="Open AI Agent"
                     onClick={() => openAgentChat()}
                     data-test-subj="workflowYamlEditorAiAgentButton"
@@ -682,7 +684,7 @@ export const WorkflowYAMLEditor = ({
                       id="workflows.yamlEditor.aiAgentButtonLabel"
                       defaultMessage="AI Agent"
                     />
-                  </EuiButtonEmpty>
+                  </AiButton>
                 </EuiToolTip>
               </EuiFlexItem>
             )}

--- a/src/platform/plugins/shared/workflows_management/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_management/tsconfig.json
@@ -82,6 +82,7 @@
     "@kbn/securitysolution-rules",
     "@kbn/alerts-as-data-utils",
     "@kbn/shared-ux-utility",
+    "@kbn/shared-ux-ai-components",
     "@kbn/licensing-types",
     "@kbn/core-lifecycle-server-mocks",
     "@kbn/scout",

--- a/x-pack/platform/plugins/shared/streams_app/moon.yml
+++ b/x-pack/platform/plugins/shared/streams_app/moon.yml
@@ -109,6 +109,7 @@ dependsOn:
   - '@kbn/inference-endpoint-ui-common'
   - '@kbn/stack-connectors-plugin'
   - '@kbn/std'
+  - '@kbn/shared-ux-ai-components'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.tsx
@@ -4,8 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { EuiLoadingSpinnerProps } from '@elastic/eui';
+import type { EuiButtonProps } from '@elastic/eui';
 import {
+  EuiButton,
   EuiButtonIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -15,10 +16,10 @@ import {
   EuiPopover,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import { i18n } from '@kbn/i18n';
 import { useBoolean } from '@kbn/react-hooks';
 import React from 'react';
-import { AiButton, type AiButtonProps } from '@kbn/shared-ux-ai-components';
 import type { AIFeatures } from '../../hooks/use_ai_features';
 import { useAIFeatures } from '../../hooks/use_ai_features';
 import { EnableAIFeaturesLink } from '../enable_ai_features_link/enable_ai_features_link';
@@ -35,10 +36,7 @@ export function ConnectorListButtonBase({
   buttonProps,
   aiFeatures,
 }: {
-  buttonProps: AiButtonProps & {
-    fill?: boolean;
-    size?: EuiLoadingSpinnerProps['size'];
-  };
+  buttonProps: EuiButtonProps & { onClick?: () => void };
   aiFeatures: Pick<AIFeatures, 'couldBeEnabled' | 'enabled' | 'genAiConnectors'> | null;
 }) {
   const [isPopoverOpen, { off: closePopover, toggle: togglePopover }] = useBoolean(false);
@@ -62,20 +60,44 @@ export function ConnectorListButtonBase({
 
   const connectorsResult = aiFeatures.genAiConnectors;
 
+  let primaryButton: React.ReactElement;
+  if (
+    buttonProps.iconType === 'sparkles' ||
+    buttonProps.iconType === 'aiAssistantLogo' ||
+    buttonProps.iconType === 'productAgent'
+  ) {
+    const {
+      iconType: _unusedIconType,
+      fill: sparklesFill,
+      css: _unusedSparklesCss,
+      ...rest
+    } = buttonProps;
+    primaryButton = (
+      <AiButton
+        isDisabled={!connectorsResult?.connectors?.length}
+        isLoading={connectorsResult?.loading}
+        size={buttonSize}
+        variant={sparklesFill ?? false ? 'accent' : 'base'}
+        iconType="sparkles"
+        {...rest}
+      />
+    );
+  } else {
+    const { css: _unusedEuiButtonCss, ...rest } = buttonProps;
+    primaryButton = (
+      <EuiButton
+        isDisabled={!connectorsResult?.connectors?.length}
+        isLoading={connectorsResult?.loading}
+        size={buttonSize}
+        fill={fill}
+        {...rest}
+      />
+    );
+  }
+
   return (
     <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
-      <EuiFlexItem grow={false}>
-        <AiButton
-          isDisabled={!connectorsResult?.connectors?.length}
-          isLoading={connectorsResult?.loading}
-          size={buttonSize}
-          variant={fill ? 'accent' : 'base'}
-          iconType="sparkles"
-          {...buttonProps}
-        >
-          {buttonProps.children}
-        </AiButton>
-      </EuiFlexItem>
+      <EuiFlexItem grow={false}>{primaryButton}</EuiFlexItem>
       {connectorsResult?.connectors && connectorsResult.connectors.length >= 2 && (
         <EuiFlexItem grow={false}>
           <EuiPopover
@@ -126,10 +148,7 @@ export function ConnectorListButtonBase({
 export function ConnectorListButton({
   buttonProps,
 }: {
-  buttonProps: AiButtonProps & {
-    fill?: boolean;
-    size?: EuiLoadingSpinnerProps['size'];
-  };
+  buttonProps: EuiButtonProps & { onClick?: () => void };
 }) {
   const aiFeatures = useAIFeatures();
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/connector_list_button/connector_list_button.tsx
@@ -4,9 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { EuiButtonProps } from '@elastic/eui';
+import type { EuiLoadingSpinnerProps } from '@elastic/eui';
 import {
-  EuiButton,
   EuiButtonIcon,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -19,6 +18,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useBoolean } from '@kbn/react-hooks';
 import React from 'react';
+import { AiButton, type AiButtonProps } from '@kbn/shared-ux-ai-components';
 import type { AIFeatures } from '../../hooks/use_ai_features';
 import { useAIFeatures } from '../../hooks/use_ai_features';
 import { EnableAIFeaturesLink } from '../enable_ai_features_link/enable_ai_features_link';
@@ -35,7 +35,10 @@ export function ConnectorListButtonBase({
   buttonProps,
   aiFeatures,
 }: {
-  buttonProps: EuiButtonProps & { onClick?: () => void };
+  buttonProps: AiButtonProps & {
+    fill?: boolean;
+    size?: EuiLoadingSpinnerProps['size'];
+  };
   aiFeatures: Pick<AIFeatures, 'couldBeEnabled' | 'enabled' | 'genAiConnectors'> | null;
 }) {
   const [isPopoverOpen, { off: closePopover, toggle: togglePopover }] = useBoolean(false);
@@ -62,13 +65,16 @@ export function ConnectorListButtonBase({
   return (
     <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <AiButton
           isDisabled={!connectorsResult?.connectors?.length}
           isLoading={connectorsResult?.loading}
           size={buttonSize}
-          fill={fill}
+          variant={fill ? 'accent' : 'base'}
+          iconType="sparkles"
           {...buttonProps}
-        />
+        >
+          {buttonProps.children}
+        </AiButton>
       </EuiFlexItem>
       {connectorsResult?.connectors && connectorsResult.connectors.length >= 2 && (
         <EuiFlexItem grow={false}>
@@ -120,7 +126,10 @@ export function ConnectorListButtonBase({
 export function ConnectorListButton({
   buttonProps,
 }: {
-  buttonProps: EuiButtonProps & { onClick?: () => void };
+  buttonProps: AiButtonProps & {
+    fill?: boolean;
+    size?: EuiLoadingSpinnerProps['size'];
+  };
 }) {
   const aiFeatures = useAIFeatures();
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/feature_identification_control.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_significant_events_view/feature_identification_control.tsx
@@ -10,6 +10,7 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useBoolean } from '@kbn/react-hooks';
 import { i18n } from '@kbn/i18n';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import { TaskStatus, type Streams } from '@kbn/streams-schema';
 import type { AIFeatures } from '../../hooks/use_ai_features';
 import { useStreamFeaturesApi } from '../../hooks/use_stream_features_api';
@@ -183,14 +184,15 @@ interface TriggerButtonProps {
 
 function TriggerButton({ isLoading, onClick, aiFeatures }: TriggerButtonProps) {
   return (
-    <EuiButton
+    <AiButton
       {...COMMON_BUTTON_PROPS}
+      variant="base"
       isLoading={isLoading}
       onClick={onClick}
       isDisabled={!aiFeatures?.enabled}
     >
       {IDENTIFY_FEATURES_BUTTON_LABEL}
-    </EuiButton>
+    </AiButton>
   );
 }
 
@@ -247,14 +249,15 @@ function InProgressState({ onCancel }: InProgressStateProps) {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiButton
-          iconType="sparkle"
+        <AiButton
+          iconType="sparkles"
           iconSide="left"
           isLoading
+          variant="base"
           data-test-subj="feature_identification_identify_features_button"
         >
           {IN_PROGRESS_BUTTON_LABEL}
-        </EuiButton>
+        </AiButton>
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiButtonEmpty

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_description/description_generation_control.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_systems/stream_description/description_generation_control.tsx
@@ -6,9 +6,10 @@
  */
 
 import { useEffect, useState } from 'react';
-import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import type { DescriptionGenerationTaskResult } from '@kbn/streams-plugin/server/routes/internal/streams/description_generation/route';
 import type { AIFeatures } from '../../../hooks/use_ai_features';
 import { useTaskPolling } from '../../../hooks/use_task_polling';
@@ -108,10 +109,11 @@ export function DescriptionGenerationControl({
     return (
       <EuiFlexGroup gutterSize="xs">
         <EuiFlexItem grow={false}>
-          <EuiButton
-            iconType="sparkle"
+          <AiButton
+            iconType="sparkles"
             iconSide="right"
             isLoading={true}
+            variant="base"
             data-test-subj="generate_description_button"
           >
             {i18n.translate(
@@ -120,7 +122,7 @@ export function DescriptionGenerationControl({
                 defaultMessage: 'Generating description',
               }
             )}
-          </EuiButton>
+          </AiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty

--- a/x-pack/platform/plugins/shared/streams_app/tsconfig.json
+++ b/x-pack/platform/plugins/shared/streams_app/tsconfig.json
@@ -110,5 +110,6 @@
     "@kbn/inference-endpoint-ui-common",
     "@kbn/stack-connectors-plugin",
     "@kbn/std",
+    "@kbn/shared-ux-ai-components",
   ]
 }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/moon.yml
@@ -47,6 +47,7 @@ dependsOn:
   - '@kbn/logging'
   - '@kbn/ai-assistant-common'
   - '@kbn/kibana-react-plugin'
+  - '@kbn/shared-ux-ai-components'
   - '@kbn/shared-ux-utility'
   - '@kbn/discover-shared-plugin'
   - '@kbn/i18n'

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/ai_insight.tsx
@@ -20,6 +20,7 @@ import {
   EuiMarkdownFormat,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import { AIChatExperience } from '@kbn/ai-assistant-common';
 import { AI_CHAT_EXPERIENCE_TYPE } from '@kbn/management-settings-ids';
@@ -161,6 +162,7 @@ export function AiInsight({ title, insightType, createStream, buildAttachments }
                 color={euiTheme.colors.primary}
                 style={{ marginTop: 6 }}
                 size="l"
+                aria-hidden={true}
               />
             </EuiFlexItem>
             <EuiFlexItem>
@@ -229,16 +231,17 @@ export function AiInsight({ title, insightType, createStream, buildAttachments }
               <EuiSpacer size="s" />
               <EuiFlexGroup justifyContent="flexEnd" gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty
+                  <AiButton
                     data-test-subj="observabilityAgentBuilderRegenerateButton"
                     size="s"
                     iconType="sparkles"
+                    variant="empty"
                     onClick={regenerate}
                   >
                     {i18n.translate('xpack.observabilityAgentBuilder.aiInsight.regenerateButton', {
                       defaultMessage: 'Regenerate',
                     })}
-                  </EuiButtonEmpty>
+                  </AiButton>
                 </EuiFlexItem>
                 {Boolean(summary && summary.trim()) && (
                   <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/start_conversation_button.tsx
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/public/components/ai_insight/start_conversation_button.tsx
@@ -8,18 +8,18 @@
 import React from 'react';
 import { upperFirst } from 'lodash';
 import { i18n } from '@kbn/i18n';
-import { EuiButton } from '@elastic/eui';
+import { AiButton, type AiButtonProps } from '@kbn/shared-ux-ai-components';
 import type { InsightType } from '../../analytics';
 
-type StartConversationButtonProps = React.ComponentProps<typeof EuiButton> & {
+type StartConversationButtonProps = AiButtonProps & {
   insightType: InsightType;
 };
 
 export function StartConversationButton({ insightType, ...props }: StartConversationButtonProps) {
   return (
-    <EuiButton
+    <AiButton
       data-test-subj={`observabilityAgentBuilder${upperFirst(insightType)}StartConversationButton`}
-      fill
+      variant="accent"
       iconType="productAgent"
       size="s"
       {...props}
@@ -27,6 +27,6 @@ export function StartConversationButton({ insightType, ...props }: StartConversa
       {i18n.translate('xpack.observabilityAgentBuilder.aiInsight.startConversationButton.label', {
         defaultMessage: 'Start conversation',
       })}
-    </EuiButton>
+    </AiButton>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability_agent_builder/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_agent_builder/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/logging",
     "@kbn/ai-assistant-common",
     "@kbn/kibana-react-plugin",
+    "@kbn/shared-ux-ai-components",
     "@kbn/shared-ux-utility",
     "@kbn/discover-shared-plugin",
     "@kbn/i18n",

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useAbortableAsync } from '@kbn/observability-ai-assistant-plugin/public';
 import { EuiShowFor, EuiToolTip } from '@elastic/eui';
 import { v4 } from 'uuid';
@@ -140,9 +140,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     title: undefined,
     hideConversationList: false,
   };
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const tooltipRef = useRef<EuiToolTip>(null);
-  const [tooltipVisible, setTooltipVisible] = useState(true);
+
   useEffect(() => {
     const keyboardListener = (event: KeyboardEvent) => {
       const hasModifier = isMac ? event.metaKey : event.ctrlKey;
@@ -152,10 +150,6 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
           messages: [],
         });
       }
-      if (event.key === 'Escape' && isOpen) {
-        setTooltipVisible(true);
-        buttonRef.current?.focus();
-      }
     };
 
     window.addEventListener('keydown', keyboardListener);
@@ -163,7 +157,14 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     return () => {
       window.removeEventListener('keydown', keyboardListener);
     };
-  }, [service.conversations, isOpen, setFlyoutSettings, setIsOpen, setTooltipVisible]);
+  }, [service.conversations]);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const tooltipRef = useRef<EuiToolTip>(null);
+
+  const handleTooltipMouseOut = useCallback(() => {
+    tooltipRef.current?.hideToolTip();
+  }, []);
 
   const buttonLabel = i18n.translate('xpack.observabilityAiAssistant.navControl.assistantNavLink', {
     defaultMessage: 'AI Assistant',
@@ -192,7 +193,6 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
 
   const handleClick = () => {
     tooltipRef.current?.hideToolTip();
-    setTooltipVisible(false);
     if (isOpen) {
       setFlyoutSettings((prev) => ({ ...prev, isOpen: false }));
       setIsOpen(false);
@@ -203,58 +203,42 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     }
   };
   const variant = isOpen ? 'accent' : 'base';
-  const showTooltip = !isOpen && tooltipVisible;
-  const textButton = (
-    <AiButton
-      buttonRef={buttonRef}
-      variant={variant}
-      size="s"
-      iconType="aiAssistantLogo"
-      data-test-subj="observabilityAiAssistantAppNavControlButton"
-      isLoading={chatService.loading}
-      onClick={handleClick}
-      onMouseLeave={() => setTooltipVisible(true)}
-      onBlur={() => setTooltipVisible(true)}
-    >
-      {buttonLabel}
-    </AiButton>
-  );
-
-  const iconButton = (
-    <AiButton
-      buttonRef={buttonRef}
-      iconOnly
-      variant={variant}
-      size="s"
-      iconType="aiAssistantLogo"
-      aria-label={openAIAssistantLabel}
-      data-test-subj="observabilityAiAssistantAppNavControlButtonIcon"
-      isLoading={chatService.loading}
-      onClick={handleClick}
-      onMouseLeave={() => setTooltipVisible(true)}
-      onBlur={() => setTooltipVisible(true)}
-    />
-  );
   return (
     <>
       <EuiShowFor sizes={['m', 'l', 'xl']}>
-        {showTooltip ? (
-          <EuiToolTip content={shortcutLabel} ref={tooltipRef}>
-            {textButton}
-          </EuiToolTip>
-        ) : (
-          textButton
-        )}
+        <EuiToolTip content={shortcutLabel} ref={tooltipRef} onMouseOut={handleTooltipMouseOut}>
+          <AiButton
+            buttonRef={buttonRef}
+            variant={variant}
+            size="s"
+            iconType="aiAssistantLogo"
+            onClick={handleClick}
+            data-test-subj="observabilityAiAssistantAppNavControlButton"
+            isLoading={chatService.loading}
+          >
+            {buttonLabel}
+          </AiButton>
+        </EuiToolTip>
       </EuiShowFor>
 
       <EuiShowFor sizes={['xs', 's']}>
-        {showTooltip ? (
-          <EuiToolTip content={fullTooltipContent} ref={tooltipRef}>
-            {iconButton}
-          </EuiToolTip>
-        ) : (
-          iconButton
-        )}
+        <EuiToolTip
+          content={fullTooltipContent}
+          ref={tooltipRef}
+          onMouseOut={handleTooltipMouseOut}
+        >
+          <AiButton
+            buttonRef={buttonRef}
+            iconOnly
+            variant={variant}
+            size="s"
+            iconType="aiAssistantLogo"
+            onClick={handleClick}
+            aria-label={openAIAssistantLabel}
+            data-test-subj="observabilityAiAssistantAppNavControlButtonIcon"
+            isLoading={chatService.loading}
+          />
+        </EuiToolTip>
       </EuiShowFor>
       {chatService.value ? (
         <ObservabilityAIAssistantChatServiceContext.Provider value={chatService.value}>
@@ -267,7 +251,6 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
             onClose={() => {
               setFlyoutSettings((prev) => ({ ...prev, isOpen: false }));
               setIsOpen(false);
-              setTooltipVisible(true);
               if (document.activeElement?.matches(':focus-visible')) {
                 buttonRef.current?.focus();
               }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useAbortableAsync } from '@kbn/observability-ai-assistant-plugin/public';
 import { EuiShowFor, EuiToolTip } from '@elastic/eui';
 import { v4 } from 'uuid';
@@ -140,7 +140,9 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     title: undefined,
     hideConversationList: false,
   };
-
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const tooltipRef = useRef<EuiToolTip>(null);
+  const [tooltipVisible, setTooltipVisible] = useState(true);
   useEffect(() => {
     const keyboardListener = (event: KeyboardEvent) => {
       const hasModifier = isMac ? event.metaKey : event.ctrlKey;
@@ -150,6 +152,10 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
           messages: [],
         });
       }
+      if (event.key === 'Escape' && isOpen) {
+        setTooltipVisible(true);
+        buttonRef.current?.focus();
+      }
     };
 
     window.addEventListener('keydown', keyboardListener);
@@ -157,14 +163,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     return () => {
       window.removeEventListener('keydown', keyboardListener);
     };
-  }, [service.conversations]);
-
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const tooltipRef = useRef<EuiToolTip>(null);
-
-  const handleTooltipMouseOut = useCallback(() => {
-    tooltipRef.current?.hideToolTip();
-  }, []);
+  }, [service.conversations, isOpen, setFlyoutSettings, setIsOpen, setTooltipVisible]);
 
   const buttonLabel = i18n.translate('xpack.observabilityAiAssistant.navControl.assistantNavLink', {
     defaultMessage: 'AI Assistant',
@@ -193,6 +192,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
 
   const handleClick = () => {
     tooltipRef.current?.hideToolTip();
+    setTooltipVisible(false);
     if (isOpen) {
       setFlyoutSettings((prev) => ({ ...prev, isOpen: false }));
       setIsOpen(false);
@@ -203,42 +203,58 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     }
   };
   const variant = isOpen ? 'accent' : 'base';
+  const showTooltip = !isOpen && tooltipVisible;
+  const textButton = (
+    <AiButton
+      buttonRef={buttonRef}
+      variant={variant}
+      size="s"
+      iconType="aiAssistantLogo"
+      data-test-subj="observabilityAiAssistantAppNavControlButton"
+      isLoading={chatService.loading}
+      onClick={handleClick}
+      onMouseLeave={() => setTooltipVisible(true)}
+      onBlur={() => setTooltipVisible(true)}
+    >
+      {buttonLabel}
+    </AiButton>
+  );
+
+  const iconButton = (
+    <AiButton
+      buttonRef={buttonRef}
+      iconOnly
+      variant={variant}
+      size="s"
+      iconType="aiAssistantLogo"
+      aria-label={openAIAssistantLabel}
+      data-test-subj="observabilityAiAssistantAppNavControlButtonIcon"
+      isLoading={chatService.loading}
+      onClick={handleClick}
+      onMouseLeave={() => setTooltipVisible(true)}
+      onBlur={() => setTooltipVisible(true)}
+    />
+  );
   return (
     <>
       <EuiShowFor sizes={['m', 'l', 'xl']}>
-        <EuiToolTip content={shortcutLabel} ref={tooltipRef} onMouseOut={handleTooltipMouseOut}>
-          <AiButton
-            buttonRef={buttonRef}
-            variant={variant}
-            size="s"
-            iconType="aiAssistantLogo"
-            onClick={handleClick}
-            data-test-subj="observabilityAiAssistantAppNavControlButton"
-            isLoading={chatService.loading}
-          >
-            {buttonLabel}
-          </AiButton>
-        </EuiToolTip>
+        {showTooltip ? (
+          <EuiToolTip content={shortcutLabel} ref={tooltipRef}>
+            {textButton}
+          </EuiToolTip>
+        ) : (
+          textButton
+        )}
       </EuiShowFor>
 
       <EuiShowFor sizes={['xs', 's']}>
-        <EuiToolTip
-          content={fullTooltipContent}
-          ref={tooltipRef}
-          onMouseOut={handleTooltipMouseOut}
-        >
-          <AiButton
-            buttonRef={buttonRef}
-            iconOnly
-            variant={variant}
-            size="s"
-            iconType="aiAssistantLogo"
-            onClick={handleClick}
-            aria-label={openAIAssistantLabel}
-            data-test-subj="observabilityAiAssistantAppNavControlButtonIcon"
-            isLoading={chatService.loading}
-          />
-        </EuiToolTip>
+        {showTooltip ? (
+          <EuiToolTip content={fullTooltipContent} ref={tooltipRef}>
+            {iconButton}
+          </EuiToolTip>
+        ) : (
+          iconButton
+        )}
       </EuiShowFor>
       {chatService.value ? (
         <ObservabilityAIAssistantChatServiceContext.Provider value={chatService.value}>
@@ -251,6 +267,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
             onClose={() => {
               setFlyoutSettings((prev) => ({ ...prev, isOpen: false }));
               setIsOpen(false);
+              setTooltipVisible(true);
               if (document.activeElement?.matches(':focus-visible')) {
                 buttonRef.current?.focus();
               }

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/rca/rca_callout/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/rca/rca_callout/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiButton,
   EuiCallOut,
   EuiCheckbox,
   EuiFlexGroup,
@@ -19,6 +18,7 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
+import { AiButton } from '@kbn/shared-ux-ai-components';
 import { css } from '@emotion/css';
 import { AssistantIcon } from '@kbn/ai-assistant-icon';
 
@@ -87,16 +87,16 @@ export function RootCauseAnalysisCallout({
                   )}
                 </EuiFormLabel>
               </EuiFlexGroup>
-              <EuiButton
+              <AiButton
                 data-test-subj="observabilityAiAssistantAppRootCauseAnalysisCalloutStartAnalysisButton"
                 iconType="sparkles"
-                fill
+                variant="accent"
                 onClick={onClick}
               >
                 {i18n.translate('xpack.observabilityAiAssistant.rca.calloutText', {
                   defaultMessage: 'Start analysis',
                 })}
-              </EuiButton>
+              </AiButton>
             </EuiFlexGroup>
           </EuiFlexGroup>
         </EuiFlexGroup>


### PR DESCRIPTION
## Summary
This PR is a part of initiative to migrate our Ai related buttons to use our new AiButton custom component.
Here is a [Storybook](https://ci-artifacts.kibana.dev/storybooks/main/shared_ux/index.html?path=/story/ai-components-aibutton--default&args=withIcon:!true;icon:sparkles) to see how they look.

#### Please, let me know if there are more buttons that can benefit from this migration, so we can add them here, or you could push the additional instances.

Please test in the UI.
Thank you in advance!