### PR TITLE
[Security Solution] fix event overview tab not showing in Discover security profile

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { ALERT_RULE_TYPE_ID, ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/rule-data-utils';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
 import { createProfileProviderSharedServicesMock } from '../../../__mocks__';
 import { createSecurityDocumentProfileProvider } from './profile';
@@ -44,11 +44,42 @@ describe('createSecurityDocumentProfileProvider — getDocViewer', () => {
     });
   });
 
-  it('does NOT register the overview tab for a non-alert event', () => {
+  it('registers the overview tab for a signal with an unrelated rule type', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(
+      buildRecord({
+        'event.kind': 'signal',
+        [ALERT_RULE_TYPE_ID]: 'siem.queryRule',
+      })
+    );
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]).toMatchObject({
+      id: 'doc_view_alerts_overview',
+      title: 'Alert Overview',
+    });
+  });
+
+  it('registers the overview tab for a non-alert event', () => {
     const registry = new DocViewsRegistry();
     const docViewer = getDocViewerFor(buildRecord({ 'event.kind': 'event' }));
     docViewer.docViewsRegistry(registry);
-    expect(registry.getAll()).toHaveLength(0);
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]).toMatchObject({
+      id: 'doc_view_alerts_overview',
+      title: 'Event Overview',
+    });
+  });
+
+  it('registers the overview tab when event.kind is absent', () => {
+    const registry = new DocViewsRegistry();
+    const docViewer = getDocViewerFor(buildRecord({}));
+    docViewer.docViewsRegistry(registry);
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]).toMatchObject({
+      id: 'doc_view_alerts_overview',
+      title: 'Event Overview',
+    });
   });
 
   it('does NOT register the overview tab for a scheduled attack discovery alert', () => {
@@ -56,7 +87,7 @@ describe('createSecurityDocumentProfileProvider — getDocViewer', () => {
     const docViewer = getDocViewerFor(
       buildRecord({
         'event.kind': 'signal',
-        [ALERT_RULE_TYPE_ID]: 'attack-discovery',
+        [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
       })
     );
     docViewer.docViewsRegistry(registry);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_document_profile/profile.tsx
@@ -15,7 +15,7 @@ import { SECURITY_PROFILE_ID } from '../constants';
 import * as i18n from '../translations';
 import type { SecurityProfileProviderFactory } from '../types';
 import { AlertEventOverviewLazy } from '../components';
-import { isAlertDocument } from '../utils/is_alert_document';
+import { isAlertDocument, isEventDocument } from '../utils/is_alert_document';
 
 export const createSecurityDocumentProfileProvider: SecurityProfileProviderFactory<
   DocumentProfileProvider
@@ -26,11 +26,12 @@ export const createSecurityDocumentProfileProvider: SecurityProfileProviderFacto
       getDocViewer: (prev) => (params) => {
         const prevDocViewer = prev(params);
         const isAlert = isAlertDocument(params.record);
+        const isEvent = isEventDocument(params.record);
 
         return {
           ...prevDocViewer,
           docViewsRegistry: (registry) => {
-            if (isAlert) {
+            if (isAlert || isEvent) {
               registry.add({
                 id: 'doc_view_alerts_overview',
                 title: i18n.overviewTabTitle(isAlert),

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { ALERT_RULE_TYPE_ID, ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/rule-data-utils';
 import type { ProfileProviderServices } from '../profile_provider_services';
 import { DocumentType } from '../../profiles';
 import { createSecurityDocumentProfileProviders } from './security_profile_providers';
@@ -47,9 +48,21 @@ describe('createSecurityDocumentProfileProviders', () => {
       expect(result.renderHeader).not.toBe(prevRenderHeader);
     });
 
-    it('does not override renderHeader for non-alert documents', () => {
+    it('overrides renderHeader for non-alert events', () => {
       const { result, prevRenderHeader } = getDocViewerResult(
         createRecord({ 'event.kind': 'event' })
+      );
+
+      expect(result.renderHeader).toBeDefined();
+      expect(result.renderHeader).not.toBe(prevRenderHeader);
+    });
+
+    it('does not override renderHeader for attack discovery alerts', () => {
+      const { result, prevRenderHeader } = getDocViewerResult(
+        createRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+        })
       );
 
       expect(result.renderHeader).toBe(prevRenderHeader);
@@ -65,8 +78,23 @@ describe('createSecurityDocumentProfileProviders', () => {
       );
     });
 
-    it('does not add the overview tab to the registry for non-alert documents', () => {
+    it('adds the overview tab to the registry for non-alert events', () => {
       const { result } = getDocViewerResult(createRecord({ 'event.kind': 'event' }));
+      const registry = { add: jest.fn() };
+      result.docViewsRegistry(registry as never);
+
+      expect(registry.add).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'doc_view_alerts_overview' })
+      );
+    });
+
+    it('does not add the overview tab to the registry for attack discovery alerts', () => {
+      const { result } = getDocViewerResult(
+        createRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+        })
+      );
       const registry = { add: jest.fn() };
       result.docViewsRegistry(registry as never);
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/security_profile_providers.tsx
@@ -14,7 +14,7 @@ import { extendProfileProvider } from '../extend_profile_provider';
 import { createSecurityDocumentProfileProvider } from './security_document_profile';
 import type { ProfileProviderServices } from '../profile_provider_services';
 import * as i18n from './translations';
-import { isAlertDocument } from './utils/is_alert_document';
+import { isAlertDocument, isEventDocument } from './utils/is_alert_document';
 
 export const createSecurityDocumentProfileProviders = (
   providerServices: ProfileProviderServices
@@ -27,20 +27,22 @@ export const createSecurityDocumentProfileProviders = (
       getDocViewer: (prev) => (params) => {
         const prevDocViewer = prev(params);
         const isAlert = isAlertDocument(params.record);
+        const isEvent = isEventDocument(params.record);
 
         return {
           ...prevDocViewer,
-          renderHeader: isAlert
-            ? (props) => (
-                <EnhancedAlertFlyoutHeaderLazy
-                  {...props}
-                  providerServices={providerServices}
-                  fallbackRenderHeader={prevDocViewer.renderHeader}
-                />
-              )
-            : prevDocViewer.renderHeader,
+          renderHeader:
+            isAlert || isEvent
+              ? (props) => (
+                  <EnhancedAlertFlyoutHeaderLazy
+                    {...props}
+                    providerServices={providerServices}
+                    fallbackRenderHeader={prevDocViewer.renderHeader}
+                  />
+                )
+              : prevDocViewer.renderHeader,
           docViewsRegistry: (registry) => {
-            if (isAlert) {
+            if (isAlert || isEvent) {
               registry.add({
                 id: 'doc_view_alerts_overview',
                 title: i18n.overviewTabTitle(isAlert),

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/translations.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/translations.ts
@@ -9,12 +9,6 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const exploreRowActionLabel = (isAlert: boolean) =>
-  i18n.translate('discover.profile.security.rowAction.exploreButtonLabel', {
-    values: { isAlert },
-    defaultMessage: 'Explore {isAlert, select, true {Alert} other {Event}} in Security',
-  });
-
 export const overviewTabTitle = (isAlert: boolean) =>
   i18n.translate('discover.profile.security.flyout.overviewTabTitle', {
     values: { isAlert },

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.test.ts
@@ -8,11 +8,68 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
-import { ALERT_RULE_TYPE_ID } from '@kbn/rule-data-utils';
-import { isAlertDocument } from './is_alert_document';
+import { ALERT_RULE_TYPE_ID, ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID } from '@kbn/rule-data-utils';
+import { isAlertDocument, isAttackDocument, isEventDocument } from './is_alert_document';
 
 const buildRecord = (fields: Record<string, unknown>): DataTableRecord =>
   ({ flattened: fields, raw: {}, id: 'test-id' } as unknown as DataTableRecord);
+
+describe('isEventDocument', () => {
+  it('returns false for signal events', () => {
+    expect(isEventDocument(buildRecord({ 'event.kind': 'signal' }))).toBe(false);
+  });
+
+  it('returns true for non-signal events', () => {
+    expect(isEventDocument(buildRecord({ 'event.kind': 'event' }))).toBe(true);
+  });
+
+  it('returns true when event.kind is absent', () => {
+    expect(isEventDocument(buildRecord({}))).toBe(true);
+  });
+});
+
+describe('isAttackDocument', () => {
+  it('returns true for a scheduled attack discovery alert', () => {
+    expect(
+      isAttackDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('returns true for an ad-hoc attack discovery alert', () => {
+    expect(
+      isAttackDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: 'attack_discovery_ad_hoc_rule_type_id',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for a signal with an unrelated rule type', () => {
+    expect(
+      isAttackDocument(
+        buildRecord({
+          'event.kind': 'signal',
+          [ALERT_RULE_TYPE_ID]: 'siem.queryRule',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for a non-signal event', () => {
+    expect(isAttackDocument(buildRecord({ 'event.kind': 'event' }))).toBe(false);
+  });
+
+  it('returns false when event.kind is absent', () => {
+    expect(isAttackDocument(buildRecord({}))).toBe(false);
+  });
+});
 
 describe('isAlertDocument', () => {
   it('returns true for a regular security alert', () => {
@@ -32,7 +89,7 @@ describe('isAlertDocument', () => {
       isAlertDocument(
         buildRecord({
           'event.kind': 'signal',
-          [ALERT_RULE_TYPE_ID]: 'attack-discovery',
+          [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
         })
       )
     ).toBe(false);

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/utils/is_alert_document.ts
@@ -18,14 +18,30 @@ import {
 const ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID = 'attack_discovery_ad_hoc_rule_type_id' as const;
 
 /**
- * Returns true if the document is a security alert — i.e. event.kind is 'signal'
- * and the rule type is not an attack discovery rule type.
+ * Returns true if the document is not an alert or an attack (event.kind is not 'signal')
  */
-export const isAlertDocument = (record: DataTableRecord): boolean => {
-  if (getFieldValue(record, EVENT_KIND) !== 'signal') return false;
+export const isEventDocument = (record: DataTableRecord): boolean => {
+  return getFieldValue(record, EVENT_KIND) !== 'signal';
+};
+
+/**
+ * Returns true if the document is not an alert or an attack (event.kind is not 'signal')
+ */
+export const isAttackDocument = (record: DataTableRecord): boolean => {
+  const eventKind = getFieldValue(record, EVENT_KIND);
   const ruleTypeId = getFieldValue(record, ALERT_RULE_TYPE_ID);
   return (
-    ruleTypeId !== ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID &&
-    ruleTypeId !== ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID
+    eventKind === 'signal' &&
+    (ruleTypeId === ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID ||
+      ruleTypeId === ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID)
   );
+};
+
+/**
+ * Returns true if the document is a security alert (not an event and not an attack)
+ */
+export const isAlertDocument = (record: DataTableRecord): boolean => {
+  if (isEventDocument(record)) return false;
+  if (isAttackDocument(record)) return false;
+  return getFieldValue(record, EVENT_KIND) === 'signal';
 };


### PR DESCRIPTION
## Summary

This [PR](https://github.com/elastic/kibana/pull/259456) merged a couple of days ago actually introduced a small bug, where the `Event Overview` tab does not show up anymore.
My intention was to exclude attacks from rendering the `Alert Overview` tab, and in the process I actually excluded non-alert documents as well.

### Code changes

This PR makes a very small change where we now check if the document is an alert or an event, but NOT an attack. We only render the `Alert/Event Overview` tab accordingly. This is applied to both the base security profile as well as the enhanced one (still experimental).

### UI changes

For the base profile, you can see in the video below 3 documents being opened:
- first a non-alert non-attack document (event.kind != signal)
- then second an attack document
- and lastly an alert document

https://github.com/user-attachments/assets/60d20ac5-d9b2-4139-bf0a-754fbab82541

For the enhanced profile, you can see in the video below the same 3 documents being opened:
- first a non-alert non-attack document (event.kind != signal)
- then second an attack document
- and lastly an alert document


https://github.com/user-attachments/assets/8d3624e8-ad38-4f68-81a0-d1f0c5fbb195

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
