### PR TITLE
[Agent Builder] UX fixes for buttons being cut

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_rounds/round_response/attachments/inline_attachment_with_actions.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@kbn/agent-builder-common/attachments';
 import type { AttachmentPreviewState } from '@kbn/agent-builder-browser/attachments';
 import { EuiSplitPanel } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { AttachmentsService } from '../../../../../../services/attachments/attachements_service';
 import { useConversationContext } from '../../../../../context/conversation/conversation_context';
 import { usePersistedConversationId } from '../../../../../hooks/use_persisted_conversation_id';
@@ -116,7 +117,14 @@ export const InlineAttachmentWithActions: React.FC<InlineAttachmentWithActionsPr
   const title = uiDefinition?.getLabel?.(attachment) ?? attachment.type.toUpperCase();
 
   return (
-    <EuiSplitPanel.Outer grow hasShadow={false} hasBorder={true}>
+    <EuiSplitPanel.Outer
+      grow
+      hasShadow={false}
+      hasBorder={true}
+      css={css`
+        overflow: visible; // allow vis actions to overflow
+      `}
+    >
       <AttachmentHeader
         title={title}
         actionButtons={inlineActionButtons}

--- a/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
+++ b/x-pack/platform/plugins/shared/dashboard_agent/public/attachment_types/dashboard_canvas_content.tsx
@@ -35,11 +35,16 @@ const dashboardCanvasContentStyles = {
     css({
       padding: euiTheme.size.m,
     }),
-  renderer: css({
-    flex: 1,
-    minHeight: 0,
-    display: 'flex',
-  }),
+  renderer: ({ euiTheme }: UseEuiTheme) =>
+    css({
+      flex: 1,
+      minHeight: 0,
+      display: 'flex',
+      '.controlGroup': {
+        padding: `${euiTheme.size.s} !important`,
+        borderBottom: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
+      },
+    }),
   searchBar: ({ euiTheme }: UseEuiTheme) =>
     css({
       flexShrink: 0,


### PR DESCRIPTION
## Summary
Before (the buttons for the vis are cut):
<img width="1594" height="562" alt="image" src="https://github.com/user-attachments/assets/849fd2a2-7376-43d7-b3f7-1223226d27a0" />

After:

<img width="838" height="404" alt="Screenshot 2026-03-30 at 14 10 25" src="https://github.com/user-attachments/assets/61c8b8a3-e9e2-41e9-adf7-e69b2f388016" />



2. Paddings for Unified Search/controls, after:
<img width="853" height="742" alt="Screenshot 2026-03-30 at 17 20 11" src="https://github.com/user-attachments/assets/3f887ba6-215d-4e74-8583-44e0556d41b1" />
<img width="843" height="737" alt="Screenshot 2026-03-30 at 17 19 53" src="https://github.com/user-attachments/assets/03c42f27-a88a-4571-a143-696d769b21e6" />
