### PR TITLE
[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
@@ -33,6 +33,8 @@ jest.mock('../../../../../detections/containers/detection_engine/alerts/use_sign
 jest.mock('../../../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
 
 describe('Endpoint exceptions flyout', () => {
+  jest.setTimeout(10000);
+
   let mockedContext: AppContextTestRender;
   let render: (
     props?: Partial<EndpointExceptionsFlyoutProps>
@@ -189,16 +191,12 @@ describe('Endpoint exceptions flyout', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253883
-  // FLAKY: https://github.com/elastic/kibana/issues/253640
-  describe.skip('When valid form state', () => {
+  describe('When valid form state', () => {
     it('should enable "Add endpoint exception" button when form is valid', async () => {
       render({ alertData, isAlertDataLoading: false });
 
-      await userEvent.type(
-        renderResult.getByTestId('endpointExceptions-form-name-input'),
-        'Test exception'
-      );
+      await userEvent.clear(renderResult.getByTestId('endpointExceptions-form-name-input'));
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       expect(confirmButton.hasAttribute('disabled')).toBeFalsy();
@@ -219,10 +217,8 @@ describe('Endpoint exceptions flyout', () => {
       (useCloseAlertsFromExceptions as jest.Mock).mockImplementation(() => [true, jest.fn()]);
 
       render({ alertData, isAlertDataLoading: false });
-      await userEvent.type(
-        renderResult.getByTestId('endpointExceptions-form-name-input'),
-        'Test exception'
-      );
+      await userEvent.clear(renderResult.getByTestId('endpointExceptions-form-name-input'));
+      await userEvent.paste('Test exception');
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
 
       await waitFor(() => {
@@ -234,7 +230,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -252,7 +249,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -268,7 +266,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -285,7 +284,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -306,7 +306,8 @@ describe('Endpoint exceptions flyout', () => {
         render({ alertData, isAlertDataLoading: false, alertStatus: 'open', rules });
 
         const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-        await userEvent.type(nameInput, 'Test exception');
+        await userEvent.clear(nameInput);
+        await userEvent.paste('Test exception');
 
         confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       });
@@ -373,15 +374,15 @@ describe('Endpoint exceptions flyout', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253648
-  describe.skip('When wildcard warning is active', () => {
+  describe('When wildcard warning is active', () => {
     beforeEach(async () => {
       alertData.file!.path = 'lets*contain*wildcards';
 
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
     });
 
     it('pressing confirm should show confirm modal instead of saving exception', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.test.tsx
@@ -46,6 +46,8 @@ jest.mock('../../../../../common/containers/source', () => ({
 import { useFetchIndex } from '../../../../../common/containers/source';
 
 describe('Trusted devices form', () => {
+  jest.setTimeout(10000);
+
   const formPrefix = 'trustedDevices-form';
   let resetHTMLElementOffsetWidth: ReturnType<typeof forceHTMLElementOffsetWidth>;
 
@@ -119,11 +121,9 @@ describe('Trusted devices form', () => {
     textField: HTMLInputElement | HTMLTextAreaElement,
     value: string
   ) => {
-    // For EuiComboBox (has role="combobox"), use userEvent.type
     if (textField.getAttribute('role') === 'combobox') {
       await userEvent.clear(textField);
-      await userEvent.type(textField, value);
-      // Press Enter to create the custom option
+      await userEvent.paste(value);
       await userEvent.keyboard('{Enter}');
     } else {
       // For regular text fields
@@ -298,8 +298,7 @@ describe('Trusted devices form', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253353
-  describe.skip('Conditions', () => {
+  describe('Conditions', () => {
     beforeEach(async () => {
       await render();
     });


### PR DESCRIPTION
Fixes flaky Jest test timeouts in two test files by replacing slow `userEvent.type` (per-character keystroke simulation) with `userEvent.clear` + `userEvent.paste` (single event), and adding `jest.setTimeout(10000)` as CI safety margin.

### `endpoint_exceptions_flyout.test.tsx`
Unskips two `describe` blocks ("When valid form state" and "When wildcard warning is active"). All 8 instances of `userEvent.type` replaced. 20 tests now pass.

### `form.test.tsx` (trusted devices)
Unskips the "Conditions" `describe` block. Fixed `setTextFieldValue` helper to use `paste` instead of `type` for EuiComboBox inputs. 28 tests now pass.

Closes https://github.com/elastic/kibana/issues/253883
Closes https://github.com/elastic/kibana/issues/253640
Closes https://github.com/elastic/kibana/issues/253648
Closes https://github.com/elastic/kibana/issues/253353
Closes https://github.com/elastic/kibana/issues/253368
Closes https://github.com/elastic/kibana/issues/253563

<!--ONMERGE {"backportTargets":["9.3"]} ONMERGE-->