### PR TITLE
[Osquery] Fix: Disable "Add tags" button for scheduled queries in new history layout

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
@@ -116,15 +116,20 @@ export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
                   </EuiFlexItem>
                   {showAddTags && (
                     <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
-                        size="m"
-                        iconType="tag"
-                        color="primary"
-                        onClick={handleOpenFlyout}
-                        data-test-subj="add-tags-button"
+                      <EuiToolTip
+                        content={isScheduled ? SCHEDULED_TAGS_DISABLED_LABEL : ADD_TAGS_LABEL}
                       >
-                        {ADD_TAGS_LABEL}
-                      </EuiButtonEmpty>
+                        <EuiButtonEmpty
+                          size="m"
+                          iconType="tag"
+                          color="primary"
+                          onClick={handleOpenFlyout}
+                          isDisabled={isScheduled}
+                          data-test-subj="add-tags-button"
+                        >
+                          {ADD_TAGS_LABEL}
+                        </EuiButtonEmpty>
+                      </EuiToolTip>
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>


### PR DESCRIPTION
## 
### What

The "Add tags" button in the results header was fully clickable for scheduled query executions when the `queryHistoryRework` feature flag was enabled.

### Why

PR #258222 correctly disabled the tags button for scheduled queries in the **legacy** layout path of `pack_results_header.tsx`. However, PR #258190 (UI refactor) introduced a **new** `isHistoryEnabled` rendering path that renders the button as an `EuiButtonEmpty` without carrying over the `isDisabled={isScheduled}` guard or the `EuiToolTip` wrapper.

Since the `queryHistoryRework` flag is now enabled, all users hit the new layout — bypassing the fix entirely.

The server-side API guard (returns 400 for scheduled queries) prevented data corruption, but the UI was not reflecting the restriction.

### How

Added `isDisabled={isScheduled}` and an `EuiToolTip` wrapper to the "Add tags" button in the new `isHistoryEnabled` branch of `PackResultsHeader`, matching the existing pattern in the legacy branch.
