### PR TITLE
[9.2] [Security Solution] remove index existence checks in useShowTimelineForGivenPath (#259212)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/timelines.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { recurse } from 'cypress-recurse';
 import { initializeDataViews } from '../../tasks/login';
 import { takeOsqueryActionWithParams } from '../../tasks/live_query';
 import { ServerlessRoleName } from '../../support/roles';
@@ -27,9 +28,22 @@ describe('ALL - Timelines', { tags: ['@ess'] }, () => {
     cy.getBySel('timeline-bottom-bar').within(() => {
       cy.getBySel('timeline-bottom-bar-title-button').click();
     });
-    cy.getBySel('timelineQueryInput').type(
-      'NOT host.name: "dev-fleet-server*" and component.type: "osquery" AND (_index: "logs-*" OR _index: "filebeat-*"){enter}'
+    const timelineQuery =
+      'NOT host.name: "dev-fleet-server*" and component.type: "osquery" AND (_index: "logs-*" OR _index: "filebeat-*")';
+    recurse(
+      () => {
+        cy.getBySel('timelineQueryInput').focus();
+        cy.getBySel('timelineQueryInput').clear();
+        cy.getBySel('timelineQueryInput').type(timelineQuery, {
+          parseSpecialCharSequences: false,
+        });
+
+        return cy.getBySel('timelineQueryInput').invoke('val');
+      },
+      (val) => `${val ?? ''}` === timelineQuery,
+      { limit: 5, delay: 100 }
     );
+    cy.getBySel('timelineQueryInput').type('{enter}');
 
     // Force true due to pointer-events: none on parent prevents user mouse interaction.
     cy.getBySel('docTableExpandToggleColumn').first().click({ force: true });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline.test.tsx
@@ -115,11 +115,11 @@ describe('sourcererDataView', () => {
     expect(result.current).toEqual([true]);
   });
 
-  it('should not show timeline when dataViewId is not null and indices does not exist', () => {
+  it('should show timeline even when indices do not exist (data view state does not gate visibility)', () => {
     jest.mocked(useDataView).mockImplementation(defaultImplementation);
     mockUseSourcererDataView.mockReturnValueOnce({ indicesExist: false, dataViewId: 'test' });
     const { result } = renderUseShowTimeline();
-    expect(result.current).toEqual([false]);
+    expect(result.current).toEqual([true]);
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/utils/timeline/use_show_timeline_for_path.ts
@@ -8,15 +8,10 @@
 import { useCallback, useMemo } from 'react';
 import { matchPath } from 'react-router-dom';
 
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import type { NormalizedLink } from '../../links';
 import { useNormalizedAppLinks } from '../../links/links_hooks';
 import { useKibana } from '../../lib/kibana';
 import { hasAccessToSecuritySolution } from '../../../helpers_access';
-
-import { SourcererScopeName } from '../../../sourcerer/store/model';
-import { useSourcererDataView } from '../../../sourcerer/containers';
-import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 
 const useHiddenTimelineRoutes = () => {
   const normalizedLinks = useNormalizedAppLinks();
@@ -37,34 +32,16 @@ export const useShowTimelineForGivenPath = () => {
   const { capabilities } = useKibana().services.application;
   const userHasSecuritySolutionVisible = hasAccessToSecuritySolution(capabilities);
 
-  const { indicesExist: oldIndicesExist, dataViewId } = useSourcererDataView(
-    SourcererScopeName.timeline
-  );
-
-  const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
-  const { dataView } = useDataView(SourcererScopeName.timeline);
-
-  const indicesExist = newDataViewPickerEnabled ? dataView.hasMatchedIndices() : oldIndicesExist;
-
   const hiddenTimelineRoutes = useHiddenTimelineRoutes();
-
-  const isTimelineAllowed = useMemo(() => {
-    // NOTE: with new Data View Picker, data view is always defined
-    if (newDataViewPickerEnabled) {
-      return userHasSecuritySolutionVisible && indicesExist;
-    }
-
-    return userHasSecuritySolutionVisible && (indicesExist || dataViewId === null);
-  }, [newDataViewPickerEnabled, userHasSecuritySolutionVisible, indicesExist, dataViewId]);
 
   const getIsTimelineVisible = useCallback(
     (pathname: string) => {
-      if (!isTimelineAllowed) {
+      if (!userHasSecuritySolutionVisible) {
         return false;
       }
       return !hiddenTimelineRoutes.some((route) => matchPath(pathname, route));
     },
-    [isTimelineAllowed, hiddenTimelineRoutes]
+    [userHasSecuritySolutionVisible, hiddenTimelineRoutes]
   );
 
   return getIsTimelineVisible;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -88,6 +88,7 @@ const StatefulTimelineComponent: React.FC<Props> = ({
     timelineType,
     description,
     initialized,
+    changed,
   } = useDeepEqualSelector((state) =>
     pick(
       [
@@ -99,6 +100,7 @@ const StatefulTimelineComponent: React.FC<Props> = ({
         'initialized',
         'show',
         'activeTab',
+        'changed',
       ],
       getTimeline(state, timelineId) ?? timelineDefaults
     )
@@ -166,7 +168,16 @@ const StatefulTimelineComponent: React.FC<Props> = ({
         indexNames: selectedPatterns,
       })
     );
+    // This is an automatic data view sync, not a user-initiated change. If the timeline was
+    // not in a changed state before the sync, reset the changed flag so that page navigation
+    // (e.g. on serverless with the new data view picker, where navigating between pages can
+    // re-initialize the data view and trigger this sync) does not cause a false unsaved-changes
+    // prompt.
+    if (!changed) {
+      dispatch(timelineActions.setChanged({ id: timelineId, changed: false }));
+    }
   }, [
+    changed,
     dispatch,
     savedObjectId,
     selectedDataViewId,

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
@@ -11,10 +11,11 @@ import { visitWithTimeRange } from '../../../tasks/navigation';
 
 import { ALERTS_URL, TIMELINES_URL } from '../../../urls/navigation';
 import { ALERTS_HISTOGRAM_SERIES, ALERT_RULE_NAME, MESSAGE } from '../../../screens/alerts';
-import { TIMELINE_QUERY, TIMELINE_VIEW_IN_ANALYZER } from '../../../screens/timeline';
+import { TIMELINE_VIEW_IN_ANALYZER } from '../../../screens/timeline';
 import { selectAlertsHistogram } from '../../../tasks/alerts';
 import { openTimelineUsingToggle } from '../../../tasks/security_main';
 import { deleteTimelines } from '../../../tasks/api_calls/timelines';
+import { executeTimelineSearch } from '../../../tasks/timeline';
 
 describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
@@ -57,7 +58,7 @@ describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () =>
 
     it('should show ransomware entries in timelines table', () => {
       openTimelineUsingToggle();
-      cy.get(TIMELINE_QUERY).type('event.code: "ransomware"{enter}');
+      executeTimelineSearch('event.code: "ransomware"');
 
       // Wait for grid to load, it should have an analyzer icon
       cy.get(TIMELINE_VIEW_IN_ANALYZER).should('exist');

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -112,10 +112,31 @@ import { getDataTestSubjectSelector } from '../helpers/common';
 
 const hostExistsQuery = 'host.name: *';
 
+const typeAndVerifyValue = (
+  selector: string,
+  value: string,
+  options?: Partial<Cypress.TypeOptions>
+) => {
+  recurse(
+    () => {
+      cy.get(selector).focus();
+      cy.get(selector).clear();
+      cy.get(selector).type(value, options);
+      return cy.get(selector).invoke('val');
+    },
+    (nextValue) => `${nextValue ?? ''}` === value,
+    {
+      limit: 5,
+      delay: 100,
+    }
+  );
+};
+
 export const addNameToTimelineAndSave = (name: string) => {
   cy.get(SAVE_TIMELINE_ACTION_BTN).first().click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.be.disabled').clear();
-  cy.get(TIMELINE_TITLE_INPUT).type(`${name}{enter}`);
+  typeAndVerifyValue(TIMELINE_TITLE_INPUT, name);
+  cy.get(TIMELINE_TITLE_INPUT).type('{enter}');
   cy.get(TIMELINE_TITLE_INPUT).should('have.attr', 'value', name);
   cy.get(TIMELINE_SAVE_MODAL_SAVE_BUTTON).click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.exist');
@@ -124,7 +145,8 @@ export const addNameToTimelineAndSave = (name: string) => {
 export const addNameToTimelineAndSaveAsNew = (name: string) => {
   cy.get(SAVE_TIMELINE_ACTION_BTN).first().click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.be.disabled').clear();
-  cy.get(TIMELINE_TITLE_INPUT).type(`${name}{enter}`);
+  typeAndVerifyValue(TIMELINE_TITLE_INPUT, name);
+  cy.get(TIMELINE_TITLE_INPUT).type('{enter}');
   cy.get(TIMELINE_TITLE_INPUT).should('have.attr', 'value', name);
   cy.get(TIMELINE_SAVE_MODAL_SAVE_AS_NEW_SWITCH).should('exist');
   cy.get(TIMELINE_SAVE_MODAL_SAVE_AS_NEW_SWITCH).click();
@@ -150,9 +172,10 @@ export const addNameAndDescriptionToTimeline = (
   if (!modalAlreadyOpen) {
     cy.get(SAVE_TIMELINE_ACTION).click();
   }
-  cy.get(TIMELINE_TITLE_INPUT).type(`${timeline.title}{enter}`);
+  typeAndVerifyValue(TIMELINE_TITLE_INPUT, timeline.title);
+  cy.get(TIMELINE_TITLE_INPUT).type('{enter}');
   cy.get(TIMELINE_TITLE_INPUT).should('have.attr', 'value', timeline.title);
-  cy.get(TIMELINE_DESCRIPTION_INPUT).type(timeline.description);
+  typeAndVerifyValue(TIMELINE_DESCRIPTION_INPUT, timeline.description);
   cy.get(TIMELINE_DESCRIPTION_INPUT).invoke('val').should('equal', timeline.description);
   cy.get(TIMELINE_SAVE_MODAL_SAVE_BUTTON).click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.exist');
@@ -196,7 +219,7 @@ export const addNotesToTimeline = (notes: string) => {
     .invoke('text')
     .then(parseInt)
     .then((notesCount) => {
-      cy.get(NOTES_TEXT_AREA).type(notes, {
+      typeAndVerifyValue(NOTES_TEXT_AREA, notes, {
         parseSpecialCharSequences: false,
       });
 
@@ -363,7 +386,8 @@ export const executeTimelineKQL = (query: string) => {
 };
 
 export const executeTimelineSearch = (query: string) => {
-  cy.get(TIMELINE_QUERY).type(`${query} {enter}`);
+  typeAndVerifyValue(TIMELINE_QUERY, query);
+  cy.get(TIMELINE_QUERY).type(' {enter}');
 };
 
 export const expandFirstTimelineEventDetails = () => {

--- a/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/solutions/security/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -381,8 +381,8 @@ export const createTimelineTemplateFromBottomBar = () => {
 };
 
 export const executeTimelineKQL = (query: string) => {
-  cy.get(`${SEARCH_OR_FILTER_CONTAINER} textarea`).clear();
-  cy.get(`${SEARCH_OR_FILTER_CONTAINER} textarea`).type(`${query} {enter}`);
+  typeAndVerifyValue(`${SEARCH_OR_FILTER_CONTAINER} textarea`, query);
+  cy.get(`${SEARCH_OR_FILTER_CONTAINER} textarea`).type('{enter}');
 };
 
 export const executeTimelineSearch = (query: string) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution] remove index existence checks in useShowTimelineForGivenPath (#259212)](https://github.com/elastic/kibana/pull/259212)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kelvin Tan","email":"141756464+kelvtanv@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-26T02:01:30Z","message":"[Security Solution] remove index existence checks in useShowTimelineForGivenPath (#259212)\n\n## Summary\n\n[See modal issue](https://github.com/elastic/kibana/issues/259195) \n[Related issue](https://github.com/elastic/kibana/issues/258599)\n\n#### Written by AI\nIn `use_timeline_save_prompt.ts`, the `history.block` condition used\n`!getIsTimelineVisible(relativePath)` which depends on\n`isTimelineAllowed`. With `newDataViewPickerEnabled = true`,\n`isTimelineAllowed` is computed as `userHasSecuritySolutionVisible &&\ndataView.hasMatchedIndices()`. During the initial loading state on the\nattacks/alerts page, `hasMatchedIndices()` returns false, making\n`isTimelineAllowed = false` and `getIsTimelineVisible(any_path) =\nfalse`. This caused the block to fire for ALL navigations, including to\nattacks/alerts (which should show the timeline).","sha":"7f47ab1856beeb1d5c3809d20e89b01f462d6d26","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","Team: SecuritySolution","Team:Threat Hunting:Investigations","backport:all-open","v9.4.0","9.4.0"],"title":"[Security Solution] remove index existence checks in useShowTimelineForGivenPath","number":259212,"url":"https://github.com/elastic/kibana/pull/259212","mergeCommit":{"message":"[Security Solution] remove index existence checks in useShowTimelineForGivenPath (#259212)\n\n## Summary\n\n[See modal issue](https://github.com/elastic/kibana/issues/259195) \n[Related issue](https://github.com/elastic/kibana/issues/258599)\n\n#### Written by AI\nIn `use_timeline_save_prompt.ts`, the `history.block` condition used\n`!getIsTimelineVisible(relativePath)` which depends on\n`isTimelineAllowed`. With `newDataViewPickerEnabled = true`,\n`isTimelineAllowed` is computed as `userHasSecuritySolutionVisible &&\ndataView.hasMatchedIndices()`. During the initial loading state on the\nattacks/alerts page, `hasMatchedIndices()` returns false, making\n`isTimelineAllowed = false` and `getIsTimelineVisible(any_path) =\nfalse`. This caused the block to fire for ALL navigations, including to\nattacks/alerts (which should show the timeline).","sha":"7f47ab1856beeb1d5c3809d20e89b01f462d6d26"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259212","number":259212,"mergeCommit":{"message":"[Security Solution] remove index existence checks in useShowTimelineForGivenPath (#259212)\n\n## Summary\n\n[See modal issue](https://github.com/elastic/kibana/issues/259195) \n[Related issue](https://github.com/elastic/kibana/issues/258599)\n\n#### Written by AI\nIn `use_timeline_save_prompt.ts`, the `history.block` condition used\n`!getIsTimelineVisible(relativePath)` which depends on\n`isTimelineAllowed`. With `newDataViewPickerEnabled = true`,\n`isTimelineAllowed` is computed as `userHasSecuritySolutionVisible &&\ndataView.hasMatchedIndices()`. During the initial loading state on the\nattacks/alerts page, `hasMatchedIndices()` returns false, making\n`isTimelineAllowed = false` and `getIsTimelineVisible(any_path) =\nfalse`. This caused the block to fire for ALL navigations, including to\nattacks/alerts (which should show the timeline).","sha":"7f47ab1856beeb1d5c3809d20e89b01f462d6d26"}},{"url":"https://github.com/elastic/kibana/pull/259680","number":259680,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->