### PR TITLE
[9.2] [Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness (#259955)

### DIFF
--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
@@ -157,22 +157,6 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
         id: createdRule.id,
       });
     });
-
-    async function waitForEventLogDocs(
-      id: string,
-      actions: Map<string, { gte: number } | { equal: number }>
-    ) {
-      return await retry.try(async () => {
-        return await getEventLog({
-          getService,
-          spaceId: Spaces.space1.id,
-          type: 'alert',
-          id,
-          provider: 'alerting',
-          actions,
-        });
-      });
-    }
   });
 
   async function waitForEventLogDocs(

--- a/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
+++ b/x-pack/platform/test/alerting_api_integration/spaces_only/tests/alerting/group4/last_run_outcome_msg_migration.ts
@@ -34,7 +34,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
       await objectRemover.removeAll();
     });
 
-    async function getAlertFromEs(ruleId: string): Promise<RawRule> {
+    async function getRuleFromEs(ruleId: string): Promise<RawRule> {
       const response = await es.get<{ alert: RawRule }>(
         {
           index: ALERTING_CASES_SAVED_OBJECT_INDEX,
@@ -79,7 +79,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
 
       await injectLegacyStringOutcomeMsg(createdRule.id);
 
-      const beforeBulk = await getAlertFromEs(createdRule.id);
+      const beforeBulk = await getRuleFromEs(createdRule.id);
       expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
         LEGACY_OUTCOME_MSG
       );
@@ -92,7 +92,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
         })
         .expect(200);
 
-      const afterBulk = await getAlertFromEs(createdRule.id);
+      const afterBulk = await getRuleFromEs(createdRule.id);
       expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
       expect(afterBulk.enabled).to.eql(false);
 
@@ -126,7 +126,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
 
       await injectLegacyStringOutcomeMsg(createdRule.id);
 
-      const beforeBulk = await getAlertFromEs(createdRule.id);
+      const beforeBulk = await getRuleFromEs(createdRule.id);
       expect((beforeBulk.lastRun as { outcomeMsg?: unknown } | undefined)?.outcomeMsg).to.eql(
         LEGACY_OUTCOME_MSG
       );
@@ -139,7 +139,7 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
         })
         .expect(200);
 
-      const afterBulk = await getAlertFromEs(createdRule.id);
+      const afterBulk = await getRuleFromEs(createdRule.id);
       expect(afterBulk.lastRun?.outcomeMsg).to.eql([LEGACY_OUTCOME_MSG]);
       expect(afterBulk.enabled).to.eql(true);
 
@@ -174,4 +174,20 @@ export default function lastRunOutcomeMsgMigrationTests({ getService }: FtrProvi
       });
     }
   });
+
+  async function waitForEventLogDocs(
+    id: string,
+    actions: Map<string, { gte: number } | { equal: number }>
+  ) {
+    return await retry.try(async () => {
+      return await getEventLog({
+        getService,
+        spaceId: Spaces.space1.id,
+        type: 'alert',
+        id,
+        provider: 'alerting',
+        actions,
+      });
+    });
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness (#259955)](https://github.com/elastic/kibana/pull/259955)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2026-03-27T16:29:05Z","message":"[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness (#259955)\n\n**Resolves: https://github.com/elastic/kibana/issues/259634**\n**Relates to:** https://github.com/elastic/kibana/pull/258105\n\n## Summary\n\nThis PR fixes rule's `lastRun.outcomeMsg` functional test flakiness. The flakiness was caused by race condition between rule execution and setting the legacy `outcomeMsg`'s value.","sha":"737848bc8a0a670e95d9613635683d5e9a17796e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","Team:ResponseOps","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14"],"title":"[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness","number":259955,"url":"https://github.com/elastic/kibana/pull/259955","mergeCommit":{"message":"[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness (#259955)\n\n**Resolves: https://github.com/elastic/kibana/issues/259634**\n**Relates to:** https://github.com/elastic/kibana/pull/258105\n\n## Summary\n\nThis PR fixes rule's `lastRun.outcomeMsg` functional test flakiness. The flakiness was caused by race condition between rule execution and setting the legacy `outcomeMsg`'s value.","sha":"737848bc8a0a670e95d9613635683d5e9a17796e"}},"sourceBranch":"main","suggestedTargetBranches":["9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259955","number":259955,"mergeCommit":{"message":"[Security Solution] Fix rule's lastRun.outcomeMsg functional test flakiness (#259955)\n\n**Resolves: https://github.com/elastic/kibana/issues/259634**\n**Relates to:** https://github.com/elastic/kibana/pull/258105\n\n## Summary\n\nThis PR fixes rule's `lastRun.outcomeMsg` functional test flakiness. The flakiness was caused by race condition between rule execution and setting the legacy `outcomeMsg`'s value.","sha":"737848bc8a0a670e95d9613635683d5e9a17796e"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260055","number":260055,"state":"OPEN"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->