### PR TITLE
Add ConnectorAuthorizationError for connector re-auth, propagate metadata

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -16,3 +16,6 @@ export { EARS_PROVIDERS } from './src/auth_types/ears';
 export { getConnectorSpec } from './src/get_connector_spec';
 export { isToolAction } from './src/connector_spec';
 export { normalizeAuthorizationHeaderValue } from './src/auth_types/oauth_authz_code_and_ears_helpers';
+
+export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
+export type { ConnectorAuthorizationReason } from './src/errors';

--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -11,7 +11,8 @@ export * as connectorsSpecs from './src/all_specs';
 export type * from './src/connector_spec';
 
 export * as authTypeSpecs from './src/all_auth_types';
-export { EARS_PROVIDERS } from './src/auth_types/ears';
+export { EARS_AUTH_ID, EARS_PROVIDERS } from './src/auth_types/ears';
+export { OAUTH_AUTHORIZATION_CODE_AUTH_ID } from './src/auth_types/oauth_authorization_code';
 
 export { getConnectorSpec } from './src/get_connector_spec';
 export { isToolAction } from './src/connector_spec';

--- a/src/platform/packages/shared/kbn-connector-specs/src/all_auth_types.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/all_auth_types.ts
@@ -15,7 +15,7 @@ export * from './auth_types/basic';
 export * from './auth_types/gcp_service_account';
 export * from './auth_types/none';
 export * from './auth_types/oauth';
-export * from './auth_types/oauth_authorization_code';
+export { OAuthAuthorizationCode } from './auth_types/oauth_authorization_code';
 export { Ears } from './auth_types/ears';
 
 // Skipping PFX and CRT exports for now as they will require updates to

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/ears.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/ears.ts
@@ -10,9 +10,11 @@
 import { z } from '@kbn/zod/v4';
 import type { AxiosInstance } from 'axios';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
+import { isConnectorAuthorizationError } from '../errors/connector_authorization_error';
 import { normalizeAuthorizationHeaderValue } from './oauth_authz_code_and_ears_helpers';
 import * as i18n from './translations';
 
+export const EARS_AUTH_ID = 'ears';
 export const EARS_PROVIDERS = ['google', 'microsoft', 'slack'] as const;
 
 const authSchema = z
@@ -42,7 +44,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
  * 6. Tokens are auto-refreshed when expired during connector execution
  */
 export const Ears: AuthTypeSpec<AuthSchemaType> = {
-  id: 'ears',
+  id: EARS_AUTH_ID,
   schema: authSchema,
   authMode: 'per-user',
   configure: async (
@@ -58,6 +60,9 @@ export const Ears: AuthTypeSpec<AuthSchemaType> = {
         scope: secret.scope,
       });
     } catch (error) {
+      if (isConnectorAuthorizationError(error)) {
+        throw error;
+      }
       throw new Error(
         `Unable to retrieve/refresh the access token. User may need to re-authorize: ${error.message}`
       );

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth_authorization_code.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth_authorization_code.ts
@@ -14,6 +14,8 @@ import { normalizeAuthorizationHeaderValue } from './oauth_authz_code_and_ears_h
 import { isConnectorAuthorizationError } from '../errors';
 import * as i18n from './translations';
 
+export const OAUTH_AUTHORIZATION_CODE_AUTH_ID = 'oauth_authorization_code';
+
 const authSchema = z
   .object({
     authorizationUrl: z.url().meta({
@@ -97,7 +99,7 @@ type AuthSchemaType = z.infer<typeof authSchema>;
  * The _start_oauth_flow and _oauth_callback routes are generic and work with any provider.
  */
 export const OAuthAuthorizationCode: AuthTypeSpec<AuthSchemaType> = {
-  id: 'oauth_authorization_code',
+  id: OAUTH_AUTHORIZATION_CODE_AUTH_ID,
   schema: authSchema,
   authMode: 'per-user',
   configure: async (

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth_authorization_code.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/oauth_authorization_code.ts
@@ -11,6 +11,7 @@ import { z } from '@kbn/zod/v4';
 import type { AxiosInstance } from 'axios';
 import type { AuthContext, AuthTypeSpec } from '../connector_spec';
 import { normalizeAuthorizationHeaderValue } from './oauth_authz_code_and_ears_helpers';
+import { isConnectorAuthorizationError } from '../errors';
 import * as i18n from './translations';
 
 const authSchema = z
@@ -120,6 +121,9 @@ export const OAuthAuthorizationCode: AuthTypeSpec<AuthSchemaType> = {
         tokenType: secret.tokenType,
       });
     } catch (error) {
+      if (isConnectorAuthorizationError(error)) {
+        throw error;
+      }
       throw new Error(
         `Unable to retrieve/refresh the access token. User may need to re-authorize: ${error.message}`
       );

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  ConnectorAuthorizationError,
+  isConnectorAuthorizationError,
+} from './connector_authorization_error';
+
+describe('isConnectorAuthorizationError', () => {
+  it('returns true for a ConnectorAuthorizationError instance', () => {
+    const error = new ConnectorAuthorizationError({
+      authMethod: 'oauth_authorization_code',
+      reason: 'no_token',
+      message: 'no token',
+    });
+
+    expect(isConnectorAuthorizationError(error)).toBe(true);
+  });
+
+  it('returns true for an Error-like object with matching name (cross-realm)', () => {
+    // Simulates an error thrown from a different JS realm (vm context, worker,
+    // iframe, etc.) where `instanceof ConnectorAuthorizationError` is false
+    // but the error's shape and name are preserved.
+    const crossRealmError = Object.assign(new Error('no token'), {
+      name: 'ConnectorAuthorizationError',
+      authMethod: 'ears',
+      reason: 'no_token',
+    });
+
+    expect(crossRealmError).not.toBeInstanceOf(ConnectorAuthorizationError);
+    expect(isConnectorAuthorizationError(crossRealmError)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isConnectorAuthorizationError(new Error('boom'))).toBe(false);
+  });
+
+  it('returns false for a subclassed Error whose name does not match', () => {
+    class SomeOtherError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'SomeOtherError';
+      }
+    }
+
+    expect(isConnectorAuthorizationError(new SomeOtherError('boom'))).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
@@ -41,5 +41,8 @@ export class ConnectorAuthorizationError extends Error {
 export const isConnectorAuthorizationError = (
   error: unknown
 ): error is ConnectorAuthorizationError => {
-  return error instanceof ConnectorAuthorizationError;
+  return (
+    error instanceof ConnectorAuthorizationError ||
+    (Error.isError(error) && error.name === 'ConnectorAuthorizationError')
+  );
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { isError } from 'lodash';
+
 export type ConnectorAuthorizationReason =
   | 'no_token'
   | 'token_expired'
@@ -43,6 +45,6 @@ export const isConnectorAuthorizationError = (
 ): error is ConnectorAuthorizationError => {
   return (
     error instanceof ConnectorAuthorizationError ||
-    (Error.isError(error) && error.name === 'ConnectorAuthorizationError')
+    (isError(error) && error.name === 'ConnectorAuthorizationError')
   );
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type ConnectorAuthorizationReason = 'no_token' | 'token_expired' | 'refresh_token_expired';
+
+/**
+ * Structured error thrown when a connector fails to authorize, and should
+ * specifically be used to signal that the connector requires user re-authorization.
+ */
+export class ConnectorAuthorizationError extends Error {
+  public readonly authMethod: string;
+  public readonly reason: ConnectorAuthorizationReason;
+
+  constructor({
+    authMethod,
+    reason,
+    message,
+  }: {
+    authMethod: string;
+    reason: ConnectorAuthorizationReason;
+    message: string;
+  }) {
+    super(message);
+    this.name = 'ConnectorAuthorizationError';
+    this.authMethod = authMethod;
+    this.reason = reason;
+  }
+}
+
+export const isConnectorAuthorizationError = (
+  error: unknown
+): error is ConnectorAuthorizationError => {
+  return error instanceof ConnectorAuthorizationError;
+};

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_authorization_error.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type ConnectorAuthorizationReason = 'no_token' | 'token_expired' | 'refresh_token_expired';
+export type ConnectorAuthorizationReason =
+  | 'no_token'
+  | 'token_expired'
+  | 'refresh_token_expired'
+  | 'token_revoked'
+  | 'refresh_failed';
 
 /**
  * Structured error thrown when a connector fails to authorize, and should

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export {
+  ConnectorAuthorizationError,
+  isConnectorAuthorizationError,
+} from './connector_authorization_error';
+export type { ConnectorAuthorizationReason } from './connector_authorization_error';

--- a/x-pack/platform/plugins/shared/actions/common/routes/connector/response/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/actions/common/routes/connector/response/schemas/v1.ts
@@ -188,4 +188,20 @@ export const connectorExecuteResponseSchema = schema.object({
       },
     })
   ),
+  error_name: schema.maybe(
+    schema.string({
+      meta: {
+        description:
+          'When the status is error, identifies the error class name so consumers can branch on specific error types (e.g. ConnectorAuthorizationError).',
+      },
+    })
+  ),
+  error_meta: schema.maybe(
+    schema.recordOf(schema.string(), schema.any(), {
+      meta: {
+        description:
+          'When the status is error, carries structured metadata describing the failure (e.g. the auth method and reason for a ConnectorAuthorizationError).',
+      },
+    })
+  ),
 });

--- a/x-pack/platform/plugins/shared/actions/common/types.ts
+++ b/x-pack/platform/plugins/shared/actions/common/types.ts
@@ -58,6 +58,8 @@ export interface ActionTypeExecutorResult<Data> {
   data?: Data;
   retry?: null | boolean | Date;
   errorSource?: TaskErrorSource;
+  errorName?: string;
+  errorMeta?: Record<string, unknown>;
 }
 
 export type ActionTypeExecutorRawResult<Data> = ActionTypeExecutorResult<Data> & {

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -31,6 +31,7 @@ import { finished } from 'stream/promises';
 import { PassThrough } from 'stream';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { createTaskRunError, getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
+import { ConnectorAuthorizationError } from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import type { ConnectorRateLimiter } from './connector_rate_limiter';
 import { createMockInMemoryConnector } from '../application/connector/mocks';
@@ -1507,6 +1508,51 @@ describe('Action Executor', () => {
       expect(executorResult?.errorSource).toBe(TaskErrorSource.USER);
       expect(loggerMock.warn).toBeCalledWith(
         'action execution failure: test:1: 1: an error occurred while running the action: this action execution is intended to fail; retry: true'
+      );
+      expect(loggerMock.error).toBeCalledWith(err, {
+        error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
+        tags: ['test', '1', 'action-run-failed', 'user-error'],
+      });
+    });
+
+    test(`${label} returns structured error result when executor throws ConnectorAuthorizationError`, async () => {
+      const err = new ConnectorAuthorizationError({
+        authMethod: 'oauth_authorization_code',
+        reason: 'refresh_token_expired',
+        message: 'Refresh token expired. User must re-authorize.',
+      });
+      err.stack = 'foo error\n  stack 1\n  stack 2\n  stack 3';
+      (
+        connectorType.executor as jest.MockedFunction<NonNullable<ConnectorType['executor']>>
+      ).mockRejectedValueOnce(err);
+      encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValueOnce(
+        connectorSavedObject
+      );
+      connectorTypeRegistry.get.mockReturnValueOnce(connectorType);
+
+      let executorResult;
+      if (executeUnsecure) {
+        executorResult = await actionExecutor.executeUnsecured(executeUnsecuredParams);
+      } else {
+        executorResult = await actionExecutor.execute(executeParams);
+      }
+
+      expect(executorResult).toEqual({
+        actionId: CONNECTOR_ID,
+        status: 'error',
+        message: 'an error occurred while running the action',
+        serviceMessage: 'Refresh token expired. User must re-authorize.',
+        errorName: 'ConnectorAuthorizationError',
+        errorMeta: {
+          connectorName: '1',
+          authMethod: 'oauth_authorization_code',
+          reason: 'refresh_token_expired',
+        },
+        retry: false,
+        errorSource: TaskErrorSource.USER,
+      });
+      expect(loggerMock.warn).toBeCalledWith(
+        'action execution failure: test:1: 1: an error occurred while running the action: Refresh token expired. User must re-authorize.'
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -21,6 +21,7 @@ import type { IEventLogger } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource as getTaskManagerErrorSource } from '@kbn/task-manager-plugin/server/task_running';
+import { isConnectorAuthorizationError } from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import { ConnectorUsageCollector } from '../usage/connector_usage_collector';
 import {
@@ -583,6 +584,22 @@ export class ActionExecutor {
           const errorSource = getErrorSource(err) || TaskErrorSource.FRAMEWORK;
           if (err.reason === ActionExecutionErrorReason.Authorization) {
             rawResult = err.result;
+          } else if (isConnectorAuthorizationError(err)) {
+            rawResult = {
+              actionId,
+              status: 'error',
+              message: 'an error occurred while running the action',
+              serviceMessage: err.message,
+              errorName: 'ConnectorAuthorizationError',
+              errorMeta: {
+                connectorName: name,
+                authMethod: err.authMethod,
+                reason: err.reason,
+              },
+              error: err,
+              retry: false,
+              errorSource: TaskErrorSource.USER,
+            };
           } else {
             rawResult = {
               actionId,

--- a/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
@@ -252,7 +252,7 @@ describe('getEarsAccessToken', () => {
   });
 
   describe('error handling', () => {
-    it('returns null and logs an error when requestEarsRefreshToken throws', async () => {
+    it('throws ConnectorAuthorizationError with reason refresh_failed when requestEarsRefreshToken throws', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: expiredToken,
@@ -261,15 +261,17 @@ describe('getEarsAccessToken', () => {
         new Error('EARS endpoint unreachable')
       );
 
-      const result = await getEarsAccessToken(baseOpts);
+      const error = await getEarsAccessToken(baseOpts).catch((e) => e);
 
-      expect(result).toBeNull();
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_failed');
+      expect(error.authMethod).toBe('oauth_authorization_code');
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: EARS endpoint unreachable'
       );
     });
 
-    it('returns null and logs an error when persisting the refreshed token fails', async () => {
+    it('throws ConnectorAuthorizationError with reason refresh_failed when persisting the refreshed token fails', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: expiredToken,
@@ -279,9 +281,11 @@ describe('getEarsAccessToken', () => {
         new Error('DB write failed')
       );
 
-      const result = await getEarsAccessToken(baseOpts);
+      const error = await getEarsAccessToken(baseOpts).catch((e) => e);
 
-      expect(result).toBeNull();
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_failed');
+      expect(error.authMethod).toBe('oauth_authorization_code');
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: DB write failed'
       );

--- a/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
@@ -112,7 +112,7 @@ describe('getEarsAccessToken', () => {
 
       expect(error).toBeInstanceOf(ConnectorAuthorizationError);
       expect(error.reason).toBe('no_token');
-      expect(error.authMethod).toBe('oauth_authorization_code');
+      expect(error.authMethod).toBe('ears');
     });
 
     it('returns the stored token without refreshing when it has not expired', async () => {
@@ -151,7 +151,7 @@ describe('getEarsAccessToken', () => {
 
       expect(error).toBeInstanceOf(ConnectorAuthorizationError);
       expect(error.reason).toBe('token_expired');
-      expect(error.authMethod).toBe('oauth_authorization_code');
+      expect(error.authMethod).toBe('ears');
     });
 
     it('throws ConnectorAuthorizationError with reason refresh_token_expired when the refresh token itself is expired', async () => {
@@ -167,7 +167,7 @@ describe('getEarsAccessToken', () => {
 
       expect(error).toBeInstanceOf(ConnectorAuthorizationError);
       expect(error.reason).toBe('refresh_token_expired');
-      expect(error.authMethod).toBe('oauth_authorization_code');
+      expect(error.authMethod).toBe('ears');
     });
 
     it('returns the refreshed token formatted as "tokenType accessToken"', async () => {
@@ -265,7 +265,7 @@ describe('getEarsAccessToken', () => {
 
       expect(error).toBeInstanceOf(ConnectorAuthorizationError);
       expect(error.reason).toBe('refresh_failed');
-      expect(error.authMethod).toBe('oauth_authorization_code');
+      expect(error.authMethod).toBe('ears');
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: EARS endpoint unreachable'
       );
@@ -285,7 +285,7 @@ describe('getEarsAccessToken', () => {
 
       expect(error).toBeInstanceOf(ConnectorAuthorizationError);
       expect(error.reason).toBe('refresh_failed');
-      expect(error.authMethod).toBe('oauth_authorization_code');
+      expect(error.authMethod).toBe('ears');
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: DB write failed'
       );

--- a/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.test.ts
@@ -8,6 +8,7 @@
 import sinon from 'sinon';
 import type { Logger } from '@kbn/core/server';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { ConnectorAuthorizationError } from '@kbn/connector-specs';
 import { actionsConfigMock } from '../../actions_config.mock';
 import { connectorTokenClientMock } from '../connector_token_client.mock';
 import { getEarsAccessToken } from './get_ears_access_token';
@@ -104,15 +105,14 @@ describe('getEarsAccessToken', () => {
       );
     });
 
-    it('returns null and warns when no token is stored (user has not authorized yet)', async () => {
+    it('throws ConnectorAuthorizationError with reason no_token when no token is stored', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({ hasErrors: false, connectorToken: null });
 
-      const result = await getEarsAccessToken(baseOpts);
+      const error = await getEarsAccessToken(baseOpts).catch((e) => e);
 
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'No access token found for connectorId: connector-1. User must complete OAuth authorization flow.'
-      );
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('no_token');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns the stored token without refreshing when it has not expired', async () => {
@@ -141,21 +141,20 @@ describe('getEarsAccessToken', () => {
   });
 
   describe('token refresh', () => {
-    it('returns null and warns when access token is expired but no refresh token is stored', async () => {
+    it('throws ConnectorAuthorizationError with reason token_expired when access token is expired but no refresh token is stored', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: { ...expiredToken, refreshToken: undefined },
       });
 
-      const result = await getEarsAccessToken(baseOpts);
+      const error = await getEarsAccessToken(baseOpts).catch((e) => e);
 
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Access token expired and no refresh token available for connectorId: connector-1. User must re-authorize.'
-      );
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
-    it('returns null and warns when the refresh token itself is expired', async () => {
+    it('throws ConnectorAuthorizationError with reason refresh_token_expired when the refresh token itself is expired', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: {
@@ -164,12 +163,11 @@ describe('getEarsAccessToken', () => {
         },
       });
 
-      const result = await getEarsAccessToken(baseOpts);
+      const error = await getEarsAccessToken(baseOpts).catch((e) => e);
 
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Refresh token expired for connectorId: connector-1. User must re-authorize.'
-      );
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns the refreshed token formatted as "tokenType accessToken"', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.ts
@@ -63,6 +63,7 @@ export const getEarsAccessToken = async ({
     isPerUser,
     profileUid,
     authMode,
+    treatRefreshFailureAsAuthError: true,
     refreshFn: (refreshToken) =>
       requestEarsRefreshToken(provider, logger, { refreshToken }, configurationUtilities),
   });

--- a/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/ears/get_ears_access_token.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/core/server';
 import type { AuthMode } from '@kbn/connector-specs';
+import { EARS_AUTH_ID } from '@kbn/connector-specs';
 import type { ActionsConfigurationUtilities } from '../../actions_config';
 import type { ConnectorTokenClientContract } from '../../types';
 import { requestEarsRefreshToken } from './request_ears_refresh_token';
@@ -59,6 +60,7 @@ export const getEarsAccessToken = async ({
     connectorId,
     logger,
     connectorTokenClient,
+    authMethod: EARS_AUTH_ID,
     forceRefresh,
     isPerUser,
     profileUid,

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.test.ts
@@ -381,7 +381,7 @@ describe('getOAuthAuthorizationCodeAccessToken', () => {
   });
 
   describe('error handling', () => {
-    it('returns null and logs an error when requestOAuthRefreshToken throws', async () => {
+    it('returns null and logs an error when requestOAuthRefreshToken throws a non-auth error', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: expiredToken,
@@ -396,6 +396,22 @@ describe('getOAuthAuthorizationCodeAccessToken', () => {
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: token endpoint unreachable'
       );
+    });
+
+    it('throws ConnectorAuthorizationError with reason token_revoked when the OAuth server returns invalid_grant', async () => {
+      connectorTokenClient.get.mockResolvedValueOnce({
+        hasErrors: false,
+        connectorToken: expiredToken,
+      });
+      (requestOAuthRefreshToken as jest.Mock).mockRejectedValueOnce(
+        new Error('{"error":"invalid_grant","error_description":"Token has been revoked"}')
+      );
+
+      const error = await getOAuthAuthorizationCodeAccessToken(baseOpts).catch((e) => e);
+
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('token_revoked');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns null and logs an error when persisting the refreshed token fails', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.test.ts
@@ -10,6 +10,7 @@ import type { Logger } from '@kbn/core/server';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { actionsConfigMock } from '../actions_config.mock';
 import { connectorTokenClientMock } from './connector_token_client.mock';
+import { ConnectorAuthorizationError } from '@kbn/connector-specs';
 import { getOAuthAuthorizationCodeAccessToken } from './get_oauth_authorization_code_access_token';
 import { requestOAuthRefreshToken } from './request_oauth_refresh_token';
 
@@ -141,15 +142,13 @@ describe('getOAuthAuthorizationCodeAccessToken', () => {
       );
     });
 
-    it('returns null and warns when no token is stored (user has not authorized yet)', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({ hasErrors: false, connectorToken: null });
+    it('throws ConnectorAuthorizationError with reason no_token when no token is stored', async () => {
+      connectorTokenClient.get.mockResolvedValue({ hasErrors: false, connectorToken: null });
 
-      const result = await getOAuthAuthorizationCodeAccessToken(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'No access token found for connectorId: connector-1. User must complete OAuth authorization flow.'
-      );
+      const error = await getOAuthAuthorizationCodeAccessToken(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('no_token');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns the stored token without refreshing when it has not expired', async () => {
@@ -178,22 +177,20 @@ describe('getOAuthAuthorizationCodeAccessToken', () => {
   });
 
   describe('token refresh', () => {
-    it('returns null and warns when access token is expired but no refresh token is stored', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({
+    it('throws ConnectorAuthorizationError with reason token_expired when access token is expired but no refresh token is stored', async () => {
+      connectorTokenClient.get.mockResolvedValue({
         hasErrors: false,
         connectorToken: { ...expiredToken, refreshToken: undefined },
       });
 
-      const result = await getOAuthAuthorizationCodeAccessToken(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Access token expired and no refresh token available for connectorId: connector-1. User must re-authorize.'
-      );
+      const error = await getOAuthAuthorizationCodeAccessToken(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
-    it('returns null and warns when the refresh token itself is expired', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({
+    it('throws ConnectorAuthorizationError with reason refresh_token_expired when the refresh token itself is expired', async () => {
+      connectorTokenClient.get.mockResolvedValue({
         hasErrors: false,
         connectorToken: {
           ...expiredToken,
@@ -201,12 +198,10 @@ describe('getOAuthAuthorizationCodeAccessToken', () => {
         },
       });
 
-      const result = await getOAuthAuthorizationCodeAccessToken(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Refresh token expired for connectorId: connector-1. User must re-authorize.'
-      );
+      const error = await getOAuthAuthorizationCodeAccessToken(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns the refreshed token formatted as "tokenType accessToken"', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_oauth_authorization_code_access_token.ts
@@ -7,6 +7,7 @@
 
 import type { Logger } from '@kbn/core/server';
 import type { AuthMode } from '@kbn/connector-specs';
+import { OAUTH_AUTHORIZATION_CODE_AUTH_ID } from '@kbn/connector-specs';
 import type { ActionsConfigurationUtilities } from '../actions_config';
 import type { ConnectorTokenClientContract } from '../types';
 import type { TokenResponseOptions } from './request_oauth_token';
@@ -85,6 +86,7 @@ export const getOAuthAuthorizationCodeAccessToken = async ({
     connectorId,
     logger,
     connectorTokenClient,
+    authMethod: OAUTH_AUTHORIZATION_CODE_AUTH_ID,
     forceRefresh,
     isPerUser,
     profileUid,

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
@@ -70,6 +70,7 @@ const baseOpts = {
   connectorId: 'connector-1',
   logger,
   connectorTokenClient,
+  authMethod: 'oauth_authorization_code',
   refreshFn,
 };
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
@@ -235,7 +235,7 @@ describe('getStoredTokenWithRefresh', () => {
   });
 
   describe('error handling', () => {
-    it('returns null and logs an error when refreshFn throws', async () => {
+    it('returns null and logs an error when refreshFn throws a non-auth error', async () => {
       connectorTokenClient.get.mockResolvedValueOnce({
         hasErrors: false,
         connectorToken: expiredToken,
@@ -248,6 +248,39 @@ describe('getStoredTokenWithRefresh', () => {
       expect(logger.error).toHaveBeenCalledWith(
         'Failed to refresh access token for connectorId: connector-1. Error: upstream auth failed'
       );
+    });
+
+    it('throws ConnectorAuthorizationError with reason token_revoked when the error contains invalid_grant', async () => {
+      connectorTokenClient.get.mockResolvedValueOnce({
+        hasErrors: false,
+        connectorToken: expiredToken,
+      });
+      refreshFn.mockRejectedValueOnce(
+        new Error('{"error":"invalid_grant","error_description":"Token has been revoked"}')
+      );
+
+      const error = await getStoredTokenWithRefresh(baseOpts).catch((e) => e);
+
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('token_revoked');
+      expect(error.authMethod).toBe('oauth_authorization_code');
+    });
+
+    it('throws ConnectorAuthorizationError with reason refresh_failed when treatRefreshFailureAsAuthError is true', async () => {
+      connectorTokenClient.get.mockResolvedValueOnce({
+        hasErrors: false,
+        connectorToken: expiredToken,
+      });
+      refreshFn.mockRejectedValueOnce(new Error('opaque refresh error'));
+
+      const error = await getStoredTokenWithRefresh({
+        ...baseOpts,
+        treatRefreshFailureAsAuthError: true,
+      }).catch((e) => e);
+
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_failed');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('returns null and logs an error when persisting the refreshed token fails', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
@@ -8,6 +8,7 @@
 import sinon from 'sinon';
 import type { Logger } from '@kbn/core/server';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { ConnectorAuthorizationError } from '@kbn/connector-specs';
 import { connectorTokenClientMock } from './connector_token_client.mock';
 import { getStoredTokenWithRefresh } from './get_stored_oauth_token_with_refresh';
 
@@ -97,15 +98,13 @@ describe('getStoredTokenWithRefresh', () => {
       expect(refreshFn).not.toHaveBeenCalled();
     });
 
-    it('returns null and warns when no token is stored', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({ hasErrors: false, connectorToken: null });
+    it('throws ConnectorAuthorizationError with reason no_token when no token is stored', async () => {
+      connectorTokenClient.get.mockResolvedValue({ hasErrors: false, connectorToken: null });
 
-      const result = await getStoredTokenWithRefresh(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'No access token found for connectorId: connector-1. User must complete OAuth authorization flow.'
-      );
+      const error = await getStoredTokenWithRefresh(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('no_token');
+      expect(error.authMethod).toBe('oauth_authorization_code');
       expect(refreshFn).not.toHaveBeenCalled();
     });
 
@@ -135,22 +134,20 @@ describe('getStoredTokenWithRefresh', () => {
   });
 
   describe('token refresh', () => {
-    it('returns null and warns when the access token is expired but no refresh token is stored', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({
+    it('throws ConnectorAuthorizationError with reason token_expired when the access token is expired but no refresh token is stored', async () => {
+      connectorTokenClient.get.mockResolvedValue({
         hasErrors: false,
         connectorToken: { ...expiredToken, refreshToken: undefined },
       });
 
-      const result = await getStoredTokenWithRefresh(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Access token expired and no refresh token available for connectorId: connector-1. User must re-authorize.'
-      );
+      const error = await getStoredTokenWithRefresh(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
-    it('returns null and warns when the refresh token itself is expired', async () => {
-      connectorTokenClient.get.mockResolvedValueOnce({
+    it('throws ConnectorAuthorizationError with reason refresh_token_expired when the refresh token itself is expired', async () => {
+      connectorTokenClient.get.mockResolvedValue({
         hasErrors: false,
         connectorToken: {
           ...expiredToken,
@@ -158,12 +155,10 @@ describe('getStoredTokenWithRefresh', () => {
         },
       });
 
-      const result = await getStoredTokenWithRefresh(baseOpts);
-
-      expect(result).toBeNull();
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Refresh token expired for connectorId: connector-1. User must re-authorize.'
-      );
+      const error = await getStoredTokenWithRefresh(baseOpts).catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectorAuthorizationError);
+      expect(error.reason).toBe('refresh_token_expired');
+      expect(error.authMethod).toBe('oauth_authorization_code');
     });
 
     it('calls refreshFn with the stored refresh token when the access token is expired', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.test.ts
@@ -390,6 +390,21 @@ describe('getStoredTokenWithRefresh', () => {
       }
     );
 
+    it('removes the lock entry even when the callback throws', async () => {
+      const deleteSpy = jest.spyOn(Map.prototype, 'delete');
+      const connectorId = 'connector-cleanup-on-throw';
+
+      connectorTokenClient.get.mockResolvedValueOnce({
+        hasErrors: false,
+        connectorToken: null,
+      });
+
+      await getStoredTokenWithRefresh({ ...baseOpts, connectorId }).catch(() => {});
+
+      expect(deleteSpy).toHaveBeenCalledWith(connectorId);
+      deleteSpy.mockRestore();
+    });
+
     it('allows concurrent per-user calls for different users on the same connector to refresh independently', async () => {
       const lockedConnectorId = 'connector-lock-per-user-diff';
       // Different profileUids => different lock keys => independent execution.

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
@@ -8,6 +8,7 @@
 import { get } from 'lodash';
 import pLimit from 'p-limit';
 import type { Logger } from '@kbn/core/server';
+import { ConnectorAuthorizationError } from '@kbn/connector-specs';
 import type { OAuthTokenResponse } from './request_oauth_token';
 import type { ConnectorToken, ConnectorTokenClientContract, UserConnectorToken } from '../types';
 
@@ -119,10 +120,11 @@ export const getStoredTokenWithRefresh = async ({
 
     // No token found - user must authorize first
     if (!connectorToken) {
-      logger.warn(
-        `No access token found for connectorId: ${connectorId}. User must complete OAuth authorization flow.`
-      );
-      return null;
+      throw new ConnectorAuthorizationError({
+        authMethod: 'oauth_authorization_code',
+        reason: 'no_token',
+        message: `No access token found for connectorId: ${connectorId}. User must complete OAuth authorization flow.`,
+      });
     }
 
     // Check if access token is still valid (may have been refreshed by another request)
@@ -150,10 +152,11 @@ export const getStoredTokenWithRefresh = async ({
     }
 
     if (!storedRefreshToken) {
-      logger.warn(
-        `Access token expired and no refresh token available for connectorId: ${connectorId}. User must re-authorize.`
-      );
-      return null;
+      throw new ConnectorAuthorizationError({
+        authMethod: 'oauth_authorization_code',
+        reason: 'token_expired',
+        message: `Access token expired and no refresh token available for connectorId: ${connectorId}. User must re-authorize.`,
+      });
     }
 
     // Check if the refresh token is expired
@@ -161,8 +164,11 @@ export const getStoredTokenWithRefresh = async ({
       connectorToken.refreshTokenExpiresAt &&
       Date.parse(connectorToken.refreshTokenExpiresAt) <= now
     ) {
-      logger.warn(`Refresh token expired for connectorId: ${connectorId}. User must re-authorize.`);
-      return null;
+      throw new ConnectorAuthorizationError({
+        authMethod: 'oauth_authorization_code',
+        reason: 'refresh_token_expired',
+        message: `Refresh token expired for connectorId: ${connectorId}. User must re-authorize.`,
+      });
     }
 
     // Refresh the token

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
@@ -27,6 +27,12 @@ export interface GetStoredTokenWithRefreshOpts {
   logger: Logger;
   connectorTokenClient: ConnectorTokenClientContract;
   /**
+   * Identifies the auth type that initiated the refresh (e.g. 'oauth_authorization_code',
+   * 'ears'). Propagated onto any `ConnectorAuthorizationError` thrown from this function
+   * so downstream consumers can report which auth flow needs re-authorization.
+   */
+  authMethod: string;
+  /**
    * When true, skip the expiration check and force a token refresh.
    * Use this when you've received a 401 and know the token is invalid
    * even if it hasn't "expired" according to the stored timestamp.
@@ -100,6 +106,7 @@ export const getStoredTokenWithRefresh = async ({
   connectorId,
   logger,
   connectorTokenClient,
+  authMethod,
   forceRefresh = false,
   isPerUser = false,
   profileUid,
@@ -134,7 +141,7 @@ export const getStoredTokenWithRefresh = async ({
       // No token found - user must authorize first
       if (!connectorToken) {
         throw new ConnectorAuthorizationError({
-          authMethod: 'oauth_authorization_code',
+          authMethod,
           reason: 'no_token',
           message: `No access token found for connectorId: ${connectorId}. User must complete OAuth authorization flow.`,
         });
@@ -166,7 +173,7 @@ export const getStoredTokenWithRefresh = async ({
 
       if (!storedRefreshToken) {
         throw new ConnectorAuthorizationError({
-          authMethod: 'oauth_authorization_code',
+          authMethod,
           reason: 'token_expired',
           message: `Access token expired and no refresh token available for connectorId: ${connectorId}. User must re-authorize.`,
         });
@@ -178,7 +185,7 @@ export const getStoredTokenWithRefresh = async ({
         Date.parse(connectorToken.refreshTokenExpiresAt) <= now
       ) {
         throw new ConnectorAuthorizationError({
-          authMethod: 'oauth_authorization_code',
+          authMethod,
           reason: 'refresh_token_expired',
           message: `Refresh token expired for connectorId: ${connectorId}. User must re-authorize.`,
         });
@@ -215,7 +222,7 @@ export const getStoredTokenWithRefresh = async ({
 
         if (isTokenRevoked) {
           throw new ConnectorAuthorizationError({
-            authMethod: 'oauth_authorization_code',
+            authMethod,
             reason: 'token_revoked',
             message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
           });
@@ -223,7 +230,7 @@ export const getStoredTokenWithRefresh = async ({
 
         if (treatRefreshFailureAsAuthError) {
           throw new ConnectorAuthorizationError({
-            authMethod: 'oauth_authorization_code',
+            authMethod,
             reason: 'refresh_failed',
             message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
           });

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
@@ -42,6 +42,17 @@ export interface GetStoredTokenWithRefreshOpts {
    * and must return a new token response from the auth server.
    */
   refreshFn: (refreshToken: string) => Promise<OAuthTokenResponse>;
+  /**
+   * When true, treat any refresh failure as an authorization error requiring
+   * user re-authorization. Use when the refresh endpoint does not return
+   * structured error codes (e.g. EARS), so transient failures cannot be
+   * distinguished from permanent authorization failures.
+   *
+   * When false (default), only `invalid_grant` errors from the OAuth server
+   * are treated as authorization failures; other errors return null and let
+   * the caller decide whether to retry.
+   */
+  treatRefreshFailureAsAuthError?: boolean;
 }
 
 interface ExtractedStoredOAuthTokens {
@@ -94,6 +105,7 @@ export const getStoredTokenWithRefresh = async ({
   profileUid,
   authMode,
   refreshFn,
+  treatRefreshFailureAsAuthError = false,
 }: GetStoredTokenWithRefreshOpts): Promise<string | null> => {
   // Acquire lock scoped to the connector (shared mode) or to the connector + user (per-user mode),
   // so concurrent requests for different users don't block each other unnecessarily.
@@ -196,6 +208,26 @@ export const getStoredTokenWithRefresh = async ({
       logger.error(
         `Failed to refresh access token for connectorId: ${connectorId}. Error: ${err.message}`
       );
+
+      const isTokenRevoked =
+        typeof err.message === 'string' && err.message.includes('invalid_grant');
+
+      if (isTokenRevoked) {
+        throw new ConnectorAuthorizationError({
+          authMethod: 'oauth_authorization_code',
+          reason: 'token_revoked',
+          message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
+        });
+      }
+
+      if (treatRefreshFailureAsAuthError) {
+        throw new ConnectorAuthorizationError({
+          authMethod: 'oauth_authorization_code',
+          reason: 'refresh_failed',
+          message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
+        });
+      }
+
       return null;
     }
   });

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_stored_oauth_token_with_refresh.ts
@@ -112,129 +112,131 @@ export const getStoredTokenWithRefresh = async ({
   const lockKey = isPerUser ? `${connectorId}:${profileUid}` : connectorId;
   const lock = getOrCreateLock(lockKey);
 
-  const result = await lock(async () => {
-    // Re-fetch token inside lock - another request may have already refreshed it
-    const { connectorToken, hasErrors } = isPerUser
-      ? await connectorTokenClient.get({
-          profileUid: profileUid!,
-          connectorId,
-          tokenType: 'access_token',
-        })
-      : await connectorTokenClient.get({
-          connectorId,
+  try {
+    const result = await lock(async () => {
+      // Re-fetch token inside lock - another request may have already refreshed it
+      const { connectorToken, hasErrors } = isPerUser
+        ? await connectorTokenClient.get({
+            profileUid: profileUid!,
+            connectorId,
+            tokenType: 'access_token',
+          })
+        : await connectorTokenClient.get({
+            connectorId,
+            tokenType: 'access_token',
+          });
+
+      if (hasErrors) {
+        logger.warn(`Errors fetching connector token for connectorId: ${connectorId}`);
+        return null;
+      }
+
+      // No token found - user must authorize first
+      if (!connectorToken) {
+        throw new ConnectorAuthorizationError({
+          authMethod: 'oauth_authorization_code',
+          reason: 'no_token',
+          message: `No access token found for connectorId: ${connectorId}. User must complete OAuth authorization flow.`,
+        });
+      }
+
+      // Check if access token is still valid (may have been refreshed by another request)
+      const now = Date.now();
+      const expiresAt = connectorToken.expiresAt ? Date.parse(connectorToken.expiresAt) : Infinity;
+
+      const extractedTokens = extractStoredOAuthTokens({
+        connectorToken: connectorToken as ConnectorToken | UserConnectorToken,
+        isPerUser,
+      });
+
+      const { accessToken: storedAccessToken, refreshToken: storedRefreshToken } = extractedTokens;
+
+      if (!forceRefresh && expiresAt > now) {
+        // Token still valid
+        logger.debug(`Using stored access token for connectorId: ${connectorId}`);
+        if (storedAccessToken === null) {
+          logger.warn(
+            `Stored token has unexpected shape for connectorId: ${connectorId} (authMode: ${
+              authMode ?? 'shared'
+            }). User must re-authorize.`
+          );
+        }
+        return storedAccessToken;
+      }
+
+      if (!storedRefreshToken) {
+        throw new ConnectorAuthorizationError({
+          authMethod: 'oauth_authorization_code',
+          reason: 'token_expired',
+          message: `Access token expired and no refresh token available for connectorId: ${connectorId}. User must re-authorize.`,
+        });
+      }
+
+      // Check if the refresh token is expired
+      if (
+        connectorToken.refreshTokenExpiresAt &&
+        Date.parse(connectorToken.refreshTokenExpiresAt) <= now
+      ) {
+        throw new ConnectorAuthorizationError({
+          authMethod: 'oauth_authorization_code',
+          reason: 'refresh_token_expired',
+          message: `Refresh token expired for connectorId: ${connectorId}. User must re-authorize.`,
+        });
+      }
+
+      // Refresh the token
+      logger.debug(`Refreshing access token for connectorId: ${connectorId}`);
+      try {
+        const tokenResult = await refreshFn(storedRefreshToken);
+
+        const newAccessToken = `${tokenResult.tokenType} ${tokenResult.accessToken}`;
+
+        const updatedRefreshToken: string | undefined =
+          tokenResult.refreshToken ?? storedRefreshToken;
+
+        // Update stored token
+        await connectorTokenClient.updateWithRefreshToken({
+          id: connectorToken.id!,
+          token: newAccessToken,
+          refreshToken: updatedRefreshToken,
+          expiresIn: tokenResult.expiresIn,
+          refreshTokenExpiresIn: tokenResult.refreshTokenExpiresIn,
           tokenType: 'access_token',
         });
 
-    if (hasErrors) {
-      logger.warn(`Errors fetching connector token for connectorId: ${connectorId}`);
-      return null;
-    }
+        return newAccessToken;
+      } catch (err) {
+        logger.error(
+          `Failed to refresh access token for connectorId: ${connectorId}. Error: ${err.message}`
+        );
 
-    // No token found - user must authorize first
-    if (!connectorToken) {
-      throw new ConnectorAuthorizationError({
-        authMethod: 'oauth_authorization_code',
-        reason: 'no_token',
-        message: `No access token found for connectorId: ${connectorId}. User must complete OAuth authorization flow.`,
-      });
-    }
+        const isTokenRevoked =
+          typeof err.message === 'string' && err.message.includes('invalid_grant');
 
-    // Check if access token is still valid (may have been refreshed by another request)
-    const now = Date.now();
-    const expiresAt = connectorToken.expiresAt ? Date.parse(connectorToken.expiresAt) : Infinity;
+        if (isTokenRevoked) {
+          throw new ConnectorAuthorizationError({
+            authMethod: 'oauth_authorization_code',
+            reason: 'token_revoked',
+            message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
+          });
+        }
 
-    const extractedTokens = extractStoredOAuthTokens({
-      connectorToken: connectorToken as ConnectorToken | UserConnectorToken,
-      isPerUser,
+        if (treatRefreshFailureAsAuthError) {
+          throw new ConnectorAuthorizationError({
+            authMethod: 'oauth_authorization_code',
+            reason: 'refresh_failed',
+            message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
+          });
+        }
+
+        return null;
+      }
     });
 
-    const { accessToken: storedAccessToken, refreshToken: storedRefreshToken } = extractedTokens;
-
-    if (!forceRefresh && expiresAt > now) {
-      // Token still valid
-      logger.debug(`Using stored access token for connectorId: ${connectorId}`);
-      if (storedAccessToken === null) {
-        logger.warn(
-          `Stored token has unexpected shape for connectorId: ${connectorId} (authMode: ${
-            authMode ?? 'shared'
-          }). User must re-authorize.`
-        );
-      }
-      return storedAccessToken;
+    return result;
+  } finally {
+    if (lock.pendingCount === 0 && lock.activeCount === 0) {
+      tokenRefreshLocks.delete(lockKey);
     }
-
-    if (!storedRefreshToken) {
-      throw new ConnectorAuthorizationError({
-        authMethod: 'oauth_authorization_code',
-        reason: 'token_expired',
-        message: `Access token expired and no refresh token available for connectorId: ${connectorId}. User must re-authorize.`,
-      });
-    }
-
-    // Check if the refresh token is expired
-    if (
-      connectorToken.refreshTokenExpiresAt &&
-      Date.parse(connectorToken.refreshTokenExpiresAt) <= now
-    ) {
-      throw new ConnectorAuthorizationError({
-        authMethod: 'oauth_authorization_code',
-        reason: 'refresh_token_expired',
-        message: `Refresh token expired for connectorId: ${connectorId}. User must re-authorize.`,
-      });
-    }
-
-    // Refresh the token
-    logger.debug(`Refreshing access token for connectorId: ${connectorId}`);
-    try {
-      const tokenResult = await refreshFn(storedRefreshToken);
-
-      const newAccessToken = `${tokenResult.tokenType} ${tokenResult.accessToken}`;
-
-      const updatedRefreshToken: string | undefined =
-        tokenResult.refreshToken ?? storedRefreshToken;
-
-      // Update stored token
-      await connectorTokenClient.updateWithRefreshToken({
-        id: connectorToken.id!,
-        token: newAccessToken,
-        refreshToken: updatedRefreshToken,
-        expiresIn: tokenResult.expiresIn,
-        refreshTokenExpiresIn: tokenResult.refreshTokenExpiresIn,
-        tokenType: 'access_token',
-      });
-
-      return newAccessToken;
-    } catch (err) {
-      logger.error(
-        `Failed to refresh access token for connectorId: ${connectorId}. Error: ${err.message}`
-      );
-
-      const isTokenRevoked =
-        typeof err.message === 'string' && err.message.includes('invalid_grant');
-
-      if (isTokenRevoked) {
-        throw new ConnectorAuthorizationError({
-          authMethod: 'oauth_authorization_code',
-          reason: 'token_revoked',
-          message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
-        });
-      }
-
-      if (treatRefreshFailureAsAuthError) {
-        throw new ConnectorAuthorizationError({
-          authMethod: 'oauth_authorization_code',
-          reason: 'refresh_failed',
-          message: `Failed to refresh access token for connectorId: ${connectorId}. User must re-authorize.`,
-        });
-      }
-
-      return null;
-    }
-  });
-
-  if (lock.pendingCount === 0 && lock.activeCount === 0) {
-    tokenRefreshLocks.delete(lockKey);
   }
-
-  return result;
 };

--- a/x-pack/platform/plugins/shared/actions/server/routes/connector/execute/transforms/transform_connector_response/v1.ts
+++ b/x-pack/platform/plugins/shared/actions/server/routes/connector/execute/transforms/transform_connector_response/v1.ts
@@ -12,10 +12,14 @@ export const transformExecuteConnectorResponse = ({
   actionId,
   retry,
   serviceMessage,
+  errorName,
+  errorMeta,
   ...res
 }: ActionTypeExecutorResult<unknown>): ConnectorExecuteResponseV1 => ({
   ...res,
   connector_id: actionId,
   ...(retry && retry instanceof Date ? { retry: retry.toISOString() } : { retry }),
   ...(serviceMessage ? { service_message: serviceMessage } : {}),
+  ...(errorName ? { error_name: errorName } : {}),
+  ...(errorMeta ? { error_meta: errorMeta } : {}),
 });


### PR DESCRIPTION
## Summary

Propagates structured OAuth authorization errors from Stack Connectors through the Actions plugin, replacing silent `null` returns with a typed `ConnectorAuthorizationError` that carries the `authMethod` and reason metadata. This gives downstream consumers (Workflows engine, Agent Builder) the metadata needed to distinguish authorization failures from generic connector errors and prompt users to re-authorize.

### Demo

https://github.com/user-attachments/assets/3df88c22-1c67-45da-be3d-202b3b7057af


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
