### PR TITLE
Add V2 Alerting Preview section to Stack Management

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -14,6 +14,18 @@ import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import { mountAlertingV2App } from './main';
 import { ALERTING_V2_APP_ID } from './constants';
+import {
+  PREVIEW_SECTION_ID,
+  PREVIEW_WHY_V2_APP_ID,
+  PREVIEW_RULES_APP_ID,
+  PREVIEW_ALERTS_APP_ID,
+  PREVIEW_NOTIFICATION_POLICIES_APP_ID,
+} from './preview/constants';
+import { createMountFn } from './preview/mount';
+import { WhyV2App } from './preview/apps/why_v2_app';
+import { RulesApp } from './preview/apps/rules_app';
+import { AlertsApp } from './preview/apps/alerts_app';
+import { NotificationPoliciesApp } from './preview/apps/notification_policies_app';
 import { NotificationPoliciesApi } from './services/notification_policies_api';
 import { RulesApi } from './services/rules_api';
 import { WorkflowsApi } from './services/workflows_api';
@@ -55,6 +67,49 @@ export const module = new ContainerModule(({ bind }) => {
       async mount(params) {
         const [coreStart] = await getStartServices();
         return mountAlertingV2App({ params, container: coreStart.injection.getContainer() });
+      },
+    });
+
+    const previewSection = management.sections.register({
+      id: PREVIEW_SECTION_ID,
+      title: 'V2 Alerting Preview',
+      order: 1,
+      tip: 'Preview the next-generation alerting experience',
+    });
+
+    previewSection.registerApp({
+      id: PREVIEW_WHY_V2_APP_ID,
+      title: 'Why v2?',
+      order: 0,
+      async mount(params) {
+        return createMountFn(WhyV2App)(params);
+      },
+    });
+
+    previewSection.registerApp({
+      id: PREVIEW_RULES_APP_ID,
+      title: 'Rules',
+      order: 1,
+      async mount(params) {
+        return createMountFn(RulesApp)(params);
+      },
+    });
+
+    previewSection.registerApp({
+      id: PREVIEW_ALERTS_APP_ID,
+      title: 'Alerts & Episodes',
+      order: 2,
+      async mount(params) {
+        return createMountFn(AlertsApp)(params);
+      },
+    });
+
+    previewSection.registerApp({
+      id: PREVIEW_NOTIFICATION_POLICIES_APP_ID,
+      title: 'Notification Policies',
+      order: 3,
+      async mount(params) {
+        return createMountFn(NotificationPoliciesApp)(params);
       },
     });
   });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/alerts_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/alerts_app.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Route, Routes } from '@kbn/shared-ux-router';
+import { AlertsPage } from '../pages/alerts_page';
+import { AlertDetailPage } from '../pages/alert_detail_page';
+
+export const AlertsApp = () => (
+  <Routes>
+    <Route exact path="/:id">
+      <AlertDetailPage />
+    </Route>
+    <Route exact path="/">
+      <AlertsPage />
+    </Route>
+  </Routes>
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/notification_policies_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/notification_policies_app.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Route, Routes } from '@kbn/shared-ux-router';
+import { NotificationPoliciesPage } from '../pages/notification_policies_page';
+import { NotificationPolicyDetailPage } from '../pages/notification_policy_detail_page';
+
+export const NotificationPoliciesApp = () => (
+  <Routes>
+    <Route exact path="/:id">
+      <NotificationPolicyDetailPage />
+    </Route>
+    <Route exact path="/">
+      <NotificationPoliciesPage />
+    </Route>
+  </Routes>
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/rules_app.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Route, Routes } from '@kbn/shared-ux-router';
+import { RulesPage } from '../pages/rules_page';
+import { RuleDetailPage } from '../pages/rule_detail_page';
+
+export const RulesApp = () => (
+  <Routes>
+    <Route exact path="/:id">
+      <RuleDetailPage />
+    </Route>
+    <Route exact path="/">
+      <RulesPage />
+    </Route>
+  </Routes>
+);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/why_v2_app.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/apps/why_v2_app.tsx
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { WhyV2Page } from '../pages/why_v2_page';
+
+export const WhyV2App = () => <WhyV2Page />;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/constants.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const PREVIEW_SECTION_ID = 'alertingV2Preview';
+
+export const PREVIEW_WHY_V2_APP_ID = 'whyV2';
+export const PREVIEW_RULES_APP_ID = 'rules';
+export const PREVIEW_ALERTS_APP_ID = 'alerts';
+export const PREVIEW_NOTIFICATION_POLICIES_APP_ID = 'notificationPolicies';

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/mount.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/mount.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import type { AppMountParameters, AppUnmount } from '@kbn/core-application-browser';
+import { Router } from '@kbn/shared-ux-router';
+import { I18nProvider } from '@kbn/i18n-react';
+
+type PreviewMountParams = Pick<AppMountParameters, 'element' | 'history'>;
+
+export const createMountFn =
+  (AppComponent: React.ComponentType) =>
+  ({ element, history }: PreviewMountParams): AppUnmount => {
+    ReactDOM.render(
+      <I18nProvider>
+        <Router history={history}>
+          <AppComponent />
+        </Router>
+      </I18nProvider>,
+      element
+    );
+
+    return () => ReactDOM.unmountComponentAtNode(element);
+  };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/alert_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/alert_detail_page.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCode,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiSteps,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { previewPaths } from '../preview_paths';
+
+export const AlertDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const history = useHistory();
+
+  const timelineSteps = [
+    {
+      title: 'Breached (Active)',
+      status: 'danger' as const,
+      children: (
+        <EuiText size="xs" color="subdued">
+          Now — CPU at 92% on prod-web-01
+        </EuiText>
+      ),
+    },
+    {
+      title: 'Breached (Active)',
+      status: 'danger' as const,
+      children: (
+        <EuiText size="xs" color="subdued">
+          1m ago — CPU at 89%
+        </EuiText>
+      ),
+    },
+    {
+      title: 'Breached (Pending → Active)',
+      status: 'warning' as const,
+      children: (
+        <EuiText size="xs" color="subdued">
+          2m ago — Threshold exceeded, transitioned to Active
+        </EuiText>
+      ),
+    },
+    {
+      title: 'Breached (Pending)',
+      status: 'warning' as const,
+      children: (
+        <EuiText size="xs" color="subdued">
+          3m ago — First breach detected, CPU at 86%
+        </EuiText>
+      ),
+    },
+    {
+      title: 'Episode started',
+      status: 'incomplete' as const,
+      children: (
+        <EuiText size="xs" color="subdued">
+          2h 15m ago — New episode created
+        </EuiText>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiHealth color="danger" style={{ fontSize: 'inherit' }}>
+                Episode: prod-web-01
+              </EuiHealth>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        breadcrumbs={[
+          { text: 'V2 Alerting Preview' },
+          { text: 'Alerts & Episodes', onClick: () => history.push('/') },
+          { text: `Episode ${id}` },
+        ]}
+        rightSideItems={[
+          <EuiButton key="ack" iconType="check" color="primary">
+            Acknowledge
+          </EuiButton>,
+          <EuiButtonEmpty key="snooze" iconType="bellSlash">
+            Snooze
+          </EuiButtonEmpty>,
+        ]}
+      />
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={2}>
+          <EuiTitle size="xs">
+            <h3>Episode Timeline</h3>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <EuiSteps steps={timelineSteps} />
+
+          <EuiSpacer size="l" />
+
+          <EuiTitle size="xs">
+            <h3>Notification History</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+            <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">2m ago</EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs">
+                  Dispatched via <strong>Critical PagerDuty</strong> →{' '}
+                  <EuiCode transparentBackground>PagerDuty Escalation</EuiCode>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+          <EuiSpacer size="xs" />
+          <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+            <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="hollow">5m ago</EuiBadge>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="xs">
+                  Dispatched via <strong>Slack #ops-alerts</strong> →{' '}
+                  <EuiCode transparentBackground>Slack Notification</EuiCode>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={1}>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiTitle size="xs">
+              <h3>Episode Details</h3>
+            </EuiTitle>
+            <EuiHorizontalRule margin="s" />
+            <EuiDescriptionList
+              compressed
+              type="column"
+              listItems={[
+                { title: 'Episode ID', description: id },
+                {
+                  title: 'Status',
+                  description: <EuiHealth color="danger">Active</EuiHealth>,
+                },
+                {
+                  title: 'Severity',
+                  description: <EuiBadge color="danger">critical</EuiBadge>,
+                },
+                { title: 'Duration', description: '2h 15m' },
+                { title: 'Status count', description: '135 (consecutive breaches)' },
+                {
+                  title: 'Group',
+                  description: (
+                    <EuiCode transparentBackground>host.name: prod-web-01</EuiCode>
+                  ),
+                },
+                {
+                  title: 'Rule',
+                  description: (
+                    <EuiLink href={previewPaths.ruleDetail('1')}>
+                      High CPU on prod hosts
+                    </EuiLink>
+                  ),
+                },
+                { title: 'Acknowledged', description: 'No' },
+                { title: 'Snoozed', description: 'No' },
+              ]}
+            />
+          </EuiPanel>
+
+          <EuiSpacer size="m" />
+
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiTitle size="xs">
+              <h3>Latest Event Data</h3>
+            </EuiTitle>
+            <EuiHorizontalRule margin="s" />
+            <EuiDescriptionList
+              compressed
+              type="column"
+              listItems={[
+                { title: 'host.name', description: 'prod-web-01' },
+                { title: 'avg_cpu', description: '0.92' },
+                { title: '@timestamp', description: '2026-03-26T18:45:12Z' },
+              ]}
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/alerts_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/alerts_page.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButtonGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiLink,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
+
+import { previewPaths } from '../preview_paths';
+
+interface FakeEpisode {
+  id: string;
+  rule: string;
+  ruleId: string;
+  group: string;
+  status: 'active' | 'pending' | 'recovering' | 'inactive';
+  severity: string;
+  started: string;
+  duration: string;
+  lastEvent: string;
+  acked: boolean;
+}
+
+const fakeEpisodes: FakeEpisode[] = [
+  { id: 'ep-1', rule: 'High CPU on prod hosts', ruleId: '1', group: 'host: prod-web-01', status: 'active', severity: 'critical', started: '2h ago', duration: '2h 15m', lastEvent: '12s ago', acked: false },
+  { id: 'ep-2', rule: 'High CPU on prod hosts', ruleId: '1', group: 'host: prod-web-03', status: 'active', severity: 'critical', started: '45m ago', duration: '45m', lastEvent: '12s ago', acked: true },
+  { id: 'ep-3', rule: 'High CPU on prod hosts', ruleId: '1', group: 'host: prod-api-02', status: 'recovering', severity: 'warning', started: '3h ago', duration: '3h 10m', lastEvent: '1m ago', acked: false },
+  { id: 'ep-4', rule: 'Error rate > 5%', ruleId: '2', group: 'service: checkout', status: 'active', severity: 'high', started: '20m ago', duration: '20m', lastEvent: '45s ago', acked: false },
+  { id: 'ep-5', rule: 'Disk usage > 90%', ruleId: '3', group: 'host: db-primary', status: 'active', severity: 'critical', started: '6h ago', duration: '6h 5m', lastEvent: '2m ago', acked: true },
+  { id: 'ep-6', rule: 'Disk usage > 90%', ruleId: '3', group: 'host: db-replica-02', status: 'pending', severity: 'warning', started: '5m ago', duration: '5m', lastEvent: '2m ago', acked: false },
+  { id: 'ep-7', rule: 'Latency p99 > 500ms', ruleId: '5', group: 'service: search-api', status: 'active', severity: 'high', started: '1h ago', duration: '1h 2m', lastEvent: '15s ago', acked: false },
+  { id: 'ep-8', rule: 'No data: payment service', ruleId: '7', group: 'service: payments', status: 'active', severity: 'critical', started: '10m ago', duration: '10m', lastEvent: '3m ago', acked: false },
+];
+
+const statusColorMap: Record<string, string> = {
+  active: 'danger',
+  pending: 'warning',
+  recovering: 'primary',
+  inactive: 'subdued',
+};
+
+const severityColorMap: Record<string, string> = {
+  critical: 'danger',
+  high: '#BD271E',
+  warning: 'warning',
+  low: 'subdued',
+};
+
+export const AlertsPage = () => {
+  const history = useHistory();
+  const [view, setView] = React.useState('episodes');
+
+  const columns: Array<EuiBasicTableColumn<FakeEpisode>> = [
+    {
+      field: 'status',
+      name: 'Status',
+      width: '110px',
+      render: (status: string) => (
+        <EuiHealth color={statusColorMap[status]}>
+          {status.charAt(0).toUpperCase() + status.slice(1)}
+        </EuiHealth>
+      ),
+    },
+    {
+      field: 'severity',
+      name: 'Severity',
+      width: '90px',
+      render: (severity: string) => (
+        <EuiBadge color={severityColorMap[severity] || 'hollow'}>
+          {severity}
+        </EuiBadge>
+      ),
+    },
+    {
+      field: 'rule',
+      name: 'Rule',
+      render: (name: string, episode: FakeEpisode) => (
+        <EuiLink href={previewPaths.ruleDetail(episode.ruleId)}>{name}</EuiLink>
+      ),
+    },
+    {
+      field: 'group',
+      name: 'Group',
+      render: (group: string) => (
+        <EuiText size="xs">
+          <code>{group}</code>
+        </EuiText>
+      ),
+    },
+    {
+      field: 'started',
+      name: 'Started',
+      width: '90px',
+    },
+    {
+      field: 'duration',
+      name: 'Duration',
+      width: '90px',
+    },
+    {
+      field: 'acked',
+      name: 'Ack',
+      width: '60px',
+      render: (acked: boolean) =>
+        acked ? (
+          <EuiBadge color="hollow" iconType="check">
+            Yes
+          </EuiBadge>
+        ) : null,
+    },
+    {
+      field: 'id',
+      name: '',
+      width: '80px',
+      render: (id: string) => (
+        <EuiLink onClick={() => history.push(`/${id}`)}>Details</EuiLink>
+      ),
+    },
+  ];
+
+  const activeCount = fakeEpisodes.filter((e) => e.status === 'active').length;
+  const pendingCount = fakeEpisodes.filter((e) => e.status === 'pending').length;
+  const recoveringCount = fakeEpisodes.filter((e) => e.status === 'recovering').length;
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Alerts & Episodes</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description="Alert episodes track the full lifecycle of a detected condition — from first breach through recovery."
+        breadcrumbs={[{ text: 'V2 Alerting Preview' }, { text: 'Alerts & Episodes' }]}
+      />
+
+      <EuiSpacer size="m" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiStat title={activeCount} description="Active" titleColor="danger" titleSize="m" />
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiStat
+              title={pendingCount}
+              description="Pending"
+              titleColor="warning"
+              titleSize="m"
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiStat
+              title={recoveringCount}
+              description="Recovering"
+              titleColor="primary"
+              titleSize="m"
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiButtonGroup
+            legend="View selector"
+            options={[
+              { id: 'episodes', label: 'Episodes' },
+              { id: 'events', label: 'Rule Events' },
+            ]}
+            idSelected={view}
+            onChange={setView}
+            buttonSize="compressed"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            {view === 'events'
+              ? 'Rule events are append-only documents — queryable in Discover via ES|QL'
+              : `Showing ${fakeEpisodes.length} episodes across ${new Set(fakeEpisodes.map((e) => e.ruleId)).size} rules`}
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      {view === 'episodes' ? (
+        <EuiBasicTable
+          items={fakeEpisodes}
+          columns={columns}
+          itemId="id"
+          tableCaption="Alert Episodes"
+          responsiveBreakpoint={false}
+        />
+      ) : (
+        <EuiPanel hasShadow={false} hasBorder color="subdued" paddingSize="xl">
+          <EuiFlexGroup direction="column" alignItems="center" gutterSize="m">
+            <EuiText textAlign="center">
+              <h3>Rule Events Explorer</h3>
+              <p>
+                Rule events are append-only documents written to{' '}
+                <code>.alerting-events</code>. Use Discover with ES|QL to query
+                them directly.
+              </p>
+              <p>
+                <EuiLink href="#" external>
+                  Open in Discover →
+                </EuiLink>
+              </p>
+            </EuiText>
+          </EuiFlexGroup>
+        </EuiPanel>
+      )}
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/notification_policies_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/notification_policies_page.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButton,
+  EuiCode,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiIcon,
+  EuiLink,
+  EuiPageHeader,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
+
+interface FakePolicy {
+  id: string;
+  name: string;
+  enabled: boolean;
+  snoozed: boolean;
+  matcher: string;
+  groupBy: string;
+  throttle: string;
+  workflow: string;
+  linkedRules: number;
+  lastDispatched: string;
+}
+
+const fakePolicies: FakePolicy[] = [
+  { id: 'np-1', name: 'Critical PagerDuty', enabled: true, snoozed: false, matcher: 'severity: critical', groupBy: 'service', throttle: '5m', workflow: 'PagerDuty Escalation', linkedRules: 5, lastDispatched: '2m ago' },
+  { id: 'np-2', name: 'Slack #ops-alerts', enabled: true, snoozed: false, matcher: '', groupBy: 'host.name', throttle: '15m', workflow: 'Slack Notification', linkedRules: 8, lastDispatched: '10m ago' },
+  { id: 'np-3', name: 'Email digest — daily', enabled: true, snoozed: true, matcher: 'severity: low OR severity: warning', groupBy: '', throttle: '24h', workflow: 'Email Digest', linkedRules: 3, lastDispatched: '1d ago' },
+  { id: 'np-4', name: 'Jira ticket creation', enabled: true, snoozed: false, matcher: 'labels: "business"', groupBy: 'service', throttle: '1h', workflow: 'Jira Create Issue', linkedRules: 2, lastDispatched: '30m ago' },
+  { id: 'np-5', name: 'Teams channel — infra', enabled: false, snoozed: false, matcher: 'labels: "infra"', groupBy: '', throttle: '10m', workflow: 'Teams Notification', linkedRules: 4, lastDispatched: '2h ago' },
+];
+
+export const NotificationPoliciesPage = () => {
+  const history = useHistory();
+
+  const columns: Array<EuiBasicTableColumn<FakePolicy>> = [
+    {
+      field: 'name',
+      name: 'Name',
+      render: (name: string, policy: FakePolicy) => (
+        <EuiLink onClick={() => history.push(`/${policy.id}`)}>
+          {name}
+        </EuiLink>
+      ),
+    },
+    {
+      field: 'enabled',
+      name: 'State',
+      width: '90px',
+      render: (enabled: boolean, policy: FakePolicy) => {
+        if (!enabled) return <EuiHealth color="subdued">Disabled</EuiHealth>;
+        if (policy.snoozed) return <EuiHealth color="warning">Snoozed</EuiHealth>;
+        return <EuiHealth color="success">Enabled</EuiHealth>;
+      },
+    },
+    {
+      field: 'matcher',
+      name: 'Matcher',
+      width: '200px',
+      render: (matcher: string) =>
+        matcher ? (
+          <EuiCode transparentBackground>{matcher}</EuiCode>
+        ) : (
+          <EuiToolTip content="Matches all episodes">
+            <EuiBadge color="hollow">catch-all</EuiBadge>
+          </EuiToolTip>
+        ),
+    },
+    {
+      field: 'groupBy',
+      name: 'Group by',
+      width: '120px',
+      render: (groupBy: string) =>
+        groupBy ? (
+          <EuiCode transparentBackground>{groupBy}</EuiCode>
+        ) : (
+          <EuiText size="xs" color="subdued">per episode</EuiText>
+        ),
+    },
+    {
+      field: 'throttle',
+      name: 'Throttle',
+      width: '80px',
+    },
+    {
+      field: 'workflow',
+      name: 'Workflow',
+      width: '170px',
+      render: (workflow: string) => (
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="pipelineApp" size="s" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs">{workflow}</EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+    {
+      field: 'linkedRules',
+      name: 'Rules',
+      width: '70px',
+      render: (count: number) => <EuiBadge color="hollow">{count}</EuiBadge>,
+    },
+    {
+      field: 'lastDispatched',
+      name: 'Last dispatched',
+      width: '120px',
+      render: (val: string) => (
+        <EuiText size="xs" color="subdued">{val}</EuiText>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Notification Policies</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description="Notification policies control how alert episodes reach your team — match, group, throttle, then route to a workflow."
+        rightSideItems={[
+          <EuiButton key="create" fill iconType="plusInCircle">
+            Create policy
+          </EuiButton>,
+        ]}
+        breadcrumbs={[{ text: 'V2 Alerting Preview' }, { text: 'Notification Policies' }]}
+      />
+      <EuiSpacer size="m" />
+      <EuiText size="xs">
+        Showing <strong>{fakePolicies.length}</strong> notification policies
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiBasicTable
+        items={fakePolicies}
+        columns={columns}
+        itemId="id"
+        tableCaption="Notification Policies"
+        responsiveBreakpoint={false}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/notification_policy_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/notification_policy_detail_page.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCode,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { previewPaths } from '../preview_paths';
+
+export const NotificationPolicyDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const history = useHistory();
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Critical PagerDuty</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiHealth color="success">Enabled</EuiHealth>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        breadcrumbs={[
+          { text: 'V2 Alerting Preview' },
+          { text: 'Notification Policies', onClick: () => history.push('/') },
+          { text: 'Critical PagerDuty' },
+        ]}
+        rightSideItems={[
+          <EuiButton key="edit" iconType="pencil">
+            Edit policy
+          </EuiButton>,
+          <EuiButtonEmpty key="snooze" iconType="bellSlash">
+            Snooze
+          </EuiButtonEmpty>,
+        ]}
+      />
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={2}>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiTitle size="xs">
+              <h3>Policy Configuration</h3>
+            </EuiTitle>
+            <EuiHorizontalRule margin="s" />
+            <EuiDescriptionList
+              type="column"
+              listItems={[
+                { title: 'ID', description: id },
+                {
+                  title: 'Matcher (KQL)',
+                  description: (
+                    <EuiCode transparentBackground>severity: critical</EuiCode>
+                  ),
+                },
+                {
+                  title: 'Group by',
+                  description: (
+                    <EuiCode transparentBackground>service</EuiCode>
+                  ),
+                },
+                { title: 'Throttle', description: '5 minutes' },
+                {
+                  title: 'Workflow',
+                  description: (
+                    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type="pipelineApp" size="s" />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>PagerDuty Escalation</EuiFlexItem>
+                    </EuiFlexGroup>
+                  ),
+                },
+              ]}
+            />
+          </EuiPanel>
+
+          <EuiSpacer size="l" />
+
+          <EuiTitle size="xs">
+            <h3>Linked Rules</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s">
+            This policy is attached to <strong>5 rules</strong>. When any of
+            these rules produce alert episodes matching{' '}
+            <EuiCode transparentBackground>severity: critical</EuiCode>, the
+            dispatcher will group by <code>service</code> and route to PagerDuty.
+          </EuiText>
+          <EuiSpacer size="s" />
+          {['High CPU on prod hosts', 'Error rate > 5%', 'Disk usage > 90%', 'No data: payment service', 'HTTP 5xx spike'].map(
+            (name, i) => (
+              <React.Fragment key={name}>
+                <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+                  <EuiLink href={previewPaths.ruleDetail(String(i + 1))}>
+                    {name}
+                  </EuiLink>
+                </EuiPanel>
+                {i < 4 && <EuiSpacer size="xs" />}
+              </React.Fragment>
+            )
+          )}
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={1}>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiTitle size="xs">
+              <h3>Recent Dispatches</h3>
+            </EuiTitle>
+            <EuiHorizontalRule margin="s" />
+            {[
+              { time: '2m ago', group: 'service: checkout', status: 'fired' },
+              { time: '7m ago', group: 'service: search-api', status: 'fired' },
+              { time: '12m ago', group: 'service: checkout', status: 'throttled' },
+              { time: '20m ago', group: 'service: payments', status: 'fired' },
+            ].map((d, i) => (
+              <React.Fragment key={i}>
+                <EuiFlexGroup gutterSize="s" alignItems="center">
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">{d.time}</EuiBadge>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiCode transparentBackground>{d.group}</EuiCode>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    {d.status === 'fired' ? (
+                      <EuiBadge color="success">fired</EuiBadge>
+                    ) : (
+                      <EuiBadge color="warning">throttled</EuiBadge>
+                    )}
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                {i < 3 && <EuiSpacer size="xs" />}
+              </React.Fragment>
+            ))}
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/rule_detail_page.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCode,
+  EuiCodeBlock,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { previewPaths } from '../preview_paths';
+
+const FAKE_ESQL = `FROM metrics-*
+| WHERE @timestamp > NOW() - 5 minutes
+| STATS avg_cpu = AVG(system.cpu.total.pct) BY host.name
+| WHERE avg_cpu > 0.85`;
+
+export const RuleDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const history = useHistory();
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>High CPU on prod hosts</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="success">Enabled</EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        breadcrumbs={[
+          { text: 'V2 Alerting Preview' },
+          { text: 'Rules', onClick: () => history.push('/') },
+          { text: 'High CPU on prod hosts' },
+        ]}
+        rightSideItems={[
+          <EuiButton key="edit" iconType="pencil">
+            Edit rule
+          </EuiButton>,
+          <EuiButtonEmpty key="disable" iconType="bellSlash">
+            Disable
+          </EuiButtonEmpty>,
+        ]}
+      />
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={2}>
+          <EuiTitle size="xs">
+            <h3>ES|QL Query</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiCodeBlock language="esql" paddingSize="m" isCopyable>
+            {FAKE_ESQL}
+          </EuiCodeBlock>
+
+          <EuiSpacer size="l" />
+
+          <EuiTitle size="xs">
+            <h3>Active Episodes</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="s">
+            This rule currently has <EuiBadge color="danger">3 active episodes</EuiBadge>.{' '}
+            <EuiLink href={previewPaths.alerts}>View in Alerts & Episodes →</EuiLink>
+          </EuiText>
+
+          <EuiSpacer size="l" />
+
+          <EuiTitle size="xs">
+            <h3>Notification Policies</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup gutterSize="s" direction="column">
+            <EuiFlexItem>
+              <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+                <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+                  <EuiFlexItem grow={false}>
+                    <EuiLink href={previewPaths.notificationPolicyDetail('np-1')}>
+                      Critical PagerDuty
+                    </EuiLink>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiCode transparentBackground>severity: critical</EuiCode>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">PagerDuty Escalation</EuiBadge>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+                <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+                  <EuiFlexItem grow={false}>
+                    <EuiLink href={previewPaths.notificationPolicyDetail('np-2')}>
+                      Slack #ops-alerts
+                    </EuiLink>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">catch-all</EuiBadge>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">Slack Notification</EuiBadge>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={1}>
+          <EuiPanel hasShadow={false} hasBorder>
+            <EuiTitle size="xs">
+              <h3>Configuration</h3>
+            </EuiTitle>
+            <EuiHorizontalRule margin="s" />
+            <EuiDescriptionList
+              compressed
+              type="column"
+              listItems={[
+                { title: 'ID', description: id },
+                { title: 'Kind', description: 'alert' },
+                { title: 'Schedule', description: 'Every 1 minute' },
+                { title: 'Lookback', description: '5 minutes' },
+                { title: 'Group by', description: 'host.name' },
+                { title: 'Source', description: 'metrics-*' },
+                { title: 'Pending threshold', description: '0 (immediate)' },
+                { title: 'Recovery threshold', description: '3 consecutive' },
+                { title: 'No-data behavior', description: 'Last status' },
+                { title: 'Owner', description: 'SRE team' },
+                { title: 'Labels', description: 'infra, critical' },
+              ]}
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/rules_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/rules_page.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHealth,
+  EuiIcon,
+  EuiLink,
+  EuiPageHeader,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
+
+interface FakeRule {
+  id: string;
+  name: string;
+  kind: 'alert' | 'signal';
+  source: string;
+  schedule: string;
+  enabled: boolean;
+  labels: string[];
+  lastRun: string;
+  activeEpisodes: number;
+}
+
+const fakeRules: FakeRule[] = [
+  { id: '1', name: 'High CPU on prod hosts', kind: 'alert', source: 'metrics-*', schedule: '1m', enabled: true, labels: ['infra', 'critical'], lastRun: '12s ago', activeEpisodes: 3 },
+  { id: '2', name: 'Error rate > 5%', kind: 'alert', source: 'logs-*', schedule: '1m', enabled: true, labels: ['apm'], lastRun: '45s ago', activeEpisodes: 1 },
+  { id: '3', name: 'Disk usage > 90%', kind: 'alert', source: 'metrics-*', schedule: '5m', enabled: true, labels: ['infra'], lastRun: '2m ago', activeEpisodes: 2 },
+  { id: '4', name: 'K8s pod restarts', kind: 'alert', source: 'metrics-k8s-*', schedule: '1m', enabled: true, labels: ['k8s'], lastRun: '30s ago', activeEpisodes: 0 },
+  { id: '5', name: 'Latency p99 > 500ms', kind: 'alert', source: 'traces-*', schedule: '1m', enabled: true, labels: ['apm', 'slo'], lastRun: '15s ago', activeEpisodes: 1 },
+  { id: '6', name: 'Security: failed logins', kind: 'signal', source: 'logs-auth-*', schedule: '1m', enabled: true, labels: ['security'], lastRun: '20s ago', activeEpisodes: 0 },
+  { id: '7', name: 'No data: payment service', kind: 'alert', source: 'logs-*', schedule: '5m', enabled: true, labels: ['business'], lastRun: '3m ago', activeEpisodes: 1 },
+  { id: '8', name: 'Memory pressure > 80%', kind: 'alert', source: 'metrics-*', schedule: '2m', enabled: false, labels: ['infra'], lastRun: '1h ago', activeEpisodes: 0 },
+  { id: '9', name: 'Log volume anomaly', kind: 'signal', source: 'logs-*', schedule: '5m', enabled: true, labels: ['ml'], lastRun: '4m ago', activeEpisodes: 0 },
+  { id: '10', name: 'SLO burn rate breach', kind: 'alert', source: '.rule-events-*', schedule: '1m', enabled: true, labels: ['slo', 'rules-on-rules'], lastRun: '10s ago', activeEpisodes: 0 },
+  { id: '11', name: 'Multi-signal correlation', kind: 'alert', source: '.rule-events-*', schedule: '2m', enabled: true, labels: ['rules-on-rules'], lastRun: '1m ago', activeEpisodes: 0 },
+  { id: '12', name: 'External: Datadog import', kind: 'alert', source: 'external-datadog', schedule: '1m', enabled: true, labels: ['external'], lastRun: '25s ago', activeEpisodes: 0 },
+  { id: '13', name: 'HTTP 5xx spike', kind: 'alert', source: 'logs-*', schedule: '1m', enabled: true, labels: ['apm'], lastRun: '8s ago', activeEpisodes: 0 },
+  { id: '14', name: 'Queue depth > threshold', kind: 'alert', source: 'metrics-*', schedule: '2m', enabled: false, labels: ['infra'], lastRun: '30m ago', activeEpisodes: 0 },
+];
+
+export const RulesPage = () => {
+  const history = useHistory();
+
+  const columns: Array<EuiBasicTableColumn<FakeRule>> = [
+    {
+      field: 'name',
+      name: 'Name',
+      render: (name: string, rule: FakeRule) => (
+        <EuiLink onClick={() => history.push(`/${rule.id}`)}>{name}</EuiLink>
+      ),
+    },
+    {
+      field: 'kind',
+      name: 'Mode',
+      width: '110px',
+      render: (kind: string) => (
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type={kind === 'alert' ? 'bell' : 'securitySignalResolved'} size="s" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs">{kind === 'alert' ? 'Alerting' : 'Detect only'}</EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+    {
+      field: 'source',
+      name: 'Source',
+      width: '140px',
+      render: (source: string) => <EuiBadge color="hollow">{source}</EuiBadge>,
+    },
+    {
+      field: 'labels',
+      name: 'Labels',
+      width: '160px',
+      render: (labels: string[]) => (
+        <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+          {labels.map((l) => (
+            <EuiFlexItem key={l} grow={false}>
+              <EuiBadge color="hollow">{l}</EuiBadge>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      ),
+    },
+    {
+      field: 'schedule',
+      name: 'Interval',
+      width: '80px',
+    },
+    {
+      field: 'enabled',
+      name: 'Status',
+      width: '90px',
+      render: (enabled: boolean) =>
+        enabled ? (
+          <EuiHealth color="success">Enabled</EuiHealth>
+        ) : (
+          <EuiHealth color="subdued">Disabled</EuiHealth>
+        ),
+    },
+    {
+      field: 'activeEpisodes',
+      name: 'Episodes',
+      width: '90px',
+      render: (count: number) =>
+        count > 0 ? (
+          <EuiBadge color="danger">{count} active</EuiBadge>
+        ) : (
+          <EuiText size="xs" color="subdued">
+            —
+          </EuiText>
+        ),
+    },
+    {
+      field: 'lastRun',
+      name: 'Last run',
+      width: '90px',
+      render: (val: string) => (
+        <EuiText size="xs" color="subdued">
+          {val}
+        </EuiText>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Rules</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description="ES|QL-powered detection rules that produce append-only rule events."
+        rightSideItems={[
+          <EuiButton key="create" fill iconType="plusInCircle">
+            Create rule
+          </EuiButton>,
+        ]}
+        breadcrumbs={[{ text: 'V2 Alerting Preview' }, { text: 'Rules' }]}
+      />
+      <EuiSpacer size="m" />
+      <EuiFlexGroup alignItems="center" gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs">
+            Showing <strong>1–{fakeRules.length}</strong> of{' '}
+            <strong>{fakeRules.length} rules</strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content="Rules that query .rule-events-* are 'rules on rules' — they detect patterns across other rule outputs">
+            <EuiBadge
+              color="hollow"
+              iconType="questionInCircle"
+              iconSide="right"
+            >
+              2 rules-on-rules
+            </EuiBadge>
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      <EuiBasicTable
+        items={fakeRules}
+        columns={columns}
+        itemId="id"
+        tableCaption="Rules"
+        responsiveBreakpoint={false}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/why_v2_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/why_v2_page.tsx
@@ -1,0 +1,444 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiCard,
+  EuiCode,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiStat,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { previewPaths } from '../preview_paths';
+
+const Section = ({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: string;
+  children: React.ReactNode;
+}) => (
+  <>
+    <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiIcon type={icon} size="l" color="primary" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="s">
+          <h2>{title}</h2>
+        </EuiTitle>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer size="m" />
+    {children}
+    <EuiSpacer size="xl" />
+  </>
+);
+
+const ComparisonRow = ({
+  aspect,
+  v1,
+  v2,
+}: {
+  aspect: string;
+  v1: string;
+  v2: string;
+}) => (
+  <EuiFlexGroup gutterSize="m" responsive={false}>
+    <EuiFlexItem grow={2}>
+      <EuiText size="s">
+        <strong>{aspect}</strong>
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem grow={3}>
+      <EuiText size="s" color="subdued">
+        {v1}
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem grow={3}>
+      <EuiText size="s">{v2}</EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+export const WhyV2Page = () => {
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Why Alerting v2?</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description="A ground-up rethink of how alerting works in Kibana — built on ES|QL, append-only event data, and a unified notification pipeline."
+        breadcrumbs={[{ text: 'V2 Alerting Preview' }, { text: 'Why v2?' }]}
+      />
+      <EuiSpacer size="l" />
+
+      {/* Headline stats */}
+      <EuiFlexGroup gutterSize="l">
+        <EuiFlexItem>
+          <EuiPanel paddingSize="l" hasShadow={false} hasBorder>
+            <EuiStat title="ES|QL" description="Query language" titleColor="primary" />
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel paddingSize="l" hasShadow={false} hasBorder>
+            <EuiStat title="Append-only" description="Event model" titleColor="primary" />
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel paddingSize="l" hasShadow={false} hasBorder>
+            <EuiStat title="Signals + Alerts" description="Dual rule modes" titleColor="primary" />
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel paddingSize="l" hasShadow={false} hasBorder>
+            <EuiStat
+              title="Rules on rules"
+              description="Correlation & escalation"
+              titleColor="primary"
+            />
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="xl" />
+
+      {/* The problem with v1 */}
+      <Section title="The problem with v1" icon="alert">
+        <EuiText>
+          <p>
+            Kibana Alerting v1 has served well, but its architecture creates friction that
+            compounds over time:
+          </p>
+          <ul>
+            <li>
+              <strong>Rule types are black boxes.</strong> Each solution team registers an executor
+              function with arbitrary code. What gets stored in an alert document varies wildly
+              between rule types — and users can't change it.
+            </li>
+            <li>
+              <strong>Alerts are updated in place.</strong> Only the latest value is kept. There's no
+              history of how an alert evolved, making investigation painful.
+            </li>
+            <li>
+              <strong>Alert data is hard to query.</strong> Bespoke indices, complex RBAC, and
+              inconsistent schemas mean you can't just "look at your alerts" in Discover.
+            </li>
+            <li>
+              <strong>Notification control is scattered.</strong> Flapping suppression, per-action
+              frequency, run-when conditions, KQL filters, timeframe constraints, mute, snooze,
+              disable — all configured in different places with overlapping semantics.
+            </li>
+            <li>
+              <strong>Rules can't build on other rules.</strong> There's no way to detect patterns
+              across rule outputs, making escalation and correlation impossible within the framework.
+            </li>
+          </ul>
+        </EuiText>
+      </Section>
+
+      {/* What changes in v2 */}
+      <Section title="What changes in v2" icon="sparkles">
+        <EuiPanel hasShadow={false} hasBorder paddingSize="l">
+          <EuiFlexGroup gutterSize="none" responsive={false}>
+            <EuiFlexItem grow={2}>
+              <EuiText size="s">
+                <strong>Aspect</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={3}>
+              <EuiText size="s" color="subdued">
+                <strong>v1</strong>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={3}>
+              <EuiText size="s">
+                <strong>v2</strong>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiHorizontalRule margin="s" />
+          <ComparisonRow
+            aspect="What gets stored"
+            v1="Rule type decides; unpredictable across types"
+            v2="Author chooses via ES|QL KEEP — stored in the data field"
+          />
+          <EuiSpacer size="s" />
+          <ComparisonRow
+            aspect="Alert persistence"
+            v1="Updated in-place; only latest value"
+            v2="Append-only; new event per evaluation"
+          />
+          <EuiSpacer size="s" />
+          <ComparisonRow
+            aspect="Queryability"
+            v1="Bespoke indices, complex RBAC"
+            v2="ES|QL in Discover, like any other data"
+          />
+          <EuiSpacer size="s" />
+          <ComparisonRow
+            aspect="Rule definition"
+            v1="Plugin-registered executor with arbitrary code"
+            v2="ES|QL queries; rule types are parameterized abstractions"
+          />
+          <EuiSpacer size="s" />
+          <ComparisonRow
+            aspect="Notification control"
+            v1="Per-action frequency, flapping, mute/snooze/disable on rules"
+            v2="Notification policies with KQL matchers, per-series snooze, ack/unack on episodes"
+          />
+          <EuiSpacer size="s" />
+          <ComparisonRow
+            aspect="Rules on rules"
+            v1="Not possible"
+            v2="Natural consequence — rule events are queryable data"
+          />
+        </EuiPanel>
+      </Section>
+
+      {/* Core concepts */}
+      <Section title="Core concepts" icon="list">
+        <EuiFlexGroup gutterSize="l" wrap>
+          <EuiFlexItem style={{ minWidth: 260 }}>
+            <EuiCard
+              title="Rules"
+              titleSize="xs"
+              description="Declarative ES|QL logic evaluated on a schedule. Each evaluation writes immutable rule events. Rules operate in two modes: alerting (lifecycle tracking) or signal (observation only)."
+              icon={<EuiIcon type="editorCodeBlock" size="xl" color="primary" />}
+              footer={
+                <EuiLink href={previewPaths.rules}>
+                  Explore rules <EuiIcon type="arrowRight" size="s" />
+                </EuiLink>
+              }
+            />
+          </EuiFlexItem>
+          <EuiFlexItem style={{ minWidth: 260 }}>
+            <EuiCard
+              title="Episodes"
+              titleSize="xs"
+              description="A lifecycle arc for an alerting rule's grouped series — from first breach through active, recovering, and back to inactive. Episodes are the primary unit of triage."
+              icon={<EuiIcon type="timeline" size="xl" color="primary" />}
+              footer={
+                <EuiLink href={previewPaths.alerts}>
+                  Explore alerts & episodes <EuiIcon type="arrowRight" size="s" />
+                </EuiLink>
+              }
+            />
+          </EuiFlexItem>
+          <EuiFlexItem style={{ minWidth: 260 }}>
+            <EuiCard
+              title="Notification Policies"
+              titleSize="xs"
+              description="The gating layer between episodes and workflows. Match by KQL, group related episodes, throttle by interval, and route to the right workflow."
+              icon={<EuiIcon type="bell" size="xl" color="primary" />}
+              footer={
+                <EuiLink href={previewPaths.notificationPolicies}>
+                  Explore policies <EuiIcon type="arrowRight" size="s" />
+                </EuiLink>
+              }
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </Section>
+
+      {/* ES|QL first */}
+      <Section title="ES|QL first" icon="editorCodeBlock">
+        <EuiText>
+          <p>
+            Every v2 rule is an ES|QL query. The query defines the data source, the computation,
+            and what gets persisted. There's no arbitrary executor code — the framework runs
+            the query, writes the results, and handles lifecycle transitions.
+          </p>
+        </EuiText>
+        <EuiSpacer size="m" />
+        <EuiCodeBlock language="sql" fontSize="m" paddingSize="m" isCopyable>
+          {`FROM metrics-*
+| WHERE @timestamp > NOW() - 5 minutes
+| STATS avg_cpu = AVG(system.cpu.total.pct) BY host.name
+| WHERE avg_cpu > 0.9
+| KEEP host.name, avg_cpu`}
+        </EuiCodeBlock>
+        <EuiSpacer size="s" />
+        <EuiText size="s" color="subdued">
+          <p>
+            The <EuiCode>KEEP</EuiCode> fields become the rule event's{' '}
+            <EuiCode>data</EuiCode> payload. Because rule events are written to standard
+            Elasticsearch indices, you can query them in Discover just like any other data —
+            and other rules can query them too.
+          </p>
+        </EuiText>
+      </Section>
+
+      {/* Rules on rules */}
+      <Section title="Rules on rules" icon="layers">
+        <EuiText>
+          <p>
+            Because rule events are data in <EuiCode>.rule-events-*</EuiCode>, rules can query
+            other rules' output. This enables escalation, correlation, and noise reduction
+            patterns that are structurally impossible in v1.
+          </p>
+        </EuiText>
+        <EuiSpacer size="m" />
+        <EuiCodeBlock language="sql" fontSize="m" paddingSize="m" isCopyable>
+          {`FROM .rule-events-*
+| WHERE @timestamp > NOW() - 10 minutes AND status == "breached"
+| STATS
+    rule_count = COUNT_DISTINCT(rule.id),
+    event_count = COUNT(*)
+  BY data.service
+| WHERE rule_count >= 2 AND event_count >= 3`}
+        </EuiCodeBlock>
+        <EuiSpacer size="s" />
+        <EuiText size="s" color="subdued">
+          <p>
+            This higher-order rule fires only when multiple underlying rules are breaching for
+            the same service — turning low-level signals into meaningful, correlated alerts.
+          </p>
+        </EuiText>
+      </Section>
+
+      {/* Lifecycle */}
+      <Section title="Episode lifecycle" icon="timeline">
+        <EuiText>
+          <p>
+            Alerting rules (<EuiCode>kind: alert</EuiCode>) track episodes through a four-state
+            lifecycle. Configurable thresholds control when episodes promote from pending to active
+            and when they demote from recovering to inactive — reducing noise from transient
+            conditions.
+          </p>
+        </EuiText>
+        <EuiSpacer size="m" />
+        <EuiPanel hasShadow={false} hasBorder paddingSize="l" color="subdued">
+          <EuiText size="s" style={{ fontFamily: 'monospace', whiteSpace: 'pre' }}>
+            {`  ┌──────────┐     ┌─────────┐     ┌────────┐     ┌────────────┐
+  │ Inactive ├────►│ Pending ├────►│ Active ├────►│ Recovering │
+  └──────────┘     └─────────┘     └────────┘     └─────┬──────┘
+       ▲                                                 │
+       └─────────────────────────────────────────────────┘`}
+          </EuiText>
+        </EuiPanel>
+        <EuiSpacer size="m" />
+        <EuiText size="s">
+          <ul>
+            <li>
+              <strong>Inactive → Pending:</strong> Condition first detected. The episode begins.
+            </li>
+            <li>
+              <strong>Pending → Active:</strong> Condition persists past the activation threshold
+              (configurable count and/or timeframe).
+            </li>
+            <li>
+              <strong>Active → Recovering:</strong> Condition no longer detected, but recovery
+              threshold not yet met.
+            </li>
+            <li>
+              <strong>Recovering → Inactive:</strong> Recovery threshold satisfied. The episode ends.
+            </li>
+          </ul>
+        </EuiText>
+      </Section>
+
+      {/* Unified notification pipeline */}
+      <Section title="Unified notification pipeline" icon="bell">
+        <EuiText>
+          <p>
+            v1 scatters notification control across per-action frequency, flapping suppression,
+            run-when conditions, KQL filters, mute, snooze, and disable. v2 replaces all of this
+            with <strong>notification policies</strong> — a single, composable layer between
+            episodes and workflows.
+          </p>
+        </EuiText>
+        <EuiSpacer size="m" />
+        <EuiPanel hasShadow={false} hasBorder paddingSize="l" color="subdued">
+          <EuiText size="s" style={{ fontFamily: 'monospace', whiteSpace: 'pre' }}>
+            {`  Episodes
+      │
+      ▼
+  ┌──────────────────────┐
+  │  Notification Policy  │
+  │                       │
+  │  Match:  KQL matcher  │
+  │  Group:  data.* fields│
+  │  Throttle: interval   │
+  └───────────┬───────────┘
+              │
+              ▼
+         Workflow
+    (actions, enrichment,
+     external integrations)`}
+          </EuiText>
+        </EuiPanel>
+        <EuiSpacer size="m" />
+        <EuiText size="s" color="subdued">
+          <p>
+            Suppression actions (acknowledge, snooze, silence, maintenance windows) all gate at the
+            notification policy layer — not on the rule. Rules keep detecting; only notifications
+            are suppressed.
+          </p>
+        </EuiText>
+      </Section>
+
+      {/* Migration */}
+      <Section title="Migration path" icon="merge">
+        <EuiCallOut
+          title="v1 is not going away"
+          iconType="iInCircle"
+          color="primary"
+        >
+          <p>
+            v2 runs alongside v1. There is no forced migration. Users copy rules from v1 to v2 at
+            their own pace, verify the output, and optionally disable the v1 rule. v2 can display
+            v1 alerts as read-only (via the <EuiCode>source</EuiCode> field), but v1 will never
+            show v2 rule events.
+          </p>
+        </EuiCallOut>
+      </Section>
+
+      {/* Explore links */}
+      <EuiHorizontalRule />
+      <EuiTitle size="xs">
+        <h3>Explore the preview</h3>
+      </EuiTitle>
+      <EuiSpacer size="m" />
+      <EuiFlexGroup gutterSize="m">
+        <EuiFlexItem grow={false}>
+          <EuiLink href={previewPaths.rules}>
+            <EuiIcon type="editorCodeBlock" /> Rules
+          </EuiLink>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiLink href={previewPaths.alerts}>
+            <EuiIcon type="timeline" /> Alerts & Episodes
+          </EuiLink>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiLink href={previewPaths.notificationPolicies}>
+            <EuiIcon type="bell" /> Notification Policies
+          </EuiLink>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="xl" />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/workflows_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/pages/workflows_page.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLink,
+  EuiPageHeader,
+  EuiSpacer,
+  EuiText,
+  type EuiBasicTableColumn,
+} from '@elastic/eui';
+interface FakeWorkflow {
+  id: string;
+  name: string;
+  type: string;
+  steps: number;
+  linkedPolicies: number;
+  lastTriggered: string;
+}
+
+const fakeWorkflows: FakeWorkflow[] = [
+  { id: 'wf-1', name: 'PagerDuty Escalation', type: 'PagerDuty', steps: 3, linkedPolicies: 1, lastTriggered: '2m ago' },
+  { id: 'wf-2', name: 'Slack Notification', type: 'Slack', steps: 1, linkedPolicies: 2, lastTriggered: '10m ago' },
+  { id: 'wf-3', name: 'Jira Create Issue', type: 'Jira', steps: 2, linkedPolicies: 1, lastTriggered: '30m ago' },
+];
+
+export const WorkflowsPage = () => {
+  const columns: Array<EuiBasicTableColumn<FakeWorkflow>> = [
+    {
+      field: 'name',
+      name: 'Name',
+      render: (name: string) => <EuiLink>{name}</EuiLink>,
+    },
+    {
+      field: 'type',
+      name: 'Type',
+      width: '120px',
+      render: (type: string) => (
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="pipelineApp" size="s" />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{type}</EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+    {
+      field: 'steps',
+      name: 'Steps',
+      width: '80px',
+      render: (steps: number) => <EuiBadge color="hollow">{steps}</EuiBadge>,
+    },
+    {
+      field: 'linkedPolicies',
+      name: 'Policies',
+      width: '80px',
+      render: (count: number) => <EuiBadge color="hollow">{count}</EuiBadge>,
+    },
+    {
+      field: 'lastTriggered',
+      name: 'Last triggered',
+      width: '120px',
+      render: (val: string) => (
+        <EuiText size="xs" color="subdued">{val}</EuiText>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+            <EuiFlexItem grow={false}>Workflows</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="accent">Preview</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        description="Workflows are automated sequences of tasks triggered by notification policies. They handle the actual notification delivery and external integrations."
+        breadcrumbs={[{ text: 'V2 Alerting Preview' }, { text: 'Workflows' }]}
+      />
+      <EuiSpacer size="m" />
+      <EuiText size="xs" color="subdued">
+        Workflows are managed by the Workflows plugin. This view shows workflows
+        referenced by your notification policies.
+      </EuiText>
+      <EuiSpacer size="m" />
+      <EuiBasicTable
+        items={fakeWorkflows}
+        columns={columns}
+        itemId="id"
+        tableCaption="Workflows"
+        responsiveBreakpoint={false}
+      />
+    </>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/preview/preview_paths.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/preview/preview_paths.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PREVIEW_SECTION_ID, PREVIEW_WHY_V2_APP_ID, PREVIEW_RULES_APP_ID, PREVIEW_ALERTS_APP_ID, PREVIEW_NOTIFICATION_POLICIES_APP_ID } from './constants';
+
+const base = (appId: string) => `/app/management/${PREVIEW_SECTION_ID}/${appId}`;
+
+export const previewPaths = {
+  whyV2: base(PREVIEW_WHY_V2_APP_ID),
+  rules: base(PREVIEW_RULES_APP_ID),
+  ruleDetail: (id: string) => `${base(PREVIEW_RULES_APP_ID)}/${id}`,
+  alerts: base(PREVIEW_ALERTS_APP_ID),
+  alertDetail: (id: string) => `${base(PREVIEW_ALERTS_APP_ID)}/${id}`,
+  notificationPolicies: base(PREVIEW_NOTIFICATION_POLICIES_APP_ID),
+  notificationPolicyDetail: (id: string) => `${base(PREVIEW_NOTIFICATION_POLICIES_APP_ID)}/${id}`,
+} as const;


### PR DESCRIPTION
## Summary

Adds a new top-level **V2 Alerting Preview** section to Stack Management, registered via `management.sections.register()` so it appears as its own nav group (outside of "Insights and Alerting"). This is a UX prototype with mock data for visualizing the v2 alerting experience as a unified management hub.

**Nav items:**
- **Why v2?** — Explainer page covering the architectural differences from v1, core concepts (ES|QL-first rules, append-only events, episodes, notification policies, rules-on-rules), lifecycle diagrams, and migration path.
- **Rules** — Mock rules list and detail pages with fake ES|QL-powered rules.
- **Alerts & Episodes** — Mock alerts/episodes list and detail pages showing lifecycle states.
- **Notification Policies** — Mock policies list and detail pages showing KQL matchers, grouping, throttling, and workflow routing.

All pages use EUI components, cross-link to each other, and include a `Preview` badge. No backend changes — purely frontend mock UI.

**To enable locally**, add to `kibana.yml`:
```yaml
xpack.alerting_v2.enabled: true
xpack.alerting_v2.ui.enabled: true
```

## Test plan

- [ ] Enable the plugin via `kibana.yml` config above
- [ ] Navigate to Stack Management — verify "V2 Alerting Preview" appears as a top-level section
- [ ] Verify nav order: Why v2?, Rules, Alerts & Episodes, Notification Policies
- [ ] Click through each page and verify cross-links work between sections
- [ ] Verify "Why v2?" page renders all sections (comparison table, lifecycle diagram, ES|QL examples, etc.)


Made with [Cursor](https://cursor.com)