### PR TITLE
fix(check-saved-objects): only apply name/title field type check to importable/exportable SO types

### DIFF
--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -260,7 +260,9 @@ export function validateNoIndexOrEnabledFalseInAllMappings(
 export function validateNameTitleFieldTypes(
   name: string,
   to: MigrationInfoRecord,
-  registeredType: SavedObjectsType
+  registeredType: SavedObjectsType,
+  from?: MigrationInfoRecord,
+  log?: (message: string) => void
 ): void {
   // Search API compatibility is only relevant for types that are exposed via the Search API.
   // Hidden types and types that are not importable/exportable are internal-only and exempt.
@@ -268,21 +270,61 @@ export function validateNameTitleFieldTypes(
     return;
   }
 
-  const invalidFields: string[] = [];
+  const invalidFields: Array<{ fieldName: string; description: string }> = [];
 
   if ('properties.name.type' in to.mappings && to.mappings['properties.name.type'] !== 'text') {
-    invalidFields.push(`name (type: ${to.mappings['properties.name.type']}, expected: text)`);
+    invalidFields.push({
+      fieldName: 'name',
+      description: `name (type: ${to.mappings['properties.name.type']}, expected: text)`,
+    });
   }
 
   if ('properties.title.type' in to.mappings && to.mappings['properties.title.type'] !== 'text') {
-    invalidFields.push(`title (type: ${to.mappings['properties.title.type']}, expected: text)`);
+    invalidFields.push({
+      fieldName: 'title',
+      description: `title (type: ${to.mappings['properties.title.type']}, expected: text)`,
+    });
   }
 
-  if (invalidFields.length > 0) {
-    throw new Error(
-      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields.join(
-        ', '
-      )}. ` + `These fields must be of type 'text' for Search API compatibility.`
-    );
+  if (invalidFields.length === 0) {
+    return;
   }
+
+  // When a baseline is available, distinguish pre-existing issues (warn) from newly introduced
+  // ones (fail). A field type cannot be changed from 'keyword' to 'text' without reindexing,
+  // so there is nothing the developer can do if the incorrect type was shipped in a previous
+  // model version.
+  if (from) {
+    const preExisting = invalidFields.filter(
+      ({ fieldName }) => `properties.${fieldName}.type` in from.mappings
+    );
+    const newlyIntroduced = invalidFields.filter(
+      ({ fieldName }) => !(`properties.${fieldName}.type` in from.mappings)
+    );
+
+    if (preExisting.length > 0) {
+      log?.(
+        `⚠️  The SO type '${name}' has pre-existing 'name' or 'title' fields with incorrect types: ${preExisting
+          .map(({ description }) => description)
+          .join(', ')}. ` +
+          `These fields must be of type 'text' for Search API compatibility, but cannot be changed without reindexing existing data.`
+      );
+    }
+
+    if (newlyIntroduced.length > 0) {
+      throw new Error(
+        `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${newlyIntroduced
+          .map(({ description }) => description)
+          .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
+      );
+    }
+
+    return;
+  }
+
+  throw new Error(
+    `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
+      .map(({ description }) => description)
+      .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
+  );
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -261,7 +261,7 @@ export function validateNoIndexOrEnabledFalseInAllMappings(
  * Returns the invalid name/title fields for a given mapping snapshot, expressed as
  * `{ fieldName, description }` pairs. The caller decides whether to warn or throw.
  */
-function getInvalidNameTitleFields(
+export function getInvalidNameTitleFields(
   to: MigrationInfoRecord
 ): Array<{ fieldName: string; description: string }> {
   const invalidFields: Array<{ fieldName: string; description: string }> = [];
@@ -289,80 +289,7 @@ function getInvalidNameTitleFields(
  * explicitly `true` (the registry treats the absence of the flag as `false`). Only those types
  * need their `name`/`title` fields to be `type: text` for full-text search to work correctly.
  */
-function isSearchableViaManagement(registeredType: SavedObjectsType): boolean {
+export function isSearchableViaManagement(registeredType: SavedObjectsType): boolean {
   return registeredType.management?.importableAndExportable === true;
 }
 
-/**
- * Validates that `name` and `title` mapping fields use `type: text` on a **new** SO type being
- * introduced. Types that are not searchable via the management page are exempt.
- *
- * Throws if an incorrect field type is found.
- */
-export function validateNameTitleFieldTypesNewType(
-  name: string,
-  to: MigrationInfoRecord,
-  registeredType: SavedObjectsType
-): void {
-  if (!isSearchableViaManagement(registeredType)) {
-    return;
-  }
-
-  const invalidFields = getInvalidNameTitleFields(to);
-  if (invalidFields.length > 0) {
-    throw new Error(
-      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
-        .map(({ description }) => description)
-        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
-    );
-  }
-}
-
-/**
- * Validates that `name` and `title` mapping fields use `type: text` on an **existing** SO type.
- * Types that are not searchable via the management page are exempt.
- *
- * A field type cannot be changed from 'keyword' to 'text' without reindexing, so when a field
- * with an incorrect type was already present in the baseline (`from`), a warning is emitted
- * instead of throwing. Only fields newly introduced with the wrong type cause a hard failure.
- */
-export function validateNameTitleFieldTypesExistingType(
-  name: string,
-  to: MigrationInfoRecord,
-  from: MigrationInfoRecord,
-  registeredType: SavedObjectsType,
-  log: (message: string) => void
-): void {
-  if (!isSearchableViaManagement(registeredType)) {
-    return;
-  }
-
-  const invalidFields = getInvalidNameTitleFields(to);
-  if (invalidFields.length === 0) {
-    return;
-  }
-
-  const preExisting = invalidFields.filter(
-    ({ fieldName }) => `properties.${fieldName}.type` in from.mappings
-  );
-  const newlyIntroduced = invalidFields.filter(
-    ({ fieldName }) => !(`properties.${fieldName}.type` in from.mappings)
-  );
-
-  if (preExisting.length > 0) {
-    log(
-      `⚠️  The SO type '${name}' has pre-existing 'name' or 'title' fields with incorrect types: ${preExisting
-        .map(({ description }) => description)
-        .join(', ')}. ` +
-        `These fields must be of type 'text' for Search API compatibility, but cannot be changed without reindexing existing data.`
-    );
-  }
-
-  if (newlyIntroduced.length > 0) {
-    throw new Error(
-      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${newlyIntroduced
-        .map(({ description }) => description)
-        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
-    );
-  }
-}

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -257,7 +257,17 @@ export function validateNoIndexOrEnabledFalseInAllMappings(
   throwIfIndexOrEnabledFalse(name, fieldsWithIndexFalse, fieldsWithEnabledFalse);
 }
 
-export function validateNameTitleFieldTypes(name: string, to: MigrationInfoRecord): void {
+export function validateNameTitleFieldTypes(
+  name: string,
+  to: MigrationInfoRecord,
+  registeredType: SavedObjectsType
+): void {
+  // Search API compatibility is only relevant for types that are exposed via the Search API.
+  // Hidden types and types that are not importable/exportable are internal-only and exempt.
+  if (registeredType.hidden || registeredType.management?.importableAndExportable === false) {
+    return;
+  }
+
   const invalidFields: string[] = [];
 
   if ('properties.name.type' in to.mappings && to.mappings['properties.name.type'] !== 'text') {

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -292,4 +292,3 @@ export function getInvalidNameTitleFields(
 export function isSearchableViaManagement(registeredType: SavedObjectsType): boolean {
   return registeredType.management?.importableAndExportable === true;
 }
-

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/common_utils.ts
@@ -257,19 +257,13 @@ export function validateNoIndexOrEnabledFalseInAllMappings(
   throwIfIndexOrEnabledFalse(name, fieldsWithIndexFalse, fieldsWithEnabledFalse);
 }
 
-export function validateNameTitleFieldTypes(
-  name: string,
-  to: MigrationInfoRecord,
-  registeredType: SavedObjectsType,
-  from?: MigrationInfoRecord,
-  log?: (message: string) => void
-): void {
-  // Search API compatibility is only relevant for types that are exposed via the Search API.
-  // Hidden types and types that are not importable/exportable are internal-only and exempt.
-  if (registeredType.hidden || registeredType.management?.importableAndExportable === false) {
-    return;
-  }
-
+/**
+ * Returns the invalid name/title fields for a given mapping snapshot, expressed as
+ * `{ fieldName, description }` pairs. The caller decides whether to warn or throw.
+ */
+function getInvalidNameTitleFields(
+  to: MigrationInfoRecord
+): Array<{ fieldName: string; description: string }> {
   const invalidFields: Array<{ fieldName: string; description: string }> = [];
 
   if ('properties.name.type' in to.mappings && to.mappings['properties.name.type'] !== 'text') {
@@ -286,45 +280,89 @@ export function validateNameTitleFieldTypes(
     });
   }
 
+  return invalidFields;
+}
+
+/**
+ * Returns true when the SO type participates in the Saved Objects management page search.
+ * The management find route queries only types whose `management.importableAndExportable` is
+ * explicitly `true` (the registry treats the absence of the flag as `false`). Only those types
+ * need their `name`/`title` fields to be `type: text` for full-text search to work correctly.
+ */
+function isSearchableViaManagement(registeredType: SavedObjectsType): boolean {
+  return registeredType.management?.importableAndExportable === true;
+}
+
+/**
+ * Validates that `name` and `title` mapping fields use `type: text` on a **new** SO type being
+ * introduced. Types that are not searchable via the management page are exempt.
+ *
+ * Throws if an incorrect field type is found.
+ */
+export function validateNameTitleFieldTypesNewType(
+  name: string,
+  to: MigrationInfoRecord,
+  registeredType: SavedObjectsType
+): void {
+  if (!isSearchableViaManagement(registeredType)) {
+    return;
+  }
+
+  const invalidFields = getInvalidNameTitleFields(to);
+  if (invalidFields.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
+        .map(({ description }) => description)
+        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
+    );
+  }
+}
+
+/**
+ * Validates that `name` and `title` mapping fields use `type: text` on an **existing** SO type.
+ * Types that are not searchable via the management page are exempt.
+ *
+ * A field type cannot be changed from 'keyword' to 'text' without reindexing, so when a field
+ * with an incorrect type was already present in the baseline (`from`), a warning is emitted
+ * instead of throwing. Only fields newly introduced with the wrong type cause a hard failure.
+ */
+export function validateNameTitleFieldTypesExistingType(
+  name: string,
+  to: MigrationInfoRecord,
+  from: MigrationInfoRecord,
+  registeredType: SavedObjectsType,
+  log: (message: string) => void
+): void {
+  if (!isSearchableViaManagement(registeredType)) {
+    return;
+  }
+
+  const invalidFields = getInvalidNameTitleFields(to);
   if (invalidFields.length === 0) {
     return;
   }
 
-  // When a baseline is available, distinguish pre-existing issues (warn) from newly introduced
-  // ones (fail). A field type cannot be changed from 'keyword' to 'text' without reindexing,
-  // so there is nothing the developer can do if the incorrect type was shipped in a previous
-  // model version.
-  if (from) {
-    const preExisting = invalidFields.filter(
-      ({ fieldName }) => `properties.${fieldName}.type` in from.mappings
+  const preExisting = invalidFields.filter(
+    ({ fieldName }) => `properties.${fieldName}.type` in from.mappings
+  );
+  const newlyIntroduced = invalidFields.filter(
+    ({ fieldName }) => !(`properties.${fieldName}.type` in from.mappings)
+  );
+
+  if (preExisting.length > 0) {
+    log(
+      `⚠️  The SO type '${name}' has pre-existing 'name' or 'title' fields with incorrect types: ${preExisting
+        .map(({ description }) => description)
+        .join(', ')}. ` +
+        `These fields must be of type 'text' for Search API compatibility, but cannot be changed without reindexing existing data.`
     );
-    const newlyIntroduced = invalidFields.filter(
-      ({ fieldName }) => !(`properties.${fieldName}.type` in from.mappings)
-    );
-
-    if (preExisting.length > 0) {
-      log?.(
-        `⚠️  The SO type '${name}' has pre-existing 'name' or 'title' fields with incorrect types: ${preExisting
-          .map(({ description }) => description)
-          .join(', ')}. ` +
-          `These fields must be of type 'text' for Search API compatibility, but cannot be changed without reindexing existing data.`
-      );
-    }
-
-    if (newlyIntroduced.length > 0) {
-      throw new Error(
-        `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${newlyIntroduced
-          .map(({ description }) => description)
-          .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
-      );
-    }
-
-    return;
   }
 
-  throw new Error(
-    `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
-      .map(({ description }) => description)
-      .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
-  );
+  if (newlyIntroduced.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${newlyIntroduced
+        .map(({ description }) => description)
+        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
+    );
+  }
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
@@ -235,20 +235,21 @@ describe('validateChangesExistingType', () => {
       mappings,
     });
 
-    const nonHiddenType: SavedObjectsType = {
+    const importableExportableType: SavedObjectsType = {
       name: 'my-type',
       namespaceType: 'agnostic',
       hidden: false,
+      management: { importableAndExportable: true },
       mappings: { dynamic: false, properties: {} },
       modelVersions: {},
-    };
+    } as unknown as SavedObjectsType;
 
     it('should warn (not throw) when name or title field was already keyword in a previous model version', () => {
       const from = buildRecord({ 'properties.name.type': 'keyword' });
       const to = buildRecord({ 'properties.name.type': 'keyword' });
 
       expect(() =>
-        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+        validateChangesExistingType({ from, to, registeredType: importableExportableType, log })
       ).not.toThrow();
       expect(log).toHaveBeenCalledWith(
         expect.stringContaining("pre-existing 'name' or 'title' fields with incorrect types")
@@ -261,7 +262,7 @@ describe('validateChangesExistingType', () => {
       const to = buildRecord({ 'properties.name.type': 'keyword' });
 
       expect(() =>
-        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+        validateChangesExistingType({ from, to, registeredType: importableExportableType, log })
       ).toThrowError(
         /The SO type 'my-type' has 'name' or 'title' fields with incorrect types.*name \(type: keyword, expected: text\)/
       );
@@ -275,9 +276,29 @@ describe('validateChangesExistingType', () => {
       });
 
       expect(() =>
-        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+        validateChangesExistingType({ from, to, registeredType: importableExportableType, log })
       ).toThrowError(/name \(type: keyword, expected: text\)/);
       expect(log).toHaveBeenCalledWith(expect.stringContaining('title (type: keyword'));
+    });
+
+    it('should not validate types not searchable via the management page', () => {
+      const internalType: SavedObjectsType = {
+        name: 'my-type',
+        namespaceType: 'agnostic',
+        hidden: false,
+        management: { importableAndExportable: false },
+        mappings: { dynamic: false, properties: {} },
+        modelVersions: {},
+      } as unknown as SavedObjectsType;
+      // Use the same keyword mapping in both from and to so that the model-version check does not
+      // fire — we only want to verify that the name/title check is skipped for internal types.
+      const from = buildRecord({ 'properties.name.type': 'keyword' });
+      const to = buildRecord({ 'properties.name.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: internalType, log })
+      ).not.toThrow();
+      expect(log).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.test.ts
@@ -12,7 +12,7 @@ import fs from 'fs';
 import { schema } from '@kbn/config-schema';
 import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
 import { validateChangesExistingType } from './existing_type';
-import type { MigrationSnapshot } from '../../types';
+import type { MigrationInfoRecord, MigrationSnapshot } from '../../types';
 
 function loadSnapshot(filename: string): MigrationSnapshot {
   const filePath = path.join(__dirname, '..', 'mocks', filename);
@@ -214,5 +214,70 @@ describe('validateChangesExistingType', () => {
     expect(() => validateChangesWrapper({ from, to, type: { name: 'task' } })).toThrowError(
       /The SO type 'task' has new mapping fields with 'enabled: false': fieldWithEnabledFalse/
     );
+  });
+
+  describe('name/title field type validation', () => {
+    const sharedModelVersion = {
+      version: '1',
+      modelVersionHash: 'hash',
+      changeTypes: [],
+      hasTransformation: false,
+      newMappings: [],
+      schemas: { create: 'hash', forwardCompatibility: 'hash' },
+    };
+
+    const buildRecord = (mappings: Record<string, unknown> = {}): MigrationInfoRecord => ({
+      name: 'my-type',
+      hash: 'hash',
+      migrationVersions: [],
+      schemaVersions: [],
+      modelVersions: [sharedModelVersion],
+      mappings,
+    });
+
+    const nonHiddenType: SavedObjectsType = {
+      name: 'my-type',
+      namespaceType: 'agnostic',
+      hidden: false,
+      mappings: { dynamic: false, properties: {} },
+      modelVersions: {},
+    };
+
+    it('should warn (not throw) when name or title field was already keyword in a previous model version', () => {
+      const from = buildRecord({ 'properties.name.type': 'keyword' });
+      const to = buildRecord({ 'properties.name.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+      ).not.toThrow();
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining("pre-existing 'name' or 'title' fields with incorrect types")
+      );
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('name (type: keyword'));
+    });
+
+    it('should throw when a name or title field is newly introduced with wrong type', () => {
+      const from = buildRecord({});
+      const to = buildRecord({ 'properties.name.type': 'keyword' });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+      ).toThrowError(
+        /The SO type 'my-type' has 'name' or 'title' fields with incorrect types.*name \(type: keyword, expected: text\)/
+      );
+    });
+
+    it('should warn for pre-existing fields and throw for newly introduced ones in the same type', () => {
+      const from = buildRecord({ 'properties.title.type': 'keyword' });
+      const to = buildRecord({
+        'properties.name.type': 'keyword',
+        'properties.title.type': 'keyword',
+      });
+
+      expect(() =>
+        validateChangesExistingType({ from, to, registeredType: nonHiddenType, log })
+      ).toThrowError(/name \(type: keyword, expected: text\)/);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('title (type: keyword'));
+    });
   });
 });

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
@@ -62,7 +62,7 @@ export function validateChangesExistingType({
   validateModelVersionNumbers(name, to.modelVersions);
 
   // validate that name and title fields are of type "text"
-  validateNameTitleFieldTypes(name, to, registeredType);
+  validateNameTitleFieldTypes(name, to, registeredType, from, log);
 
   const newModelVersionCount = to.modelVersions.length - from.modelVersions.length;
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
@@ -62,7 +62,7 @@ export function validateChangesExistingType({
   validateModelVersionNumbers(name, to.modelVersions);
 
   // validate that name and title fields are of type "text"
-  validateNameTitleFieldTypes(name, to);
+  validateNameTitleFieldTypes(name, to, registeredType);
 
   const newModelVersionCount = to.modelVersions.length - from.modelVersions.length;
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
@@ -13,7 +13,6 @@ import type { MigrationInfoRecord } from '../../types';
 import {
   validateNewModelVersionSchemas,
   validateModelVersionNumbers,
-  validateNameTitleFieldTypesExistingType,
   validateNoIndexOrEnabledFalse,
   getLatestModelVersion,
   validateInitialModelVersion,
@@ -23,6 +22,7 @@ import {
   validateNoModelVersionChanges,
   validateModelVersionsChanges,
   validateNewMappingsInModelVersion,
+  validateNameTitleFieldTypesExistingType,
 } from './existing_type_utils';
 
 interface ValidateChangesExistingTypeParams {

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type.ts
@@ -13,7 +13,7 @@ import type { MigrationInfoRecord } from '../../types';
 import {
   validateNewModelVersionSchemas,
   validateModelVersionNumbers,
-  validateNameTitleFieldTypes,
+  validateNameTitleFieldTypesExistingType,
   validateNoIndexOrEnabledFalse,
   getLatestModelVersion,
   validateInitialModelVersion,
@@ -62,7 +62,7 @@ export function validateChangesExistingType({
   validateModelVersionNumbers(name, to.modelVersions);
 
   // validate that name and title fields are of type "text"
-  validateNameTitleFieldTypes(name, to, registeredType, from, log);
+  validateNameTitleFieldTypesExistingType(name, to, from, registeredType, log);
 
   const newModelVersionCount = to.modelVersions.length - from.modelVersions.length;
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/existing_type_utils.ts
@@ -15,6 +15,8 @@ import {
   getMappingFieldPaths,
   validateAllMappingsInModelVersion,
   getLatestModelVersion,
+  getInvalidNameTitleFields,
+  isSearchableViaManagement,
 } from './common_utils';
 
 export function mappingsUpdated(
@@ -150,6 +152,55 @@ export function validateNewMappingsInModelVersion(
         newModelVersion.version
       }': ${undeclaredFields.join(', ')}. ` +
         `All new mapping fields must be declared via 'mappings_addition' changes in the corresponding model version.`
+    );
+  }
+}
+
+/**
+ * Validates that `name` and `title` mapping fields use `type: text` on an **existing** SO type.
+ * Types that are not searchable via the management page are exempt.
+ *
+ * A field type cannot be changed from 'keyword' to 'text' without reindexing, so when a field
+ * with an incorrect type was already present in the baseline (`from`), a warning is emitted
+ * instead of throwing. Only fields newly introduced with the wrong type cause a hard failure.
+ */
+export function validateNameTitleFieldTypesExistingType(
+  name: string,
+  to: MigrationInfoRecord,
+  from: MigrationInfoRecord,
+  registeredType: SavedObjectsType,
+  log: (message: string) => void
+): void {
+  if (!isSearchableViaManagement(registeredType)) {
+    return;
+  }
+
+  const invalidFields = getInvalidNameTitleFields(to);
+  if (invalidFields.length === 0) {
+    return;
+  }
+
+  const preExisting = invalidFields.filter(
+    ({ fieldName }) => `properties.${fieldName}.type` in from.mappings
+  );
+  const newlyIntroduced = invalidFields.filter(
+    ({ fieldName }) => !(`properties.${fieldName}.type` in from.mappings)
+  );
+
+  if (preExisting.length > 0) {
+    log(
+      `⚠️  The SO type '${name}' has pre-existing 'name' or 'title' fields with incorrect types: ${preExisting
+        .map(({ description }) => description)
+        .join(', ')}. ` +
+        `These fields must be of type 'text' for Search API compatibility, but cannot be changed without reindexing existing data.`
+    );
+  }
+
+  if (newlyIntroduced.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${newlyIntroduced
+        .map(({ description }) => description)
+        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
     );
   }
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
@@ -25,6 +25,7 @@ function createMockType(name: string, schemaFields: string[]): SavedObjectsType 
     name,
     namespaceType: 'agnostic',
     hidden: false,
+    management: { importableAndExportable: true },
     mappings: { dynamic: false, properties: {} },
     modelVersions: {
       1: {
@@ -248,28 +249,35 @@ describe('validateChangesNewType', () => {
     expect(() => callValidate(to, createMockType('my-type', ['name']))).not.toThrow();
   });
 
-  it('should not throw when the type is hidden, even if name field has non-text type', () => {
-    const to = buildNewType('my-hidden-type', {
-      mappings: { 'properties.name.type': 'keyword' },
-    });
-    const hiddenType = {
-      ...createMockType('my-hidden-type', ['name']),
-      hidden: true,
-    } as unknown as SavedObjectsType;
-
-    expect(() => callValidate(to, hiddenType)).not.toThrow();
-  });
-
-  it('should not throw for non-importable/exportable types, even if name field has non-text type', () => {
+  it('should not throw for types not searchable via the management page, even if name field has non-text type', () => {
     const to = buildNewType('my-internal-type', {
       mappings: { 'properties.name.type': 'keyword' },
     });
+    // importableAndExportable: false is the exemption criterion — the management find route
+    // only searches types with importableAndExportable: true
     const internalType = {
       ...createMockType('my-internal-type', ['name']),
       management: { importableAndExportable: false },
     } as unknown as SavedObjectsType;
 
     expect(() => callValidate(to, internalType)).not.toThrow();
+  });
+
+  it('should throw for hidden types that are also importable/exportable, if name field has non-text type', () => {
+    // Hidden types that are also importableAndExportable: true DO appear in the management
+    // find route (via includedHiddenTypes), so they are subject to the same validation.
+    const to = buildNewType('my-hidden-exportable-type', {
+      mappings: { 'properties.name.type': 'keyword' },
+    });
+    const hiddenExportableType = {
+      ...createMockType('my-hidden-exportable-type', ['name']),
+      hidden: true,
+      management: { importableAndExportable: true },
+    } as unknown as SavedObjectsType;
+
+    expect(() => callValidate(to, hiddenExportableType)).toThrow(
+      /The SO type 'my-hidden-exportable-type' has 'name' or 'title' fields with incorrect types/
+    );
   });
 
   it('should not throw when mapping has nested fields that match schema (path format normalization)', () => {

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.test.ts
@@ -248,6 +248,30 @@ describe('validateChangesNewType', () => {
     expect(() => callValidate(to, createMockType('my-type', ['name']))).not.toThrow();
   });
 
+  it('should not throw when the type is hidden, even if name field has non-text type', () => {
+    const to = buildNewType('my-hidden-type', {
+      mappings: { 'properties.name.type': 'keyword' },
+    });
+    const hiddenType = {
+      ...createMockType('my-hidden-type', ['name']),
+      hidden: true,
+    } as unknown as SavedObjectsType;
+
+    expect(() => callValidate(to, hiddenType)).not.toThrow();
+  });
+
+  it('should not throw for non-importable/exportable types, even if name field has non-text type', () => {
+    const to = buildNewType('my-internal-type', {
+      mappings: { 'properties.name.type': 'keyword' },
+    });
+    const internalType = {
+      ...createMockType('my-internal-type', ['name']),
+      management: { importableAndExportable: false },
+    } as unknown as SavedObjectsType;
+
+    expect(() => callValidate(to, internalType)).not.toThrow();
+  });
+
   it('should not throw when mapping has nested fields that match schema (path format normalization)', () => {
     const snapshot = loadSnapshot('nested_mapping_fields.json');
 

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
@@ -13,7 +13,7 @@ import {
   validateAllMappingsInModelVersion,
   validateNewModelVersionSchemas,
   validateModelVersionNumbers,
-  validateNameTitleFieldTypes,
+  validateNameTitleFieldTypesNewType,
   validateNoIndexOrEnabledFalseInAllMappings,
   getLatestModelVersion,
   validateInitialModelVersion,
@@ -52,5 +52,5 @@ export function validateChangesNewType({ to, registeredType }: ValidateChangesNe
   validateNoIndexOrEnabledFalseInAllMappings(name, to);
 
   // validate that name and title fields are of type "text"
-  validateNameTitleFieldTypes(name, to, registeredType);
+  validateNameTitleFieldTypesNewType(name, to, registeredType);
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
@@ -52,5 +52,5 @@ export function validateChangesNewType({ to, registeredType }: ValidateChangesNe
   validateNoIndexOrEnabledFalseInAllMappings(name, to);
 
   // validate that name and title fields are of type "text"
-  validateNameTitleFieldTypes(name, to);
+  validateNameTitleFieldTypes(name, to, registeredType);
 }

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type.ts
@@ -13,12 +13,12 @@ import {
   validateAllMappingsInModelVersion,
   validateNewModelVersionSchemas,
   validateModelVersionNumbers,
-  validateNameTitleFieldTypesNewType,
   validateNoIndexOrEnabledFalseInAllMappings,
   getLatestModelVersion,
   validateInitialModelVersion,
   getFirstModelVersion,
 } from './common_utils';
+import { validateNameTitleFieldTypesNewType } from './new_type_utils';
 
 interface ValidateChangesNewTypeParams {
   to: MigrationInfoRecord;

--- a/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
+++ b/packages/kbn-check-saved-objects-cli/src/snapshots/validate_changes/new_type_utils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { SavedObjectsType } from '@kbn/core-saved-objects-server';
+import type { MigrationInfoRecord } from '../../types';
+import { getInvalidNameTitleFields, isSearchableViaManagement } from './common_utils';
+
+/**
+ * Validates that `name` and `title` mapping fields use `type: text` on a **new** SO type being
+ * introduced. Types that are not searchable via the management page are exempt.
+ *
+ * Throws if an incorrect field type is found.
+ */
+export function validateNameTitleFieldTypesNewType(
+  name: string,
+  to: MigrationInfoRecord,
+  registeredType: SavedObjectsType
+): void {
+  if (!isSearchableViaManagement(registeredType)) {
+    return;
+  }
+
+  const invalidFields = getInvalidNameTitleFields(to);
+  if (invalidFields.length > 0) {
+    throw new Error(
+      `❌ The SO type '${name}' has 'name' or 'title' fields with incorrect types: ${invalidFields
+        .map(({ description }) => description)
+        .join(', ')}. ` + `These fields must be of type 'text' for Search API compatibility.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/3162

The \`validateNameTitleFieldTypes\` check in \`kbn-check-saved-objects-cli\` enforces that any SO type with a \`name\` or \`title\` mapping field must use \`type: text\`, citing Search API compatibility. There are two distinct cases where the check was incorrect:

### Case 1: Types not searchable via the management page

The check was applied unconditionally to all SO types, but the Saved Objects management page search only queries types where \`management.importableAndExportable === true\`. The registry treats the absence of that flag as \`false\`, so types without it set are never included in management search and the full-text requirement does not apply to them.

Flagging such types also creates pressure to change \`keyword\` → \`text\`, which is a **breaking Elasticsearch mapping change** (reindex required) that is entirely unnecessary.

Note: the \`hidden\` flag alone is **not** the right exemption criterion — the management find route explicitly includes hidden types that are also \`importableAndExportable: true\` (via \`includedHiddenTypes\`), so those remain subject to the check.

### Case 2: Pre-existing keyword fields from shipped model versions

Even for importable/exportable types, if \`name\` or \`title\` was already shipped as \`keyword\` in a previous model version, **there is nothing the developer can do to fix it** without a full reindex. Failing the CI check in this case blocks the PR with no actionable resolution.

## Changes

- Split \`validateNameTitleFieldTypes\` into two focused functions:
  - \`validateNameTitleFieldTypesNewType\` (in \`new_type_utils.ts\`) — throws for any wrong field type on importable/exportable types; no baseline exists for new types so the full error always applies
  - \`validateNameTitleFieldTypesExistingType\` (in \`existing_type_utils.ts\`) — warns for pre-existing wrong field types, fails only for newly introduced ones
- Shared helpers \`getInvalidNameTitleFields\` and \`isSearchableViaManagement\` extracted to \`common_utils.ts\`
- Exemption condition uses \`!== true\` (not \`=== false\`) to also cover types where \`management\` is absent, matching the registry's \`?? false\` default
- \`createMockType\` in tests now defaults to \`importableAndExportable: true\` so the positive (participates-in-management-search) path is exercised correctly
- Tests updated: exemption test covers \`importableAndExportable: false\`; a new test confirms that hidden types with \`importableAndExportable: true\` are still subject to the check

## Context

This was first surfaced by https://github.com/elastic/kibana/pull/260095, which adds model version 2 to \`gap_auto_fill_scheduler\` — a type with \`importableAndExportable\` not set to \`true\` and a pre-existing \`name: keyword\` mapping from model version 1.

## Test plan

- [ ] Existing tests in \`new_type.test.ts\` still pass
- [ ] Tests in \`existing_type.test.ts\` confirm: warning for pre-existing keyword fields, fail for newly introduced ones, exempt for non-importable/exportable types, and fail for hidden types that are importable/exportable