### PR TITLE
[Osquery] Fix pagination stale data problem

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.test.tsx
@@ -85,17 +85,20 @@ const mockHistory = ({
   nextPage,
   isLoading = false,
   isFetching = false,
+  isPlaceholderData = false,
 }: {
   data?: UnifiedHistoryResponse['data'];
   hasMore?: boolean;
   nextPage?: string;
   isLoading?: boolean;
   isFetching?: boolean;
+  isPlaceholderData?: boolean;
 }) => {
   useUnifiedHistoryMock.mockReturnValue({
     data: { data, hasMore, nextPage },
     isLoading,
     isFetching,
+    isPlaceholderData,
     refetch: jest.fn(),
   } as never);
 };
@@ -480,6 +483,26 @@ describe('UnifiedHistoryTable', () => {
       expect(useUnifiedHistoryMock).toHaveBeenCalledWith(
         expect.objectContaining({ sortDirection: 'desc' })
       );
+    });
+  });
+
+  describe('pagination', () => {
+    it('does not advertise extra pages while showing placeholder (stale) data', () => {
+      const rows = Array.from({ length: 20 }, () => createMockLiveRow());
+      mockHistory({
+        data: rows,
+        hasMore: true,
+        nextPage: 'cursor-abc',
+        isPlaceholderData: true,
+      });
+
+      const { container } = renderWithProviders(<UnifiedHistoryTable />);
+
+      // When data is stale (placeholder), the forward arrow should be disabled
+      // even though the stale response has hasMore: true.
+      const nextButton = container.querySelector('[data-test-subj="pagination-button-next"]');
+      expect(nextButton).toBeTruthy();
+      expect(nextButton).toBeDisabled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
@@ -238,6 +238,7 @@ const UnifiedHistoryTableComponent = () => {
     data: historyData,
     isLoading,
     isFetching,
+    isPlaceholderData,
     refetch,
   } = useUnifiedHistory({
     pageSize,
@@ -668,7 +669,7 @@ const UnifiedHistoryTableComponent = () => {
     []
   );
 
-  const hasMore = historyData?.hasMore ?? false;
+  const hasMore = (historyData?.hasMore ?? false) && !isPlaceholderData;
 
   // pageCount drives the navigation arrows: when hasMore is true we advertise
   // one extra page so the forward arrow stays enabled.


### PR DESCRIPTION

### Summary
- Fixed a race condition where an extra pagination page would briefly appear and disappear when navigating forward
- Root cause: `keepPreviousData: true` in React Query causes stale data (`hasMore: true` from the previous page) to render momentarily with the new `pageIndex`, inflating `pageCount`
- Fix: suppress `hasMore` while `isPlaceholderData` is true, preventing the forward arrow from activating on stale data

