### PR TITLE
[Entity Analytics][Watchlist] Build watchlist directly from store

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/data_source/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/data_source/common.gen.ts
@@ -17,7 +17,7 @@
 import { z } from '@kbn/zod/v4';
 
 export type EntitySourceType = z.infer<typeof EntitySourceType>;
-export const EntitySourceType = z.enum(['index', 'entity_analytics_integration']);
+export const EntitySourceType = z.enum(['index', 'entity_analytics_integration', 'store']);
 export type EntitySourceTypeEnum = typeof EntitySourceType.enum;
 export const EntitySourceTypeEnum = EntitySourceType.enum;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/data_source/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/watchlists/data_source/common.schema.yaml
@@ -12,6 +12,7 @@ components:
       enum:
         - index
         - entity_analytics_integration
+        - store
 
     UpdateableMonitoringEntitySourceProperties:
       type: object

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
@@ -8,6 +8,7 @@
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { getLatestEntitiesIndexName } from '@kbn/entity-store/server';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
+import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 
 import { get } from 'lodash';
 import type { Entity as EntityStoreEntity } from '../../../../../common/api/entity_analytics/entity_store/entities/common.gen';
@@ -20,7 +21,8 @@ export type EntityStoreEntityIdsByType = Record<EntityType, string[]>;
 
 export type IdentityProvider =
   | { type: 'integration'; name: IntegrationType }
-  | { type: 'index'; field: string };
+  | { type: 'index'; field: string }
+  | { type: 'store'; queryRule: string };
 
 export interface IndexSourceResult {
   entityIdsByType: EntityStoreEntityIdsByType;
@@ -43,15 +45,22 @@ export const createWatchlistEntitiesService = ({
   function listEntityStoreEntities(
     idp: IdentityProvider & { type: 'integration' }
   ): Promise<EntityStoreEntityIdsByType>;
+  function listEntityStoreEntities(
+    idp: IdentityProvider & { type: 'store' }
+  ): Promise<EntityStoreEntityIdsByType>;
   async function listEntityStoreEntities(
     idp: IdentityProvider
   ): Promise<EntityStoreEntityIdsByType | IndexSourceResult> {
     const isIndexSync = idp.type === 'index';
 
-    const query =
-      idp.type === 'integration'
-        ? { term: { 'entity.namespace': integrationToStoreNamespaceMap[idp.name] } }
-        : { exists: { field: idp.field } };
+    let query: Record<string, unknown>;
+    if (idp.type === 'integration') {
+      query = { term: { 'entity.namespace': integrationToStoreNamespaceMap[idp.name] } };
+    } else if (idp.type === 'store') {
+      query = toElasticsearchQuery(fromKueryExpression(idp.queryRule));
+    } else {
+      query = { exists: { field: idp.field } };
+    }
 
     const entityIdsByType = createEmptyEntityStoreEntityIdsByType();
     const correlationMap: CorrelationMap = new Map();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/bulk/soft_delete.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/bulk/soft_delete.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { StaleEntity } from './soft_delete';
+import { bulkRemoveSourceOperationsFactory, REMOVE_SOURCE_SCRIPT } from './soft_delete';
+
+const logger = loggingSystemMock.createLogger();
+
+describe('bulkRemoveSourceOperationsFactory', () => {
+  const buildOps = bulkRemoveSourceOperationsFactory(logger);
+  const targetIndex = '.entity-analytics.watchlists.test-watchlist-default';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('generates update operations with the remove-source script', () => {
+    const staleEntities: StaleEntity[] = [
+      { docId: 'doc-1', sourceId: 'source-1' },
+      { docId: 'doc-2', sourceId: 'source-1' },
+    ];
+
+    const ops = buildOps({ staleEntities, sourceType: 'index', targetIndex });
+
+    expect(ops).toHaveLength(4);
+
+    expect(ops[0]).toEqual({ update: { _index: targetIndex, _id: 'doc-1' } });
+    expect(ops[1]).toEqual(
+      expect.objectContaining({
+        script: expect.objectContaining({
+          source: REMOVE_SOURCE_SCRIPT,
+          params: expect.objectContaining({
+            source_id: 'source-1',
+            source_type: 'index',
+          }),
+        }),
+      })
+    );
+
+    expect(ops[2]).toEqual({ update: { _index: targetIndex, _id: 'doc-2' } });
+    expect(ops[3]).toEqual(
+      expect.objectContaining({
+        script: expect.objectContaining({
+          source: REMOVE_SOURCE_SCRIPT,
+          params: expect.objectContaining({
+            source_id: 'source-1',
+            source_type: 'index',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('returns an empty array when no stale entities are provided', () => {
+    const ops = buildOps({ staleEntities: [], sourceType: 'index', targetIndex });
+    expect(ops).toHaveLength(0);
+  });
+
+  it('includes a valid ISO timestamp in params.now', () => {
+    const staleEntities: StaleEntity[] = [{ docId: 'doc-1', sourceId: 'source-1' }];
+
+    const ops = buildOps({ staleEntities, sourceType: 'index', targetIndex });
+    const scriptBody = ops[1] as { script: { params: { now: string } } };
+
+    expect(scriptBody.script.params.now).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/bulk/soft_delete.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/bulk/soft_delete.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { getErrorFromBulkResponse, errorsMsg } from '../sync/utils';
+
+export interface StaleEntity {
+  docId: string;
+  sourceId: string;
+}
+
+/**
+ * Painless script that removes a source from an entity document.
+ * - Removes `params.source_id` from `labels.source_ids`
+ * - If `source_ids` is now empty, removes `params.source_type` from `labels.sources`
+ * - If `sources` is now empty, hard-deletes the document via `ctx.op = 'delete'`
+ */
+export const REMOVE_SOURCE_SCRIPT = `
+if (ctx._source.labels?.source_ids != null) {
+  ctx._source.labels.source_ids.removeIf(sid -> sid == params.source_id);
+}
+
+if (ctx._source.labels?.source_ids == null || ctx._source.labels.source_ids.isEmpty()) {
+  if (ctx._source.labels?.sources != null) {
+    ctx._source.labels.sources.removeIf(src -> src == params.source_type);
+  }
+}
+
+if (ctx._source.labels?.sources == null || ctx._source.labels.sources.isEmpty()) {
+  ctx.op = 'delete';
+} else {
+  ctx._source['@timestamp'] = params.now;
+  if (ctx._source.event == null) { ctx._source.event = new HashMap(); }
+  ctx._source.event.ingested = params.now;
+}
+`;
+
+export const bulkRemoveSourceOperationsFactory =
+  (logger: Logger) =>
+  ({
+    staleEntities,
+    sourceType,
+    targetIndex,
+  }: {
+    staleEntities: StaleEntity[];
+    sourceType: string;
+    targetIndex: string;
+  }): object[] => {
+    const ops: object[] = [];
+    const now = new Date().toISOString();
+    logger.debug(
+      `[WatchlistSync] Building bulk remove-source operations for ${staleEntities.length} entities`
+    );
+    for (const entity of staleEntities) {
+      ops.push(
+        { update: { _index: targetIndex, _id: entity.docId } },
+        {
+          script: {
+            source: REMOVE_SOURCE_SCRIPT,
+            params: {
+              source_id: entity.sourceId,
+              source_type: sourceType,
+              now,
+            },
+          },
+        }
+      );
+    }
+    return ops;
+  };
+
+export const applyBulkRemoveSource = async ({
+  esClient,
+  logger,
+  staleEntities,
+  sourceType,
+  targetIndex,
+}: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  staleEntities: StaleEntity[];
+  sourceType: string;
+  targetIndex: string;
+}): Promise<void> => {
+  if (staleEntities.length === 0) {
+    return;
+  }
+
+  const chunkSize = 500;
+  const buildOps = bulkRemoveSourceOperationsFactory(logger);
+
+  for (let start = 0; start < staleEntities.length; start += chunkSize) {
+    const chunk = staleEntities.slice(start, start + chunkSize);
+    const operations = buildOps({ staleEntities: chunk, sourceType, targetIndex });
+    if (operations.length > 0) {
+      const resp = await esClient.bulk({ refresh: 'wait_for', body: operations });
+      const errors = getErrorFromBulkResponse(resp);
+      if (errors.length > 0) {
+        logger.error(`[WatchlistSync] Bulk remove-source errors: ${errorsMsg(errors)}`);
+      }
+    }
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/entity_sources_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/entity_sources_service.ts
@@ -58,6 +58,16 @@ export const createEntitySourcesService = ({
             };
           }
 
+          if (source.type === 'store') {
+            const identity: IdentityProvider = {
+              type: 'store',
+              queryRule: source.queryRule || '',
+            };
+            const entityStoreEntityIdsByType =
+              await watchlistEntitiesService.listEntityStoreEntities(identity);
+            return { sourceId: source.id, entityStoreEntityIdsByType };
+          }
+
           const identity: IdentityProvider = {
             type: 'integration',
             name: source.integrationName as IntegrationType,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  elasticsearchServiceMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
+import type { WatchlistDataSources } from '../../../../../../../common/api/entity_analytics';
+import { createDeletionDetectionService } from './deletion_detection';
+
+jest.mock('../../infra/entity_source_client');
+jest.mock('../../bulk/soft_delete');
+
+const { WatchlistEntitySourceClient, mockGetLastFullSyncMarker, mockUpdateLastFullSyncMarker } =
+  jest.requireMock('../../infra/entity_source_client') as {
+    WatchlistEntitySourceClient: jest.Mock;
+    mockGetLastFullSyncMarker: jest.Mock;
+    mockUpdateLastFullSyncMarker: jest.Mock;
+  };
+
+const { applyBulkRemoveSource } = jest.requireMock('../../bulk/soft_delete') as {
+  applyBulkRemoveSource: jest.Mock;
+};
+
+describe('DeletionDetectionService', () => {
+  const esClient = elasticsearchServiceMock.createElasticsearchClient();
+  const logger = loggingSystemMock.createLogger();
+  const targetIndex = '.entity-analytics.watchlists.test-default';
+
+  const createService = () => {
+    const descriptorClient = new WatchlistEntitySourceClient({
+      soClient: savedObjectsClientMock.create(),
+      namespace: 'default',
+    });
+    return createDeletionDetectionService({
+      esClient,
+      logger,
+      targetIndex,
+      descriptorClient,
+    });
+  };
+
+  const indexSource: WatchlistDataSources.MonitoringEntitySource = {
+    id: 'source-idx',
+    type: 'index',
+    name: 'test-index-source',
+    indexPattern: 'my-index-*',
+    identifierField: 'user.name',
+    enabled: true,
+  };
+
+  const integrationSource: WatchlistDataSources.MonitoringEntitySource = {
+    id: 'source-int',
+    type: 'entity_analytics_integration',
+    name: 'test-integration-source',
+    indexPattern: 'logs-entityanalytics_okta.user-default',
+    integrationName: 'entityanalytics_okta',
+    enabled: true,
+    integrations: {
+      syncMarkerIndex: 'logs-entityanalytics_okta.entity-default',
+      syncData: {},
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no stale entities found
+    esClient.search.mockResolvedValue({
+      hits: { hits: [], total: { value: 0, relation: 'eq' } },
+    });
+  });
+
+  describe('index sources', () => {
+    it('skips bulk operations when no stale entities are found', async () => {
+      const service = createService();
+      await service.deletionDetection(indexSource, ['euid-1', 'euid-2']);
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: targetIndex,
+          query: {
+            bool: {
+              must: [{ term: { 'labels.source_ids': 'source-idx' } }],
+              must_not: [{ terms: { 'entity.id': ['euid-1', 'euid-2'] } }],
+            },
+          },
+        })
+      );
+      expect(applyBulkRemoveSource).not.toHaveBeenCalled();
+    });
+
+    it('calls applyBulkRemoveSource when stale entities are found', async () => {
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            { _id: 'doc-stale-1', _source: {}, sort: ['sort-1'] },
+            { _id: 'doc-stale-2', _source: {}, sort: ['sort-2'] },
+          ],
+          total: { value: 2, relation: 'eq' },
+        },
+      });
+
+      const service = createService();
+      await service.deletionDetection(indexSource, ['euid-1']);
+
+      expect(applyBulkRemoveSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          staleEntities: [
+            { docId: 'doc-stale-1', sourceId: 'source-idx' },
+            { docId: 'doc-stale-2', sourceId: 'source-idx' },
+          ],
+          sourceType: 'index',
+          targetIndex,
+        })
+      );
+    });
+
+    it('omits must_not when currentEuids is empty (all entities are stale)', async () => {
+      const service = createService();
+      await service.deletionDetection(indexSource, []);
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            bool: {
+              must: [{ term: { 'labels.source_ids': 'source-idx' } }],
+            },
+          },
+        })
+      );
+    });
+
+    it('does not check detectNewFullSync for index sources', async () => {
+      const service = createService();
+      await service.deletionDetection(indexSource, ['euid-1']);
+
+      // detectNewFullSync queries the sync marker index — should not happen for index sources
+      // The only search call should be the stale entity query on the target index
+      expect(esClient.search).toHaveBeenCalledTimes(1);
+      expect(esClient.search).toHaveBeenCalledWith(expect.objectContaining({ index: targetIndex }));
+    });
+  });
+
+  describe('integration sources', () => {
+    it('skips deletion detection when no new full sync is detected', async () => {
+      // No completed event in sync marker index
+      mockGetLastFullSyncMarker.mockResolvedValue(undefined);
+      esClient.search.mockResolvedValueOnce({
+        hits: { hits: [], total: { value: 0, relation: 'eq' } },
+      });
+
+      const service = createService();
+      await service.deletionDetection(integrationSource, ['euid-1']);
+
+      // Only the sync marker index query should happen, NOT the stale entity query
+      expect(esClient.search).toHaveBeenCalledTimes(1);
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: 'logs-entityanalytics_okta.entity-default',
+        })
+      );
+      expect(applyBulkRemoveSource).not.toHaveBeenCalled();
+    });
+
+    it('runs deletion detection when a new full sync is detected', async () => {
+      mockGetLastFullSyncMarker.mockResolvedValue(undefined);
+      // First call: sync marker index query returns a completed event
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: 'marker-1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
+        },
+      });
+      // Second call: stale entity query returns one stale entity
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: 'doc-stale', _source: {}, sort: ['s'] }],
+          total: { value: 1, relation: 'eq' },
+        },
+      });
+
+      const service = createService();
+      await service.deletionDetection(integrationSource, ['euid-1']);
+
+      expect(mockUpdateLastFullSyncMarker).toHaveBeenCalledWith(
+        integrationSource,
+        '2024-03-01T00:00:00Z'
+      );
+      expect(applyBulkRemoveSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          staleEntities: [{ docId: 'doc-stale', sourceId: 'source-int' }],
+          sourceType: 'entity_analytics_integration',
+        })
+      );
+    });
+
+    it('skips when completed event is not newer than last full sync marker', async () => {
+      mockGetLastFullSyncMarker.mockResolvedValue('2024-03-01T00:00:00Z');
+      // Completed event is same as last full sync
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: 'marker-1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
+        },
+      });
+
+      const service = createService();
+      await service.deletionDetection(integrationSource, ['euid-1']);
+
+      expect(applyBulkRemoveSource).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
@@ -104,7 +104,6 @@ describe('DeletionDetectionService', () => {
           total: { value: 2, relation: 'eq' },
         },
       } as unknown as ReturnType<typeof esClient.search>);
-      });
 
       const service = createService();
       await service.deletionDetection(indexSource, ['euid-1']);
@@ -175,14 +174,14 @@ describe('DeletionDetectionService', () => {
         hits: {
           hits: [{ _id: 'marker-1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
         },
-      });
+      } as unknown as ReturnType<typeof esClient.search>);
       // Second call: stale entity query returns one stale entity
       esClient.search.mockResolvedValueOnce({
         hits: {
           hits: [{ _id: 'doc-stale', _source: {}, sort: ['s'] }],
           total: { value: 1, relation: 'eq' },
         },
-      });
+      } as unknown as ReturnType<typeof esClient.search>);
 
       const service = createService();
       await service.deletionDetection(integrationSource, ['euid-1']);
@@ -206,7 +205,7 @@ describe('DeletionDetectionService', () => {
         hits: {
           hits: [{ _id: 'marker-1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
         },
-      });
+      } as unknown as ReturnType<typeof esClient.search>);
 
       const service = createService();
       await service.deletionDetection(integrationSource, ['euid-1']);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.test.ts
@@ -72,7 +72,7 @@ describe('DeletionDetectionService', () => {
     // Default: no stale entities found
     esClient.search.mockResolvedValue({
       hits: { hits: [], total: { value: 0, relation: 'eq' } },
-    });
+    } as unknown as ReturnType<typeof esClient.search>);
   });
 
   describe('index sources', () => {
@@ -103,6 +103,7 @@ describe('DeletionDetectionService', () => {
           ],
           total: { value: 2, relation: 'eq' },
         },
+      } as unknown as ReturnType<typeof esClient.search>);
       });
 
       const service = createService();
@@ -152,7 +153,7 @@ describe('DeletionDetectionService', () => {
       mockGetLastFullSyncMarker.mockResolvedValue(undefined);
       esClient.search.mockResolvedValueOnce({
         hits: { hits: [], total: { value: 0, relation: 'eq' } },
-      });
+      } as unknown as ReturnType<typeof esClient.search>);
 
       const service = createService();
       await service.deletionDetection(integrationSource, ['euid-1']);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/deletion_detection/deletion_detection.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
+import type { MonitoringEntitySource } from '../../../../../../../common/api/entity_analytics/watchlists/data_source/common.gen';
+import type { WatchlistEntityDoc } from '../../../entities/types';
+import type { WatchlistEntitySourceClient } from '../../infra';
+import type { StaleEntity } from '../../bulk/soft_delete';
+import { applyBulkRemoveSource } from '../../bulk/soft_delete';
+import { createWatchlistSyncMarkersService } from '../sync_markers';
+
+export type DeletionDetectionService = ReturnType<typeof createDeletionDetectionService>;
+
+export const createDeletionDetectionService = ({
+  esClient,
+  logger,
+  targetIndex,
+  descriptorClient,
+}: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  targetIndex: string;
+  descriptorClient: WatchlistEntitySourceClient;
+}) => {
+  const syncMarkersService = createWatchlistSyncMarkersService(descriptorClient, esClient);
+
+  const findStaleEntities = async (
+    sourceId: string,
+    currentEuids: string[]
+  ): Promise<StaleEntity[]> => {
+    const query: Record<string, unknown> = {
+      bool: {
+        must: [{ term: { 'labels.source_ids': sourceId } }],
+        ...(currentEuids.length > 0
+          ? { must_not: [{ terms: { 'entity.id': currentEuids } }] }
+          : {}),
+      },
+    };
+
+    const allStaleEntities: StaleEntity[] = [];
+    let searchAfter: SortResults | undefined;
+    const pageSize = 1000;
+
+    while (true) {
+      const response = await esClient.search<WatchlistEntityDoc>({
+        index: targetIndex,
+        size: pageSize,
+        query,
+        _source: false,
+        sort: [{ 'entity.id': 'asc' }],
+        ...(searchAfter ? { search_after: searchAfter } : {}),
+      });
+
+      for (const hit of response.hits.hits) {
+        if (hit._id) {
+          allStaleEntities.push({ docId: hit._id, sourceId });
+        }
+      }
+
+      if (response.hits.hits.length < pageSize) break;
+      const lastHit = response.hits.hits[response.hits.hits.length - 1];
+      searchAfter = lastHit.sort;
+    }
+
+    return allStaleEntities;
+  };
+
+  const deletionDetection = async (
+    source: MonitoringEntitySource,
+    currentEuids: string[]
+  ): Promise<void> => {
+    if (source.type === 'entity_analytics_integration') {
+      const hasNewFullSync = await syncMarkersService.detectNewFullSync(source);
+      if (!hasNewFullSync) {
+        logger.debug(
+          `[WatchlistSync] No new full sync for source ${source.id}; skipping deletion detection.`
+        );
+        return;
+      }
+    }
+
+    const staleEntities = await findStaleEntities(source.id, currentEuids);
+
+    if (staleEntities.length === 0) {
+      logger.debug(`[WatchlistSync] No stale entities for source ${source.id}`);
+      return;
+    }
+
+    logger.info(
+      `[WatchlistSync] Deletion detection: found ${staleEntities.length} stale entities for source ${source.id}`
+    );
+
+    await applyBulkRemoveSource({
+      esClient,
+      logger,
+      staleEntities,
+      sourceType: source.type ?? 'index',
+      targetIndex,
+    });
+  };
+
+  return { deletionDetection };
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/index_sync.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/index_sync.ts
@@ -10,6 +10,7 @@ import type { WatchlistEntitySourceClient } from '../infra';
 import { createSourcesSyncService } from './sources_sync';
 import type { SyncSourceEntry } from './sources_sync';
 import { createUpdateDetectionService } from './update_detection/update_detection';
+import { createDeletionDetectionService } from './deletion_detection/deletion_detection';
 
 export type IndexSyncService = ReturnType<typeof createIndexSyncService>;
 
@@ -30,6 +31,12 @@ export const createIndexSyncService = ({
     targetIndex,
     descriptorClient,
   });
+  const deletionDetectionService = createDeletionDetectionService({
+    esClient,
+    logger,
+    targetIndex,
+    descriptorClient,
+  });
   const sourcesSyncService = createSourcesSyncService({ logger });
 
   const plainIndexSync = async (sources: SyncSourceEntry[]) => {
@@ -37,11 +44,13 @@ export const createIndexSyncService = ({
       descriptorClient,
       sources,
       process: async (source, entityStoreEntityIdsByType, correlationMap) => {
-        await updateDetectionService.updateDetection(
+        const entities = await updateDetectionService.updateDetection(
           source,
           entityStoreEntityIdsByType,
           correlationMap
         );
+        const currentEuids = entities.map((e) => e.euid);
+        await deletionDetectionService.deletionDetection(source, currentEuids);
       },
     });
   };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/sync_markers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/sync_markers.test.ts
@@ -5,20 +5,30 @@
  * 2.0.
  */
 
-import { savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { savedObjectsClientMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import type { MonitoringEntitySource } from '../../../../../../common/api/entity_analytics';
 import { createWatchlistSyncMarkersService } from './sync_markers';
+import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 
 jest.mock('../infra/entity_source_client');
 
-const { WatchlistEntitySourceClient, mockGetLastProcessedMarker, mockUpdateLastProcessedMarker } =
-  jest.requireMock('../infra/entity_source_client') as {
-    WatchlistEntitySourceClient: jest.Mock;
-    mockGetLastProcessedMarker: jest.Mock;
-    mockUpdateLastProcessedMarker: jest.Mock;
-  };
+const {
+  WatchlistEntitySourceClient,
+  mockGetLastProcessedMarker,
+  mockUpdateLastProcessedMarker,
+  mockGetLastFullSyncMarker,
+  mockUpdateLastFullSyncMarker,
+} = jest.requireMock('../infra/entity_source_client') as {
+  WatchlistEntitySourceClient: jest.Mock;
+  mockGetLastProcessedMarker: jest.Mock;
+  mockUpdateLastProcessedMarker: jest.Mock;
+  mockGetLastFullSyncMarker: jest.Mock;
+  mockUpdateLastFullSyncMarker: jest.Mock;
+};
 
 describe('Watchlist sync markers service', () => {
+  const esClient = elasticsearchServiceMock.createElasticsearchClient();
+
   const createDescriptorClient = () =>
     new WatchlistEntitySourceClient({
       soClient: savedObjectsClientMock.create(),
@@ -32,6 +42,10 @@ describe('Watchlist sync markers service', () => {
     indexPattern: 'logs-entityanalytics_okta.user-default',
     integrationName: 'entityanalytics_okta',
     enabled: true,
+    integrations: {
+      syncMarkerIndex: 'logs-entityanalytics_okta.entity-default',
+      syncData: {},
+    },
   };
 
   beforeEach(() => {
@@ -44,7 +58,7 @@ describe('Watchlist sync markers service', () => {
       const descriptorClient = createDescriptorClient();
       mockGetLastProcessedMarker.mockResolvedValue(lastProcessedMarker);
 
-      const service = createWatchlistSyncMarkersService(descriptorClient);
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
       const result = await service.getLastProcessedMarker(mockSource);
 
       expect(result).toBe(lastProcessedMarker);
@@ -55,7 +69,7 @@ describe('Watchlist sync markers service', () => {
       const descriptorClient = createDescriptorClient();
       mockGetLastProcessedMarker.mockResolvedValue(undefined);
 
-      const service = createWatchlistSyncMarkersService(descriptorClient);
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
       const result = await service.getLastProcessedMarker(mockSource);
 
       expect(typeof result).toBe('string');
@@ -69,11 +83,134 @@ describe('Watchlist sync markers service', () => {
       const descriptorClient = createDescriptorClient();
       mockUpdateLastProcessedMarker.mockResolvedValue(undefined);
 
-      const service = createWatchlistSyncMarkersService(descriptorClient);
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
       const timestamp = '2024-02-01T00:00:00Z';
       await service.updateLastProcessedMarker(mockSource, timestamp);
 
       expect(mockUpdateLastProcessedMarker).toHaveBeenCalledWith(mockSource, timestamp);
+    });
+  });
+
+  describe('findLastEventMarkerInIndex', () => {
+    it('returns the timestamp of the latest event marker', async () => {
+      const descriptorClient = createDescriptorClient();
+
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            {
+              _id: '1',
+              _source: { '@timestamp': '2024-03-01T00:00:00Z' },
+            },
+          ],
+        },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.findLastEventMarkerInIndex(mockSource, 'completed');
+
+      expect(result).toBe('2024-03-01T00:00:00Z');
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: 'logs-entityanalytics_okta.entity-default',
+          query: { term: { 'event.action': 'completed' } },
+        })
+      );
+    });
+
+    it('returns undefined when no event marker is found', async () => {
+      const descriptorClient = createDescriptorClient();
+      esClient.search.mockResolvedValueOnce({
+        hits: { hits: [] },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.findLastEventMarkerInIndex(mockSource, 'completed');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when syncMarkerIndex is not configured', async () => {
+      const descriptorClient = createDescriptorClient();
+      const sourceWithoutMarkerIndex: MonitoringEntitySource = {
+        ...mockSource,
+        integrations: undefined,
+      };
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.findLastEventMarkerInIndex(
+        sourceWithoutMarkerIndex,
+        'completed'
+      );
+
+      expect(result).toBeUndefined();
+      expect(esClient.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('detectNewFullSync', () => {
+    it('returns true when a completed event is found and no previous marker exists', async () => {
+      const descriptorClient = createDescriptorClient();
+      mockGetLastFullSyncMarker.mockResolvedValue(undefined);
+      mockUpdateLastFullSyncMarker.mockResolvedValue(undefined);
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: '1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
+        },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.detectNewFullSync(mockSource);
+
+      expect(result).toBe(true);
+      expect(mockUpdateLastFullSyncMarker).toHaveBeenCalledWith(mockSource, '2024-03-01T00:00:00Z');
+    });
+
+    it('returns true when a completed event is newer than the saved marker', async () => {
+      const descriptorClient = createDescriptorClient();
+      mockGetLastFullSyncMarker.mockResolvedValue('2024-02-01T00:00:00Z');
+      mockUpdateLastFullSyncMarker.mockResolvedValue(undefined);
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: '1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
+        },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.detectNewFullSync(mockSource);
+
+      expect(result).toBe(true);
+      expect(mockUpdateLastFullSyncMarker).toHaveBeenCalledWith(mockSource, '2024-03-01T00:00:00Z');
+    });
+
+    it('returns false when the completed event is not newer than the saved marker', async () => {
+      const descriptorClient = createDescriptorClient();
+      mockGetLastFullSyncMarker.mockResolvedValue('2024-03-01T00:00:00Z');
+      esClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [{ _id: '1', _source: { '@timestamp': '2024-03-01T00:00:00Z' } }],
+        },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.detectNewFullSync(mockSource);
+
+      expect(result).toBe(false);
+      expect(mockUpdateLastFullSyncMarker).not.toHaveBeenCalled();
+    });
+
+    it('returns false when no completed event exists in the sync marker index', async () => {
+      const descriptorClient = createDescriptorClient();
+      mockGetLastFullSyncMarker.mockResolvedValue(undefined);
+      esClient.search.mockResolvedValueOnce({
+        hits: { hits: [] },
+      } as unknown as SearchResponse<unknown>);
+
+      const service = createWatchlistSyncMarkersService(descriptorClient, esClient);
+      const result = await service.detectNewFullSync(mockSource);
+
+      expect(result).toBe(false);
+      expect(mockUpdateLastFullSyncMarker).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/sync_markers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/sync_markers.ts
@@ -6,10 +6,16 @@
  */
 
 import datemath from '@kbn/datemath';
+import type { ElasticsearchClient } from '@kbn/core/server';
 import type { MonitoringEntitySource } from '../../../../../../common/api/entity_analytics/watchlists/data_source/common.gen';
 import type { WatchlistEntitySourceClient } from '../infra';
 
 const FIRST_RUN_DEFAULT_RANGE = 'now-1M'; // on first run (update detection), look back over last month
+
+interface EventDoc {
+  '@timestamp': string;
+  event?: { action?: 'started' | 'completed' };
+}
 
 const parseOrThrow = (expr: string): string => {
   const date = datemath.parse(expr);
@@ -20,7 +26,8 @@ const parseOrThrow = (expr: string): string => {
 export type WatchlistSyncMarkersService = ReturnType<typeof createWatchlistSyncMarkersService>;
 
 export const createWatchlistSyncMarkersService = (
-  descriptorClient: WatchlistEntitySourceClient
+  descriptorClient: WatchlistEntitySourceClient,
+  esClient: ElasticsearchClient
 ) => {
   const getLastProcessedMarker = async (source: MonitoringEntitySource): Promise<string> => {
     const lastProcessedMarker = await descriptorClient.getLastProcessedMarker(source);
@@ -37,8 +44,37 @@ export const createWatchlistSyncMarkersService = (
     await descriptorClient.updateLastProcessedMarker(source, lastProcessedMarker);
   };
 
+  const findLastEventMarkerInIndex = async (
+    source: MonitoringEntitySource,
+    action: 'started' | 'completed'
+  ): Promise<string | undefined> => {
+    if (!source.integrations?.syncMarkerIndex) return undefined;
+    const resp = await esClient.search<EventDoc>({
+      index: source.integrations.syncMarkerIndex,
+      sort: [{ '@timestamp': { order: 'desc' } }],
+      size: 1,
+      query: { term: { 'event.action': action } },
+      _source: ['@timestamp'],
+    });
+    return resp?.hits?.hits?.[0]?._source?.['@timestamp'] ?? undefined;
+  };
+
+  const detectNewFullSync = async (source: MonitoringEntitySource): Promise<boolean> => {
+    const lastFullSync = await descriptorClient.getLastFullSyncMarker(source);
+    const latestCompletedEvent = await findLastEventMarkerInIndex(source, 'completed');
+    if (!latestCompletedEvent) return false;
+
+    const shouldUpdate = !lastFullSync || latestCompletedEvent > lastFullSync;
+    if (!shouldUpdate) return false;
+
+    await descriptorClient.updateLastFullSyncMarker(source, latestCompletedEvent);
+    return true;
+  };
+
   return {
     getLastProcessedMarker,
     updateLastProcessedMarker,
+    findLastEventMarkerInIndex,
+    detectNewFullSync,
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/update_detection/update_detection.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/update_detection/update_detection.ts
@@ -137,7 +137,7 @@ export const createUpdateDetectionService = ({
   descriptorClient?: WatchlistEntitySourceClient;
 }) => {
   const syncMarkersService = descriptorClient
-    ? createWatchlistSyncMarkersService(descriptorClient)
+    ? createWatchlistSyncMarkersService(descriptorClient, esClient)
     : undefined;
 
   const detectForIntegrationEntityType = async (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/update_detection/update_detection.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/update_detection/update_detection.ts
@@ -231,6 +231,36 @@ export const createUpdateDetectionService = ({
     return paginatedDetection(esClient, targetIndex, search, mapBucket);
   };
 
+  const detectForStoreSource = async (
+    source: WatchlistDataSources.MonitoringEntitySource,
+    entityStoreEntityIdsByType: EntityStoreEntityIdsByType
+  ) => {
+    const allEntities: WatchlistBulkEntity[] = [];
+    for (const entityType of ALL_ENTITY_TYPES) {
+      const euids = getAllowedEntityIds(entityStoreEntityIdsByType, entityType);
+      for (const euid of euids) {
+        allEntities.push({ euid, type: entityType, sourceId: source.id });
+      }
+    }
+
+    if (allEntities.length === 0) {
+      return { entities: [] as WatchlistBulkEntity[] };
+    }
+
+    // Check which entities already exist in the target index
+    const pageSize = 100;
+    for (let start = 0; start < allEntities.length; start += pageSize) {
+      const batch = allEntities.slice(start, start + pageSize);
+      const batchEuids = batch.map((e) => e.euid);
+      const existingMap = await getExistingEntitiesMap(esClient, targetIndex, batchEuids);
+      for (const entity of batch) {
+        entity.existingEntityId = existingMap.get(entity.euid);
+      }
+    }
+
+    return { entities: allEntities };
+  };
+
   const updateDetection: UpdateDetection = async (
     source: WatchlistDataSources.MonitoringEntitySource,
     entityStoreEntityIdsByType: EntityStoreEntityIdsByType,
@@ -264,6 +294,9 @@ export const createUpdateDetectionService = ({
       if (maxProcessedTimestamp) {
         await syncMarkersService.updateLastProcessedMarker(source, maxProcessedTimestamp);
       }
+    } else if (source.type === 'store') {
+      const { entities } = await detectForStoreSource(source, entityStoreEntityIdsByType);
+      allEntities.push(...entities);
     } else {
       if (!correlationMap) {
         logger.warn(

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/utils.ts
@@ -11,7 +11,7 @@ import moment from 'moment';
 export const getErrorFromBulkResponse = (resp: BulkResponse): ErrorCause[] =>
   resp.errors
     ? resp.items
-        .map((item) => item.index?.error ?? item.update?.error)
+        .map((item) => item.index?.error ?? item.update?.error ?? item.delete?.error)
         .filter((e): e is ErrorCause => e !== undefined)
     : [];
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/entity_sources/create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/management/routes/entity_sources/create.ts
@@ -27,24 +27,6 @@ import {
 } from '../../../entity_sources/infra';
 import type { IntegrationType } from '../../../entity_sources/infra';
 
-const getLastFullSyncMarkersIndex = (namespace: string, integration: IntegrationType): string => {
-  if (integration === 'entityanalytics_ad') {
-    return getStreamPatternFor(integration, namespace);
-  }
-  return oktaLastFullSyncMarkersIndex(namespace);
-};
-
-const buildIntegrationSourceAttributes = (
-  namespace: string,
-  integrationName: IntegrationType
-): WatchlistDataSources.CreateWatchlistEntitySourceRequestBody => ({
-  type: 'entity_analytics_integration',
-  name: integrationsSourceIndex(namespace, integrationName),
-  indexPattern: getStreamPatternFor(integrationName, namespace),
-  integrationName,
-  enabled: true,
-});
-
 export const createEntitySourceRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
   logger: Logger
@@ -86,48 +68,7 @@ export const createEntitySourceRoute = (
               namespace,
             });
 
-            let body: WatchlistDataSources.CreateWatchlistEntitySourceResponse;
-
-            if (monitoringSource.type === 'entity_analytics_integration') {
-              const integrationName = monitoringSource.integrationName;
-              if (
-                !integrationName ||
-                !INTEGRATION_TYPES.includes(integrationName as IntegrationType)
-              ) {
-                return siemResponse.error({
-                  statusCode: 400,
-                  body: `integrationName is required and must be one of: ${INTEGRATION_TYPES.join(
-                    ', '
-                  )}`,
-                });
-              }
-
-              const sourceAttrs = buildIntegrationSourceAttributes(
-                namespace,
-                integrationName as IntegrationType
-              );
-              const derivedName = sourceAttrs.name;
-
-              const { sources } = await client.list({ name: derivedName, per_page: 1 });
-              const existing = sources[0];
-
-              if (existing) {
-                body = existing;
-              } else {
-                const created = await client.create({
-                  ...sourceAttrs,
-                  integrations: {
-                    syncMarkerIndex: getLastFullSyncMarkersIndex(
-                      namespace,
-                      integrationName as IntegrationType
-                    ),
-                  },
-                });
-                body = created;
-              }
-            } else {
-              body = await client.create(monitoringSource);
-            }
+            const body = await createSourceForType(client, monitoringSource, namespace);
 
             const watchlistClient = new WatchlistConfigClient({
               logger,
@@ -150,4 +91,68 @@ export const createEntitySourceRoute = (
         'platinum'
       )
     );
+};
+
+const createSourceForType = async (
+  client: WatchlistEntitySourceClient,
+  source: WatchlistDataSources.CreateWatchlistEntitySourceRequestBody,
+  namespace: string
+): Promise<WatchlistDataSources.CreateWatchlistEntitySourceResponse> => {
+  if (source.type === 'entity_analytics_integration') {
+    if (!validateIntegrationName(source.integrationName)) {
+      throw new Error(
+        `integrationName is required and must be one of: ${INTEGRATION_TYPES.join(', ')}`
+      );
+    }
+    return createIntegrationSource(client, source.integrationName, namespace);
+  }
+
+  if (source.type === 'store' && !source.queryRule) {
+    throw new Error('queryRule is required for store-type sources');
+  }
+
+  return client.create(source);
+};
+
+const getLastFullSyncMarkersIndex = (namespace: string, integration: IntegrationType): string => {
+  if (integration === 'entityanalytics_ad') {
+    return getStreamPatternFor(integration, namespace);
+  }
+  return oktaLastFullSyncMarkersIndex(namespace);
+};
+
+const buildIntegrationSourceAttributes = (
+  namespace: string,
+  integrationName: IntegrationType
+): WatchlistDataSources.CreateWatchlistEntitySourceRequestBody => ({
+  type: 'entity_analytics_integration',
+  name: integrationsSourceIndex(namespace, integrationName),
+  indexPattern: getStreamPatternFor(integrationName, namespace),
+  integrationName,
+  enabled: true,
+});
+
+const validateIntegrationName = (
+  integrationName: string | undefined
+): integrationName is IntegrationType => {
+  return !!integrationName && INTEGRATION_TYPES.includes(integrationName as IntegrationType);
+};
+
+const createIntegrationSource = async (
+  client: WatchlistEntitySourceClient,
+  integrationName: IntegrationType,
+  namespace: string
+): Promise<WatchlistDataSources.CreateWatchlistEntitySourceResponse> => {
+  const sourceAttrs = buildIntegrationSourceAttributes(namespace, integrationName);
+  const { sources } = await client.list({ name: sourceAttrs.name, per_page: 1 });
+
+  return (
+    sources[0] ??
+    client.create({
+      ...sourceAttrs,
+      integrations: {
+        syncMarkerIndex: getLastFullSyncMarkersIndex(namespace, integrationName),
+      },
+    })
+  );
 };


### PR DESCRIPTION
## Summary

This PR adds delete detection and a new entity source which loads entities that pass a KQL filter directly from the store onto a watchlist


### How to test

Make sure your es instance is seeded with data. I find the easiest way is via this little script in the security documents generator:


```sh
#!/bin/bash
# Usage: ./populate_entity_store
# remember to add your base path to the KIBANA_URL if you are using a base path
KIBANA_URL='http://elastic-admin:elastic-password@localhost:5601'

H=(-H 'Content-Type: application/json' -H 'x-elastic-internal-origin: Kibana' -H 'kbn-xsrf: true')

printf "\nEnabling entity store v2 feature flag\n"
curl -k -X POST "${H[@]}" "${KIBANA_URL}/internal/kibana/settings" \
  -d '{"changes":{"securitySolution:entityStoreEnableV2":true}}'

printf "\nEnabling entity store v2\n"
curl -k -X POST "${H[@]}" "${KIBANA_URL}/internal/security/entity_store/install?apiVersion=2" \
  -d '{}'

# Enable risk scoring engine so risk index has correct mappings
printf "\nEnabling risk score engine \n"
curl -k -X POST "${H[@]}" -H 'elastic-api-version: 1' "${KIBANA_URL}/internal/risk_score/engine/init" \
  -d '{}'

printf "\nAdding organization data\n"
yarn start organization-quick

printf "\nWaiting 1 minute so entity store can run\n"
sleep 60

printf "\nEnriching entity store data\n"
yarn start generate-entity-maintainers-data --quick

printf "\nDone 🚀\n"
```


1. Create a watchlist

```

POST kbn:/api/entity_analytics/watchlists 
{
    "name": "test-name",
    "description": "Test watchlist for index sync",
    "riskModifier": 1.5,
    "managed": false,
}
```

Note the watchlist id in the response


2. Create an entity source

```
POST kbn:/api/entity_analytics/watchlists/{WATCHLIST_ID}/entity_source
{
    "type": "index",
    "name": "My Custom Index Source",
    "indexPattern": "my-sinc-index",
    "identifierField": "user.name",
    "queryRule": <your KQL query>,
    "enabled": true
}

POST kbn:/api/entity_analytics/watchlists/{WATCHLIST_ID}/entity_source
{
    "type": "index",
    "name": "My Custom entity store Source",
    "queryRule": <your KQL query>,
}
```

3. Make sure your source index has some data
Check out [this comment](https://github.com/elastic/kibana/pull/260108#issuecomment-4148163361) with instructions

4. Trigger a sync

```
POST kbn:/api/entity_analytics/watchlists/{WATCHLIST_ID}/sync
```

You should get an ACK response. Wait a few seconds to allow kibana some time to perform the sync

5. Verify the internal watchlist index

```
GET .entity-analytics.watchlists.{your-watchlist-name}/_search
```

This index should have been populated with 2 sets of entities:

> Store entities whose `identifierField` shows up in the respective source index and which pass the KQL filter provided. 
> Store entities which pass the KQL filter provided for the store entity source



6. To verify delete detection, delete some documents from your source index or from the store (Only for testing, normally we dont delete from store directly)

7. Run sync endpoint again

8. Verify these deleted entities do not show up in the internal watchlist index

