### PR TITLE
 [Discover][Metrics] Fix chart panels rendering above push flyout in fullscreen

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.test.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.test.ts
@@ -112,4 +112,19 @@ describe('useMetricsGridFullScreen', () => {
       /logicalCSS\s*\(\s*['"]right['"]\s*,\s*['"]var\(--euiPushFlyoutOffsetInlineEnd,\s*0px\)['"]\s*\)/
     );
   });
+
+  it('fullscreen styles reset embPanel z-index to prevent stacking above overlay', () => {
+    // Embeddable panels (.embPanel) set high z-index values that can stack above
+    // the fullscreen overlay and interfere with flyouts (e.g. chart tooltips or
+    // action menus rendering behind panels). Resetting z-index to auto ensures
+    // panels participate in normal stacking context while in fullscreen mode.
+    // See https://github.com/elastic/kibana/issues/260087
+
+    const sourceCode = fs.readFileSync(
+      path.join(__dirname, 'use_metrics_grid_fullscreen.ts'),
+      'utf-8'
+    );
+
+    expect(sourceCode).toMatch(/\.embPanel\s*\{\s*z-index:\s*auto\s*!important;/);
+  });
 });

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -83,7 +83,8 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         ${logicalCSS('right', 'var(--euiPushFlyoutOffsetInlineEnd, 0px)')}
         background-color: ${euiTheme.colors.backgroundBasePlain};
 
-        .embPanel {
+        .embPanel,
+        .embPanel__hoverActions {
           z-index: auto !important;
         }
       `,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -83,9 +83,12 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         ${logicalCSS('right', 'var(--euiPushFlyoutOffsetInlineEnd, 0px)')}
         background-color: ${euiTheme.colors.backgroundBasePlain};
 
-        .embPanel,
-        .embPanel__hoverActions {
+        .embPanel {
           z-index: auto !important;
+        }
+
+        .embPanel__hoverActions {
+          z-index: ${Number(euiTheme.levels.flyout) - 2} !important;
         }
       `,
       [METRICS_GRID_RESTRICT_BODY_CLASS]: css`

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -82,6 +82,10 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         inset: 0;
         ${logicalCSS('right', 'var(--euiPushFlyoutOffsetInlineEnd, 0px)')}
         background-color: ${euiTheme.colors.backgroundBasePlain};
+
+        .embPanel {
+          z-index: auto !important;
+        }
       `,
       [METRICS_GRID_RESTRICT_BODY_CLASS]: css`
         overflow: hidden;

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/hooks/use_metrics_grid_fullscreen.ts
@@ -83,6 +83,10 @@ export const useMetricsGridFullScreen = ({ prefix }: { prefix: string }) => {
         ${logicalCSS('right', 'var(--euiPushFlyoutOffsetInlineEnd, 0px)')}
         background-color: ${euiTheme.colors.backgroundBasePlain};
 
+        // Embeddable panels set high z-index values that can stack above the
+        // fullscreen overlay and interfere with flyouts. Reset to auto so they
+        // participate in normal stacking context.
+        // See https://github.com/elastic/kibana/issues/260087
         .embPanel {
           z-index: auto !important;
         }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
Fixes #260087                                                                                                                                                                                                                                
                                                                                                                                                                                                                                             
In the fullscreen metrics view, hovering over a chart panel caused it to render on top of the metric insights flyout. This happened because:                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                             
- The metric insights flyout uses `EuiFlyout` with `type="push"`, which renders inline (no portal), so the flyout lives inside the fullscreen metrics grid's stacking context                                                                                                                                                                                                   
- The presentation panel hover styles elevate `.embPanel` to `euiTheme.levels.menu`, which is higher than the flyout's z-index within that same stacking context                                                                                                                                                                                                            

The fix resets `.embPanel` z-index to `auto` inside the fullscreen grid class, preventing chart panels from stacking above the push flyout on hover.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                             
## Test plan                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                             
- Open Discover with a data view that has metric fields                                                                                                                                                                                      
- Switch to the Metrics tab and enter fullscreen mode                                                                                                                                                                                        
- Click "View details" on a chart to open the metric insights flyout                                                                                                                                                                         
- Hover over other chart panels and verify they do not render above the flyout                                                                                                                                                                                                                                   
- Verify chart hover actions (toolbar buttons) still appear correctly within the chart area                                                                                                                                                                                                                       
- Exit fullscreen and verify normal chart hover behavior is unaffected  

### Examples

#### Before

![20260327203329](https://github.com/user-attachments/assets/df0dce6c-9346-444a-8647-e1ef506f8949)

#### After

![20260327204555](https://github.com/user-attachments/assets/d1e16b78-87e4-4831-a8cb-444333595053)
