### PR TITLE
Updates LLM proxy support messaging

### DIFF
--- a/docs/reference/connectors-kibana/gen-ai-connectors.md
+++ b/docs/reference/connectors-kibana/gen-ai-connectors.md
@@ -9,3 +9,9 @@ Use these connectors to connect to third-party large language model (LLM) servic
 
 :::{include} _snippets/gen-ai-connectors-list.md
 :::
+
+::::{important}
+Connecting to LLM providers through a proxy is in technical preview. If you use a proxy, it should support streaming and be SSE-compatible. Elastic only parses streamed responses.
+
+To check if problems are caused by using a proxy, you can test your LLM service without using a proxy.
+::::

--- a/docs/reference/connectors-kibana/openai-action-type.md
+++ b/docs/reference/connectors-kibana/openai-action-type.md
@@ -24,12 +24,6 @@ You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For 
 :screenshot:
 :::
 
-::::{important}
-Elastic provides no official support for connecting to the Azure OpenAI service through a proxy. However if you must use a proxy, ensure that the proxy supports streaming and is SSE-compatible. Elastic will only parse streamed responses.
-
-To validate that your connectivity problems are caused by using a proxy, you can attempt to set up the connector and access the Azure OpenAI service without using a proxy.
-::::
-
 ### Connector configuration [openai-connector-configuration]
 
 OpenAI connectors have the following configuration properties:


### PR DESCRIPTION
Fixes [/docs-content-internal/issue/529](https://github.com/elastic/docs-content-internal/issues/529)

Removes a warning in the OpenAI connector doc about proxy support, and adds it to the section that contains that doc, since the limitation applies across all the LLM connectors per [this thread](https://elastic.slack.com/archives/C0560E41DD0/p1763745349843239). Also changes the wording of the warning to soften it. Technical reviewers, please let me know if this is all accurate.