### PR TITLE
[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
@@ -11,7 +11,13 @@ import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { Spaces } from '../../../scenarios';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
-import { getUrlPrefix, getTestRuleData, ObjectRemover, checkAAD } from '../../../../common/lib';
+import {
+  getUrlPrefix,
+  getTestRuleData,
+  ObjectRemover,
+  checkAAD,
+  getEventLog,
+} from '../../../../common/lib';
 
 /** Simulates 7.x documents where lastRun.outcomeMsg was stored as a string. */
 const LEGACY_OUTCOME_MSG = 'legacy outcome message string';
@@ -19,16 +25,16 @@ const LEGACY_OUTCOME_MSG = 'legacy outcome message string';
 export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProviderContext) {
   const es = getService('es');
   const supertest = getService('supertest');
+  const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/259634
-  describe.skip('lastRun outcomeMsg migration', () => {
+  describe('lastRun outcomeMsg migration', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     afterEach(async () => {
       await objectRemover.removeAll();
     });
 
-    async function getAlertFromEs(ruleId: string): Promise<RawRule> {
+    async function getRuleFromEs(ruleId: string): Promise<RawRule> {
       const response = await es.get<{ alert: RawRule }>(
         {
           index: ALERTING_CASES_SAVED_OBJECT_INDEX,
@@ -67,11 +73,13 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
           })
         )
         .expect(200);
+      // Wait for rule execution to complete to avoid race conditions with injectLegacyStringOutcomeMsg()
+      await waitForEventLogDocs(createdRule.id, new Map());
       objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
 
       await injectLegacyStringOutcomeMsg(createdRule.id);
 
-      const beforeBulk = await getAlertFromEs(createdRule.id);
+      const beforeBulk = await getRuleFromEs(createdRule.id);
       expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
         LEGACY_OUTCOME_MSG
       );
@@ -84,7 +92,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
         })
         .expect(200);
 
-      const afterBulk = await getAlertFromEs(createdRule.id);
+      const afterBulk = await getRuleFromEs(createdRule.id);
       expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
       expect(afterBulk.enabled).to.eql(false);
 
@@ -118,7 +126,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
 
       await injectLegacyStringOutcomeMsg(createdRule.id);
 
-      const beforeBulk = await getAlertFromEs(createdRule.id);
+      const beforeBulk = await getRuleFromEs(createdRule.id);
       expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
         LEGACY_OUTCOME_MSG
       );
@@ -131,7 +139,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
         })
         .expect(200);
 
-      const afterBulk = await getAlertFromEs(createdRule.id);
+      const afterBulk = await getRuleFromEs(createdRule.id);
       expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
       expect(afterBulk.enabled).to.eql(true);
 
@@ -150,4 +158,20 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
       });
     });
   });
+
+  async function waitForEventLogDocs(
+    id: string,
+    actions: Map<string, { gte: number } | { equal: number }>
+  ) {
+    return await retry.try(async () => {
+      return await getEventLog({
+        getService,
+        spaceId: Spaces.space1.id,
+        type: 'alert',
+        id,
+        provider: 'alerting',
+        actions,
+      });
+    });
+  }
 }


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/259634**
**Relates to:** https://github.com/elastic/kibana/pull/258105

## Summary

This PR fixes rule's `lastRun.outcomeMsg` functional test flakiness. The flakiness was caused by race condition between rule execution and setting the legacy `outcomeMsg`'s value.




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->