### PR TITLE
[EDR Workflows] Unskip flaky policy settings layout tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_layout/policy_settings_layout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_layout/policy_settings_layout.test.tsx
@@ -64,8 +64,7 @@ describe('When rendering PolicySettingsLayout', () => {
     cleanup();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/254544
-  describe.skip('and user has Edit permissions', () => {
+  describe('and user has Edit permissions', () => {
     const clickSave = async (andConfirm: boolean = true, ensureApiIsCalled: boolean = true) => {
       const { getByTestId } = renderResult;
 
@@ -120,7 +119,9 @@ describe('When rendering PolicySettingsLayout', () => {
       set(policySettings, 'linux.popup.behavior_protection.enabled', false);
 
       // Set Ransomware User Notification message
-      await userEvent.type(getByTestId(testSubj.ransomware.notifyCustomMessage), 'foo message');
+      const messageInput = getByTestId(testSubj.ransomware.notifyCustomMessage);
+      await userEvent.clear(messageInput);
+      await userEvent.paste('foo message');
       set(policySettings, 'windows.popup.ransomware.message', 'foo message');
 
       // skipping Advanced Options as changing them takes too long.


### PR DESCRIPTION
Fixes flaky Jest test timeout in `policy_settings_layout.test.tsx` by replacing slow `userEvent.type` (per-character keystroke simulation, 44+ DOM events) with `userEvent.clear` + `userEvent.paste` (single event). This prevents the 15s timeout on resource-constrained CI machines while preserving full test coverage — the test still verifies that all policy changes (malware toggle, behavior protection toggle, ransomware notification message) are correctly sent to the API.

Closes https://github.com/elastic/kibana/issues/254544