### PR TITLE
[Security Solution] render footer ai actions in document flyout in Security Solution and Discover

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.test.tsx
@@ -11,17 +11,17 @@ import { TestProviders } from '../../../common/mock';
 import { mockContextValue } from '../shared/mocks/mock_context';
 import { DocumentDetailsContext } from '../shared/context';
 import { FLYOUT_FOOTER_TEST_ID } from './test_ids';
-import { AGENT_ATTACHMENT_BUTTON_TEST_ID, CHAT_BUTTON_TEST_ID } from './components/test_ids';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from '../shared/components/test_ids';
 import { useKibana } from '../../../common/lib/kibana';
-import { useAssistant } from './hooks/use_assistant';
 import { useAlertExceptionActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_exception_actions';
 import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
-import { useAgentBuilderAvailability } from '../../../agent_builder/hooks/use_agent_builder_availability';
+import { FooterAiActions } from '../../../flyout_v2/document/components/footer_ai_actions';
 
-jest.mock('../../../agent_builder/hooks/use_agent_builder_availability');
 jest.mock('../../../common/lib/kibana');
+jest.mock('../../../flyout_v2/document/components/footer_ai_actions', () => ({
+  FooterAiActions: jest.fn(() => <div data-test-subj="footerAiActions" />),
+}));
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
   return {
@@ -34,7 +34,6 @@ jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
 jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions');
-jest.mock('./hooks/use_assistant');
 
 const renderPanelFooter = (isPreview: boolean) =>
   render(
@@ -47,17 +46,7 @@ const renderPanelFooter = (isPreview: boolean) =>
 
 describe('PanelFooter', () => {
   beforeEach(() => {
-    jest.mocked(useAssistant).mockReturnValue({
-      showAssistantOverlay: jest.fn(),
-      showAssistant: true,
-      promptContextId: '',
-    });
-    (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
-      isAgentBuilderEnabled: false,
-      hasAgentBuilderPrivilege: false,
-      isAgentChatExperienceEnabled: false,
-      hasValidAgentBuilderLicense: true,
-    });
+    jest.clearAllMocks();
   });
 
   it('should not render the take action dropdown if preview mode', () => {
@@ -85,33 +74,21 @@ describe('PanelFooter', () => {
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should render chat button', () => {
+  it('should render footer AI actions with document details context data', () => {
     const { getByTestId } = renderPanelFooter(false);
 
-    expect(getByTestId(CHAT_BUTTON_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should render agent button', () => {
-    (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
-      isAgentBuilderEnabled: true,
-      hasAgentBuilderPrivilege: true,
-      isAgentChatExperienceEnabled: true,
-      hasValidAgentBuilderLicense: true,
-    });
-    const { getByTestId } = renderPanelFooter(false);
-
-    expect(getByTestId(AGENT_ATTACHMENT_BUTTON_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should not render chat button', () => {
-    jest.mocked(useAssistant).mockReturnValue({
-      showAssistantOverlay: jest.fn(),
-      showAssistant: false,
-      promptContextId: '',
-    });
-
-    const { queryByTestId } = renderPanelFooter(true);
-
-    expect(queryByTestId(CHAT_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId('footerAiActions')).toBeInTheDocument();
+    expect(FooterAiActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataFormattedForFieldBrowser: mockContextValue.dataFormattedForFieldBrowser,
+        hit: expect.objectContaining({
+          raw: expect.objectContaining({
+            _id: mockContextValue.searchHit._id,
+            _index: mockContextValue.searchHit._index,
+          }),
+        }),
+      }),
+      {}
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/footer.tsx
@@ -8,33 +8,12 @@
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFlyoutFooter, EuiPanel } from '@elastic/eui';
-import { i18n } from '@kbn/i18n';
-import { NewChatByTitle } from '@kbn/elastic-assistant';
-import {
-  ALERT_ATTACHMENT_PROMPT,
-  EVENT_ATTACHMENT_PROMPT,
-} from '../../../agent_builder/components/prompts';
-import { useBasicDataFromDetailsData } from '../shared/hooks/use_basic_data_from_details_data';
+import type { EsHitRecord } from '@kbn/discover-utils';
+import { buildDataTableRecord } from '@kbn/discover-utils';
 import { useDocumentDetailsContext } from '../shared/context';
-import { useAssistant } from './hooks/use_assistant';
 import { FLYOUT_FOOTER_TEST_ID } from './test_ids';
 import { TakeActionButton } from '../shared/components/take_action_button';
-import { useAgentBuilderAvailability } from '../../../agent_builder/hooks/use_agent_builder_availability';
-import { NewAgentBuilderAttachment } from '../../../agent_builder/components/new_agent_builder_attachment';
-import { useAgentBuilderAttachment } from '../../../agent_builder/hooks/use_agent_builder_attachment';
-import { getRawData } from '../../../assistant/helpers';
-import { stringifyEssentialAlertData } from '../../../agent_builder/helpers';
-import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
-
-export const ASK_AI_ASSISTANT = i18n.translate(
-  'xpack.securitySolution.ease.flyout.right.footer.askAIAssistant',
-  {
-    defaultMessage: 'Ask AI Assistant',
-  }
-);
-export const EVENT = i18n.translate('xpack.securitySolution.flyout.right.footer.event', {
-  defaultMessage: 'Security Event',
-});
+import { FooterAiActions } from '../../../flyout_v2/document/components/footer_ai_actions';
 
 interface PanelFooterProps {
   /**
@@ -47,27 +26,8 @@ interface PanelFooterProps {
  * Bottom section of the flyout that contains the take action button
  */
 export const PanelFooter: FC<PanelFooterProps> = ({ isRulePreview }) => {
-  const { dataFormattedForFieldBrowser } = useDocumentDetailsContext();
-  const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
-  const { showAssistant, showAssistantOverlay } = useAssistant({
-    dataFormattedForFieldBrowser,
-    isAlert,
-  });
-  const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
-
-  const alertAttachment = useMemo(() => {
-    const rawData = getRawData(dataFormattedForFieldBrowser ?? []);
-    return {
-      attachmentType: SecurityAgentBuilderAttachments.alert,
-      attachmentData: {
-        alert: stringifyEssentialAlertData(rawData),
-        attachmentLabel: isAlert ? rawData['kibana.alert.rule.name']?.[0] : EVENT,
-      },
-      attachmentPrompt: isAlert ? ALERT_ATTACHMENT_PROMPT : EVENT_ATTACHMENT_PROMPT,
-    };
-  }, [dataFormattedForFieldBrowser, isAlert]);
-
-  const { openAgentBuilderFlyout } = useAgentBuilderAttachment(alertAttachment);
+  const { searchHit, dataFormattedForFieldBrowser } = useDocumentDetailsContext();
+  const hit = useMemo(() => buildDataTableRecord(searchHit as EsHitRecord), [searchHit]);
 
   if (isRulePreview) return null;
 
@@ -76,22 +36,10 @@ export const PanelFooter: FC<PanelFooterProps> = ({ isRulePreview }) => {
       <EuiPanel color="transparent">
         <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
           <EuiFlexItem grow={false}>
-            {isAgentChatExperienceEnabled ? (
-              <NewAgentBuilderAttachment
-                onClick={openAgentBuilderFlyout}
-                telemetry={{
-                  pathway: 'alerts_flyout',
-                  attachments: ['alert'],
-                }}
-              />
-            ) : (
-              showAssistant && (
-                <NewChatByTitle
-                  showAssistantOverlay={showAssistantOverlay}
-                  text={ASK_AI_ASSISTANT}
-                />
-              )
-            )}
+            <FooterAiActions
+              hit={hit}
+              dataFormattedForFieldBrowser={dataFormattedForFieldBrowser}
+            />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <TakeActionButton />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/ease/footer.tsx
@@ -13,7 +13,7 @@ import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { TakeActionButton } from './components/take_action_button';
 import { useEaseDetailsContext } from './context';
 import { useBasicDataFromDetailsData } from '../document_details/shared/hooks/use_basic_data_from_details_data';
-import { useAssistant } from '../document_details/right/hooks/use_assistant';
+import { useAssistant } from '../../flyout_v2/document/hooks/use_assistant';
 import { useAgentBuilderAvailability } from '../../agent_builder/hooks/use_agent_builder_availability';
 import { NewAgentBuilderAttachment } from '../../agent_builder/components/new_agent_builder_attachment';
 import { useAgentBuilderAttachment } from '../../agent_builder/hooks/use_agent_builder_attachment';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/footer_ai_actions.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/footer_ai_actions.test.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { FooterAiActionsProps } from './footer_ai_actions';
+import { FooterAiActions } from './footer_ai_actions';
+import { useEventDetails } from '../../../flyout/document_details/shared/hooks/use_event_details';
+import { useAssistant } from '../hooks/use_assistant';
+import { useAgentBuilderAvailability } from '../../../agent_builder/hooks/use_agent_builder_availability';
+import { useAgentBuilderAttachment } from '../../../agent_builder/hooks/use_agent_builder_attachment';
+
+jest.mock('../../../flyout/document_details/shared/hooks/use_event_details');
+jest.mock('../hooks/use_assistant');
+jest.mock('../../../agent_builder/hooks/use_agent_builder_availability');
+jest.mock('../../../agent_builder/hooks/use_agent_builder_attachment');
+// Mock leaf UI components with their known data-test-subj values
+jest.mock('../../../agent_builder/components/new_agent_builder_attachment', () => ({
+  NewAgentBuilderAttachment: () => <div data-test-subj="newAgentBuilderAttachment" />,
+}));
+jest.mock('@kbn/elastic-assistant', () => ({
+  NewChatByTitle: () => <div data-test-subj="newChatByTitle" />,
+}));
+
+const AGENT_BUTTON_TEST_ID = 'newAgentBuilderAttachment';
+const CHAT_BUTTON_TEST_ID = 'newChatByTitle';
+
+const createMockHit = (flattened: DataTableRecord['flattened'] = {}): DataTableRecord =>
+  ({
+    id: 'test-id',
+    raw: { _id: 'test-id', _index: 'test-index' },
+    flattened,
+  } as DataTableRecord);
+
+const alertHit = createMockHit({ 'kibana.alert.rule.uuid': 'rule-uuid' });
+const eventHit = createMockHit({ 'event.kind': 'event' });
+
+const renderFooterAiActions = (props: FooterAiActionsProps) =>
+  render(
+    <IntlProvider locale="en">
+      <FooterAiActions {...props} />
+    </IntlProvider>
+  );
+
+describe('<FooterAiActions />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useEventDetails as jest.Mock).mockReturnValue({
+      dataFormattedForFieldBrowser: [],
+      loading: false,
+    });
+    (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
+      isAgentChatExperienceEnabled: false,
+    });
+    (useAgentBuilderAttachment as jest.Mock).mockReturnValue({
+      openAgentBuilderFlyout: jest.fn(),
+    });
+    (useAssistant as jest.Mock).mockReturnValue({
+      showAssistant: false,
+      showAssistantOverlay: jest.fn(),
+      promptContextId: '',
+    });
+  });
+
+  describe('loading state', () => {
+    it('renders null while data is loading and no prop is provided', () => {
+      (useEventDetails as jest.Mock).mockReturnValue({
+        dataFormattedForFieldBrowser: null,
+        loading: true,
+      });
+
+      const { container } = renderFooterAiActions({ hit: alertHit });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('does not return null while loading when dataFormattedForFieldBrowser prop is provided', () => {
+      (useEventDetails as jest.Mock).mockReturnValue({
+        dataFormattedForFieldBrowser: null,
+        loading: true,
+      });
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { getByTestId } = renderFooterAiActions({
+        hit: alertHit,
+        dataFormattedForFieldBrowser: [],
+      });
+
+      expect(getByTestId(CHAT_BUTTON_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
+  describe('fetch behaviour', () => {
+    it('skips the internal fetch when dataFormattedForFieldBrowser prop is provided', () => {
+      renderFooterAiActions({ hit: alertHit, dataFormattedForFieldBrowser: [] });
+
+      expect(useEventDetails).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+    });
+
+    it('performs the internal fetch when dataFormattedForFieldBrowser prop is not provided', () => {
+      renderFooterAiActions({ hit: alertHit });
+
+      expect(useEventDetails).toHaveBeenCalledWith(expect.objectContaining({ skip: false }));
+    });
+
+    it('passes hit _id and _index to useEventDetails', () => {
+      renderFooterAiActions({ hit: alertHit });
+
+      expect(useEventDetails).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'test-id', indexName: 'test-index' })
+      );
+    });
+  });
+
+  describe('agent builder button', () => {
+    it('renders the agent builder button when isAgentChatExperienceEnabled is true', () => {
+      (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
+        isAgentChatExperienceEnabled: true,
+      });
+
+      const { getByTestId } = renderFooterAiActions({ hit: alertHit });
+
+      expect(getByTestId(AGENT_BUTTON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('does not render the assistant button when agent builder is enabled', () => {
+      (useAgentBuilderAvailability as jest.Mock).mockReturnValue({
+        isAgentChatExperienceEnabled: true,
+      });
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { queryByTestId } = renderFooterAiActions({ hit: alertHit });
+
+      expect(queryByTestId(CHAT_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('assistant button', () => {
+    it('renders the assistant button when showAssistant is true and agent builder is disabled', () => {
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { getByTestId } = renderFooterAiActions({ hit: alertHit });
+
+      expect(getByTestId(CHAT_BUTTON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('does not render the agent builder button when only the assistant is shown', () => {
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { queryByTestId } = renderFooterAiActions({ hit: alertHit });
+
+      expect(queryByTestId(AGENT_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('neither feature available', () => {
+    it('renders null when agent builder is disabled and showAssistant is false', () => {
+      const { container } = renderFooterAiActions({ hit: alertHit });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('alert vs event', () => {
+    it('renders for an alert hit', () => {
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { getByTestId } = renderFooterAiActions({ hit: alertHit });
+
+      expect(getByTestId(CHAT_BUTTON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('renders for an event hit', () => {
+      (useAssistant as jest.Mock).mockReturnValue({
+        showAssistant: true,
+        showAssistantOverlay: jest.fn(),
+        promptContextId: '123',
+      });
+
+      const { getByTestId } = renderFooterAiActions({ hit: eventHit });
+
+      expect(getByTestId(CHAT_BUTTON_TEST_ID)).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/footer_ai_actions.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/footer_ai_actions.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { NewChatByTitle } from '@kbn/elastic-assistant';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
+import type { AgentBuilderAddToChatTelemetry } from '../../../agent_builder/hooks/use_report_add_to_chat';
+import {
+  ALERT_ATTACHMENT_PROMPT,
+  EVENT_ATTACHMENT_PROMPT,
+} from '../../../agent_builder/components/prompts';
+import { useAssistant } from '../hooks/use_assistant';
+import { useEventDetails } from '../../../flyout/document_details/shared/hooks/use_event_details';
+import { useAgentBuilderAvailability } from '../../../agent_builder/hooks/use_agent_builder_availability';
+import { NewAgentBuilderAttachment } from '../../../agent_builder/components/new_agent_builder_attachment';
+import { useAgentBuilderAttachment } from '../../../agent_builder/hooks/use_agent_builder_attachment';
+import { getRawData } from '../../../assistant/helpers';
+import { stringifyEssentialAlertData } from '../../../agent_builder/helpers';
+import { SecurityAgentBuilderAttachments } from '../../../../common/constants';
+
+const ASK_AI_ASSISTANT = i18n.translate(
+  'xpack.securitySolution.flyout.footerAiActions.askAIAssistant',
+  { defaultMessage: 'Ask AI Assistant' }
+);
+const EVENT = i18n.translate('xpack.securitySolution.flyout.footerAiActions.event', {
+  defaultMessage: 'Security Event',
+});
+
+const TELEMETRY: AgentBuilderAddToChatTelemetry = {
+  pathway: 'alerts_flyout',
+  attachments: ['alert'],
+};
+const EMPTY_ARRAY: TimelineEventsDetailsItem[] = [];
+
+export interface FooterAiActionsProps {
+  /**
+   * The document record to derive AI context from
+   */
+  hit: DataTableRecord;
+  /**
+   * Pre-fetched ECS-expanded field data. When provided the internal fetch is skipped.
+   * The old flyout passes this from its context to avoid a duplicate network request.
+   * When omitted (new flyout) the data is fetched internally via the timeline strategy.
+   */
+  dataFormattedForFieldBrowser?: TimelineEventsDetailsItem[];
+}
+
+/**
+ * Renders the agent builder or classic assistant button for use in flyout footers.
+ * Returns null when neither feature is available or while data is loading.
+ */
+export const FooterAiActions: FC<FooterAiActionsProps> = ({
+  hit,
+  dataFormattedForFieldBrowser: dataFormattedForFieldBrowserProp,
+}) => {
+  const { dataFormattedForFieldBrowser: fetchedData, loading } = useEventDetails({
+    eventId: hit.raw._id,
+    indexName: hit.raw._index,
+    skip: dataFormattedForFieldBrowserProp != null,
+  });
+
+  const isAlert = Boolean(getFieldValue(hit, ALERT_RULE_UUID));
+
+  // Use the prop when available (old flyout), fall back to fetched data (new flyout).
+  // Use empty array while loading so hooks below can be called unconditionally.
+  const safeData = useMemo(
+    () => dataFormattedForFieldBrowserProp ?? fetchedData ?? EMPTY_ARRAY,
+    [dataFormattedForFieldBrowserProp, fetchedData]
+  );
+
+  const { isAgentChatExperienceEnabled } = useAgentBuilderAvailability();
+
+  const alertAttachment = useMemo(() => {
+    const rawData = getRawData(safeData);
+    return {
+      attachmentType: SecurityAgentBuilderAttachments.alert,
+      attachmentData: {
+        alert: stringifyEssentialAlertData(rawData),
+        attachmentLabel: isAlert ? rawData[ALERT_RULE_NAME]?.[0] : EVENT,
+      },
+      attachmentPrompt: isAlert ? ALERT_ATTACHMENT_PROMPT : EVENT_ATTACHMENT_PROMPT,
+    };
+  }, [safeData, isAlert]);
+
+  const { openAgentBuilderFlyout } = useAgentBuilderAttachment(alertAttachment);
+
+  const { showAssistant, showAssistantOverlay } = useAssistant({
+    dataFormattedForFieldBrowser: safeData,
+    isAlert,
+  });
+
+  if (loading && dataFormattedForFieldBrowserProp == null) return null;
+
+  if (isAgentChatExperienceEnabled) {
+    return <NewAgentBuilderAttachment onClick={openAgentBuilderFlyout} telemetry={TELEMETRY} />;
+  }
+
+  if (showAssistant) {
+    return <NewChatByTitle showAssistantOverlay={showAssistantOverlay} text={ASK_AI_ASSISTANT} />;
+  }
+
+  return null;
+};
+
+FooterAiActions.displayName = 'FooterAiActions';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { Footer } from './footer';
+
+jest.mock('./components/footer_ai_actions', () => ({
+  FooterAiActions: ({ hit }: { hit: DataTableRecord }) => (
+    <div data-test-subj="footerAiActions" data-hit-id={hit.id} />
+  ),
+}));
+
+const createMockHit = (): DataTableRecord =>
+  ({
+    id: 'test-id',
+    raw: { _id: 'test-id', _index: 'test-index' },
+    flattened: {},
+  } as DataTableRecord);
+
+describe('<Footer />', () => {
+  it('renders FooterAiActions with the provided hit', () => {
+    const hit = createMockHit();
+
+    const { getByTestId } = render(<Footer hit={hit} />);
+
+    const aiActions = getByTestId('footerAiActions');
+    expect(aiActions).toBeInTheDocument();
+    expect(aiActions).toHaveAttribute('data-hit-id', 'test-id');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { memo } from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
+import { FooterAiActions } from './components/footer_ai_actions';
 
 export interface FooterProps {
   /**
@@ -15,8 +17,17 @@ export interface FooterProps {
   hit: DataTableRecord;
 }
 
+/**
+ * Footer component rendered at the top of the new document flyout in Security Solution and in Discover
+ */
 export const Footer = memo(({ hit }: FooterProps) => {
-  return <></>;
+  return (
+    <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <FooterAiActions hit={hit} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
 });
 
 Footer.displayName = 'Footer';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/hooks/use_assistant.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/hooks/use_assistant.test.tsx
@@ -9,11 +9,11 @@ import type { RenderHookResult } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import type { UseAssistantParams, UseAssistantResult } from './use_assistant';
 import { useAssistant } from './use_assistant';
-import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
+import { mockDataFormattedForFieldBrowser } from '../../../flyout/document_details/shared/mocks/mock_data_formatted_for_field_browser';
 import { useAssistantContext, useAssistantOverlay } from '@kbn/elastic-assistant';
-import { useAssistantAvailability } from '../../../../assistant/use_assistant_availability';
+import { useAssistantAvailability } from '../../../assistant/use_assistant_availability';
 
-jest.mock('../../../../assistant/use_assistant_availability');
+jest.mock('../../../assistant/use_assistant_availability');
 jest.mock('@kbn/elastic-assistant');
 
 const dataFormattedForFieldBrowser = mockDataFormattedForFieldBrowser;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/hooks/use_assistant.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/hooks/use_assistant.ts
@@ -9,8 +9,8 @@ import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import { useAssistantContext, useAssistantOverlay } from '@kbn/elastic-assistant';
 import { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
-import { useAssistantAvailability } from '../../../../assistant/use_assistant_availability';
-import { getRawData } from '../../../../assistant/helpers';
+import { useAssistantAvailability } from '../../../assistant/use_assistant_availability';
+import { getRawData } from '../../../assistant/helpers';
 import {
   ALERT_SUMMARY_CONTEXT_DESCRIPTION,
   ALERT_SUMMARY_CONVERSATION_ID,
@@ -18,11 +18,11 @@ import {
   EVENT_SUMMARY_CONTEXT_DESCRIPTION,
   EVENT_SUMMARY_CONVERSATION_ID,
   EVENT_SUMMARY_VIEW_CONTEXT_TOOLTIP,
-} from '../../../../common/components/event_details/translations';
+} from '../../../common/components/event_details/translations';
 import {
   PROMPT_CONTEXT_ALERT_CATEGORY,
   PROMPT_CONTEXT_EVENT_CATEGORY,
-} from '../../../../assistant/content/prompt_contexts';
+} from '../../../assistant/content/prompt_contexts';
 
 const SUMMARY_VIEW = i18n.translate('xpack.securitySolution.eventDetails.summaryView', {
   defaultMessage: 'summary',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
@@ -27,6 +27,9 @@ jest.mock('../../../common/components/discover_in_timeline/provider', () => ({
 jest.mock('../../../assistant/provider', () => ({
   AssistantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+jest.mock('../../../cases/components/provider/provider', () => ({
+  CaseProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
 const services = {
   uiActions: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.test.tsx
@@ -24,6 +24,9 @@ jest.mock('../../../common/components/discover_in_timeline/provider', () => ({
     <>{children}</>
   ),
 }));
+jest.mock('../../../assistant/provider', () => ({
+  AssistantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
 const services = {
   uiActions: {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -21,6 +21,7 @@ import { UserPrivilegesProvider } from '../../../common/components/user_privileg
 import { UpsellingProvider } from '../../../common/components/upselling_provider';
 import { DiscoverInTimelineContextProvider } from '../../../common/components/discover_in_timeline/provider';
 import { AssistantProvider } from '../../../assistant/provider';
+import { CaseProvider } from '../../../cases/components/provider/provider';
 
 export const flyoutProviders = ({
   services,
@@ -54,7 +55,9 @@ export const flyoutProviders = ({
               <UserPrivilegesProvider kibanaCapabilities={services.application.capabilities}>
                 <UpsellingProvider upsellingService={services.upselling}>
                   <DiscoverInTimelineContextProvider>
-                    <AssistantProvider>{flyoutContent}</AssistantProvider>
+                    <CaseProvider>
+                      <AssistantProvider>{flyoutContent}</AssistantProvider>
+                    </CaseProvider>
                   </DiscoverInTimelineContextProvider>
                 </UpsellingProvider>
               </UserPrivilegesProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/components/flyout_provider.tsx
@@ -20,6 +20,7 @@ import { KibanaContextProvider } from '../../../common/lib/kibana';
 import { UserPrivilegesProvider } from '../../../common/components/user_privileges/user_privileges_context';
 import { UpsellingProvider } from '../../../common/components/upselling_provider';
 import { DiscoverInTimelineContextProvider } from '../../../common/components/discover_in_timeline/provider';
+import { AssistantProvider } from '../../../assistant/provider';
 
 export const flyoutProviders = ({
   services,
@@ -53,7 +54,7 @@ export const flyoutProviders = ({
               <UserPrivilegesProvider kibanaCapabilities={services.application.capabilities}>
                 <UpsellingProvider upsellingService={services.upselling}>
                   <DiscoverInTimelineContextProvider>
-                    {flyoutContent}
+                    <AssistantProvider>{flyoutContent}</AssistantProvider>
                   </DiscoverInTimelineContextProvider>
                 </UpsellingProvider>
               </UserPrivilegesProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -36,6 +36,14 @@ jest.mock('../../common/components/discover_in_timeline/provider', () => ({
   ),
 }));
 
+jest.mock('../../cases/components/provider/provider', () => ({
+  CaseProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../../assistant/provider', () => ({
+  AssistantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 describe('AlertFlyoutHeader', () => {
   beforeEach(() => {
     mockDocumentHeader.mockClear();

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_overview_tab_component/index.test.tsx
@@ -33,6 +33,14 @@ jest.mock('../../common/components/discover_in_timeline/provider', () => ({
   ),
 }));
 
+jest.mock('../../cases/components/provider/provider', () => ({
+  CaseProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../../assistant/provider', () => ({
+  AssistantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 const mockUseInitDataViewManager = jest.fn();
 jest.mock('../../data_view_manager/hooks/use_init_data_view_manager', () => ({
   useInitDataViewManager: () => mockUseInitDataViewManager(),


### PR DESCRIPTION
## Summary

This PR adds the `Add to chat` or `Ask AI assistant` button at the bottom of the document flyout.

### Code changes

The PR adds and changes the following:
- moves the logic responsible for the AI buttons a new component, shared between the old and new flyouts
- update the `flyoutProviders` to ensure the new flyout renders correctly in Security Solution and Discover
- moves the necesarry hooks to the `flyout_v2` folder for colocation

> [!TIP]
> The footer is rendered both in the expandable flyout (in Security Solution) and in this new EUI flyout system (in Security Solution and Discover). The UIUX experience in the expandable flyout remains totally unchanged.

### UI changes

The UI of the current alert/event flyouts (using the expandable flyout framework) in Security Solution should remain unchanged after this PR (when the feature flag is off).

<img width="1398" height="855" alt="Screenshot 2026-03-30 at 5 19 20 PM" src="https://github.com/user-attachments/assets/67c02ca6-356c-450f-9aa9-ec09bd96203d" />

In the new flyout when loaded in Security Solution, we show the new tools flyout:

<img width="1402" height="852" alt="Screenshot 2026-03-30 at 5 19 48 PM" src="https://github.com/user-attachments/assets/91b624a1-0b26-43cb-b69d-a5f34123cf01" />

Which also works in Discover

With ai assistant

https://github.com/user-attachments/assets/1c1c48c6-7182-46e3-b1cd-0a38bee36bb6

With agent builder

https://github.com/user-attachments/assets/9de5e19c-f8a4-4f44-b7e6-b1e158c3ab4a

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

## What to look for when testing

- verify that the footer has not changed in the expandable flyout (`newFlyoutSystemEnabled` feature flag off)
- verify that the footer shows correctly in the new flyout (`newFlyoutSystemEnabled` feature flag on)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
