### PR TITLE
[One Workflow] feat: support dynamic bracket access in variable path validation

### DIFF
--- a/src/platform/plugins/shared/workflows_management/common/lib/parse_variable_path.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/parse_variable_path.test.ts
@@ -64,6 +64,16 @@ describe('validateVariablePath', () => {
   it('should validate a complex path with filters', () => {
     expect(validateVariablePath('steps.data["key"] | join(",") | upper')).toBe(true);
   });
+
+  it('should validate paths with dynamic bracket access', () => {
+    expect(
+      validateVariablePath(
+        'steps.load_comment_sync_state.output._source[steps.note_sync_space_comment.output].id'
+      )
+    ).toBe(true);
+    expect(validateVariablePath('data[fieldName]')).toBe(true);
+    expect(validateVariablePath('obj[steps.a.output] | json')).toBe(true);
+  });
 });
 
 describe('parseVariablePath', () => {
@@ -72,6 +82,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: [],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -80,6 +91,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'steps.data["key"][0]',
       filters: [],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -97,6 +109,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['title'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -105,6 +118,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['join(",")'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -113,6 +127,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['replace("foo", "bar")', 'capitalize'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -121,6 +136,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'steps.data["key"]',
       filters: ['join(",")', 'upper', 'trim'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -129,6 +145,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['replace("(test)", "bar")', 'title'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -137,6 +154,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ["replace('old', 'new')"],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -145,6 +163,7 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['replace(old="old", new="new")'],
+      hasDynamicBracketAccess: false,
     });
   });
 
@@ -153,6 +172,52 @@ describe('parseVariablePath', () => {
     expect(result).toEqual({
       propertyPath: 'foo',
       filters: ['title', 'upper'],
+      hasDynamicBracketAccess: false,
+    });
+  });
+
+  it('should parse paths with dynamic bracket access', () => {
+    const result = parseVariablePath(
+      'steps.load_comment_sync_state.output._source[steps.note_sync_space_comment.output].id'
+    );
+    expect(result).toEqual({
+      propertyPath:
+        'steps.load_comment_sync_state.output._source[steps.note_sync_space_comment.output].id',
+      filters: [],
+      hasDynamicBracketAccess: true,
+      dynamicAccess: {
+        prefixPath: 'steps.load_comment_sync_state.output._source',
+        dynamicKey: 'steps.note_sync_space_comment.output',
+        suffixPath: 'id',
+      },
+    });
+  });
+
+  it('should parse simple dynamic bracket access', () => {
+    const result = parseVariablePath('data[fieldName]');
+    expect(result).toEqual({
+      propertyPath: 'data[fieldName]',
+      filters: [],
+      hasDynamicBracketAccess: true,
+      dynamicAccess: {
+        prefixPath: 'data',
+        dynamicKey: 'fieldName',
+        suffixPath: null,
+      },
+    });
+  });
+
+  it('should parse dynamic bracket access with filters', () => {
+    const result = parseVariablePath('obj[steps.a.output] | json');
+    expect(result).toEqual({
+      propertyPath: 'obj[steps.a.output]',
+      filters: ['json'],
+      hasDynamicBracketAccess: true,
+      dynamicAccess: {
+        prefixPath: 'obj',
+        dynamicKey: 'steps.a.output',
+        suffixPath: null,
+      },
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/common/lib/parse_variable_path.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/parse_variable_path.ts
@@ -7,16 +7,24 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ALLOWED_KEY_REGEX, PROPERTY_PATH_REGEX } from './regex';
+import { ALLOWED_KEY_REGEX, DYNAMIC_BRACKET_ACCESS_REGEX, PROPERTY_PATH_REGEX } from './regex';
 
 export function validateVariablePath(path: string) {
   return ALLOWED_KEY_REGEX.test(path);
+}
+
+export interface DynamicBracketAccessInfo {
+  prefixPath: string;
+  dynamicKey: string;
+  suffixPath: string | null;
 }
 
 export interface ParsedVariablePath {
   errors?: string[];
   propertyPath: string | null;
   filters: string[];
+  hasDynamicBracketAccess?: boolean;
+  dynamicAccess?: DynamicBracketAccessInfo;
 }
 
 // Receives a variable path e.g. 'items[0].name' or 'items[0].name | title' or 'items[0].name | title | uppercase'
@@ -65,10 +73,30 @@ export function parseVariablePath(path: string): ParsedVariablePath | null {
     };
   }
 
+  const hasDynamicBracketAccess = DYNAMIC_BRACKET_ACCESS_REGEX.test(propertyPath);
+  const dynamicAccess = hasDynamicBracketAccess
+    ? extractDynamicBracketAccess(propertyPath)
+    : undefined;
+
   return {
     propertyPath,
     filters,
+    hasDynamicBracketAccess,
+    dynamicAccess,
   };
+}
+
+function extractDynamicBracketAccess(propertyPath: string): DynamicBracketAccessInfo | undefined {
+  const match = propertyPath.match(DYNAMIC_BRACKET_ACCESS_REGEX);
+  if (!match || match.index === undefined) return undefined;
+
+  const prefixPath = propertyPath.slice(0, match.index);
+  const bracketContent = match[0];
+  const dynamicKey = bracketContent.slice(1, -1).trim();
+  const afterBracket = propertyPath.slice(match.index + bracketContent.length);
+  const suffixPath = afterBracket.startsWith('.') ? afterBracket.slice(1) : afterBracket || null;
+
+  return { prefixPath, dynamicKey, suffixPath: suffixPath || null };
 }
 
 function splitByPipeRespectingParentheses(input: string): string[] {

--- a/src/platform/plugins/shared/workflows_management/common/lib/regex.test.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/regex.test.ts
@@ -9,6 +9,7 @@
 
 import {
   ALLOWED_KEY_REGEX,
+  DYNAMIC_BRACKET_ACCESS_REGEX,
   isLiquidTagValue,
   LIQUID_FILTER_REGEX,
   PROPERTY_PATH_REGEX,
@@ -106,12 +107,23 @@ describe('regex patterns', () => {
       });
     });
 
+    it('should match paths with dynamic bracket access', () => {
+      const dynamicPaths = [
+        'data._source[steps.other_step.output].id',
+        'obj[steps.a.output]',
+        'data[fieldName]',
+      ];
+
+      dynamicPaths.forEach((path) => {
+        expect(ALLOWED_KEY_REGEX.test(path)).toBe(true);
+      });
+    });
+
     it('should not match invalid property paths', () => {
       const invalidPaths = [
         '123invalid', // starts with number
         '.user', // starts with dot
         'user..name', // double dots
-        'user[abc]', // unquoted string in brackets
         'user]invalid[', // wrong bracket order
       ];
 
@@ -139,6 +151,18 @@ describe('regex patterns', () => {
       });
     });
 
+    it('should match paths with dynamic bracket access', () => {
+      const dynamicPaths = [
+        'data._source[steps.other_step.output].id',
+        'obj[steps.a.output]',
+        'data[fieldName]',
+      ];
+
+      dynamicPaths.forEach((path) => {
+        expect(PROPERTY_PATH_REGEX.test(path)).toBe(true);
+      });
+    });
+
     it('should not match paths with liquid filters', () => {
       const pathsWithFilters = ['user.name | upcase', 'price | round: 2', 'items | map: "title"'];
 
@@ -152,12 +176,26 @@ describe('regex patterns', () => {
         '123invalid', // starts with number
         '.user', // starts with dot
         'user..name', // double dots
-        'user[abc]', // unquoted string in brackets
       ];
 
       invalidPaths.forEach((path) => {
         expect(PROPERTY_PATH_REGEX.test(path)).toBe(false);
       });
+    });
+  });
+
+  describe('DYNAMIC_BRACKET_ACCESS_REGEX', () => {
+    it('should match paths containing dynamic variable bracket access', () => {
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('data[fieldName]')).toBe(true);
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('_source[steps.other.output].id')).toBe(true);
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('obj[a.b.c]')).toBe(true);
+    });
+
+    it('should not match paths with only static bracket access', () => {
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('data[0]')).toBe(false);
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('data["key"]')).toBe(false);
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test("data['key']")).toBe(false);
+      expect(DYNAMIC_BRACKET_ACCESS_REGEX.test('simple.path')).toBe(false);
     });
   });
 

--- a/src/platform/plugins/shared/workflows_management/common/lib/regex.ts
+++ b/src/platform/plugins/shared/workflows_management/common/lib/regex.ts
@@ -12,11 +12,15 @@ export const VARIABLE_REGEX_GLOBAL = new RegExp(VARIABLE_REGEX.source, 'g');
 export const UNFINISHED_VARIABLE_REGEX_GLOBAL =
   /\{\{\s*(?<key>[\w.\s|()\[\],"']*?[\w.\s|()\[\],"']?)\s*$/g;
 
-export const ALLOWED_KEY_REGEX =
-  /^[a-zA-Z_$][a-zA-Z0-9_$]*(?:\.[a-zA-Z_$][a-zA-Z0-9_$]*|\[\s*(?:\d+|"[^"]*"|'[^']*')\s*\])*(?:\s*\|.*)?$/;
+const BRACKET_ACCESSOR = String.raw`\[\s*(?:\d+|"[^"]*"|'[^']*'|[a-zA-Z_$][a-zA-Z0-9_$.]*)\s*\]`;
+const SEGMENT = String.raw`(?:\.[a-zA-Z_$][a-zA-Z0-9_$]*|${BRACKET_ACCESSOR})`;
+const PATH_BASE = String.raw`[a-zA-Z_$][a-zA-Z0-9_$]*${SEGMENT}*`;
 
-export const PROPERTY_PATH_REGEX =
-  /^[a-zA-Z_$][a-zA-Z0-9_$]*(?:\.[a-zA-Z_$][a-zA-Z0-9_$]*|\[\s*(?:\d+|"[^"]*"|'[^']*')\s*\])*$/;
+export const ALLOWED_KEY_REGEX = new RegExp(`^${PATH_BASE}(?:\\s*\\|.*)?$`);
+
+export const PROPERTY_PATH_REGEX = new RegExp(`^${PATH_BASE}$`);
+
+export const DYNAMIC_BRACKET_ACCESS_REGEX = /\[\s*[a-zA-Z_$][a-zA-Z0-9_$.]*\s*\]/;
 
 // Liquid-specific regex patterns
 // Matches: {{ variable | filter_prefix (but not {{ variable | filter }})

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_variable.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_variable.test.ts
@@ -274,6 +274,109 @@ describe('validateVariable', () => {
     });
   });
 
+  it('should validate prefix and dynamic key for dynamic bracket access', () => {
+    const variableItem = createVariableItem({
+      key: 'steps.load.output._source[steps.space.output].id',
+    });
+    mockParseVariablePath
+      .mockReturnValueOnce({
+        propertyPath: 'steps.load.output._source[steps.space.output].id',
+        filters: [],
+        hasDynamicBracketAccess: true,
+        dynamicAccess: {
+          prefixPath: 'steps.load.output._source',
+          dynamicKey: 'steps.space.output',
+          suffixPath: 'id',
+        },
+      })
+      .mockReturnValueOnce({
+        propertyPath: 'steps.space.output',
+        filters: [],
+        hasDynamicBracketAccess: false,
+      });
+    mockGetSchemaAtPath
+      .mockReturnValueOnce({ schema: z.record(z.string(), z.unknown()), scopedToPath: null })
+      .mockReturnValueOnce({ schema: z.string(), scopedToPath: null });
+
+    const result = validateVariable(variableItem, mockContext);
+
+    expect(result).toMatchObject({
+      message: null,
+      severity: null,
+      owner: 'variable-validation',
+    });
+    expect(result.hoverMessage).toContain('Dynamic bracket access');
+    expect(mockGetSchemaAtPath).toHaveBeenCalledTimes(2);
+    expect(mockGetSchemaAtPath).toHaveBeenCalledWith(mockContext, 'steps.load.output._source');
+    expect(mockGetSchemaAtPath).toHaveBeenCalledWith(mockContext, 'steps.space.output');
+  });
+
+  it('should return error when dynamic bracket prefix path is invalid', () => {
+    const variableItem = createVariableItem({
+      key: 'steps.load.output._source[steps.space.output].id',
+    });
+    mockParseVariablePath
+      .mockReturnValueOnce({
+        propertyPath: 'steps.load.output._source[steps.space.output].id',
+        filters: [],
+        hasDynamicBracketAccess: true,
+        dynamicAccess: {
+          prefixPath: 'steps.load.output._source',
+          dynamicKey: 'steps.space.output',
+          suffixPath: 'id',
+        },
+      })
+      .mockReturnValueOnce({
+        propertyPath: 'steps.space.output',
+        filters: [],
+        hasDynamicBracketAccess: false,
+      });
+    mockGetSchemaAtPath
+      .mockReturnValueOnce({ schema: null, scopedToPath: null })
+      .mockReturnValueOnce({ schema: z.string(), scopedToPath: null });
+
+    const result = validateVariable(variableItem, mockContext);
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining('Invalid prefix path'),
+      severity: 'error',
+      owner: 'variable-validation',
+    });
+  });
+
+  it('should return error when dynamic bracket key is invalid', () => {
+    const variableItem = createVariableItem({
+      key: 'steps.load.output._source[steps.nonexistent.output].id',
+    });
+    mockParseVariablePath
+      .mockReturnValueOnce({
+        propertyPath: 'steps.load.output._source[steps.nonexistent.output].id',
+        filters: [],
+        hasDynamicBracketAccess: true,
+        dynamicAccess: {
+          prefixPath: 'steps.load.output._source',
+          dynamicKey: 'steps.nonexistent.output',
+          suffixPath: 'id',
+        },
+      })
+      .mockReturnValueOnce({
+        propertyPath: 'steps.nonexistent.output',
+        filters: [],
+        hasDynamicBracketAccess: false,
+      });
+    mockGetSchemaAtPath
+      .mockReturnValueOnce({ schema: z.record(z.string(), z.unknown()), scopedToPath: null })
+      .mockReturnValueOnce({ schema: null, scopedToPath: null });
+
+    const result = validateVariable(variableItem, mockContext);
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining('Dynamic key steps.nonexistent.output is invalid'),
+      severity: 'error',
+      owner: 'variable-validation',
+    });
+  });
+
   it('should handle array input with default value in foreach validation', () => {
     const variableItem = createVariableItem({
       key: 'inputs.days_to_plan',

--- a/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_variable.ts
+++ b/src/platform/plugins/shared/workflows_management/public/features/validate_workflow_yaml/lib/validate_variable.ts
@@ -9,12 +9,120 @@
 
 import type { DynamicStepContextSchema } from '@kbn/workflows/spec/schema';
 import { z } from '@kbn/zod/v4';
+import type {
+  DynamicBracketAccessInfo,
+  ParsedVariablePath,
+} from '../../../../common/lib/parse_variable_path';
 import { parseVariablePath } from '../../../../common/lib/parse_variable_path';
 import { getSchemaAtPath } from '../../../../common/lib/zod';
 import { getDetailedTypeDescription } from '../../../../common/lib/zod/zod_type_description';
 import { InvalidForeachParameterError } from '../../workflow_context/lib/errors';
 import { getForeachItemSchema } from '../../workflow_context/lib/get_foreach_state_schema';
 import type { VariableItem, YamlValidationResult } from '../model/types';
+
+function validateDynamicBracketAccess(
+  dynamicAccess: DynamicBracketAccessInfo,
+  context: typeof DynamicStepContextSchema
+): string[] {
+  const { prefixPath, dynamicKey } = dynamicAccess;
+  const errors: string[] = [];
+
+  if (prefixPath) {
+    const { schema: prefixSchema } = getSchemaAtPath(context, prefixPath);
+    if (!prefixSchema) {
+      errors.push(`Invalid prefix path: ${prefixPath}`);
+    }
+  }
+
+  const dynamicKeyParsed = parseVariablePath(dynamicKey);
+  if (!dynamicKeyParsed || dynamicKeyParsed.errors) {
+    const detail = dynamicKeyParsed?.errors?.join(', ') ?? dynamicKey;
+    errors.push(`Invalid dynamic key: ${detail}`);
+  } else if (dynamicKeyParsed.propertyPath) {
+    const { schema: keySchema } = getSchemaAtPath(context, dynamicKeyParsed.propertyPath);
+    if (!keySchema) {
+      errors.push(`Dynamic key ${dynamicKeyParsed.propertyPath} is invalid`);
+    }
+  }
+
+  return errors;
+}
+
+function validateStaticPath(
+  variableItem: VariableItem,
+  propertyPath: string,
+  context: typeof DynamicStepContextSchema
+): YamlValidationResult {
+  const { schema: refSchema } = getSchemaAtPath(context, propertyPath);
+
+  if (!refSchema) {
+    return {
+      ...variableItem,
+      message: `Variable ${propertyPath} is invalid`,
+      severity: 'error',
+      owner: 'variable-validation',
+      hoverMessage: null,
+    };
+  }
+
+  if (refSchema instanceof z.ZodAny && refSchema.description) {
+    return {
+      ...variableItem,
+      message: refSchema.description,
+      severity: 'warning',
+      owner: 'variable-validation',
+      hoverMessage: getVariableHoverMessage(propertyPath, refSchema),
+    };
+  }
+
+  if (refSchema instanceof z.ZodUnknown) {
+    return {
+      ...variableItem,
+      message: `Variable ${propertyPath} cannot be validated, because it's type is unknown`,
+      severity: 'warning',
+      owner: 'variable-validation',
+      hoverMessage: getVariableHoverMessage(propertyPath, refSchema),
+    };
+  }
+
+  return {
+    ...variableItem,
+    message: null,
+    severity: null,
+    owner: 'variable-validation',
+    hoverMessage: getVariableHoverMessage(propertyPath, refSchema),
+  };
+}
+
+function validateParsedPath(
+  variableItem: VariableItem,
+  parsedPath: ParsedVariablePath,
+  propertyPath: string,
+  context: typeof DynamicStepContextSchema
+): YamlValidationResult {
+  if (parsedPath.hasDynamicBracketAccess && parsedPath.dynamicAccess) {
+    const errors = validateDynamicBracketAccess(parsedPath.dynamicAccess, context);
+    if (errors.length > 0) {
+      return {
+        ...variableItem,
+        message: errors.join(', '),
+        severity: 'error',
+        owner: 'variable-validation',
+        hoverMessage: null,
+      };
+    }
+
+    return {
+      ...variableItem,
+      message: null,
+      severity: null,
+      owner: 'variable-validation',
+      hoverMessage: `Dynamic bracket access — prefix and key are valid, suffix resolved at runtime: \`${propertyPath}\``,
+    };
+  }
+
+  return validateStaticPath(variableItem, propertyPath, context);
+}
 
 export function validateVariable(
   variableItem: VariableItem,
@@ -97,7 +205,7 @@ export function validateVariable(
     };
   }
 
-  if (!parsedPath?.propertyPath) {
+  if (!parsedPath.propertyPath) {
     return {
       ...variableItem,
       message: 'Failed to parse variable path',
@@ -107,45 +215,7 @@ export function validateVariable(
     };
   }
 
-  const { schema: refSchema } = getSchemaAtPath(context, parsedPath.propertyPath);
-
-  if (!refSchema) {
-    return {
-      ...variableItem,
-      message: `Variable ${parsedPath.propertyPath} is invalid`,
-      severity: 'error',
-      owner: 'variable-validation',
-      hoverMessage: null,
-    };
-  }
-
-  if (refSchema instanceof z.ZodAny && refSchema.description) {
-    return {
-      ...variableItem,
-      message: refSchema.description,
-      severity: 'warning',
-      owner: 'variable-validation',
-      hoverMessage: getVariableHoverMessage(parsedPath.propertyPath, refSchema),
-    };
-  }
-
-  if (refSchema instanceof z.ZodUnknown) {
-    return {
-      ...variableItem,
-      message: `Variable ${parsedPath.propertyPath} cannot be validated, because it's type is unknown`,
-      severity: 'warning',
-      owner: 'variable-validation',
-      hoverMessage: getVariableHoverMessage(parsedPath.propertyPath, refSchema),
-    };
-  }
-
-  return {
-    ...variableItem,
-    message: null,
-    severity: null,
-    owner: 'variable-validation',
-    hoverMessage: getVariableHoverMessage(parsedPath.propertyPath, refSchema),
-  };
+  return validateParsedPath(variableItem, parsedPath, parsedPath.propertyPath, context);
 }
 
 // This function will be replaced with a hover provider,


### PR DESCRIPTION
## Summary

- Add support for dynamic bracket access patterns (e.g. `data[fieldName]`, `steps.load.output._source[steps.space.output].id`) in variable path regex validation and parsing
- Extend `ParsedVariablePath` with `hasDynamicBracketAccess` and `dynamicAccess` fields to decompose dynamic paths into prefix, dynamic key, and suffix
- Refactor `validateVariable` into smaller focused functions (`validateParsedPath`, `validateStaticPath`, `validateDynamicBracketAccess`) that validate both the prefix path and the dynamic key against the workflow schema context

## References

N/A