### PR TITLE
[Chrome Next] Remove AppMenuConfigNext

### DIFF
--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/index.ts
@@ -23,7 +23,6 @@ export type {
   AppMenuPrimaryActionItem,
   AppMenuPopoverItem,
   AppMenuSplitButtonProps,
-  AppMenuConfigNext,
 } from './src';
 
 export {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/index.ts
@@ -23,7 +23,6 @@ export type {
   AppMenuPrimaryActionItem,
   AppMenuPopoverItem,
   AppMenuSplitButtonProps,
-  AppMenuConfigNext,
 } from './types';
 
 export {

--- a/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
+++ b/src/core/packages/chrome/app-menu/core-chrome-app-menu-components/src/types.ts
@@ -288,5 +288,3 @@ export interface AppMenuConfig {
    */
   secondaryActionItem?: AppMenuSecondaryActionItem;
 }
-
-export type AppMenuConfigNext = AppMenuConfig;

--- a/src/core/packages/chrome/browser-components/src/project_next/hooks/use_project_next_app_menu.ts
+++ b/src/core/packages/chrome/browser-components/src/project_next/hooks/use_project_next_app_menu.ts
@@ -7,14 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AppMenuConfigNext } from '@kbn/core-chrome-app-menu-components';
+import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 import { useAppMenu, useNextHeader } from '../../shared/chrome_hooks';
 
 /**
  * Returns the app menu config for the Chrome-Next project header.
  * Fallback: `config.appMenu` from `chrome.next.header.set()` -> global `chrome.getAppMenu$()`.
  */
-export function useProjectNextAppMenu(): AppMenuConfigNext | undefined {
+export function useProjectNextAppMenu(): AppMenuConfig | undefined {
   const config = useNextHeader();
   const globalAppMenu = useAppMenu();
   return config?.appMenu ?? globalAppMenu;

--- a/src/core/packages/chrome/browser/src/next_header.ts
+++ b/src/core/packages/chrome/browser/src/next_header.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { AppMenuConfigNext } from '@kbn/core-chrome-app-menu-components';
+import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
 
 /**
  * Unified configuration for the Chrome-controlled Chrome-Next header.
@@ -51,9 +51,8 @@ export interface ChromeNextHeaderConfig {
 
   /**
    * App menu (toolbar actions). Items, primary action, secondary action.
-   * TODO: Consider strict type independent from `@kbn/core-chrome-app-menu-components`
    */
-  appMenu?: AppMenuConfigNext;
+  appMenu?: AppMenuConfig;
 
   /**
    * Optional explicit back navigation for the Chrome-Next header back control.


### PR DESCRIPTION
## Summary

This PR removes `AppMenuConfigNext` as we'll be modifying `AppMenuConfig` and going straight to main with it (https://github.com/elastic/kibana/pull/259949)

