### PR TITLE
[9.3] [a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples (#259359)

### DIFF
--- a/examples/search_examples/public/search/app.tsx
+++ b/examples/search_examples/public/search/app.tsx
@@ -558,8 +558,9 @@ export const SearchExamplesApp = ({
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormLabel>Field (using {bucketAggType} buckets)</EuiFormLabel>
+            <EuiFormLabel id="bucketFieldLabel">Field (using {bucketAggType} buckets)</EuiFormLabel>
             <EuiComboBox
+              aria-labelledby="bucketFieldLabel"
               options={formatFieldsToComboBox(getAggregatableStrings(fields))}
               selectedOptions={formatFieldToComboBox(selectedBucketField)}
               singleSelection={true}
@@ -576,8 +577,11 @@ export const SearchExamplesApp = ({
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormLabel>Numeric Field (using {metricAggType} metrics)</EuiFormLabel>
+            <EuiFormLabel id="metricFieldLabel">
+              Numeric Field (using {metricAggType} metrics)
+            </EuiFormLabel>
             <EuiComboBox
+              aria-labelledby="metricFieldLabel"
               options={formatFieldsToComboBox(getNumeric(fields))}
               selectedOptions={formatFieldToComboBox(selectedNumericField)}
               singleSelection={true}
@@ -594,8 +598,9 @@ export const SearchExamplesApp = ({
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormLabel>Fields to queryString</EuiFormLabel>
+            <EuiFormLabel id="queryStringFieldsLabel">Fields to queryString</EuiFormLabel>
             <EuiComboBox
+              aria-labelledby="queryStringFieldsLabel"
               options={formatFieldsToComboBox(fields)}
               selectedOptions={formatFieldsToComboBox(selectedFields)}
               singleSelection={false}

--- a/examples/search_examples/public/search_sessions/app.tsx
+++ b/examples/search_examples/public/search_sessions/app.tsx
@@ -296,8 +296,9 @@ export const SearchSessionsExampleApp = ({
                   />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiFormLabel>Numeric Field to Aggregate</EuiFormLabel>
+                  <EuiFormLabel id="numericFieldLabel">Numeric Field to Aggregate</EuiFormLabel>
                   <EuiComboBox
+                    aria-labelledby="numericFieldLabel"
                     options={formatFieldsToComboBox(getNumeric(fields))}
                     selectedOptions={formatFieldToComboBox(selectedField)}
                     singleSelection={true}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples (#259359)](https://github.com/elastic/kibana/pull/259359)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T14:45:01Z","message":"[a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples (#259359)\n\nCloses: https://github.com/elastic/kibana/issues/259345\n\nFour `EuiComboBox` components in `search_examples` lacked accessible\nlabels, violating `@elastic/eui/no-unnamed-interactive-element`. Each\ncombo box had a visible `EuiFormLabel` sibling but no programmatic\nassociation.\n\n## Changes\n\n- **`search_sessions/app.tsx`** — Added `id=\"numericFieldLabel\"` to the\n`EuiFormLabel` and `aria-labelledby=\"numericFieldLabel\"` to the numeric\nfield selector combo box.\n- **`search/app.tsx`** — Added `id` to three `EuiFormLabel` elements and\ncorresponding `aria-labelledby` to their adjacent combo boxes:\n  - `Field (using {bucketAggType} buckets)` → `id=\"bucketFieldLabel\"`\n- `Numeric Field (using {metricAggType} metrics)` →\n`id=\"metricFieldLabel\"`\n  - `Fields to queryString` → `id=\"queryStringFieldsLabel\"`\n\n```tsx\n// Before\n<EuiFormLabel>Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox options={...} ... />\n\n// After\n<EuiFormLabel id=\"numericFieldLabel\">Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox aria-labelledby=\"numericFieldLabel\" options={...} ... />\n```\n\nUsing `aria-labelledby` (rather than `aria-label`) is the preferred WCAG\napproach when a visible label element already exists on screen, as it\nassociates the interactive element directly with the rendered label\ntext.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"9c736c967eb62172519c928a076535536857808c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","v9.3.3","a11y:agent-pr"],"title":"[a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples","number":259359,"url":"https://github.com/elastic/kibana/pull/259359","mergeCommit":{"message":"[a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples (#259359)\n\nCloses: https://github.com/elastic/kibana/issues/259345\n\nFour `EuiComboBox` components in `search_examples` lacked accessible\nlabels, violating `@elastic/eui/no-unnamed-interactive-element`. Each\ncombo box had a visible `EuiFormLabel` sibling but no programmatic\nassociation.\n\n## Changes\n\n- **`search_sessions/app.tsx`** — Added `id=\"numericFieldLabel\"` to the\n`EuiFormLabel` and `aria-labelledby=\"numericFieldLabel\"` to the numeric\nfield selector combo box.\n- **`search/app.tsx`** — Added `id` to three `EuiFormLabel` elements and\ncorresponding `aria-labelledby` to their adjacent combo boxes:\n  - `Field (using {bucketAggType} buckets)` → `id=\"bucketFieldLabel\"`\n- `Numeric Field (using {metricAggType} metrics)` →\n`id=\"metricFieldLabel\"`\n  - `Fields to queryString` → `id=\"queryStringFieldsLabel\"`\n\n```tsx\n// Before\n<EuiFormLabel>Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox options={...} ... />\n\n// After\n<EuiFormLabel id=\"numericFieldLabel\">Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox aria-labelledby=\"numericFieldLabel\" options={...} ... />\n```\n\nUsing `aria-labelledby` (rather than `aria-label`) is the preferred WCAG\napproach when a visible label element already exists on screen, as it\nassociates the interactive element directly with the rendered label\ntext.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"9c736c967eb62172519c928a076535536857808c"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259359","number":259359,"mergeCommit":{"message":"[a11y] Add aria-labelledby to unnamed EuiComboBox components in search_examples (#259359)\n\nCloses: https://github.com/elastic/kibana/issues/259345\n\nFour `EuiComboBox` components in `search_examples` lacked accessible\nlabels, violating `@elastic/eui/no-unnamed-interactive-element`. Each\ncombo box had a visible `EuiFormLabel` sibling but no programmatic\nassociation.\n\n## Changes\n\n- **`search_sessions/app.tsx`** — Added `id=\"numericFieldLabel\"` to the\n`EuiFormLabel` and `aria-labelledby=\"numericFieldLabel\"` to the numeric\nfield selector combo box.\n- **`search/app.tsx`** — Added `id` to three `EuiFormLabel` elements and\ncorresponding `aria-labelledby` to their adjacent combo boxes:\n  - `Field (using {bucketAggType} buckets)` → `id=\"bucketFieldLabel\"`\n- `Numeric Field (using {metricAggType} metrics)` →\n`id=\"metricFieldLabel\"`\n  - `Fields to queryString` → `id=\"queryStringFieldsLabel\"`\n\n```tsx\n// Before\n<EuiFormLabel>Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox options={...} ... />\n\n// After\n<EuiFormLabel id=\"numericFieldLabel\">Numeric Field to Aggregate</EuiFormLabel>\n<EuiComboBox aria-labelledby=\"numericFieldLabel\" options={...} ... />\n```\n\nUsing `aria-labelledby` (rather than `aria-label`) is the preferred WCAG\napproach when a visible label element already exists on screen, as it\nassociates the interactive element directly with the rendered label\ntext.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"9c736c967eb62172519c928a076535536857808c"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->