### PR TITLE
Improve EIS CCM script error handling and developer experience

### DIFF
--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -45,28 +45,44 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 
 ### Prerequisites
 
-1. **Vault Access**: Make sure you have configured Vault to point at Elastic's [Infra Vault](https://docs.elastic.dev/vault#infra-vault) server and that you're logged in via `vault login --method oidc`. The script will fetch the EIS API key from `secret/kibana-issues/dev/inference/kibana-eis-ccm`.
-
-2. **Elasticsearch**: Start Elasticsearch with the EIS URL of the QA environment and an Enterprise trial license:
+1. **Elasticsearch**: Start Elasticsearch with the EIS URL of the QA environment and an Enterprise trial license:
 
    ```bash
    yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
    ```
 
-3. **Credentials**: The script will automatically detect Elasticsearch credentials from:
+2. **Vault Access**: The script fetches the EIS API key from Vault. Make sure you are logged in:
+
+   ```bash
+   VAULT_ADDR=https://secrets.elastic.co:8200 vault login --method oidc
+   ```
+
+   See [Infra Vault docs](https://docs.elastic.dev/vault#infra-vault) for setup.
+
+   Alternatively, if you already have a key, you can skip Vault entirely by setting:
+
+   ```bash
+   export KIBANA_EIS_CCM_API_KEY=<your-key>
+   ```
+
+3. **Credentials**: The script automatically detects Elasticsearch credentials from:
    - Environment variables: `ES_USERNAME`/`ES_PASSWORD` or `ELASTICSEARCH_USERNAME`/`ELASTICSEARCH_PASSWORD`
    - Default credentials: `elastic:changeme` (hosted) or `elastic_serverless:changeme` (serverless)
 
 ### Usage
 
 ```bash
-# Start Elasticsearch with the EIS URL of the QA environment and an Enterprise trial license
+# Terminal 1: Start Elasticsearch with the EIS URL
 yarn es snapshot --license trial -E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud
 
-# In a separate terminal, configure EIS API key
+# Terminal 2: Configure EIS API key, once Elasticsearch is green
 node scripts/eis.js
 ```
 
-The script will fetch the EIS API key from Vault and register it in your local Elasticsearch instance using an internal Cloud Connect API.
+The script will:
+1. Connect to Elasticsearch and log the endpoint and credentials it found
+2. Check if the EIS endpoint (`xpack.inference.elastic.url`) is configured
+3. Fetch the CCM API key (from `KIBANA_EIS_CCM_API_KEY` env var, or from Vault)
+4. Register the key in Elasticsearch via the CCM API
 
-**Important**: note that the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected to the Cloud Connect page in Kibana. However, you should have access to all built-in EIS inference endpoints after running this script. 
+**Important**: the script only enables EIS. It does not go through the full Cloud Connect onboarding. The cluster will not show as connected on the Cloud Connect page in Kibana. However, you should have access to all built-in EIS inference endpoints after running this script.

--- a/x-pack/platform/packages/shared/kbn-inference-cli/README.md
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/README.md
@@ -67,7 +67,15 @@ You can connect your local Elasticsearch to the Elastic Inference Service (EIS) 
 
 3. **Credentials**: The script automatically detects Elasticsearch credentials from:
    - Environment variables: `ES_USERNAME`/`ES_PASSWORD` or `ELASTICSEARCH_USERNAME`/`ELASTICSEARCH_PASSWORD`
-   - Default credentials: `elastic:changeme` (hosted) or `elastic_serverless:changeme` (serverless)
+   - Default credentials: `elastic:changeme` (stateful) or `elastic_serverless:changeme` (serverless)
+
+4. **Custom host/port** (optional): By default the script connects to `localhost:9200` (trying both HTTPS and HTTP). Override with:
+
+   ```bash
+   export ES_HOST=my-host              # tries both HTTPS and HTTP
+   export ES_HOST=https://my-host      # uses HTTPS only
+   export ES_PORT=9220
+   ```
 
 ### Usage
 

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -23,7 +23,7 @@ interface ElasticsearchConnection {
 }
 
 const EIS_QA_URL = 'https://inference.eu-west-1.aws.svc.qa.elastic.cloud';
-const EIS_SNAPSHOT_CMD = `yarn es snapshot --license trial -E xpack.inference.elastic.url=${EIS_QA_URL}`;
+const EIS_URL_FLAG = `-E xpack.inference.elastic.url=${EIS_QA_URL}`;
 
 const createBasicAuthHeader = (credentials: ElasticsearchCredentials): string =>
   Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
@@ -90,8 +90,13 @@ async function testCredentials(
 }
 
 async function getES(log: ToolingLog) {
-  const localhost = 'localhost:9200';
-  const protocols = ['https', 'http'];
+  const rawHost = process.env.ES_HOST || 'localhost';
+  const port = process.env.ES_PORT || '9200';
+
+  const protocolMatch = rawHost.match(/^(https?):\/\/(.+)$/);
+  const protocols = protocolMatch ? [protocolMatch[1]] : ['https', 'http'];
+  const hostname = protocolMatch ? protocolMatch[2] : rawHost;
+  const esAddress = `${hostname}:${port}`;
 
   const envUsername = process.env.ES_USERNAME || process.env.ELASTICSEARCH_USERNAME;
   const envPassword = process.env.ES_PASSWORD || process.env.ELASTICSEARCH_PASSWORD;
@@ -116,7 +121,7 @@ async function getES(log: ToolingLog) {
   );
 
   for (const protocol of protocols) {
-    const baseUrl = `${protocol}://${localhost}`;
+    const baseUrl = `${protocol}://${esAddress}`;
 
     for (const credentials of credentialsToTry) {
       const isSsl = protocol === 'https';
@@ -148,11 +153,11 @@ async function getES(log: ToolingLog) {
 
   throw new Error(
     [
-      'Could not connect to Elasticsearch at localhost:9200.',
+      `Could not connect to Elasticsearch at ${esAddress}.`,
       '',
-      'Make sure Elasticsearch is running:',
+      `Make sure Elasticsearch is running with the EIS URL flag:`,
       '',
-      `  ${chalk.cyan(EIS_SNAPSHOT_CMD)}`,
+      `  ${chalk.cyan(EIS_URL_FLAG)}`,
       '',
       'If using custom credentials, set ES_USERNAME and ES_PASSWORD environment variables.',
     ].join('\n')
@@ -163,34 +168,43 @@ async function getEisApiKeyFromVault(vaultAddress: string): Promise<string> {
   const secretPath = 'secret/kibana-issues/dev/inference/kibana-eis-ccm';
 
   let stdout: string;
+  let stderr: string;
   try {
-    ({ stdout } = await execa('vault', ['read', '-field', 'key', secretPath], {
+    ({ stdout, stderr } = await execa('vault', ['read', '-field', 'key', secretPath], {
       env: { VAULT_ADDR: vaultAddress },
     }));
   } catch (error) {
-    throw new Error(
-      [
-        'Failed to read EIS API key from vault.',
-        '',
-        'Make sure you are logged in:',
-        '',
-        `  ${chalk.cyan(`VAULT_ADDR=${vaultAddress} vault login --method oidc`)}`,
-        '',
-        'See https://docs.elastic.dev/vault for setup instructions.',
-      ].join('\n'),
-      { cause: error }
-    );
+    const vaultStderr = error.stderr?.trim();
+    const parts = [
+      'Failed to read EIS API key from vault.',
+      ...(vaultStderr ? [`Vault output: ${vaultStderr}`] : []),
+      '',
+      'Make sure you are logged in:',
+      '',
+      `  ${chalk.cyan(`VAULT_ADDR=${vaultAddress} vault login --method oidc`)}`,
+      '',
+      'See https://docs.elastic.dev/vault for setup instructions.',
+    ];
+    throw new Error(parts.join('\n'), { cause: error });
   }
 
   const apiKey = stdout.trim();
   if (!apiKey) {
-    throw new Error('Vault returned an empty API key — the secret may be missing or blank.');
+    const parts = ['Vault returned an empty API key.'];
+    const vaultOutput = stderr.trim();
+    if (vaultOutput) {
+      parts.push(`Vault output: ${vaultOutput}`);
+    }
+    throw new Error(parts.join(' '));
   }
 
   return apiKey;
 }
 
-async function getEisEndpoint(es: ElasticsearchConnection): Promise<string | undefined> {
+async function getEisEndpoint(
+  es: ElasticsearchConnection,
+  log: ToolingLog
+): Promise<string | undefined> {
   try {
     const { statusCode, data } = await httpRequest(
       `${es.baseUrl}/_cluster/settings?include_defaults=true&flat_settings=true`,
@@ -204,6 +218,7 @@ async function getEisEndpoint(es: ElasticsearchConnection): Promise<string | und
     );
 
     if (statusCode !== 200) {
+      log.warning(`Failed to get cluster settings: HTTP ${statusCode}`);
       return undefined;
     }
 
@@ -215,6 +230,7 @@ async function getEisEndpoint(es: ElasticsearchConnection): Promise<string | und
       undefined
     );
   } catch (error) {
+    log.warning(`Error fetching cluster settings: ${error.message}`);
     return undefined;
   }
 }
@@ -261,7 +277,7 @@ async function setCcmApiKey(
             '',
             'Make sure Elasticsearch was started with the EIS URL flag:',
             '',
-            `  ${chalk.cyan(EIS_SNAPSHOT_CMD)}`,
+            `  ${chalk.cyan(EIS_URL_FLAG)}`,
           ].join('\n')
         );
       }
@@ -288,7 +304,7 @@ export async function ensureEis({ log }: { log: ToolingLog }) {
   const es = await getES(log);
 
   // Step 2: Check if the EIS endpoint is configured
-  const eisEndpoint = await getEisEndpoint(es);
+  const eisEndpoint = await getEisEndpoint(es, log);
   if (eisEndpoint) {
     log.info(`EIS endpoint: ${chalk.cyan(eisEndpoint)}`);
   } else {

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -22,6 +22,12 @@ interface ElasticsearchConnection {
   ssl: boolean;
 }
 
+const EIS_QA_URL = 'https://inference.eu-west-1.aws.svc.qa.elastic.cloud';
+const EIS_SNAPSHOT_CMD = `yarn es snapshot --license trial -E xpack.inference.elastic.url=${EIS_QA_URL}`;
+
+const createBasicAuthHeader = (credentials: ElasticsearchCredentials): string =>
+  Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
+
 function httpRequest(
   url: string,
   options: http.RequestOptions | https.RequestOptions,
@@ -59,13 +65,12 @@ async function testCredentials(
   log: ToolingLog
 ): Promise<boolean> {
   try {
-    const auth = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
     const { statusCode } = await httpRequest(
       baseUrl,
       {
         method: 'GET',
         headers: {
-          Authorization: `Basic ${auth}`,
+          Authorization: `Basic ${createBasicAuthHeader(credentials)}`,
         },
         rejectUnauthorized: false,
       },
@@ -85,8 +90,6 @@ async function testCredentials(
 }
 
 async function getES(log: ToolingLog) {
-  log.debug('Determining Elasticsearch connection');
-
   const localhost = 'localhost:9200';
   const protocols = ['https', 'http'];
 
@@ -123,8 +126,8 @@ async function getES(log: ToolingLog) {
         const isValid = await testCredentials(baseUrl, credentials, isSsl, log);
 
         if (isValid) {
-          log.debug(
-            `Authorized with ${credentials.type} credentials ${credentials.username} (${protocol})`
+          log.info(
+            `Connected to Elasticsearch at ${chalk.cyan(baseUrl)} via ${protocol} (${credentials.type} credentials: ${credentials.username})`
           );
 
           return {
@@ -142,27 +145,75 @@ async function getES(log: ToolingLog) {
   }
 
   throw new Error(
-    'Could not authenticate to Elasticsearch. Please set ES_USERNAME and ES_PASSWORD environment variables or ensure Elasticsearch is running with default credentials (elastic:changeme or elastic_serverless:changeme)'
+    [
+      'Could not connect to Elasticsearch at localhost:9200.',
+      '',
+      'Make sure Elasticsearch is running:',
+      '',
+      `  ${chalk.cyan(EIS_SNAPSHOT_CMD)}`,
+      '',
+      'If using custom credentials, set ES_USERNAME and ES_PASSWORD environment variables.',
+    ].join('\n')
   );
 }
 
-async function getEisApiKey(log: ToolingLog): Promise<string> {
-  log.debug('Fetching EIS API key from vault');
-
+async function getEisApiKeyFromVault(vaultAddress: string): Promise<string> {
   const secretPath = 'secret/kibana-issues/dev/inference/kibana-eis-ccm';
-  const vaultAddress = process.env.VAULT_ADDR || 'https://secrets.elastic.co:8200';
 
+  let stdout: string;
   try {
-    const { stdout: apiKey } = await execa.command(`vault read -field key ${secretPath}`, {
+    ({ stdout } = await execa('vault', ['read', '-field', 'key', secretPath], {
       env: { VAULT_ADDR: vaultAddress },
-    });
-
-    return apiKey.trim();
+    }));
   } catch (error) {
     throw new Error(
-      'Failed to read EIS API key from vault. Please ensure you are logged in to vault (vault login --method oidc) and connected to VPN if needed. See https://docs.elastic.dev/vault',
+      [
+        'Failed to read EIS API key from vault.',
+        '',
+        'Make sure you are logged in:',
+        '',
+        `  ${chalk.cyan(`VAULT_ADDR=${vaultAddress} vault login --method oidc`)}`,
+        '',
+        'See https://docs.elastic.dev/vault for setup instructions.',
+      ].join('\n'),
       { cause: error }
     );
+  }
+
+  const apiKey = stdout.trim();
+  if (!apiKey) {
+    throw new Error('Vault returned an empty API key — the secret may be missing or blank.');
+  }
+
+  return apiKey;
+}
+
+async function getEisEndpoint(es: ElasticsearchConnection): Promise<string | undefined> {
+  try {
+    const { statusCode, data } = await httpRequest(
+      `${es.baseUrl}/_cluster/settings?include_defaults=true&flat_settings=true`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Basic ${createBasicAuthHeader(es.credentials)}` },
+        rejectUnauthorized: false,
+      },
+      undefined,
+      es.ssl
+    );
+
+    if (statusCode !== 200) {
+      return undefined;
+    }
+
+    const settings = JSON.parse(data);
+    return (
+      settings.persistent?.['xpack.inference.elastic.url'] ||
+      settings.transient?.['xpack.inference.elastic.url'] ||
+      settings.defaults?.['xpack.inference.elastic.url'] ||
+      undefined
+    );
+  } catch (error) {
+    return undefined;
   }
 }
 
@@ -176,14 +227,11 @@ async function setCcmApiKey(
   const maxRetries = 3;
   const retryDelayMs = 2000;
   const esUrl = `${es.baseUrl}/_inference/_ccm`;
+  const auth = createBasicAuthHeader(es.credentials);
+  const body = JSON.stringify({ api_key: apiKey });
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const auth = Buffer.from(`${es.credentials.username}:${es.credentials.password}`).toString(
-        'base64'
-      );
-      const body = JSON.stringify({ api_key: apiKey });
-
       const { statusCode } = await httpRequest(
         esUrl,
         {
@@ -204,15 +252,25 @@ async function setCcmApiKey(
         return;
       }
 
+      if (statusCode === 401 || statusCode === 403) {
+        throw new Error(
+          [
+            `HTTP ${statusCode} — Elasticsearch rejected the CCM request.`,
+            '',
+            'Make sure Elasticsearch was started with the EIS URL flag:',
+            '',
+            `  ${chalk.cyan(EIS_SNAPSHOT_CMD)}`,
+          ].join('\n')
+        );
+      }
+
       throw new Error(`HTTP ${statusCode}`);
     } catch (error) {
-      if (attempt < maxRetries) {
+      if (attempt < maxRetries && !(error instanceof Error && /HTTP (401|403)/.test(error.message))) {
         log.debug(`Attempt ${attempt} failed, retrying in ${retryDelayMs}ms...`);
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
       } else {
-        throw new Error(`Failed to set CCM API key after ${maxRetries} attempts`, {
-          cause: error,
-        });
+        throw new Error(`Failed to set CCM API key.`, { cause: error });
       }
     }
   }
@@ -220,21 +278,37 @@ async function setCcmApiKey(
 
 export async function ensureEis({ log }: { log: ToolingLog }) {
   log.info('Setting up Cloud Connected Mode for EIS');
-  // Get Elasticsearch connection info
+
+  // Step 1: Connect to Elasticsearch and log what we're using
   const es = await getES(log);
 
-  // Get EIS API key from vault
-  const apiKey = await getEisApiKey(log);
+  // Step 2: Check if the EIS endpoint is configured
+  const eisEndpoint = await getEisEndpoint(es);
+  if (eisEndpoint) {
+    log.info(`EIS endpoint: ${chalk.cyan(eisEndpoint)}`);
+  } else {
+    log.warning(
+      `Could not detect xpack.inference.elastic.url — make sure Elasticsearch was started with ${chalk.cyan('-E xpack.inference.elastic.url=...')}`
+    );
+  }
 
-  // Set CCM API key in Elasticsearch
+  // Step 3: Resolve the CCM API key
+  const envApiKey = process.env.KIBANA_EIS_CCM_API_KEY?.trim();
+  let apiKey: string;
+
+  if (envApiKey) {
+    log.info('Using CCM API key from KIBANA_EIS_CCM_API_KEY environment variable');
+    apiKey = envApiKey;
+  } else {
+    const vaultAddress = process.env.VAULT_ADDR || 'https://secrets.elastic.co:8200';
+    log.info('Fetching CCM API key from vault...');
+    apiKey = await getEisApiKeyFromVault(vaultAddress);
+  }
+
+  // Step 4: Set the CCM API key in Elasticsearch
   await setCcmApiKey(apiKey, es, log);
 
   log.write('');
   log.write(`${chalk.green('✔')} EIS API key successfully set in Cloud Connected Mode`);
-  log.write('');
-  const eisUrlFlag = chalk.cyan(
-    '-E xpack.inference.elastic.url=https://inference.eu-west-1.aws.svc.qa.elastic.cloud'
-  );
-  log.write(`${chalk.yellow('⚠')} Remember: Elasticsearch must be started with ${eisUrlFlag}`);
   log.write('');
 }

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -127,7 +127,7 @@ async function getES(log: ToolingLog) {
 
         if (isValid) {
           log.info(
-            `Connected to Elasticsearch at ${chalk.cyan(baseUrl)} via ${protocol} (${credentials.type} credentials: ${credentials.username})`
+            `Connected to Elasticsearch at ${chalk.cyan(baseUrl)} (${credentials.type} credentials: ${credentials.username})`
           );
 
           return {

--- a/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
+++ b/x-pack/platform/packages/shared/kbn-inference-cli/src/eis/ensure_eis.ts
@@ -127,7 +127,9 @@ async function getES(log: ToolingLog) {
 
         if (isValid) {
           log.info(
-            `Connected to Elasticsearch at ${chalk.cyan(baseUrl)} (${credentials.type} credentials: ${credentials.username})`
+            `Connected to Elasticsearch at ${chalk.cyan(baseUrl)} (${
+              credentials.type
+            } credentials: ${credentials.username})`
           );
 
           return {
@@ -266,7 +268,10 @@ async function setCcmApiKey(
 
       throw new Error(`HTTP ${statusCode}`);
     } catch (error) {
-      if (attempt < maxRetries && !(error instanceof Error && /HTTP (401|403)/.test(error.message))) {
+      if (
+        attempt < maxRetries &&
+        !(error instanceof Error && /HTTP (401|403)/.test(error.message))
+      ) {
         log.debug(`Attempt ${attempt} failed, retrying in ${retryDelayMs}ms...`);
         await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
       } else {
@@ -288,7 +293,9 @@ export async function ensureEis({ log }: { log: ToolingLog }) {
     log.info(`EIS endpoint: ${chalk.cyan(eisEndpoint)}`);
   } else {
     log.warning(
-      `Could not detect xpack.inference.elastic.url — make sure Elasticsearch was started with ${chalk.cyan('-E xpack.inference.elastic.url=...')}`
+      `Could not detect xpack.inference.elastic.url — make sure Elasticsearch was started with ${chalk.cyan(
+        '-E xpack.inference.elastic.url=...'
+      )}`
     );
   }
 


### PR DESCRIPTION
## Summary

- Add clear, step-by-step logging to `node scripts/eis.js` so users can see what's happening at each stage (ES connection, EIS endpoint detection, API key resolution, CCM setup)
- Bail immediately on non-retryable errors (401/403) instead of retrying 3 times with delays
- Validate the vault API key is non-empty before sending it to ES
- Support `KIBANA_EIS_CCM_API_KEY` env var as an alternative to vault
- Include the correct `VAULT_ADDR` in error messages so users can copy-paste the login command
- Update README with revised prerequisites and usage instructions

## Context

Several users hit cryptic errors from the EIS script without clear guidance on what went wrong. Common issues can be: vault not authenticated (or expired token), ES not started with the EIS URL flag, and empty API keys being silently sent. This change makes each failure mode obvious from the logs.