### PR TITLE
[Agent Builder] Use markdown renderer for skill instructions in read-only view

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/render_skill_content_read_only.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/common/render_skill_content_read_only.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButtonGroup,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiMarkdownFormat,
+  EuiPanel,
+} from '@elastic/eui';
+import { labels } from '../../../utils/i18n';
+
+const viewToggleOptions = [
+  {
+    id: 'rendered',
+    label: labels.agentSkills.instructionsViewRenderedLabel,
+    iconType: 'eye',
+  },
+  {
+    id: 'raw',
+    label: labels.agentSkills.instructionsViewRawLabel,
+    iconType: 'code',
+  },
+];
+
+interface RenderSkillContentReadOnlyProps {
+  content: string;
+}
+
+export const RenderSkillContentReadOnly: React.FC<RenderSkillContentReadOnlyProps> = ({
+  content,
+}) => {
+  const [showRaw, setShowRaw] = useState(false);
+
+  return (
+    <EuiPanel borderRadius="m" hasBorder paddingSize="m">
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup justifyContent="flexEnd" responsive={false} gutterSize="none">
+            <EuiFlexItem grow={false}>
+              <EuiButtonGroup
+                legend={labels.agentSkills.instructionsViewModeLegend}
+                options={viewToggleOptions}
+                idSelected={showRaw ? 'raw' : 'rendered'}
+                onChange={(id) => setShowRaw(id === 'raw')}
+                isIconOnly
+                buttonSize="compressed"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {showRaw ? (
+            <EuiCodeBlock language="markdown" lineNumbers transparentBackground paddingSize="none">
+              {content}
+            </EuiCodeBlock>
+          ) : (
+            <EuiMarkdownFormat textSize="s">{content}</EuiMarkdownFormat>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_detail_panel.tsx
@@ -27,6 +27,7 @@ import { usePlugin } from '../../../hooks/plugins/use_plugin';
 import { useSkill } from '../../../hooks/skills/use_skills';
 import { DetailRow } from '../common/detail_row';
 import { DetailPanelLayout } from '../common/detail_panel_layout';
+import { RenderSkillContentReadOnly } from '../common/render_skill_content_read_only';
 
 interface PluginDetailPanelProps {
   pluginId: string;
@@ -161,44 +162,32 @@ const SkillDetailFlyout: React.FC<{
             <EuiLoadingSpinner size="l" />
           </EuiFlexGroup>
         ) : skill ? (
-          <>
-            <EuiFlexGroup direction="column" gutterSize="l">
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="xxxs">
-                  <h4>{labels.agentPlugins.pluginDetailNameLabel}</h4>
-                </EuiTitle>
-                <EuiText size="s">{skill.name}</EuiText>
-              </EuiFlexItem>
-              <EuiHorizontalRule margin="none" />
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="xxxs">
-                  <h4>{labels.agentPlugins.pluginDetailIdLabel}</h4>
-                </EuiTitle>
-                <EuiText size="s">{skill.id}</EuiText>
-              </EuiFlexItem>
-              <EuiHorizontalRule margin="none" />
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="xxxs">
-                  <h4>{labels.agentPlugins.pluginDetailDescriptionLabel}</h4>
-                </EuiTitle>
-                <EuiText size="s">{skill.description || '\u2014'}</EuiText>
-              </EuiFlexItem>
-              <EuiHorizontalRule margin="none" />
-              <EuiFlexItem grow={false}>
-                <EuiTitle size="xxxs">
-                  <h4>{labels.agentSkills.skillDetailInstructionsLabel}</h4>
-                </EuiTitle>
-                <div
-                  css={css`
-                    white-space: pre-wrap;
-                    word-break: break-word;
-                  `}
-                >
-                  <EuiText size="s">{skill.content || '\u2014'}</EuiText>
-                </div>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </>
+          <EuiFlexGroup direction="column" gutterSize="l">
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxxs">
+                <h4>{labels.agentPlugins.pluginDetailNameLabel}</h4>
+              </EuiTitle>
+              <EuiText size="s">{skill.name}</EuiText>
+            </EuiFlexItem>
+            <EuiHorizontalRule margin="none" />
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxxs">
+                <h4>{labels.agentPlugins.pluginDetailIdLabel}</h4>
+              </EuiTitle>
+              <EuiText size="s">{skill.id}</EuiText>
+            </EuiFlexItem>
+            <EuiHorizontalRule margin="none" />
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxxs">
+                <h4>{labels.agentPlugins.pluginDetailDescriptionLabel}</h4>
+              </EuiTitle>
+              <EuiText size="s">{skill.description || '\u2014'}</EuiText>
+            </EuiFlexItem>
+            <EuiHorizontalRule margin="none" />
+            <EuiFlexItem grow={false}>
+              <RenderSkillContentReadOnly content={skill.content ?? ''} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         ) : null}
       </EuiFlyoutBody>
     </EuiFlyout>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/plugin_detail_panel.tsx
@@ -149,9 +149,18 @@ const SkillDetailFlyout: React.FC<{
   return (
     <EuiFlyout onClose={onClose} size="m" aria-labelledby="pluginSkillDetailFlyoutTitle">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="s">
-          <h2 id="pluginSkillDetailFlyoutTitle">{skill?.name ?? skillId}</h2>
-        </EuiTitle>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h2 id="pluginSkillDetailFlyoutTitle">{skill?.name ?? skillId}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow" iconType="lock">
+              {labels.agentSkills.readOnlyBadge}
+            </EuiBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiText size="xs" color="subdued">
           {labels.agentPlugins.skillDetailInstalledVia(pluginName)}
         </EuiText>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_create_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_create_flyout.tsx
@@ -91,18 +91,13 @@ export const SkillCreateFlyout: React.FC<SkillCreateFlyoutProps> = ({
   return (
     <EuiFlyout onClose={onClose} size={FLYOUT_WIDTH} aria-labelledby="skillCreateFlyoutTitle">
       <EuiFlyoutHeader hasBorder>
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h2 id="skillCreateFlyoutTitle">{labels.agentSkills.createSkillFlyoutTitle}</h2>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiLink href={skillLibraryUrl} external>
-              {labels.agentSkills.viewSkillLibraryLink}
-            </EuiLink>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiTitle size="s">
+          <h2 id="skillCreateFlyoutTitle">{labels.agentSkills.createSkillFlyoutTitle}</h2>
+        </EuiTitle>
+        <EuiSpacer size="xs" />
+        <EuiLink href={skillLibraryUrl} target="_blank">
+          {labels.agentSkills.viewSkillLibraryLink}
+        </EuiLink>
       </EuiFlyoutHeader>
       <EuiCallOut
         color="primary"

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
@@ -19,6 +19,7 @@ import { labels } from '../../../utils/i18n';
 import { useSkill } from '../../../hooks/skills/use_skills';
 import { DetailRow } from '../common/detail_row';
 import { DetailPanelLayout } from '../common/detail_panel_layout';
+import { RenderSkillContentReadOnly } from '../common/render_skill_content_read_only';
 
 interface SkillDetailPanelProps {
   skillId: string;
@@ -97,19 +98,13 @@ export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
           padding: ${euiTheme.size.m};
         `}
       >
-        <DetailRow
-          label={labels.agentSkills.skillDetailInstructionsLabel}
-          isLast={!skill?.tool_ids || skill.tool_ids.length === 0}
+        <div
+          css={css`
+            padding: ${euiTheme.size.m};
+          `}
         >
-          <div
-            css={css`
-              white-space: pre-wrap;
-              word-break: break-word;
-            `}
-          >
-            <EuiText size="s">{skill?.content}</EuiText>
-          </div>
-        </DetailRow>
+          <RenderSkillContentReadOnly content={skill?.content ?? ''} />
+        </div>
         {skill?.tool_ids && skill.tool_ids.length > 0 && (
           <DetailRow label={labels.skills.toolsLabel} isLast>
             <EuiFlexGroup direction="column" gutterSize="xs">

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/skill_detail_panel.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiBadge,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiText,
   useEuiTheme,
 } from '@elastic/eui';
@@ -20,6 +21,7 @@ import { useSkill } from '../../../hooks/skills/use_skills';
 import { DetailRow } from '../common/detail_row';
 import { DetailPanelLayout } from '../common/detail_panel_layout';
 import { RenderSkillContentReadOnly } from '../common/render_skill_content_read_only';
+import { ToolReadOnlyFlyout } from '../tools/tool_readonly_flyout';
 
 interface SkillDetailPanelProps {
   skillId: string;
@@ -36,89 +38,98 @@ export const SkillDetailPanel: React.FC<SkillDetailPanelProps> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const { skill, isLoading } = useSkill({ skillId });
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
 
   return (
-    <DetailPanelLayout
-      isLoading={isLoading}
-      isEmpty={!skill}
-      title={skill?.name ?? skillId}
-      showAutoIcon={isReadOnly}
-      headerContent={
-        <>
-          <EuiText
-            size="xs"
-            color="subdued"
-            css={css`
-              margin-top: ${euiTheme.size.xs};
-            `}
-          >
-            {skill?.id}
-          </EuiText>
-          <EuiText
-            size="s"
-            color="subdued"
-            css={css`
-              margin-top: ${euiTheme.size.s};
-            `}
-          >
-            {skill?.description}
-          </EuiText>
-        </>
-      }
-      headerActions={(openConfirmRemove) =>
-        isReadOnly ? (
-          <EuiBadge color="hollow">{labels.agentSkills.autoIncludedBadgeLabel}</EuiBadge>
-        ) : (
-          <EuiFlexGroup gutterSize="s" responsive={false}>
-            {!skill?.readonly && (
+    <>
+      <DetailPanelLayout
+        isLoading={isLoading}
+        isEmpty={!skill}
+        title={skill?.name ?? skillId}
+        showAutoIcon={isReadOnly}
+        headerContent={
+          <>
+            <EuiText
+              size="xs"
+              color="subdued"
+              css={css`
+                margin-top: ${euiTheme.size.xs};
+              `}
+            >
+              {skill?.id}
+            </EuiText>
+            <EuiText
+              size="s"
+              color="subdued"
+              css={css`
+                margin-top: ${euiTheme.size.s};
+              `}
+            >
+              {skill?.description}
+            </EuiText>
+          </>
+        }
+        headerActions={(openConfirmRemove) =>
+          isReadOnly ? (
+            <EuiBadge color="hollow">{labels.agentSkills.autoIncludedBadgeLabel}</EuiBadge>
+          ) : (
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              {!skill?.readonly && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty iconType="pencil" size="xs" onClick={onEdit}>
+                    {labels.skills.editSkillButtonLabel}
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
-                <EuiButtonEmpty iconType="pencil" size="xs" onClick={onEdit}>
-                  {labels.skills.editSkillButtonLabel}
+                <EuiButtonEmpty
+                  iconType="cross"
+                  size="xs"
+                  color="danger"
+                  onClick={openConfirmRemove}
+                >
+                  {labels.agentSkills.removeSkillButtonLabel}
                 </EuiButtonEmpty>
               </EuiFlexItem>
-            )}
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty iconType="cross" size="xs" color="danger" onClick={openConfirmRemove}>
-                {labels.agentSkills.removeSkillButtonLabel}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )
-      }
-      confirmRemove={{
-        title: labels.agentSkills.removeSkillConfirmTitle(skill?.name ?? skillId),
-        body: labels.agentSkills.removeSkillConfirmBody,
-        confirmButtonText: labels.agentSkills.removeSkillConfirmButton,
-        cancelButtonText: labels.agentSkills.removeSkillCancelButton,
-        onConfirm: onRemove,
-      }}
-    >
-      <div
-        css={css`
-          padding: ${euiTheme.size.m};
-        `}
+            </EuiFlexGroup>
+          )
+        }
+        confirmRemove={{
+          title: labels.agentSkills.removeSkillConfirmTitle(skill?.name ?? skillId),
+          body: labels.agentSkills.removeSkillConfirmBody,
+          confirmButtonText: labels.agentSkills.removeSkillConfirmButton,
+          cancelButtonText: labels.agentSkills.removeSkillCancelButton,
+          onConfirm: onRemove,
+        }}
       >
         <div
           css={css`
             padding: ${euiTheme.size.m};
           `}
         >
-          <RenderSkillContentReadOnly content={skill?.content ?? ''} />
+          <div
+            css={css`
+              padding: ${euiTheme.size.m};
+            `}
+          >
+            <RenderSkillContentReadOnly content={skill?.content ?? ''} />
+          </div>
+          {skill?.tool_ids && skill.tool_ids.length > 0 && (
+            <DetailRow label={labels.skills.toolsLabel} isLast>
+              <EuiFlexGroup direction="column" gutterSize="xs">
+                {skill.tool_ids.map((toolId) => (
+                  <EuiFlexItem key={toolId} grow={false}>
+                    <EuiLink onClick={() => setSelectedToolId(toolId)}>{toolId}</EuiLink>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+            </DetailRow>
+          )}
         </div>
-        {skill?.tool_ids && skill.tool_ids.length > 0 && (
-          <DetailRow label={labels.skills.toolsLabel} isLast>
-            <EuiFlexGroup direction="column" gutterSize="xs">
-              {skill.tool_ids.map((toolId) => (
-                <EuiFlexItem key={toolId} grow={false}>
-                  <EuiText size="s" color="primary">
-                    {toolId}
-                  </EuiText>
-                </EuiFlexItem>
-              ))}
-            </EuiFlexGroup>
-          </DetailRow>
-        )}
-      </div>
-    </DetailPanelLayout>
+      </DetailPanelLayout>
+      {selectedToolId && (
+        <ToolReadOnlyFlyout toolId={selectedToolId} onClose={() => setSelectedToolId(null)} />
+      )}
+    </>
   );
 };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_readonly_flyout.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/tool_readonly_flyout.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { labels } from '../../../utils/i18n';
+import { useToolService } from '../../../hooks/tools/use_tools';
+
+interface ToolReadOnlyFlyoutProps {
+  toolId: string;
+  onClose: () => void;
+}
+
+export const ToolReadOnlyFlyout: React.FC<ToolReadOnlyFlyoutProps> = ({ toolId, onClose }) => {
+  const { tool, isLoading } = useToolService(toolId);
+
+  return (
+    <EuiFlyout onClose={onClose} size="m" aria-labelledby="toolReadOnlyFlyoutTitle">
+      <EuiFlyoutHeader hasBorder>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h2 id="toolReadOnlyFlyoutTitle">{tool?.id ?? toolId}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow" iconType="lock">
+              {labels.agentTools.readOnlyBadge}
+            </EuiBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {isLoading ? (
+          <EuiFlexGroup justifyContent="center" alignItems="center">
+            <EuiLoadingSpinner size="l" />
+          </EuiFlexGroup>
+        ) : tool ? (
+          <EuiFlexGroup direction="column" gutterSize="l">
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxxs">
+                <h4>{labels.agentTools.toolDetailIdLabel}</h4>
+              </EuiTitle>
+              <EuiText size="s">{tool.id}</EuiText>
+            </EuiFlexItem>
+            <EuiHorizontalRule margin="none" />
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xxxs">
+                <h4>{labels.agentTools.toolDetailDescriptionLabel}</h4>
+              </EuiTitle>
+              <EuiText size="s">{tool.description || '\u2014'}</EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ) : null}
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -769,6 +769,24 @@ export const labels = {
         defaultMessage: 'Instructions',
       }
     ),
+    instructionsViewModeLegend: i18n.translate(
+      'xpack.agentBuilder.agentSkills.instructionsViewModeLegend',
+      {
+        defaultMessage: 'Instructions view mode',
+      }
+    ),
+    instructionsViewRenderedLabel: i18n.translate(
+      'xpack.agentBuilder.agentSkills.instructionsViewRenderedLabel',
+      {
+        defaultMessage: 'Rendered',
+      }
+    ),
+    instructionsViewRawLabel: i18n.translate(
+      'xpack.agentBuilder.agentSkills.instructionsViewRawLabel',
+      {
+        defaultMessage: 'Raw',
+      }
+    ),
     noSkillSelectedMessage: i18n.translate(
       'xpack.agentBuilder.agentSkills.noSkillSelectedMessage',
       {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/utils/i18n.ts
@@ -829,6 +829,9 @@ export const labels = {
         defaultMessage: 'Auto',
       }
     ),
+    readOnlyBadge: i18n.translate('xpack.agentBuilder.agentSkills.readOnlyBadge', {
+      defaultMessage: 'Read only',
+    }),
     autoIncludedBadgeLabel: i18n.translate(
       'xpack.agentBuilder.agentSkills.autoIncludedBadgeLabel',
       {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/b84b5268-af85-4841-b3ec-ed00c7486009


- [x] Uses markdown renderer/EuiCodeBlock for skill read-only instructions
- [x] Adds links for tools within skills to open them in a tool read only flyout

