### PR TITLE
[Agent Builder] Add SML attach internal API

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/common/http_api/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/http_api/sml.ts
@@ -11,6 +11,9 @@
  */
 export const SML_HTTP_SEARCH_QUERY_MAX_LENGTH = 512;
 
+/** Max items per `POST /internal/agent_builder/sml/_attach` (matches `sml_attach` tool). */
+export const SML_HTTP_ATTACH_ITEMS_MAX = 50;
+
 /**
  * Response body for `POST /internal/agent_builder/sml/_search` (internal only).
  */
@@ -34,4 +37,28 @@ export interface SmlSearchHttpResultItem {
   score: number;
   /** Indexed searchable text; omitted when `skip_content` was true on the request. */
   content?: string;
+}
+
+/**
+ * Response body for `POST /internal/agent_builder/sml/_attach` (internal only).
+ */
+export interface SmlAttachHttpResponse {
+  results: SmlAttachHttpResultItem[];
+}
+
+export type SmlAttachHttpResultItem = SmlAttachHttpSuccessItem | SmlAttachHttpErrorItem;
+
+export interface SmlAttachHttpSuccessItem {
+  success: true;
+  chunk_id: string;
+  conversation_attachment_id: string;
+  attachment_type: string;
+  message: string;
+}
+
+export interface SmlAttachHttpErrorItem {
+  success: false;
+  chunk_id: string;
+  attachment_type: string;
+  message: string;
 }

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sml.ts
@@ -6,34 +6,51 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { pick } from 'lodash';
+import { createAttachmentStateManager } from '@kbn/agent-builder-server/attachments';
+import {
+  ATTACHMENT_REF_ACTOR,
+  type VersionedAttachment,
+} from '@kbn/agent-builder-common/attachments';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
 import type { RouteDependencies } from '../types';
 import { getHandlerWrapper } from '../wrap_handler';
 import { internalApiPath } from '../../../common/constants';
 import {
+  SML_HTTP_ATTACH_ITEMS_MAX,
   SML_HTTP_SEARCH_QUERY_MAX_LENGTH,
+  type SmlAttachHttpResponse,
+  type SmlAttachHttpResultItem,
   type SmlSearchHttpResponse,
 } from '../../../common/http_api/sml';
-import { AGENT_BUILDER_READ_SECURITY } from '../route_security';
+import { AGENT_BUILDER_READ_SECURITY, AGENT_BUILDER_WRITE_SECURITY } from '../route_security';
+import { resolveSmlAttachItems } from '../../services/sml/execute_sml_attach_items';
+import { applyAttachmentRefsToRounds } from '../../services/conversation/client/migrate_attachments';
 
 /** Max page size for SML HTTP search (separate from default UI size). */
 const SML_SEARCH_SIZE_MAX = 1000;
 
-/** Fields exposed on `SmlSearchHttpResponse.results` (subset of `SmlSearchResult`). */
-const SML_SEARCH_HTTP_RESULT_KEYS = [
-  'id',
-  'type',
-  'origin_id',
-  'title',
-  'score',
-  'content',
-] as const;
+const mergeAttachmentsById = (
+  latestAttachments: VersionedAttachment[],
+  stateManagerAttachments: VersionedAttachment[]
+) => {
+  const mergedAttachments = new Map<string, VersionedAttachment>();
+
+  for (const attachment of stateManagerAttachments) {
+    mergedAttachments.set(attachment.id, attachment);
+  }
+
+  for (const attachment of latestAttachments) {
+    mergedAttachments.set(attachment.id, attachment);
+  }
+
+  return Array.from(mergedAttachments.values());
+};
 
 export function registerInternalSmlRoutes({
   router,
   getInternalServices,
   logger,
+  coreSetup,
 }: RouteDependencies) {
   const wrapHandler = getHandlerWrapper({ logger });
 
@@ -68,8 +85,134 @@ export function registerInternalSmlRoutes({
 
         const body: SmlSearchHttpResponse = {
           total,
-          results: results.map((hit) => pick(hit, ...SML_SEARCH_HTTP_RESULT_KEYS)),
+          results: results.map(({ id, type, origin_id, title, score, content }) => ({
+            id,
+            type,
+            origin_id,
+            title,
+            score,
+            ...(skipContent ? {} : { content }),
+          })),
         };
+
+        return response.ok({ body });
+      },
+      {
+        featureFlag: AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID,
+      }
+    )
+  );
+
+  router.post(
+    {
+      path: `${internalApiPath}/sml/_attach`,
+      validate: {
+        body: schema.object({
+          conversation_id: schema.string(),
+          items: schema.arrayOf(
+            schema.object({
+              chunk_id: schema.string(),
+              attachment_id: schema.string(),
+              attachment_type: schema.string(),
+            }),
+            { minSize: 1, maxSize: SML_HTTP_ATTACH_ITEMS_MAX }
+          ),
+        }),
+      },
+      options: { access: 'internal' },
+      security: AGENT_BUILDER_WRITE_SECURITY,
+    },
+    wrapHandler(
+      async (ctx, request, response) => {
+        const {
+          sml,
+          conversations: conversationsService,
+          attachments: attachmentsService,
+        } = getInternalServices();
+        const { conversation_id: conversationId, items } = request.body;
+        const [coreStart] = await coreSetup.getStartServices();
+        const spaceId = (await ctx.agentBuilder).spaces.getSpaceId();
+        const esClient = (await ctx.core).elasticsearch.client.asCurrentUser;
+        const savedObjectsClient = coreStart.savedObjects.getScopedClient(request);
+        const conversationClient = await conversationsService.getScopedClient({ request });
+        const resolvedItems = await resolveSmlAttachItems({
+          items,
+          sml,
+          esClient,
+          request,
+          spaceId,
+          savedObjectsClient,
+          logger,
+        });
+
+        const conversationForAttach = await conversationClient.get(conversationId);
+        if (conversationForAttach.rounds.length === 0) {
+          return response.badRequest({
+            body: {
+              message: `Conversation '${conversationId}' has no rounds — cannot attach SML items without an existing round`,
+            },
+          });
+        }
+
+        const stateManager = createAttachmentStateManager(conversationForAttach.attachments ?? [], {
+          getTypeDefinition: attachmentsService.getTypeDefinition,
+        });
+
+        // Format the results for the HTTP API
+        const resultItems = await Promise.all(
+          resolvedItems.map(async (r): Promise<SmlAttachHttpResultItem> => {
+            if (!r.success) {
+              return {
+                success: false,
+                chunk_id: r.chunk_id,
+                attachment_type: r.attachment_type,
+                message: r.message,
+              };
+            }
+
+            const added = await stateManager.add(r.attachment, ATTACHMENT_REF_ACTOR.user, {
+              request,
+              spaceId,
+              savedObjectsClient,
+            });
+
+            return {
+              success: true,
+              chunk_id: r.chunk_id,
+              conversation_attachment_id: added.id,
+              attachment_type: r.attachment.type,
+              message: `Attachment '${added.id}' of type '${r.attachment.type}' created from SML item '${r.chunk_id}'`,
+            };
+          })
+        );
+
+        // Update the conversation with the new attachments
+        if (resultItems.some((r) => r.success)) {
+          const latestConversation = await conversationClient.get(conversationId);
+          // get the new attachment refs
+          const newRefs = stateManager
+            .getAccessedRefs()
+            .map((ref) => ({ ...ref, actor: ATTACHMENT_REF_ACTOR.system }));
+
+          const lastRoundIndex = latestConversation.rounds.length - 1;
+          const updatedRounds = applyAttachmentRefsToRounds(
+            latestConversation.rounds,
+            new Map([[lastRoundIndex, newRefs]])
+          );
+          // Merge attachments to prevent duplication or overwriting older attachments
+          const mergedAttachments = mergeAttachmentsById(
+            latestConversation.attachments ?? [],
+            stateManager.getAll()
+          );
+
+          await conversationClient.update({
+            id: conversationId,
+            attachments: mergedAttachments,
+            rounds: updatedRounds,
+          });
+        }
+
+        const body: SmlAttachHttpResponse = { results: resultItems };
 
         return response.ok({ body });
       },

--- a/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sml.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/routes/internal/sml.ts
@@ -135,15 +135,6 @@ export function registerInternalSmlRoutes({
         const esClient = (await ctx.core).elasticsearch.client.asCurrentUser;
         const savedObjectsClient = coreStart.savedObjects.getScopedClient(request);
         const conversationClient = await conversationsService.getScopedClient({ request });
-        const resolvedItems = await resolveSmlAttachItems({
-          items,
-          sml,
-          esClient,
-          request,
-          spaceId,
-          savedObjectsClient,
-          logger,
-        });
 
         const conversationForAttach = await conversationClient.get(conversationId);
         if (conversationForAttach.rounds.length === 0) {
@@ -153,6 +144,16 @@ export function registerInternalSmlRoutes({
             },
           });
         }
+
+        const resolvedItems = await resolveSmlAttachItems({
+          items,
+          sml,
+          esClient,
+          request,
+          spaceId,
+          savedObjectsClient,
+          logger,
+        });
 
         const stateManager = createAttachmentStateManager(conversationForAttach.attachments ?? [], {
           getTypeDefinition: attachmentsService.getTypeDefinition,
@@ -170,29 +171,35 @@ export function registerInternalSmlRoutes({
               };
             }
 
-            const added = await stateManager.add(r.attachment, ATTACHMENT_REF_ACTOR.user, {
-              request,
-              spaceId,
-              savedObjectsClient,
-            });
+            try {
+              const added = await stateManager.add(r.attachment, ATTACHMENT_REF_ACTOR.system, {
+                request,
+                spaceId,
+                savedObjectsClient,
+              });
 
-            return {
-              success: true,
-              chunk_id: r.chunk_id,
-              conversation_attachment_id: added.id,
-              attachment_type: r.attachment.type,
-              message: `Attachment '${added.id}' of type '${r.attachment.type}' created from SML item '${r.chunk_id}'`,
-            };
+              return {
+                success: true,
+                chunk_id: r.chunk_id,
+                conversation_attachment_id: added.id,
+                attachment_type: r.attachment.type,
+                message: `Attachment '${added.id}' of type '${r.attachment.type}' created from SML item '${r.chunk_id}'`,
+              };
+            } catch (e) {
+              return {
+                success: false,
+                chunk_id: r.chunk_id,
+                attachment_type: r.attachment.type,
+                message: e instanceof Error ? e.message : String(e),
+              };
+            }
           })
         );
 
         // Update the conversation with the new attachments
         if (resultItems.some((r) => r.success)) {
           const latestConversation = await conversationClient.get(conversationId);
-          // get the new attachment refs
-          const newRefs = stateManager
-            .getAccessedRefs()
-            .map((ref) => ({ ...ref, actor: ATTACHMENT_REF_ACTOR.system }));
+          const newRefs = stateManager.getAccessedRefs();
 
           const lastRoundIndex = latestConversation.rounds.length - 1;
           const updatedRounds = applyAttachmentRefsToRounds(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { loggerMock } from '@kbn/logging-mocks';
+import type { SmlDocument, SmlService } from './types';
+import { resolveSmlAttachItems } from './execute_sml_attach_items';
+
+const mockCheckItemsAccess = jest.fn();
+const mockGetDocuments = jest.fn();
+const mockGetTypeDefinition = jest.fn();
+
+const createSmlService = (): SmlService =>
+  ({
+    checkItemsAccess: mockCheckItemsAccess,
+    getDocuments: mockGetDocuments,
+    getTypeDefinition: mockGetTypeDefinition,
+  } as unknown as SmlService);
+
+const createSmlDoc = (overrides: Partial<SmlDocument> = {}): SmlDocument => ({
+  id: 'chunk-1',
+  type: 'visualization',
+  title: 'Test Viz',
+  origin_id: 'ref-1',
+  content: 'content',
+  created_at: '2024-01-01',
+  updated_at: '2024-01-02',
+  spaces: ['default'],
+  permissions: [],
+  ...overrides,
+});
+
+const mockLogger = loggerMock.create();
+
+const baseParams = {
+  sml: createSmlService(),
+  esClient: {} as ElasticsearchClient,
+  request: {} as KibanaRequest,
+  spaceId: 'default',
+  savedObjectsClient: {} as SavedObjectsClientContract,
+  logger: mockLogger,
+};
+
+describe('resolveSmlAttachItems', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls checkItemsAccess with chunk_id mapped to id and attachment_type to type', async () => {
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', false]]));
+    await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(mockCheckItemsAccess).toHaveBeenCalledWith({
+      items: [{ id: 'chunk-1', type: 'visualization' }],
+      spaceId: 'default',
+      esClient: baseParams.esClient,
+      request: baseParams.request,
+    });
+  });
+
+  it('calls getDocuments only for chunk ids that passed access check', async () => {
+    mockCheckItemsAccess.mockResolvedValue(
+      new Map([
+        ['a', true],
+        ['b', false],
+      ])
+    );
+    mockGetDocuments.mockResolvedValue(new Map());
+    await resolveSmlAttachItems({
+      ...baseParams,
+      items: [
+        { chunk_id: 'a', attachment_id: 'o-a', attachment_type: 'visualization' },
+        { chunk_id: 'b', attachment_id: 'o-b', attachment_type: 'visualization' },
+      ],
+    });
+    expect(mockGetDocuments).toHaveBeenCalledWith({
+      ids: ['a'],
+      spaceId: 'default',
+      esClient: baseParams.esClient,
+    });
+  });
+
+  it('returns access denied when checkItemsAccess denies the chunk', async () => {
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', false]]));
+    mockGetDocuments.mockResolvedValue(new Map());
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('Access denied');
+      expect(results[0].chunk_id).toBe('chunk-1');
+    }
+    expect(mockGetTypeDefinition).not.toHaveBeenCalled();
+  });
+
+  it('returns not found when document is missing from getDocuments', async () => {
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map());
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('not found in the index');
+    }
+    expect(mockGetTypeDefinition).not.toHaveBeenCalled();
+  });
+
+  it('returns error when attachment_id does not match document origin_id', async () => {
+    const smlDoc = createSmlDoc({ origin_id: 'expected' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'wrong', attachment_type: 'visualization' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('do not match');
+    }
+    expect(mockGetTypeDefinition).not.toHaveBeenCalled();
+  });
+
+  it('returns error when attachment_type does not match document type', async () => {
+    const smlDoc = createSmlDoc({ type: 'visualization' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'dashboard' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('do not match');
+    }
+    expect(mockGetTypeDefinition).not.toHaveBeenCalled();
+  });
+
+  it('returns error when getTypeDefinition is undefined', async () => {
+    const smlDoc = createSmlDoc({ type: 'orphan-type' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue(undefined);
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'orphan-type' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('does not support conversion');
+      expect(results[0].attachment_type).toBe('orphan-type');
+    }
+  });
+
+  it('returns error when toAttachment returns undefined', async () => {
+    const smlDoc = createSmlDoc();
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue(undefined),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain('toAttachment returned undefined');
+    }
+  });
+
+  it('returns attachment data on success without persisting', async () => {
+    const smlDoc = createSmlDoc();
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue({
+        type: 'visualization',
+        data: { layers: [] },
+        origin: 'custom-origin',
+      }),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(results[0].success).toBe(true);
+    if (results[0].success) {
+      expect(results[0].attachment).toEqual({
+        type: 'visualization',
+        data: { layers: [] },
+        origin: 'custom-origin',
+      });
+      expect(results[0].chunk_id).toBe('chunk-1');
+    }
+  });
+
+  it('uses smlDoc.origin_id when converted attachment has no origin', async () => {
+    const smlDoc = createSmlDoc({ origin_id: 'fallback-origin' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue({ type: 'visualization', data: {} }),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [
+        { chunk_id: 'chunk-1', attachment_id: 'fallback-origin', attachment_type: 'visualization' },
+      ],
+    });
+    expect(results[0].success).toBe(true);
+    if (results[0].success) {
+      expect(results[0].attachment.origin).toBe('fallback-origin');
+    }
+  });
+
+  it('returns failure and logs when toAttachment throws', async () => {
+    const smlDoc = createSmlDoc();
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [{ chunk_id: 'chunk-1', attachment_id: 'ref-1', attachment_type: 'visualization' }],
+    });
+    expect(results[0].success).toBe(false);
+    if (!results[0].success) {
+      expect(results[0].message).toContain("Failed to convert SML item 'chunk-1'");
+    }
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('processes multiple items independently', async () => {
+    const docOk = createSmlDoc({ id: 'chunk-ok', origin_id: 'r-ok' });
+    mockCheckItemsAccess.mockResolvedValue(
+      new Map([
+        ['chunk-denied', false],
+        ['chunk-ok', true],
+      ])
+    );
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-ok', docOk]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue({ type: 'visualization', data: {} }),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      items: [
+        { chunk_id: 'chunk-denied', attachment_id: 'x', attachment_type: 'visualization' },
+        { chunk_id: 'chunk-ok', attachment_id: 'r-ok', attachment_type: 'visualization' },
+      ],
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0].success).toBe(false);
+    expect(results[1].success).toBe(true);
+    if (results[1].success) {
+      expect(results[1].attachment).toEqual({
+        type: 'visualization',
+        data: {},
+        origin: 'r-ok',
+      });
+    }
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { Logger } from '@kbn/logging';
+import type { SmlService } from './types';
+
+/** One item to attach — same shape as the `sml_attach` tool and `POST .../sml/_attach`. */
+export interface SmlAttachItemInput {
+  chunk_id: string;
+  attachment_id: string;
+  attachment_type: string;
+}
+
+export type SmlResolvedItemResult =
+  | {
+      success: true;
+      chunk_id: string;
+      attachment: {
+        type: string;
+        data: unknown;
+        origin: string;
+      };
+    }
+  | {
+      success: false;
+      chunk_id: string;
+      attachment_type: string;
+      message: string;
+    };
+
+/**
+ * Resolves SML index hits into attachment data (access checks, fetch, toAttachment).
+ * Does NOT persist — callers are responsible for adding the returned attachments
+ * to the conversation via their own `AttachmentStateManager`.
+ *
+ * Used by the `sml_attach` built-in tool and the internal HTTP `_attach` route.
+ */
+export const resolveSmlAttachItems = async ({
+  items,
+  sml,
+  esClient,
+  request,
+  spaceId,
+  savedObjectsClient,
+  logger,
+}: {
+  items: SmlAttachItemInput[];
+  sml: SmlService;
+  esClient: ElasticsearchClient;
+  request: KibanaRequest;
+  spaceId: string;
+  savedObjectsClient: SavedObjectsClientContract;
+  logger: Logger;
+}): Promise<SmlResolvedItemResult[]> => {
+  const accessMap = await sml.checkItemsAccess({
+    items: items.map((item) => ({ id: item.chunk_id, type: item.attachment_type })),
+    spaceId,
+    esClient,
+    request,
+  });
+
+  const chunkIds = items.filter((item) => accessMap.get(item.chunk_id)).map((i) => i.chunk_id);
+  const smlDocs = await sml.getDocuments({
+    ids: chunkIds,
+    spaceId,
+    esClient,
+  });
+
+  return Promise.all(
+    items.map(async (item) => {
+      if (!accessMap.get(item.chunk_id)) {
+        return {
+          success: false,
+          chunk_id: item.chunk_id,
+          attachment_type: item.attachment_type,
+          message: `Access denied: you do not have the required permissions to access SML item '${item.chunk_id}'`,
+        };
+      }
+
+      const smlDoc = smlDocs.get(item.chunk_id);
+      if (!smlDoc) {
+        return {
+          success: false,
+          chunk_id: item.chunk_id,
+          attachment_type: item.attachment_type,
+          message: `SML document '${item.chunk_id}' not found in the index`,
+        };
+      }
+
+      // Validate that client-supplied attachment_id and attachment_type match the fetched document.
+      // Prevents TOCTOU mismatches and ensures the access check is consistent with the actual data.
+      if (item.attachment_id !== smlDoc.origin_id || item.attachment_type !== smlDoc.type) {
+        return {
+          success: false,
+          chunk_id: item.chunk_id,
+          attachment_type: item.attachment_type,
+          message: `Provided attachment_id/attachment_type do not match the SML document '${item.chunk_id}'`,
+        };
+      }
+
+      const typeDefinition = sml.getTypeDefinition(smlDoc.type);
+      if (!typeDefinition) {
+        return {
+          success: false,
+          chunk_id: item.chunk_id,
+          attachment_type: smlDoc.type,
+          message: `SML type '${smlDoc.type}' does not support conversion to attachment`,
+        };
+      }
+
+      try {
+        const convertedAttachment = await typeDefinition.toAttachment(smlDoc, {
+          request,
+          savedObjectsClient,
+          spaceId,
+        });
+
+        if (!convertedAttachment) {
+          return {
+            success: false,
+            chunk_id: item.chunk_id,
+            attachment_type: item.attachment_type,
+            message: `Failed to convert SML item '${item.chunk_id}' to attachment — toAttachment returned undefined`,
+          };
+        }
+
+        return {
+          success: true,
+          chunk_id: item.chunk_id,
+          attachment: {
+            type: convertedAttachment.type,
+            data: convertedAttachment.data,
+            origin: convertedAttachment.origin ?? smlDoc.origin_id,
+          },
+        };
+      } catch (error) {
+        logger.error(
+          `sml_attach: error converting item '${item.chunk_id}' (type: ${item.attachment_type}): ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        return {
+          success: false,
+          chunk_id: item.chunk_id,
+          attachment_type: item.attachment_type,
+          message: `Failed to convert SML item '${item.chunk_id}' to attachment`,
+        };
+      }
+    })
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
@@ -87,6 +87,25 @@ describe('createSmlAttachTool', () => {
     expect((result.results[0] as ErrorResult).data.message).toContain('chunk-1');
   });
 
+  it('returns error when attachment_id does not match indexed document', async () => {
+    const smlDoc = createSmlDoc({ origin_id: 'expected-origin' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    const tool = createSmlAttachTool({ getSmlService });
+    const result = (await tool.handler(
+      {
+        items: [
+          { chunk_id: 'chunk-1', attachment_id: 'wrong-origin', attachment_type: 'visualization' },
+        ],
+      },
+      mockContext as unknown as ToolHandlerContext
+    )) as { results: unknown[] };
+    expect(result.results).toHaveLength(1);
+    expect((result.results[0] as { type: string }).type).toBe(ToolResultType.error);
+    expect((result.results[0] as ErrorResult).data.message).toContain('do not match');
+    expect(mockGetTypeDefinition).not.toHaveBeenCalled();
+  });
+
   it('returns error when document not found', async () => {
     mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
     mockGetDocuments.mockResolvedValue(new Map());
@@ -185,7 +204,7 @@ describe('createSmlAttachTool', () => {
         data: { layers: [] },
         origin: 'ref-1',
       },
-      expect.any(String)
+      'agent'
     );
   });
 
@@ -213,7 +232,7 @@ describe('createSmlAttachTool', () => {
   });
 
   it('handles multiple items with mix of authorized and unauthorized', async () => {
-    const smlDoc = createSmlDoc({ id: 'chunk-2' });
+    const smlDoc = createSmlDoc({ id: 'chunk-2', origin_id: 'ref-2' });
     const typeDef = {
       id: 'visualization',
       list: jest.fn(),
@@ -255,6 +274,7 @@ describe('createSmlAttachTool', () => {
       id: 'chunk-real',
       title: 'Real Document Title',
       type: 'dashboard',
+      origin_id: 'ref-real',
     });
     const toAttachment = jest.fn().mockResolvedValue({ type: 'dashboard', data: {} });
     mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-real', true]]));

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.ts
@@ -12,6 +12,7 @@ import { ATTACHMENT_REF_ACTOR } from '@kbn/agent-builder-common/attachments';
 import type { BuiltinToolDefinition } from '@kbn/agent-builder-server';
 import { getToolResultId, createErrorResult } from '@kbn/agent-builder-server';
 import { AGENT_BUILDER_EXPERIMENTAL_FEATURES_SETTING_ID } from '@kbn/management-settings-ids';
+import { resolveSmlAttachItems } from '../../../sml/execute_sml_attach_items';
 import type { SmlToolsOptions } from './types';
 
 const smlAttachItemSchema = z.object({
@@ -71,89 +72,37 @@ export const createSmlAttachTool = ({
     const smlService = getSmlService();
     const { spaceId, savedObjectsClient, request, attachments, esClient, logger } = context;
 
-    const accessMap = await smlService.checkItemsAccess({
-      items: items.map((item) => ({ id: item.chunk_id, type: item.attachment_type })),
-      spaceId,
+    const resolvedItems = await resolveSmlAttachItems({
+      items,
+      sml: smlService,
       esClient: esClient.asCurrentUser,
       request,
-    });
-
-    const chunkIds = items.filter((item) => accessMap.get(item.chunk_id)).map((i) => i.chunk_id);
-    const smlDocs = await smlService.getDocuments({
-      ids: chunkIds,
       spaceId,
-      esClient: esClient.asCurrentUser,
+      savedObjectsClient,
+      logger,
     });
 
     const results = await Promise.all(
-      items.map(async (item) => {
-        if (!accessMap.get(item.chunk_id)) {
+      resolvedItems.map(async (r) => {
+        if (!r.success) {
           return createErrorResult({
-            message: `Access denied: you do not have the required permissions to access SML item '${item.chunk_id}'`,
-            metadata: { chunk_id: item.chunk_id, attachment_type: item.attachment_type },
+            message: r.message,
+            metadata: { chunk_id: r.chunk_id, attachment_type: r.attachment_type },
           });
         }
 
-        const smlDoc = smlDocs.get(item.chunk_id);
-        if (!smlDoc) {
-          return createErrorResult({
-            message: `SML document '${item.chunk_id}' not found in the index`,
-            metadata: { chunk_id: item.chunk_id, attachment_type: item.attachment_type },
-          });
-        }
+        const added = await attachments.add(r.attachment, ATTACHMENT_REF_ACTOR.agent);
 
-        const typeDefinition = smlService.getTypeDefinition(smlDoc.type);
-        if (!typeDefinition) {
-          return createErrorResult({
-            message: `SML type '${smlDoc.type}' does not support conversion to attachment`,
-            metadata: { chunk_id: item.chunk_id, attachment_type: smlDoc.type },
-          });
-        }
-
-        try {
-          const convertedAttachment = await typeDefinition.toAttachment(smlDoc, {
-            request,
-            savedObjectsClient,
-            spaceId,
-          });
-
-          if (!convertedAttachment) {
-            return createErrorResult({
-              message: `Failed to convert SML item '${item.chunk_id}' to attachment — toAttachment returned undefined`,
-              metadata: { chunk_id: item.chunk_id, attachment_type: item.attachment_type },
-            });
-          }
-
-          const added = await attachments.add(
-            {
-              type: convertedAttachment.type,
-              data: convertedAttachment.data,
-              origin: convertedAttachment.origin ?? smlDoc.origin_id,
-            },
-            ATTACHMENT_REF_ACTOR.agent
-          );
-
-          return {
-            tool_result_id: getToolResultId(),
-            type: ToolResultType.other as const,
-            data: {
-              success: true,
-              attachment_id: added.id,
-              attachment_type: convertedAttachment.type,
-              message: `Attachment '${added.id}' of type '${convertedAttachment.type}' created from SML item '${item.chunk_id}'`,
-            },
-          };
-        } catch (error) {
-          logger.error(
-            `sml_attach: error converting item '${item.chunk_id}' (type: ${
-              item.attachment_type
-            }): ${(error as Error).message}`
-          );
-          return createErrorResult({
-            message: `Failed to convert SML item '${item.chunk_id}' to attachment`,
-            metadata: { chunk_id: item.chunk_id, attachment_type: item.attachment_type },
-          });
-        }
+        return {
+          tool_result_id: getToolResultId(),
+          type: ToolResultType.other,
+          data: {
+            success: true,
+            attachment_id: added.id,
+            attachment_type: r.attachment.type,
+            message: `Attachment '${added.id}' of type '${r.attachment.type}' created from SML item '${r.chunk_id}'`,
+          },
+        };
       })
     );
 

--- a/x-pack/platform/test/agent_builder_api_integration/apis/sml.ts
+++ b/x-pack/platform/test/agent_builder_api_integration/apis/sml.ts
@@ -8,12 +8,24 @@
 import expect from '@kbn/expect';
 import { v4 as uuidv4 } from 'uuid';
 import { smlElasticsearchIndexMappings, smlIndexName } from '@kbn/agent-builder-plugin/server';
-import type { SmlSearchHttpResponse } from '@kbn/agent-builder-plugin/common/http_api/sml';
+import type {
+  SmlAttachHttpResponse,
+  SmlSearchHttpResponse,
+} from '@kbn/agent-builder-plugin/common/http_api/sml';
 import type { FtrProviderContext } from '../../api_integration/ftr_provider_context';
+import { createLlmProxy, type LlmProxy } from '../utils/llm_proxy';
+import { setupAgentDirectAnswer } from '../utils/proxy_scenario';
+import {
+  createLlmProxyActionConnector,
+  deleteActionConnector,
+} from '../utils/llm_proxy/llm_proxy_action_connector';
+import { createAgentBuilderApiClient } from '../utils/agent_builder_client';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const es = getService('es');
+  const log = getService('log');
+  const agentBuilderApiClient = createAgentBuilderApiClient(supertest);
 
   describe('SML internal API', function () {
     this.tags(['skipServerless']);
@@ -131,6 +143,137 @@ export default function ({ getService }: FtrProviderContext) {
           .set('x-elastic-internal-origin', 'kibana')
           .send({ query: '' })
           .expect(400);
+      });
+    });
+
+    describe('POST /internal/agent_builder/sml/_attach', () => {
+      let llmProxy: LlmProxy;
+      let connectorId: string;
+      const runId = uuidv4();
+      const chunkId = `sml-ftr-attach-${runId}`;
+      const indexedTitle = `sml ftr attach ${runId}`;
+
+      before(async () => {
+        llmProxy = await createLlmProxy(log);
+        connectorId = await createLlmProxyActionConnector(getService, { port: llmProxy.getPort() });
+
+        const exists = await es.indices.exists({ index: smlIndexName });
+        if (!exists) {
+          await es.indices.create({
+            index: smlIndexName,
+            mappings: smlElasticsearchIndexMappings,
+          });
+        }
+
+        const now = '2024-06-01T12:00:00.000Z';
+        await es.index({
+          index: smlIndexName,
+          id: chunkId,
+          refresh: 'wait_for',
+          document: {
+            id: chunkId,
+            type: 'connector',
+            title: indexedTitle,
+            origin_id: connectorId,
+            content: `attach content for ${runId}`,
+            created_at: now,
+            updated_at: now,
+            spaces: ['default'],
+            permissions: [],
+          },
+        });
+      });
+
+      after(async () => {
+        llmProxy.close();
+        await deleteActionConnector(getService, { actionId: connectorId });
+
+        try {
+          await es.delete({
+            index: smlIndexName,
+            id: chunkId,
+            refresh: true,
+          });
+        } catch {
+          // ignore cleanup failures
+        }
+      });
+
+      it('returns 404 when the conversation does not exist', async () => {
+        const response = await supertest
+          .post('/internal/agent_builder/sml/_attach')
+          .set('kbn-xsrf', 'kibana')
+          .set('x-elastic-internal-origin', 'kibana')
+          .send({
+            conversation_id: 'non-existent-conversation-id-for-sml-attach-ftr',
+            items: [
+              {
+                chunk_id: 'irrelevant',
+                attachment_id: 'irrelevant',
+                attachment_type: 'visualization',
+              },
+            ],
+          })
+          .expect(404);
+
+        expect(response.body).to.have.property('message');
+      });
+
+      it('attaches SML items and persists conversation attachment refs', async () => {
+        await setupAgentDirectAnswer({
+          proxy: llmProxy,
+          title: `SML attach title ${runId}`,
+          response: 'SML attach response',
+        });
+
+        const converseResponse = await agentBuilderApiClient.converse({
+          input: 'Create round for SML attach',
+          attachments: [
+            {
+              type: 'text',
+              data: {
+                content: `existing text attachment ${runId}`,
+              },
+            },
+          ],
+          connector_id: connectorId,
+        });
+
+        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+        const attachResponse = await supertest
+          .post('/internal/agent_builder/sml/_attach')
+          .set('kbn-xsrf', 'kibana')
+          .set('x-elastic-internal-origin', 'kibana')
+          .send({
+            conversation_id: converseResponse.conversation_id,
+            items: [
+              {
+                chunk_id: chunkId,
+                attachment_id: connectorId,
+                attachment_type: 'connector',
+              },
+            ],
+          })
+          .expect(200);
+
+        // Assert the attachment was created successfully
+        const attachBody = attachResponse.body as SmlAttachHttpResponse;
+        expect(attachBody.results).to.have.length(1);
+        expect(attachBody.results[0].success).to.be(true);
+
+        // Assert all attachments are present in the conversation
+        const conversation = await agentBuilderApiClient.getConversation(
+          converseResponse.conversation_id
+        );
+        const attachments = conversation.attachments ?? [];
+        expect(attachments[0].type).to.be('text');
+        expect(attachments[1].type).to.be('connector');
+
+        // Assert the attachment refs are present
+        const lastRound = conversation.rounds[conversation.rounds.length - 1];
+        expect(lastRound.input.attachment_refs?.[0].attachment_id).to.be(attachments[0].id);
+        expect(lastRound.input.attachment_refs?.[1].attachment_id).to.be(attachments[1].id);
       });
     });
   });


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/pull/259980

## Summary

Adds an internal SML attach API to Agent Builder at `POST /internal/agent_builder/sml/_attach` and refactors SML-to-attachment resolution into a shared server utility used by both the HTTP route and the `sml_attach` built-in tool.

This consolidates permission checks and conversion validation in one place, reducing duplicate logic and keeping tool and HTTP behavior consistent.

### Architecture

- Adds a new internal route in `server/routes/internal/sml.ts` behind the existing experimental feature flag.
- Introduces `resolveSmlAttachItems()` in `server/services/sml/execute_sml_attach_items.ts` to centralize:
  - access checks,
  - document fetch,
  - input-to-document consistency checks (`attachment_id`/`attachment_type`),
  - conversion through SML type definitions.
- Keeps persistence concerns in callers:
  - HTTP route persists via attachment state manager + conversation update,
  - built-in tool persists via tool attachment context.

### Visuals


https://github.com/user-attachments/assets/adaee83e-41ca-401a-ac9a-82d496791014



### How to test

1. Enable `agentBuilder:experimentalFeatures` in Advanced Settings.
2. Create or use an existing conversation that already has at least one round.
3. Call `POST /internal/agent_builder/sml/_attach` with valid SML items and verify:
   - successful items return `success: true` with `conversation_attachment_id`,
   - conversation attachments and last round refs are updated.
4. Call the same endpoint with invalid inputs and verify error behavior:
   - nonexistent conversation returns 404,
   - missing permissions or mismatched `attachment_id`/`attachment_type` return per-item `success: false` messages.

### Checklist

Check the PR satisfies following conditions.

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
