### PR TITLE
[Synthtrace] Fix MaxListenersExceededWarning in live mode

### DIFF
--- a/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/stream_manager.ts
+++ b/src/platform/packages/shared/kbn-synthtrace/src/cli/utils/stream_manager.ts
@@ -104,6 +104,9 @@ export class StreamManager {
     const generatorArray = castArray(generator);
     const streams: Readable[] = [];
 
+    // Allow enough listeners for all source generators piping into generatorStream
+    generatorStream.setMaxListeners(generatorArray.length + 5);
+
     generatorArray.reverse().forEach((current) => {
       const currentStream = isGeneratorObject(current) ? Readable.from(current) : current;
       currentStream.pipe(generatorStream, { end: false });
@@ -136,6 +139,7 @@ export class StreamManager {
     this.trackedGeneratorStreams.push(generatorStream);
 
     await awaitStream(generatorStream).finally(() => {
+      generatorStream.unpipe(clientStream);
       pull(this.trackedGeneratorStreams, generatorStream);
       pull(streams, generatorStream);
     });
@@ -148,6 +152,9 @@ export class StreamManager {
       stream = this.clientStreams.get(client)!;
     } else {
       stream = new PassThrough({ objectMode: true });
+      // In live mode this stream receives a new pipe per bucket interval,
+      // so disable the default listener limit.
+      stream.setMaxListeners(0);
       this.clientStreams.set(client, stream);
       this.clientIndexPromises.set(client, client.index(stream));
     }


### PR DESCRIPTION
## Summary

Fixes `MaxListenersExceededWarning` warnings that are emitted repeatedly when running synthtrace with the `--live` flag.

<img width="1604" height="108" alt="image" src="https://github.com/user-attachments/assets/d4a90af8-f126-45e0-b30f-f413092dea0d" />


In live mode, `StreamManager.index()` is called once per bucket interval (default every 1s). Each call creates a new `generatorStream` PassThrough and pipes it into the long-lived `clientStream` PassThrough. These pipe operations register `unpipe`, `error`, `close`, `finish`, and `drain` listeners on the destination stream, which accumulated beyond Node.js's default limit of 10.

**Changes:**
- **Set dynamic `maxListeners` on `generatorStream`** — proportional to the number of source generators piping into it, preventing warnings for scenarios like `infra_hosts_with_apm_hosts` that produce many generators per client.
- **Explicitly `unpipe` `generatorStream` from `clientStream`** in the `.finally()` block to guarantee listener cleanup between bucket intervals.
- **Disable listener limit on reused `clientStream`** via `setMaxListeners(0)`, since in live mode it legitimately receives a new pipe per bucket for the entire session duration.