### PR TITLE
[Cases][Templates] Add DATE_PICKER field control type

### DIFF
--- a/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
+++ b/x-pack/platform/plugins/shared/cases/common/types/domain/template/fields.ts
@@ -7,6 +7,16 @@
 
 import { z } from '@kbn/zod/v4';
 
+export const FieldType = {
+  INPUT_TEXT: 'INPUT_TEXT',
+  INPUT_NUMBER: 'INPUT_NUMBER',
+  SELECT_BASIC: 'SELECT_BASIC',
+  TEXTAREA: 'TEXTAREA',
+  DATE_PICKER: 'DATE_PICKER',
+} as const;
+
+export type FieldType = (typeof FieldType)[keyof typeof FieldType];
+
 export const ConditionRuleSchema = z.object({
   field: z.string(),
   operator: z.enum(['eq', 'neq', 'contains', 'empty', 'not_empty']),
@@ -65,18 +75,21 @@ const BaseFieldSchema = z.object({
   validation: ValidationSchema.optional(),
   metadata: z
     .object({
-      default: z.string().optional(),
+      default: z.preprocess(
+        (val) => (val instanceof Date ? val.toISOString() : val),
+        z.string().optional()
+      ),
     })
     .catchall(z.unknown())
     .optional(),
 });
 
 export const InputTextFieldSchema = BaseFieldSchema.extend({
-  control: z.literal('INPUT_TEXT'),
+  control: z.literal(FieldType.INPUT_TEXT),
 });
 
 export const InputNumberFieldSchema = BaseFieldSchema.extend({
-  control: z.literal('INPUT_NUMBER'),
+  control: z.literal(FieldType.INPUT_NUMBER),
   type: z.union([
     z.literal('long'),
     z.literal('integer'),
@@ -97,7 +110,7 @@ export const InputNumberFieldSchema = BaseFieldSchema.extend({
 });
 
 export const SelectBasicFieldSchema = BaseFieldSchema.extend({
-  control: z.literal('SELECT_BASIC'),
+  control: z.literal(FieldType.SELECT_BASIC),
   metadata: z
     .object({
       options: z.array(z.string()),
@@ -106,7 +119,19 @@ export const SelectBasicFieldSchema = BaseFieldSchema.extend({
 });
 
 export const TextareaFieldSchema = BaseFieldSchema.extend({
-  control: z.literal('TEXTAREA'),
+  control: z.literal(FieldType.TEXTAREA),
+});
+
+export const DatePickerFieldSchema = BaseFieldSchema.extend({
+  control: z.literal(FieldType.DATE_PICKER),
+  type: z.literal('date'),
+  metadata: z
+    .object({
+      show_time: z.boolean().optional(),
+      timezone: z.enum(['utc', 'local']).optional(),
+    })
+    .catchall(z.unknown())
+    .optional(),
 });
 
 /**
@@ -117,4 +142,5 @@ export const FieldSchema = z.discriminatedUnion('control', [
   InputNumberFieldSchema,
   SelectBasicFieldSchema,
   TextareaFieldSchema,
+  DatePickerFieldSchema,
 ]);

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/template_fields.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 
 import type { CaseUI } from '../../../../common';
 import type { ParsedTemplate } from '../../../../common/types/domain/template/v1';
-import { FieldType } from '../../templates_v2/field_types/constants';
+import { FieldType } from '../../../../common/types/domain/template/fields';
 import { TemplateFields } from './template_fields';
 import { renderWithTestingProviders } from '../../../common/mock';
 

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/components/template_form_layout.tsx
@@ -23,7 +23,7 @@ import { TemplateFormHeader } from './template_form_header';
 import { TemplateResetModal } from './template_reset_modal';
 import { TemplateEditorLayout } from './template_editor_layout';
 import { updateYamlFieldDefault } from '../utils/update_yaml_field_default';
-import { FieldType } from '../field_types/constants';
+import { FieldType } from '../../../../common/types/domain/template/fields';
 
 interface TemplateFormLayoutProps {
   form: UseFormReturn<YamlEditorFormValues>;

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/constants.ts
@@ -5,16 +5,10 @@
  * 2.0.
  */
 
-export const FieldType = {
-  INPUT_TEXT: 'INPUT_TEXT',
-  INPUT_NUMBER: 'INPUT_NUMBER',
-  SELECT_BASIC: 'SELECT_BASIC',
-  TEXTAREA: 'TEXTAREA',
-} as const;
+import { FieldType } from '../../../../common/types/domain/template/fields';
+import type { FieldType as FieldTypeType } from '../../../../common/types/domain/template/fields';
 
-export type FieldType = (typeof FieldType)[keyof typeof FieldType];
-
-export const fieldTypesArray = Object.keys(FieldType) as FieldType[];
+export const fieldTypesArray = Object.keys(FieldType) as FieldTypeType[];
 
 export const exampleTemplateDefinition = `
 # name is required
@@ -29,6 +23,16 @@ category: General
 tags:
   - example
 fields:
+  - name: start_date
+    control: DATE_PICKER
+    label: Start date
+    type: date
+    metadata:
+      default: "2024-01-01T00:00:00Z"
+      # set to true to include time selection
+      # show_time: true
+      # 'utc' (default) or 'local' to use the browser's timezone
+      # timezone: local     
   - name: summary
     control: INPUT_TEXT
     label: Summary
@@ -84,4 +88,36 @@ fields:
       required: true
       min: 0
       max: 100
+  # DATE_PICKER with show_time enabled and local timezone
+  # show_when: not_empty — this field appears only when a date is selected above
+  - name: scheduled_at
+    control: DATE_PICKER
+    label: Scheduled date and time
+    type: date
+    metadata:
+      show_time: true
+      timezone: local
+  # deadline_notes is shown and required only when scheduled_at has been filled in
+  - name: deadline_notes
+    control: TEXTAREA
+    label: Deadline notes
+    type: keyword
+    display:
+      show_when:
+        field: scheduled_at
+        operator: not_empty
+    validation:
+      required_when:
+        field: scheduled_at
+        operator: not_empty
+  # kickoff_agenda is shown only when scheduled_at equals a specific ISO datetime value
+  - name: kickoff_agenda
+    control: TEXTAREA
+    label: Kickoff agenda
+    type: keyword
+    display:
+      show_when:
+        field: scheduled_at
+        operator: eq
+        value: "2024-06-01T09:00:00.000Z"
 `.trimStart();

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import moment from 'moment-timezone';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, FormProvider } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import { DatePicker } from './date_picker';
+
+interface FormWrapperProps {
+  isRequired?: boolean;
+  showTime?: boolean;
+  timezone?: 'utc' | 'local';
+  initialValue?: string;
+  onSubmitResult: (result: { isValid: boolean; data: Record<string, unknown> }) => void;
+}
+
+const FormWrapper: React.FC<FormWrapperProps> = ({
+  isRequired,
+  showTime,
+  timezone,
+  initialValue,
+  onSubmitResult,
+}) => {
+  const { form } = useForm<{}>({
+    defaultValue: {
+      [CASE_EXTENDED_FIELDS]: initialValue ? { due_date_as_date: initialValue } : {},
+    },
+    options: { stripEmptyFields: false },
+  });
+
+  const handleSubmit = async () => {
+    const { isValid, data } = await form.submit();
+    onSubmitResult({ isValid: isValid ?? false, data: data as Record<string, unknown> });
+  };
+
+  return (
+    <FormProvider form={form}>
+      <DatePicker
+        name="due_date"
+        control="DATE_PICKER"
+        type="date"
+        label="Due date"
+        isRequired={isRequired}
+        metadata={
+          showTime !== undefined || timezone !== undefined
+            ? { show_time: showTime, timezone }
+            : undefined
+        }
+      />
+      <button type="button" onClick={handleSubmit}>
+        {'Submit'}
+      </button>
+    </FormProvider>
+  );
+};
+
+describe('DatePicker', () => {
+  describe('rendering', () => {
+    it('renders the label', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByText('Due date')).toBeInTheDocument();
+    });
+
+    it('renders an input element', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('isRequired validation', () => {
+    it('blocks form submission when isRequired is true and no date is selected', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: false }));
+      });
+    });
+
+    it('allows form submission when isRequired is false and no date is selected', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired={false} onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: true }));
+      });
+    });
+
+    it('allows form submission when isRequired is true and a date is pre-populated', async () => {
+      const onSubmitResult = jest.fn();
+      render(
+        <FormWrapper
+          isRequired
+          initialValue="2024-06-01T00:00:00.000Z"
+          onSubmitResult={onSubmitResult}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalledWith(expect.objectContaining({ isValid: true }));
+      });
+    });
+
+    it('shows an error message when required validation fails', async () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper isRequired onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/required/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('show_time metadata', () => {
+    it('does not show the time selector by default', () => {
+      const onSubmitResult = jest.fn();
+      render(<FormWrapper onSubmitResult={onSubmitResult} />);
+
+      // react-datepicker renders a time input only when showTimeSelect is true
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('serializer', () => {
+    it('serializes a UTC ISO string default to a UTC ISO string on submit', async () => {
+      const onSubmitResult = jest.fn();
+      const isoValue = '2024-06-01T09:00:00.000Z';
+
+      render(<FormWrapper initialValue={isoValue} onSubmitResult={onSubmitResult} />);
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmitResult).toHaveBeenCalled();
+      });
+
+      const { data } = onSubmitResult.mock.calls[0][0];
+      const submittedValue = (data as Record<string, Record<string, unknown>>)[CASE_EXTENDED_FIELDS]
+        ?.due_date_as_date;
+
+      // The serializer must always emit a UTC ISO string
+      expect(typeof submittedValue).toBe('string');
+      expect(submittedValue).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(moment.utc(submittedValue as string).isValid()).toBe(true);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/controls/date_picker.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { z } from '@kbn/zod/v4';
+import type { Moment } from 'moment';
+import moment from 'moment-timezone';
+import {
+  UseField,
+  getFieldValidityAndErrorMessage,
+} from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
+import React from 'react';
+import { EuiDatePicker, EuiFormRow } from '@elastic/eui';
+import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
+import {
+  type DatePickerFieldSchema,
+  type ConditionRenderProps,
+} from '../../../../../common/types/domain/template/fields';
+import { FIELD_REQUIRED } from '../../translations';
+
+type DatePickerProps = z.infer<typeof DatePickerFieldSchema> & ConditionRenderProps;
+
+const { emptyField } = fieldValidators;
+
+const toMoment = (value: unknown, isLocal: boolean): Moment | null => {
+  if (!value) return null;
+  if (typeof value === 'string') return isLocal ? moment(value) : moment.utc(value);
+  if (moment.isMoment(value)) return value;
+  return null;
+};
+
+const makeSerializer =
+  (isLocal: boolean) =>
+  (value: unknown): string => {
+    const m = toMoment(value, isLocal);
+    return m ? m.utc().toISOString() : '';
+  };
+
+export const DatePicker: React.FC<DatePickerProps> = ({
+  label,
+  name,
+  type,
+  metadata,
+  isRequired,
+}) => {
+  const isLocal = metadata?.timezone === 'local';
+  const serializer = makeSerializer(isLocal);
+
+  const validations = isRequired ? [{ validator: emptyField(FIELD_REQUIRED) }] : [];
+
+  return (
+    <UseField
+      key={name}
+      path={`${CASE_EXTENDED_FIELDS}.${name}_as_${type}`}
+      serializer={serializer}
+      config={{ validations }}
+    >
+      {(field) => {
+        const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
+        return (
+          <EuiFormRow label={label} error={errorMessage} isInvalid={isInvalid} fullWidth>
+            <EuiDatePicker
+              selected={toMoment(field.value, isLocal)}
+              onChange={(date) => field.setValue(date)}
+              showTimeSelect={metadata?.show_time ?? false}
+              utcOffset={isLocal ? undefined : 0}
+              isInvalid={isInvalid}
+              fullWidth
+            />
+          </EuiFormRow>
+        );
+      }}
+    </UseField>
+  );
+};
+DatePicker.displayName = 'DatePicker';

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_types_registry.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/field_types_registry.tsx
@@ -8,7 +8,7 @@
 import type { FC } from 'react';
 import type { z } from '@kbn/zod/v4';
 
-import { FieldType } from './constants';
+import { FieldType } from '../../../../common/types/domain/template/fields';
 import type {
   FieldSchema,
   ConditionRenderProps,
@@ -18,6 +18,7 @@ import { InputText } from './controls/input_text';
 import { SelectBasic } from './controls/select_basic';
 import { Textarea } from './controls/textarea';
 import { InputNumber } from './controls/input_number';
+import { DatePicker } from './controls/date_picker';
 
 // NOTE: this guarantees the control will receive props aligned with the schema plus condition render props
 export type FieldMap = {
@@ -30,4 +31,5 @@ export const controlRegistry: FieldMap = {
   [FieldType.INPUT_NUMBER]: InputNumber,
   [FieldType.SELECT_BASIC]: SelectBasic,
   [FieldType.TEXTAREA]: Textarea,
+  [FieldType.DATE_PICKER]: DatePicker,
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react';
+import moment from 'moment-timezone';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { useYamlFormSync } from './use_yaml_form_sync';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
@@ -405,7 +406,7 @@ describe('useYamlFormSync', () => {
       });
     });
 
-    it('handles multiple fields with different controls', () => {
+    it('handles multiple fields with different controls including DATE_PICKER', () => {
       const mockOnFieldDefaultChange = jest.fn();
       const parsedFields = createParsedFields([
         { name: 'text', type: 'keyword', control: 'INPUT_TEXT', defaultValue: 'text' },
@@ -440,6 +441,137 @@ describe('useYamlFormSync', () => {
 
       expect(mockOnFieldDefaultChange).toHaveBeenCalledWith('number', '20', 'INPUT_NUMBER');
       expect(mockOnFieldDefaultChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('DATE_PICKER serialization', () => {
+    const dateField = [
+      {
+        name: 'scheduled_at',
+        type: 'date',
+        control: 'DATE_PICKER',
+        defaultValue: '2024-06-01T09:00:00.000Z',
+      },
+    ];
+
+    it('serializes a Moment object to a UTC ISO string', () => {
+      const mockOnFieldDefaultChange = jest.fn();
+      const parsedFields = createParsedFields(dateField);
+
+      renderHook(() => useYamlFormSync(mockForm, parsedFields, mockOnFieldDefaultChange));
+
+      act(() => {
+        jest.advanceTimersByTime(0);
+      });
+
+      const momentValue = moment.utc('2024-06-15T14:30:00.000Z');
+
+      act(() => {
+        mockSubscriptionCallback({
+          data: {
+            internal: {
+              [CASE_EXTENDED_FIELDS]: {
+                scheduled_at_as_date: momentValue,
+              },
+            },
+          },
+        });
+      });
+
+      expect(mockOnFieldDefaultChange).toHaveBeenCalledWith(
+        'scheduled_at',
+        '2024-06-15T14:30:00.000Z',
+        'DATE_PICKER'
+      );
+    });
+
+    it('converts a local-timezone Moment to UTC ISO string', () => {
+      const mockOnFieldDefaultChange = jest.fn();
+      const parsedFields = createParsedFields(dateField);
+
+      renderHook(() => useYamlFormSync(mockForm, parsedFields, mockOnFieldDefaultChange));
+
+      act(() => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Moment in a non-UTC timezone — should still serialize as UTC
+      const localMoment = moment('2024-06-15T14:30:00.000').tz('America/New_York');
+
+      act(() => {
+        mockSubscriptionCallback({
+          data: {
+            internal: {
+              [CASE_EXTENDED_FIELDS]: {
+                scheduled_at_as_date: localMoment,
+              },
+            },
+          },
+        });
+      });
+
+      const [[, isoValue]] = mockOnFieldDefaultChange.mock.calls;
+      expect(isoValue).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(isoValue).toBe(localMoment.utc().toISOString());
+    });
+
+    it('does not call onFieldDefaultChange when Moment value matches YAML default', () => {
+      const mockOnFieldDefaultChange = jest.fn();
+      const parsedFields = createParsedFields(dateField);
+
+      renderHook(() => useYamlFormSync(mockForm, parsedFields, mockOnFieldDefaultChange));
+
+      act(() => {
+        jest.advanceTimersByTime(0);
+      });
+
+      // Moment that serializes to the same value as the YAML default
+      const momentValue = moment.utc('2024-06-01T09:00:00.000Z');
+
+      act(() => {
+        mockSubscriptionCallback({
+          data: {
+            internal: {
+              [CASE_EXTENDED_FIELDS]: {
+                scheduled_at_as_date: momentValue,
+              },
+            },
+          },
+        });
+      });
+
+      expect(mockOnFieldDefaultChange).not.toHaveBeenCalled();
+    });
+
+    it('serializes a native Date object to an ISO string', () => {
+      const mockOnFieldDefaultChange = jest.fn();
+      const parsedFields = createParsedFields(dateField);
+
+      renderHook(() => useYamlFormSync(mockForm, parsedFields, mockOnFieldDefaultChange));
+
+      act(() => {
+        jest.advanceTimersByTime(0);
+      });
+
+      const dateValue = new Date('2024-06-15T14:30:00.000Z');
+
+      act(() => {
+        mockSubscriptionCallback({
+          data: {
+            internal: {
+              [CASE_EXTENDED_FIELDS]: {
+                scheduled_at_as_date: dateValue,
+              },
+            },
+          },
+        });
+      });
+
+      expect(mockOnFieldDefaultChange).toHaveBeenCalledWith(
+        'scheduled_at',
+        '2024-06-15T14:30:00.000Z',
+        'DATE_PICKER'
+      );
     });
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/field_types/hooks/use_yaml_form_sync.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import moment from 'moment-timezone';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { CASE_EXTENDED_FIELDS } from '../../../../../common/constants';
 import { getYamlDefaultAsString } from '../../utils';
@@ -70,14 +71,20 @@ export const useYamlFormSync = (
         return;
       }
 
-      const extendedFields = (data.internal as Record<string, Record<string, string>>)?.[
+      const extendedFields = (data.internal as Record<string, Record<string, unknown>>)?.[
         CASE_EXTENDED_FIELDS
       ];
       if (!extendedFields) return;
 
       for (const field of parsedFields) {
         const fieldKey = `${field.name}_as_${field.type}`;
-        const currentFormValue = String(extendedFields[fieldKey] ?? '');
+        const rawValue = extendedFields[fieldKey];
+        const currentFormValue =
+          rawValue instanceof Date
+            ? rawValue.toISOString()
+            : moment.isMoment(rawValue)
+            ? rawValue.utc().toISOString()
+            : String(rawValue ?? '');
         const currentYamlValue = yamlDefaultsRef.current[field.name] ?? '';
 
         if (currentFormValue !== currentYamlValue) {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/index.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/index.ts
@@ -56,5 +56,8 @@ export const getYamlDefaultAsString = (rawDefault: unknown): string => {
   if (typeof rawDefault === 'number') {
     return String(rawDefault);
   }
+  if (rawDefault instanceof Date) {
+    return rawDefault.toISOString();
+  }
   return '';
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.test.ts
@@ -82,6 +82,213 @@ describe('templatesToYaml', () => {
 
     expect(yaml).toContain('# Bulk Export: 0 templates');
   });
+
+  it('serializes DATE_PICKER field with show_time, timezone and default', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-dp',
+        name: 'DatePicker Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        deletedAt: null,
+        definition: {
+          name: 'DatePicker Template',
+          fields: [
+            {
+              name: 'due_date',
+              label: 'Due date',
+              control: 'DATE_PICKER',
+              type: 'date',
+              metadata: {
+                default: '2024-06-01T00:00:00.000Z',
+                show_time: true,
+                timezone: 'local',
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).toContain('      metadata:');
+    expect(yaml).toContain('        default: "2024-06-01T00:00:00.000Z"');
+    expect(yaml).toContain('        show_time: true');
+    expect(yaml).toContain('        timezone: local');
+  });
+
+  it('serializes DATE_PICKER default when js-yaml parses it as a Date object (unquoted ISO)', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-dp',
+        name: 'DatePicker Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        deletedAt: null,
+        definition: {
+          name: 'DatePicker Template',
+          fields: [
+            {
+              name: 'due_date',
+              control: 'DATE_PICKER',
+              type: 'date',
+              // js-yaml parses unquoted ISO timestamps as native Date objects
+              metadata: { default: new Date('2024-06-01T00:00:00.000Z') } as unknown as {
+                show_time?: boolean;
+                timezone?: 'utc' | 'local';
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).toContain('        default: "2024-06-01T00:00:00.000Z"');
+  });
+
+  it('serializes DATE_PICKER field without optional metadata when absent', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-dp',
+        name: 'DatePicker Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        deletedAt: null,
+        definition: {
+          name: 'DatePicker Template',
+          fields: [
+            {
+              name: 'due_date',
+              control: 'DATE_PICKER',
+              type: 'date',
+            },
+          ],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).not.toContain('show_time');
+    expect(yaml).not.toContain('timezone');
+  });
+
+  it('serializes fields with display show_when conditions', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-cond',
+        name: 'Conditions Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        deletedAt: null,
+        definition: {
+          name: 'Conditions Template',
+          fields: [
+            {
+              name: 'urgency_reason',
+              control: 'TEXTAREA',
+              type: 'keyword',
+              display: {
+                show_when: { field: 'priority', operator: 'eq', value: 'urgent' },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).toContain('      display:');
+    expect(yaml).toContain('show_when:');
+    expect(yaml).toContain('field: priority');
+    expect(yaml).toContain('operator: eq');
+    expect(yaml).toContain('value: urgent');
+  });
+
+  it('serializes fields with validation rules', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-val',
+        name: 'Validation Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        deletedAt: null,
+        definition: {
+          name: 'Validation Template',
+          fields: [
+            {
+              name: 'score',
+              control: 'INPUT_NUMBER',
+              type: 'integer',
+              validation: { required: true, min: 0, max: 100 },
+            },
+            {
+              name: 'code',
+              control: 'INPUT_TEXT',
+              type: 'keyword',
+              validation: {
+                min_length: 3,
+                max_length: 10,
+                pattern: { regex: '^[A-Z]+$', message: 'Must be uppercase' },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).toContain('      validation:');
+    expect(yaml).toContain('required: true');
+    expect(yaml).toContain('min: 0');
+    expect(yaml).toContain('max: 100');
+    expect(yaml).toContain('min_length: 3');
+    expect(yaml).toContain('max_length: 10');
+    expect(yaml).toContain('regex: ^[A-Z]+$');
+    expect(yaml).toContain('message: Must be uppercase');
+  });
+
+  it('serializes template-level severity, category and isEnabled', () => {
+    const templates: ParsedTemplate[] = [
+      {
+        templateId: 'template-meta',
+        name: 'Meta Template',
+        owner: 'securitySolution',
+        templateVersion: 1,
+        latestVersion: 1,
+        isLatest: true,
+        isEnabled: false,
+        deletedAt: null,
+        definition: {
+          name: 'Meta Template',
+          severity: 'high',
+          category: 'Security',
+          fields: [],
+        },
+      },
+    ];
+
+    const yaml = templatesToYaml(templates);
+
+    expect(yaml).toContain('severity: high');
+    expect(yaml).toContain('category: "Security"');
+    expect(yaml).toContain('isEnabled: false');
+  });
 });
 
 describe('templateToYaml', () => {

--- a/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/templates_v2/utils/templates_to_yaml.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
+import { dump as yamlDump } from 'js-yaml';
+import type { z } from '@kbn/zod/v4';
+import { FieldType, type FieldSchema } from '../../../../common/types/domain/template/fields';
 import type { ParsedTemplate } from '../../../../common/types/domain/template/v1';
+
+type Field = z.infer<typeof FieldSchema>;
 
 const yamlString = (value: string | number | undefined | null) => {
   if (value == null) {
@@ -17,62 +22,154 @@ const yamlString = (value: string | number | undefined | null) => {
   return JSON.stringify(value);
 };
 
-const serializeTemplate = (yamlSections: string[], template: ParsedTemplate) => {
-  yamlSections.push(`templateId: ${yamlString(template.templateId)}`);
-  yamlSections.push(`name: ${yamlString(template.name)}`);
-  yamlSections.push(`owner: ${yamlString(template.owner)}`);
+const indentYaml = (yamlStr: string, spaces: number): string => {
+  const prefix = ' '.repeat(spaces);
+  return yamlStr
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => prefix + line)
+    .join('\n');
+};
+
+const serializeTemplateHeader = (out: string[], template: ParsedTemplate) => {
+  out.push(`templateId: ${yamlString(template.templateId)}`);
+  out.push(`name: ${yamlString(template.name)}`);
+  out.push(`owner: ${yamlString(template.owner)}`);
 
   if (template.author) {
-    yamlSections.push(`author: ${yamlString(template.author)}`);
+    out.push(`author: ${yamlString(template.author)}`);
   }
 
-  yamlSections.push(`description: ${yamlString(template.description ?? '')}`);
-  yamlSections.push(`templateVersion: ${template.templateVersion}`);
-  yamlSections.push(`latestVersion: ${template.latestVersion}`);
-  yamlSections.push(`isLatest: ${template.isLatest}`);
-  yamlSections.push(
-    `deletedAt: ${template.deletedAt == null ? 'null' : yamlString(template.deletedAt)}`
-  );
-  yamlSections.push(`fieldCount: ${template.fieldCount ?? 0}`);
-  yamlSections.push(`usageCount: ${template.usageCount ?? 0}`);
-  yamlSections.push(`lastUsedAt: ${template.lastUsedAt ? yamlString(template.lastUsedAt) : '""'}`);
-  yamlSections.push(`isDefault: ${template.isDefault ?? false}`);
+  out.push(`description: ${yamlString(template.description ?? '')}`);
+  out.push(`templateVersion: ${template.templateVersion}`);
+  out.push(`latestVersion: ${template.latestVersion}`);
+  out.push(`isLatest: ${template.isLatest}`);
+  out.push(`deletedAt: ${template.deletedAt == null ? 'null' : yamlString(template.deletedAt)}`);
+  out.push(`fieldCount: ${template.fieldCount ?? 0}`);
+  out.push(`usageCount: ${template.usageCount ?? 0}`);
+  out.push(`lastUsedAt: ${template.lastUsedAt ? yamlString(template.lastUsedAt) : '""'}`);
+  out.push(`isDefault: ${template.isDefault ?? false}`);
 
-  yamlSections.push('tags:');
+  if (template.isEnabled !== undefined) {
+    out.push(`isEnabled: ${template.isEnabled}`);
+  }
+
+  // severity and category live inside the parsed definition
+  if (template.definition.severity) {
+    out.push(`severity: ${template.definition.severity}`);
+  }
+  if (template.definition.category != null) {
+    out.push(`category: ${yamlString(template.definition.category)}`);
+  }
+
+  out.push('tags:');
   for (const tag of template.tags ?? []) {
-    yamlSections.push(`  - ${yamlString(tag)}`);
+    out.push(`  - ${yamlString(tag)}`);
+  }
+};
+
+const serializeFieldMetadata = (out: string[], field: Field) => {
+  if (field.control === FieldType.SELECT_BASIC) {
+    out.push(`      metadata:`);
+    out.push(`        options:`);
+    for (const option of field.metadata.options) {
+      out.push(`          - ${yamlString(option)}`);
+    }
+    const defaultValue = field.metadata?.default;
+    if (
+      defaultValue !== undefined &&
+      (typeof defaultValue === 'string' || typeof defaultValue === 'number')
+    ) {
+      out.push(`        default: ${yamlString(defaultValue)}`);
+    }
+    return;
   }
 
-  yamlSections.push('definition:');
-  yamlSections.push('  fields:');
-  for (const field of template.definition.fields) {
-    yamlSections.push(`    - name: ${yamlString(field.name)}`);
-    if (field.label) {
-      yamlSections.push(`      label: ${yamlString(field.label)}`);
-    }
-    yamlSections.push(`      control: ${yamlString(field.control)}`);
-    yamlSections.push(`      type: ${yamlString(field.type)}`);
-
-    const defaultValue = field.metadata?.default;
+  if (field.control === FieldType.DATE_PICKER) {
+    const meta = field.metadata;
+    if (!meta) return;
+    // `default` is in the catchall bucket, typed as unknown
+    const defaultValue = meta.default;
     const hasDefault =
-      defaultValue !== undefined &&
-      (typeof defaultValue === 'string' || typeof defaultValue === 'number');
-
-    if (field.control === 'SELECT_BASIC') {
-      yamlSections.push(`      metadata:`);
-      yamlSections.push(`        options:`);
-      for (const option of field.metadata.options) {
-        yamlSections.push(`          - ${yamlString(option)}`);
-      }
-      if (hasDefault) {
-        yamlSections.push(`        default: ${yamlString(defaultValue)}`);
-      }
-    } else if (hasDefault) {
-      yamlSections.push(`      metadata:`);
-      yamlSections.push(`        default: ${yamlString(defaultValue)}`);
+      typeof defaultValue === 'string' ||
+      typeof defaultValue === 'number' ||
+      defaultValue instanceof Date;
+    if (!hasDefault && meta.show_time === undefined && meta.timezone === undefined) return;
+    out.push(`      metadata:`);
+    if (hasDefault) {
+      const serialized =
+        defaultValue instanceof Date
+          ? defaultValue.toISOString()
+          : (defaultValue as string | number);
+      out.push(`        default: ${yamlString(serialized)}`);
     }
+    if (meta.show_time !== undefined) {
+      out.push(`        show_time: ${meta.show_time}`);
+    }
+    if (meta.timezone !== undefined) {
+      out.push(`        timezone: ${meta.timezone}`);
+    }
+    return;
+  }
 
-    yamlSections.push('');
+  // INPUT_TEXT, INPUT_NUMBER, TEXTAREA
+  const defaultValue = field.metadata?.default;
+  if (
+    defaultValue !== undefined &&
+    (typeof defaultValue === 'string' || typeof defaultValue === 'number')
+  ) {
+    out.push(`      metadata:`);
+    out.push(`        default: ${yamlString(defaultValue)}`);
+  }
+};
+
+const serializeFieldDisplay = (out: string[], field: Field) => {
+  if (!field.display?.show_when) return;
+  out.push(`      display:`);
+  out.push(
+    indentYaml(
+      yamlDump({ show_when: field.display.show_when }, { indent: 2, lineWidth: -1, noRefs: true }),
+      8
+    )
+  );
+};
+
+const serializeFieldValidation = (out: string[], field: Field) => {
+  if (!field.validation) return;
+  const v = field.validation;
+  const filteredValidation: Record<string, unknown> = {};
+  if (v.required !== undefined) filteredValidation.required = v.required;
+  if (v.required_when !== undefined) filteredValidation.required_when = v.required_when;
+  if (v.pattern !== undefined) filteredValidation.pattern = v.pattern;
+  if (v.min !== undefined) filteredValidation.min = v.min;
+  if (v.max !== undefined) filteredValidation.max = v.max;
+  if (v.min_length !== undefined) filteredValidation.min_length = v.min_length;
+  if (v.max_length !== undefined) filteredValidation.max_length = v.max_length;
+
+  if (Object.keys(filteredValidation).length === 0) return;
+  out.push(`      validation:`);
+  out.push(indentYaml(yamlDump(filteredValidation, { indent: 2, lineWidth: -1, noRefs: true }), 8));
+};
+
+const serializeField = (out: string[], field: Field) => {
+  out.push(`    - name: ${yamlString(field.name)}`);
+  if (field.label) {
+    out.push(`      label: ${yamlString(field.label)}`);
+  }
+  out.push(`      control: ${yamlString(field.control)}`);
+  out.push(`      type: ${yamlString(field.type)}`);
+  serializeFieldMetadata(out, field);
+  serializeFieldDisplay(out, field);
+  serializeFieldValidation(out, field);
+  out.push('');
+};
+
+const serializeTemplate = (out: string[], template: ParsedTemplate) => {
+  serializeTemplateHeader(out, template);
+  out.push('definition:');
+  out.push('  fields:');
+  for (const field of template.definition.fields) {
+    serializeField(out, field);
   }
 };
 
@@ -83,26 +180,26 @@ const serializeTemplate = (yamlSections: string[], template: ParsedTemplate) => 
  * of the original author-provided YAML formatting.
  */
 export const templatesToYaml = (templates: ParsedTemplate[]): string => {
-  const yamlSections: string[] = [
+  const out: string[] = [
     `# Bulk Export: ${templates.length} templates`,
     `# Exported: ${new Date().toISOString()}`,
     '',
   ];
 
   for (const template of templates) {
-    yamlSections.push('---');
-    serializeTemplate(yamlSections, template);
+    out.push('---');
+    serializeTemplate(out, template);
   }
 
-  return yamlSections.join('\n');
+  return out.join('\n');
 };
 
 export const templateToYaml = (template: ParsedTemplate): string => {
-  const yamlSections: string[] = [
+  const out: string[] = [
     `# Template: ${template.name}`,
     `# Exported: ${new Date().toISOString()}`,
     '',
   ];
-  serializeTemplate(yamlSections, template);
-  return yamlSections.join('\n');
+  serializeTemplate(out, template);
+  return out.join('\n');
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/extended_fields.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import React from 'react';
 import { startCase } from 'lodash';
 import type { SnakeToCamelCase } from '../../../common/types';
 import type { ExtendedFieldsUserAction } from '../../../common/types/domain';
 import type { UserActionBuilder } from './types';
 import { createCommonUpdateUserActionBuilder } from './common';
+import { PreferenceFormattedDate } from '../formatted_date';
 import * as i18n from './translations';
+import { getMaybeDate } from '../formatted_date/maybe_date';
 
 const getFieldDisplayName = (key: string): string => {
   // The key arrives as camelCase (e.g. "riskScoreAsKeyword") because convertToCamelCase
@@ -20,13 +23,27 @@ const getFieldDisplayName = (key: string): string => {
   return startCase(withoutTypeSuffix);
 };
 
-const getLabelTitle = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): string => {
+const getLabelTitle = (userAction: SnakeToCamelCase<ExtendedFieldsUserAction>): React.ReactNode => {
   const extendedFields = userAction.payload.extendedFields ?? {};
   const entries = Object.entries(extendedFields);
 
   if (entries.length === 1) {
     const [key, value] = entries[0];
-    return i18n.SET_TEMPLATE_FIELD_LABEL(getFieldDisplayName(key), String(value));
+    const displayName = getFieldDisplayName(key);
+
+    if (key.endsWith('AsDate') && typeof value === 'string') {
+      const maybeDate = getMaybeDate(value);
+      if (maybeDate.isValid()) {
+        return (
+          <>
+            {i18n.SET_TEMPLATE_FIELD_LABEL_PREFIX(displayName)}{' '}
+            <PreferenceFormattedDate value={maybeDate.toDate()} stripMs />
+          </>
+        );
+      }
+    }
+
+    return i18n.SET_TEMPLATE_FIELD_LABEL(displayName, String(value));
   }
 
   return i18n.UPDATED_TEMPLATE_FIELDS;

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/translations.ts
@@ -174,6 +174,12 @@ export const SET_TEMPLATE_FIELD_LABEL = (fieldName: string, value: string) =>
     values: { fieldName, value },
   });
 
+export const SET_TEMPLATE_FIELD_LABEL_PREFIX = (fieldName: string) =>
+  i18n.translate('xpack.cases.caseView.userActions.setTemplateFieldLabelPrefix', {
+    defaultMessage: 'set {fieldName} to',
+    values: { fieldName },
+  });
+
 export const EXTENDED_FIELDS = i18n.translate('xpack.cases.caseView.userActions.extendedFields', {
   defaultMessage: 'Template Fields',
 });


### PR DESCRIPTION
## What & Why
Adds `DATE_PICKER` as a new field control type in the Templates V2 field definition system. Template authors can now include date fields (with optional time selection and UTC/local timezone) in template YAML definitions. The user action timeline renders date values using the locale-aware date formatter instead of a raw ISO string.

## How to Test
1. Navigate to **Cases → Settings → Templates** and open a template for editing.
2. Add a `DATE_PICKER` field to the YAML definition (e.g. `control: DATE_PICKER`, `type: date`). Confirm the live preview renders a date picker input.
3. Set `metadata.show_time: true` — confirm a time selector appears. Set `metadata.timezone: local` — confirm the picker uses local time.
4. Add `validation: required: true` to the field, save the template, open a case using that template, and submit without picking a date — confirm the form blocks submission with an error.
5. Pick a date, save the case, and open the activity timeline — confirm the user action reads "set <field> to <formatted date>" rather than a raw ISO string.

## Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.