### PR TITLE
[Cases][Attachment] Fix decode error when pushing a case with unified shape comment

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -326,6 +326,63 @@ describe('AttachmentService', () => {
       );
     });
 
+    it('when enabled, bulkUpdate accepts partial attributes for push metadata only', async () => {
+      const serviceWithFlagOn = new AttachmentService({
+        log: mockLogger,
+        persistableStateAttachmentTypeRegistry,
+        unsecuredSavedObjectsClient,
+        config: createAttachmentServiceConfig(true),
+      });
+      const unifiedAttrs = {
+        type: 'comment',
+        data: { content: 'hello' },
+        owner: SECURITY_SOLUTION_OWNER,
+        created_at: '2024-01-01T00:00:00.000Z',
+        created_by: { username: 'u', full_name: null, email: null },
+        pushed_at: null,
+        pushed_by: null,
+        updated_at: null,
+        updated_by: null,
+      };
+      const pushedAt = '2024-01-02T00:00:00.000Z';
+      const pushedBy = { username: 'pusher', full_name: null, email: null };
+      unsecuredSavedObjectsClient.bulkUpdate.mockResolvedValue({
+        saved_objects: [
+          {
+            id: 'ef2942ed-c4b6-4dd4-a85b-8ce90e8f2d47',
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+            attributes: { ...unifiedAttrs, pushed_at: pushedAt, pushed_by: pushedBy },
+            references: [],
+            version: 'v2',
+          },
+        ],
+      });
+
+      await expect(
+        serviceWithFlagOn.bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'ef2942ed-c4b6-4dd4-a85b-8ce90e8f2d47',
+              updatedAttributes: { pushed_at: pushedAt, pushed_by: pushedBy },
+            },
+          ],
+          refresh: false,
+          requestWithoutType: true,
+        })
+      ).resolves.not.toThrow();
+
+      expect(unsecuredSavedObjectsClient.bulkUpdate).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            type: CASE_ATTACHMENT_SAVED_OBJECT,
+            id: 'ef2942ed-c4b6-4dd4-a85b-8ce90e8f2d47',
+            attributes: { pushed_at: pushedAt, pushed_by: pushedBy },
+          }),
+        ],
+        expect.any(Object)
+      );
+    });
+
     it('when disabled, bulkCreate writes to CASE_COMMENT_SAVED_OBJECT', async () => {
       unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
         saved_objects: [createUserAttachment()],

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.test.ts
@@ -383,6 +383,30 @@ describe('AttachmentService', () => {
       );
     });
 
+    it('when enabled, bulkUpdate throws for typed patches without owner when requestWithoutType is false', async () => {
+      const serviceWithFlagOn = new AttachmentService({
+        log: mockLogger,
+        persistableStateAttachmentTypeRegistry,
+        unsecuredSavedObjectsClient,
+        config: createAttachmentServiceConfig(true),
+      });
+
+      await expect(
+        serviceWithFlagOn.bulkUpdate({
+          comments: [
+            {
+              savedObjectId: 'ef2942ed-c4b6-4dd4-a85b-8ce90e8f2d47',
+              updatedAttributes: { type: 'comment', data: { content: 'hello' } },
+            },
+          ],
+          refresh: false,
+          requestWithoutType: false,
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Invalid attributes: expected owner when transforming attachment patch"`
+      );
+    });
+
     it('when disabled, bulkCreate writes to CASE_COMMENT_SAVED_OBJECT', async () => {
       unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue({
         saved_objects: [createUserAttachment()],

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -36,7 +36,6 @@ import {
   getAttachmentTypeTransformers,
   resolveAttachmentSavedObjectType,
 } from '../../common/attachments';
-import { passThroughTransformer } from '../../common/attachments/base';
 
 import { buildFilter, combineFilters } from '../../client/utils';
 import { defaultSortField } from '../../common/utils';
@@ -77,7 +76,7 @@ import type {
   UnifiedAttachmentSavedObjectTransformed,
 } from '../../common/types/attachments_v2';
 import { isSOError } from '../../common/error';
-import { transformAttributesForMode } from './operations/utils';
+import { getTransformerForPatchAttributes, transformAttributesForMode } from './operations/utils';
 
 /**
  * Ensures alert attachments have rule.name, or else existing tests will fail
@@ -535,12 +534,10 @@ export class AttachmentService {
               const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
                 c.updatedAttributes
               );
-              const transformer = requestWithoutType
-                ? passThroughTransformer
-                : getAttachmentTypeTransformers(
-                    getAttachmentTypeFromAttributes(decodedAttributes),
-                    decodedAttributes.owner
-                  );
+              const transformer = getTransformerForPatchAttributes(
+                decodedAttributes,
+                requestWithoutType
+              );
               const unifiedAttributes = transformer.toUnifiedSchema(decodedAttributes);
 
               return {
@@ -562,12 +559,10 @@ export class AttachmentService {
               c.updatedAttributes
             );
             assertAlertAttachmentHasRuleName(decodedAttributes as Record<string, unknown>);
-            const transformer = requestWithoutType
-              ? passThroughTransformer
-              : getAttachmentTypeTransformers(
-                  getAttachmentTypeFromAttributes(decodedAttributes),
-                  decodedAttributes.owner ?? ''
-                );
+            const transformer = getTransformerForPatchAttributes(
+              decodedAttributes,
+              requestWithoutType
+            );
             const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
             const {
               attributes: extractedAttributes,
@@ -636,12 +631,7 @@ export class AttachmentService {
         const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
           comments[i].updatedAttributes
         );
-        const transformer = requestWithoutType
-          ? passThroughTransformer
-          : getAttachmentTypeTransformers(
-              getAttachmentTypeFromAttributes(decodedAttributes),
-              decodedAttributes.owner ?? ''
-            );
+        const transformer = getTransformerForPatchAttributes(decodedAttributes, requestWithoutType);
         const legacyAttributes = transformer.toLegacySchema(decodedAttributes);
         const transformedAttachment = injectAttachmentSOAttributesFromRefsForPatch(
           legacyAttributes,

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -518,7 +518,9 @@ export class AttachmentService {
     comments,
     refresh,
     requestWithoutType = false,
-  }: BulkUpdateAttachmentArgs): Promise<SavedObjectsBulkUpdateResponse<AttachmentAttributesV2>> {
+  }: BulkUpdateAttachmentArgs): Promise<
+    SavedObjectsBulkUpdateResponse<AttachmentTransformedAttributesV2>
+  > {
     try {
       this.context.log.debug(
         `Attempting to UPDATE attachments ${comments.map((c) => c.savedObjectId).join(', ')}`
@@ -530,7 +532,7 @@ export class AttachmentService {
         const res =
           await this.context.unsecuredSavedObjectsClient.bulkUpdate<UnifiedAttachmentAttributes>(
             comments.map((c) => {
-              const decodedAttributes = decodeOrThrow(AttachmentAttributesRtV2)(
+              const decodedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
                 c.updatedAttributes
               );
               const transformer = requestWithoutType
@@ -624,8 +626,10 @@ export class AttachmentService {
         // TODO: we should fix the return type of this function so that it can return errors
         validatedAttachments.push(attachment as SavedObjectsUpdateResponse<AttachmentAttributesV2>);
       } else if (attachment.type === CASE_ATTACHMENT_SAVED_OBJECT) {
-        const validatedAttributes = decodeOrThrow(UnifiedAttachmentAttributesRt)(
-          attachment.attributes
+        // Saved Objects bulkUpdate may return only the attributes that were sent in the request, not
+        // the full merged document. Match single update(): return the validated patch from the request.
+        const validatedAttributes = decodeOrThrow(AttachmentPatchAttributesRtV2)(
+          comments[i].updatedAttributes
         );
         validatedAttachments.push(Object.assign(attachment, { attributes: validatedAttributes }));
       } else {

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/utils.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { passThroughTransformer } from '../../../common/attachments/base';
 import { decodeOrThrow } from '../../../common/runtime_types';
 import type { AttachmentPersistedAttributes } from '../../../common/types/attachments_v1';
 import type { UnifiedAttachmentAttributes } from '../../../common/types/attachments_v2';
@@ -45,4 +46,22 @@ export function transformAttributesForMode({
 
   const legacyAttrs = transformer.toLegacySchema(attributes);
   return { isUnified: false, attributes: legacyAttrs };
+}
+
+export function getTransformerForPatchAttributes(
+  decodedAttributes: AttachmentPatchAttributesV2,
+  requestWithoutType: boolean
+) {
+  if (requestWithoutType) {
+    return passThroughTransformer;
+  }
+
+  if (!decodedAttributes.owner) {
+    throw new Error('Invalid attributes: expected owner when transforming attachment patch');
+  }
+
+  return getAttachmentTypeTransformers(
+    getAttachmentTypeFromAttributes(decodedAttributes),
+    decodedAttributes.owner
+  );
 }


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/258910

This PR updated the decode in push case to use a partial shape instead of full shape. This aligns with the case comments path. When an external connector is added (IBM Resilient for example), pushing a case should not throw an error.

**How to test**
- Turn on feature flag `xpack.cases.attachments.enabled`
- Add a connector to a case
- Add a comment, then push
- Observe there is no error

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
