### PR TITLE
[9.2] [CI] set diskSizeGb=120g across the board for all Defend Workflow jobs (#259398)

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -264,10 +264,11 @@ for (const testSuite of testSuites) {
         );
       }
       const agentQueue = suiteName.includes('defend_workflows') ? 'n2-4-virt' : 'n2-4-spot';
+      const diskSizeGb = suiteName.includes('defend_workflows') ? 120 : undefined;
       steps.push({
         command: `.buildkite/scripts/steps/functional/${suiteName}.sh`,
         label: group.name,
-        agents: expandAgentQueue(agentQueue),
+        agents: expandAgentQueue(agentQueue, diskSizeGb),
         key: `${TestSuiteType.CYPRESS}-${suiteIndex++}`,
         depends_on: 'build',
         timeout_in_minutes: 150,

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -238,7 +238,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60
@@ -258,7 +258,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/cypress_burn.yml
@@ -5,6 +5,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -5,7 +5,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 150
+      diskSizeGb: 120
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_defend_workflows.yml
@@ -11,6 +11,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          diskSizeGb: 120
         timeout_in_minutes: 300
         parallelism: 5
         retry:
@@ -30,6 +31,7 @@ steps:
           provider: gcp
           enableNestedVirtualization: true
           machineType: n2-standard-4
+          diskSizeGb: 120
         timeout_in_minutes: 300
         parallelism: 3
         retry:

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_defend_workflows.yml
@@ -8,6 +8,7 @@ steps:
       provider: gcp
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 120
     timeout_in_minutes: 300
     parallelism: 1
     retry:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] set diskSizeGb=120g across the board for all Defend Workflow jobs (#259398)](https://github.com/elastic/kibana/pull/259398)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-03-24T17:01:02Z","message":"[CI] set diskSizeGb=120g across the board for all Defend Workflow jobs (#259398)\n\n## Summary\nDW cypress runs seem to break occasionally around the 100g mark, because\nVagrant wants 10g+ to be free at the time of starting.\n\nWe've had different disk requests here and there for defend workflows\njobs. This PR sets all requests to 120g. This gives some headroom, and\nreduces the entropy in randomly set values. If we breach this, we can\nincrease it across the board again.","sha":"cac15700c7c58db01bbde1d14bf52d41599d5f99","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0","reviewer:skip-ai"],"title":"[CI] set diskSizeGb=120g across the board for all Defend Workflow jobs","number":259398,"url":"https://github.com/elastic/kibana/pull/259398","mergeCommit":{"message":"[CI] set diskSizeGb=120g across the board for all Defend Workflow jobs (#259398)\n\n## Summary\nDW cypress runs seem to break occasionally around the 100g mark, because\nVagrant wants 10g+ to be free at the time of starting.\n\nWe've had different disk requests here and there for defend workflows\njobs. This PR sets all requests to 120g. This gives some headroom, and\nreduces the entropy in randomly set values. If we breach this, we can\nincrease it across the board again.","sha":"cac15700c7c58db01bbde1d14bf52d41599d5f99"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259398","number":259398,"mergeCommit":{"message":"[CI] set diskSizeGb=120g across the board for all Defend Workflow jobs (#259398)\n\n## Summary\nDW cypress runs seem to break occasionally around the 100g mark, because\nVagrant wants 10g+ to be free at the time of starting.\n\nWe've had different disk requests here and there for defend workflows\njobs. This PR sets all requests to 120g. This gives some headroom, and\nreduces the entropy in randomly set values. If we breach this, we can\nincrease it across the board again.","sha":"cac15700c7c58db01bbde1d14bf52d41599d5f99"}}]}] BACKPORT-->