### PR TITLE
[ML] Ensure local routing is used for anomaly results searches

### DIFF
--- a/x-pack/platform/plugins/shared/ml/server/lib/ml_client/search.ts
+++ b/x-pack/platform/plugins/shared/ml/server/lib/ml_client/search.ts
@@ -61,6 +61,9 @@ export function searchProvider(
       {
         ...searchParams,
         index: ML_RESULTS_INDEX_PATTERN,
+        ...(serverless.isServerless && serverless.cpsEnabled
+          ? { project_routing: '_alias:_origin' }
+          : {}),
       },
       options
     );


### PR DESCRIPTION
When searching anomaly results indices, we need to ensure local project routing is used.

This breaks out a change which was originally added in the larger CPS support for anomaly detection [PR](https://github.com/elastic/kibana/pull/251270/)