### PR TITLE
[Security Solution] fix broken unit test on main

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/utils/get_columns.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/correlations/utils/get_columns.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { formatDate } from '@elastic/eui';
+import { EntityStoreEuidApiProvider } from '@kbn/entity-store/public';
 import { ALERT_REASON, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { TestProviders } from '../../../common/mock';
@@ -24,6 +25,7 @@ jest.mock('../../../common/lib/kibana', () => ({
       telemetry: { reportEvent: jest.fn() },
     },
   }),
+  useUiSetting: jest.fn(() => false),
 }));
 
 const scopeId = 'test-scope';
@@ -32,7 +34,11 @@ const mockOnShowAlert = jest.fn();
 const useUserPrivilegesMock = useUserPrivileges as jest.Mock;
 
 const renderColumn = (element: React.ReactElement) =>
-  render(<TestProviders>{element}</TestProviders>);
+  render(
+    <TestProviders>
+      <EntityStoreEuidApiProvider>{element}</EntityStoreEuidApiProvider>
+    </TestProviders>
+  );
 
 describe('getColumns', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

This PR fixes a failing test unit test in `main`. The reason this happened is because these 2 PRs ([this one](https://github.com/elastic/kibana/pull/255429) and [that one](https://github.com/elastic/kibana/pull/258973)) were merged close to each other without restarting a build in between. There were no conflicts but something introduced in the first PR broke the test in the second...

Ran linting locally for the modified file ✅ 
<img width="1004" height="35" alt="Screenshot 2026-03-27 at 3 56 43 PM" src="https://github.com/user-attachments/assets/66285e33-b6e0-4fc3-956a-b3d663981a3d" />

And ran the test locally ✅ 
<img width="898" height="395" alt="Screenshot 2026-03-27 at 3 56 18 PM" src="https://github.com/user-attachments/assets/641a4d0b-f198-4edd-9a5c-a1de6ec64b47" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

https://github.com/elastic/kibana/issues/260101
https://github.com/elastic/kibana/issues/260100