### PR TITLE
[Agent Builder] index-explorer: reduce token usage for resource representation

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/index_explorer.test.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/index_explorer.test.ts
@@ -49,6 +49,59 @@ describe('createIndexSelectorPrompt', () => {
   });
 });
 
+describe('formatResource', () => {
+  it('formats a resource with description and fields', () => {
+    const result = formatResource({
+      type: EsResourceType.index,
+      name: 'my-index',
+      description: 'My index description',
+      fields: ['field1', 'field2', 'field3'],
+    });
+    expect(result).toEqual(
+      '- my-index (index): My index description\n  fields: field1, field2, field3'
+    );
+  });
+
+  it('omits description when not provided', () => {
+    const result = formatResource({
+      type: EsResourceType.dataStream,
+      name: 'logs-nginx',
+      fields: ['@timestamp', 'message'],
+    });
+    expect(result).toEqual('- logs-nginx (data_stream)\n  fields: @timestamp, message');
+  });
+
+  it('omits fields line when fields is empty', () => {
+    const result = formatResource({
+      type: EsResourceType.alias,
+      name: 'my-alias',
+      description: 'An alias',
+      fields: [],
+    });
+    expect(result).toEqual('- my-alias (alias): An alias');
+  });
+
+  it('omits fields line when fields is undefined', () => {
+    const result = formatResource({
+      type: EsResourceType.alias,
+      name: 'my-alias',
+    });
+    expect(result).toEqual('- my-alias (alias)');
+  });
+
+  it('truncates fields to 10 entries', () => {
+    const fields = Array.from({ length: 15 }, (_, i) => `field${i + 1}`);
+    const result = formatResource({
+      type: EsResourceType.index,
+      name: 'big-index',
+      fields,
+    });
+    expect(result).toContain('fields: field1,');
+    expect(result).toContain('[and 5 more]');
+    expect(result).not.toContain('field11');
+  });
+});
+
 describe('indexExplorer', () => {
   let esClient: ReturnType<typeof elasticsearchServiceMock.createElasticsearchClient>;
   let model: ScopedModel;

--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/index_explorer.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-genai-utils/tools/index_explorer.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { take } from 'lodash';
 import { z } from '@kbn/zod/v4';
 import type { Logger } from '@kbn/logging';
 import { EsResourceType } from '@kbn/agent-builder-common';
@@ -20,7 +19,6 @@ import type {
 import { listSearchSources } from './steps/list_search_sources';
 import { flattenMapping, getDataStreamMappings } from './utils/mappings';
 import { getIndexFields, partitionByCcs, getBatchedFieldsFromFieldCaps } from './utils/ccs';
-import { generateXmlTree } from './utils/formatting/xml';
 
 export interface RelevantResource {
   type: EsResourceType;
@@ -38,6 +36,13 @@ export interface ResourceDescriptor {
   description?: string;
   fields?: string[];
 }
+
+const truncateList = (fields: string[], max: number): string[] => {
+  if (fields.length <= max) {
+    return fields;
+  }
+  return [...fields.slice(0, max), `[and ${fields.length - max} more]`];
+};
 
 /**
  * Builds resource descriptors for a list of indices by delegating
@@ -76,7 +81,7 @@ const createAliasSummaries = async ({
     return {
       type: EsResourceType.alias,
       name: aliasName,
-      description: `Point to the following indices: ${indices.join(', ')}`,
+      description: `Point to the following indices: ${truncateList(indices, 20).join(', ')}`,
     };
   });
 };
@@ -216,27 +221,11 @@ export interface SelectedResource {
   reason: string;
 }
 
-// Helper function to format each resource in an XML-like block
 export const formatResource = (res: ResourceDescriptor): string => {
-  const topFields = take(res.fields ?? [], 10);
-
-  return generateXmlTree({
-    tagName: 'resource',
-    attributes: {
-      type: res.type,
-      name: res.name,
-      description: res.description ?? 'No description provided.',
-    },
-    children: [
-      {
-        tagName: 'sample_fields',
-        children:
-          topFields.length > 0
-            ? topFields.map((field) => ({ tagName: 'field', children: [field] }))
-            : ['(No fields available)'],
-      },
-    ],
-  });
+  const topFields = truncateList(res.fields ?? [], 10);
+  const description = res.description ? `: ${res.description}` : '';
+  const fields = topFields.length > 0 ? `\n  fields: ${topFields.join(', ')}` : '';
+  return `- ${res.name} (${res.type})${description}${fields}`;
 };
 
 export const createIndexSelectorPrompt = ({
@@ -287,7 +276,9 @@ The 'select_resources' tool expects this exact structure:
 
 ## Available Resources
 
+<available_resources>
 ${resources.map(formatResource).join('\n')}
+</available_resources>
 
 Call the 'select_resources' tool now with your selection. Maximum ${limit} target(s). Use an empty targets array if none match.`,
     ],


### PR DESCRIPTION
Follow-up of #258472

Optimize the representation of resources during index selection, using plain text instead of the much more token-verbose xml format.

Tested on the set of indices used for our eval dataset: 1381 to 596 tokens used for representation, so 57% decrease.