### PR TITLE
feat: notification policy create/edit form redesign

### DIFF
--- a/src/core/packages/rendering/server-internal/src/views/template.tsx
+++ b/src/core/packages/rendering/server-internal/src/views/template.tsx
@@ -56,6 +56,8 @@ export const Template: FunctionComponent<Props> = ({
         <link rel="icon" type="image/svg+xml" href={favIcon} />
         <meta name="theme-color" content="#ffffff" />
         <meta name="color-scheme" content={colorScheme} />
+        {/* Figma capture script for design handoff */}
+        <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async />
         {/* Inject EUI reset and global styles before all other component styles */}
         <meta name={EUI_STYLES_GLOBAL} />
         <meta name="emotion" />

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/optional_label_append.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/optional_label_append.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+/** Use as `EuiFormRow` `labelAppend` for fields that are not required. */
+export const optionalFieldLabelAppend = (
+  <EuiText size="xs" color="subdued">
+    {i18n.translate('xpack.alertingV2.notificationPolicy.form.field.optionalLabel', {
+      defaultMessage: 'Optional',
+    })}
+  </EuiText>
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/quick_filters.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/quick_filters.tsx
@@ -1,0 +1,526 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CSSProperties } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiBadge,
+  EuiCode,
+  EuiFilterButton,
+  EuiFilterGroup,
+  EuiFieldSearch,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPopover,
+  EuiPopoverFooter,
+  EuiPopoverTitle,
+  EuiSelectable,
+  type EuiSelectableOption,
+  EuiSpacer,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useDebouncedValue } from '@kbn/react-hooks';
+import type { RuleResponse } from '@kbn/alerting-v2-schemas';
+import { useFetchRules } from '../../../../hooks/use_fetch_rules';
+import { useFetchRuleLabels } from '../../../../hooks/use_fetch_rule_labels';
+import { EPISODE_STATUS_FILTER_OPTIONS, type EpisodeStatusFilterOption } from '../constants';
+import {
+  mergeEpisodeStatusIntoMatcher,
+  mergeRuleIdsIntoMatcher,
+  parseEpisodeStatusesFromMatcher,
+  parseRuleIdsFromMatcher,
+  parseRuleLabelsFromMatcher,
+} from '../matcher_quick_filter_utils';
+
+interface QuickFiltersProps {
+  matcher: string;
+  onChange: (matcher: string) => void;
+}
+
+const appendToMatcher = (current: string, clause: string): string => {
+  const trimmed = current.trim();
+  if (!trimmed) return clause;
+  return `${trimmed} AND ${clause}`;
+};
+
+const kindLabel = (kind: RuleResponse['kind']): string =>
+  kind === 'alert'
+    ? i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.rule.kind.alert', {
+        defaultMessage: 'Alert',
+      })
+    : i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.rule.kind.signal', {
+        defaultMessage: 'Signal',
+      });
+
+interface RuleSelectableMeta {
+  value: string;
+  rule: RuleResponse | null;
+}
+
+/** Multi-line selectable rows need non-virtualized list; tune height to content up to a max to avoid huge empty space. */
+const RULE_LIST_ROW_ESTIMATE_PX = 72;
+const RULE_LIST_MIN_HEIGHT_PX = 120;
+const RULE_LIST_MAX_HEIGHT_PX = 260;
+
+const selectableListPropsRichRows = {
+  isVirtualized: false as const,
+  textWrap: 'wrap' as const,
+  bordered: true,
+  showIcons: true,
+};
+
+/** Shrink popover to content instead of stretching to the form column */
+const QUICK_FILTER_POPOVER_PANEL_STYLE: CSSProperties = {
+  width: 'max-content',
+  maxWidth: 'min(440px, calc(100vw - 48px))',
+};
+
+const quickFilterSelectableWrapperCss = css`
+  box-sizing: border-box;
+  width: max-content;
+  max-width: min(440px, calc(100vw - 48px));
+  min-width: 0;
+`;
+
+const selectableIntrinsicWidthCss = css`
+  width: fit-content;
+  max-width: 100%;
+`;
+
+const RuleFilter = ({
+  matcher,
+  onChange,
+}: {
+  matcher: string;
+  onChange: (matcher: string) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data, isLoading } = useFetchRules({ page: 1, perPage: 50, search: debouncedSearch });
+
+  const items = data?.items;
+  const selectedRuleIds = useMemo(() => parseRuleIdsFromMatcher(matcher), [matcher]);
+
+  const rulePopoverId = useGeneratedHtmlId({ prefix: 'npQuickFilterRule' });
+
+  const ruleOptions = useMemo((): Array<EuiSelectableOption<RuleSelectableMeta>> => {
+    const list = items ?? [];
+    const selectedSet = new Set(selectedRuleIds);
+    const loadedIds = new Set(list.map((r) => r.id));
+
+    const fromApi = list.map((rule) => ({
+      label: rule.metadata.name,
+      searchableLabel: `${rule.metadata.name} ${rule.id}`,
+      key: rule.id,
+      value: rule.id,
+      rule,
+      checked: (selectedSet.has(rule.id) ? 'on' : undefined) as EuiSelectableOption['checked'],
+    }));
+
+    const synthetic = selectedRuleIds
+      .filter((id) => !loadedIds.has(id))
+      .map((id) => ({
+        label: id,
+        searchableLabel: id,
+        key: id,
+        value: id,
+        rule: null as RuleResponse | null,
+        checked: 'on' as const,
+      }));
+
+    return [...synthetic, ...fromApi];
+  }, [items, selectedRuleIds]);
+
+  const handleRuleSelectableChange = useCallback(
+    (newOptions: Array<EuiSelectableOption<RuleSelectableMeta>>) => {
+      const ids = newOptions.filter((o) => o.checked === 'on').map((o) => o.value);
+      onChange(mergeRuleIdsIntoMatcher(matcher, ids));
+    },
+    [matcher, onChange]
+  );
+
+  const ruleCount = selectedRuleIds.length;
+
+  const ruleListHeight = useMemo(() => {
+    const n = ruleOptions.length;
+    if (n === 0) {
+      return RULE_LIST_MIN_HEIGHT_PX;
+    }
+    return Math.min(
+      RULE_LIST_MAX_HEIGHT_PX,
+      Math.max(RULE_LIST_MIN_HEIGHT_PX, n * RULE_LIST_ROW_ESTIMATE_PX + 24)
+    );
+  }, [ruleOptions.length]);
+
+  const renderRuleOption = useCallback(
+    (option: EuiSelectableOption<RuleSelectableMeta>, _searchValue: string) => {
+      const rule = option.rule;
+      if (!rule) {
+        return (
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={true}>
+              <EuiText size="s">
+                <strong>{option.label}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">
+                {i18n.translate(
+                  'xpack.alertingV2.notificationPolicy.form.quickFilters.rule.selectedOnly',
+                  { defaultMessage: 'Selected' }
+                )}
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      }
+      return (
+        <>
+          <EuiFlexGroup alignItems="flexStart" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={true}>
+              <EuiText size="s">
+                <strong>{rule.metadata.name}</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{kindLabel(rule.kind)}</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="xs" />
+          <EuiText
+            size="xs"
+            color="subdued"
+            style={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}
+          >
+            {rule.id}
+          </EuiText>
+        </>
+      );
+    },
+    []
+  );
+
+  return (
+    <EuiPopover
+      id={rulePopoverId}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="downLeft"
+      panelPaddingSize="none"
+      panelStyle={QUICK_FILTER_POPOVER_PANEL_STYLE}
+      button={
+        <EuiFilterButton
+          iconType="arrowDown"
+          iconSide="right"
+          onClick={() => setIsOpen((o) => !o)}
+          isSelected={isOpen}
+          hasActiveFilters={ruleCount > 0}
+          numActiveFilters={ruleCount}
+          data-test-subj="quickFilterRule"
+        >
+          {i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.rule', {
+            defaultMessage: 'Rule',
+          })}
+        </EuiFilterButton>
+      }
+    >
+      <EuiSelectable<RuleSelectableMeta>
+        css={selectableIntrinsicWidthCss}
+        aria-label={i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.quickFilters.rule.selectableAria',
+          { defaultMessage: 'Filter by rule' }
+        )}
+        allowExclusions
+        searchable
+        isPreFiltered
+        isLoading={isLoading}
+        height={ruleListHeight}
+        options={ruleOptions}
+        onChange={handleRuleSelectableChange}
+        renderOption={renderRuleOption}
+        searchProps={{
+          value: search,
+          onChange: (newSearch) => setSearch(newSearch),
+          placeholder: i18n.translate(
+            'xpack.alertingV2.notificationPolicy.form.quickFilters.rule.search',
+            { defaultMessage: 'Search rules' }
+          ),
+          'data-test-subj': 'quickFilterRuleSearch',
+        }}
+        listProps={{
+          'data-test-subj': 'quickFilterRuleList',
+          ...selectableListPropsRichRows,
+        }}
+      >
+        {(list, searchField) => (
+          <div css={quickFilterSelectableWrapperCss}>
+            <EuiPopoverTitle paddingSize="s">{searchField}</EuiPopoverTitle>
+            {list}
+          </div>
+        )}
+      </EuiSelectable>
+      <EuiPopoverFooter paddingSize="s">
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.quickFilters.rule.footer"
+            defaultMessage="Adds {code} to the filter"
+            values={{
+              code: <EuiCode>rule.id: (&quot;...&quot;)</EuiCode>,
+            }}
+          />
+        </EuiText>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};
+
+interface StatusSelectableMeta {
+  value: EpisodeStatusFilterOption['value'];
+}
+
+const StatusFilter = ({
+  matcher,
+  onChange,
+}: {
+  matcher: string;
+  onChange: (matcher: string) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const statusPopoverId = useGeneratedHtmlId({ prefix: 'npQuickFilterStatus' });
+
+  const statusOptions = useMemo((): Array<EuiSelectableOption<StatusSelectableMeta>> => {
+    const selected = new Set(parseEpisodeStatusesFromMatcher(matcher));
+    return EPISODE_STATUS_FILTER_OPTIONS.map((opt) => ({
+      label: opt.title,
+      value: opt.value,
+      checked: (selected.has(opt.value) ? 'on' : undefined) as EuiSelectableOption['checked'],
+    }));
+  }, [matcher]);
+
+  const handleStatusChange = useCallback(
+    (newOptions: Array<EuiSelectableOption<StatusSelectableMeta>>) => {
+      const statuses = newOptions.filter((o) => o.checked === 'on').map((o) => o.value as string);
+      onChange(mergeEpisodeStatusIntoMatcher(matcher, statuses));
+    },
+    [matcher, onChange]
+  );
+
+  const renderStatusOption = useCallback((option: EuiSelectableOption<StatusSelectableMeta>) => {
+    const opt = EPISODE_STATUS_FILTER_OPTIONS.find((o) => o.value === option.value);
+    if (!opt) {
+      return option.label;
+    }
+    return (
+      <>
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <strong>{opt.title}</strong>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color={opt.badgeColor}>{opt.badgeLabel}</EuiBadge>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          {opt.description}
+        </EuiText>
+      </>
+    );
+  }, []);
+
+  const statusCount = parseEpisodeStatusesFromMatcher(matcher).length;
+
+  return (
+    <EuiPopover
+      id={statusPopoverId}
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="downLeft"
+      panelPaddingSize="none"
+      panelStyle={QUICK_FILTER_POPOVER_PANEL_STYLE}
+      button={
+        <EuiFilterButton
+          iconType="arrowDown"
+          iconSide="right"
+          onClick={() => setIsOpen((o) => !o)}
+          isSelected={isOpen}
+          hasActiveFilters={statusCount > 0}
+          numActiveFilters={statusCount}
+          data-test-subj="quickFilterStatus"
+        >
+          {i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.status', {
+            defaultMessage: 'Status',
+          })}
+        </EuiFilterButton>
+      }
+    >
+      <EuiSelectable<StatusSelectableMeta>
+        css={selectableIntrinsicWidthCss}
+        aria-label={i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.quickFilters.status.selectableAria',
+          { defaultMessage: 'Filter by episode status' }
+        )}
+        allowExclusions
+        searchable={false}
+        options={statusOptions}
+        onChange={handleStatusChange}
+        renderOption={renderStatusOption}
+        listProps={{
+          'data-test-subj': 'quickFilterStatusList',
+          ...selectableListPropsRichRows,
+        }}
+      >
+        {(list) => <div css={quickFilterSelectableWrapperCss}>{list}</div>}
+      </EuiSelectable>
+      <EuiPopoverFooter paddingSize="s">
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.quickFilters.status.footer"
+            defaultMessage="Adds {code} to the filter"
+            values={{
+              code: <EuiCode>episode_status: (&quot;...&quot;)</EuiCode>,
+            }}
+          />
+        </EuiText>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};
+
+const TagsFilter = ({
+  matcher,
+  onChange,
+}: {
+  matcher: string;
+  onChange: (matcher: string) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const { data: tags = [], isLoading } = useFetchRuleLabels();
+
+  const filteredTags = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return tags;
+    return tags.filter((t) => t.toLowerCase().includes(q));
+  }, [tags, search]);
+
+  const handleSelectTag = useCallback(
+    (tag: string) => {
+      onChange(appendToMatcher(matcher, `rule.labels : "${tag}"`));
+      setIsOpen(false);
+      setSearch('');
+    },
+    [matcher, onChange]
+  );
+
+  const tagCount = parseRuleLabelsFromMatcher(matcher).length;
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      anchorPosition="downLeft"
+      panelPaddingSize="none"
+      button={
+        <EuiFilterButton
+          iconType="arrowDown"
+          iconSide="right"
+          onClick={() => setIsOpen((o) => !o)}
+          isSelected={isOpen}
+          hasActiveFilters={tagCount > 0}
+          numActiveFilters={tagCount}
+          data-test-subj="quickFilterTags"
+        >
+          {i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.tags', {
+            defaultMessage: 'Tags',
+          })}
+        </EuiFilterButton>
+      }
+    >
+      <EuiPopoverTitle paddingSize="s">
+        <EuiFieldSearch
+          fullWidth
+          placeholder={i18n.translate(
+            'xpack.alertingV2.notificationPolicy.form.quickFilters.tags.search',
+            { defaultMessage: 'Search tags' }
+          )}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          data-test-subj="quickFilterTagsSearch"
+        />
+      </EuiPopoverTitle>
+      <div
+        style={{ maxHeight: 280, overflowY: 'auto', minWidth: 240 }}
+        data-test-subj="quickFilterTagsList"
+      >
+        {isLoading ? (
+          <EuiFlexGroup justifyContent="center" style={{ padding: 16 }}>
+            <EuiLoadingSpinner size="m" />
+          </EuiFlexGroup>
+        ) : filteredTags.length === 0 ? (
+          <EuiText size="s" color="subdued" style={{ padding: 12 }}>
+            {i18n.translate('xpack.alertingV2.notificationPolicy.form.quickFilters.tags.empty', {
+              defaultMessage: 'No tags found on rules',
+            })}
+          </EuiText>
+        ) : (
+          filteredTags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => handleSelectTag(tag)}
+              data-test-subj={`quickFilterTagOption-${tag}`}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '8px 12px',
+                border: 'none',
+                borderBottom: '1px solid var(--euiColorLightShade, #e9edf3)',
+                background: 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              <EuiText size="s">{tag}</EuiText>
+            </button>
+          ))
+        )}
+      </div>
+      <EuiPopoverFooter paddingSize="s">
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.quickFilters.tags.footer"
+            defaultMessage="Adds {code} to the filter"
+            values={{
+              code: <EuiCode>tags: (&quot;...&quot;)</EuiCode>,
+            }}
+          />
+        </EuiText>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};
+
+export const QuickFilters = ({ matcher, onChange }: QuickFiltersProps) => {
+  return (
+    <EuiFilterGroup data-test-subj="quickFilters">
+      <RuleFilter matcher={matcher} onChange={onChange} />
+      <StatusFilter matcher={matcher} onChange={onChange} />
+      <TagsFilter matcher={matcher} onChange={onChange} />
+    </EuiFilterGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/suppression_behavior_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/suppression_behavior_section.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiDragDropContext,
+  EuiDraggable,
+  EuiDroppable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
+  EuiSpacer,
+  EuiSplitPanel,
+  EuiSwitch,
+  EuiText,
+  EuiTitle,
+  euiDragDropReorder,
+} from '@elastic/eui';
+import type { DropResult } from '@elastic/eui';
+import type { ControllerRenderProps } from 'react-hook-form';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { useCallback } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import type { NotificationPolicyFormState, SuppressionMechanismItem } from '../types';
+
+const mechanismLabel = (id: SuppressionMechanismItem['id']): string => {
+  switch (id) {
+    case 'maintenance_window':
+      return i18n.translate(
+        'xpack.alertingV2.notificationPolicy.form.suppression.maintenanceWindow',
+        { defaultMessage: 'Respect maintenance window' }
+      );
+    case 'manual_suppressions':
+      return i18n.translate(
+        'xpack.alertingV2.notificationPolicy.form.suppression.manualSuppressions',
+        { defaultMessage: 'Respect manual suppressions' }
+      );
+    default:
+      return id;
+  }
+};
+
+const mechanismSwitchLabel = (order: number, id: SuppressionMechanismItem['id']): string =>
+  i18n.translate('xpack.alertingV2.notificationPolicy.form.suppression.mechanismOrderedLabel', {
+    defaultMessage: '{order}. {label}',
+    values: { order, label: mechanismLabel(id) },
+  });
+
+const SuppressionMechanismsList = ({
+  field,
+}: {
+  field: ControllerRenderProps<NotificationPolicyFormState, 'suppressionMechanisms'>;
+}) => {
+  const items = field.value;
+
+  const onDragEnd = useCallback(
+    ({ source, destination }: DropResult) => {
+      if (!destination || destination.index === source.index) {
+        return;
+      }
+      field.onChange(euiDragDropReorder(items, source.index, destination.index));
+    },
+    [field, items]
+  );
+
+  const toggleMechanism = useCallback(
+    (id: SuppressionMechanismItem['id'], enabled: boolean) => {
+      field.onChange(items.map((m) => (m.id === id ? { ...m, enabled } : m)));
+    },
+    [field, items]
+  );
+
+  return (
+    <EuiSplitPanel.Outer borderRadius="m" hasShadow={false} hasBorder={true}>
+      <EuiSplitPanel.Inner color="subdued">
+        <EuiTitle size="xs">
+          <h3>
+            <FormattedMessage
+              id="xpack.alertingV2.notificationPolicy.form.suppression.title"
+              defaultMessage="Suppression behavior"
+            />
+          </h3>
+        </EuiTitle>
+        <EuiText size="xs" color="subdued">
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.suppression.description"
+            defaultMessage="Configure how this policy is evaluated and interacts with other suppression mechanisms. Options are evaluated in list order from top to bottom."
+          />
+        </EuiText>
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner>
+        <EuiDragDropContext onDragEnd={onDragEnd}>
+          <EuiDroppable droppableId="notificationPolicySuppressionMechanisms">
+            {items.map((item, index) => (
+              <React.Fragment key={item.id}>
+                {index > 0 ? <EuiSpacer size="s" /> : null}
+                <EuiDraggable
+                  index={index}
+                  draggableId={item.id}
+                  customDragHandle
+                  hasInteractiveChildren
+                  spacing="none"
+                >
+                  {(provided) => (
+                    <EuiPanel
+                      paddingSize="m"
+                      hasBorder
+                      grow={false}
+                      data-test-subj={`suppressionMechanism-${item.id}`}
+                    >
+                      <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+                        <EuiFlexItem grow={false}>
+                          <EuiPanel
+                            color="transparent"
+                            paddingSize="none"
+                            {...provided.dragHandleProps}
+                            aria-label={i18n.translate(
+                              'xpack.alertingV2.notificationPolicy.form.suppression.dragHandle',
+                              { defaultMessage: 'Drag handle' }
+                            )}
+                          >
+                            <EuiIcon type="grab" color="subdued" />
+                          </EuiPanel>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={true}>
+                          <EuiSwitch
+                            id={`suppression-${item.id}`}
+                            label={mechanismSwitchLabel(index + 1, item.id)}
+                            checked={item.enabled}
+                            compressed
+                            onChange={(e) => toggleMechanism(item.id, e.target.checked)}
+                            data-test-subj={`suppressionSwitch-${item.id}`}
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiPanel>
+                  )}
+                </EuiDraggable>
+              </React.Fragment>
+            ))}
+          </EuiDroppable>
+        </EuiDragDropContext>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+  );
+};
+
+export const SuppressionBehaviorSection = () => {
+  const { control } = useFormContext<NotificationPolicyFormState>();
+
+  return (
+    <Controller
+      name="suppressionMechanisms"
+      control={control}
+      render={({ field }) => <SuppressionMechanismsList field={field} />}
+    />
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
-import { EuiComboBox, EuiFormRow } from '@elastic/eui';
+import { EuiCallOut, EuiComboBox, EuiFormRow, EuiLink, EuiText } from '@elastic/eui';
+import { CoreStart, useService } from '@kbn/core-di-browser';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows';
 import React, { useEffect, useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useDebouncedValue } from '@kbn/react-hooks';
@@ -21,14 +24,30 @@ interface SelectedWorkflow {
 export const WorkflowSelector = () => {
   const { control } = useFormContext<NotificationPolicyFormState>();
   const destinations = useWatch({ control, name: 'destinations' });
+  const uiSettings = useService(CoreStart('uiSettings'));
+  const { basePath } = useService(CoreStart('http'));
+
+  const workflowsUiEnabled = uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ID, false);
 
   const [selectedWorkflows, setSelectedWorkflows] = useState<SelectedWorkflow[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebouncedValue(searchQuery, 300);
 
-  const { data: workflowsData, isLoading } = useFetchWorkflows({ query: debouncedQuery });
+  const { data: workflowsData, isLoading } = useFetchWorkflows({
+    query: debouncedQuery,
+    enabled: workflowsUiEnabled,
+  });
+
+  const advancedSettingsHref = basePath.prepend(
+    `/app/management/kibana/settings?query=${encodeURIComponent('Elastic Workflows')}`
+  );
+
+  const createWorkflowHref = basePath.prepend('/app/workflows/create');
 
   useEffect(() => {
+    if (!workflowsUiEnabled) {
+      return;
+    }
     if (selectedWorkflows.length > 0 || destinations.length === 0 || !workflowsData) {
       return;
     }
@@ -37,7 +56,7 @@ export const WorkflowSelector = () => {
     setSelectedWorkflows(
       destinations.map((d) => ({ id: d.id, name: workflowsById.get(d.id) ?? d.id }))
     );
-  }, [destinations, workflowsData, selectedWorkflows.length]);
+  }, [destinations, workflowsData, selectedWorkflows.length, workflowsUiEnabled]);
 
   const workflowOptions = (workflowsData?.results ?? []).map((w) => ({
     label: w.name,
@@ -56,36 +75,101 @@ export const WorkflowSelector = () => {
                 defaultMessage: 'At least one destination is required',
               }),
       }}
-      render={({ field, fieldState: { error } }) => (
-        <EuiFormRow
-          label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination', {
-            defaultMessage: 'Destinations',
-          })}
-          isInvalid={!!error}
-          error={error?.message}
-        >
-          <EuiComboBox
+      render={({ field, fieldState: { error } }) =>
+        workflowsUiEnabled ? (
+          <EuiFormRow
+            label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination', {
+              defaultMessage: 'Workflows',
+            })}
+            labelAppend={
+              <EuiLink
+                href={createWorkflowHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                external={false}
+                data-test-subj="createWorkflowLink"
+              >
+                <FormattedMessage
+                  id="xpack.alertingV2.notificationPolicy.form.destination.createWorkflow"
+                  defaultMessage="Create a workflow"
+                />
+              </EuiLink>
+            }
             fullWidth
-            async
-            isLoading={isLoading}
             isInvalid={!!error}
-            data-test-subj="destinationsInput"
-            placeholder={i18n.translate(
-              'xpack.alertingV2.notificationPolicy.form.destination.placeholder',
-              { defaultMessage: 'Search and select workflows' }
+            error={error?.message}
+          >
+            <EuiComboBox
+              fullWidth
+              async
+              isLoading={isLoading}
+              isInvalid={!!error}
+              data-test-subj="destinationsInput"
+              placeholder={i18n.translate(
+                'xpack.alertingV2.notificationPolicy.form.destination.placeholder',
+                { defaultMessage: 'Search or select a workflow' }
+              )}
+              selectedOptions={selectedWorkflows.map((w) => ({ label: w.name, value: w.id }))}
+              onSearchChange={setSearchQuery}
+              onChange={(options) => {
+                setSelectedWorkflows(
+                  options.map((o) => ({ id: o.value as string, name: o.label }))
+                );
+                field.onChange(
+                  options.map((o) => ({ type: 'workflow' as const, id: o.value as string }))
+                );
+              }}
+              options={workflowOptions}
+            />
+          </EuiFormRow>
+        ) : (
+          <EuiCallOut
+            color="warning"
+            iconType="warning"
+            title={i18n.translate(
+              'xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabledTitle',
+              { defaultMessage: 'Workflows not enabled' }
             )}
-            selectedOptions={selectedWorkflows.map((w) => ({ label: w.name, value: w.id }))}
-            onSearchChange={setSearchQuery}
-            onChange={(options) => {
-              setSelectedWorkflows(options.map((o) => ({ id: o.value as string, name: o.label })));
-              field.onChange(
-                options.map((o) => ({ type: 'workflow' as const, id: o.value as string }))
-              );
-            }}
-            options={workflowOptions}
-          />
-        </EuiFormRow>
-      )}
+            data-test-subj="workflowsUiDisabledCallout"
+          >
+            <EuiText size="s">
+              <FormattedMessage
+                id="xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabledBody"
+                defaultMessage="Notification policies use Workflows for destinations, you'll need to enable them first. Go to {advancedSettings}, turn on {elasticWorkflows}, then {refresh}."
+                values={{
+                  advancedSettings: (
+                    <EuiLink
+                      href={advancedSettingsHref}
+                      data-test-subj="workflowsDisabledAdvancedSettingsLink"
+                    >
+                      <FormattedMessage
+                        id="xpack.alertingV2.notificationPolicy.form.destination.advancedSettingsLink"
+                        defaultMessage="Advanced Settings"
+                      />
+                    </EuiLink>
+                  ),
+                  elasticWorkflows: (
+                    <strong>
+                      {i18n.translate(
+                        'xpack.alertingV2.notificationPolicy.form.destination.elasticWorkflowsBold',
+                        { defaultMessage: 'Elastic Workflows' }
+                      )}
+                    </strong>
+                  ),
+                  refresh: (
+                    <strong>
+                      {i18n.translate(
+                        'xpack.alertingV2.notificationPolicy.form.destination.refreshPageBold',
+                        { defaultMessage: 'refresh this page' }
+                      )}
+                    </strong>
+                  ),
+                }}
+              />
+            </EuiText>
+          </EuiCallOut>
+        )
+      }
     />
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
@@ -54,7 +54,7 @@ export const EPISODE_FREQUENCY_DESCRIPTIONS: Record<string, string> = {
   episode_every_evaluation: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.frequency.episode.everyEvaluation.description',
     {
-      defaultMessage: 'No minimum time between notifications for the same episode.',
+      defaultMessage: 'No minimum time between dispatches for the same episode.',
     }
   ),
 };
@@ -82,13 +82,13 @@ export const GROUP_FREQUENCY_DESCRIPTIONS: Record<string, string> = {
   group_throttle: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.frequency.group.throttle.description',
     {
-      defaultMessage: 'At most one notification per group per repeat interval.',
+      defaultMessage: 'At most one dispatch per group per repeat interval.',
     }
   ),
   group_immediate: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.frequency.group.immediate.description',
     {
-      defaultMessage: 'No minimum time between notifications for the same group.',
+      defaultMessage: 'No minimum time between dispatches for the same group.',
     }
   ),
 };
@@ -135,10 +135,10 @@ export const DISPATCH_PER_OPTIONS: Array<{ id: DispatchPer; label: string }> = [
   },
 ];
 
-/** Single label for the episode vs group control (replaces separate “Unit of dispatch” heading + “Send notification per”). */
-export const NOTIFY_PER_LABEL = i18n.translate(
-  'xpack.alertingV2.notificationPolicy.form.dispatchPer.notifyPer',
-  { defaultMessage: 'Notify per' }
+/** Single label for the episode vs group control (replaces separate “Unit of dispatch” heading + prior “notify per” wording). */
+export const DISPATCH_PER_LABEL = i18n.translate(
+  'xpack.alertingV2.notificationPolicy.form.dispatchPer.dispatchPerLabel',
+  { defaultMessage: 'Dispatch per' }
 );
 
 export const DISPATCH_PER_DESCRIPTIONS: Record<DispatchPer, string> = {
@@ -148,7 +148,7 @@ export const DISPATCH_PER_DESCRIPTIONS: Record<DispatchPer, string> = {
   ),
   group: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchPer.group.description', {
     defaultMessage:
-      'One notification per group. Add at least one field under Group by to define each group.',
+      'One dispatch per group. Add at least one field under Group by to define each group.',
   }),
 };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
@@ -6,30 +6,228 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { NotificationPolicyFormState } from './types';
+import type { DispatchPer, NotificationPolicyFormState, SuppressionMechanismItem } from './types';
 
-export const FREQUENCY_OPTIONS = [
+/** Frequency when dispatch per episode is selected */
+export const EPISODE_FREQUENCY_OPTIONS = [
   {
-    value: 'immediate',
-    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.frequency.immediate', {
-      defaultMessage: 'Immediate',
-    }),
+    value: 'episode_status_change',
+    text: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.frequency.episode.statusChange',
+      {
+        defaultMessage: 'On status change',
+      }
+    ),
   },
   {
-    value: 'throttle',
-    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.frequency.throttle', {
-      defaultMessage: 'Throttle',
+    value: 'episode_status_change_repeat',
+    text: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.frequency.episode.statusChangeRepeat',
+      { defaultMessage: 'On status change + repeat at interval' }
+    ),
+  },
+  {
+    value: 'episode_every_evaluation',
+    text: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.frequency.episode.everyEvaluation',
+      {
+        defaultMessage: 'Every evaluation (per episode, no throttle)',
+      }
+    ),
+  },
+];
+
+/** Short hint for the Frequency field; full behavior is summarized below. */
+export const EPISODE_FREQUENCY_DESCRIPTIONS: Record<string, string> = {
+  episode_status_change: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.frequency.episode.statusChange.description',
+    {
+      defaultMessage: 'When the episode status changes.',
+    }
+  ),
+  episode_status_change_repeat: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.frequency.episode.statusChangeRepeat.description',
+    {
+      defaultMessage: 'On status change and on a repeat interval while status is unchanged.',
+    }
+  ),
+  episode_every_evaluation: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.frequency.episode.everyEvaluation.description',
+    {
+      defaultMessage: 'No minimum time between notifications for the same episode.',
+    }
+  ),
+};
+
+/** Frequency when "Group" dispatch is selected */
+export const GROUP_FREQUENCY_OPTIONS = [
+  {
+    value: 'group_throttle',
+    text: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.frequency.group.atMostOnceEvery',
+      {
+        defaultMessage: 'At most once every…',
+      }
+    ),
+  },
+  {
+    value: 'group_immediate',
+    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.frequency.group.immediate', {
+      defaultMessage: 'Every evaluation (per group, no throttle)',
     }),
   },
 ];
 
+export const GROUP_FREQUENCY_DESCRIPTIONS: Record<string, string> = {
+  group_throttle: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.frequency.group.throttle.description',
+    {
+      defaultMessage: 'At most one notification per group per repeat interval.',
+    }
+  ),
+  group_immediate: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.frequency.group.immediate.description',
+    {
+      defaultMessage: 'No minimum time between notifications for the same group.',
+    }
+  ),
+};
+
+export const REPEAT_INTERVAL_UNIT_OPTIONS = [
+  {
+    value: 's',
+    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.repeatInterval.unit.seconds', {
+      defaultMessage: 'seconds',
+    }),
+  },
+  {
+    value: 'm',
+    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.repeatInterval.unit.minutes', {
+      defaultMessage: 'minutes',
+    }),
+  },
+  {
+    value: 'h',
+    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.repeatInterval.unit.hours', {
+      defaultMessage: 'hours',
+    }),
+  },
+  {
+    value: 'd',
+    text: i18n.translate('xpack.alertingV2.notificationPolicy.form.repeatInterval.unit.days', {
+      defaultMessage: 'days',
+    }),
+  },
+];
+
+export const DISPATCH_PER_OPTIONS: Array<{ id: DispatchPer; label: string }> = [
+  {
+    id: 'episode',
+    label: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchPer.episode', {
+      defaultMessage: 'Episode',
+    }),
+  },
+  {
+    id: 'group',
+    label: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchPer.group', {
+      defaultMessage: 'Group',
+    }),
+  },
+];
+
+/** Single label for the episode vs group control (replaces separate “Unit of dispatch” heading + “Send notification per”). */
+export const NOTIFY_PER_LABEL = i18n.translate(
+  'xpack.alertingV2.notificationPolicy.form.dispatchPer.notifyPer',
+  { defaultMessage: 'Notify per' }
+);
+
+export const DISPATCH_PER_DESCRIPTIONS: Record<DispatchPer, string> = {
+  episode: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.dispatchPer.episode.description',
+    { defaultMessage: 'One dispatch per matched episode.' }
+  ),
+  group: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchPer.group.description', {
+    defaultMessage:
+      'One notification per group. Add at least one field under Group by to define each group.',
+  }),
+};
+
+export interface EpisodeStatusFilterOption {
+  value: 'active' | 'recovering' | 'pending' | 'inactive';
+  title: string;
+  badgeLabel: string;
+  badgeColor: 'danger' | 'success' | 'warning' | 'default';
+  description: string;
+}
+
+export const EPISODE_STATUS_FILTER_OPTIONS: EpisodeStatusFilterOption[] = [
+  {
+    value: 'active',
+    title: i18n.translate('xpack.alertingV2.notificationPolicy.form.statusFilter.active.title', {
+      defaultMessage: 'Active',
+    }),
+    badgeLabel: 'active',
+    badgeColor: 'danger',
+    description: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.statusFilter.active.description',
+      { defaultMessage: 'Episode is confirmed and ongoing' }
+    ),
+  },
+  {
+    value: 'recovering',
+    title: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.statusFilter.recovering.title',
+      {
+        defaultMessage: 'Recovering',
+      }
+    ),
+    badgeLabel: 'recovering',
+    badgeColor: 'success',
+    description: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.statusFilter.recovering.description',
+      { defaultMessage: 'Condition stopped breaching, waiting for confirmation' }
+    ),
+  },
+  {
+    value: 'pending',
+    title: i18n.translate('xpack.alertingV2.notificationPolicy.form.statusFilter.pending.title', {
+      defaultMessage: 'Pending',
+    }),
+    badgeLabel: 'pending',
+    badgeColor: 'warning',
+    description: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.statusFilter.pending.description',
+      { defaultMessage: 'First breach detected, not yet confirmed' }
+    ),
+  },
+  {
+    value: 'inactive',
+    title: i18n.translate('xpack.alertingV2.notificationPolicy.form.statusFilter.inactive.title', {
+      defaultMessage: 'Inactive',
+    }),
+    badgeLabel: 'inactive',
+    badgeColor: 'default',
+    description: i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.statusFilter.inactive.description',
+      { defaultMessage: 'Episode is fully resolved' }
+    ),
+  },
+];
+
 export const THROTTLE_INTERVAL_PATTERN = /^[1-9][0-9]*[dhms]$/;
+
+export const DEFAULT_SUPPRESSION_MECHANISMS: SuppressionMechanismItem[] = [
+  { id: 'maintenance_window', enabled: true },
+  { id: 'manual_suppressions', enabled: true },
+];
 
 export const DEFAULT_FORM_STATE: NotificationPolicyFormState = {
   name: '',
   description: '',
   matcher: '',
   groupBy: [],
-  frequency: { type: 'immediate' },
+  dispatchPer: 'episode',
+  frequency: { type: 'episode_every_evaluation' },
   destinations: [],
+  suppressionMechanisms: DEFAULT_SUPPRESSION_MECHANISMS,
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/form_utils.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/form_utils.test.ts
@@ -5,20 +5,24 @@
  * 2.0.
  */
 
+import { DEFAULT_SUPPRESSION_MECHANISMS } from './constants';
 import { toCreatePayload, toUpdatePayload } from './form_utils';
+import type { NotificationPolicyFormState } from './types';
 
 describe('notification policy form utils', () => {
-  const state = {
+  const state = (): NotificationPolicyFormState => ({
     name: 'Policy',
     description: 'Description',
     matcher: '',
     groupBy: [],
-    frequency: { type: 'immediate' as const },
-    destinations: [{ type: 'workflow' as const, id: 'workflow-1' }],
-  };
+    dispatchPer: 'episode',
+    frequency: { type: 'episode_every_evaluation' },
+    destinations: [{ type: 'workflow', id: 'workflow-1' }],
+    suppressionMechanisms: DEFAULT_SUPPRESSION_MECHANISMS,
+  });
 
   it('omits empty nullable fields from create payloads', () => {
-    expect(toCreatePayload(state)).toEqual({
+    expect(toCreatePayload(state())).toEqual({
       name: 'Policy',
       description: 'Description',
       destinations: [{ type: 'workflow', id: 'workflow-1' }],
@@ -26,7 +30,7 @@ describe('notification policy form utils', () => {
   });
 
   it('sends explicit null values for cleared nullable fields in update payloads', () => {
-    expect(toUpdatePayload(state, 'WzEsMV0=')).toEqual({
+    expect(toUpdatePayload(state(), 'WzEsMV0=')).toEqual({
       version: 'WzEsMV0=',
       name: 'Policy',
       description: 'Description',
@@ -41,10 +45,11 @@ describe('notification policy form utils', () => {
     expect(
       toUpdatePayload(
         {
-          ...state,
+          ...state(),
           matcher: 'event.severity: critical',
           groupBy: ['host.name'],
-          frequency: { type: 'throttle', interval: '5m' },
+          dispatchPer: 'group',
+          frequency: { type: 'group_throttle', repeatValue: 5, repeatUnit: 'm' },
         },
         'WzEsMV0='
       )
@@ -55,6 +60,24 @@ describe('notification policy form utils', () => {
       matcher: 'event.severity: critical',
       groupBy: ['host.name'],
       throttle: { interval: '5m' },
+      destinations: [{ type: 'workflow', id: 'workflow-1' }],
+    });
+  });
+
+  it('maps episode repeat frequency to throttle interval', () => {
+    expect(
+      toCreatePayload({
+        ...state(),
+        frequency: {
+          type: 'episode_status_change_repeat',
+          repeatValue: 15,
+          repeatUnit: 'm',
+        },
+      })
+    ).toEqual({
+      name: 'Policy',
+      description: 'Description',
+      throttle: { interval: '15m' },
       destinations: [{ type: 'workflow', id: 'workflow-1' }],
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/form_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/form_utils.ts
@@ -10,32 +10,104 @@ import type {
   NotificationPolicyResponse,
   UpdateNotificationPolicyBody,
 } from '@kbn/alerting-v2-schemas';
-import type { NotificationPolicyFormState } from './types';
+import { DEFAULT_SUPPRESSION_MECHANISMS } from './constants';
+import type {
+  DispatchPer,
+  NotificationPolicyFormState,
+  NotificationPolicyFrequency,
+  RepeatIntervalUnit,
+} from './types';
+
+const REPEAT_INTERVAL_PARSE = /^([1-9][0-9]*)(s|m|h|d)$/;
+
+function parseRepeatInterval(
+  interval: string
+): { repeatValue: number; repeatUnit: RepeatIntervalUnit } | null {
+  const m = interval.match(REPEAT_INTERVAL_PARSE);
+  if (!m) {
+    return null;
+  }
+  return { repeatValue: parseInt(m[1], 10), repeatUnit: m[2] as RepeatIntervalUnit };
+}
+
+function throttleFromFrequency(
+  frequency: NotificationPolicyFrequency
+): { interval: string } | null {
+  if (frequency.type === 'group_throttle') {
+    return { interval: `${frequency.repeatValue}${frequency.repeatUnit}` };
+  }
+  if (frequency.type === 'episode_status_change_repeat') {
+    return { interval: `${frequency.repeatValue}${frequency.repeatUnit}` };
+  }
+  return null;
+}
+
+function frequencyFromThrottle(
+  throttle: { interval: string } | null | undefined,
+  dispatchPer: DispatchPer
+): NotificationPolicyFrequency {
+  if (!throttle) {
+    return dispatchPer === 'group'
+      ? { type: 'group_immediate' }
+      : { type: 'episode_every_evaluation' };
+  }
+  if (dispatchPer === 'group') {
+    const parsed = parseRepeatInterval(throttle.interval);
+    if (parsed) {
+      return {
+        type: 'group_throttle',
+        repeatValue: parsed.repeatValue,
+        repeatUnit: parsed.repeatUnit,
+      };
+    }
+    return {
+      type: 'group_throttle',
+      repeatValue: 10,
+      repeatUnit: 'm',
+    };
+  }
+  const parsed = parseRepeatInterval(throttle.interval);
+  if (parsed) {
+    return {
+      type: 'episode_status_change_repeat',
+      repeatValue: parsed.repeatValue,
+      repeatUnit: parsed.repeatUnit,
+    };
+  }
+  // Throttle present but not in Ns/Nm/Nh/Nd form — show a safe default repeat; user can adjust.
+  return {
+    type: 'episode_status_change_repeat',
+    repeatValue: 5,
+    repeatUnit: 'm',
+  };
+}
 
 export const toFormState = (response: NotificationPolicyResponse): NotificationPolicyFormState => {
+  const hasGroup = (response.groupBy?.length ?? 0) > 0;
+  const dispatchPer: DispatchPer = hasGroup ? 'group' : 'episode';
+
   return {
     name: response.name,
     description: response.description,
     matcher: response.matcher ?? '',
     groupBy: response.groupBy ?? [],
-    frequency: response.throttle
-      ? { type: 'throttle', interval: response.throttle.interval }
-      : { type: 'immediate' },
+    dispatchPer,
+    frequency: frequencyFromThrottle(response.throttle, dispatchPer),
     destinations: response.destinations.map((d) => ({ type: d.type, id: d.id })),
+    suppressionMechanisms: DEFAULT_SUPPRESSION_MECHANISMS,
   };
 };
 
 export const toCreatePayload = (
   state: NotificationPolicyFormState
 ): CreateNotificationPolicyData => {
+  const throttle = throttleFromFrequency(state.frequency);
   return {
     name: state.name,
     description: state.description,
     ...(state.matcher ? { matcher: state.matcher } : {}),
     ...(state.groupBy.length > 0 ? { groupBy: state.groupBy } : {}),
-    ...(state.frequency.type === 'throttle'
-      ? { throttle: { interval: state.frequency.interval } }
-      : {}),
+    ...(throttle ? { throttle } : {}),
     destinations: state.destinations.map((d) => ({ type: d.type, id: d.id })),
   };
 };
@@ -44,13 +116,14 @@ export const toUpdatePayload = (
   state: NotificationPolicyFormState,
   version: string
 ): UpdateNotificationPolicyBody => {
+  const throttle = throttleFromFrequency(state.frequency);
   return {
     version,
     name: state.name,
     description: state.description,
     matcher: state.matcher || null,
     groupBy: state.groupBy.length > 0 ? state.groupBy : null,
-    throttle: state.frequency.type === 'throttle' ? { interval: state.frequency.interval } : null,
+    throttle: throttle ?? null,
     destinations: state.destinations.map((d) => ({ type: d.type, id: d.id })),
   };
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/matcher_quick_filter_utils.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/matcher_quick_filter_utils.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  buildEpisodeStatusClause,
+  mergeEpisodeStatusIntoMatcher,
+  mergeRuleIdsIntoMatcher,
+  parseEpisodeStatusesFromMatcher,
+  parseRuleIdsFromMatcher,
+  stripEpisodeStatusClauses,
+  stripRuleIdClauses,
+} from './matcher_quick_filter_utils';
+
+describe('matcher_quick_filter_utils', () => {
+  describe('stripEpisodeStatusClauses', () => {
+    it('removes episode_status clauses', () => {
+      expect(stripEpisodeStatusClauses('foo : "a" AND episode_status : "active"')).toBe(
+        'foo : "a"'
+      );
+    });
+  });
+
+  describe('buildEpisodeStatusClause', () => {
+    it('returns null for empty', () => {
+      expect(buildEpisodeStatusClause([])).toBeNull();
+    });
+
+    it('builds single-value clause', () => {
+      expect(buildEpisodeStatusClause(['active'])).toBe('episode_status : "active"');
+    });
+
+    it('builds OR group for multiple values', () => {
+      expect(buildEpisodeStatusClause(['active', 'pending'])).toBe(
+        '(episode_status : "active" or episode_status : "pending")'
+      );
+    });
+  });
+
+  describe('mergeEpisodeStatusIntoMatcher', () => {
+    it('appends when base empty', () => {
+      expect(mergeEpisodeStatusIntoMatcher('', ['inactive'])).toBe('episode_status : "inactive"');
+    });
+
+    it('merges with existing non-status clauses', () => {
+      expect(
+        mergeEpisodeStatusIntoMatcher('rule.id : "x"', ['active', 'recovering'])
+      ).toBe(
+        'rule.id : "x" AND (episode_status : "active" or episode_status : "recovering")'
+      );
+    });
+  });
+
+  describe('parseEpisodeStatusesFromMatcher', () => {
+    it('parses quoted episode_status values', () => {
+      expect(
+        parseEpisodeStatusesFromMatcher('episode_status : "active" AND episode_status : "pending"')
+      ).toEqual(['active', 'pending']);
+    });
+  });
+
+  describe('rule id helpers', () => {
+    it('stripRuleIdClauses removes rule.id segments', () => {
+      expect(stripRuleIdClauses('episode_status : "a" AND rule.id : "x"')).toBe(
+        'episode_status : "a"'
+      );
+    });
+
+    it('parseRuleIdsFromMatcher collects ids', () => {
+      expect(parseRuleIdsFromMatcher('rule.id : "a" AND rule.id : "b"')).toEqual(['a', 'b']);
+    });
+
+    it('mergeRuleIdsIntoMatcher builds OR group', () => {
+      expect(mergeRuleIdsIntoMatcher('', ['u1', 'u2'])).toBe(
+        '(rule.id : "u1" or rule.id : "u2")'
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/matcher_quick_filter_utils.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/matcher_quick_filter_utils.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/** Removes AND-separated parts that reference episode_status (quick-filter managed). */
+export const stripEpisodeStatusClauses = (matcher: string): string =>
+  matcher
+    .split(/\s+AND\s+/i)
+    .map((p) => p.trim())
+    .filter((p) => p && !p.toLowerCase().includes('episode_status'))
+    .join(' AND ');
+
+export const buildEpisodeStatusClause = (statuses: readonly string[]): string | null => {
+  if (statuses.length === 0) {
+    return null;
+  }
+  if (statuses.length === 1) {
+    return `episode_status : "${statuses[0]}"`;
+  }
+  return `(${statuses.map((s) => `episode_status : "${s}"`).join(' or ')})`;
+};
+
+export const mergeEpisodeStatusIntoMatcher = (
+  matcher: string,
+  statuses: readonly string[]
+): string => {
+  const base = stripEpisodeStatusClauses(matcher).trim();
+  const clause = buildEpisodeStatusClause(statuses);
+  if (!clause) {
+    return base;
+  }
+  return base ? `${base} AND ${clause}` : clause;
+};
+
+/** Best-effort parse of episode_status values already in the matcher (for checkbox sync). */
+export const parseEpisodeStatusesFromMatcher = (matcher: string): string[] => {
+  const found = new Set<string>();
+  const re = /episode_status\s*:\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null = re.exec(matcher);
+  while (m !== null) {
+    found.add(m[1]);
+    m = re.exec(matcher);
+  }
+  return [...found];
+};
+
+/** Removes AND-separated parts that reference rule.id (quick-filter managed). */
+export const stripRuleIdClauses = (matcher: string): string =>
+  matcher
+    .split(/\s+AND\s+/i)
+    .map((p) => p.trim())
+    .filter((p) => p && !p.toLowerCase().includes('rule.id'))
+    .join(' AND ');
+
+export const parseRuleIdsFromMatcher = (matcher: string): string[] => {
+  const found = new Set<string>();
+  const re = /rule\.id\s*:\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null = re.exec(matcher);
+  while (m !== null) {
+    found.add(m[1]);
+    m = re.exec(matcher);
+  }
+  return [...found];
+};
+
+export const mergeRuleIdsIntoMatcher = (matcher: string, ids: readonly string[]): string => {
+  const base = stripRuleIdClauses(matcher).trim();
+  if (ids.length === 0) {
+    return base;
+  }
+  const clause =
+    ids.length === 1
+      ? `rule.id : "${ids[0]}"`
+      : `(${ids.map((id) => `rule.id : "${id}"`).join(' or ')})`;
+  return base ? `${base} AND ${clause}` : clause;
+};
+
+export const parseRuleLabelsFromMatcher = (matcher: string): string[] => {
+  const found: string[] = [];
+  const re = /rule\.labels\s*:\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null = re.exec(matcher);
+  while (m !== null) {
+    found.push(m[1]);
+    m = re.exec(matcher);
+  }
+  return found;
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.stories.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.stories.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { DEFAULT_FORM_STATE } from './constants';
+import { DEFAULT_FORM_STATE, DEFAULT_SUPPRESSION_MECHANISMS } from './constants';
 import { NotificationPolicyForm } from './notification_policy_form';
 import type { NotificationPolicyFormState } from './types';
 
@@ -59,8 +59,10 @@ export const EditMode: Story = {
       description: 'Routes critical production alerts to escalation workflows',
       matcher: 'data.severity : "critical" and data.env : "prod"',
       groupBy: ['host.name', 'service.name'],
-      frequency: { type: 'throttle', interval: '5m' },
+      dispatchPer: 'group',
+      frequency: { type: 'group_throttle', repeatValue: 5, repeatUnit: 'm' },
       destinations: [{ type: 'workflow', id: 'workflow-2' }],
+      suppressionMechanisms: DEFAULT_SUPPRESSION_MECHANISMS.map((m) => ({ ...m })),
     },
   },
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
@@ -15,6 +15,29 @@ import { DEFAULT_FORM_STATE } from './constants';
 import { NotificationPolicyForm } from './notification_policy_form';
 import type { NotificationPolicyFormState } from './types';
 
+jest.mock('@kbn/core-di-browser', () => {
+  const { WORKFLOWS_UI_SETTING_ID } = jest.requireActual('@kbn/workflows') as {
+    WORKFLOWS_UI_SETTING_ID: string;
+  };
+  return {
+    useService: jest.fn((token: unknown) => {
+      const tokenStr = String(token);
+      if (tokenStr.includes('uiSettings')) {
+        return {
+          get: jest.fn((key: string, defaultValue?: boolean) =>
+            key === WORKFLOWS_UI_SETTING_ID ? true : defaultValue
+          ),
+        };
+      }
+      if (tokenStr.includes('http')) {
+        return { basePath: { prepend: (path: string) => `/mock${path}` } };
+      }
+      return {};
+    }),
+    CoreStart: jest.fn((name: string) => `CoreStart(${name})`),
+  };
+});
+
 jest.mock('./components/matcher_input', () => ({
   MatcherInput: (props: {
     value: string;
@@ -27,6 +50,10 @@ jest.mock('./components/matcher_input', () => ({
       onChange={(e) => props.onChange(e.target.value)}
     />
   ),
+}));
+
+jest.mock('./components/quick_filters', () => ({
+  QuickFilters: () => null,
 }));
 
 jest.mock('../../../hooks/use_fetch_workflows', () => ({
@@ -59,7 +86,7 @@ const TEST_SUBJ = {
   nameInput: 'nameInput',
   descriptionInput: 'descriptionInput',
   frequencySelect: 'frequencySelect',
-  throttleIntervalInput: 'throttleIntervalInput',
+  repeatIntervalValueInput: 'repeatIntervalValueInput',
 } as const;
 
 describe('NotificationPolicyForm', () => {
@@ -72,30 +99,19 @@ describe('NotificationPolicyForm', () => {
     expect(await screen.findByText('Name is required.')).toBeInTheDocument();
   });
 
-  it('shows throttle interval input only when throttle frequency is selected', async () => {
+  it('shows repeat interval controls when group throttle frequency is selected', async () => {
     const user = userEvent.setup();
-    renderForm();
+    renderForm({
+      ...DEFAULT_FORM_STATE,
+      dispatchPer: 'group',
+      groupBy: ['host.name'],
+      frequency: { type: 'group_immediate' },
+    });
 
-    expect(screen.queryByTestId(TEST_SUBJ.throttleIntervalInput)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_SUBJ.repeatIntervalValueInput)).not.toBeInTheDocument();
 
-    await user.selectOptions(screen.getByTestId(TEST_SUBJ.frequencySelect), 'throttle');
+    await user.selectOptions(screen.getByTestId(TEST_SUBJ.frequencySelect), 'group_throttle');
 
-    expect(screen.getByTestId(TEST_SUBJ.throttleIntervalInput)).toBeInTheDocument();
-  });
-
-  it('validates throttle interval format when in throttle mode', async () => {
-    const user = userEvent.setup();
-    renderForm();
-
-    await user.selectOptions(screen.getByTestId(TEST_SUBJ.frequencySelect), 'throttle');
-
-    const intervalInput = screen.getByTestId(TEST_SUBJ.throttleIntervalInput);
-    await user.clear(intervalInput);
-    await user.type(intervalInput, '10x');
-    await user.tab();
-
-    expect(
-      await screen.findByText('Invalid throttle interval. Must be in the format of 1h, 5m, 30s')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId(TEST_SUBJ.repeatIntervalValueInput)).toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
@@ -31,7 +31,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import {
   DISPATCH_PER_DESCRIPTIONS,
   DISPATCH_PER_OPTIONS,
-  NOTIFY_PER_LABEL,
+  DISPATCH_PER_LABEL,
   EPISODE_FREQUENCY_DESCRIPTIONS,
   EPISODE_FREQUENCY_OPTIONS,
   GROUP_FREQUENCY_DESCRIPTIONS,
@@ -333,7 +333,7 @@ export const NotificationPolicyForm = () => {
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.alertingV2.notificationPolicy.form.dispatch.description"
-              defaultMessage="Dispatch sets what counts as one notification (per episode or per group) and how often it can be sent."
+              defaultMessage="Dispatch sets what counts as one dispatch (per episode or per group) and how often it can be sent."
             />
           </EuiText>
         </EuiSplitPanel.Inner>
@@ -343,12 +343,12 @@ export const NotificationPolicyForm = () => {
             control={control}
             render={({ field }) => (
               <EuiFormRow
-                label={NOTIFY_PER_LABEL}
+                label={DISPATCH_PER_LABEL}
                 helpText={DISPATCH_PER_DESCRIPTIONS[field.value as DispatchPer]}
                 fullWidth
               >
                 <EuiButtonGroup
-                  legend={NOTIFY_PER_LABEL}
+                  legend={DISPATCH_PER_LABEL}
                   options={DISPATCH_PER_OPTIONS}
                   idSelected={field.value}
                   onChange={(id: string) => {
@@ -393,7 +393,7 @@ export const NotificationPolicyForm = () => {
                       'xpack.alertingV2.notificationPolicy.form.groupBy.help',
                       {
                         defaultMessage:
-                          'Episodes that share these field values are notified as one group.',
+                          'Episodes that share these field values are grouped together for dispatch.',
                       }
                     )}
                     fullWidth

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
@@ -6,9 +6,17 @@
  */
 
 import {
+  EuiButtonGroup,
   EuiComboBox,
+  type EuiComboBoxOptionOption,
+  EuiFieldNumber,
   EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormLabel,
   EuiFormRow,
+  EuiHorizontalRule,
+  EuiPanel,
   EuiSelect,
   EuiSpacer,
   EuiSplitPanel,
@@ -18,20 +26,155 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { FREQUENCY_OPTIONS, THROTTLE_INTERVAL_PATTERN } from './constants';
+import {
+  DISPATCH_PER_DESCRIPTIONS,
+  DISPATCH_PER_OPTIONS,
+  NOTIFY_PER_LABEL,
+  EPISODE_FREQUENCY_DESCRIPTIONS,
+  EPISODE_FREQUENCY_OPTIONS,
+  GROUP_FREQUENCY_DESCRIPTIONS,
+  GROUP_FREQUENCY_OPTIONS,
+  REPEAT_INTERVAL_UNIT_OPTIONS,
+} from './constants';
 import { MatcherInput } from './components/matcher_input';
+import { optionalFieldLabelAppend } from './components/optional_label_append';
+import { QuickFilters } from './components/quick_filters';
+import { SuppressionBehaviorSection } from './components/suppression_behavior_section';
 import { WorkflowSelector } from './components/workflow_selector';
-import type { NotificationPolicyFormState } from './types';
+import type {
+  DispatchPer,
+  NotificationPolicyFormState,
+  NotificationPolicyFrequency,
+} from './types';
+
+function isEpisodeFrequency(f: NotificationPolicyFrequency): boolean {
+  return (
+    f.type === 'episode_status_change' ||
+    f.type === 'episode_status_change_repeat' ||
+    f.type === 'episode_every_evaluation'
+  );
+}
+
+function isGroupFrequency(f: NotificationPolicyFrequency): boolean {
+  return f.type === 'group_immediate' || f.type === 'group_throttle';
+}
+
+function createFrequencyForType(
+  dispatchPer: DispatchPer,
+  value: string
+): NotificationPolicyFrequency {
+  if (dispatchPer === 'episode') {
+    switch (value) {
+      case 'episode_status_change':
+        return { type: 'episode_status_change' };
+      case 'episode_status_change_repeat':
+        return { type: 'episode_status_change_repeat', repeatValue: 5, repeatUnit: 'm' };
+      case 'episode_every_evaluation':
+      default:
+        return { type: 'episode_every_evaluation' };
+    }
+  }
+  switch (value) {
+    case 'group_throttle':
+      return { type: 'group_throttle', repeatValue: 10, repeatUnit: 'm' };
+    case 'group_immediate':
+    default:
+      return { type: 'group_immediate' };
+  }
+}
 
 export const NotificationPolicyForm = () => {
-  const { control } = useFormContext<NotificationPolicyFormState>();
-  const frequency = useWatch({ control, name: 'frequency' });
+  const { control, setValue, getValues } = useFormContext<NotificationPolicyFormState>();
+  const [frequency, dispatchPer, groupBy] = useWatch({
+    control,
+    name: ['frequency', 'dispatchPer', 'groupBy'],
+  });
+
+  const dispatchBasis = useMemo(() => {
+    if (dispatchPer === 'episode') {
+      return DISPATCH_PER_DESCRIPTIONS.episode;
+    }
+    if (groupBy.length > 0) {
+      return i18n.translate(
+        'xpack.alertingV2.notificationPolicy.form.dispatchConfig.groupFieldsDetail',
+        {
+          defaultMessage:
+            'Episodes with the same values for {fields} are grouped together. One dispatch per group.',
+          values: { fields: groupBy.join(', ') },
+        }
+      );
+    }
+    return i18n.translate(
+      'xpack.alertingV2.notificationPolicy.form.dispatchConfig.groupByPending',
+      {
+        defaultMessage:
+          'Group dispatch: add at least one field under Group by so episodes can be grouped.',
+      }
+    );
+  }, [dispatchPer, groupBy]);
+
+  const dispatchConfigCallout = useMemo(() => {
+    if (!frequency) {
+      return dispatchBasis;
+    }
+    switch (frequency.type) {
+      case 'group_throttle':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.dispatchConfig.callout.groupThrottle"
+            defaultMessage="{dispatchBasis} Frequency: at most once per {interval}."
+            values={{
+              dispatchBasis,
+              interval: `${frequency.repeatValue}${frequency.repeatUnit}`,
+            }}
+          />
+        );
+      case 'episode_status_change_repeat':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.dispatchConfig.callout.episodeRepeat"
+            defaultMessage="{dispatchBasis} Frequency: on status change and repeat every {interval}."
+            values={{
+              dispatchBasis,
+              interval: `${frequency.repeatValue}${frequency.repeatUnit}`,
+            }}
+          />
+        );
+      case 'episode_status_change':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.dispatchConfig.callout.episodeStatusChange"
+            defaultMessage="{dispatchBasis} Frequency: once per status transition."
+            values={{ dispatchBasis }}
+          />
+        );
+      case 'episode_every_evaluation':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.dispatchConfig.callout.episodeEveryEvaluation"
+            defaultMessage="{dispatchBasis} Frequency: every evaluation cycle per episode (no throttle)."
+            values={{ dispatchBasis }}
+          />
+        );
+      case 'group_immediate':
+        return (
+          <FormattedMessage
+            id="xpack.alertingV2.notificationPolicy.form.dispatchConfig.callout.groupImmediate"
+            defaultMessage="{dispatchBasis} Frequency: every evaluation cycle per group (no throttle)."
+            values={{ dispatchBasis }}
+          />
+        );
+      default:
+        return dispatchBasis;
+    }
+  }, [dispatchBasis, frequency]);
 
   return (
     <>
-      <EuiSplitPanel.Outer borderRadius="m" hasShadow={true} hasBorder={true}>
+      {/* ── Basic information ───────────────────────────────────────────── */}
+      <EuiSplitPanel.Outer borderRadius="m" hasShadow={false} hasBorder={true}>
         <EuiSplitPanel.Inner color="subdued">
           <EuiTitle size="xs">
             <h3>
@@ -88,6 +231,7 @@ export const NotificationPolicyForm = () => {
                 label={i18n.translate('xpack.alertingV2.notificationPolicy.form.description', {
                   defaultMessage: 'Description',
                 })}
+                labelAppend={optionalFieldLabelAppend}
                 fullWidth
               >
                 <EuiTextArea
@@ -109,7 +253,8 @@ export const NotificationPolicyForm = () => {
 
       <EuiSpacer size="m" />
 
-      <EuiSplitPanel.Outer borderRadius="m" hasShadow={true} hasBorder={true}>
+      {/* ── Match conditions ────────────────────────────────────────────── */}
+      <EuiSplitPanel.Outer borderRadius="m" hasShadow={false} hasBorder={true}>
         <EuiSplitPanel.Inner color="subdued">
           <EuiTitle size="xs">
             <h3>
@@ -122,7 +267,7 @@ export const NotificationPolicyForm = () => {
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.alertingV2.notificationPolicy.form.matchConditions.description"
-              defaultMessage="Define conditions that must be met for this policy to trigger"
+              defaultMessage="Define conditions that must be met for this policy to trigger. Leave empty to match all alert episodes."
             />
           </EuiText>
         </EuiSplitPanel.Inner>
@@ -131,23 +276,42 @@ export const NotificationPolicyForm = () => {
             name="matcher"
             control={control}
             render={({ field }) => (
-              <EuiFormRow
-                label={i18n.translate('xpack.alertingV2.notificationPolicy.form.matcher', {
-                  defaultMessage: 'Matcher',
-                })}
-                fullWidth
-              >
-                <MatcherInput
-                  value={field.value}
-                  onChange={field.onChange}
+              <>
+                <EuiFormRow
+                  label={
+                    <EuiFormLabel>
+                      {i18n.translate(
+                        'xpack.alertingV2.notificationPolicy.form.quickFilters.label',
+                        { defaultMessage: 'Quick filters' }
+                      )}
+                    </EuiFormLabel>
+                  }
                   fullWidth
-                  data-test-subj="matcherInput"
-                  placeholder={i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.matcher.placeholder',
-                    { defaultMessage: 'e.g. episode_status : "active" and rule.name : "my-rule"' }
-                  )}
-                />
-              </EuiFormRow>
+                >
+                  <QuickFilters matcher={field.value} onChange={field.onChange} />
+                </EuiFormRow>
+                <EuiFormRow
+                  label={i18n.translate('xpack.alertingV2.notificationPolicy.form.matcher', {
+                    defaultMessage: 'Matcher',
+                  })}
+                  labelAppend={optionalFieldLabelAppend}
+                  fullWidth
+                >
+                  <MatcherInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    fullWidth
+                    data-test-subj="matcherInput"
+                    placeholder={i18n.translate(
+                      'xpack.alertingV2.notificationPolicy.form.matcher.placeholder',
+                      {
+                        defaultMessage:
+                          'Filter episodes. e.g. episode_status:active AND rule_name: "my-rule"',
+                      }
+                    )}
+                  />
+                </EuiFormRow>
+              </>
             )}
           />
         </EuiSplitPanel.Inner>
@@ -155,164 +319,287 @@ export const NotificationPolicyForm = () => {
 
       <EuiSpacer size="m" />
 
-      <EuiSplitPanel.Outer borderRadius="m" hasShadow={true} hasBorder={true}>
+      {/* ── Dispatch ────────────────────────────────────────────────────── */}
+      <EuiSplitPanel.Outer borderRadius="m" hasShadow={false} hasBorder={true}>
         <EuiSplitPanel.Inner color="subdued">
           <EuiTitle size="xs">
             <h3>
               <FormattedMessage
-                id="xpack.alertingV2.notificationPolicy.form.grouping.title"
-                defaultMessage="Grouping configuration"
+                id="xpack.alertingV2.notificationPolicy.form.dispatch.title"
+                defaultMessage="Dispatch"
               />
             </h3>
           </EuiTitle>
           <EuiText size="xs" color="subdued">
             <FormattedMessage
-              id="xpack.alertingV2.notificationPolicy.form.grouping.description"
-              defaultMessage="Group notifications by specific fields to reduce alert noise"
+              id="xpack.alertingV2.notificationPolicy.form.dispatch.description"
+              defaultMessage="Dispatch sets what counts as one notification (per episode or per group) and how often it can be sent."
             />
           </EuiText>
         </EuiSplitPanel.Inner>
         <EuiSplitPanel.Inner>
           <Controller
-            name="groupBy"
+            name="dispatchPer"
             control={control}
             render={({ field }) => (
               <EuiFormRow
-                label={i18n.translate('xpack.alertingV2.notificationPolicy.form.groupBy', {
-                  defaultMessage: 'Fields',
-                })}
+                label={NOTIFY_PER_LABEL}
+                helpText={DISPATCH_PER_DESCRIPTIONS[field.value as DispatchPer]}
                 fullWidth
               >
-                <EuiComboBox
-                  fullWidth
-                  data-test-subj="groupByInput"
-                  placeholder={i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.groupBy.placeholder',
-                    { defaultMessage: 'Select or type a field name' }
-                  )}
-                  selectedOptions={field.value.map((g: string) => ({ label: g }))}
-                  noSuggestions
-                  onCreateOption={(val) => {
-                    field.onChange([...field.value, val]);
+                <EuiButtonGroup
+                  legend={NOTIFY_PER_LABEL}
+                  options={DISPATCH_PER_OPTIONS}
+                  idSelected={field.value}
+                  onChange={(id: string) => {
+                    const next = id as DispatchPer;
+                    field.onChange(next);
+                    const currentFreq = getValues('frequency');
+                    if (next === 'episode' && isGroupFrequency(currentFreq)) {
+                      setValue('frequency', { type: 'episode_every_evaluation' });
+                    } else if (next === 'group' && isEpisodeFrequency(currentFreq)) {
+                      setValue('frequency', { type: 'group_immediate' });
+                    }
                   }}
-                  onChange={(options) => {
-                    field.onChange(options.map((o) => o.label));
-                  }}
+                  data-test-subj="dispatchPerGroup"
                 />
               </EuiFormRow>
             )}
           />
-        </EuiSplitPanel.Inner>
-      </EuiSplitPanel.Outer>
 
-      <EuiSpacer size="m" />
-
-      <EuiSplitPanel.Outer borderRadius="m" hasShadow={true} hasBorder={true}>
-        <EuiSplitPanel.Inner color="subdued">
-          <EuiTitle size="xs">
-            <h3>
-              <FormattedMessage
-                id="xpack.alertingV2.notificationPolicy.form.frequency.title"
-                defaultMessage="Frequency and timing configuration"
-              />
-            </h3>
-          </EuiTitle>
-          <EuiText size="xs" color="subdued">
-            <FormattedMessage
-              id="xpack.alertingV2.notificationPolicy.form.frequency.description"
-              defaultMessage="Control when and how often notifications are sent"
-            />
-          </EuiText>
-        </EuiSplitPanel.Inner>
-        <EuiSplitPanel.Inner>
-          <Controller
-            name="frequency.type"
-            control={control}
-            render={({ field: { ref, ...field } }) => (
-              <EuiFormRow
-                label={i18n.translate('xpack.alertingV2.notificationPolicy.form.frequencyType', {
-                  defaultMessage: 'Frequency',
-                })}
-                fullWidth
-              >
-                <EuiSelect
-                  {...field}
-                  inputRef={ref}
-                  fullWidth
-                  options={FREQUENCY_OPTIONS}
-                  data-test-subj="frequencySelect"
-                />
-              </EuiFormRow>
-            )}
-          />
-          {frequency.type === 'throttle' && (
-            <Controller
-              name="frequency.interval"
-              control={control}
-              rules={{
-                pattern: {
-                  value: THROTTLE_INTERVAL_PATTERN,
-                  message: i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.throttleInterval.pattern',
-                    {
-                      defaultMessage:
-                        'Invalid throttle interval. Must be in the format of 1h, 5m, 30s',
-                    }
-                  ),
-                },
-                required: i18n.translate(
-                  'xpack.alertingV2.notificationPolicy.form.throttleInterval.required',
-                  { defaultMessage: 'Throttle interval is required.' }
-                ),
-              }}
-              render={({ field: { ref, ...field }, fieldState: { error } }) => (
-                <EuiFormRow
-                  label={i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.throttleInterval',
-                    {
-                      defaultMessage: 'Throttle interval',
-                    }
-                  )}
-                  helpText={i18n.translate(
-                    'xpack.alertingV2.notificationPolicy.form.throttleInterval.help',
-                    { defaultMessage: 'e.g. 1h, 5m, 30s' }
-                  )}
-                  fullWidth
-                  isInvalid={!!error}
-                  error={error?.message}
-                >
-                  <EuiFieldText
-                    {...field}
-                    inputRef={ref}
-                    value={field.value ?? ''}
+          {dispatchPer === 'group' && (
+            <>
+              <EuiSpacer size="m" />
+              <Controller
+                name="groupBy"
+                control={control}
+                rules={{
+                  validate: (value: string[]) =>
+                    getValues('dispatchPer') !== 'group' ||
+                    value.length > 0 ||
+                    i18n.translate('xpack.alertingV2.notificationPolicy.form.groupBy.required', {
+                      defaultMessage: 'Add at least one field to group by.',
+                    }),
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <EuiFormRow
+                    label={i18n.translate(
+                      'xpack.alertingV2.notificationPolicy.form.groupBy.label',
+                      {
+                        defaultMessage: 'Group by',
+                      }
+                    )}
+                    helpText={i18n.translate(
+                      'xpack.alertingV2.notificationPolicy.form.groupBy.help',
+                      {
+                        defaultMessage:
+                          'Episodes that share these field values are notified as one group.',
+                      }
+                    )}
                     fullWidth
                     isInvalid={!!error}
-                    data-test-subj="throttleIntervalInput"
+                    error={error?.message}
+                  >
+                    <EuiComboBox
+                      fullWidth
+                      noSuggestions
+                      isInvalid={!!error}
+                      data-test-subj="groupByInput"
+                      placeholder={i18n.translate(
+                        'xpack.alertingV2.notificationPolicy.form.groupBy.placeholder',
+                        { defaultMessage: 'Add field…' }
+                      )}
+                      selectedOptions={field.value.map((v) => ({ label: v, value: v }))}
+                      onChange={(options: EuiComboBoxOptionOption[]) => {
+                        field.onChange(options.map((o) => String(o.label)));
+                      }}
+                      onCreateOption={(value: string) => {
+                        const trimmed = value.trim();
+                        if (!trimmed || field.value.includes(trimmed)) {
+                          return;
+                        }
+                        field.onChange([...field.value, trimmed]);
+                      }}
+                    />
+                  </EuiFormRow>
+                )}
+              />
+            </>
+          )}
+
+          <EuiHorizontalRule margin="m" />
+
+          <Controller
+            name="frequency"
+            control={control}
+            render={({ field }) => {
+              const freq = field.value;
+              const freqType = freq.type;
+              const isEpisode = dispatchPer === 'episode';
+              const options = isEpisode ? EPISODE_FREQUENCY_OPTIONS : GROUP_FREQUENCY_OPTIONS;
+              const helpText = isEpisode
+                ? EPISODE_FREQUENCY_DESCRIPTIONS[freqType]
+                : GROUP_FREQUENCY_DESCRIPTIONS[freqType];
+              return (
+                <EuiFormRow
+                  label={i18n.translate('xpack.alertingV2.notificationPolicy.form.frequencyType', {
+                    defaultMessage: 'Frequency',
+                  })}
+                  helpText={helpText ?? ''}
+                  fullWidth
+                >
+                  <EuiSelect
+                    fullWidth
+                    data-test-subj="frequencySelect"
+                    options={options}
+                    value={freqType}
+                    onChange={(e) => {
+                      field.onChange(createFrequencyForType(dispatchPer, e.target.value));
+                    }}
                   />
                 </EuiFormRow>
+              );
+            }}
+          />
+
+          {(frequency?.type === 'episode_status_change_repeat' ||
+            frequency?.type === 'group_throttle') && (
+            <>
+              <EuiSpacer size="m" />
+              <EuiFormRow
+                label={i18n.translate(
+                  'xpack.alertingV2.notificationPolicy.form.frequency.repeatInterval.label',
+                  { defaultMessage: 'Repeat interval' }
+                )}
+                fullWidth
+              >
+                <EuiFlexGroup gutterSize="s" alignItems="flexEnd" responsive={false} wrap={false}>
+                  <EuiFlexItem grow={true}>
+                    <Controller
+                      name="frequency.repeatValue"
+                      control={control}
+                      rules={{
+                        required: true,
+                        min: {
+                          value: 1,
+                          message: i18n.translate(
+                            'xpack.alertingV2.notificationPolicy.form.frequency.repeatValue.min',
+                            { defaultMessage: 'Enter a value of at least 1.' }
+                          ),
+                        },
+                      }}
+                      render={({ field: f, fieldState: { error } }) => (
+                        <EuiFieldNumber
+                          fullWidth
+                          min={1}
+                          step={1}
+                          prepend={i18n.translate(
+                            'xpack.alertingV2.notificationPolicy.form.frequency.repeatInterval.everyPrefix',
+                            { defaultMessage: 'Every' }
+                          )}
+                          placeholder={i18n.translate(
+                            'xpack.alertingV2.notificationPolicy.form.frequency.repeatInterval.numberPlaceholder',
+                            { defaultMessage: 'Number' }
+                          )}
+                          value={f.value}
+                          onChange={(e) =>
+                            f.onChange(e.target.value === '' ? '' : Number(e.target.value))
+                          }
+                          isInvalid={!!error}
+                          data-test-subj="repeatIntervalValueInput"
+                        />
+                      )}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false} style={{ flexShrink: 0, minWidth: 120, width: 120 }}>
+                    <Controller
+                      name="frequency.repeatUnit"
+                      control={control}
+                      render={({ field: f }) => (
+                        <EuiSelect
+                          fullWidth
+                          options={REPEAT_INTERVAL_UNIT_OPTIONS}
+                          value={f.value}
+                          onChange={f.onChange}
+                          data-test-subj="repeatIntervalUnitSelect"
+                        />
+                      )}
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFormRow>
+              {frequency?.type === 'episode_status_change_repeat' && (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiText
+                    size="xs"
+                    color="subdued"
+                    data-test-subj="repeatLookbackHint"
+                  >
+                    {i18n.translate(
+                      'xpack.alertingV2.notificationPolicy.form.frequency.repeatLookback.body',
+                      {
+                        defaultMessage:
+                          'The dispatcher looks back 10 minutes for new events. Intervals longer than 10 minutes may cause gaps.',
+                      }
+                    )}
+                  </EuiText>
+                </>
               )}
-            />
+            </>
           )}
+
+          <EuiSpacer size="m" />
+
+          <EuiPanel
+            color="subdued"
+            paddingSize="m"
+            borderRadius="m"
+            hasShadow={false}
+            hasBorder={false}
+            data-test-subj="dispatchConfigCallout"
+          >
+            <EuiTitle size="xxs">
+              <h4>
+                {i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchConfig.title', {
+                  defaultMessage: 'Dispatch configuration',
+                })}
+              </h4>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <EuiText size="s">{dispatchConfigCallout}</EuiText>
+          </EuiPanel>
         </EuiSplitPanel.Inner>
       </EuiSplitPanel.Outer>
 
       <EuiSpacer size="m" />
 
-      <EuiSplitPanel.Outer borderRadius="m" hasShadow={true} hasBorder={true}>
+      {/* ── Destinations ────────────────────────────────────────────────── */}
+      <EuiSplitPanel.Outer borderRadius="m" hasShadow={false} hasBorder={true}>
         <EuiSplitPanel.Inner color="subdued">
           <EuiTitle size="xs">
             <h3>
               <FormattedMessage
                 id="xpack.alertingV2.notificationPolicy.form.destination.title"
-                defaultMessage="Destination"
+                defaultMessage="Destinations"
               />
             </h3>
           </EuiTitle>
+          <EuiText size="xs" color="subdued">
+            <FormattedMessage
+              id="xpack.alertingV2.notificationPolicy.form.destination.subtitle"
+              defaultMessage="Where should dispatches be sent."
+            />
+          </EuiText>
         </EuiSplitPanel.Inner>
         <EuiSplitPanel.Inner>
           <WorkflowSelector />
         </EuiSplitPanel.Inner>
       </EuiSplitPanel.Outer>
+
+      <EuiSpacer size="m" />
+
+      <SuppressionBehaviorSection />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/types.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/types.ts
@@ -5,20 +5,54 @@
  * 2.0.
  */
 
-export interface ThrottleFrequency {
-  type: 'throttle';
-  interval: string; // e.g. '1h', '30m', '5m'
+/** Throttle-style suffix for repeat interval (matches API `30s`, `5m`, `2h`, `1d`). */
+export type RepeatIntervalUnit = 's' | 'm' | 'h' | 'd';
+
+/** Per-episode dispatch: align with notification timing (status vs evaluation). */
+export interface EpisodeStatusChangeFrequency {
+  type: 'episode_status_change';
 }
 
-export interface ImmediateFrequency {
-  type: 'immediate';
+export interface EpisodeStatusChangeRepeatFrequency {
+  type: 'episode_status_change_repeat';
+  repeatValue: number;
+  repeatUnit: RepeatIntervalUnit;
 }
 
-export type NotificationPolicyFrequency = ThrottleFrequency | ImmediateFrequency;
+export interface EpisodeEveryEvaluationFrequency {
+  type: 'episode_every_evaluation';
+}
+
+/** Per-group dispatch: classic throttle vs every evaluation. */
+export interface GroupImmediateFrequency {
+  type: 'group_immediate';
+}
+
+export interface GroupThrottleFrequency {
+  type: 'group_throttle';
+  repeatValue: number;
+  repeatUnit: RepeatIntervalUnit;
+}
+
+export type NotificationPolicyFrequency =
+  | EpisodeStatusChangeFrequency
+  | EpisodeStatusChangeRepeatFrequency
+  | EpisodeEveryEvaluationFrequency
+  | GroupImmediateFrequency
+  | GroupThrottleFrequency;
 
 export interface NotificationPolicyDestination {
   type: 'workflow';
   id: string;
+}
+
+export type DispatchPer = 'episode' | 'group';
+
+export type SuppressionMechanismId = 'maintenance_window' | 'manual_suppressions';
+
+export interface SuppressionMechanismItem {
+  id: SuppressionMechanismId;
+  enabled: boolean;
 }
 
 export interface NotificationPolicyFormState {
@@ -26,6 +60,8 @@ export interface NotificationPolicyFormState {
   description: string;
   matcher: string;
   groupBy: string[];
+  dispatchPer: DispatchPer;
   frequency: NotificationPolicyFrequency;
   destinations: NotificationPolicyDestination[];
+  suppressionMechanisms: SuppressionMechanismItem[];
 }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.test.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.test.ts
@@ -8,7 +8,7 @@
 import { renderHook, act } from '@testing-library/react';
 import type { NotificationPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { useNotificationPolicyForm } from './use_notification_policy_form';
-import { DEFAULT_FORM_STATE } from './constants';
+import { DEFAULT_FORM_STATE, DEFAULT_SUPPRESSION_MECHANISMS } from './constants';
 
 const EXISTING_POLICY: NotificationPolicyResponse = {
   id: 'policy-1',
@@ -137,8 +137,10 @@ describe('useNotificationPolicyForm', () => {
         description: 'Routes critical alerts',
         matcher: 'data.severity : "critical"',
         groupBy: ['host.name', 'service.name'],
-        frequency: { type: 'throttle', interval: '5m' },
+        dispatchPer: 'group',
+        frequency: { type: 'group_throttle', repeatValue: 5, repeatUnit: 'm' },
         destinations: [{ type: 'workflow', id: 'workflow-2' }],
+        suppressionMechanisms: DEFAULT_SUPPRESSION_MECHANISMS,
       });
     });
 
@@ -155,7 +157,7 @@ describe('useNotificationPolicyForm', () => {
         })
       );
 
-      expect(result.current.methods.getValues().frequency).toEqual({ type: 'immediate' });
+      expect(result.current.methods.getValues().frequency).toEqual({ type: 'group_immediate' });
     });
 
     it('calls onSubmitUpdate with id, payload, and version on submit', async () => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/use_notification_policy_form.ts
@@ -12,7 +12,6 @@ import type {
 } from '@kbn/alerting-v2-schemas';
 import { useCallback, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { THROTTLE_INTERVAL_PATTERN } from './constants';
 import { DEFAULT_FORM_STATE } from './constants';
 import { toCreatePayload, toFormState, toUpdatePayload } from './form_utils';
 import type { NotificationPolicyFormState } from './types';
@@ -40,19 +39,26 @@ export const useNotificationPolicyForm = ({
     defaultValues,
   });
 
-  const [name, destinations, frequency] = useWatch({
+  const [name, destinations, frequency, dispatchPer, groupBy] = useWatch({
     control: methods.control,
-    name: ['name', 'destinations', 'frequency'],
+    name: ['name', 'destinations', 'frequency', 'dispatchPer', 'groupBy'],
   });
 
   const isSubmitEnabled = useMemo(() => {
     const hasName = name.trim().length > 0;
     const hasDestinations = destinations.length > 0;
-    const hasValidThrottleInterval =
-      frequency.type !== 'throttle' || THROTTLE_INTERVAL_PATTERN.test(frequency.interval);
 
-    return hasName && hasDestinations && hasValidThrottleInterval;
-  }, [destinations.length, frequency, name]);
+    let frequencyValid = true;
+    if (frequency.type === 'group_throttle' || frequency.type === 'episode_status_change_repeat') {
+      const { repeatValue } = frequency;
+      frequencyValid =
+        typeof repeatValue === 'number' && !Number.isNaN(repeatValue) && repeatValue >= 1;
+    }
+
+    const groupByValid = dispatchPer !== 'group' || groupBy.length > 0;
+
+    return hasName && hasDestinations && frequencyValid && groupByValid;
+  }, [destinations.length, dispatchPer, frequency, groupBy.length, name]);
 
   const onSubmitValid = useCallback(
     (values: NotificationPolicyFormState) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/notification_policy_snooze_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/notification_policy_snooze_form.tsx
@@ -131,7 +131,6 @@ export const NotificationPolicySnoozeForm = ({
             min={1}
             value={durationValue}
             onChange={(e) => setDurationValue(Math.max(1, parseInt(e.target.value, 10) || 1))}
-            compressed
             aria-label={i18n.translate(
               'xpack.alertingV2.notificationPolicy.snooze.durationValueAriaLabel',
               { defaultMessage: 'Snooze duration value' }
@@ -143,7 +142,6 @@ export const NotificationPolicySnoozeForm = ({
             options={UNIT_OPTIONS}
             value={durationUnit}
             onChange={(e) => setDurationUnit(e.target.value as DurationUnit)}
-            compressed
             aria-label={i18n.translate(
               'xpack.alertingV2.notificationPolicy.snooze.unitSelectAriaLabel',
               { defaultMessage: 'Snooze duration unit' }

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_rule_labels.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_rule_labels.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@kbn/react-query';
+import { i18n } from '@kbn/i18n';
+import { useService, CoreStart } from '@kbn/core-di-browser';
+import { RulesApi } from '../services/rules_api';
+import { ruleKeys } from './query_key_factory';
+
+export const useFetchRuleLabels = () => {
+  const rulesApi = useService(RulesApi);
+  const { toasts } = useService(CoreStart('notifications'));
+
+  return useQuery({
+    queryKey: [...ruleKeys.all, 'labels'] as const,
+    queryFn: async () => {
+      const labels = new Set<string>();
+      let page = 1;
+      const perPage = 1000;
+
+      for (;;) {
+        const res = await rulesApi.listRules({ page, perPage, search: undefined });
+        for (const item of res.items) {
+          item.metadata.labels?.forEach((l) => labels.add(l));
+        }
+        if (page * perPage >= res.total || res.items.length === 0) {
+          break;
+        }
+        page += 1;
+      }
+
+      return Array.from(labels).sort((a, b) => a.localeCompare(b));
+    },
+    onError: () => {
+      toasts.addDanger(
+        i18n.translate('xpack.alertingV2.hooks.useFetchRuleLabels.errorMessage', {
+          defaultMessage: 'Failed to load rule tags',
+        })
+      );
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
@@ -14,15 +14,18 @@ import { workflowKeys } from './query_key_factory';
 
 interface UseFetchWorkflowsParams {
   query: string;
+  /** When false, the query does not run (for example workflows UI is disabled in Advanced Settings). */
+  enabled?: boolean;
 }
 
-export const useFetchWorkflows = ({ query }: UseFetchWorkflowsParams) => {
+export const useFetchWorkflows = ({ query, enabled = true }: UseFetchWorkflowsParams) => {
   const workflowsApi = useService(WorkflowsApi);
   const { toasts } = useService(CoreStart('notifications'));
 
   return useQuery<WorkflowListDto, Error>({
     queryKey: workflowKeys.search({ query }),
     queryFn: () => workflowsApi.searchWorkflows({ query, size: 100, page: 1 }),
+    enabled,
     refetchOnWindowFocus: false,
     keepPreviousData: true,
     onError: (error: Error) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/notification_policy_form_page/notification_policy_form_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/notification_policy_form_page/notification_policy_form_page.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiPageHeader,
+  EuiPageTemplate,
   EuiSpacer,
 } from '@elastic/eui';
 import type {
@@ -71,7 +72,7 @@ export const NotificationPolicyFormPage = () => {
 
   if (isEditMode && isFetchingPolicy) {
     return (
-      <>
+      <EuiPageTemplate.Section paddingSize="none" restrictWidth={true}>
         {returnButton}
         <EuiPageHeader
           pageTitle={
@@ -85,13 +86,13 @@ export const NotificationPolicyFormPage = () => {
         <EuiFlexGroup justifyContent="center">
           <EuiLoadingSpinner size="l" data-test-subj="loadingSpinner" />
         </EuiFlexGroup>
-      </>
+      </EuiPageTemplate.Section>
     );
   }
 
   if (isEditMode && isFetchError) {
     return (
-      <>
+      <EuiPageTemplate.Section paddingSize="none" restrictWidth={true}>
         {returnButton}
         <EuiPageHeader
           pageTitle={
@@ -116,7 +117,7 @@ export const NotificationPolicyFormPage = () => {
         >
           {fetchError?.message}
         </EuiCallOut>
-      </>
+      </EuiPageTemplate.Section>
     );
   }
 
@@ -158,7 +159,7 @@ const NotificationPolicyFormPageContent = ({
   const isLoading = isCreating || isUpdating;
 
   return (
-    <>
+    <EuiPageTemplate.Section paddingSize="none" restrictWidth={true}>
       <EuiFlexGroup justifyContent="flexStart">
         <EuiFlexItem grow={false}>
           <EuiButtonEmpty
@@ -196,7 +197,15 @@ const NotificationPolicyFormPageContent = ({
           <NotificationPolicyForm />
         </FormProvider>
         <EuiSpacer size="l" />
-        <EuiFlexGroup justifyContent="flexStart" gutterSize="m">
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={onCancel} isLoading={isLoading} data-test-subj="cancelButton">
+              <FormattedMessage
+                id="xpack.alertingV2.notificationPolicy.formPage.cancel"
+                defaultMessage="Cancel"
+              />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
               fill
@@ -208,26 +217,18 @@ const NotificationPolicyFormPageContent = ({
               {isEditMode ? (
                 <FormattedMessage
                   id="xpack.alertingV2.notificationPolicy.formPage.update"
-                  defaultMessage="Update"
+                  defaultMessage="Update policy"
                 />
               ) : (
                 <FormattedMessage
                   id="xpack.alertingV2.notificationPolicy.formPage.save"
-                  defaultMessage="Save"
+                  defaultMessage="Create policy"
                 />
               )}
             </EuiButton>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={onCancel} isLoading={isLoading} data-test-subj="cancelButton">
-              <FormattedMessage
-                id="xpack.alertingV2.notificationPolicy.formPage.cancel"
-                defaultMessage="Cancel"
-              />
-            </EuiButtonEmpty>
-          </EuiFlexItem>
         </EuiFlexGroup>
       </div>
-    </>
+    </EuiPageTemplate.Section>
   );
 };


### PR DESCRIPTION
## Summary

Draft PR for the **notification policy** create/edit form redesign.

**Branch is rebased onto `main`** so this PR contains only this change set (one commit), not the historical `alerting_v2` integration branch.

### Changes (high level)
- Reworked notification policy form layout and sections (split panels, dispatch/frequency, destinations).
- Added **suppression behavior** section and related form state.
- **Quick filters** and **workflow selector** improvements; matcher quick filter helpers and tests.
- **Rule labels** hook for filters; workflow fetch hook updates.
- Repeat-interval lookback hint uses plain text (warning icon removed).
- Tests, Storybook, and form utilities updated.

### Notes
- Open questions and follow-ups can go in review comments.

### Checklist
- [ ] Screenshots / UX sign-off
- [ ] `node scripts/check_changes.ts`
- [ ] Targeted Jest for touched files