### PR TITLE
[Streams] Show stream description for all users

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.test.tsx
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { Streams } from '@kbn/streams-schema';
+import { I18nProvider } from '@kbn/i18n-react';
+import { StreamDescription } from './stream_description';
+import type { AIFeatures } from '../../../hooks/use_ai_features';
+
+const mockUseStreamDescriptionApi = jest.fn();
+
+jest.mock('./stream_description/use_stream_description_api', () => ({
+  useStreamDescriptionApi: (...args: unknown[]) => mockUseStreamDescriptionApi(...args),
+}));
+
+jest.mock('./stream_description/description_generation_control', () => ({
+  DescriptionGenerationControl: () => <button type="button">Generate description mock</button>,
+}));
+
+jest.mock(
+  '../../stream_management/data_management/stream_detail_management/advanced_view/row',
+  () => ({
+    Row: ({ left, right }: { left: React.ReactNode; right: React.ReactNode }) => (
+      <div>
+        <div data-testid="row-left">{left}</div>
+        <div data-testid="row-right">{right}</div>
+      </div>
+    ),
+  })
+);
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+const createMockDefinition = (description?: string): Streams.all.GetResponse =>
+  ({
+    stream: {
+      name: 'logs-test',
+      description: description || '',
+    },
+    privileges: { manage: true, simulate: true, read: true },
+  } as unknown as Streams.all.GetResponse);
+
+const mockAiFeatures: AIFeatures = {
+  loading: false,
+  enabled: true,
+  couldBeEnabled: true,
+  genAiConnectors: { selectedConnector: 'test-connector' } as AIFeatures['genAiConnectors'],
+  isManagedAIConnector: false,
+  hasAcknowledgedAdditionalCharges: true,
+  acknowledgeAdditionalCharges: jest.fn(),
+};
+
+const defaultApiReturn = {
+  description: '',
+  setDescription: jest.fn(),
+  isUpdating: false,
+  isEditing: false,
+  onCancelEdit: jest.fn(),
+  onStartEditing: jest.fn(),
+  onSaveDescription: jest.fn(),
+  isTaskLoading: false,
+  task: undefined,
+  taskError: null,
+  refreshTask: jest.fn(),
+  getDescriptionGenerationStatus: jest.fn().mockResolvedValue({ status: 'not_started' }),
+  scheduleDescriptionGenerationTask: jest.fn(),
+  cancelDescriptionGenerationTask: jest.fn(),
+  acknowledgeDescriptionGenerationTask: jest.fn(),
+  areButtonsDisabled: false,
+};
+
+describe('StreamDescription', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStreamDescriptionApi.mockReturnValue(defaultApiReturn);
+  });
+
+  it('should render the panel title', () => {
+    renderWithProviders(
+      <StreamDescription
+        definition={createMockDefinition()}
+        refreshDefinition={jest.fn()}
+        aiFeatures={null}
+      />
+    );
+
+    expect(screen.getByText('Stream description')).toBeInTheDocument();
+  });
+
+  it('should show the "Enter manually" button when there is no description and not editing', () => {
+    renderWithProviders(
+      <StreamDescription
+        definition={createMockDefinition()}
+        refreshDefinition={jest.fn()}
+        aiFeatures={null}
+      />
+    );
+
+    expect(screen.getByText('Enter manually')).toBeInTheDocument();
+  });
+
+  describe('without AI features', () => {
+    it('should NOT show the generate description button', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={null}
+        />
+      );
+
+      expect(screen.queryByText('Generate description mock')).not.toBeInTheDocument();
+    });
+
+    it('should show only the basic help text', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={null}
+        />
+      );
+
+      expect(
+        screen.getByText('A natural language description of the data in this stream.')
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/AI workflows/)).not.toBeInTheDocument();
+    });
+
+    it('should pass enableGeneration=false to the API hook', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={null}
+        />
+      );
+
+      expect(mockUseStreamDescriptionApi).toHaveBeenCalledWith(
+        expect.objectContaining({ enableGeneration: false })
+      );
+    });
+
+    it('should show the markdown editor when there is an existing description', () => {
+      mockUseStreamDescriptionApi.mockReturnValue({
+        ...defaultApiReturn,
+        description: 'Test description',
+      });
+
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition('Test description')}
+          refreshDefinition={jest.fn()}
+          aiFeatures={null}
+        />
+      );
+
+      expect(screen.queryByText('Enter manually')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with AI features', () => {
+    it('should show the generate description button when no description exists', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={mockAiFeatures}
+        />
+      );
+
+      expect(screen.getByText('Generate description mock')).toBeInTheDocument();
+    });
+
+    it('should show the AI help text', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={mockAiFeatures}
+        />
+      );
+
+      expect(screen.getByText(/AI workflows/)).toBeInTheDocument();
+    });
+
+    it('should pass enableGeneration=true to the API hook', () => {
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={mockAiFeatures}
+        />
+      );
+
+      expect(mockUseStreamDescriptionApi).toHaveBeenCalledWith(
+        expect.objectContaining({ enableGeneration: true })
+      );
+    });
+
+    it('should not show the generate description button when AI features are absent and description exists', () => {
+      mockUseStreamDescriptionApi.mockReturnValue({
+        ...defaultApiReturn,
+        description: 'Test description',
+        isEditing: true,
+      });
+
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition('Test description')}
+          refreshDefinition={jest.fn()}
+          aiFeatures={null}
+        />
+      );
+
+      expect(screen.queryByText('Generate description mock')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.test.tsx
@@ -148,6 +148,26 @@ describe('StreamDescription', () => {
       );
     });
 
+    it('should pass enableGeneration=false when aiFeatures is present but not enabled', () => {
+      const disabledAiFeatures: AIFeatures = {
+        ...mockAiFeatures,
+        enabled: false,
+      };
+
+      renderWithProviders(
+        <StreamDescription
+          definition={createMockDefinition()}
+          refreshDefinition={jest.fn()}
+          aiFeatures={disabledAiFeatures}
+        />
+      );
+
+      expect(mockUseStreamDescriptionApi).toHaveBeenCalledWith(
+        expect.objectContaining({ enableGeneration: false })
+      );
+      expect(screen.queryByText('Generate description mock')).not.toBeInTheDocument();
+    });
+
     it('should show the markdown editor when there is an existing description', () => {
       mockUseStreamDescriptionApi.mockReturnValue({
         ...defaultApiReturn,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.tsx
@@ -38,8 +38,15 @@ const STREAM_DESCRIPTION_PANEL_TITLE = i18n.translate(
 const STREAM_DESCRIPTION_HELP = i18n.translate(
   'xpack.streams.streamDetailView.streamDescription.helpText',
   {
+    defaultMessage: 'A natural language description of the data in this stream.',
+  }
+);
+
+const STREAM_DESCRIPTION_AI_HELP = i18n.translate(
+  'xpack.streams.streamDetailView.streamDescription.aiHelpText',
+  {
     defaultMessage:
-      'This is a natural language description of your data. This will be used in AI workflows like feature identification and significant event generation. Generation uses the last 24 hours of data.',
+      'This will be used in AI workflows like feature identification and significant event generation. Generation uses the last 24 hours of data.',
   }
 );
 
@@ -83,6 +90,7 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
   refreshDefinition,
   aiFeatures,
 }) => {
+  const hasAiFeatures = aiFeatures !== null;
   const {
     description,
     isUpdating,
@@ -99,7 +107,11 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
     scheduleDescriptionGenerationTask,
     cancelDescriptionGenerationTask,
     areButtonsDisabled,
-  } = useStreamDescriptionApi({ definition, refreshDefinition });
+  } = useStreamDescriptionApi({ definition, refreshDefinition, enableGeneration: hasAiFeatures });
+
+  const helpText = hasAiFeatures
+    ? `${STREAM_DESCRIPTION_HELP} ${STREAM_DESCRIPTION_AI_HELP}`
+    : STREAM_DESCRIPTION_HELP;
 
   return (
     <EuiPanel hasBorder={true} hasShadow={false} paddingSize="none" grow={false}>
@@ -112,7 +124,7 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
         {definition.stream.description || description || isEditing ? (
           <EuiFlexGroup direction="column" gutterSize="m">
             <EuiText size="s" color="subdued">
-              {STREAM_DESCRIPTION_HELP}
+              {helpText}
             </EuiText>
             <EuiMarkdownEditor
               value={description}
@@ -166,18 +178,20 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
                         {isEditing ? SAVE_DESCRIPTION_BUTTON_LABEL : EDIT_DESCRIPTION_BUTTON_LABEL}
                       </EuiButton>
                     </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <DescriptionGenerationControl
-                        isTaskLoading={isTaskLoading}
-                        task={task}
-                        taskError={taskError}
-                        refreshTask={refreshTask}
-                        getDescriptionGenerationStatus={getDescriptionGenerationStatus}
-                        scheduleDescriptionGenerationTask={scheduleDescriptionGenerationTask}
-                        cancelDescriptionGenerationTask={cancelDescriptionGenerationTask}
-                        aiFeatures={aiFeatures}
-                      />
-                    </EuiFlexItem>
+                    {hasAiFeatures && (
+                      <EuiFlexItem grow={false}>
+                        <DescriptionGenerationControl
+                          isTaskLoading={isTaskLoading}
+                          task={task}
+                          taskError={taskError}
+                          refreshTask={refreshTask}
+                          getDescriptionGenerationStatus={getDescriptionGenerationStatus}
+                          scheduleDescriptionGenerationTask={scheduleDescriptionGenerationTask}
+                          cancelDescriptionGenerationTask={cancelDescriptionGenerationTask}
+                          aiFeatures={aiFeatures}
+                        />
+                      </EuiFlexItem>
+                    )}
                   </EuiFlexGroup>
                 ),
               }}
@@ -188,7 +202,7 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
             left={
               <EuiFlexItem grow={false}>
                 <EuiText size="s" color="subdued">
-                  {STREAM_DESCRIPTION_HELP}
+                  {helpText}
                 </EuiText>
               </EuiFlexItem>
             }
@@ -204,18 +218,20 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
                     {MANUAL_ENTRY_BUTTON_LABEL}
                   </EuiButton>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <DescriptionGenerationControl
-                    isTaskLoading={isTaskLoading}
-                    task={task}
-                    taskError={taskError}
-                    refreshTask={refreshTask}
-                    getDescriptionGenerationStatus={getDescriptionGenerationStatus}
-                    scheduleDescriptionGenerationTask={scheduleDescriptionGenerationTask}
-                    cancelDescriptionGenerationTask={cancelDescriptionGenerationTask}
-                    aiFeatures={aiFeatures}
-                  />
-                </EuiFlexItem>
+                {hasAiFeatures && (
+                  <EuiFlexItem grow={false}>
+                    <DescriptionGenerationControl
+                      isTaskLoading={isTaskLoading}
+                      task={task}
+                      taskError={taskError}
+                      refreshTask={refreshTask}
+                      getDescriptionGenerationStatus={getDescriptionGenerationStatus}
+                      scheduleDescriptionGenerationTask={scheduleDescriptionGenerationTask}
+                      cancelDescriptionGenerationTask={cancelDescriptionGenerationTask}
+                      aiFeatures={aiFeatures}
+                    />
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
             }
           />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.tsx
@@ -90,7 +90,7 @@ export const StreamDescription: React.FC<AISummaryProps> = ({
   refreshDefinition,
   aiFeatures,
 }) => {
-  const hasAiFeatures = aiFeatures !== null;
+  const hasAiFeatures = aiFeatures !== null && aiFeatures.enabled;
   const {
     description,
     isUpdating,

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/description_generation_control.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/description_generation_control.tsx
@@ -110,7 +110,6 @@ export function DescriptionGenerationControl({
         <EuiFlexItem grow={false}>
           <EuiButton
             iconType="sparkle"
-            iconSide="right"
             isLoading={true}
             data-test-subj="generate_description_button"
           >
@@ -145,7 +144,6 @@ export function DescriptionGenerationControl({
         buttonProps={{
           size: 'm',
           iconType: 'sparkles',
-          iconSide: 'right',
           isDisabled: true,
           isLoading: true,
           'data-test-subj': 'cancel_description_generation_button',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
@@ -198,7 +198,8 @@ export const useStreamDescriptionApi = ({
   }, [definition.stream.name, enableGeneration, signal, streams.streamsRepositoryClient]);
 
   const [{ loading: isTaskLoading, value: task, error: taskError }, refreshTask] = useAsyncFn(
-    getDescriptionGenerationStatus
+    getDescriptionGenerationStatus,
+    [getDescriptionGenerationStatus]
   );
 
   const onCancelEdit = useCallback(() => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
@@ -118,20 +118,21 @@ export const useStreamDescriptionApi = ({
     setIsEditing(true);
   }, [setIsEditing]);
 
-  const getDescriptionGenerationStatus = useCallback(async (): Promise<DescriptionGenerationTaskResult> => {
-    if (!enableGeneration) {
-      return { status: TaskStatus.NotStarted };
-    }
-    return await streams.streamsRepositoryClient.fetch(
-      'GET /internal/streams/{name}/_description_generation/_status',
-      {
-        signal,
-        params: {
-          path: { name: definition.stream.name },
-        },
+  const getDescriptionGenerationStatus =
+    useCallback(async (): Promise<DescriptionGenerationTaskResult> => {
+      if (!enableGeneration) {
+        return { status: TaskStatus.NotStarted };
       }
-    );
-  }, [definition.stream.name, enableGeneration, signal, streams.streamsRepositoryClient]);
+      return await streams.streamsRepositoryClient.fetch(
+        'GET /internal/streams/{name}/_description_generation/_status',
+        {
+          signal,
+          params: {
+            path: { name: definition.stream.name },
+          },
+        }
+      );
+    }, [definition.stream.name, enableGeneration, signal, streams.streamsRepositoryClient]);
 
   const scheduleDescriptionGenerationTask = useCallback(
     async (connectorId: string) => {

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
@@ -21,10 +21,12 @@ export const useStreamDescriptionApi = ({
   definition,
   refreshDefinition,
   silent = false,
+  enableGeneration = true,
 }: {
   definition: Streams.all.GetResponse;
   refreshDefinition: () => void;
   silent?: boolean;
+  enableGeneration?: boolean;
 }) => {
   const { signal } = useAbortController();
 
@@ -116,6 +118,9 @@ export const useStreamDescriptionApi = ({
   }, [setIsEditing]);
 
   const getDescriptionGenerationStatus = useCallback(async () => {
+    if (!enableGeneration) {
+      return { status: 'not_started' as const };
+    }
     return await streams.streamsRepositoryClient.fetch(
       'GET /internal/streams/{name}/_description_generation/_status',
       {
@@ -125,7 +130,7 @@ export const useStreamDescriptionApi = ({
         },
       }
     );
-  }, [definition.stream.name, signal, streams.streamsRepositoryClient]);
+  }, [definition.stream.name, enableGeneration, signal, streams.streamsRepositoryClient]);
 
   const scheduleDescriptionGenerationTask = useCallback(
     async (connectorId: string) => {
@@ -169,6 +174,9 @@ export const useStreamDescriptionApi = ({
   }, [definition.stream.name, signal, streams.streamsRepositoryClient]);
 
   const acknowledgeDescriptionGenerationTask = useCallback(async () => {
+    if (!enableGeneration) {
+      return;
+    }
     try {
       await streams.streamsRepositoryClient.fetch(
         'POST /internal/streams/{name}/_description_generation/_task',
@@ -187,7 +195,7 @@ export const useStreamDescriptionApi = ({
         throw error;
       }
     }
-  }, [definition.stream.name, signal, streams.streamsRepositoryClient]);
+  }, [definition.stream.name, enableGeneration, signal, streams.streamsRepositoryClient]);
 
   const [{ loading: isTaskLoading, value: task, error: taskError }, refreshTask] = useAsyncFn(
     getDescriptionGenerationStatus

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description/use_stream_description_api.ts
@@ -6,7 +6,8 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Streams } from '@kbn/streams-schema';
+import { Streams, TaskStatus } from '@kbn/streams-schema';
+import type { DescriptionGenerationTaskResult } from '@kbn/streams-plugin/server/routes/internal/sig_events/description_generation/route';
 import { omit } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { useAbortController } from '@kbn/react-hooks';
@@ -117,9 +118,9 @@ export const useStreamDescriptionApi = ({
     setIsEditing(true);
   }, [setIsEditing]);
 
-  const getDescriptionGenerationStatus = useCallback(async () => {
+  const getDescriptionGenerationStatus = useCallback(async (): Promise<DescriptionGenerationTaskResult> => {
     if (!enableGeneration) {
-      return { status: 'not_started' as const };
+      return { status: TaskStatus.NotStarted };
     }
     return await streams.streamsRepositoryClient.fetch(
       'GET /internal/streams/{name}/_description_generation/_status',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/classic_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/classic_advanced_view.test.tsx
@@ -195,11 +195,11 @@ describe('ClassicAdvancedView', () => {
     jest.clearAllMocks();
   });
 
-  describe('Significant Events Feature (Stream Description & Feature Configuration)', () => {
-    it('should render Stream description panel when significantEvents feature is enabled and available', () => {
+  describe('Stream Description', () => {
+    it('should always render Stream description panel regardless of significantEvents feature flag', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
-          significantEvents: { enabled: true, available: true },
+          significantEvents: { enabled: false, available: false },
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
@@ -211,10 +211,29 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      // Check the Stream description panel title is rendered
       expect(screen.getByText('Stream description')).toBeInTheDocument();
     });
 
+    it('should render Stream description panel when significantEvents is undefined', () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        features: {
+          significantEvents: undefined,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderWithProviders(
+        <ClassicAdvancedView
+          definition={createMockDefinition()}
+          refreshDefinition={mockRefreshDefinition}
+        />
+      );
+
+      expect(screen.getByText('Stream description')).toBeInTheDocument();
+    });
+  });
+
+  describe('Significant Events Feature (Stream Discovery)', () => {
     it('should render Stream discovery panel when significantEvents feature is enabled and available', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
@@ -230,11 +249,10 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      // Check the Stream discovery panel title is rendered
       expect(screen.getByText('Stream discovery')).toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents is disabled', () => {
+    it('should NOT render Stream discovery when significantEvents is disabled', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           significantEvents: { enabled: false, available: true },
@@ -249,11 +267,10 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents is enabled but not available (basic license)', () => {
+    it('should NOT render Stream discovery when significantEvents is enabled but not available (basic license)', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           significantEvents: { enabled: true, available: false },
@@ -268,12 +285,10 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      // These components require enterprise license and should NOT render with basic license
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents is undefined', () => {
+    it('should NOT render Stream discovery when significantEvents is undefined', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           significantEvents: undefined,
@@ -288,11 +303,10 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents available is undefined', () => {
+    it('should NOT render Stream discovery when significantEvents available is undefined', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           significantEvents: { enabled: true, available: undefined },
@@ -307,7 +321,6 @@ describe('ClassicAdvancedView', () => {
         />
       );
 
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/classic_advanced_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/classic_advanced_view.tsx
@@ -29,14 +29,14 @@ export function ClassicAdvancedView({
 
   return (
     <>
+      <StreamDescription
+        definition={definition}
+        refreshDefinition={refreshDefinition}
+        aiFeatures={aiFeatures}
+      />
+      <EuiSpacer />
       {significantEvents?.enabled && significantEvents?.available ? (
         <>
-          <StreamDescription
-            definition={definition}
-            refreshDefinition={refreshDefinition}
-            aiFeatures={aiFeatures}
-          />
-          <EuiSpacer />
           <StreamDiscoveryConfiguration definition={definition.stream} aiFeatures={aiFeatures} />
           <EuiSpacer />
         </>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.test.tsx
@@ -205,12 +205,12 @@ describe('WiredAdvancedView', () => {
     });
   });
 
-  describe('Significant Events Feature (Stream Description & Feature Configuration)', () => {
-    it('should render Stream description panel when significantEvents feature is enabled and available', () => {
+  describe('Stream Description', () => {
+    it('should always render Stream description panel regardless of significantEvents feature flag', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           contentPacks: { enabled: false },
-          significantEvents: { enabled: true, available: true },
+          significantEvents: { enabled: false, available: false },
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
@@ -222,10 +222,30 @@ describe('WiredAdvancedView', () => {
         />
       );
 
-      // Check the Stream description panel title is rendered
       expect(screen.getByText('Stream description')).toBeInTheDocument();
     });
 
+    it('should render Stream description panel when significantEvents is undefined', () => {
+      mockUseStreamsPrivileges.mockReturnValue({
+        features: {
+          contentPacks: { enabled: false },
+          significantEvents: undefined,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderWithProviders(
+        <WiredAdvancedView
+          definition={createMockDefinition()}
+          refreshDefinition={mockRefreshDefinition}
+        />
+      );
+
+      expect(screen.getByText('Stream description')).toBeInTheDocument();
+    });
+  });
+
+  describe('Significant Events Feature (Stream Discovery)', () => {
     it('should render Stream discovery panel when significantEvents feature is enabled and available', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
@@ -242,11 +262,10 @@ describe('WiredAdvancedView', () => {
         />
       );
 
-      // Check the Stream discovery panel title is rendered
       expect(screen.getByText('Stream discovery')).toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents is disabled', () => {
+    it('should NOT render Stream discovery when significantEvents is disabled', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           contentPacks: { enabled: false },
@@ -262,11 +281,10 @@ describe('WiredAdvancedView', () => {
         />
       );
 
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents is enabled but not available (basic license)', () => {
+    it('should NOT render Stream discovery when significantEvents is enabled but not available (basic license)', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           contentPacks: { enabled: false },
@@ -282,12 +300,10 @@ describe('WiredAdvancedView', () => {
         />
       );
 
-      // These components require enterprise license and should NOT render with basic license
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
 
-    it('should NOT render Stream description or Stream discovery when significantEvents available is undefined', () => {
+    it('should NOT render Stream discovery when significantEvents available is undefined', () => {
       mockUseStreamsPrivileges.mockReturnValue({
         features: {
           contentPacks: { enabled: false },
@@ -303,7 +319,6 @@ describe('WiredAdvancedView', () => {
         />
       );
 
-      expect(screen.queryByText('Stream description')).not.toBeInTheDocument();
       expect(screen.queryByText('Stream discovery')).not.toBeInTheDocument();
     });
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.tsx
@@ -54,14 +54,14 @@ export function WiredAdvancedView({
           <EuiSpacer />
         </>
       )}
+      <StreamDescription
+        definition={definition}
+        refreshDefinition={refreshDefinition}
+        aiFeatures={aiFeatures}
+      />
+      <EuiSpacer />
       {significantEvents?.enabled && significantEvents?.available && (
         <>
-          <StreamDescription
-            definition={definition}
-            refreshDefinition={refreshDefinition}
-            aiFeatures={aiFeatures}
-          />
-          <EuiSpacer />
           <StreamDiscoveryConfiguration definition={definition.stream} aiFeatures={aiFeatures} />
           <EuiSpacer />
         </>


### PR DESCRIPTION
## Summary

- Stream description editing panel is now **always visible** in the advanced view for both classic and wired streams, independent of the significant events feature flag
- The AI-powered "Generate description" button is **only shown when AI features are available** (enterprise license + AI connectors configured)
- Stream discovery configuration remains gated behind the significant events feature flag
- Help text is updated: basic text for all users, AI-specific text only when AI features are available
- The `useStreamDescriptionApi` hook skips generation-related API calls when AI features are disabled

## Test plan

- [ ] Verify stream description panel appears in advanced view without significant events enabled
- [ ] Verify "Enter manually" and edit/save buttons work without AI features
- [ ] Verify "Generate description" button only appears when AI features are available
- [ ] Verify help text shows AI-specific guidance only when AI features are present
- [ ] Verify stream discovery configuration still requires significant events feature flag
- [ ] Run unit tests: `node scripts/jest x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/classic_advanced_view.test.tsx`
- [ ] Run unit tests: `node scripts/jest x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.test.tsx`
- [ ] Run unit tests: `node scripts/jest x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_systems/stream_description.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)