### PR TITLE
[Server Timings] remove flaky test

### DIFF
--- a/src/core/packages/http/router-server-internal/src/timing/request_timing.test.ts
+++ b/src/core/packages/http/router-server-internal/src/timing/request_timing.test.ts
@@ -10,8 +10,7 @@
 import { RequestTimingImpl } from './request_timing';
 import type { RequestTimingState } from './types';
 
-// Failing: See https://github.com/elastic/kibana/issues/259867
-describe.skip('RequestTimingImpl', () => {
+describe('RequestTimingImpl', () => {
   let state: RequestTimingState;
   let timing: RequestTimingImpl;
 
@@ -42,14 +41,6 @@ describe.skip('RequestTimingImpl', () => {
       timer.end();
 
       expect(state.events[0].description).toBe('Test description');
-    });
-
-    it('measures correct duration', async () => {
-      const timer = timing.start('test-operation');
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      timer.end();
-
-      expect(state.events[0].duration).toBeGreaterThanOrEqual(10);
     });
 
     it('does not create an event if timer.end() is not called', () => {


### PR DESCRIPTION
## Summary

Removes the problematic timing test. We can rely on Node's performance API.

Close https://github.com/elastic/kibana/issues/259867