### PR TITLE
[Agent Builder] Return pending prompt from ai.agent workflow step on HITL

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
+++ b/src/platform/plugins/shared/workflows_extensions/test/scout/api/fixtures/approved_step_definitions.ts
@@ -26,7 +26,7 @@
 export const APPROVED_STEP_DEFINITIONS: Array<{ id: string; handlerHash: string }> = [
   {
     id: 'ai.agent',
-    handlerHash: '800765ba855e1e4a93d5bb7a6fce558ec5e369ed416bfb763047305c5d7f40ca',
+    handlerHash: 'd3413a731038c29f96427e36d5e4411a9b7052307a0af30865f4df1ba3e2d402',
   },
   {
     id: 'ai.classify',

--- a/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/common/step_types/run_agent_step.ts
@@ -83,6 +83,32 @@ export const OutputSchema = z.object({
     .describe(
       'Conversation ID associated with this step execution. Present when create_conversation is enabled or conversation_id is provided.'
     ),
+  awaiting_human_input: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, the agent is awaiting human approval before proceeding. The pending_prompt field contains the prompt details.'
+    ),
+  pending_prompt: z
+    .object({
+      id: z
+        .string()
+        .describe(
+          'Unique identifier for the prompt. Use this to respond to the prompt via the converse API.'
+        ),
+      type: z.string().describe('The type of prompt (e.g., "confirmation").'),
+      title: z.string().optional().describe('Optional title for the prompt.'),
+      message: z
+        .string()
+        .optional()
+        .describe('Optional message describing what the agent wants to do.'),
+      confirm_text: z.string().optional().describe('Optional label for the confirm button.'),
+      cancel_text: z.string().optional().describe('Optional label for the cancel button.'),
+    })
+    .optional()
+    .describe(
+      'Present when awaiting_human_input is true. Contains the prompt details needed to approve or deny the agent action.'
+    ),
 });
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.test.ts
@@ -262,6 +262,56 @@ describe('ai.agent workflow step (Agent Builder)', () => {
     expect(res.error?.message).toContain('aborted');
   });
 
+  it('returns awaiting_human_input and pending_prompt when agent hits HITL', async () => {
+    const pendingPrompt = {
+      id: 'tools.k8s.resources_scale.confirmation.call-1',
+      type: 'confirmation',
+      title: 'Tool requires confirmation',
+      message: 'k8s.resources_scale',
+      confirm_text: 'Allow',
+      cancel_text: 'Deny',
+    };
+
+    const events$ = of(
+      {
+        type: ChatEventType.conversationCreated,
+        data: { conversation_id: 'c-hitl', title: 't' },
+      },
+      {
+        type: ChatEventType.roundComplete,
+        data: {
+          round: {
+            id: 'r-1',
+            response: { message: '' },
+            pending_prompt: pendingPrompt,
+          },
+        },
+      }
+    );
+
+    const execution = createExecutionMock(events$);
+
+    const serviceManager = {
+      internalStart: { execution },
+    } as any;
+
+    const step = getRunAgentStepDefinition(serviceManager);
+    const res = await step.handler(
+      createContext({
+        input: {
+          message: 'investigate and remediate',
+        },
+        config: {
+          'create-conversation': true,
+        },
+      })
+    );
+
+    expect(res.output?.awaiting_human_input).toBe(true);
+    expect(res.output?.pending_prompt).toEqual(pendingPrompt);
+    expect(res.output?.conversation_id).toBe('c-hitl');
+  });
+
   it('propagates attachments to execution service nextInput', async () => {
     const attachments = [
       {

--- a/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/step_types/run_agent_step.ts
@@ -100,6 +100,10 @@ export const getRunAgentStepDefinition = (serviceManager: ServiceManager) => {
             message: outputMessage,
             structured_output: round.response.structured_output,
             ...(outputConversationId && { conversation_id: outputConversationId }),
+            ...(round.pending_prompt && {
+              awaiting_human_input: true,
+              pending_prompt: round.pending_prompt,
+            }),
           },
         };
       } catch (error) {


### PR DESCRIPTION
## Summary

 When an agent hits tool confirmation (HITL) during a workflow, the `ai.agent` step now returns `awaiting_human_input` and `pending_prompt` in its output. This enables workflow authors to build approval flows by using the prompt details in subsequent steps (e.g., posting approve/deny buttons to Slack, then resuming the conversation via the converse API with the pending_prompt.id and conversation_id).

Note: This is a pragmatic short-term approach. The better long-term solution is to have the ai.agent trigger workflow's `WAITING_FOR_INPUT` state when HITL triggers.
