### PR TITLE
[One Workflow] Mark workflow-authoring skill as experimental

### DIFF
--- a/src/platform/plugins/shared/workflows_management/server/agent_builder/skills/workflow_authoring_skill.ts
+++ b/src/platform/plugins/shared/workflows_management/server/agent_builder/skills/workflow_authoring_skill.ts
@@ -17,6 +17,7 @@ import {
 export const workflowAuthoringSkill = defineSkillType({
   id: 'workflow-authoring',
   name: 'workflow-authoring',
+  experimental: true,
   basePath: 'skills/platform/workflows',
   description:
     'Create, modify, and validate Elastic workflow YAML definitions using natural language. Covers step types, triggers, Liquid templating, connector integrations, and validation.',


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16537

## Summary

The workflow tools are gated behind the `WORKFLOWS_AI_AGENT_SETTING_ID` UI setting, but the `workflow-authoring` skill that references them has no equivalent gating. This means when skills go GA, the skill would be visible but non-functional (tools not available).

This PR adds `experimental: true` to the skill definition so it stays hidden from GA users until the UI setting flag is removed from tools.