### PR TITLE
[Entity Store] Do not nest entity section under type-specific sections

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
@@ -160,13 +160,13 @@ describe('crud_client utils', () => {
     });
 
     describe('name defaulting on create vs update', () => {
-      it('defaults type.name from entity.id on create when name is not present', () => {
+      it('defaults entity.name from entity.id on create when name is not present', () => {
         mockGetEntityDefinition.mockReturnValue(createDefinition('host', []));
 
         const doc: Entity = { entity: { id: 'entity-host' } };
         const result = validateAndTransformDoc('create', 'host', 'default', doc, undefined, true);
 
-        expect(result.doc).toHaveProperty('host.name', 'entity-host');
+        expect(result.doc).toHaveProperty('entity.name', 'entity-host');
       });
 
       it('does not default type.name on update when name is not present', () => {
@@ -337,9 +337,8 @@ describe('crud_client utils', () => {
 
         expect(result.doc).toHaveProperty('entity');
         expect(result.doc).toHaveProperty('entity.id', 'svc-1');
-        expect(result.doc).toHaveProperty('service');
-        expect(result.doc).toHaveProperty('service.name', 'svc-1');
-        expect(result.doc).not.toHaveProperty('service.entity');
+        expect(result.doc).toHaveProperty('entity.name', 'svc-1');
+        expect(result.doc).not.toHaveProperty('service');
       });
     });
 

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
@@ -159,22 +159,6 @@ describe('crud_client utils', () => {
       expect(result.id).toBe('doc-id');
     });
 
-    it('does not entity under typed field for non-generic types', () => {
-      mockGetEntityDefinition.mockReturnValue(createDefinition('host', [createField('host.name')]));
-
-      const doc: Entity = {
-        entity: { id: 'entity-host' },
-        host: { name: 'original-host-name' },
-      };
-      const result = validateAndTransformDoc('update', 'host', 'default', doc, undefined, false);
-
-      expect(result.doc).toHaveProperty('@timestamp');
-      expect(result.doc).toHaveProperty('entity');
-      expect(result.doc).not.toHaveProperty('host.entity');
-      expect(result.doc).toHaveProperty('entity.id', 'entity-host');
-      expect(result.doc).toHaveProperty('host.name', 'original-host-name');
-    });
-
     describe('name defaulting on create vs update', () => {
       it('defaults type.name from entity.id on create when name is not present', () => {
         mockGetEntityDefinition.mockReturnValue(createDefinition('host', []));

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.test.ts
@@ -159,7 +159,7 @@ describe('crud_client utils', () => {
       expect(result.id).toBe('doc-id');
     });
 
-    it('nests entity under typed field for non-generic types', () => {
+    it('does not entity under typed field for non-generic types', () => {
       mockGetEntityDefinition.mockReturnValue(createDefinition('host', [createField('host.name')]));
 
       const doc: Entity = {
@@ -168,9 +168,10 @@ describe('crud_client utils', () => {
       };
       const result = validateAndTransformDoc('update', 'host', 'default', doc, undefined, false);
 
-      expect(result.doc['@timestamp']).toEqual(expect.any(String));
-      expect(result.doc).not.toHaveProperty('entity');
-      expect(result.doc).toHaveProperty('host.entity.id', 'entity-host');
+      expect(result.doc).toHaveProperty('@timestamp');
+      expect(result.doc).toHaveProperty('entity');
+      expect(result.doc).not.toHaveProperty('host.entity');
+      expect(result.doc).toHaveProperty('entity.id', 'entity-host');
       expect(result.doc).toHaveProperty('host.name', 'original-host-name');
     });
 
@@ -337,24 +338,6 @@ describe('crud_client utils', () => {
         expect(result.doc).toHaveProperty('@timestamp');
       });
 
-      it('nests entity under type key and removes root entity for typed entities', () => {
-        mockGetEntityDefinition.mockReturnValue(
-          createDefinition('host', [createField('host.name')])
-        );
-
-        const doc: Entity = {
-          entity: { id: 'host-1', type: 'Host' },
-          host: { name: 'my-host' },
-        };
-        const result = validateAndTransformDoc('update', 'host', 'default', doc, undefined, true);
-
-        expect(result.doc).not.toHaveProperty('entity');
-        expect(result.doc).toHaveProperty('host.entity.id', 'host-1');
-        expect(result.doc).toHaveProperty('host.entity.type', 'Host');
-        expect(result.doc).toHaveProperty('host.name', 'my-host');
-        expect(result.doc).toHaveProperty('@timestamp');
-      });
-
       it('creates the type object when not present in typed entity', () => {
         mockGetEntityDefinition.mockReturnValue(createDefinition('service', []));
 
@@ -368,9 +351,11 @@ describe('crud_client utils', () => {
           true
         );
 
-        expect(result.doc).not.toHaveProperty('entity');
-        expect(result.doc).toHaveProperty('service.entity.id', 'svc-1');
+        expect(result.doc).toHaveProperty('entity');
+        expect(result.doc).toHaveProperty('entity.id', 'svc-1');
+        expect(result.doc).toHaveProperty('service');
         expect(result.doc).toHaveProperty('service.name', 'svc-1');
+        expect(result.doc).not.toHaveProperty('service.entity');
       });
     });
 
@@ -416,8 +401,8 @@ describe('crud_client utils', () => {
         const result = validateAndTransformDoc('update', 'host', 'default', doc, undefined, false);
 
         expect(result.id).toBe('host:flat-host');
-        expect(result.doc).not.toHaveProperty('entity');
-        expect(result.doc).toHaveProperty('host.entity.id', 'host:flat-host');
+        expect(result.doc).not.toHaveProperty('host.entity');
+        expect(result.doc).toHaveProperty('entity.id', 'host:flat-host');
         expect(result.doc).toHaveProperty('host.name', 'flat-host');
       });
     });

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.ts
@@ -20,7 +20,6 @@ import { HASH_ALG } from '../constants';
 import { BadCRUDRequestError } from '../errors';
 
 type CrudOperation = 'create' | 'update';
-const GENERIC_TYPE = 'generic' as EntityType;
 
 export function hashEuid(id: string): string {
   return createHash(HASH_ALG).update(id).digest('hex');
@@ -69,7 +68,16 @@ export function validateAndTransformDoc(
     assertOnlyNonForcedAttributesInReq(fieldDescriptions);
   }
 
-  return { id, doc: transformDoc(operation, entityType, doc) };
+  if (operation === 'create' && !doc.entity.name) {
+    doc.entity.name = id;
+  }
+
+  const transformedDoc: Record<string, unknown> = {
+    ...doc,
+    '@timestamp': new Date().toISOString(),
+  };
+
+  return { id, doc: transformedDoc };
 }
 
 function getFieldDescriptions(
@@ -128,31 +136,4 @@ function assertOnlyNonForcedAttributesInReq(fields: Record<string, EntityField>)
         `updated without forcing it (?force=true): ${notAllowedPropsString}`
     );
   }
-}
-
-function transformDoc(
-  operation: CrudOperation,
-  type: EntityType,
-  data: Entity
-): Record<string, unknown> {
-  const doc: Record<string, unknown> = {
-    ...data,
-    '@timestamp': new Date().toISOString(),
-  };
-
-  if (type === GENERIC_TYPE) {
-    return doc;
-  }
-
-  // Set <entityType>.name if not set
-  const key = type as string;
-  if (!doc[key]) {
-    doc[key] = {};
-  }
-  const typeSection = doc[key] as Record<string, unknown>;
-  if (operation === 'create' && !typeSection.name) {
-    typeSection.name = data.entity?.id;
-  }
-
-  return doc;
 }

--- a/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/crud/utils.ts
@@ -144,19 +144,15 @@ function transformDoc(
     return doc;
   }
 
-  const typeKey = type as keyof typeof doc;
-  if (!doc[typeKey] || typeof doc[typeKey] !== 'object') {
-    doc[typeKey] = {};
+  // Set <entityType>.name if not set
+  const key = type as string;
+  if (!doc[key]) {
+    doc[key] = {};
   }
-  const typeDoc = doc[typeKey] as Record<string, unknown>;
-
-  if (operation === 'create' && !typeDoc.name) {
-    typeDoc.name = data.entity?.id;
+  const typeSection = doc[key] as Record<string, unknown>;
+  if (operation === 'create' && !typeSection.name) {
+    typeSection.name = data.entity?.id;
   }
-  typeDoc.entity = data.entity;
-
-  // Remove entity from root
-  delete doc.entity;
 
   return doc;
 }

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/crud_api.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/crud_api.spec.ts
@@ -121,7 +121,8 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
 
       // The stored entity.id should be the generated EUID
       const source = byGenerated._source as HostEntity;
-      expect(source.host?.entity?.id).toBe(expectedEuid);
+      expect(source.host?.entity?.id).toBeUndefined();
+      expect(source.entity?.id).toBe(expectedEuid);
     }
   );
 
@@ -220,17 +221,14 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
       index: LATEST_INDEX,
       query: {
         term: {
-          'host.entity.id': 'host:this-is-update',
+          'entity.id': 'host:this-is-update',
         },
       },
     });
     expect(entities.hits.hits).toHaveLength(1);
     const received = entities.hits.hits[0]._source as HostEntity;
-    expect(received.entity).toBeUndefined();
+    expect(received.entity?.id).toBe(entityObj.entity?.id);
     expect(received.host).toMatchObject({
-      entity: {
-        id: entityObj.entity?.id,
-      },
       name: 'this-is-update',
     });
   });
@@ -265,11 +263,11 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
 
       const entities = await esClient.search({
         index: LATEST_INDEX,
-        query: { term: { 'host.entity.id': 'host:update-id-only' } },
+        query: { term: { 'entity.id': 'host:update-id-only' } },
       });
       expect(entities.hits.hits).toHaveLength(1);
       const received = entities.hits.hits[0]._source as HostEntity;
-      expect(received.host?.entity?.name).toBe('updated-name');
+      expect(received.entity?.name).toBe('updated-name');
     }
   );
 
@@ -305,11 +303,11 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
 
       const entities = await esClient.search({
         index: LATEST_INDEX,
-        query: { term: { 'host.entity.id': 'host:update-identity-only' } },
+        query: { term: { 'entity.id': 'host:update-identity-only' } },
       });
       expect(entities.hits.hits).toHaveLength(1);
       const received = entities.hits.hits[0]._source as HostEntity;
-      expect(received.host?.entity?.name).toBe('updated-via-identity');
+      expect(received.entity?.name).toBe('updated-via-identity');
     }
   );
 
@@ -407,11 +405,11 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
 
     const entities = await esClient.search({
       index: LATEST_INDEX,
-      query: { term: { 'host.entity.id': 'host:flat-update' } },
+      query: { term: { 'entity.id': 'host:flat-update' } },
     });
     expect(entities.hits.hits).toHaveLength(1);
     const received = entities.hits.hits[0]._source as HostEntity;
-    expect(received.host?.entity?.name).toBe('flat-updated-name');
+    expect(received.entity?.name).toBe('flat-updated-name');
   });
 
   apiTest(
@@ -461,14 +459,14 @@ apiTest.describe('Entity Store CRUD API tests', { tag: ENTITY_STORE_TAGS }, () =
 
       const entities = await esClient.search({
         index: LATEST_INDEX,
-        query: { term: { 'host.entity.id': 'host:flat-double-update' } },
+        query: { term: { 'entity.id': 'host:flat-double-update' } },
       });
       expect(entities.hits.hits).toHaveLength(1);
       const received = entities.hits.hits[0]._source as HostEntity;
 
       // Values must be strings, not arrays. Confirms replace, not merge
-      expect(received.host?.entity?.name).toBe('second-name');
-      expect(typeof received.host?.entity?.name).toBe('string');
+      expect(received.entity?.name).toBe('second-name');
+      expect(typeof received.entity?.name).toBe('string');
       expect(received.host?.name).toBe('flat-double-update');
       expect(typeof received.host?.name).toBe('string');
     }


### PR DESCRIPTION
## Summary

Changes document transformation for `create` operations. It will no longer nest `entity` section under type-specific sections, e.g. `service.entity`.

:thread: For context see Slack thread: <https://elastic.slack.com/archives/C08G9NL55K4/p1774534680361539>

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
