### PR TITLE
[9.2] [Dataset Quality] Fixes for failing degraded field flyout tests (#258549)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/server/services/privileges.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/server/services/privileges.ts
@@ -6,6 +6,7 @@
  */
 
 import { forbidden } from '@hapi/boom';
+import { errors } from '@elastic/elasticsearch';
 import type {
   SecurityHasPrivilegesPrivileges,
   SecurityIndexPrivilege,
@@ -19,17 +20,61 @@ import {
   MANAGE_FAILURE_STORE_PRIVILEGE,
 } from '../../common/constants';
 
+const FAILURE_STORE_PRIVILEGES = [FAILURE_STORE_PRIVILEGE, MANAGE_FAILURE_STORE_PRIVILEGE] as const;
+
 class DatasetQualityPrivileges {
   public async getHasIndexPrivileges(
     esClient: ElasticsearchClient,
     indexes: string[],
     privileges: SecurityIndexPrivilege[]
   ): Promise<Awaited<Record<string, SecurityHasPrivilegesPrivileges>>> {
-    const indexPrivileges = await esClient.security.hasPrivileges({
-      index: indexes.map((dataStream) => ({ names: dataStream, privileges })),
-    });
+    try {
+      const indexPrivileges = await esClient.security.hasPrivileges({
+        index: indexes.map((dataStream) => ({ names: dataStream, privileges })),
+      });
 
-    return indexPrivileges.index;
+      return indexPrivileges.index;
+    } catch (error) {
+      if (
+        error instanceof errors.ResponseError &&
+        isUnknownPrivilegeError(error, FAILURE_STORE_PRIVILEGES)
+      ) {
+        return this.getHasIndexPrivilegesWithoutFailureStore(esClient, indexes, privileges);
+      }
+      throw error;
+    }
+  }
+
+  private async getHasIndexPrivilegesWithoutFailureStore(
+    esClient: ElasticsearchClient,
+    indexes: string[],
+    privileges: SecurityIndexPrivilege[]
+  ): Promise<Record<string, SecurityHasPrivilegesPrivileges>> {
+    const filteredPrivileges = privileges.filter(
+      (p) => !FAILURE_STORE_PRIVILEGES.includes(p as (typeof FAILURE_STORE_PRIVILEGES)[number])
+    );
+
+    const result: Record<string, SecurityHasPrivilegesPrivileges> =
+      filteredPrivileges.length > 0
+        ? (
+            await esClient.security.hasPrivileges({
+              index: indexes.map((dataStream) => ({
+                names: dataStream,
+                privileges: filteredPrivileges,
+              })),
+            })
+          ).index
+        : Object.fromEntries(indexes.map((i) => [i, {} as SecurityHasPrivilegesPrivileges]));
+
+    for (const index of indexes) {
+      for (const fsPriv of FAILURE_STORE_PRIVILEGES) {
+        if (privileges.includes(fsPriv as SecurityIndexPrivilege)) {
+          (result[index] as Record<string, boolean>)[fsPriv] = false;
+        }
+      }
+    }
+
+    return result;
   }
 
   public async getCanViewIntegrations(
@@ -131,3 +176,13 @@ class DatasetQualityPrivileges {
 }
 
 export const datasetQualityPrivileges = new DatasetQualityPrivileges();
+
+function isUnknownPrivilegeError(
+  error: errors.ResponseError,
+  privilegeNames: ReadonlyArray<string>
+): boolean {
+  const reason = (error.body as { error?: { reason?: string } } | undefined)?.error?.reason;
+  return Boolean(
+    reason && privilegeNames.some((name) => reason.includes(`unknown index privilege [${name}]`))
+  );
+}

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/custom_mappings/custom_apm_mappings.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/custom_mappings/custom_apm_mappings.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+
+// 27 fields total (same structure as logsSynthMappings, with event.ingested and tags added)
+export const logsApmAppMappings = (_dataset: string): MappingTypeMapping => ({
+  properties: {
+    '@timestamp': {
+      type: 'date',
+      ignore_malformed: false,
+    },
+    data_stream: {
+      properties: {
+        dataset: {
+          type: 'constant_keyword',
+        },
+        namespace: {
+          type: 'constant_keyword',
+        },
+        type: {
+          type: 'constant_keyword',
+        },
+      },
+    },
+    event: {
+      properties: {
+        dataset: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+        ingested: {
+          type: 'date',
+          format: 'strict_date_time_no_millis||strict_date_optional_time||epoch_millis',
+          ignore_malformed: false,
+        },
+      },
+    },
+    host: {
+      properties: {
+        name: {
+          type: 'keyword',
+          fields: {
+            text: {
+              type: 'match_only_text',
+            },
+          },
+        },
+      },
+    },
+    input: {
+      properties: {
+        type: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+    log: {
+      properties: {
+        level: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+    message: {
+      type: 'match_only_text',
+    },
+    network: {
+      properties: {
+        bytes: {
+          type: 'long',
+        },
+      },
+    },
+    service: {
+      properties: {
+        name: {
+          type: 'keyword',
+          fields: {
+            text: {
+              type: 'match_only_text',
+            },
+          },
+        },
+      },
+    },
+    tags: {
+      type: 'keyword',
+      ignore_above: 1024,
+    },
+    test_field: {
+      type: 'keyword',
+      ignore_above: 1024,
+    },
+    tls: {
+      properties: {
+        established: {
+          type: 'boolean',
+        },
+      },
+    },
+    trace: {
+      properties: {
+        id: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+  },
+});

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -19,6 +19,7 @@ import {
 } from './data';
 import { logsSynthMappings } from './custom_mappings/custom_synth_mappings';
 import { logsNginxMappings } from './custom_mappings/custom_integration_mappings';
+import { logsApmAppMappings } from './custom_mappings/custom_apm_mappings';
 
 export default function ({ getService, getPageObjects }: DatasetQualityFtrProviderContext) {
   const PageObjects = getPageObjects([
@@ -53,14 +54,15 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
   const apmAppDatasetName = 'apm.app.tug';
   const apmAppDataStreamName = `${type}-${apmAppDatasetName}-${defaultNamespace}`;
+  // Custom index template name for APM (2 dash-separated parts for isDedicatedComponentTemplate check)
+  const customIndexTemplateNameApm = `logs-${apmAppDatasetName}`;
+  const customComponentTemplateNameApm = `${customIndexTemplateNameApm}@custom`;
 
-  // Failing: See https://github.com/elastic/kibana/issues/255900
-  describe.skip('Degraded fields flyout', function () {
+  describe('Degraded fields flyout', () => {
     // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
     // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
     // and running these tests will result in an "unknown index privilege [read_failure_store]" error.
     this.onlyEsVersion('8.19 || >=9.1');
-
     describe('degraded field flyout open-close', () => {
       before(async () => {
         await synthtrace.index([
@@ -161,6 +163,35 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         await synthtrace.createComponentTemplate({
           name: customComponentTemplateNameNginx,
           mappings: logsNginxMappings(nginxAccessDatasetName),
+        });
+
+        // Create custom component template for APM to control field count precisely,
+        // avoiding flakiness from @apm-app built-in template changes across ES versions
+        await synthtrace.createComponentTemplate({
+          name: customComponentTemplateNameApm,
+          mappings: logsApmAppMappings(apmAppDatasetName),
+        });
+
+        // Create custom index template for APM data stream.
+        // Uses _meta.managed: true so areAssetsAvailable resolves to true.
+        await esClient.indices.putIndexTemplate({
+          name: customIndexTemplateNameApm,
+          _meta: {
+            managed: true,
+            description: 'custom apm template created for dataset quality testing.',
+          },
+          priority: 500,
+          index_patterns: [apmAppDataStreamName],
+          composed_of: [
+            customComponentTemplateNameApm,
+            'logs@mappings',
+            'logs@settings',
+            'ecs@mappings',
+          ],
+          allow_auto_create: true,
+          data_stream: {
+            hidden: false,
+          },
         });
 
         await synthtrace.index([
@@ -1036,6 +1067,10 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         await synthtrace.deleteComponentTemplate(customComponentTemplateName);
         await PageObjects.observabilityLogsExplorer.uninstallPackage(nginxPkg);
         await synthtrace.deleteComponentTemplate(customComponentTemplateNameNginx);
+        await esClient.indices.deleteIndexTemplate({
+          name: customIndexTemplateNameApm,
+        });
+        await synthtrace.deleteComponentTemplate(customComponentTemplateNameApm);
       });
     });
   });

--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -58,7 +58,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const customIndexTemplateNameApm = `logs-${apmAppDatasetName}`;
   const customComponentTemplateNameApm = `${customIndexTemplateNameApm}@custom`;
 
-  describe('Degraded fields flyout', () => {
+  describe('Degraded fields flyout', function () {
     // This disables the forward-compatibility test for Elasticsearch 8.19 with Kibana and ES 9.0.
     // These versions are not expected to work together. Note: Failure store is not available in ES 9.0,
     // and running these tests will result in an "unknown index privilege [read_failure_store]" error.

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/custom_mappings/custom_apm_mappings.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/custom_mappings/custom_apm_mappings.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+
+// 27 fields total (same structure as logsSynthMappings, with event.ingested and tags added)
+export const logsApmAppMappings = (_dataset: string): MappingTypeMapping => ({
+  properties: {
+    '@timestamp': {
+      type: 'date',
+      ignore_malformed: false,
+    },
+    data_stream: {
+      properties: {
+        dataset: {
+          type: 'constant_keyword',
+        },
+        namespace: {
+          type: 'constant_keyword',
+        },
+        type: {
+          type: 'constant_keyword',
+        },
+      },
+    },
+    event: {
+      properties: {
+        dataset: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+        ingested: {
+          type: 'date',
+          format: 'strict_date_time_no_millis||strict_date_optional_time||epoch_millis',
+          ignore_malformed: false,
+        },
+      },
+    },
+    host: {
+      properties: {
+        name: {
+          type: 'keyword',
+          fields: {
+            text: {
+              type: 'match_only_text',
+            },
+          },
+        },
+      },
+    },
+    input: {
+      properties: {
+        type: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+    log: {
+      properties: {
+        level: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+    message: {
+      type: 'match_only_text',
+    },
+    network: {
+      properties: {
+        bytes: {
+          type: 'long',
+        },
+      },
+    },
+    service: {
+      properties: {
+        name: {
+          type: 'keyword',
+          fields: {
+            text: {
+              type: 'match_only_text',
+            },
+          },
+        },
+      },
+    },
+    tags: {
+      type: 'keyword',
+      ignore_above: 1024,
+    },
+    test_field: {
+      type: 'keyword',
+      ignore_above: 1024,
+    },
+    tls: {
+      properties: {
+        established: {
+          type: 'boolean',
+        },
+      },
+    },
+    trace: {
+      properties: {
+        id: {
+          type: 'keyword',
+          ignore_above: 1024,
+        },
+      },
+    },
+  },
+});

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/dataset_quality/degraded_field_flyout.ts
@@ -19,6 +19,7 @@ import {
 import type { FtrProviderContext } from '../../ftr_provider_context';
 import { logsSynthMappings } from './custom_mappings/custom_synth_mappings';
 import { logsNginxMappings } from './custom_mappings/custom_integration_mappings';
+import { logsApmAppMappings } from './custom_mappings/custom_apm_mappings';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects([
@@ -55,6 +56,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   const apmAppDatasetName = 'apm.app.tug';
   const apmAppDataStreamName = `${type}-${apmAppDatasetName}-${defaultNamespace}`;
+  // Custom index template name for APM (2 dash-separated parts for isDedicatedComponentTemplate check)
+  const customIndexTemplateNameApm = `logs-${apmAppDatasetName}`;
+  const customComponentTemplateNameApm = `${customIndexTemplateNameApm}@custom`;
 
   describe('Degraded fields flyout', function () {
     describe('degraded field flyout open-close', () => {
@@ -154,6 +158,35 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await synthtrace.createComponentTemplate({
           name: customComponentTemplateNameNginx,
           mappings: logsNginxMappings(nginxAccessDatasetName),
+        });
+
+        // Create custom component template for APM to control field count precisely,
+        // avoiding flakiness from @apm-app built-in template changes across ES versions
+        await synthtrace.createComponentTemplate({
+          name: customComponentTemplateNameApm,
+          mappings: logsApmAppMappings(apmAppDatasetName),
+        });
+
+        // Create custom index template for APM data stream.
+        // Uses _meta.managed: true so areAssetsAvailable resolves to true.
+        await esClient.indices.putIndexTemplate({
+          name: customIndexTemplateNameApm,
+          _meta: {
+            managed: true,
+            description: 'custom apm template created for dataset quality testing.',
+          },
+          priority: 500,
+          index_patterns: [apmAppDataStreamName],
+          composed_of: [
+            customComponentTemplateNameApm,
+            'logs@mappings',
+            'logs@settings',
+            'ecs@mappings',
+          ],
+          allow_auto_create: true,
+          data_stream: {
+            hidden: false,
+          },
         });
 
         await synthtrace.index([
@@ -1081,6 +1114,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await synthtrace.deleteComponentTemplate(customComponentTemplateName);
         await PageObjects.observabilityLogsExplorer.uninstallPackage(nginxPkg);
         await synthtrace.deleteComponentTemplate(customComponentTemplateNameNginx);
+        await esClient.indices.deleteIndexTemplate({
+          name: customIndexTemplateNameApm,
+        });
+        await synthtrace.deleteComponentTemplate(customComponentTemplateNameApm);
       });
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Dataset Quality] Fixes for failing degraded field flyout tests (#258549)](https://github.com/elastic/kibana/pull/258549)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Coen Warmer","email":"coen.warmer@gmail.com"},"sourceCommit":{"committedDate":"2026-03-20T08:36:05Z","message":"[Dataset Quality] Fixes for failing degraded field flyout tests (#258549)","sha":"452bec63f02d5f89b6546793635cf6fe7c6903bc","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:version","v9.1.0","v9.2.0","v9.3.0","v9.4.0","9.4.0"],"title":"[Dataset Quality] Fixes for failing degraded field flyout tests","number":258549,"url":"https://github.com/elastic/kibana/pull/258549","mergeCommit":{"message":"[Dataset Quality] Fixes for failing degraded field flyout tests (#258549)","sha":"452bec63f02d5f89b6546793635cf6fe7c6903bc"}},"sourceBranch":"main","suggestedTargetBranches":["9.1","9.2","9.3"],"targetPullRequestStates":[{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258549","number":258549,"mergeCommit":{"message":"[Dataset Quality] Fixes for failing degraded field flyout tests (#258549)","sha":"452bec63f02d5f89b6546793635cf6fe7c6903bc"}}]}] BACKPORT-->