### PR TITLE
[9.3] Fix yarn.lock v1 parser for compound package alias headers (#259640)

### DIFF
--- a/.buildkite/scripts/bootstrap.sh
+++ b/.buildkite/scripts/bootstrap.sh
@@ -29,10 +29,6 @@ if [[ "$(pwd)" != *"/local-ssd/"* && "$(pwd)" != "/dev/shm"* ]]; then
     mkdir -p ./.moon/cache
     echo "Extracting moon-cache.tar.gz to ./.moon/cache"
     tar -xzf ~/moon-cache.tar.gz -C ./
-  elif [[ -d ~/.kibana-moon-cache ]]; then
-    echo "Using ~/.moon/cache as a starting point"
-    mkdir -p ./.moon/cache
-    mv ~/.kibana-moon-cache/* ./.moon/cache
   fi
 fi
 

--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -207,7 +207,6 @@ if [[ "${CI:-}" =~ ^(1|true)$ ]]; then
   export MOON_REMOTE_CACHE_TOKEN
   export MOON_CACHE=read
 fi
-export MOON_CACHE=off
 
 PIPELINE_PRE_COMMAND=${PIPELINE_PRE_COMMAND:-".buildkite/scripts/lifecycle/pipelines/$BUILDKITE_PIPELINE_SLUG/pre_command.sh"}
 if [[ -f "$PIPELINE_PRE_COMMAND" ]]; then

--- a/.buildkite/scripts/steps/store_cache.sh
+++ b/.buildkite/scripts/steps/store_cache.sh
@@ -6,6 +6,7 @@ source .buildkite/scripts/common/util.sh
 
 export MOON_CACHE=write
 .buildkite/scripts/bootstrap.sh
+
 echo "--- Archive moon cache"
 if [[ ! -d .moon/cache ]]; then
   echo "No moon cache directory found, skipping archive"

--- a/packages/kbn-plugin-helpers/src/tasks/build_webpack_packages.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/build_webpack_packages.ts
@@ -22,7 +22,10 @@ export async function buildWebpackPackages({ log, quiet, dist }: TaskContext) {
 
   const args = ['kbn', 'build-shared'];
   if (quiet) args.push('--quiet');
-  if (dist) args.push('--dist');
+  if (dist) {
+    args.push('--dist');
+    args.push('--no-cache');
+  }
 
   await execa('yarn', args, { cwd: REPO_ROOT, stdio });
 }

--- a/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
+++ b/src/dev/kbn_pm/src/commands/bootstrap/bootstrap_command.mjs
@@ -112,8 +112,8 @@ export const command = {
 
     await Promise.all([
       time('prepare webpack bundles for packages', async () => {
-        log.info('extract relevant versions for packages and pre-build webpack bundles');
-        await moonRun([':extract-version-dependencies', ':build-webpack'], {
+        log.info('pre-build webpack bundles');
+        await moonRun([':build-webpack'], {
           pipe: !quiet,
           quiet,
           noCache: forceInstall,

--- a/src/dev/yarn/yarn_lock_v1.test.ts
+++ b/src/dev/yarn/yarn_lock_v1.test.ts
@@ -72,4 +72,25 @@ shared@~1.2.0:
       },
     });
   });
+
+  it('indexes each package alias in a compound yarn.lock header', () => {
+    const lockfile = `
+"@scope/alias@npm:@scope/alias@2.0.1", "plain-name@1 - 2", "plain-name@npm:@scope/alias@2.0.1":
+  version "2.0.1"
+  resolved "https://example.invalid/pkg.tgz"
+`;
+
+    const parsed = parseYarnLock(lockfile);
+
+    expect(parsed['plain-name@2.0.1']).toMatchObject({
+      name: 'plain-name',
+      requestedVersions: ['1 - 2', 'npm:@scope/alias@2.0.1'],
+      resolvedVersion: '2.0.1',
+    });
+    expect(parsed['@scope/alias@2.0.1']).toMatchObject({
+      name: '@scope/alias',
+      requestedVersions: ['npm:@scope/alias@2.0.1'],
+      resolvedVersion: '2.0.1',
+    });
+  });
 });

--- a/src/dev/yarn/yarn_lock_v1.ts
+++ b/src/dev/yarn/yarn_lock_v1.ts
@@ -22,6 +22,23 @@ export interface PackageInfo {
 
 const makeKey = (name: string, version: string) => `${name}@${version}`;
 const trimQuotes = (str: string) => str.replace(/(^"|"$)/g, '');
+
+/** Splits a yarn.lock header descriptor into [packageName, requestedRangeOrDescriptor]. */
+const splitYarnLockDescriptor = (entry: string): [string, string] => {
+  if (entry.startsWith('@')) {
+    const versionSeparator = entry.indexOf('@', 1);
+    if (versionSeparator === -1) {
+      throw new Error(`Invalid yarn.lock descriptor: ${entry}`);
+    }
+    return [entry.slice(0, versionSeparator), entry.slice(versionSeparator + 1)];
+  }
+  const at = entry.indexOf('@');
+  if (at === -1) {
+    throw new Error(`Invalid yarn.lock descriptor: ${entry}`);
+  }
+  return [entry.slice(0, at), entry.slice(at + 1)];
+};
+
 const splitDependencyLine = (line: string) => {
   const match = line.trim().match(/^(\S+)\s+(.+)$/);
 
@@ -44,37 +61,40 @@ export const parseYarnLock = (content: string, focus?: string[]): Record<string,
 
     const header = lines[0].replace(/:$/, '').trim();
     const headerEntries = header.split(', ').map(trimQuotes);
-    const name = headerEntries[0].split(/(?!^)@/)[0];
 
-    if (focusSet !== null && !focusSet.has(name)) {
-      continue;
+    if (focusSet !== null) {
+      const anyFocused = headerEntries.some((entry) => {
+        const [pkgName] = splitYarnLockDescriptor(entry);
+        return focusSet.has(pkgName);
+      });
+      if (!anyFocused) {
+        continue;
+      }
     }
 
-    const requestedVersions = headerEntries.map((entry) => entry.substring(name.length + 1));
-
-    const packageInfo: PackageInfo = {
-      name,
-      requestedVersions,
-    };
+    let resolvedVersion: string | undefined;
+    let resolvedUrl: string | undefined;
+    let integrity: string | undefined;
+    let blockDependencies: { [key: string]: string } | undefined;
 
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       const [key, value] = line.split(/\s+/, 2).map(trimQuotes);
       if (key === 'version') {
-        packageInfo.resolvedVersion = value;
+        resolvedVersion = value;
       } else if (key === 'resolved') {
-        packageInfo.resolvedUrl = value;
+        resolvedUrl = value;
       } else if (key === 'integrity') {
-        packageInfo.integrity = value;
+        integrity = value;
       } else if (key === 'dependencies:' || key === 'optionalDependencies:') {
         let depCount = 0;
         if (focusSet === null) {
-          packageInfo.dependencies = packageInfo.dependencies || {};
+          blockDependencies = blockDependencies || {};
           for (let j = i + 1; j < lines.length; j++) {
             const depLine = lines[j];
             if (!/^\s{4,}\S/.test(depLine)) break;
             const [depKey, depVersion] = splitDependencyLine(depLine);
-            packageInfo.dependencies![depKey] = depVersion;
+            blockDependencies[depKey] = depVersion;
             depCount++;
           }
         } else {
@@ -87,18 +107,35 @@ export const parseYarnLock = (content: string, focus?: string[]): Record<string,
       }
     }
 
-    if (!packageInfo.resolvedVersion) {
-      console.warn(`No resolved version found for package ${name}. Skipping.`);
+    if (!resolvedVersion) {
+      console.warn(
+        `No resolved version found for package block starting with ${headerEntries[0]}. Skipping.`
+      );
       continue;
     }
-    const entryKey = makeKey(name, packageInfo.resolvedVersion!);
-    if (!packages[entryKey]) {
-      packages[entryKey] = packageInfo;
-    } else {
-      const existing = packages[entryKey];
-      existing.requestedVersions = Array.from(
-        new Set([...existing.requestedVersions, ...packageInfo.requestedVersions])
-      ).sort();
+
+    for (const headerEntry of headerEntries) {
+      const [pkgName, requestedVersion] = splitYarnLockDescriptor(headerEntry);
+      if (focusSet !== null && !focusSet.has(pkgName)) {
+        continue;
+      }
+
+      const entryKey = makeKey(pkgName, resolvedVersion);
+      if (!packages[entryKey]) {
+        packages[entryKey] = {
+          name: pkgName,
+          requestedVersions: [requestedVersion],
+          resolvedVersion,
+          resolvedUrl,
+          integrity,
+          dependencies: blockDependencies ? { ...blockDependencies } : undefined,
+        };
+      } else {
+        const existing = packages[entryKey];
+        existing.requestedVersions = Array.from(
+          new Set([...existing.requestedVersions, requestedVersion])
+        ).sort();
+      }
     }
   }
   return packages;

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/moon.extend.yml
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/moon.extend.yml
@@ -7,7 +7,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
       - --collect
       - '@babel/runtime'
@@ -108,7 +108,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
       - '^:build-webpack'
     inputs:
       - '@group(src)'

--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/moon.yml
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/moon.yml
@@ -36,7 +36,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
       - '--collect'
       - '@babel/runtime'
@@ -137,7 +137,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
       - ^:build-webpack
     inputs:
       - '@group(src)'

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/moon.extend.yml
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/moon.extend.yml
@@ -9,7 +9,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
       - --collect
       - '@babel/plugin-transform-numeric-separator'
@@ -46,7 +46,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
       - '^:build-webpack'
     inputs:
       - '@group(src)'

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/moon.yml
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/moon.yml
@@ -38,7 +38,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/private/kbn-ui-shared-deps-src/version_dependencies.txt
       - '--collect'
       - '@babel/plugin-transform-numeric-separator'
@@ -75,7 +75,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
       - ^:build-webpack
     inputs:
       - '@group(src)'

--- a/src/platform/packages/shared/kbn-monaco/moon.extend.yml
+++ b/src/platform/packages/shared/kbn-monaco/moon.extend.yml
@@ -7,7 +7,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/shared/kbn-monaco/version_dependencies.txt
       - --collect
       - babel-loader
@@ -34,7 +34,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
     inputs:
       - '@group(src)'
       - package.json

--- a/src/platform/packages/shared/kbn-monaco/moon.yml
+++ b/src/platform/packages/shared/kbn-monaco/moon.yml
@@ -62,7 +62,7 @@ tasks:
   extract-version-dependencies:
     command: node
     args:
-      - $workspaceRoot/scripts/extract_version_dependencies.js
+      - scripts/extract_version_dependencies.js
       - src/platform/packages/shared/kbn-monaco/version_dependencies.txt
       - '--collect'
       - babel-loader
@@ -89,7 +89,7 @@ tasks:
     args:
       - build
     deps:
-      - extract-version-dependencies
+      - ~:extract-version-dependencies
     inputs:
       - '@group(src)'
       - package.json


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix yarn.lock v1 parser for compound package alias headers (#259640)](https://github.com/elastic/kibana/pull/259640)
 - [[CI] Fix moon cache usage (#259760)](https://github.com/elastic/kibana/pull/259760)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2026-03-25T19:33:17Z","message":"Fix yarn.lock v1 parser for compound package alias headers (#259640)\n\n## Summary\n\nFixes `extract-version-dependencies` failing with `Unable to resolve\nd3-color@1 - 2 from yarn.lock dependency graph` when Yarn merges\nmultiple lockfile descriptors (aliases) into a single block.\n\n## Changes\n\n- **`yarn_lock_v1.ts`**: Parse each comma-separated header descriptor\nwith correct scoped vs unscoped `@` splitting; register `PackageInfo`\nper alias; merge `requestedVersions` for duplicate\n`name@resolvedVersion` keys. In `focus` mode, include a block if any\nalias matches.\n- **`yarn_lock_v1.test.ts`**: Regression test for compound headers.\n- **`yarn.lock`**: Refreshed merged descriptor lines (e.g. `d3-color` /\n`@elastic/kibana-d3-color`, `ajv` / `@redocly/ajv`).\n- **`version_dependencies.txt`**: Regenerated via\n`extract-version-dependencies`.\n\n## Testing\n\n- `node scripts/jest src/dev/yarn/yarn_lock_v1.test.ts`\n- `moon run @kbn/ui-shared-deps-npm:extract-version-dependencies`\n- `node scripts/check_changes.ts`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c82b6d42eb7fecc5116eaab557ad8a4cf8869076","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"Fix yarn.lock v1 parser for compound package alias headers","number":259640,"url":"https://github.com/elastic/kibana/pull/259640","mergeCommit":{"message":"Fix yarn.lock v1 parser for compound package alias headers (#259640)\n\n## Summary\n\nFixes `extract-version-dependencies` failing with `Unable to resolve\nd3-color@1 - 2 from yarn.lock dependency graph` when Yarn merges\nmultiple lockfile descriptors (aliases) into a single block.\n\n## Changes\n\n- **`yarn_lock_v1.ts`**: Parse each comma-separated header descriptor\nwith correct scoped vs unscoped `@` splitting; register `PackageInfo`\nper alias; merge `requestedVersions` for duplicate\n`name@resolvedVersion` keys. In `focus` mode, include a block if any\nalias matches.\n- **`yarn_lock_v1.test.ts`**: Regression test for compound headers.\n- **`yarn.lock`**: Refreshed merged descriptor lines (e.g. `d3-color` /\n`@elastic/kibana-d3-color`, `ajv` / `@redocly/ajv`).\n- **`version_dependencies.txt`**: Regenerated via\n`extract-version-dependencies`.\n\n## Testing\n\n- `node scripts/jest src/dev/yarn/yarn_lock_v1.test.ts`\n- `moon run @kbn/ui-shared-deps-npm:extract-version-dependencies`\n- `node scripts/check_changes.ts`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c82b6d42eb7fecc5116eaab557ad8a4cf8869076"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259640","number":259640,"mergeCommit":{"message":"Fix yarn.lock v1 parser for compound package alias headers (#259640)\n\n## Summary\n\nFixes `extract-version-dependencies` failing with `Unable to resolve\nd3-color@1 - 2 from yarn.lock dependency graph` when Yarn merges\nmultiple lockfile descriptors (aliases) into a single block.\n\n## Changes\n\n- **`yarn_lock_v1.ts`**: Parse each comma-separated header descriptor\nwith correct scoped vs unscoped `@` splitting; register `PackageInfo`\nper alias; merge `requestedVersions` for duplicate\n`name@resolvedVersion` keys. In `focus` mode, include a block if any\nalias matches.\n- **`yarn_lock_v1.test.ts`**: Regression test for compound headers.\n- **`yarn.lock`**: Refreshed merged descriptor lines (e.g. `d3-color` /\n`@elastic/kibana-d3-color`, `ajv` / `@redocly/ajv`).\n- **`version_dependencies.txt`**: Regenerated via\n`extract-version-dependencies`.\n\n## Testing\n\n- `node scripts/jest src/dev/yarn/yarn_lock_v1.test.ts`\n- `moon run @kbn/ui-shared-deps-npm:extract-version-dependencies`\n- `node scripts/check_changes.ts`\n\nMade with [Cursor](https://cursor.com)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c82b6d42eb7fecc5116eaab557ad8a4cf8869076"}},{"url":"https://github.com/elastic/kibana/pull/259476","number":259476,"branch":"9.2","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/259475","number":259475,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->