### PR TITLE
[Inference] Fix ActionsClientLlm failing with EIS connector IDs

### DIFF
--- a/x-pack/platform/plugins/shared/inference/moon.yml
+++ b/x-pack/platform/plugins/shared/inference/moon.yml
@@ -45,6 +45,7 @@ dependsOn:
   - '@kbn/es-errors'
   - '@kbn/anonymization-plugin'
   - '@kbn/anonymization-common'
+  - '@kbn/utility-types'
 tags:
   - plugin
   - prod

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { ActionsClientProvider } from '../types';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ChatCompleteOptions, AnonymizationRule, Model } from '@kbn/inference-common';
 import {
@@ -50,7 +50,7 @@ import { prepareAnonymization } from './prepare_anonymization';
 interface CreateChatCompleteApiOptions {
   request: KibanaRequest;
   namespace: string;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   logger: Logger;
   anonymizationRulesPromise: Promise<AnonymizationRule[]>;
   regexWorker: RegexWorkerService;
@@ -280,7 +280,7 @@ function resolveAndCreatePipeline({
   connectorId: string;
   endpointIdCache: InferenceEndpointIdCache;
   request: KibanaRequest;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   esClient: ElasticsearchClient;
   logger: Logger;
   anonymizationRulesPromise: Promise<AnonymizationRule[]>;

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/callback_api.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { ActionsClientProvider } from '../types';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ChatCompleteOptions, AnonymizationRule, Model } from '@kbn/inference-common';
 import {
@@ -22,6 +21,7 @@ import { defer, forkJoin, from, identity, share, switchMap, catchError, throwErr
 import { withChatCompleteSpan } from '@kbn/inference-tracing';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { omit } from 'lodash';
+import type { ActionsClientProvider } from '../types';
 import type {
   InferenceAdapterChatCompleteOptions,
   InferenceConnectorAdapterChatCompleteEvent,

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_executor.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_executor.ts
@@ -7,9 +7,9 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ActionTypeExecutorResult } from '@kbn/actions-plugin/common';
-import type { ActionsClientProvider } from '../../types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { InferenceConnector } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../../types';
 import { getConnectorById } from '../../util/get_connector_by_id';
 
 export interface InferenceInvokeOptions {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_executor.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_executor.ts
@@ -7,7 +7,7 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ActionTypeExecutorResult } from '@kbn/actions-plugin/common';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { ActionsClientProvider } from '../../types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { InferenceConnector } from '@kbn/inference-common';
 import { getConnectorById } from '../../util/get_connector_by_id';
@@ -35,7 +35,7 @@ export const createInferenceExecutor = ({
   request,
 }: {
   connector: InferenceConnector;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   request: KibanaRequest;
 }): InferenceExecutor => {
   return {
@@ -61,7 +61,7 @@ export const getInferenceExecutor = async ({
   logger,
 }: {
   connectorId: string;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   request: KibanaRequest;
   esClient: ElasticsearchClient;
   logger: Logger;

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/create_chat_model.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/create_chat_model.ts
@@ -7,10 +7,10 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { ActionsClientProvider } from '../types';
 import { InferenceChatModel, type InferenceChatModelParams } from '@kbn/inference-langchain';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { AnonymizationRule, InferenceCallbacks } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../types';
 import { getConnectorById } from '../util/get_connector_by_id';
 import { createClient } from './create_client';
 import type { RegexWorkerService } from '../chat_complete/anonymization/regex_worker_service';

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/create_chat_model.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/create_chat_model.ts
@@ -7,7 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { ActionsClientProvider } from '../types';
 import { InferenceChatModel, type InferenceChatModelParams } from '@kbn/inference-langchain';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { AnonymizationRule, InferenceCallbacks } from '@kbn/inference-common';
@@ -20,7 +20,7 @@ import type { InferenceEndpointIdCache } from '../util/inference_endpoint_id_cac
 export interface CreateChatModelOptions {
   request: KibanaRequest;
   connectorId: string;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   logger: Logger;
   chatModelOptions: Omit<InferenceChatModelParams, 'connector' | 'chatComplete' | 'logger'>;
   anonymizationRulesPromise: Promise<AnonymizationRule[]>;

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
@@ -7,7 +7,10 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type {
+  PluginStartContract as ActionsPluginStart,
+  ActionsClient,
+} from '@kbn/actions-plugin/server';
 import type {
   BoundOptions,
   BoundInferenceClient,
@@ -16,6 +19,7 @@ import type {
   InferenceCallbacks,
 } from '@kbn/inference-common';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import { createInferenceClient } from './inference_client';
 import { bindClient } from '../../common/inference_client/bind_client';
 import type { RegexWorkerService } from '../chat_complete/anonymization/regex_worker_service';
@@ -77,3 +81,44 @@ export function createClient(
     return client;
   }
 }
+
+interface CreateClientWithoutRequestOptions {
+  actionsClient: PublicMethodsOf<ActionsClient>;
+  logger: Logger;
+  regexWorker: RegexWorkerService;
+  esClient: ElasticsearchClient;
+  endpointIdCache: InferenceEndpointIdCache;
+}
+
+/**
+ * Creates an inference client using pre-scoped services instead of a KibanaRequest.
+ * Useful for background tasks (e.g. alerting rule executors) that have scoped clients
+ * but no HTTP request context.
+ *
+ * Internally wraps the actionsClient in an actions-like object so that the underlying
+ * createInferenceClient can resolve connectors. Anonymization is not available.
+ */
+export const createClientWithoutRequest = ({
+  actionsClient,
+  logger,
+  regexWorker,
+  esClient,
+  endpointIdCache,
+}: CreateClientWithoutRequestOptions): InferenceClient => {
+  // Wrap the pre-scoped actionsClient so that any internal code calling
+  // actions.getActionsClientWithRequest() receives this client directly.
+  const actions = {
+    getActionsClientWithRequest: () => Promise.resolve(actionsClient),
+  } as unknown as ActionsPluginStart;
+
+  return createInferenceClient({
+    request: {} as KibanaRequest,
+    namespace: 'default',
+    actions,
+    logger: logger.get('client'),
+    anonymizationRulesPromise: Promise.resolve([]),
+    regexWorker,
+    esClient,
+    endpointIdCache,
+  });
+};

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/create_client.ts
@@ -7,10 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type {
-  PluginStartContract as ActionsPluginStart,
-  ActionsClient,
-} from '@kbn/actions-plugin/server';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type {
   BoundOptions,
   BoundInferenceClient,
@@ -20,6 +17,7 @@ import type {
 } from '@kbn/inference-common';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ActionsClientProvider } from '../types';
 import { createInferenceClient } from './inference_client';
 import { bindClient } from '../../common/inference_client/bind_client';
 import type { RegexWorkerService } from '../chat_complete/anonymization/regex_worker_service';
@@ -29,7 +27,7 @@ import type { InferenceEndpointIdCache } from '../util/inference_endpoint_id_cac
 interface CreateClientOptions {
   request: KibanaRequest;
   namespace?: string;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   logger: Logger;
   anonymizationRulesPromise: Promise<AnonymizationRule[]>;
   regexWorker: RegexWorkerService;
@@ -107,9 +105,9 @@ export const createClientWithoutRequest = ({
 }: CreateClientWithoutRequestOptions): InferenceClient => {
   // Wrap the pre-scoped actionsClient so that any internal code calling
   // actions.getActionsClientWithRequest() receives this client directly.
-  const actions = {
+  const actions: ActionsClientProvider = {
     getActionsClientWithRequest: () => Promise.resolve(actionsClient),
-  } as unknown as ActionsPluginStart;
+  };
 
   return createInferenceClient({
     request: {} as KibanaRequest,

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/index.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/index.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export { createClient } from './create_client';
+export { createClient, createClientWithoutRequest } from './create_client';
 export { createChatModel } from './create_chat_model';

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
@@ -7,7 +7,6 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { ActionsClientProvider } from '../types';
 import type {
   BoundOptions,
   InferenceClient,
@@ -15,6 +14,7 @@ import type {
   InferenceCallbacks,
 } from '@kbn/inference-common';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ActionsClientProvider } from '../types';
 import { createChatCompleteApi } from '../chat_complete';
 import { createOutputApi } from '../../common/output/create_output_api';
 import { bindClient } from '../../common/inference_client/bind_client';

--- a/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
+++ b/x-pack/platform/plugins/shared/inference/server/inference_client/inference_client.ts
@@ -7,7 +7,7 @@
 
 import type { Logger } from '@kbn/logging';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { ActionsClientProvider } from '../types';
 import type {
   BoundOptions,
   InferenceClient,
@@ -43,7 +43,7 @@ export function createInferenceClient({
   request: KibanaRequest;
   namespace: string;
   logger: Logger;
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   anonymizationRulesPromise: Promise<AnonymizationRule[]>;
   regexWorker: RegexWorkerService;
   esClient: ElasticsearchClient;

--- a/x-pack/platform/plugins/shared/inference/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/inference/server/mocks.ts
@@ -14,6 +14,8 @@ const createStartContractMock = (): jest.Mocked<InferenceServerStart> => {
     getConnectorList: jest.fn(),
     getDefaultConnector: jest.fn(),
     getConnectorById: jest.fn(),
+    getClientWithoutRequest: jest.fn(),
+    getConnectorByIdWithoutClientRequest: jest.fn(),
     getInferenceEndpoints: jest.fn(),
     getInferenceEndpointById: jest.fn(),
   };

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -16,9 +16,12 @@ import type {
 } from '@kbn/inference-common';
 import { aiAnonymizationSettings } from '@kbn/inference-common';
 import type { KibanaRequest } from '@kbn/core-http-server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
-import { createClient as createInferenceClient, createChatModel } from './inference_client';
+import {
+  createClient as createInferenceClient,
+  createClientWithoutRequest,
+  createChatModel,
+} from './inference_client';
 import { RegexWorkerService } from './chat_complete/anonymization/regex_worker_service';
 import { registerRoutes } from './routes';
 import type { InferenceConfig } from './config';
@@ -269,15 +272,9 @@ export class InferencePlugin
         });
       },
       getClientWithoutRequest: (actionsClient, esClient) => {
-        return createInferenceClient({
-          request: {} as KibanaRequest, // not used for inference endpoint resolution
-          namespace: 'default',
-          actions: {
-            ...pluginsStart.actions,
-            getActionsClientWithRequest: () => Promise.resolve(actionsClient),
-          } as ActionsPluginStart,
-          logger: this.logger.get('client'),
-          anonymizationRulesPromise: Promise.resolve([]),
+        return createClientWithoutRequest({
+          actionsClient,
+          logger: this.logger,
           regexWorker: this.regexWorker!,
           esClient,
           endpointIdCache: this.endpointIdCache,

--- a/x-pack/platform/plugins/shared/inference/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/inference/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
 } from '@kbn/inference-common';
 import { aiAnonymizationSettings } from '@kbn/inference-common';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import { createClient as createInferenceClient, createChatModel } from './inference_client';
 import { RegexWorkerService } from './chat_complete/anonymization/regex_worker_service';
@@ -32,7 +33,7 @@ import type {
 import { getUiSettings } from '../common/ui_settings';
 import { getConnectorList } from './util/get_connector_list';
 import { loadDefaultConnector } from './util/load_default_connector';
-import { getConnectorById } from './util/get_connector_by_id';
+import { getConnectorById, getConnectorByIdWithoutClientRequest } from './util/get_connector_by_id';
 import { getInferenceEndpoints } from './util/get_inference_endpoints';
 import { getInferenceEndpointById } from './util/get_inference_endpoint_by_id';
 import { InferenceEndpointIdCache } from './util/inference_endpoint_id_cache';
@@ -263,6 +264,29 @@ export class InferencePlugin
           connectorId: id,
           actions: pluginsStart.actions,
           request,
+          esClient,
+          logger: this.logger,
+        });
+      },
+      getClientWithoutRequest: (actionsClient, esClient) => {
+        return createInferenceClient({
+          request: {} as KibanaRequest, // not used for inference endpoint resolution
+          namespace: 'default',
+          actions: {
+            ...pluginsStart.actions,
+            getActionsClientWithRequest: () => Promise.resolve(actionsClient),
+          } as ActionsPluginStart,
+          logger: this.logger.get('client'),
+          anonymizationRulesPromise: Promise.resolve([]),
+          regexWorker: this.regexWorker!,
+          esClient,
+          endpointIdCache: this.endpointIdCache,
+        });
+      },
+      getConnectorByIdWithoutClientRequest: async (id, actionsClient, esClient) => {
+        return getConnectorByIdWithoutClientRequest({
+          connectorId: id,
+          actionsClient,
           esClient,
           logger: this.logger,
         });

--- a/x-pack/platform/plugins/shared/inference/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/types.ts
@@ -8,9 +8,12 @@
 import type {
   PluginStartContract as ActionsPluginStart,
   PluginSetupContract as ActionsPluginSetup,
+  ActionsClient,
 } from '@kbn/actions-plugin/server';
 import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import type {
   BoundInferenceClient,
   BoundOptions,
@@ -153,6 +156,38 @@ export interface InferenceServerStart {
    * @throws Error if the connector with the specified ID does not exist
    */
   getConnectorById: (id: string, request: KibanaRequest) => Promise<InferenceConnector>;
+
+  /**
+   * Creates an {@link InferenceClient} using pre-scoped services instead of a
+   * {@link KibanaRequest}. This is useful for background tasks (e.g. alerting rule
+   * executors) that have scoped clients but no HTTP request context.
+   *
+   * Note: anonymization features are not available on clients created this way.
+   *
+   * @param actionsClient - A pre-scoped actions client
+   * @param esClient - A pre-scoped Elasticsearch client
+   */
+  getClientWithoutRequest: (
+    actionsClient: PublicMethodsOf<ActionsClient>,
+    esClient: ElasticsearchClient
+  ) => InferenceClient;
+
+  /**
+   * Retrieves a specific inference connector by its ID, using pre-scoped services
+   * instead of a {@link KibanaRequest}. This is useful for background tasks (e.g.
+   * alerting rule executors) that have scoped clients but no HTTP request.
+   *
+   * @param id - The unique identifier of the connector to retrieve
+   * @param actionsClient - A pre-scoped actions client
+   * @param esClient - A pre-scoped Elasticsearch client
+   * @returns A promise that resolves to the requested inference connector
+   * @throws Error if the connector with the specified ID does not exist
+   */
+  getConnectorByIdWithoutClientRequest: (
+    id: string,
+    actionsClient: PublicMethodsOf<ActionsClient>,
+    esClient: ElasticsearchClient
+  ) => Promise<InferenceConnector>;
 
   /**
    * Lists available Elasticsearch inference endpoints, optionally filtered by task type.

--- a/x-pack/platform/plugins/shared/inference/server/types.ts
+++ b/x-pack/platform/plugins/shared/inference/server/types.ts
@@ -14,6 +14,15 @@ import type { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
+
+/**
+ * Narrow interface for the actions plugin dependency used internally by the
+ * inference plugin. Only the `getActionsClientWithRequest` method is needed,
+ * so consumers don't have to depend on the full {@link ActionsPluginStart}.
+ */
+export interface ActionsClientProvider {
+  getActionsClientWithRequest(request: KibanaRequest): Promise<PublicMethodsOf<ActionsClient>>;
+}
 import type {
   BoundInferenceClient,
   BoundOptions,

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
@@ -78,7 +78,11 @@ export const getConnectorById = async ({
   const actionClient = await actions.getActionsClientWithRequest(request);
   const allStackConnectors = await actionClient.getAll({ includeSystemActions: false });
 
-  const result = findConnectorById({ connectorId, connectors, rawStackConnectors: allStackConnectors });
+  const result = findConnectorById({
+    connectorId,
+    connectors,
+    rawStackConnectors: allStackConnectors,
+  });
   if (result) {
     return result;
   }
@@ -111,7 +115,11 @@ export const getConnectorByIdWithoutClientRequest = async ({
 
   const allStackConnectors = await actionsClient.getAll({ includeSystemActions: false });
 
-  const result = findConnectorById({ connectorId, connectors, rawStackConnectors: allStackConnectors });
+  const result = findConnectorById({
+    connectorId,
+    connectors,
+    rawStackConnectors: allStackConnectors,
+  });
   if (result) {
     return result;
   }

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
@@ -5,13 +5,11 @@
  * 2.0.
  */
 
-import type {
-  PluginStartContract as ActionsPluginStart,
-  ActionsClient,
-} from '@kbn/actions-plugin/server';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { RawConnector } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../types';
 import {
   createInferenceRequestError,
   InferenceConnectorType,
@@ -67,7 +65,7 @@ export const getConnectorById = async ({
   esClient,
   logger,
 }: {
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   request: KibanaRequest;
   connectorId: string;
   esClient: ElasticsearchClient;

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
@@ -5,14 +5,53 @@
  * 2.0.
  */
 
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type {
+  PluginStartContract as ActionsPluginStart,
+  ActionsClient,
+} from '@kbn/actions-plugin/server';
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { RawConnector } from '@kbn/inference-common';
 import {
   createInferenceRequestError,
   InferenceConnectorType,
   type InferenceConnector,
 } from '@kbn/inference-common';
 import { getConnectorList } from './get_connector_list';
+
+/**
+ * Given a merged connector list and the raw stack connectors, find the connector
+ * matching `connectorId`. Falls back to resolving `.inference` stack connector
+ * aliases (where the stack connector ID differs from the inference endpoint ID
+ * returned in the merged list).
+ */
+const findConnectorById = ({
+  connectorId,
+  connectors,
+  rawStackConnectors,
+}: {
+  connectorId: string;
+  connectors: InferenceConnector[];
+  rawStackConnectors: RawConnector[];
+}): InferenceConnector | undefined => {
+  const match = connectors.find((c) => c.connectorId === connectorId);
+  if (match) {
+    return match;
+  }
+
+  // The requested ID may belong to a stack `.inference` connector whose underlying inference
+  // endpoint was already returned in the list under `inferenceId`. Look up the raw stack
+  // connector to resolve the alias.
+  const stackConnector = rawStackConnectors.find((c) => c.id === connectorId);
+  if (stackConnector?.actionTypeId === InferenceConnectorType.Inference) {
+    const inferenceId = stackConnector.config?.inferenceId as string | undefined;
+    if (inferenceId) {
+      return connectors.find((c) => c.connectorId === inferenceId);
+    }
+  }
+
+  return undefined;
+};
 
 /**
  * Retrieves a connector or inference endpoint given the provided `connectorId`.
@@ -35,27 +74,46 @@ export const getConnectorById = async ({
   logger: Logger;
 }): Promise<InferenceConnector> => {
   const connectors = await getConnectorList({ actions, request, esClient, logger });
-  const match = connectors.find((c) => c.connectorId === connectorId);
 
-  if (match) {
-    return match;
-  }
-
-  // The requested ID may belong to a stack `.inference` connector whose underlying inference
-  // endpoint was already returned in the list under `inferenceId`. Look up the raw stack
-  // connector to resolve the alias.
   const actionClient = await actions.getActionsClientWithRequest(request);
   const allStackConnectors = await actionClient.getAll({ includeSystemActions: false });
-  const stackConnector = allStackConnectors.find((c) => c.id === connectorId);
 
-  if (stackConnector?.actionTypeId === InferenceConnectorType.Inference) {
-    const inferenceId = stackConnector.config?.inferenceId as string | undefined;
-    if (inferenceId) {
-      const endpointMatch = connectors.find((c) => c.connectorId === inferenceId);
-      if (endpointMatch) {
-        return endpointMatch;
-      }
-    }
+  const result = findConnectorById({ connectorId, connectors, rawStackConnectors: allStackConnectors });
+  if (result) {
+    return result;
+  }
+
+  throw createInferenceRequestError(
+    `No connector or inference endpoint found for ID '${connectorId}'`,
+    404
+  );
+};
+
+/**
+ * Retrieves a connector or inference endpoint given the provided `connectorId`,
+ * using pre-scoped `actionsClient` and `esClient` instead of a {@link KibanaRequest}.
+ *
+ * This is useful for background tasks (e.g. alerting rule executors) that already
+ * have scoped clients but no HTTP request context.
+ */
+export const getConnectorByIdWithoutClientRequest = async ({
+  connectorId,
+  actionsClient,
+  esClient,
+  logger,
+}: {
+  connectorId: string;
+  actionsClient: PublicMethodsOf<ActionsClient>;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}): Promise<InferenceConnector> => {
+  const connectors = await getConnectorList({ actionsClient, esClient, logger });
+
+  const allStackConnectors = await actionsClient.getAll({ includeSystemActions: false });
+
+  const result = findConnectorById({ connectorId, connectors, rawStackConnectors: allStackConnectors });
+  if (result) {
+    return result;
   }
 
   throw createInferenceRequestError(

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_by_id.ts
@@ -9,12 +9,12 @@ import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { RawConnector } from '@kbn/inference-common';
-import type { ActionsClientProvider } from '../types';
 import {
   createInferenceRequestError,
   InferenceConnectorType,
   type InferenceConnector,
 } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../types';
 import { getConnectorList } from './get_connector_list';
 
 /**

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
@@ -6,7 +6,11 @@
  */
 
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type {
+  PluginStartContract as ActionsPluginStart,
+  ActionsClient,
+} from '@kbn/actions-plugin/server';
+import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { InferenceConnector } from '@kbn/inference-common';
 import {
   isSupportedConnector,
@@ -15,19 +19,39 @@ import {
 } from '@kbn/inference-common';
 import { getInferenceEndpoints } from './get_inference_endpoints';
 
-export const getConnectorList = async ({
-  actions,
-  request,
-  esClient,
-  logger,
-}: {
+interface GetConnectorListWithRequestOptions {
   actions: ActionsPluginStart;
   request: KibanaRequest;
   esClient: ElasticsearchClient;
   logger: Logger;
-}): Promise<InferenceConnector[]> => {
+}
+
+interface GetConnectorListWithActionsClientOptions {
+  actionsClient: PublicMethodsOf<ActionsClient>;
+  esClient: ElasticsearchClient;
+  logger: Logger;
+}
+
+type GetConnectorListOptions =
+  | GetConnectorListWithRequestOptions
+  | GetConnectorListWithActionsClientOptions;
+
+const getActionsClient = async (
+  options: GetConnectorListOptions
+): Promise<PublicMethodsOf<ActionsClient>> => {
+  if ('actionsClient' in options) {
+    return options.actionsClient;
+  }
+  return options.actions.getActionsClientWithRequest(options.request);
+};
+
+export const getConnectorList = async (
+  options: GetConnectorListOptions
+): Promise<InferenceConnector[]> => {
+  const { esClient, logger } = options;
+
   const [connectorsResult, endpointsResult] = await Promise.allSettled([
-    getStackConnectors({ actions, request }),
+    getStackConnectors(options),
     getInferenceEndpoints({ esClient, taskType: 'chat_completion' }),
   ]);
 
@@ -90,14 +114,10 @@ export const getConnectorList = async ({
   return [...filteredConnectors, ...inferenceEndpointConnectors];
 };
 
-const getStackConnectors = async ({
-  actions,
-  request,
-}: {
-  actions: ActionsPluginStart;
-  request: KibanaRequest;
-}): Promise<InferenceConnector[]> => {
-  const actionClient = await actions.getActionsClientWithRequest(request);
+const getStackConnectors = async (
+  options: GetConnectorListOptions
+): Promise<InferenceConnector[]> => {
+  const actionClient = await getActionsClient(options);
 
   const allConnectors = await actionClient.getAll({
     includeSystemActions: false,

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
@@ -6,11 +6,9 @@
  */
 
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
-import type {
-  PluginStartContract as ActionsPluginStart,
-  ActionsClient,
-} from '@kbn/actions-plugin/server';
+import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
+import type { ActionsClientProvider } from '../types';
 import type { InferenceConnector } from '@kbn/inference-common';
 import {
   isSupportedConnector,
@@ -20,7 +18,7 @@ import {
 import { getInferenceEndpoints } from './get_inference_endpoints';
 
 interface GetConnectorListWithRequestOptions {
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   request: KibanaRequest;
   esClient: ElasticsearchClient;
   logger: Logger;

--- a/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/get_connector_list.ts
@@ -8,13 +8,13 @@
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { ActionsClientProvider } from '../types';
 import type { InferenceConnector } from '@kbn/inference-common';
 import {
   isSupportedConnector,
   connectorToInference,
   InferenceConnectorType,
 } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../types';
 import { getInferenceEndpoints } from './get_inference_endpoints';
 
 interface GetConnectorListWithRequestOptions {

--- a/x-pack/platform/plugins/shared/inference/server/util/load_default_connector.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/load_default_connector.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { ActionsClientProvider } from '../types';
 import type { InferenceConnector } from '@kbn/inference-common';
 import { getDefaultConnector } from '../../common/utils/get_default_connector';
 import { getConnectorList } from './get_connector_list';
@@ -17,7 +17,7 @@ export const loadDefaultConnector = async ({
   esClient,
   logger,
 }: {
-  actions: ActionsPluginStart;
+  actions: ActionsClientProvider;
   request: KibanaRequest;
   esClient: ElasticsearchClient;
   logger: Logger;

--- a/x-pack/platform/plugins/shared/inference/server/util/load_default_connector.ts
+++ b/x-pack/platform/plugins/shared/inference/server/util/load_default_connector.ts
@@ -6,8 +6,8 @@
  */
 
 import type { KibanaRequest, ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { ActionsClientProvider } from '../types';
 import type { InferenceConnector } from '@kbn/inference-common';
+import type { ActionsClientProvider } from '../types';
 import { getDefaultConnector } from '../../common/utils/get_default_connector';
 import { getConnectorList } from './get_connector_list';
 

--- a/x-pack/platform/plugins/shared/inference/tsconfig.json
+++ b/x-pack/platform/plugins/shared/inference/tsconfig.json
@@ -46,5 +46,6 @@
     "@kbn/es-errors",
     "@kbn/anonymization-plugin",
     "@kbn/anonymization-common",
+    "@kbn/utility-types",
   ]
 }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { loggerMock } from '@kbn/logging-mocks';
-import { analyticsServiceMock } from '@kbn/core/server/mocks';
+import { analyticsServiceMock, coreMock } from '@kbn/core/server/mocks';
 import {
   ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
   AttackDiscoveryScheduleParams,
@@ -19,6 +19,7 @@ import { TaskPriority } from '@kbn/task-manager-plugin/server';
 describe('getAttackDiscoveryScheduleType', () => {
   const mockLogger = loggerMock.create();
   const mockTelemetry = analyticsServiceMock.createAnalyticsServiceSetup();
+  const mockCore = coreMock.createSetup();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -26,6 +27,7 @@ describe('getAttackDiscoveryScheduleType', () => {
 
   it('should return schedule type definition', async () => {
     const scheduleType = getAttackDiscoveryScheduleType({
+      core: mockCore,
       logger: mockLogger,
       publicBaseUrl: undefined,
       telemetry: mockTelemetry,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.ts
@@ -16,14 +16,17 @@ import { TaskPriority } from '@kbn/task-manager-plugin/server';
 import { ATTACK_DISCOVERY_ALERTS_AAD_CONFIG } from '../constants';
 import type { AttackDiscoveryExecutorOptions, AttackDiscoveryScheduleType } from '../types';
 import { attackDiscoveryScheduleExecutor } from './executor';
+import type { ElasticAssistantPluginCoreSetupDependencies } from '../../../../types';
 
 export interface GetAttackDiscoveryScheduleParams {
+  core: ElasticAssistantPluginCoreSetupDependencies;
   logger: Logger;
   publicBaseUrl: string | undefined;
   telemetry: AnalyticsServiceSetup;
 }
 
 export const getAttackDiscoveryScheduleType = ({
+  core,
   logger,
   publicBaseUrl,
   telemetry,
@@ -59,7 +62,9 @@ export const getAttackDiscoveryScheduleType = ({
     autoRecoverAlerts: false,
     alerts: ATTACK_DISCOVERY_ALERTS_AAD_CONFIG,
     executor: async (options: AttackDiscoveryExecutorOptions) => {
+      const [, startDeps] = await core.getStartServices();
       return attackDiscoveryScheduleExecutor({
+        inference: startDeps.inference,
         options,
         logger,
         publicBaseUrl,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -12,6 +12,8 @@ import type { RuleExecutorOptions } from '@kbn/alerting-plugin/server';
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
 import { analyticsServiceMock } from '@kbn/core/server/mocks';
+import { InferenceConnectorType } from '@kbn/inference-common';
+import { inferenceMock } from '@kbn/inference-plugin/server/mocks';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import {
   ELASTIC_MANAGED_LLM_CONNECTOR_ID,
@@ -75,6 +77,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
   const date = '2025-05-20T15:18:21.000Z';
   const mockLogger = loggerMock.create();
   const mockTelemetry = analyticsServiceMock.createAnalyticsServiceSetup();
+  const mockInference = inferenceMock.createStartContract();
   const actionsClient = actionsClientMock.create();
   const ruleExecutorServices = alertsMock.createRuleExecutorServices();
   const services = {
@@ -160,6 +163,17 @@ describe('attackDiscoveryScheduleExecutor', () => {
 
     (services.alertsClient.report as jest.Mock).mockReturnValue({ uuid: 'fake-alert' });
 
+    // Mock inference.getConnectorByIdWithoutClientRequest to resolve the connector for the executor
+    mockInference.getConnectorByIdWithoutClientRequest.mockResolvedValue({
+      type: params.apiConfig.actionTypeId as InferenceConnectorType,
+      connectorId: params.apiConfig.connectorId,
+      name: params.apiConfig.name,
+      config: {},
+      capabilities: {},
+      isInferenceEndpoint: false,
+      isPreconfigured: false,
+    });
+
     (findDocuments as jest.Mock).mockResolvedValue(getFindAnonymizationFieldsResultWithSingleHit());
     (generateAttackDiscoveries as jest.Mock).mockResolvedValue({
       anonymizedAlerts: mockAnonymizedAlerts,
@@ -177,6 +191,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     } as unknown as RuleExecutorOptions;
 
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -191,6 +206,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     } as unknown as RuleExecutorOptions;
 
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -205,6 +221,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -224,6 +241,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -258,6 +276,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
 
     await expect(async () => {
       await attackDiscoveryScheduleExecutor({
+        inference: mockInference,
         options,
         logger: mockLogger,
         publicBaseUrl: undefined,
@@ -277,6 +296,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -303,6 +323,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -321,6 +342,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -418,6 +440,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: 'http://fake-host.io/test',
@@ -441,6 +464,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     options.services.shouldStopExecution = () => true;
 
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -455,6 +479,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -481,6 +506,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     (deduplicateAttackDiscoveries as jest.Mock).mockResolvedValue([]);
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -497,6 +523,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     ]);
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -527,6 +554,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     (deduplicateAttackDiscoveries as jest.Mock).mockResolvedValue(mockAttackDiscoveries);
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -556,6 +584,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const spy = jest.spyOn(transforms, 'transformToBaseAlertDocument');
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -575,6 +604,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const spy = jest.spyOn(transforms, 'transformToBaseAlertDocument');
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,
@@ -597,6 +627,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
 
     await expect(
       attackDiscoveryScheduleExecutor({
+        inference: mockInference,
         options,
         logger: mockLogger,
         publicBaseUrl: undefined,
@@ -622,6 +653,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     } as unknown as RuleExecutorOptions;
 
     await attackDiscoveryScheduleExecutor({
+      inference: mockInference,
       options,
       logger: mockLogger,
       publicBaseUrl: undefined,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -12,7 +12,7 @@ import type { RuleExecutorOptions } from '@kbn/alerting-plugin/server';
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
 import { analyticsServiceMock } from '@kbn/core/server/mocks';
-import { InferenceConnectorType } from '@kbn/inference-common';
+import type { InferenceConnectorType } from '@kbn/inference-common';
 import { inferenceMock } from '@kbn/inference-plugin/server/mocks';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
@@ -12,6 +12,7 @@ import {
   getAttackDiscoveryMarkdownFields,
   resolveConnectorId,
 } from '@kbn/elastic-assistant-common';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 import { ALERT_URL } from '@kbn/rule-data-utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
@@ -39,6 +40,7 @@ import { getScheduledIndexPattern } from '../../persistence/get_scheduled_index_
 import { updateAlertsWithAttackIds } from './updateAlertsWithAttackIds';
 
 export interface AttackDiscoveryScheduleExecutorParams {
+  inference: InferenceServerStart;
   options: AttackDiscoveryExecutorOptions;
   logger: Logger;
   publicBaseUrl: string | undefined;
@@ -46,6 +48,7 @@ export interface AttackDiscoveryScheduleExecutorParams {
 }
 
 export const attackDiscoveryScheduleExecutor = async ({
+  inference,
   options,
   logger,
   publicBaseUrl,
@@ -90,6 +93,15 @@ export const attackDiscoveryScheduleExecutor = async ({
   };
 
   try {
+    // Resolve the connector server-side to get the authoritative actionTypeId.
+    // Uses pre-scoped services since the executor runs without a KibanaRequest.
+    const resolvedConnector = await inference.getConnectorByIdWithoutClientRequest(
+      params.apiConfig.connectorId,
+      actionsClient,
+      esClient
+    );
+    const inferenceClient = inference.getClientWithoutRequest(actionsClient, esClient);
+
     const { anonymizedAlerts, attackDiscoveries, replacements } = await generateAttackDiscoveries({
       actionsClient,
       config: {
@@ -98,8 +110,13 @@ export const attackDiscoveryScheduleExecutor = async ({
         filter: combinedFilter,
         anonymizationFields,
         subAction: 'invokeAI',
+        apiConfig: {
+          ...restParams.apiConfig,
+          actionTypeId: resolvedConnector.type,
+        },
       },
       esClient,
+      inferenceClient,
       logger,
       savedObjectsClient,
     });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
@@ -267,6 +267,7 @@ export class ElasticAssistantPlugin
     // Register the Attack Discovery Schedule type
     plugins.alerting.registerType(
       getAttackDiscoveryScheduleType({
+        core,
         logger: this.logger,
         publicBaseUrl: core.http.basePath.publicBaseUrl,
         telemetry: core.analytics,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/generate_and_update_discoveries.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/generate_and_update_discoveries.ts
@@ -20,6 +20,7 @@ import type {
   CreateAttackDiscoveryAlertsParams,
   Replacements,
 } from '@kbn/elastic-assistant-common';
+import type { InferenceClient } from '@kbn/inference-common';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { Document } from '@langchain/core/documents';
@@ -39,6 +40,7 @@ export interface GenerateAndUpdateAttackDiscoveriesParams {
   enableFieldRendering: boolean;
   esClient: ElasticsearchClient;
   executionUuid: string;
+  inferenceClient?: InferenceClient;
   logger: Logger;
   savedObjectsClient: SavedObjectsClientContract;
   telemetry: AnalyticsServiceSetup;
@@ -53,6 +55,7 @@ export const generateAndUpdateAttackDiscoveries = async ({
   enableFieldRendering,
   esClient,
   executionUuid,
+  inferenceClient,
   logger,
   savedObjectsClient,
   telemetry,
@@ -80,6 +83,7 @@ export const generateAndUpdateAttackDiscoveries = async ({
       actionsClient,
       config,
       esClient,
+      inferenceClient,
       logger,
       savedObjectsClient,
     });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/generate_discoveries.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/generate_discoveries.ts
@@ -8,6 +8,7 @@
 import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { AttackDiscoveryGenerationConfig, Replacements } from '@kbn/elastic-assistant-common';
+import type { InferenceClient } from '@kbn/inference-common';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 
@@ -21,6 +22,7 @@ export interface GenerateAttackDiscoveriesParams {
   actionsClient: PublicMethodsOf<ActionsClient>;
   config: AttackDiscoveryGenerationConfig;
   esClient: ElasticsearchClient;
+  inferenceClient?: InferenceClient;
   logger: Logger;
   savedObjectsClient: SavedObjectsClientContract;
 }
@@ -29,6 +31,7 @@ export const generateAttackDiscoveries = async ({
   actionsClient,
   config,
   esClient,
+  inferenceClient,
   logger,
   savedObjectsClient,
 }: GenerateAttackDiscoveriesParams) => {
@@ -61,6 +64,7 @@ export const generateAttackDiscoveries = async ({
     end,
     esClient,
     filter,
+    inferenceClient,
     langSmithProject,
     langSmithApiKey,
     latestReplacements,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/helpers/invoke_attack_discovery_graph/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/helpers/invoke_attack_discovery_graph/index.tsx
@@ -10,6 +10,7 @@ import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import type { ApiConfig, AttackDiscovery, Replacements } from '@kbn/elastic-assistant-common';
 import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas';
+import type { InferenceClient, InferenceConnectorType } from '@kbn/inference-common';
 import { ActionsClientLlm } from '@kbn/langchain/server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
@@ -35,6 +36,7 @@ export const invokeAttackDiscoveryGraph = async ({
   end,
   esClient,
   filter,
+  inferenceClient,
   langSmithProject,
   langSmithApiKey,
   latestReplacements,
@@ -52,6 +54,7 @@ export const invokeAttackDiscoveryGraph = async ({
   end?: string;
   esClient: ElasticsearchClient;
   filter?: Record<string, unknown>;
+  inferenceClient?: InferenceClient;
   langSmithProject?: string;
   langSmithApiKey?: string;
   latestReplacements: Replacements;
@@ -67,6 +70,9 @@ export const invokeAttackDiscoveryGraph = async ({
   throwIfInvalidAnonymization(anonymizationFields);
 
   const llmType = getLlmType(apiConfig.actionTypeId);
+  const isInferenceEndpoint =
+    apiConfig.actionTypeId === ('.inference' as InferenceConnectorType.Inference) &&
+    inferenceClient != null;
   const model = apiConfig.model;
   const tags = [ATTACK_DISCOVERY_TAG, llmType, model].flatMap((tag) => tag ?? []);
 
@@ -84,6 +90,8 @@ export const invokeAttackDiscoveryGraph = async ({
   const llm = new ActionsClientLlm({
     actionsClient,
     connectorId: apiConfig.connectorId,
+    inferenceClient: isInferenceEndpoint ? inferenceClient : undefined,
+    isInferenceEndpoint,
     llmType,
     logger,
     model,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.test.ts
@@ -104,7 +104,7 @@ describe('postAttackDiscoveryGenerateRoute', () => {
     context.elasticAssistant.getCurrentUser.mockResolvedValue(mockUser);
     context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(mockDataClient);
     context.elasticAssistant.actions = actionsMock.createStart();
-    context.elasticAssistant.inference.getConnectorById.mockResolvedValue({
+    (context.elasticAssistant.inference.getConnectorById as jest.Mock).mockResolvedValue({
       type: mockApiConfig.actionTypeId,
       connectorId: mockApiConfig.connectorId,
       name: 'test connector',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.test.ts
@@ -104,6 +104,15 @@ describe('postAttackDiscoveryGenerateRoute', () => {
     context.elasticAssistant.getCurrentUser.mockResolvedValue(mockUser);
     context.elasticAssistant.getAttackDiscoveryDataClient.mockResolvedValue(mockDataClient);
     context.elasticAssistant.actions = actionsMock.createStart();
+    context.elasticAssistant.inference.getConnectorById.mockResolvedValue({
+      type: mockApiConfig.actionTypeId,
+      connectorId: mockApiConfig.connectorId,
+      name: 'test connector',
+      config: {},
+      capabilities: {},
+      isInferenceEndpoint: false,
+      isPreconfigured: false,
+    });
     context.core.featureFlags.getBooleanValue = jest.fn().mockResolvedValue(false);
     postAttackDiscoveryGenerateRoute(server.router);
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts
@@ -101,6 +101,8 @@ export const postAttackDiscoveryGenerateRoute = (
           // get the actions plugin start contract from the request context:
           const actions = (await context.elasticAssistant).actions;
           const actionsClient = await actions.getActionsClientWithRequest(request);
+          const inference = (await context.elasticAssistant).inference;
+          const inferenceClient = inference.getClient({ request });
           const dataClient = await assistantContext.getAttackDiscoveryDataClient();
           const authenticatedUser = await assistantContext.getCurrentUser();
 
@@ -182,6 +184,7 @@ export const postAttackDiscoveryGenerateRoute = (
             config: request.body,
             dataClient,
             esClient,
+            inferenceClient,
             logger,
             savedObjectsClient,
             telemetry,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/public/post/post_attack_discovery_generate.ts
@@ -122,7 +122,19 @@ export const postAttackDiscoveryGenerateRoute = (
 
           // get parameters from the request body
           const alertsIndexPattern = decodeURIComponent(request.body.alertsIndexPattern);
-          const { apiConfig, size } = request.body;
+          const { size } = request.body;
+
+          // Resolve the connector server-side to get the authoritative actionTypeId,
+          // rather than relying on what the client sent. This handles inference endpoint
+          // IDs (e.g. EIS connectors) that may not match a stack connector type.
+          const resolvedConnector = await inference.getConnectorById(
+            request.body.apiConfig.connectorId,
+            request
+          );
+          const apiConfig = {
+            ...request.body.apiConfig,
+            actionTypeId: resolvedConnector.type,
+          };
 
           if (
             !requestIsValid({
@@ -181,7 +193,7 @@ export const postAttackDiscoveryGenerateRoute = (
             enableFieldRendering: true, // the _generate API always pass true for this value. It's still possible for clients who read the generated discoveries to specify false when retrieving them.
             executionUuid,
             authenticatedUser,
-            config: request.body,
+            config: { ...request.body, apiConfig },
             dataClient,
             esClient,
             inferenceClient,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
@@ -27,7 +27,11 @@ import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/i
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { Moment } from 'moment';
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { InferenceClient, InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
+import type {
+  InferenceClient,
+  InferenceConnector,
+  InferenceConnectorType,
+} from '@kbn/inference-common';
 import moment from 'moment';
 import { ActionsClientLlm } from '@kbn/langchain/server';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
@@ -27,7 +27,7 @@ import type { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/i
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { Moment } from 'moment';
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { InferenceConnector } from '@kbn/inference-common';
+import type { InferenceClient, InferenceConnector, InferenceConnectorType } from '@kbn/inference-common';
 import moment from 'moment';
 import { ActionsClientLlm } from '@kbn/langchain/server';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
@@ -107,6 +107,7 @@ export function getAssistantToolParams({
   apiConfig,
   esClient,
   connectorTimeout,
+  inferenceClient,
   langChainTimeout,
   langSmithProject,
   langSmithApiKey,
@@ -123,6 +124,7 @@ export function getAssistantToolParams({
   apiConfig: ApiConfig;
   esClient: ElasticsearchClient;
   connectorTimeout: number;
+  inferenceClient?: InferenceClient;
   langChainTimeout: number;
   langSmithProject?: string;
   langSmithApiKey?: string;
@@ -157,9 +159,15 @@ export function getAssistantToolParams({
     ],
   };
 
+  const isInferenceEndpoint =
+    apiConfig.actionTypeId === ('.inference' as InferenceConnectorType.Inference) &&
+    inferenceClient != null;
+
   const llm = new ActionsClientLlm({
     actionsClient,
     connectorId: apiConfig.connectorId,
+    inferenceClient: isInferenceEndpoint ? inferenceClient : undefined,
+    isInferenceEndpoint,
     llmType: getLlmType(apiConfig.actionTypeId),
     logger,
     temperature: 0, // zero temperature because we want structured JSON output
@@ -427,6 +435,7 @@ export const invokeDefendInsightsGraph = async ({
   apiConfig,
   connectorTimeout,
   esClient,
+  inferenceClient,
   langSmithProject,
   langSmithApiKey,
   latestReplacements,
@@ -446,6 +455,7 @@ export const invokeDefendInsightsGraph = async ({
   apiConfig: ApiConfig;
   connectorTimeout: number;
   esClient: ElasticsearchClient;
+  inferenceClient?: InferenceClient;
   langSmithProject?: string;
   langSmithApiKey?: string;
   latestReplacements: Replacements;
@@ -465,6 +475,9 @@ export const invokeDefendInsightsGraph = async ({
   }
 
   const llmType = getLlmType(apiConfig.actionTypeId);
+  const isInferenceEndpoint =
+    apiConfig.actionTypeId === ('.inference' as InferenceConnectorType.Inference) &&
+    inferenceClient != null;
   const model = apiConfig.model;
   const tags = [DEFEND_INSIGHTS_ID, llmType, model].flatMap((tag) => tag ?? []);
 
@@ -482,6 +495,8 @@ export const invokeDefendInsightsGraph = async ({
   const llm = new ActionsClientLlm({
     actionsClient,
     connectorId: apiConfig.connectorId,
+    inferenceClient: isInferenceEndpoint ? inferenceClient : undefined,
+    isInferenceEndpoint,
     llmType,
     logger,
     temperature: 0,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
@@ -88,6 +88,8 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
 
           const actions = assistantContext.actions;
           const actionsClient = await actions.getActionsClientWithRequest(request);
+          const inference = assistantContext.inference;
+          const inferenceClient = inference.getClient({ request });
           const dataClient = await assistantContext.getDefendInsightsDataClient();
           const kbDataClient = await assistantContext.getAIAssistantKnowledgeBaseDataClient();
           const authenticatedUser = await assistantContext.getCurrentUser();
@@ -153,6 +155,7 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             apiConfig,
             connectorTimeout: CONNECTOR_TIMEOUT,
             esClient,
+            inferenceClient,
             langSmithProject,
             langSmithApiKey,
             latestReplacements,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -195,6 +195,12 @@ const AttackDiscoveryPageComponent: React.FC = () => {
           size,
           start,
           overrideConnectorId: overrideOptions?.overrideConnectorId,
+          overrideConnectorName: overrideOptions?.overrideConnectorId
+            ? getConnectorNameFromId({
+                aiConnectors,
+                connectorId: overrideOptions.overrideConnectorId,
+              })
+            : undefined,
           overrideEnd: overrideOptions?.overrideEnd,
           overrideFilter: overrideOptions?.overrideFilter,
           overrideSize: overrideOptions?.overrideSize,
@@ -205,6 +211,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
       }
     },
     [
+      aiConnectors,
       end,
       fetchAttackDiscoveries,
       filterQuery,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/translations.ts
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 export const CONNECTOR_ERROR = i18n.translate(
   'xpack.securitySolution.attackDiscovery.errorConnector',
   {
-    defaultMessage: 'No connector selected, select a connector to use attack discovery',
+    defaultMessage: 'No model selected, select a model to use attack discovery',
   }
 );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/helpers.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS } from '@kbn/elastic-assistant';
-import { OpenAiProviderType } from '@kbn/connector-schemas/openai/constants';
 import type { ActionConnector } from '@kbn/triggers-actions-ui-plugin/public';
 import { omit } from 'lodash/fp';
 
@@ -142,6 +141,7 @@ describe('getRequestBody', () => {
     const result = getRequestBody({
       alertsIndexPattern,
       anonymizationFields,
+      connectorId: connector.id,
       size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
       traceOptions,
     });
@@ -151,9 +151,7 @@ describe('getRequestBody', () => {
       anonymizationFields: anonymizationFields.data,
       apiConfig: {
         actionTypeId: '',
-        connectorId: '',
-        model: undefined,
-        provider: undefined,
+        connectorId: connector.id,
       },
       langSmithProject: undefined,
       langSmithApiKey: undefined,
@@ -167,6 +165,7 @@ describe('getRequestBody', () => {
     const result = getRequestBody({
       alertsIndexPattern: undefined,
       anonymizationFields,
+      connectorId: connector.id,
       size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
       traceOptions,
     });
@@ -176,9 +175,7 @@ describe('getRequestBody', () => {
       anonymizationFields: anonymizationFields.data,
       apiConfig: {
         actionTypeId: '',
-        connectorId: '',
-        model: undefined,
-        provider: undefined,
+        connectorId: connector.id,
       },
       langSmithProject: undefined,
       langSmithApiKey: undefined,
@@ -192,6 +189,7 @@ describe('getRequestBody', () => {
     const withLangSmith = {
       alertsIndexPattern,
       anonymizationFields,
+      connectorId: connector.id,
       size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
       traceOptions: {
         apmUrl: '/app/apm',
@@ -207,72 +205,12 @@ describe('getRequestBody', () => {
       anonymizationFields: anonymizationFields.data,
       apiConfig: {
         actionTypeId: '',
-        connectorId: '',
-        model: undefined,
-        provider: undefined,
+        connectorId: connector.id,
       },
       langSmithApiKey: withLangSmith.traceOptions.langSmithApiKey,
       langSmithProject: withLangSmith.traceOptions.langSmithProject,
       size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
       replacements: {},
-      subAction: 'invokeAI',
-    });
-  });
-
-  it('returns the expected AttackDiscoveryPostRequestBody with the expected apiConfig when selectedConnector is provided', () => {
-    const result = getRequestBody({
-      alertsIndexPattern,
-      anonymizationFields,
-      selectedConnector: connector, // <-- selectedConnector is provided
-      size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
-      traceOptions,
-    });
-
-    expect(result).toEqual({
-      alertsIndexPattern,
-      anonymizationFields: anonymizationFields.data,
-      apiConfig: {
-        actionTypeId: connector.actionTypeId,
-        connectorId: connector.id,
-        model: undefined,
-        provider: undefined,
-      },
-      langSmithProject: undefined,
-      langSmithApiKey: undefined,
-      size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
-      replacements: {},
-      subAction: 'invokeAI',
-    });
-  });
-
-  it('returns the expected AttackDiscoveryPostRequestBody with the expected apiConfig when genAiConfig is provided', () => {
-    const genAiConfig = {
-      apiProvider: OpenAiProviderType.AzureAi,
-      defaultModel: '2024-02-15-preview',
-    };
-
-    const result = getRequestBody({
-      alertsIndexPattern,
-      anonymizationFields,
-      genAiConfig, // <-- genAiConfig is provided
-      selectedConnector: connector, // <-- selectedConnector is provided
-      size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
-      traceOptions,
-    });
-
-    expect(result).toEqual({
-      alertsIndexPattern,
-      anonymizationFields: anonymizationFields.data,
-      apiConfig: {
-        actionTypeId: connector.actionTypeId,
-        connectorId: connector.id,
-        model: genAiConfig.defaultModel,
-        provider: genAiConfig.apiProvider,
-      },
-      langSmithProject: undefined,
-      langSmithApiKey: undefined,
-      replacements: {},
-      size: DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS,
       subAction: 'invokeAI',
     });
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/helpers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/helpers.ts
@@ -56,8 +56,7 @@ const getAzureApiVersionParameter = (url: string): string | undefined => {
 export const getRequestBody = ({
   alertsIndexPattern,
   anonymizationFields,
-  genAiConfig,
-  selectedConnector,
+  connectorId,
   size,
   traceOptions,
 }: {
@@ -79,9 +78,8 @@ export const getRequestBody = ({
       namespace?: string | undefined;
     }>;
   };
-  genAiConfig?: GenAiConfig;
+  connectorId: string;
   size: number;
-  selectedConnector?: ActionConnector;
   traceOptions: TraceOptions;
 }): PostAttackDiscoveryGenerateRequestBody => ({
   alertsIndexPattern: alertsIndexPattern ?? '',
@@ -96,9 +94,7 @@ export const getRequestBody = ({
   size,
   subAction: 'invokeAI', // non-streaming
   apiConfig: {
-    connectorId: selectedConnector?.id ?? '',
-    actionTypeId: selectedConnector?.actionTypeId ?? '',
-    provider: genAiConfig?.apiProvider,
-    model: genAiConfig?.defaultModel,
+    connectorId,
+    actionTypeId: '', // resolved server-side via inference.getConnectorById
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -6,7 +6,6 @@
  */
 
 import { useAssistantContext } from '@kbn/elastic-assistant';
-import { useLoadConnectors } from '@kbn/inference-connectors';
 import {
   API_VERSIONS,
   ATTACK_DISCOVERY_GENERATE,
@@ -18,7 +17,7 @@ import { useFetchAnonymizationFields } from '@kbn/elastic-assistant/impl/assista
 
 import { useKibana } from '../../../common/lib/kibana';
 import { getErrorToastText } from '../helpers';
-import { getGenAiConfig, getRequestBody } from './helpers';
+import { getRequestBody } from './helpers';
 import { CONNECTOR_ERROR, ERROR_GENERATING_ATTACK_DISCOVERIES } from '../translations';
 import * as i18n from './translations';
 import { useInvalidateGetAttackDiscoveryGenerations } from '../use_get_attack_discovery_generations';
@@ -55,14 +54,7 @@ export const useAttackDiscovery = ({
   const {
     http,
     notifications: { toasts },
-    settings,
   } = useKibana().services;
-
-  const { data: aiConnectors } = useLoadConnectors({
-    http,
-    featureId: 'attack_discovery',
-    settings,
-  });
 
   // loading boilerplate:
   const [isLoading, setIsLoading] = useState(false);
@@ -86,35 +78,26 @@ export const useAttackDiscovery = ({
         const effectiveStart = options?.overrideStart ?? options?.start;
         const effectiveConnectorId = options?.overrideConnectorId ?? connectorId;
 
-        // Get the request body with the effective connector ID
-        const effectiveConnector = aiConnectors?.find(
-          (connector) => connector.id === effectiveConnectorId
-        );
-        const effectiveGenAiConfig = getGenAiConfig(effectiveConnector);
+        if (!effectiveConnectorId) {
+          throw new Error(CONNECTOR_ERROR);
+        }
+
         const effectiveRequestBody = getRequestBody({
           alertsIndexPattern,
           anonymizationFields,
-          genAiConfig: effectiveGenAiConfig,
+          connectorId: effectiveConnectorId,
           size,
-          selectedConnector: effectiveConnector,
           traceOptions,
         });
 
         const bodyWithOverrides = {
           ...effectiveRequestBody,
-          connectorName: effectiveConnector?.name ?? connectorName,
+          connectorName: connectorName,
           end: effectiveEnd,
           filter: effectiveFilter,
           size: effectiveSize,
           start: effectiveStart,
         };
-
-        if (
-          bodyWithOverrides.apiConfig.connectorId === '' ||
-          bodyWithOverrides.apiConfig.actionTypeId === ''
-        ) {
-          throw new Error(CONNECTOR_ERROR);
-        }
         setLoadingConnectorId?.(effectiveConnectorId ?? null);
 
         // call the API to generate attack discoveries:
@@ -131,7 +114,7 @@ export const useAttackDiscovery = ({
 
         toasts?.addSuccess({
           title: i18n.GENERATION_STARTED_TITLE,
-          text: i18n.GENERATION_STARTED_TEXT(effectiveConnector?.name ?? connectorName),
+          text: i18n.GENERATION_STARTED_TEXT(connectorName),
         });
       } catch (error) {
         setIsLoading(false);
@@ -144,7 +127,6 @@ export const useAttackDiscovery = ({
       }
     },
     [
-      aiConnectors,
       alertsIndexPattern,
       anonymizationFields,
       connectorId,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -92,7 +92,7 @@ export const useAttackDiscovery = ({
 
         const bodyWithOverrides = {
           ...effectiveRequestBody,
-          connectorName: connectorName,
+          connectorName,
           end: effectiveEnd,
           filter: effectiveFilter,
           size: effectiveSize,

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -26,6 +26,7 @@ interface FetchAttackDiscoveriesOptions {
   end?: string;
   filter?: Record<string, unknown>;
   overrideConnectorId?: string;
+  overrideConnectorName?: string;
   overrideEnd?: string;
   overrideFilter?: Record<string, unknown>;
   overrideSize?: number;
@@ -114,7 +115,9 @@ export const useAttackDiscovery = ({
 
         toasts?.addSuccess({
           title: i18n.GENERATION_STARTED_TITLE,
-          text: i18n.GENERATION_STARTED_TEXT(connectorName),
+          text: i18n.GENERATION_STARTED_TEXT(
+            options?.overrideConnectorName ?? connectorName
+          ),
         });
       } catch (error) {
         setIsLoading(false);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/use_attack_discovery/index.tsx
@@ -115,9 +115,7 @@ export const useAttackDiscovery = ({
 
         toasts?.addSuccess({
           title: i18n.GENERATION_STARTED_TITLE,
-          text: i18n.GENERATION_STARTED_TEXT(
-            options?.overrideConnectorName ?? connectorName
-          ),
+          text: i18n.GENERATION_STARTED_TEXT(options?.overrideConnectorName ?? connectorName),
         });
       } catch (error) {
         setIsLoading(false);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/dashboards/task/agent/graph.test.ts
@@ -15,6 +15,7 @@ import { MockDashboardMigrationsRetriever } from '../retrievers/__mocks__/mocks'
 import { getDashboardMigrationAgent } from './graph';
 import type { OriginalDashboard } from '../../../../../../common/siem_migrations/model/dashboard_migration.gen';
 import { elasticsearchServiceMock, httpServerMock } from '@kbn/core/server/mocks';
+import { inferenceMock } from '@kbn/inference-plugin/server/mocks';
 import type { IScopedClusterClient } from '@kbn/core/server';
 import type { ExperimentalFeatures } from '../../../../../../common';
 
@@ -57,16 +58,7 @@ const setupAgent = (responses: NodeResponse[]) => {
     dashboardMigrationsRetriever: mockRetriever,
     logger,
     telemetryClient: mockTelemetryClient,
-    inference: {
-      getClient: jest.fn(),
-      getChatModel: jest.fn(),
-      getConnectorList: jest.fn(),
-      getDefaultConnector: jest.fn(),
-      getConnectorById: jest.fn(),
-      getInferenceEndpoints: jest.fn(),
-      getInferenceEndpointById: jest.fn(),
-      ...model,
-    },
+    inference: inferenceMock.createStartContract(),
     request: httpServerMock.createKibanaRequest(),
     connectorId: 'test-connector',
     experimentalFeatures: { splunkV2DashboardsEnabled: false } as unknown as ExperimentalFeatures,


### PR DESCRIPTION
## Summary

After PR #258530 consolidated connector listing, EIS connectors are returned with inference endpoint IDs (e.g. anthropic-claude-3.7-sonnet- chat_completion) as their connectorId rather than Kibana saved object IDs. Attack Discovery and Defend Insights passed these IDs to ActionsClientLlm which used actionsClient.execute(), failing with "Saved object [action/...] not found".

This PR uses a new path when actionTypeId is .inference and an inference client is available. ActionsClientLlm uses its existing isInferenceEndpoint path which calls inferenceClient.chatComplete() instead of actionsClient.execute().

