### PR TITLE
[Lens][Legend] Remove pixel truncation from the list layout

### DIFF
--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -869,7 +869,7 @@ export function XYChart({
                     labelOptions: legend.shouldTruncate
                       ? {
                           maxLines: legend?.maxLines ?? 1,
-                          widthLimit: legend.maxPixels ?? 250,
+                          widthLimit: legend.maxPixels ?? 1000,
                         }
                       : {
                           maxLines: 0,

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.test.tsx
@@ -87,32 +87,6 @@ describe('Legend Settings', () => {
     expect(lineLimit).toBeDisabled();
   });
 
-  it('should have default width limit set to 250 and be enabled when it is on', async () => {
-    await renderLegendSettingsPopover({
-      shouldTruncate: true,
-      position: Position.Bottom,
-      location: 'outside',
-      layout: LegendLayout.List,
-      onLayoutChange: jest.fn(),
-    });
-    const widthLimit = screen.getByRole('spinbutton', { name: 'Width limit' });
-    expect(widthLimit).toHaveValue(250);
-    expect(widthLimit).not.toBeDisabled();
-  });
-
-  it('should have default width limit set to 250 and be disabled when it is off', async () => {
-    await renderLegendSettingsPopover({
-      shouldTruncate: false,
-      position: Position.Bottom,
-      location: 'outside',
-      layout: LegendLayout.List,
-      onLayoutChange: jest.fn(),
-    });
-    const widthLimit = screen.getByRole('spinbutton', { name: 'Width limit' });
-    expect(widthLimit).toHaveValue(250);
-    expect(widthLimit).toBeDisabled();
-  });
-
   it('should have the `Label truncation` switch enabled by default', async () => {
     await renderLegendSettingsPopover();
     const switchElement = screen.getByRole('switch', { name: 'Label truncation' });
@@ -229,7 +203,7 @@ describe('Legend Settings', () => {
     expect(onLayoutChange).toHaveBeenCalledWith(undefined);
   });
 
-  it('should show pixel truncation input when list layout is selected', async () => {
+  it('should not show a truncation input when list layout is selected', async () => {
     await renderLegendSettingsPopover({
       position: Position.Bottom,
       location: 'outside',
@@ -237,8 +211,7 @@ describe('Legend Settings', () => {
       onLayoutChange: jest.fn(),
     });
 
-    expect(screen.getByRole('spinbutton', { name: 'Width limit' })).toBeInTheDocument();
-    expect(screen.queryByRole('spinbutton', { name: 'Line limit' })).toBeNull();
+    expect(screen.queryByRole('switch', { name: 'Label truncation' })).toBeNull();
   });
 
   it('should show line truncation input when inside legend is selected', async () => {
@@ -250,7 +223,6 @@ describe('Legend Settings', () => {
     });
 
     expect(screen.getByRole('spinbutton', { name: 'Line limit' })).toBeInTheDocument();
-    expect(screen.queryByRole('spinbutton', { name: 'Pixel limit' })).toBeNull();
   });
 
   it('should not show Layout setting and should show line truncation input for vertical legends', async () => {
@@ -263,6 +235,5 @@ describe('Legend Settings', () => {
 
     expect(screen.queryByTestId('lens-legend-layout-btn')).toBeNull();
     expect(screen.getByRole('spinbutton', { name: 'Line limit' })).toBeInTheDocument();
-    expect(screen.queryByRole('spinbutton', { name: 'Pixel limit' })).toBeNull();
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
@@ -321,7 +321,7 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
     position,
     layout,
   });
-  const usesWidthLimitTruncation = effectiveLayout === LegendLayout.List;
+  const isNoTruncationLayout = effectiveLayout === LegendLayout.List;
 
   const showsLegendTitleSetting = isTableLayout && !!onLegendTitleChange;
 
@@ -476,7 +476,7 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
         </EuiFormRow>
       )}
 
-      {isLegendNotHidden && !usesWidthLimitTruncation && (
+      {isLegendNotHidden && !isNoTruncationLayout && (
         <EuiFormRow
           display="columnCompressed"
           label={labelTruncationLabel}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
@@ -321,7 +321,7 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
     position,
     layout,
   });
-  const isNoTruncationLayout = effectiveLayout === LegendLayout.List;
+  const hasLayoutTruncation = effectiveLayout !== LegendLayout.List;
 
   const showsLegendTitleSetting = isTableLayout && !!onLegendTitleChange;
 
@@ -476,7 +476,7 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
         </EuiFormRow>
       )}
 
-      {isLegendNotHidden && !isNoTruncationLayout && (
+      {isLegendNotHidden && hasLayoutTruncation && (
         <EuiFormRow
           display="columnCompressed"
           label={labelTruncationLabel}

--- a/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/shared_components/legend/legend_settings.tsx
@@ -17,8 +17,6 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiComboBox,
-  EuiFormAppend,
-  EuiFormPrepend,
 } from '@elastic/eui';
 import type { VerticalAlignment, HorizontalAlignment } from '@elastic/charts';
 import { Position, LegendValue } from '@elastic/charts';
@@ -173,9 +171,6 @@ export interface LegendSettingsProps<LegendStats extends LegendValue = XYLegendV
 const DEFAULT_TRUNCATE_LINES = 1;
 const MAX_TRUNCATE_LINES = 5;
 const MIN_TRUNCATE_LINES = 1;
-const DEFAULT_TRUNCATE_WIDTH_LIMIT = 250;
-const MIN_TRUNCATE_WIDTH_LIMIT = 10;
-const MAX_TRUNCATE_WIDTH_LIMIT = 1000;
 
 export const MaxLinesInput = ({
   value,
@@ -208,43 +203,6 @@ export const MaxLinesInput = ({
         // we want to automatically change the values to the limits
         // if the user enters a value that is outside the limits
         handleInputChange(Math.min(MAX_TRUNCATE_LINES, Math.max(val, MIN_TRUNCATE_LINES)));
-      }}
-    />
-  );
-};
-
-export const WidthLimitInput = ({
-  value,
-  setValue,
-  disabled,
-}: {
-  value: number;
-  setValue: (value: number) => void;
-  disabled?: boolean;
-}) => {
-  const { inputValue, handleInputChange } = useDebouncedValue({ value, onChange: setValue });
-  const pixelLimitLabel = i18n.translate('xpack.lens.shared.widthLimitLabel', {
-    defaultMessage: 'Width limit',
-  });
-  return (
-    <EuiFieldNumber
-      id="lensLegendWidthLimitInput"
-      disabled={disabled}
-      fullWidth
-      prepend={<EuiFormPrepend compressed label={pixelLimitLabel} />}
-      append={<EuiFormAppend compressed label="px" inputId="" />}
-      aria-label={pixelLimitLabel}
-      data-test-subj="lens-legend-width-limit-input"
-      value={inputValue}
-      min={MIN_TRUNCATE_WIDTH_LIMIT}
-      max={MAX_TRUNCATE_WIDTH_LIMIT}
-      step={10}
-      compressed
-      onChange={(e) => {
-        const val = Number(e.target.value);
-        handleInputChange(
-          Math.min(MAX_TRUNCATE_WIDTH_LIMIT, Math.max(val, MIN_TRUNCATE_WIDTH_LIMIT))
-        );
       }}
     />
   );
@@ -335,8 +293,6 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
   onLegendStatsChange = noop,
   maxLines,
   onMaxLinesChange = noop,
-  maxPixels,
-  onMaxPixelsChange = noop,
   shouldTruncate,
   onTruncateLegendChange = noop,
   legendSize,
@@ -520,7 +476,7 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
         </EuiFormRow>
       )}
 
-      {isLegendNotHidden && (
+      {isLegendNotHidden && !usesWidthLimitTruncation && (
         <EuiFormRow
           display="columnCompressed"
           label={labelTruncationLabel}
@@ -542,19 +498,11 @@ export function LegendSettings<LegendStats extends LegendValue = XYLegendValue>(
               />
             </EuiFlexItem>
             <EuiFlexItem grow>
-              {usesWidthLimitTruncation ? (
-                <WidthLimitInput
-                  disabled={!shouldTruncate}
-                  value={maxPixels ?? DEFAULT_TRUNCATE_WIDTH_LIMIT}
-                  setValue={onMaxPixelsChange}
-                />
-              ) : (
-                <MaxLinesInput
-                  disabled={!shouldTruncate}
-                  value={maxLines ?? DEFAULT_TRUNCATE_LINES}
-                  setValue={onMaxLinesChange}
-                />
-              )}
+              <MaxLinesInput
+                disabled={!shouldTruncate}
+                value={maxLines ?? DEFAULT_TRUNCATE_LINES}
+                setValue={onMaxLinesChange}
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFormRow>

--- a/x-pack/platform/test/functional/apps/lens/group15/legend_statistics.ts
+++ b/x-pack/platform/test/functional/apps/lens/group15/legend_statistics.ts
@@ -47,9 +47,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await testSubjects.missingOrFail('lens-legend-width-limit-input');
   }
 
-  async function expectListTruncationInput() {
-    await testSubjects.existOrFail('lens-legend-width-limit-input');
+  async function expectNoTruncationInput() {
     await testSubjects.missingOrFail('lens-legend-max-lines-input');
+    await testSubjects.missingOrFail('lens-legend-truncate-switch');
   }
 
   async function expectLegendListFormat() {
@@ -111,10 +111,10 @@ Max
         await expectLegendTableToHaveText(tableText);
       });
 
-      it('shows list layout and width limit truncation option', async () => {
+      it('shows list layout with no truncation option', async () => {
         await lens.openLegendSettingsFlyout();
         await setLegendPositionTop();
-        await expectListTruncationInput();
+        await expectNoTruncationInput();
         await lens.closeFlyoutWithBackButton();
 
         await expectLegendListFormat();


### PR DESCRIPTION
## Summary

This PR removes pixel truncation for the list layout and sets the default value for pixel truncation to `1000`.

<img width="1399" height="776" alt="image" src="https://github.com/user-attachments/assets/d9e7b49e-4d56-475b-8b6e-611a5f7d597c" />
