### PR TITLE
[Alerting v2] [Rule authoring] Wire up rule details to rules list

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -18,6 +18,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiIcon,
+  EuiLink,
   EuiPopover,
   EuiSpacer,
   EuiText,
@@ -161,6 +162,7 @@ export interface RulesListTableProps {
   onBulkDelete: () => void;
 
   /** Row action callbacks */
+  onNavigateToDetails: (rule: RuleApiResponse) => void;
   onEdit: (rule: RuleApiResponse) => void;
   onClone: (rule: RuleApiResponse) => void;
   onDelete: (rule: RuleApiResponse) => void;
@@ -188,6 +190,7 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
   onBulkEnable,
   onBulkDisable,
   onBulkDelete,
+  onNavigateToDetails,
   onEdit,
   onClone,
   onDelete,
@@ -254,7 +257,12 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
         truncateText: true,
         render: (metadata: RuleApiResponse['metadata'], rule: RuleApiResponse) => (
           <div>
-            {metadata?.name ?? rule.id}
+            <EuiLink
+              onClick={() => onNavigateToDetails(rule)}
+              data-test-subj={`ruleNameLink-${rule.id}`}
+            >
+              {metadata?.name ?? rule.id}
+            </EuiLink>
             {metadata?.description && (
               <EuiText size="xs" color="subdued" css={descriptionTextStyle}>
                 {metadata.description}
@@ -376,6 +384,7 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
       isRowSelected,
       onSelectPage,
       onSelectRow,
+      onNavigateToDetails,
       onEdit,
       onClone,
       onDelete,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table_container.tsx
@@ -114,6 +114,7 @@ export const RulesListTableContainer: React.FC<RulesListTableContainerProps> = (
         onBulkEnable={handleBulkEnable}
         onBulkDisable={handleBulkDisable}
         onBulkDelete={handleBulkDelete}
+        onNavigateToDetails={(r) => navigateToUrl(basePath.prepend(paths.ruleDetails(r.id)))}
         onEdit={(r) => navigateToUrl(basePath.prepend(paths.ruleEdit(r.id)))}
         onClone={(r) =>
           navigateToUrl(


### PR DESCRIPTION
## Summary

Closes: https://github.com/elastic/rna-program/issues/255

Makes rule names in the Alerting v2 rules list clickable links that navigate to the rule details page.

## Changes

- **`rules_list_table.tsx`** — Added a new `onNavigateToDetails` prop and wrapped the rule name in `EuiLink` within the Name column. Clicking the name navigates to that rule's details page.
- **`rules_list_table_container.tsx`** — Wires `onNavigateToDetails` to `navigateToUrl(basePath.prepend(paths.ruleDetails(r.id)))`, consistent with the existing edit/clone navigation pattern.

## How to test

1. Navigate to **Stack Management → Alerts and Insights → Alerting v2**
2. Confirm the rule name in the list renders as a hyperlink
3. Click a rule name — it should navigate to `/app/management/insightsAndAlerting/alerting_v2/{ruleId}`
