### PR TITLE
[Alerting] Add UI for example.pattern rule type

### DIFF
--- a/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
+++ b/x-pack/examples/alerting_example/public/alert_types/pattern.tsx
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { Fragment, useMemo } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFieldText,
+  EuiFormRow,
+  EuiButton,
+  EuiButtonIcon,
+  EuiSpacer,
+  EuiBasicTable,
+  EuiCallOut,
+  EuiBadge,
+  EuiText,
+} from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import type {
+  RuleTypeModel,
+  RuleTypeParamsExpressionProps,
+} from '@kbn/triggers-actions-ui-plugin/public';
+import type { RuleTypeParams } from '@kbn/alerting-plugin/common';
+
+interface PatternParams extends RuleTypeParams {
+  patterns?: Record<string, string>;
+}
+
+export function getAlertType(): RuleTypeModel {
+  return {
+    id: 'example.pattern',
+    description: 'Creates alerts on a configurable pattern for testing alert lifecycle states',
+    iconClass: 'visBarVerticalStacked',
+    documentationUrl: null,
+    ruleParamsExpression: PatternExpression,
+    validate: (params: PatternParams) => {
+      const validationResult = {
+        errors: {
+          patterns: new Array<string>(),
+        },
+      };
+
+      const { patterns } = params;
+      if (!patterns || Object.keys(patterns).length === 0) {
+        validationResult.errors.patterns.push('At least one alert instance pattern is required.');
+        return validationResult;
+      }
+
+      for (const [instance, pattern] of Object.entries(patterns)) {
+        if (!instance.trim()) {
+          validationResult.errors.patterns.push('Instance names cannot be empty.');
+          break;
+        }
+        const tokens = pattern.trim().split(/\s+/g);
+        const invalid = tokens.filter((t) => t !== 'a' && t !== '-');
+        if (invalid.length > 0) {
+          validationResult.errors.patterns.push(
+            `Pattern for "${instance}" contains invalid tokens: ${invalid.join(
+              ', '
+            )}. Use "a" (active) or "-" (inactive).`
+          );
+        }
+      }
+
+      return validationResult;
+    },
+    requiresAppContext: false,
+  };
+}
+
+interface PreviewRow {
+  instance: string;
+  [key: string]: string;
+}
+
+const PatternExpression: React.FunctionComponent<RuleTypeParamsExpressionProps<PatternParams>> = ({
+  ruleParams,
+  setRuleParams,
+}) => {
+  const patterns = useMemo(() => ruleParams.patterns ?? {}, [ruleParams.patterns]);
+  const entries = Object.entries(patterns);
+
+  const updatePattern = (oldName: string, newName: string, value: string) => {
+    const updated: Record<string, string> = {};
+    for (const [key, val] of Object.entries(patterns)) {
+      if (key === oldName) {
+        updated[newName] = value;
+      } else {
+        updated[key] = val;
+      }
+    }
+    setRuleParams('patterns', updated);
+  };
+
+  const removeInstance = (name: string) => {
+    const updated = { ...patterns };
+    delete updated[name];
+    setRuleParams('patterns', updated);
+  };
+
+  const addInstance = () => {
+    const existingKeys = new Set(Object.keys(patterns));
+    let index = entries.length + 1;
+    let name = `alert-${index}`;
+    while (existingKeys.has(name)) {
+      index++;
+      name = `alert-${index}`;
+    }
+    setRuleParams('patterns', { ...patterns, [name]: 'a' });
+  };
+
+  const maxSteps = useMemo(() => {
+    let max = 0;
+    for (const pattern of Object.values(patterns)) {
+      const count = pattern.trim().split(/\s+/g).length;
+      if (count > max) max = count;
+    }
+    return max;
+  }, [patterns]);
+
+  const previewRows: PreviewRow[] = useMemo(() => {
+    return entries.map(([instance, pattern]) => {
+      const tokens = pattern.trim().split(/\s+/g);
+      const row: PreviewRow = { instance };
+      for (let i = 0; i < maxSteps; i++) {
+        const token = tokens[i % tokens.length];
+        row[`run_${i + 1}`] = token === 'a' ? 'active' : '-';
+      }
+      return row;
+    });
+  }, [entries, maxSteps]);
+
+  const previewColumns: Array<EuiBasicTableColumn<PreviewRow>> = useMemo(() => {
+    const cols: Array<EuiBasicTableColumn<PreviewRow>> = [
+      {
+        field: 'instance',
+        name: 'Instance',
+        width: '120px',
+        render: (value: string) => <strong>{value}</strong>,
+      },
+    ];
+    for (let i = 1; i <= maxSteps; i++) {
+      cols.push({
+        field: `run_${i}`,
+        name: `Run ${i}`,
+        width: '70px',
+        align: 'center',
+        render: (value: string) =>
+          value === 'active' ? (
+            <EuiBadge color="success">active</EuiBadge>
+          ) : (
+            <EuiText size="s" color="subdued">
+              -
+            </EuiText>
+          ),
+      });
+    }
+    return cols;
+  }, [maxSteps]);
+
+  return (
+    <Fragment>
+      <EuiCallOut
+        title="Pattern rule for alert lifecycle testing"
+        iconType="beaker"
+        size="s"
+        color="primary"
+      >
+        <p>
+          Define alert instances and their activation pattern across executions. Use{' '}
+          <strong>a</strong> for active and <strong>-</strong> for inactive (space-separated). The
+          pattern cycles after the last step.
+        </p>
+      </EuiCallOut>
+
+      <EuiSpacer size="m" />
+
+      {entries.map(([instanceName, pattern]) => (
+        <Fragment key={instanceName}>
+          <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+            <EuiFlexItem grow={false} style={{ width: 180 }}>
+              <EuiFormRow label="Instance name" display="rowCompressed">
+                <EuiFieldText
+                  compressed
+                  value={instanceName}
+                  onChange={(e) => updatePattern(instanceName, e.target.value, pattern)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={true}>
+              <EuiFormRow label="Pattern (a = active, - = inactive)" display="rowCompressed">
+                <EuiFieldText
+                  compressed
+                  value={pattern}
+                  placeholder="a a - a -"
+                  onChange={(e) => updatePattern(instanceName, instanceName, e.target.value)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFormRow hasEmptyLabelSpace display="rowCompressed">
+                <EuiButtonIcon
+                  iconType="trash"
+                  color="danger"
+                  aria-label={`Remove ${instanceName}`}
+                  onClick={() => removeInstance(instanceName)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="xs" />
+        </Fragment>
+      ))}
+
+      <EuiSpacer size="s" />
+
+      <EuiButton size="s" iconType="plusInCircle" onClick={addInstance}>
+        Add alert instance
+      </EuiButton>
+
+      {entries.length > 0 && maxSteps > 0 && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiFormRow label="Execution preview" fullWidth>
+            <EuiBasicTable<PreviewRow>
+              tableCaption="Execution preview showing alert states per run"
+              items={previewRows}
+              columns={previewColumns}
+              tableLayout="auto"
+              compressed
+            />
+          </EuiFormRow>
+        </>
+      )}
+    </Fragment>
+  );
+};

--- a/x-pack/examples/alerting_example/public/plugin.tsx
+++ b/x-pack/examples/alerting_example/public/plugin.tsx
@@ -16,6 +16,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
 import { getAlertType as getAlwaysFiringAlertType } from './alert_types/always_firing';
 import { getAlertType as getPeopleInSpaceAlertType } from './alert_types/astros';
+import { getAlertType as getPatternAlertType } from './alert_types/pattern';
 import { registerNavigation } from './alert_types';
 
 export type Setup = void;
@@ -52,6 +53,7 @@ export class AlertingExamplePlugin implements Plugin<Setup, Start, AlertingExamp
 
     triggersActionsUi.ruleTypeRegistry.register(getAlwaysFiringAlertType());
     triggersActionsUi.ruleTypeRegistry.register(getPeopleInSpaceAlertType());
+    triggersActionsUi.ruleTypeRegistry.register(getPatternAlertType());
 
     registerNavigation(alerting);
 

--- a/x-pack/examples/alerting_example/server/plugin.ts
+++ b/x-pack/examples/alerting_example/server/plugin.ts
@@ -39,6 +39,10 @@ const alertingFeatures = [
     ruleTypeId: INDEX_THRESHOLD_ID,
     consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
   },
+  {
+    ruleTypeId: patternRule.id,
+    consumers: [ALERTING_EXAMPLE_APP_ID, ALERTING_FEATURE_ID],
+  },
 ];
 
 export class AlertingExamplePlugin implements Plugin<void, void, AlertingExampleDeps> {

--- a/x-pack/examples/alerting_example/server/rule_types/pattern.md
+++ b/x-pack/examples/alerting_example/server/rule_types/pattern.md
@@ -35,9 +35,20 @@ The context variables available are:
 - `pattern` - the entire pattern, as an array of 'a' and '-' chars
 - `runs` - total number of runs of the rule
 
-There is no UX for this (yet), so you'll need to use `curl` to create/update
-the rule.  The following also uses [`jq`](https://stedolan.github.io/jq/) 
-to create a connector and capture it's id to use with the rule.
+## Using the UI
+
+Run Kibana with `--run-examples` to enable the alerting example plugin.
+Navigate to **Stack Management > Rules** and create a new rule of type
+**Example: Creates alerts on a pattern, for testing**. The UI lets you
+add/remove alert instances, edit their patterns, and shows an execution
+preview grid. Set a long schedule (e.g. daily) and use **Run Soon** to
+step through executions manually.
+
+## Using curl
+
+You can also use `curl` to create/update the rule. The following also
+uses [`jq`](https://stedolan.github.io/jq/) to create a connector and
+capture its id to use with the rule.
 
 ```console
 SERVER_LOG_ID=`curl $KBN_URL/api/actions/connector -H "kbn-xsrf: foo" -H "content-type: application/json" -d '{

--- a/x-pack/examples/alerting_example/server/rule_types/pattern.ts
+++ b/x-pack/examples/alerting_example/server/rule_types/pattern.ts
@@ -15,6 +15,7 @@ import type {
 import { DEFAULT_AAD_CONFIG, AlertsClientError } from '@kbn/alerting-plugin/server';
 import type { DefaultAlert } from '@kbn/alerts-as-data-utils';
 import type { RecoveredActionGroupId } from '@kbn/alerting-plugin/common';
+import { ALERTING_EXAMPLE_APP_ID } from '../../common/constants';
 
 type Params = TypeOf<typeof Params>;
 const Params = schema.object(
@@ -62,10 +63,10 @@ export const ruleType: RuleType = getPatternRuleType();
 function getPatternRuleType(): RuleType {
   return {
     id: 'example.pattern',
-    name: 'Example: Creates alerts on a pattern, for testing',
+    name: 'Pattern firing',
     actionGroups: [{ id: 'default', name: 'Default' }],
     category: 'kibana',
-    producer: 'alertsFixture',
+    producer: ALERTING_EXAMPLE_APP_ID,
     solution: 'stack',
     defaultActionGroupId: 'default',
     minimumLicenseRequired: 'basic',


### PR DESCRIPTION
## Summary

The existing `example.pattern` rule type allows defining per-instance alert activation patterns (`a` for active, `-` for inactive) that cycle across executions, making it ideal for testing alert lifecycle states like flapping, delays, and recovery. However, it had no UI and was missing from the feature privileges, so it could only be created via `curl`.

This PR:
- **Adds a rule params UI component** with dynamic instance/pattern rows, add/remove buttons, and an execution preview grid
- **Registers the UI** with the triggers & actions rule type registry so the rule appears in the Create Rule modal
- **Fixes feature privileges** by adding the pattern rule to `alertingFeatures` in the server plugin
- **Fixes the producer** from `alertsFixture` (test fixture value) to `AlertingExample` to match the owning Kibana feature
- **Updates docs** in `pattern.md` to describe the UI workflow

### Usage

1. Run Kibana with `--run-examples`
2. Go to Stack Management > Rules > Create Rule
3. Select "Pattern firing"
4. Add alert instances and define their `a`/`-` patterns
5. Set a long schedule (e.g. daily) and use "Run Soon" to step through manually
6. Observe alert lifecycle transitions (new, active, recovered, flapping)

Combine with `alertDelay` on the rule to also test delayed alert transitions.

<img width="1256" height="945" alt="Screenshot 2026-03-30 at 19 14 58" src="https://github.com/user-attachments/assets/870f6e19-349b-4eba-bee0-7c537e4562e5" />

Made with [Cursor](https://cursor.com)