### PR TITLE
Only apply ILM phases filter on ECH

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
@@ -27,7 +27,7 @@ describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryEx
   beforeEach(() => {
     mockEsClient = createMockEsClient();
     mockLogger = createMockLogger();
-    queryExecutor = new CircuitBreakingQueryExecutorImpl(mockEsClient as any, mockLogger); // eslint-disable-line @typescript-eslint/no-explicit-any
+    queryExecutor = new CircuitBreakingQueryExecutorImpl(mockEsClient as any, false, mockLogger); // eslint-disable-line @typescript-eslint/no-explicit-any
   });
 
   describe('DSL queries', () => {
@@ -659,6 +659,30 @@ describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryEx
     test('should return original index when no tiers are specified', async () => {
       const query = createMockQuery(QueryType.DSL);
       const result = await queryExecutor.indicesFor(query);
+      expect(result).toEqual(['test-index']);
+      expect(mockEsClient.ilm.explainLifecycle).not.toHaveBeenCalled();
+    });
+
+    test('should return original index on serverless when no tiers are specified', async () => {
+      const serverlessExecutor = new CircuitBreakingQueryExecutorImpl(
+        mockEsClient as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        true,
+        mockLogger
+      );
+      const query = createMockQuery(QueryType.DSL);
+      const result = await serverlessExecutor.indicesFor(query);
+      expect(result).toEqual(['test-index']);
+      expect(mockEsClient.ilm.explainLifecycle).not.toHaveBeenCalled();
+    });
+
+    test('should return original index on serverless even when tiers are specified', async () => {
+      const serverlessExecutor = new CircuitBreakingQueryExecutorImpl(
+        mockEsClient as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        true,
+        mockLogger
+      );
+      const query = createMockQuery(QueryType.DSL, { tiers: ['hot', 'warm'] });
+      const result = await serverlessExecutor.indicesFor(query);
       expect(result).toEqual(['test-index']);
       expect(mockEsClient.ilm.explainLifecycle).not.toHaveBeenCalled();
     });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
@@ -42,8 +42,11 @@ import { newTelemetryLogger, withErrorMessage } from '../helpers';
 
 export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExecutor {
   private readonly logger: TelemetryLogger;
-
-  constructor(private client: ElasticsearchClient, logger: Logger) {
+  constructor(
+    private client: ElasticsearchClient,
+    private readonly isServerless: boolean,
+    logger: Logger
+  ) {
     this.logger = newTelemetryLogger(logger.get('circuit-breaking-query-executor'));
   }
 
@@ -257,6 +260,13 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
       } as LogMeta);
       return [query.index];
     }
+    if (this.isServerless) {
+      this.logger.debug('Running in serverless, returning index as is', {
+        queryName: query.name,
+      } as LogMeta);
+      return [query.index];
+    }
+
     const tiers = query.tiers;
 
     return this.client.ilm

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
@@ -65,6 +65,7 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
   private analytics?: AnalyticsServiceStart;
   private _esClient?: ElasticsearchClient;
   private telemetryConfigProvider?: TelemetryConfigProvider;
+  private isServerless = false;
 
   constructor(logger: Logger) {
     const mdc = { task_id: TASK_ID, task_type: TASK_TYPE };
@@ -73,6 +74,7 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
 
   public setup(setup: HealthDiagnosticServiceSetup) {
     this.logger.debug('Setting up health diagnostic service');
+    this.isServerless = setup.isServerless;
 
     this.registerTask(setup.taskManager);
   }
@@ -80,7 +82,11 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
   public async start(start: HealthDiagnosticServiceStart) {
     this.logger.debug('Starting health diagnostic service');
 
-    this.queryExecutor = new CircuitBreakingQueryExecutorImpl(start.esClient, this.logger);
+    this.queryExecutor = new CircuitBreakingQueryExecutorImpl(
+      start.esClient,
+      this.isServerless,
+      this.logger
+    );
     this.analytics = start.analytics;
     this._esClient = start.esClient;
     this.telemetryConfigProvider = start.telemetryConfigProvider;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
@@ -54,6 +54,7 @@ export enum QueryType {
 
 export interface HealthDiagnosticServiceSetup {
   taskManager: TaskManagerSetupContract;
+  isServerless: boolean;
 }
 
 export interface HealthDiagnosticServiceStart {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -715,6 +715,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     if (plugins.taskManager) {
       this.healthDiagnosticService.setup({
         taskManager: plugins.taskManager,
+        isServerless: this.isServerless,
       });
 
       this.trialCompanionMilestoneService.setup({


### PR DESCRIPTION
## Summary

To avoid unnecessary requests when running in serverless, do not execute the ILM indices filter when executing Diagnostic Queries with a `tiers` attribute. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->