### PR TITLE
[One Workflow] Opt-in TM recovery scan approach for interrupted workflow executions

### DIFF
--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/workflow_execution_repository.mock.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/mocks/workflow_execution_repository.mock.ts
@@ -144,6 +144,30 @@ export class WorkflowExecutionRepositoryMock implements Required<WorkflowExecuti
     }));
   }
 
+  public async searchRecoverableExecutions({
+    statuses,
+    minStartedAtIso,
+    size,
+  }: {
+    statuses: Array<EsWorkflowExecution['status']>;
+    minStartedAtIso: string;
+    size: number;
+  }): Promise<Array<{ id: string; spaceId: string; _source: EsWorkflowExecution }>> {
+    const minTime = new Date(minStartedAtIso).getTime();
+    const results = Array.from(this.workflowExecutions.values())
+      .filter(
+        (exec) => statuses.includes(exec.status) && new Date(exec.startedAt).getTime() <= minTime
+      )
+      .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime())
+      .slice(0, size);
+
+    return results.map((exec) => ({
+      id: exec.id,
+      spaceId: exec.spaceId,
+      _source: exec,
+    }));
+  }
+
   public async getRunningExecutionsByConcurrencyGroup(
     concurrencyGroupKey: string,
     spaceId: string,

--- a/src/platform/plugins/shared/workflows_execution_engine/integration_tests/workflow_run_fixture.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/integration_tests/workflow_run_fixture.ts
@@ -16,7 +16,10 @@ import { ExecutionStatus } from '@kbn/workflows';
 import { StepExecutionRepositoryMock, WorkflowExecutionRepositoryMock } from './mocks';
 import { ScopedActionsClientMock, UnsecuredActionsClientMock } from './mocks/actions_plugin_mock';
 import { TaskManagerMock } from './mocks/task_manager.mock';
-import type { WorkflowsExecutionEngineConfig } from '../server/config';
+import {
+  DEFAULT_WORKFLOW_RECOVERY_CONFIG,
+  type WorkflowsExecutionEngineConfig,
+} from '../server/config';
 import { resumeWorkflow } from '../server/execution_functions';
 import { mockContextDependencies } from '../server/execution_functions/__mock__/context_dependencies';
 import { runWorkflow } from '../server/execution_functions/run_workflow';
@@ -55,6 +58,7 @@ export class WorkflowRunFixture {
     },
     maxResponseSize: new ByteSizeValue(10 * 1024 * 1024), // 10mb default
     collectQueueMetrics: false,
+    recovery: DEFAULT_WORKFLOW_RECOVERY_CONFIG,
   };
   public readonly fakeKibanaRequest = {} as KibanaRequest;
   public readonly workflowExecutionRepositoryMock = new WorkflowExecutionRepositoryMock();

--- a/src/platform/plugins/shared/workflows_execution_engine/moon.yml
+++ b/src/platform/plugins/shared/workflows_execution_engine/moon.yml
@@ -18,6 +18,8 @@ project:
   sourceRoot: src/platform/plugins/shared/workflows_execution_engine
 dependsOn:
   - '@kbn/core'
+  - '@kbn/core-http-server-utils'
+  - '@kbn/spaces-utils'
   - '@kbn/config-schema'
   - '@kbn/actions-plugin'
   - '@kbn/workflows'

--- a/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/config.ts
@@ -54,9 +54,39 @@ const configSchema = schema.object({
         'Useful for observability but adds to document size. Disabled by default for performance.',
     },
   }),
+  /**
+   * Detects workflow executions left non-terminal after Kibana/Task Manager interruption
+   * and schedules `workflow:resume` using credentials from the original `workflow:run` task.
+   */
+  recovery: schema.object({
+    /**
+     * When true, a periodic Task Manager job scans for interrupted RUNNING executions and schedules `workflow:resume`.
+     * Defaults to false so behavior is opt-in until operators validate in their environment.
+     */
+    enabled: schema.boolean({ defaultValue: false }),
+    intervalMinutes: schema.number({ defaultValue: 5, min: 1, max: 1440 }),
+    batchSize: schema.number({ defaultValue: 25, min: 1, max: 500 }),
+    /**
+     * Only consider executions whose `startedAt` is at least this old, to avoid racing with a brand-new run.
+     */
+    minExecutionAgeSeconds: schema.number({ defaultValue: 30, min: 0, max: 86400 }),
+    /**
+     * Maximum automatic `workflow:resume` scheduling attempts per execution before marking FAILED.
+     */
+    maxAutoResumeAttempts: schema.number({ defaultValue: 5, min: 1, max: 100 }),
+  }),
 });
 
 export type WorkflowsExecutionEngineConfig = TypeOf<typeof configSchema>;
+
+/** Mirrors schema defaults for tests and mocks */
+export const DEFAULT_WORKFLOW_RECOVERY_CONFIG: WorkflowsExecutionEngineConfig['recovery'] = {
+  enabled: false,
+  intervalMinutes: 5,
+  batchSize: 25,
+  minExecutionAgeSeconds: 30,
+  maxAutoResumeAttempts: 5,
+};
 
 export const config: PluginConfigDescriptor<WorkflowsExecutionEngineConfig> = {
   schema: configSchema,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/__mock__/context_dependencies.ts
@@ -14,6 +14,8 @@ import { coreMock } from '@kbn/core/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
 import { workflowsExtensionsMock } from '@kbn/workflows-extensions/server/mocks';
 
+import { DEFAULT_WORKFLOW_RECOVERY_CONFIG } from '../../config';
+
 export const mockContextDependencies = () => ({
   cloudSetup: cloudMock.createSetup(),
   coreStart: coreMock.createStart(),
@@ -28,5 +30,6 @@ export const mockContextDependencies = () => ({
     http: { allowedHosts: ['*'] },
     maxResponseSize: new ByteSizeValue(10 * 1024 * 1024), // 10mb
     collectQueueMetrics: false,
+    recovery: DEFAULT_WORKFLOW_RECOVERY_CONFIG,
   },
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/execution_functions/setup_dependencies.test.ts
@@ -12,7 +12,7 @@ import type { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/serve
 import { WorkflowGraph } from '@kbn/workflows/graph';
 import { mockContextDependencies } from './__mock__/context_dependencies';
 import { setupDependencies } from './setup_dependencies';
-import type { WorkflowsExecutionEngineConfig } from '../config';
+import { DEFAULT_WORKFLOW_RECOVERY_CONFIG, type WorkflowsExecutionEngineConfig } from '../config';
 import { WorkflowExecutionTelemetryClient } from '../lib/telemetry/workflow_execution_telemetry_client';
 import { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
 
@@ -60,6 +60,7 @@ describe('setupDependencies', () => {
     },
     maxResponseSize: new ByteSizeValue(10 * 1024 * 1024),
     collectQueueMetrics: false,
+    recovery: DEFAULT_WORKFLOW_RECOVERY_CONFIG,
   };
 
   let mockDependencies: ReturnType<typeof mockContextDependencies>;

--- a/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/plugin.ts
@@ -57,11 +57,16 @@ import { generateExecutionTaskScope } from './utils';
 import { buildWorkflowContext } from './workflow_context_manager/build_workflow_context';
 import type { ContextDependencies } from './workflow_context_manager/types';
 import { WorkflowEventLoggerService } from './workflow_event_logger';
+import { runWorkflowRecoveryScan } from './workflow_recovery/run_workflow_recovery_scan';
+import {
+  WORKFLOW_RECOVERY_SCAN_TASK_TYPE,
+  WORKFLOW_RECOVERY_TASK_ID,
+} from './workflow_recovery/workflow_recovery_constants';
 import type {
   ResumeWorkflowExecutionParams,
   StartWorkflowExecutionParams,
 } from './workflow_task_manager/types';
-import { WORKFLOW_RESUME_TASK_TYPE } from './workflow_task_manager/types';
+import { WORKFLOW_RESUME_TASK_TYPE, WORKFLOW_RUN_TASK_TYPE } from './workflow_task_manager/types';
 import { WorkflowTaskManager } from './workflow_task_manager/workflow_task_manager';
 import { createIndexes } from '../common';
 
@@ -125,7 +130,7 @@ export class WorkflowsExecutionEnginePlugin
     }
 
     plugins.taskManager.registerTaskDefinitions({
-      'workflow:run': {
+      [WORKFLOW_RUN_TASK_TYPE]: {
         title: 'Run Workflow',
         description: 'Executes a workflow immediately',
         // Set high timeout for long-running workflows.
@@ -490,6 +495,35 @@ export class WorkflowsExecutionEnginePlugin
       },
     });
 
+    plugins.taskManager.registerTaskDefinitions({
+      [WORKFLOW_RECOVERY_SCAN_TASK_TYPE]: {
+        title: 'Workflow execution recovery scan',
+        description:
+          'Periodically scans for interrupted workflow executions and schedules workflow:resume using credentials from the original workflow:run task.',
+        timeout: '10m',
+        maxAttempts: 3,
+        createTaskRunner: () => {
+          return {
+            run: async () => {
+              const [coreStart, pluginsStart] = await core.getStartServices();
+              await checkLicense(pluginsStart.licensing);
+
+              await this.initialize(coreStart);
+
+              await runWorkflowRecoveryScan({
+                coreStart,
+                taskManager: pluginsStart.taskManager,
+                config,
+                logger: logger.get('workflowRecovery'),
+                basePath: coreStart.http.basePath,
+                licensing: pluginsStart.licensing,
+              });
+            },
+          };
+        },
+      },
+    });
+
     return {};
   }
 
@@ -509,6 +543,27 @@ export class WorkflowsExecutionEnginePlugin
       workflowTaskManager,
       workflowExecutionRepository
     );
+
+    if (this.config.recovery.enabled) {
+      void plugins.taskManager
+        .ensureScheduled({
+          id: WORKFLOW_RECOVERY_TASK_ID,
+          taskType: WORKFLOW_RECOVERY_SCAN_TASK_TYPE,
+          scope: ['workflows', 'workflow-recovery'],
+          schedule: {
+            interval: `${this.config.recovery.intervalMinutes}m`,
+          },
+          state: {},
+          params: {},
+        })
+        .catch((err) => {
+          this.logger.error(
+            `Failed to ensure workflow recovery scan task: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        });
+    }
 
     const dependencies: ContextDependencies = {
       ...this.setupDependencies,
@@ -584,7 +639,7 @@ export class WorkflowsExecutionEnginePlugin
     ) => {
       return {
         id: `workflow:${workflowExecution.id}:${workflowExecution.triggeredBy}`,
-        taskType: 'workflow:run',
+        taskType: WORKFLOW_RUN_TASK_TYPE,
         params: {
           workflowRunId: workflowExecution.id,
           spaceId: workflowExecution.spaceId,
@@ -767,7 +822,7 @@ export class WorkflowsExecutionEnginePlugin
 
       const taskInstance = {
         id: `workflow:${workflowExecution.id}:${workflowExecution.triggeredBy}`,
-        taskType: 'workflow:run',
+        taskType: WORKFLOW_RUN_TASK_TYPE,
         params: {
           workflowRunId: workflowExecution.id,
           spaceId: workflowExecution.spaceId,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/repositories/workflow_execution_repository.ts
@@ -328,4 +328,54 @@ export class WorkflowExecutionRepository {
       .map((hit) => hit._source?.id ?? hit._id)
       .filter((id): id is string => id !== undefined);
   }
+
+  /**
+   * Finds workflow executions that may need automatic recovery after Kibana/Task Manager interruption.
+   * Caller passes statuses (typically RUNNING only); results are bounded by `size`.
+   */
+  public async searchRecoverableExecutions({
+    statuses,
+    minStartedAtIso,
+    size,
+  }: {
+    statuses: Array<EsWorkflowExecution['status']>;
+    minStartedAtIso: string;
+    size: number;
+  }): Promise<Array<{ id: string; spaceId: string; _source: EsWorkflowExecution }>> {
+    const response = await this.esClient.search<EsWorkflowExecution>({
+      index: this.indexName,
+      size,
+      sort: [{ startedAt: { order: 'asc' } }],
+      _source: true,
+      query: {
+        bool: {
+          filter: [
+            { terms: { status: statuses } },
+            {
+              range: {
+                startedAt: {
+                  lte: minStartedAtIso,
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    return response.hits.hits
+      .filter(
+        (
+          hit
+        ): hit is (typeof response.hits.hits)[number] & {
+          _id: string;
+          _source: EsWorkflowExecution;
+        } => hit._id != null && hit._source != null
+      )
+      .map((hit) => ({
+        id: hit._id,
+        spaceId: hit._source.spaceId,
+        _source: hit._source,
+      }));
+  }
 }

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/build_fake_request_from_task_api_key.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/build_fake_request_from_task_api_key.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FakeRawRequest, Headers, IBasePath, KibanaRequest } from '@kbn/core/server';
+import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
+import { addSpaceIdToPath } from '@kbn/spaces-utils';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+
+/**
+ * Mirrors Task Manager's fake request construction for tasks that store an API key,
+ * so scheduled `workflow:resume` can reuse the same user scope as the original `workflow:run`.
+ */
+export function buildFakeRequestFromTaskApiKey(
+  task: Pick<ConcreteTaskInstance, 'apiKey' | 'userScope'>,
+  executionSpaceId: string,
+  basePath: IBasePath
+): KibanaRequest | undefined {
+  if (!task.apiKey) {
+    return undefined;
+  }
+
+  const requestHeaders: Headers = {};
+  requestHeaders.authorization = `ApiKey ${task.apiKey}`;
+  const path = addSpaceIdToPath('/', task.userScope?.spaceId ?? executionSpaceId);
+
+  const fakeRawRequest: FakeRawRequest = {
+    headers: requestHeaders,
+    path: '/',
+  };
+
+  const fakeRequest = kibanaRequestFactory(fakeRawRequest);
+  basePath.set(fakeRequest, path);
+  return fakeRequest;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/run_workflow_recovery_scan.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/run_workflow_recovery_scan.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ByteSizeValue } from '@kbn/config-schema';
+import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
+import { ExecutionStatus } from '@kbn/workflows';
+import { runWorkflowRecoveryScan } from './run_workflow_recovery_scan';
+import { WORKFLOW_RECOVERY_METADATA_KEY } from './workflow_recovery_constants';
+import { DEFAULT_WORKFLOW_RECOVERY_CONFIG, type WorkflowsExecutionEngineConfig } from '../config';
+import { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import { WORKFLOW_RUN_TASK_TYPE } from '../workflow_task_manager/types';
+
+jest.mock('../repositories/workflow_execution_repository');
+
+describe('runWorkflowRecoveryScan', () => {
+  const logger = loggingSystemMock.createLogger();
+  const basePath = elasticsearchServiceMock.createStart().http.basePath;
+
+  const makeConfig = (
+    recoveryOverrides?: Partial<WorkflowsExecutionEngineConfig['recovery']>
+  ): WorkflowsExecutionEngineConfig => ({
+    enabled: true,
+    eventDriven: { enabled: true, logEvents: true, maxChainDepth: 10 },
+    maxWorkflowDepth: 10,
+    logging: { console: false },
+    http: { allowedHosts: ['*'] },
+    maxResponseSize: new ByteSizeValue(1024),
+    collectQueueMetrics: false,
+    recovery: { ...DEFAULT_WORKFLOW_RECOVERY_CONFIG, ...recoveryOverrides },
+  });
+
+  const makeDeps = (options?: {
+    recovery?: Partial<WorkflowsExecutionEngineConfig['recovery']>;
+    searchHits?: Array<{ id: string; spaceId: string; _source: Record<string, unknown> }>;
+    hasActive?: boolean;
+    runTaskId?: string | null;
+    taskApiKey?: string;
+  }) => {
+    const taskManager = {
+      schedule: jest.fn().mockResolvedValue({ id: 'scheduled-resume-task' }),
+      fetch: jest.fn().mockImplementation((opts: { query?: unknown }) => {
+        const must = (opts.query as { bool?: { must?: unknown[] } })?.bool?.must;
+        const isRunLookup =
+          Array.isArray(must) &&
+          must.some(
+            (c) =>
+              typeof c === 'object' &&
+              c !== null &&
+              (c as { term?: Record<string, string> }).term?.['task.taskType'] ===
+                WORKFLOW_RUN_TASK_TYPE
+          );
+        if (isRunLookup) {
+          return Promise.resolve({
+            docs: options?.runTaskId ? [{ id: options.runTaskId }] : [],
+            versionMap: new Map(),
+          });
+        }
+        return Promise.resolve({
+          docs: options?.hasActive ? [{ id: 'active-task' }] : [],
+          versionMap: new Map(),
+        });
+      }),
+      get: jest.fn().mockResolvedValue({
+        id: options?.runTaskId ?? 'run-task-1',
+        apiKey: options?.taskApiKey ?? 'dGVzdDpwYXNz',
+        userScope: { spaceId: 'default', apiKeyId: 'key1', apiKeyCreatedByUser: false },
+      }),
+    };
+
+    const searchRecoverableExecutions = jest.fn().mockResolvedValue(options?.searchHits ?? []);
+    const updateWorkflowExecution = jest.fn().mockResolvedValue(undefined);
+
+    (WorkflowExecutionRepository as jest.Mock).mockImplementation(() => ({
+      searchRecoverableExecutions,
+      updateWorkflowExecution,
+    }));
+
+    return {
+      coreStart: elasticsearchServiceMock.createStart(),
+      taskManager: taskManager as unknown as Parameters<
+        typeof runWorkflowRecoveryScan
+      >[0]['taskManager'],
+      config: makeConfig(options?.recovery),
+      logger,
+      basePath,
+      licensing: licensingMock.createLicense(),
+      mocks: { searchRecoverableExecutions, updateWorkflowExecution },
+      taskManagerMocks: taskManager,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('no-ops when recovery is disabled', async () => {
+    const deps = makeDeps();
+    deps.config.recovery.enabled = false;
+    await runWorkflowRecoveryScan(deps);
+    expect(deps.mocks.searchRecoverableExecutions).not.toHaveBeenCalled();
+  });
+
+  it('marks FAILED when max auto-resume attempts exceeded', async () => {
+    const deps = makeDeps({
+      searchHits: [
+        {
+          id: 'exec-1',
+          spaceId: 'default',
+          _source: {
+            id: 'exec-1',
+            spaceId: 'default',
+            metadata: {
+              [WORKFLOW_RECOVERY_METADATA_KEY]: { autoResumeScheduledCount: 5 },
+            },
+          },
+        },
+      ],
+    });
+
+    await runWorkflowRecoveryScan(deps);
+
+    expect(deps.mocks.updateWorkflowExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'exec-1',
+        status: ExecutionStatus.FAILED,
+        error: expect.objectContaining({ type: 'WorkflowRecoveryError' }),
+      })
+    );
+  });
+
+  it('schedules workflow:resume and updates recovery metadata on success', async () => {
+    const deps = makeDeps({
+      recovery: { enabled: true },
+      searchHits: [
+        {
+          id: 'exec-1',
+          spaceId: 'default',
+          _source: {
+            id: 'exec-1',
+            spaceId: 'default',
+            metadata: {},
+          },
+        },
+      ],
+      runTaskId: 'run-task-1',
+    });
+
+    await runWorkflowRecoveryScan(deps);
+
+    expect(deps.taskManagerMocks.schedule).toHaveBeenCalled();
+    expect(deps.mocks.updateWorkflowExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'exec-1',
+        metadata: expect.objectContaining({
+          [WORKFLOW_RECOVERY_METADATA_KEY]: expect.objectContaining({
+            autoResumeScheduledCount: 1,
+          }),
+        }),
+      })
+    );
+  });
+});

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/run_workflow_recovery_scan.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/run_workflow_recovery_scan.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { CoreStart, IBasePath, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
+import { buildFakeRequestFromTaskApiKey } from './build_fake_request_from_task_api_key';
+import {
+  WORKFLOW_RECOVERY_METADATA_KEY,
+  type WorkflowRecoveryMetadata,
+} from './workflow_recovery_constants';
+import type { WorkflowsExecutionEngineConfig } from '../config';
+import { checkLicense } from '../lib/check_license';
+import { WorkflowExecutionRepository } from '../repositories/workflow_execution_repository';
+import { WorkflowTaskManager } from '../workflow_task_manager/workflow_task_manager';
+
+export interface RunWorkflowRecoveryScanDeps {
+  coreStart: CoreStart;
+  taskManager: TaskManagerStartContract;
+  config: WorkflowsExecutionEngineConfig;
+  logger: Logger;
+  basePath: IBasePath;
+  licensing: Parameters<typeof checkLicense>[0];
+}
+
+async function tryRecoverExecution(deps: {
+  execution: EsWorkflowExecution;
+  recovery: WorkflowsExecutionEngineConfig['recovery'];
+  workflowExecutionRepository: WorkflowExecutionRepository;
+  workflowTaskManager: WorkflowTaskManager;
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+  basePath: IBasePath;
+}): Promise<void> {
+  const {
+    execution,
+    recovery,
+    workflowExecutionRepository,
+    workflowTaskManager,
+    taskManager,
+    logger,
+    basePath,
+  } = deps;
+  const executionId = execution.id;
+
+  const recoveryMeta = getRecoveryMetadata(execution);
+  if (recoveryMeta.autoResumeScheduledCount >= recovery.maxAutoResumeAttempts) {
+    logger.warn(
+      `Workflow recovery: execution ${executionId} exceeded max auto-resume attempts (${recovery.maxAutoResumeAttempts}), marking FAILED`
+    );
+    await workflowExecutionRepository.updateWorkflowExecution({
+      id: executionId,
+      status: ExecutionStatus.FAILED,
+      error: {
+        type: 'WorkflowRecoveryError',
+        message:
+          'Automatic workflow recovery stopped after the maximum number of resume attempts. Inspect Task Manager and workflow execution state, or retry manually.',
+      },
+      metadata: {
+        ...(execution.metadata ?? {}),
+        [WORKFLOW_RECOVERY_METADATA_KEY]: {
+          ...recoveryMeta,
+          lastAutoResumeFailureReason: 'max_auto_resume_attempts_exceeded',
+        },
+      },
+    });
+    return;
+  }
+
+  const hasActive = await workflowTaskManager.hasActiveWorkflowExecutionTask(executionId);
+  if (hasActive) {
+    logger.debug(
+      `Workflow recovery: skipping ${executionId} — active workflow Task Manager task already present`
+    );
+    return;
+  }
+
+  const runTaskId = await workflowTaskManager.findWorkflowRunTaskIdForExecution(executionId);
+  if (!runTaskId) {
+    logger.debug(
+      `Workflow recovery: no workflow:run task for execution ${executionId} — skipping (likely non-task execution path)`
+    );
+    return;
+  }
+
+  let runTask;
+  try {
+    runTask = await taskManager.get(runTaskId);
+  } catch (err) {
+    logger.warn(
+      `Workflow recovery: failed to load task ${runTaskId} for execution ${executionId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return;
+  }
+
+  const fakeRequest = buildFakeRequestFromTaskApiKey(runTask, execution.spaceId, basePath);
+  if (!fakeRequest) {
+    const nextMeta: WorkflowRecoveryMetadata = {
+      ...recoveryMeta,
+      autoResumeScheduledCount: recoveryMeta.autoResumeScheduledCount + 1,
+      lastAutoResumeFailureReason: 'missing_task_api_key',
+      lastAutoResumeScheduledAt: new Date().toISOString(),
+    };
+    logger.warn(
+      `Workflow recovery: task ${runTaskId} has no API key; cannot schedule resume for ${executionId}`
+    );
+    await workflowExecutionRepository.updateWorkflowExecution({
+      id: executionId,
+      metadata: {
+        ...(execution.metadata ?? {}),
+        [WORKFLOW_RECOVERY_METADATA_KEY]: nextMeta,
+      },
+    });
+    return;
+  }
+
+  try {
+    await workflowTaskManager.scheduleImmediateResume({
+      executionId,
+      spaceId: execution.spaceId,
+      fakeRequest,
+    });
+    const nextMeta: WorkflowRecoveryMetadata = {
+      ...recoveryMeta,
+      autoResumeScheduledCount: recoveryMeta.autoResumeScheduledCount + 1,
+      lastAutoResumeScheduledAt: new Date().toISOString(),
+    };
+    await workflowExecutionRepository.updateWorkflowExecution({
+      id: executionId,
+      metadata: {
+        ...(execution.metadata ?? {}),
+        [WORKFLOW_RECOVERY_METADATA_KEY]: nextMeta,
+      },
+    });
+    logger.info(
+      `Workflow recovery: scheduled workflow:resume for execution ${executionId} (space ${execution.spaceId})`
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      `Workflow recovery: failed to schedule resume for execution ${executionId}: ${message}`
+    );
+    const nextMeta: WorkflowRecoveryMetadata = {
+      ...recoveryMeta,
+      autoResumeScheduledCount: recoveryMeta.autoResumeScheduledCount + 1,
+      lastAutoResumeFailureReason: `schedule_error:${message.slice(0, 500)}`,
+      lastAutoResumeScheduledAt: new Date().toISOString(),
+    };
+    await workflowExecutionRepository.updateWorkflowExecution({
+      id: executionId,
+      metadata: {
+        ...(execution.metadata ?? {}),
+        [WORKFLOW_RECOVERY_METADATA_KEY]: nextMeta,
+      },
+    });
+  }
+}
+
+function getRecoveryMetadata(execution: EsWorkflowExecution): WorkflowRecoveryMetadata {
+  const raw = execution.metadata?.[WORKFLOW_RECOVERY_METADATA_KEY];
+  if (!raw || typeof raw !== 'object') {
+    return { autoResumeScheduledCount: 0 };
+  }
+  const count = (raw as WorkflowRecoveryMetadata).autoResumeScheduledCount;
+  return {
+    autoResumeScheduledCount: typeof count === 'number' && count >= 0 ? count : 0,
+    lastAutoResumeScheduledAt: (raw as WorkflowRecoveryMetadata).lastAutoResumeScheduledAt,
+    lastAutoResumeFailureReason: (raw as WorkflowRecoveryMetadata).lastAutoResumeFailureReason,
+  };
+}
+
+export async function runWorkflowRecoveryScan(deps: RunWorkflowRecoveryScanDeps): Promise<void> {
+  const { coreStart, taskManager, config, logger, basePath, licensing } = deps;
+  const recovery = config.recovery;
+
+  if (!recovery.enabled) {
+    return;
+  }
+
+  await checkLicense(licensing);
+
+  const esClient = coreStart.elasticsearch.client.asInternalUser;
+  const workflowExecutionRepository = new WorkflowExecutionRepository(esClient);
+  const workflowTaskManager = new WorkflowTaskManager(taskManager);
+
+  const minStartedAt = new Date(Date.now() - recovery.minExecutionAgeSeconds * 1000).toISOString();
+
+  const candidates = await workflowExecutionRepository.searchRecoverableExecutions({
+    statuses: [ExecutionStatus.RUNNING],
+    minStartedAtIso: minStartedAt,
+    size: recovery.batchSize,
+  });
+
+  if (candidates.length === 0) {
+    logger.debug('Workflow recovery scan: no candidate executions');
+    return;
+  }
+
+  logger.debug(`Workflow recovery scan: processing ${candidates.length} candidate execution(s)`);
+
+  for (const hit of candidates) {
+    await tryRecoverExecution({
+      execution: hit._source,
+      recovery,
+      workflowExecutionRepository,
+      workflowTaskManager,
+      taskManager,
+      logger,
+      basePath,
+    });
+  }
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/workflow_recovery_constants.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_recovery/workflow_recovery_constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const WORKFLOW_RECOVERY_SCAN_TASK_TYPE = 'workflow:recovery-scan' as const;
+
+export const WORKFLOW_RECOVERY_TASK_ID = 'workflow:recovery-scan:v1' as const;
+
+/** Stored under workflow execution `metadata` */
+export const WORKFLOW_RECOVERY_METADATA_KEY = 'workflowRecovery' as const;
+
+export interface WorkflowRecoveryMetadata {
+  /** Number of times automatic recovery scheduled `workflow:resume` for this execution */
+  autoResumeScheduledCount: number;
+  lastAutoResumeScheduledAt?: string;
+  lastAutoResumeFailureReason?: string;
+}

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/types.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/types.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export const WORKFLOW_RUN_TASK_TYPE = 'workflow:run';
+
 export const WORKFLOW_RESUME_TASK_TYPE = 'workflow:resume';
 
 export interface StartWorkflowExecutionParams {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.test.ts
@@ -11,7 +11,7 @@ import type { KibanaRequest } from '@kbn/core/server';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { TaskStatus } from '@kbn/task-manager-plugin/server';
 import { type EsWorkflowExecution, ExecutionStatus } from '@kbn/workflows';
-import { WORKFLOW_RESUME_TASK_TYPE } from './types';
+import { WORKFLOW_RESUME_TASK_TYPE, WORKFLOW_RUN_TASK_TYPE } from './types';
 import type { ResumeWorkflowExecutionParams } from './types';
 import { WorkflowTaskManager } from './workflow_task_manager';
 import { generateExecutionTaskScope } from '../utils';
@@ -65,6 +65,7 @@ describe('WorkflowTaskManager', () => {
     mockTaskManager = {
       schedule: jest.fn(),
       fetch: jest.fn(),
+      get: jest.fn(),
       runSoon: jest.fn(),
     } as any;
     fakeRequest = jest.mocked({} as KibanaRequest);
@@ -311,6 +312,72 @@ describe('WorkflowTaskManager', () => {
       mockIdleTasks.forEach((task) => {
         expect(mockTaskManager.runSoon).toHaveBeenCalledWith(task.id);
       });
+    });
+  });
+
+  describe('hasActiveWorkflowExecutionTask', () => {
+    it('returns true when Task Manager returns a matching workflow task', async () => {
+      mockTaskManager.fetch.mockResolvedValue({ docs: [{ id: 't1' }] } as any);
+
+      await expect(workflowTaskManager.hasActiveWorkflowExecutionTask('exec-1')).resolves.toBe(
+        true
+      );
+
+      expect(mockTaskManager.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              must: expect.arrayContaining([
+                { term: { 'task.scope': 'workflow:execution:exec-1' } },
+                {
+                  terms: {
+                    'task.taskType': [WORKFLOW_RUN_TASK_TYPE, WORKFLOW_RESUME_TASK_TYPE],
+                  },
+                },
+              ]),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('returns false when no matching tasks exist', async () => {
+      mockTaskManager.fetch.mockResolvedValue({ docs: [] } as any);
+
+      await expect(workflowTaskManager.hasActiveWorkflowExecutionTask('exec-1')).resolves.toBe(
+        false
+      );
+    });
+  });
+
+  describe('findWorkflowRunTaskIdForExecution', () => {
+    it('returns the workflow:run task id when present', async () => {
+      mockTaskManager.fetch.mockResolvedValue({ docs: [{ id: 'run-task-1' }] } as any);
+
+      await expect(workflowTaskManager.findWorkflowRunTaskIdForExecution('exec-1')).resolves.toBe(
+        'run-task-1'
+      );
+
+      expect(mockTaskManager.fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            bool: expect.objectContaining({
+              must: expect.arrayContaining([
+                { term: { 'task.taskType': WORKFLOW_RUN_TASK_TYPE } },
+                { term: { 'task.scope': 'workflow:execution:exec-1' } },
+              ]),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('returns null when no workflow:run task is found', async () => {
+      mockTaskManager.fetch.mockResolvedValue({ docs: [] } as any);
+
+      await expect(
+        workflowTaskManager.findWorkflowRunTaskIdForExecution('exec-1')
+      ).resolves.toBeNull();
     });
   });
 });

--- a/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/workflow_task_manager/workflow_task_manager.ts
@@ -11,12 +11,60 @@ import { v4 } from 'uuid';
 import type { KibanaRequest } from '@kbn/core/server';
 import { type TaskManagerStartContract, TaskStatus } from '@kbn/task-manager-plugin/server';
 import type { EsWorkflowExecution } from '@kbn/workflows';
-import { WORKFLOW_RESUME_TASK_TYPE } from './types';
+import { WORKFLOW_RESUME_TASK_TYPE, WORKFLOW_RUN_TASK_TYPE } from './types';
 import type { ResumeWorkflowExecutionParams } from './types';
 import { generateExecutionTaskScope } from '../utils';
 
 export class WorkflowTaskManager {
   constructor(private taskManager: TaskManagerStartContract) {}
+
+  /**
+   * True when there is an idle, claiming, or running workflow:run or workflow:resume task for this execution.
+   * Used to avoid duplicate scheduling during recovery.
+   */
+  async hasActiveWorkflowExecutionTask(executionId: string): Promise<boolean> {
+    const { docs } = await this.taskManager.fetch({
+      size: 1,
+      query: {
+        bool: {
+          must: [
+            { term: { 'task.scope': `workflow:execution:${executionId}` } },
+            {
+              terms: {
+                'task.taskType': [WORKFLOW_RUN_TASK_TYPE, WORKFLOW_RESUME_TASK_TYPE],
+              },
+            },
+            {
+              terms: {
+                'task.status': [TaskStatus.Idle, TaskStatus.Claiming, TaskStatus.Running],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    return docs.length > 0;
+  }
+
+  /**
+   * Returns the first matching workflow:run task id for this execution (scope includes workflow:execution:{id}).
+   */
+  async findWorkflowRunTaskIdForExecution(executionId: string): Promise<string | null> {
+    const { docs } = await this.taskManager.fetch({
+      size: 1,
+      query: {
+        bool: {
+          must: [
+            { term: { 'task.taskType': WORKFLOW_RUN_TASK_TYPE } },
+            { term: { 'task.scope': `workflow:execution:${executionId}` } },
+          ],
+        },
+      },
+    });
+
+    return docs[0]?.id ?? null;
+  }
 
   async scheduleResumeTask({
     workflowExecution,

--- a/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
+++ b/src/platform/plugins/shared/workflows_execution_engine/tsconfig.json
@@ -14,6 +14,8 @@
   ],
   "kbn_references": [
     "@kbn/core",
+    "@kbn/core-http-server-utils",
+    "@kbn/spaces-utils",
     "@kbn/config-schema",
     "@kbn/actions-plugin",
     "@kbn/workflows",


### PR DESCRIPTION
### Summary

Adds an **opt-in** periodic Task Manager job (`workflow:recovery-scan`) that finds **RUNNING** workflow executions that look abandoned after Kibana/Task Manager interruption, then schedules **`workflow:resume`** using the **same API key / fake request pattern** as the original **`workflow:run`** task. Attempts are tracked on the execution document under `metadata.workflowRecovery`; after **`maxAutoResumeAttempts`**, the execution is marked **`FAILED`** with `WorkflowRecoveryError` to avoid endless recovery loops.

**Default:** `workflowsExecutionEngine.recovery.enabled` is **`false`**

### Config (`kibana.yml`)

- `workflowsExecutionEngine.recovery.enabled` (default: `false`)
- `workflowsExecutionEngine.recovery.intervalMinutes` (default: `5`)
- `workflowsExecutionEngine.recovery.batchSize` (default: `25`)
- `workflowsExecutionEngine.recovery.minExecutionAgeSeconds` (default: `30`)
- `workflowsExecutionEngine.recovery.maxAutoResumeAttempts` (default: `5`)

### Notes

- Executions with **no** `workflow:run` Task Manager task (e.g. **inline** runs inside another task) are **skipped** without counting toward max attempts to avoid false positives.
- Residual race: a duplicate `workflow:resume` could still be scheduled under concurrent scheduling; stronger guarantees would need execution-level idempotency beyond this change.
- Infrastructure recovery only runs when Elasticsearch says RUNNING but Task Manager no longer has an active run/resume task for that execution; workflow-defined retries keep TM active and are skipped.

```mermaid
sequenceDiagram
  autonumber
  participant TM as Task Manager
  participant WE as Workflows execution engine<br/>(recovery scan)
  participant ES as Elasticsearch<br/>(executions index)
  participant TMD as Task Manager<br/>(tasks index)
  participant R as workflow:resume<br/>(scheduled task)

  TM->>WE: Run workflow:recovery-scan (on interval)
  WE->>ES: Search RUNNING executions (batch, age filter)
  loop Each candidate
    WE->>TMD: Query active workflow:run / workflow:resume for execution scope
    alt Active task exists
      WE-->>WE: Skip (healthy or scheduled resume)
    else No active task + workflow:run doc exists
      WE->>TMD: Get workflow:run task (API key)
      WE->>TM: Schedule workflow:resume (user-scoped request)
      TM-->>R: Enqueue resume
      WE->>ES: Update metadata.workflowRecovery
    end
  end
```


Fixes https://github.com/elastic/security-team/issues/15970

Related to https://github.com/elastic/security-team/issues/15805 **partial** (this PR targets the recovery coordinator slice; distributed locking, checkpoint semantics, temporal reconciliation and recovery observability sub-issues are **not** fully covered here)