### PR TITLE
chore: clean cache before moving on with other jobs

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-echo "--- Clean up cached images to free up space (this job doesn't require any of the cached images, and they can take up a lot of space)"
+echo "--- Clean up cached images to free up space"
 clean_cached_images
 
 export KBN_NP_PLUGINS_BUILT=true

--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
+echo "--- Clean up cached images to free up space (this job doesn't require any of the cached images, and they can take up a lot of space)"
+clean_cached_images
+
 export KBN_NP_PLUGINS_BUILT=true
 
 echo "--- Build Kibana Distribution"

--- a/.buildkite/scripts/steps/artifacts/docker_context.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_context.sh
@@ -9,8 +9,7 @@ source .buildkite/scripts/steps/artifacts/env.sh
 
 KIBANA_DOCKER_CONTEXT="${KIBANA_DOCKER_CONTEXT:="default"}"
 
-
-echo "--- Clean up cached images"
+echo "--- Clean up cached images to free up space (this job doesn't require any of the cached images, and they can take up a lot of space)"
 clean_cached_images
 
 echo "--- Create contexts"

--- a/.buildkite/scripts/steps/artifacts/docker_context.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_context.sh
@@ -9,6 +9,10 @@ source .buildkite/scripts/steps/artifacts/env.sh
 
 KIBANA_DOCKER_CONTEXT="${KIBANA_DOCKER_CONTEXT:="default"}"
 
+
+echo "--- Clean up cached images"
+clean_cached_images
+
 echo "--- Create contexts"
 mkdir -p target
 node scripts/build --skip-initialize --skip-generic-folders --skip-platform-folders --skip-archives --skip-cdn-assets --docker-context-use-local-artifact "${BUILD_ARGS[@]}"

--- a/.buildkite/scripts/steps/artifacts/docker_context.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_context.sh
@@ -9,7 +9,7 @@ source .buildkite/scripts/steps/artifacts/env.sh
 
 KIBANA_DOCKER_CONTEXT="${KIBANA_DOCKER_CONTEXT:="default"}"
 
-echo "--- Clean up cached images to free up space (this job doesn't require any of the cached images, and they can take up a lot of space)"
+echo "--- Clean up cached images to free up space"
 clean_cached_images
 
 echo "--- Create contexts"


### PR DESCRIPTION
## Summary

Clear docker cache for jobs that don't require them. We are only adding this step for jobs that don't need any of the cached images and take up unnecessary space. 

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->