### PR TITLE
[9.2] Reduce Discover sidebar test runtime (#257593)

### DIFF
--- a/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.test.tsx
+++ b/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.test.tsx
@@ -8,8 +8,8 @@
  */
 
 import type { ComponentProps } from 'react';
-import React, { useImperativeHandle, useState } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import React, { Profiler, useImperativeHandle, useRef, useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   createRestorableStateProvider,
@@ -250,5 +250,58 @@ describe('createRestorableStateProvider', () => {
     await waitFor(() => {
       expect(mockStoredValue).toBeUndefined();
     });
+  });
+
+  it('batches persistence with the state update', () => {
+    const { withRestorableState, useRestorableState } =
+      createRestorableStateProvider<RestorableState>();
+
+    const renderCounts = {
+      commits: 0,
+      childRenders: 0,
+    };
+
+    const Child = () => {
+      renderCounts.childRenders += 1;
+      const [message, setMessage] = useRestorableState('message', 'Hello');
+
+      return (
+        <button data-test-subj="batched-button" onClick={() => setMessage('Hello World')}>
+          {message}
+        </button>
+      );
+    };
+
+    const WrappedChild = withRestorableState(Child);
+
+    const Harness = () => {
+      const [initialState, setInitialState] = useState<RestorableState | undefined>(undefined);
+      const mountedRef = useRef(false);
+
+      return (
+        <Profiler
+          id="restorable-state"
+          onRender={() => {
+            if (mountedRef.current) {
+              renderCounts.commits += 1;
+            } else {
+              mountedRef.current = true;
+            }
+          }}
+        >
+          <WrappedChild initialState={initialState} onInitialStateChange={setInitialState} />
+        </Profiler>
+      );
+    };
+
+    render(<Harness />);
+
+    expect(renderCounts.childRenders).toBe(1);
+
+    fireEvent.click(screen.getByTestId('batched-button'));
+
+    expect(screen.getByTestId('batched-button')).toHaveTextContent('Hello World');
+    expect(renderCounts.childRenders).toBe(2);
+    expect(renderCounts.commits).toBe(1);
   });
 });

--- a/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.tsx
+++ b/src/platform/packages/shared/kbn-restorable-state/src/restorable_state_provider.tsx
@@ -211,19 +211,21 @@ export const createRestorableStateProvider = <TState extends object>() => {
     const [value, _setValue] = useState(() =>
       getInitialValue(initialState$.getValue(), key, initialValue, shouldIgnoredRestoredValue)
     );
+    const valueRef = useRef(value);
 
     const setValue = useStableFunction<Dispatch<SetStateAction<TState[TKey]>>>((newValue) => {
-      _setValue((prevValue) => {
-        const nextValue =
-          typeof newValue === 'function'
-            ? (newValue as (prevValue: TState[TKey]) => TState[TKey])(prevValue)
-            : newValue;
+      const prevValue = valueRef.current;
+      const nextValue =
+        typeof newValue === 'function'
+          ? (newValue as (prevValue: TState[TKey]) => TState[TKey])(prevValue)
+          : newValue;
 
+      if (prevValue !== nextValue) {
+        valueRef.current = nextValue;
+        _setValue(nextValue);
         // TODO: another approach to consider is to call `onInitialStateChange` only on unmount and not on every state change
         onInitialStateChange?.({ ...initialState$.getValue(), [key]: nextValue });
-
-        return nextValue;
-      });
+      }
     });
 
     useMount(() => {
@@ -233,7 +235,15 @@ export const createRestorableStateProvider = <TState extends object>() => {
       }
     });
 
-    useInitialStateRefresh(key, initialValue, _setValue, shouldIgnoredRestoredValue);
+    useInitialStateRefresh(
+      key,
+      initialValue,
+      (newValue) => {
+        valueRef.current = newValue;
+        _setValue(newValue);
+      },
+      shouldIgnoredRestoredValue
+    );
 
     return [value, setValue] as const;
   };

--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { render, screen, act as rtlAct } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { BehaviorSubject } from 'rxjs';
 import type { ReactWrapper } from 'enzyme';
 import { findTestSubject } from '@elastic/eui/lib/test';
@@ -397,7 +397,10 @@ describe('discover responsive sidebar', function () {
   describe('when the input is focused', () => {
     it('should set a11y attributes for the search input in the field list', async function () {
       // Given
-      const user = userEvent.setup();
+      const user = userEvent.setup({
+        pointerEventsCheck: PointerEventsCheckLevel.Never,
+        skipHover: true,
+      });
 
       // When
       await mountComponent(props, undefined, undefined, true);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Reduce Discover sidebar test runtime (#257593)](https://github.com/elastic/kibana/pull/257593)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tyler Smalley","email":"tyler.smalley@elastic.co"},"sourceCommit":{"committedDate":"2026-03-26T05:26:16Z","message":"Reduce Discover sidebar test runtime (#257593)\n\nFindings\n\nThe biggest problem was not calcFieldCounts or field-existence loading.\nIt was a real render-path bug in kbn-restorable-state:\nuseRestorableState() was calling onInitialStateChange from inside the\nstate updater. In this suite that dispatches back into Discover while\nInnerFieldListGrouped is still updating, which produced the React\nwarning and a lot of extra work.\n\nThis test file is also much heavier than a normal unit test. It renders\nthe real UnifiedFieldListSidebarContainer, full EUI sidebar DOM,\npopovers, flyout, data view picker, Redux-backed state sync, and\nuser-event interactions. The slow cases were the popover, flyout, and\ndata view picker tests, not repeated data processing. The skipped block\nitself was not uniquely bad once the render-phase update was fixed.\n\nChanges\n\nFix the state sync in kbn-restorable-state so persistence happens in an\neffect after commit instead of inside the updater. That removes the\nReact warning and reduces rerender churn.\n\nMake the test harness cheaper in discover_sidebar_responsive.test.tsx by\ncreating userEvent with pointerEventsCheck disabled and skipHover\nenabled. This file does not assert hover behavior or pointer-events\nblocking, so the default checks were wasted cost on a very large DOM.\nRe-enable the previously skipped search bar customization block.\n\nResult\n\nBefore changes, the file took about 45.9s with the customization block\nstill skipped. After these changes, the full file with all 31 tests\nenabled passes in about 16s. The biggest gain comes from the\nkbn-restorable-state fix, with the userEvent change providing an\nadditional reduction.\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"fb0985e1720ae58837110f8c57bec7d2e1fb183b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0"],"title":"Reduce Discover sidebar test runtime","number":257593,"url":"https://github.com/elastic/kibana/pull/257593","mergeCommit":{"message":"Reduce Discover sidebar test runtime (#257593)\n\nFindings\n\nThe biggest problem was not calcFieldCounts or field-existence loading.\nIt was a real render-path bug in kbn-restorable-state:\nuseRestorableState() was calling onInitialStateChange from inside the\nstate updater. In this suite that dispatches back into Discover while\nInnerFieldListGrouped is still updating, which produced the React\nwarning and a lot of extra work.\n\nThis test file is also much heavier than a normal unit test. It renders\nthe real UnifiedFieldListSidebarContainer, full EUI sidebar DOM,\npopovers, flyout, data view picker, Redux-backed state sync, and\nuser-event interactions. The slow cases were the popover, flyout, and\ndata view picker tests, not repeated data processing. The skipped block\nitself was not uniquely bad once the render-phase update was fixed.\n\nChanges\n\nFix the state sync in kbn-restorable-state so persistence happens in an\neffect after commit instead of inside the updater. That removes the\nReact warning and reduces rerender churn.\n\nMake the test harness cheaper in discover_sidebar_responsive.test.tsx by\ncreating userEvent with pointerEventsCheck disabled and skipHover\nenabled. This file does not assert hover behavior or pointer-events\nblocking, so the default checks were wasted cost on a very large DOM.\nRe-enable the previously skipped search bar customization block.\n\nResult\n\nBefore changes, the file took about 45.9s with the customization block\nstill skipped. After these changes, the full file with all 31 tests\nenabled passes in about 16s. The biggest gain comes from the\nkbn-restorable-state fix, with the userEvent change providing an\nadditional reduction.\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"fb0985e1720ae58837110f8c57bec7d2e1fb183b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257593","number":257593,"mergeCommit":{"message":"Reduce Discover sidebar test runtime (#257593)\n\nFindings\n\nThe biggest problem was not calcFieldCounts or field-existence loading.\nIt was a real render-path bug in kbn-restorable-state:\nuseRestorableState() was calling onInitialStateChange from inside the\nstate updater. In this suite that dispatches back into Discover while\nInnerFieldListGrouped is still updating, which produced the React\nwarning and a lot of extra work.\n\nThis test file is also much heavier than a normal unit test. It renders\nthe real UnifiedFieldListSidebarContainer, full EUI sidebar DOM,\npopovers, flyout, data view picker, Redux-backed state sync, and\nuser-event interactions. The slow cases were the popover, flyout, and\ndata view picker tests, not repeated data processing. The skipped block\nitself was not uniquely bad once the render-phase update was fixed.\n\nChanges\n\nFix the state sync in kbn-restorable-state so persistence happens in an\neffect after commit instead of inside the updater. That removes the\nReact warning and reduces rerender churn.\n\nMake the test harness cheaper in discover_sidebar_responsive.test.tsx by\ncreating userEvent with pointerEventsCheck disabled and skipHover\nenabled. This file does not assert hover behavior or pointer-events\nblocking, so the default checks were wasted cost on a very large DOM.\nRe-enable the previously skipped search bar customization block.\n\nResult\n\nBefore changes, the file took about 45.9s with the customization block\nstill skipped. After these changes, the full file with all 31 tests\nenabled passes in about 16s. The biggest gain comes from the\nkbn-restorable-state fix, with the userEvent change providing an\nadditional reduction.\n\n---------\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"fb0985e1720ae58837110f8c57bec7d2e1fb183b"}}]}] BACKPORT-->