### PR TITLE
[One Workflow] Add documentation link and keyboard shortcuts to YAML editor bottom bar

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/index.ts
+++ b/src/platform/plugins/shared/workflows_management/common/index.ts
@@ -13,6 +13,8 @@ export const PLUGIN_NAME = 'Workflows';
 export const WORKFLOWS_EXECUTIONS_INDEX = '.workflows-executions';
 export const WORKFLOWS_STEP_EXECUTIONS_INDEX = '.workflows-step-executions';
 
+export const WORKFLOWS_DOCUMENTATION_URL = 'https://ela.st/workflows-docs';
+
 // Export shared utilities that are needed by both server and client
 // NOTE: buildRequestFromConnector removed from here to avoid main bundle bloat
 // Import directly from './elasticsearch_request_builder' if needed

--- a/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/components/workflows_empty_state/workflows_empty_state.tsx
@@ -19,6 +19,7 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { WORKFLOWS_DOCUMENTATION_URL } from '../../../common';
 import { useKibana } from '../../hooks/use_kibana';
 interface WorkflowsEmptyStateProps {
   onCreateWorkflow?: () => void;
@@ -97,7 +98,7 @@ export function WorkflowsEmptyState({
               />
             </span>
           </EuiTitle>{' '}
-          <EuiLink href="https://ela.st/workflows-docs" target="_blank">
+          <EuiLink href={WORKFLOWS_DOCUMENTATION_URL} target="_blank">
             <FormattedMessage
               id="workflows.emptyState.footer.link"
               defaultMessage="Read documentation"

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { isMac } from '@kbn/shared-ux-utility';
+import { kbdStyles } from './kbd_styles';
 
 type ActionsMenuButtonProps = Omit<EuiButtonEmptyPropsForButton, 'children'>;
 
@@ -33,7 +34,8 @@ export function ActionsMenuButton(props: ActionsMenuButtonProps) {
           />
         </b>
         <EuiTextColor color="subdued" css={styles.withKbd}>
-          <kbd>{commandKey}</kbd> {'+'} <kbd>{'K'}</kbd>
+          <kbd>{commandKey}</kbd>
+          <kbd>{'K'}</kbd>
         </EuiTextColor>
       </EuiText>
     </EuiButtonEmpty>
@@ -41,14 +43,10 @@ export function ActionsMenuButton(props: ActionsMenuButtonProps) {
 }
 
 const componentStyles = {
-  withKbd: ({ euiTheme }: UseEuiTheme) =>
+  withKbd: (euiThemeContext: UseEuiTheme) =>
     css({
-      '& kbd': {
-        borderColor: euiTheme.colors.borderBaseSubdued,
-        borderRadius: euiTheme.border.radius.small,
-        borderWidth: euiTheme.border.width.thin,
-        borderStyle: 'solid',
-        padding: `${euiTheme.size.xxs} ${euiTheme.size.xs}`,
-      },
+      display: 'flex',
+      gap: 2,
+      '& kbd': kbdStyles(euiThemeContext),
     }),
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/actions_menu_button.tsx
@@ -25,7 +25,7 @@ export function ActionsMenuButton(props: ActionsMenuButtonProps) {
   const commandKey = isMac ? '⌘' : 'Ctrl';
 
   return (
-    <EuiButtonEmpty size="s" {...props}>
+    <EuiButtonEmpty size="s" data-test-subj="workflowYamlEditorActionsMenuButton" {...props}>
       <EuiText css={{ display: 'flex', alignItems: 'center', gap: '6px' }} size="xs">
         <b>
           <FormattedMessage

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/documentation_link.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/documentation_link.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { WORKFLOWS_DOCUMENTATION_URL } from '../../../../common';
+
+export function DocumentationLink() {
+  return (
+    <EuiButtonEmpty
+      size="s"
+      href={WORKFLOWS_DOCUMENTATION_URL}
+      target="_blank"
+      iconType="popout"
+      iconSide="right"
+      iconSize="s"
+    >
+      <EuiText size="xs">
+        <b>
+          <FormattedMessage
+            id="workflows.workflowDetail.yamlEditor.documentation"
+            defaultMessage="Documentation"
+          />
+        </b>
+      </EuiText>
+    </EuiButtonEmpty>
+  );
+}

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/documentation_link.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/documentation_link.tsx
@@ -21,6 +21,7 @@ export function DocumentationLink() {
       iconType="popout"
       iconSide="right"
       iconSize="s"
+      data-test-subj="workflowYamlEditorDocumentationLink"
     >
       <EuiText size="xs">
         <b>

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/extra_actions_bar.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/extra_actions_bar.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React from 'react';
+
+export interface ExtraAction {
+  id: string;
+  content: React.ReactNode;
+  showInReadOnly?: boolean;
+}
+
+interface ExtraActionsBarProps {
+  actions: ExtraAction[];
+  isReadOnly: boolean;
+}
+
+export const ExtraActionsBar = ({ actions, isReadOnly }: ExtraActionsBarProps) => {
+  const visibleActions = actions.filter((action) => !isReadOnly || action.showInReadOnly !== false);
+
+  if (visibleActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+      {visibleActions.map((action) => (
+        <EuiFlexItem key={action.id} grow={false}>
+          {action.content}
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  );
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/kbd_styles.ts
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/kbd_styles.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+import type { CSSObject } from '@emotion/react';
+
+export const kbdStyles = ({ euiTheme }: UseEuiTheme): CSSObject => ({
+  borderColor: euiTheme.colors.borderBaseSubdued,
+  borderRadius: euiTheme.border.radius.small,
+  borderWidth: euiTheme.border.width.thin,
+  borderStyle: 'solid',
+  padding: `${euiTheme.size.xxs} ${euiTheme.size.xs}`,
+});

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/keyboard_shortcuts_popover.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/keyboard_shortcuts_popover.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { UseEuiTheme } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiToolTip,
+  useEuiTheme,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useState } from 'react';
+import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
+import { i18n } from '@kbn/i18n';
+import { isMac } from '@kbn/shared-ux-utility';
+import { kbdStyles } from './kbd_styles';
+
+const COMMAND_KEY = isMac ? '⌘' : 'Ctrl';
+
+const shortcuts = [
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.run', {
+      defaultMessage: 'Run workflow',
+    }),
+    keys: [COMMAND_KEY, 'Enter'],
+  },
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.saveAndRun', {
+      defaultMessage: 'Save and run',
+    }),
+    keys: [COMMAND_KEY, 'Shift', 'Enter'],
+  },
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.save', {
+      defaultMessage: 'Save',
+    }),
+    keys: [COMMAND_KEY, 'S'],
+  },
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.comment', {
+      defaultMessage: 'Comment/uncomment',
+    }),
+    keys: [COMMAND_KEY, '/'],
+  },
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.actionsMenu', {
+      defaultMessage: 'Open actions menu',
+    }),
+    keys: [COMMAND_KEY, 'K'],
+  },
+  {
+    label: i18n.translate('workflows.yamlEditor.shortcuts.find', {
+      defaultMessage: 'Find',
+    }),
+    keys: [COMMAND_KEY, 'F'],
+  },
+];
+
+export function KeyboardShortcutsPopover() {
+  const { euiTheme } = useEuiTheme();
+  const styles = useMemoCss(componentStyles);
+  const [isOpen, setIsOpen] = useState(false);
+  const popoverTitleId = useGeneratedHtmlId();
+
+  const label = i18n.translate('workflows.yamlEditor.shortcuts.label', {
+    defaultMessage: 'Keyboard shortcuts',
+  });
+
+  return (
+    <EuiPopover
+      data-test-subj="workflowYamlEditorKeyboardShortcutsPopover"
+      aria-labelledby={popoverTitleId}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="upRight"
+      panelPaddingSize="none"
+      button={
+        <EuiToolTip content={label} delay="long" disableScreenReaderOutput>
+          <EuiButtonIcon
+            size="xs"
+            iconType="keyboard"
+            data-test-subj="workflowYamlEditorKeyboardShortcutsButton"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label={label}
+            color="primary"
+          />
+        </EuiToolTip>
+      }
+    >
+      <EuiPopoverTitle id={popoverTitleId} paddingSize="s">
+        {label}
+      </EuiPopoverTitle>
+      <div css={{ padding: euiTheme.size.m }}>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          {shortcuts.map(({ label: shortcutLabel, keys }) => (
+            <EuiFlexItem key={shortcutLabel}>
+              <EuiFlexGroup
+                alignItems="center"
+                justifyContent="spaceBetween"
+                gutterSize="m"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s">{shortcutLabel}</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" css={styles.keys}>
+                    {keys.map((key) => (
+                      <kbd key={key}>{key}</kbd>
+                    ))}
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </div>
+    </EuiPopover>
+  );
+}
+
+const componentStyles = {
+  keys: (euiThemeContext: UseEuiTheme) =>
+    css({
+      display: 'flex',
+      gap: 2,
+      '& kbd': {
+        ...kbdStyles(euiThemeContext),
+        minWidth: 20,
+        textAlign: 'center' as const,
+        color: euiThemeContext.euiTheme.colors.textSubdued,
+        fontWeight: euiThemeContext.euiTheme.font.weight.medium,
+      },
+    }),
+};

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/ui/workflow_yaml_editor.tsx
@@ -37,8 +37,12 @@ import {
   useTriggerTypeDecorations,
   useWorkflowIdDecorations,
 } from './decorations';
+import { DocumentationLink } from './documentation_link';
+import type { ExtraAction } from './extra_actions_bar';
+import { ExtraActionsBar } from './extra_actions_bar';
 import { useAgentBuilderIntegration } from './hooks/use_agent_builder_integration';
 import { useWorkflowYamlCompletionProvider } from './hooks/use_workflow_yaml_completion_provider';
+import { KeyboardShortcutsPopover } from './keyboard_shortcuts_popover';
 import { StepActions } from './step_actions';
 import { WorkflowYamlValidationAccordion } from './workflow_yaml_validation_accordion';
 import { useAvailableConnectors } from '../../../entities/connectors/model/use_available_connectors';
@@ -634,6 +638,27 @@ export const WorkflowYAMLEditor = ({
     }
   }, [workflowJsonSchemaStrict, notifications]);
 
+  const extraActions = useMemo<ExtraAction[]>(
+    () => [
+      {
+        id: 'documentation',
+        content: <DocumentationLink />,
+        showInReadOnly: true,
+      },
+      {
+        id: 'actions-menu',
+        content: <ActionsMenuButton onClick={openActionsPopover} />,
+        showInReadOnly: false,
+      },
+      {
+        id: 'keyboard-shortcuts',
+        content: <KeyboardShortcutsPopover />,
+        showInReadOnly: true,
+      },
+    ],
+    [openActionsPopover]
+  );
+
   return (
     <div css={css([styles.container, stepExecutionStyles])} ref={containerRef}>
       <GlobalWorkflowEditorStyles />
@@ -735,10 +760,7 @@ export const WorkflowYAMLEditor = ({
           error={errorValidating}
           validationErrors={validationErrors}
           onErrorClick={handleErrorClick}
-          extraAction={
-            // Only show the shortcuts in edit mode
-            !isExecutionYaml ? <ActionsMenuButton onClick={openActionsPopover} /> : null
-          }
+          extraAction={<ExtraActionsBar actions={extraActions} isReadOnly={isExecutionYaml} />}
         />
       </div>
     </div>

--- a/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
+++ b/src/platform/plugins/shared/workflows_management/server/ui_settings.ts
@@ -15,6 +15,7 @@ import {
   WORKFLOWS_UI_SETTING_ID,
 } from '@kbn/workflows/common/constants';
 import type { WorkflowsServerPluginSetupDeps } from './types';
+import { WORKFLOWS_DOCUMENTATION_URL } from '../common';
 
 export const registerUISettings = (
   { uiSettings }: CoreSetup,
@@ -35,7 +36,7 @@ export const registerUISettings = (
         defaultMessage:
           'Enables Elastic Workflows and related experiences. {licenseText} {learnMoreLink}',
         values: {
-          learnMoreLink: `<a href="https://ela.st/workflows-docs" target="_blank" rel="noreferrer noopener">${i18n.translate(
+          learnMoreLink: `<a href="${WORKFLOWS_DOCUMENTATION_URL}" target="_blank" rel="noreferrer noopener">${i18n.translate(
             'workflowsManagement.uiSettings.ui.learnMore',
             { defaultMessage: 'Learn more' }
           )}</a>.`,
@@ -57,7 +58,7 @@ export const registerUISettings = (
         defaultMessage:
           'Enables AI-powered workflow authoring experiences. {licenseText} {learnMoreLink}',
         values: {
-          learnMoreLink: `<a href="https://ela.st/workflows-docs" target="_blank" rel="noreferrer noopener">${i18n.translate(
+          learnMoreLink: `<a href="${WORKFLOWS_DOCUMENTATION_URL}" target="_blank" rel="noreferrer noopener">${i18n.translate(
             'workflowsManagement.uiSettings.aiAgent.learnMore',
             { defaultMessage: 'Learn more' }
           )}</a>.`,


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16534

## Summary

Adds extra action buttons to the workflow YAML editor validation accordion bottom bar:

- **Documentation link** — opens Elastic workflows docs in a new tab, visible in both edit and readonly modes
- **Keyboard shortcuts popover** — icon button listing all editor keybindings (run, save, save & run, comment, actions menu, find), visible in both edit and readonly modes

Also:
- Extracts `WORKFLOWS_DOCUMENTATION_URL` into a shared constant in `common/index.ts`, replacing all hardcoded usages
- Introduces a data-driven `ExtraActionsBar` component with `showInReadOnly` visibility control for maintainable addition of future actions
- Extracts shared `kbdStyles` for consistent keyboard shortcut badge styling

### Before

<img width="1280" height="720" alt="before-readonly" src="https://github.com/user-attachments/assets/19d807e9-3ecc-408e-ad20-7876d94f1ff3" />

### After

https://github.com/user-attachments/assets/8058831e-9976-4d0e-acac-5e5d33194afe



