### PR TITLE
[SigEvents] Fix stale connector id config and improve messaging around it

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/index.ts
@@ -233,7 +233,12 @@ export {
 
 export { type IngestStreamProcessing } from './src/models/ingest/processing';
 
-export { TaskStatus, type TaskResult } from './src/tasks/types';
+export {
+  TaskStatus,
+  CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+  type TaskErrorCode,
+  type TaskResult,
+} from './src/tasks/types';
 
 export type { GenerateDescriptionResult } from './src/api/description_generation';
 export type { IdentifyFeaturesResult } from './src/api/features';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/tasks/types.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/tasks/types.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+export type TaskErrorCode = 'connector_not_configured';
+
+export const CONNECTOR_NOT_CONFIGURED_ERROR_CODE: TaskErrorCode = 'connector_not_configured';
+
 export enum TaskStatus {
   NotStarted = 'not_started',
   InProgress = 'in_progress',
@@ -29,5 +33,5 @@ export type TaskResult<TPayload> =
         | TaskStatus.BeingCanceled
         | TaskStatus.Canceled;
     }
-  | { status: TaskStatus.Failed; error: string }
+  | { status: TaskStatus.Failed; error: string; errorCode?: TaskErrorCode }
   | ({ status: TaskStatus.Completed | TaskStatus.Acknowledged } & TPayload);

--- a/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/sig_events/tasks/significant_events_queries_generation.ts
@@ -12,7 +12,7 @@ import {
   type SignificantEventsQueriesGenerationResult,
 } from '@kbn/streams-schema';
 import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
-import { getErrorMessage } from '../../streams/errors/parse_error';
+import { getErrorMessage, parseError } from '../../streams/errors/parse_error';
 import { formatInferenceProviderError } from '../../../routes/utils/create_connector_sse_error';
 import { resolveConnectorId } from '../../../routes/utils/resolve_connector_id';
 import type { TaskContext } from '../../tasks/task_definitions';
@@ -143,7 +143,8 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                 await taskClient.fail<SignificantEventsQueriesGenerationTaskParams>(
                   _task,
                   { start, end, sampleDocsSize, streamName },
-                  errorMessage
+                  errorMessage,
+                  parseError(error).errorCode
                 );
 
                 return getDeleteTaskRunResult();

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/connector_not_configured_error.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/connector_not_configured_error.ts
@@ -9,10 +9,7 @@ import { StatusError } from './status_error';
 
 export class ConnectorNotConfiguredError extends StatusError {
   constructor() {
-    super(
-      'No connector ID provided and no default AI connector configured. Please provide a connectorId or configure a default AI connector in settings.',
-      400
-    );
+    super('No connector ID provided and no default AI connector configured', 400);
     this.name = 'ConnectorNotConfiguredError';
   }
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/connector_not_configured_error.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/connector_not_configured_error.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StatusError } from './status_error';
+
+export class ConnectorNotConfiguredError extends StatusError {
+  constructor() {
+    super(
+      'No connector ID provided and no default AI connector configured. Please provide a connectorId or configure a default AI connector in settings.',
+      400
+    );
+    this.name = 'ConnectorNotConfiguredError';
+  }
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/parse_error.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/errors/parse_error.ts
@@ -6,6 +6,8 @@
  */
 
 import { errors } from '@elastic/elasticsearch';
+import { CONNECTOR_NOT_CONFIGURED_ERROR_CODE, type TaskErrorCode } from '@kbn/streams-schema';
+import { ConnectorNotConfiguredError } from './connector_not_configured_error';
 
 /**
  * Parsed error information extracted from unknown caught errors.
@@ -19,6 +21,8 @@ export interface ParsedError {
   type?: string;
   /** HTTP status code from Elasticsearch ResponseError */
   statusCode?: number;
+  /** Task error code for well-known error types */
+  errorCode?: TaskErrorCode;
   /** The original error for chaining/debugging */
   cause: unknown;
 }
@@ -47,6 +51,9 @@ export interface ParsedError {
  * ```
  */
 export function parseError(error: unknown): ParsedError {
+  const errorCode =
+    error instanceof ConnectorNotConfiguredError ? CONNECTOR_NOT_CONFIGURED_ERROR_CODE : undefined;
+
   // Handle Elasticsearch ResponseError
   if (error instanceof errors.ResponseError) {
     const { message, statusCode, body } = error;
@@ -56,6 +63,7 @@ export function parseError(error: unknown): ParsedError {
       message,
       type: typeof type === 'string' ? type : undefined,
       statusCode,
+      errorCode,
       cause: error,
     };
   }
@@ -64,6 +72,7 @@ export function parseError(error: unknown): ParsedError {
   if (error instanceof Error) {
     return {
       message: error.message,
+      errorCode,
       cause: error,
     };
   }
@@ -71,6 +80,7 @@ export function parseError(error: unknown): ParsedError {
   // Handle non-Error values
   return {
     message: String(error),
+    errorCode,
     cause: error,
   };
 }

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/cancellable_task.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/cancellable_task.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import { CONNECTOR_NOT_CONFIGURED_ERROR_CODE, TaskStatus } from '@kbn/streams-schema';
+import type { RunContext } from '@kbn/task-manager-plugin/server';
+import { cancellableTask } from './cancellable_task';
+import { ConnectorNotConfiguredError } from '../streams/errors/connector_not_configured_error';
+import type { TaskContext } from './task_definitions';
+import type { PersistedTask } from './types';
+
+const makePersistedTask = (
+  status: PersistedTask['status'] = TaskStatus.InProgress
+): PersistedTask =>
+  ({
+    id: 'task-1',
+    type: 'streams:onboarding',
+    status,
+    space: 'default',
+    created_at: new Date().toISOString(),
+    task: { params: { _task: null, streamName: 'logs' } },
+  } as unknown as PersistedTask);
+
+const makeTaskClient = (status: PersistedTask['status'] = TaskStatus.InProgress) => ({
+  get: jest.fn().mockResolvedValue(makePersistedTask(status)),
+  fail: jest.fn().mockResolvedValue(undefined),
+  markCanceled: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeRunContext = (params: object = {}): RunContext =>
+  ({
+    taskInstance: {
+      id: 'task-1',
+      params: {
+        _task: makePersistedTask(),
+        streamName: 'logs',
+        ...params,
+      },
+    },
+    fakeRequest: {},
+    abortController: new AbortController(),
+  } as unknown as RunContext);
+
+const makeTaskContext = (taskClient: ReturnType<typeof makeTaskClient>): TaskContext =>
+  ({
+    logger: loggerMock.create(),
+    getScopedClients: jest.fn().mockResolvedValue({ taskClient }),
+    telemetry: {},
+  } as unknown as TaskContext);
+
+describe('cancellableTask()', () => {
+  it('calls taskClient.fail() with CONNECTOR_NOT_CONFIGURED_ERROR_CODE when run throws ConnectorNotConfiguredError', async () => {
+    const taskClient = makeTaskClient();
+    const runContext = makeRunContext();
+    const taskContext = makeTaskContext(taskClient);
+
+    const run = jest.fn().mockRejectedValue(new ConnectorNotConfiguredError());
+
+    await expect(cancellableTask(run, runContext, taskContext)()).rejects.toThrow(
+      ConnectorNotConfiguredError
+    );
+
+    expect(taskClient.fail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.any(String),
+      CONNECTOR_NOT_CONFIGURED_ERROR_CODE
+    );
+  });
+
+  it('calls taskClient.fail() with undefined errorCode when run throws a generic error', async () => {
+    const taskClient = makeTaskClient();
+    const runContext = makeRunContext();
+    const taskContext = makeTaskContext(taskClient);
+
+    const run = jest.fn().mockRejectedValue(new Error('something went wrong'));
+
+    await expect(cancellableTask(run, runContext, taskContext)()).rejects.toThrow(
+      'something went wrong'
+    );
+
+    expect(taskClient.fail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'something went wrong',
+      undefined
+    );
+  });
+
+  it('rethrows the original error after calling taskClient.fail()', async () => {
+    const taskClient = makeTaskClient();
+    const runContext = makeRunContext();
+    const taskContext = makeTaskContext(taskClient);
+    const originalError = new ConnectorNotConfiguredError();
+
+    const run = jest.fn().mockRejectedValue(originalError);
+
+    await expect(cancellableTask(run, runContext, taskContext)()).rejects.toBe(originalError);
+  });
+
+  it('still rethrows when taskClient.fail() itself throws', async () => {
+    const taskClient = makeTaskClient();
+    taskClient.fail.mockRejectedValue(new Error('storage unavailable'));
+    const runContext = makeRunContext();
+    const taskContext = makeTaskContext(taskClient);
+    const originalError = new ConnectorNotConfiguredError();
+
+    const run = jest.fn().mockRejectedValue(originalError);
+
+    await expect(cancellableTask(run, runContext, taskContext)()).rejects.toBe(originalError);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/cancellable_task.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/cancellable_task.ts
@@ -9,7 +9,7 @@ import type { RunContext } from '@kbn/task-manager-plugin/server';
 import type { RunFunction } from '@kbn/task-manager-plugin/server/task';
 import { TaskStatus } from '@kbn/streams-schema';
 import type { LogMeta } from '@kbn/logging';
-import { getErrorMessage } from '../streams/errors/parse_error';
+import { parseError } from '../streams/errors/parse_error';
 import type { TaskContext } from './task_definitions';
 import type { TaskParams } from './types';
 
@@ -81,7 +81,8 @@ export function cancellableTask(
 
       try {
         const { _task, ...params } = runContext.taskInstance.params as TaskParams;
-        await taskClient.fail(_task, params, getErrorMessage(error));
+        const { message, errorCode } = parseError(error);
+        await taskClient.fail(_task, params, message, errorCode);
       } catch (updateError) {
         taskContext.logger.error('Failed to update task status after error', {
           error: updateError,

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggerMock } from '@kbn/logging-mocks';
+import type { KibanaRequest } from '@kbn/core/server';
+import { TaskStatus, CONNECTOR_NOT_CONFIGURED_ERROR_CODE } from '@kbn/streams-schema';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { TaskClient } from './task_client';
+import type { TaskStorageClient } from './storage';
+import type { PersistedTask } from './types';
+import { CancellationInProgressError } from './cancellation_in_progress_error';
+
+const makeStoredTask = (status: PersistedTask['status'], extra: Partial<PersistedTask> = {}) =>
+  ({
+    id: 'task-1',
+    type: 'streams:onboarding',
+    status,
+    space: 'default',
+    created_at: new Date().toISOString(),
+    task: {
+      params: {},
+      ...(status === TaskStatus.Failed ? { error: 'some error' } : {}),
+    },
+    ...extra,
+  } as PersistedTask);
+
+const makeTaskManagerStart = (): jest.Mocked<TaskManagerStartContract> => ({
+  fetch: jest.fn(),
+  get: jest.fn(),
+  bulkGet: jest.fn(),
+  aggregate: jest.fn(),
+  remove: jest.fn(),
+  bulkRemove: jest.fn(),
+  schedule: jest.fn().mockResolvedValue(undefined),
+  runSoon: jest.fn(),
+  ensureScheduled: jest.fn(),
+  removeIfExists: jest.fn().mockResolvedValue(undefined),
+  bulkUpdateSchedules: jest.fn(),
+  bulkSchedule: jest.fn(),
+  bulkDisable: jest.fn(),
+  bulkEnable: jest.fn(),
+  getRegisteredTypes: jest.fn(),
+  bulkUpdateState: jest.fn(),
+  registerEncryptedSavedObjectsClient: jest.fn(),
+  registerApiKeyInvalidateFn: jest.fn(),
+});
+
+const makeStorageClient = (stored: PersistedTask): jest.Mocked<TaskStorageClient> =>
+  ({
+    get: jest.fn().mockResolvedValue({ _source: stored }),
+    index: jest.fn().mockResolvedValue({}),
+    search: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as jest.Mocked<TaskStorageClient>);
+
+const makeScheduleRequest = () => ({
+  task: {
+    id: 'task-1',
+    type: 'streams:onboarding' as const,
+    space: 'default',
+  },
+  params: {},
+  request: {} as unknown as KibanaRequest,
+});
+
+describe('TaskClient.schedule()', () => {
+  it('calls removeIfExists before scheduling when storedTask.status is Failed', async () => {
+    const stored = makeStoredTask(TaskStatus.Failed);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await client.schedule(makeScheduleRequest());
+
+    expect(taskManagerStart.removeIfExists).toHaveBeenCalledWith('task-1');
+    expect(taskManagerStart.schedule).toHaveBeenCalled();
+  });
+
+  it('does NOT call removeIfExists when storedTask.status is NotStarted', async () => {
+    const stored = makeStoredTask(TaskStatus.NotStarted);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await client.schedule(makeScheduleRequest());
+
+    expect(taskManagerStart.removeIfExists).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call removeIfExists when storedTask.status is Completed', async () => {
+    const stored = makeStoredTask(TaskStatus.Completed);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await client.schedule(makeScheduleRequest());
+
+    expect(taskManagerStart.removeIfExists).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and continues when removeIfExists throws', async () => {
+    const stored = makeStoredTask(TaskStatus.Failed);
+    const taskManagerStart = makeTaskManagerStart();
+    taskManagerStart.removeIfExists.mockRejectedValue(new Error('ES unavailable'));
+    const storageClient = makeStorageClient(stored);
+    const logger = loggerMock.create();
+    const client = new TaskClient(taskManagerStart, storageClient, logger);
+
+    await expect(client.schedule(makeScheduleRequest())).resolves.not.toThrow();
+    expect(logger.warn).toHaveBeenCalled();
+    expect(taskManagerStart.schedule).toHaveBeenCalled();
+  });
+
+  it('propagates non-removal errors from taskManagerStart.schedule', async () => {
+    const stored = makeStoredTask(TaskStatus.NotStarted);
+    const taskManagerStart = makeTaskManagerStart();
+    taskManagerStart.schedule.mockRejectedValue(new Error('Unexpected error'));
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await expect(client.schedule(makeScheduleRequest())).rejects.toThrow('Unexpected error');
+  });
+
+  it('throws CancellationInProgressError when storedTask.status is BeingCanceled', async () => {
+    const stored = makeStoredTask(TaskStatus.BeingCanceled);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await expect(client.schedule(makeScheduleRequest())).rejects.toThrow(
+      CancellationInProgressError
+    );
+    expect(taskManagerStart.removeIfExists).not.toHaveBeenCalled();
+    expect(taskManagerStart.schedule).not.toHaveBeenCalled();
+  });
+});
+
+describe('TaskClient.fail()', () => {
+  it('persists errorCode alongside error message', async () => {
+    const stored = makeStoredTask(TaskStatus.InProgress);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await client.fail(stored, {}, 'connector error message', CONNECTOR_NOT_CONFIGURED_ERROR_CODE);
+
+    expect(storageClient.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          status: TaskStatus.Failed,
+          task: expect.objectContaining({
+            error: 'connector error message',
+            errorCode: CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+          }),
+        }),
+      })
+    );
+  });
+
+  it('persists undefined errorCode when not provided', async () => {
+    const stored = makeStoredTask(TaskStatus.InProgress);
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    await client.fail(stored, {}, 'generic error');
+
+    expect(storageClient.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          task: expect.objectContaining({
+            error: 'generic error',
+            errorCode: undefined,
+          }),
+        }),
+      })
+    );
+  });
+});
+
+describe('TaskClient.getStatus()', () => {
+  it('returns errorCode from a failed task', async () => {
+    const stored: PersistedTask = {
+      id: 'task-1',
+      type: 'streams:onboarding',
+      status: TaskStatus.Failed,
+      space: 'default',
+      created_at: new Date().toISOString(),
+      task: {
+        params: {},
+        error: 'connector error',
+        errorCode: CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+      },
+    };
+    const taskManagerStart = makeTaskManagerStart();
+    const storageClient = makeStorageClient(stored);
+    const client = new TaskClient(taskManagerStart, storageClient, loggerMock.create());
+
+    const result = await client.getStatus('task-1');
+
+    expect(result).toEqual({
+      status: TaskStatus.Failed,
+      error: 'connector error',
+      errorCode: CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_client.ts
@@ -9,7 +9,7 @@ import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { TaskPriority, type TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { isNotFoundError, isResponseError } from '@kbn/es-errors';
 import { TaskStatus } from '@kbn/streams-schema';
-import type { TaskResult } from '@kbn/streams-schema';
+import type { TaskErrorCode, TaskResult } from '@kbn/streams-schema';
 import type { TaskStorageClient } from './storage';
 import type { PersistedTask, TaskParams } from './types';
 import { CancellationInProgressError } from './cancellation_in_progress_error';
@@ -79,6 +79,7 @@ export class TaskClient<TaskType extends string> {
       return {
         status: TaskStatus.Failed,
         error: task.task.error,
+        errorCode: task.task.errorCode,
       };
     } else if (task.status === TaskStatus.Completed || task.status === TaskStatus.Acknowledged) {
       return {
@@ -100,6 +101,15 @@ export class TaskClient<TaskType extends string> {
     const storedTask = await this.get(task.id);
     if (storedTask.status === TaskStatus.BeingCanceled) {
       throw new CancellationInProgressError('Previous task run is still being canceled');
+    }
+
+    if (storedTask.status === TaskStatus.Failed) {
+      try {
+        await this.taskManagerStart.removeIfExists(task.id);
+        this.logger.debug(`Removed stale TM doc for failed task ${task.id}`);
+      } catch (removeError) {
+        this.logger.warn(`Failed to remove stale TM doc for task ${task.id}: ${removeError}`);
+      }
     }
 
     const taskDoc: PersistedTask<TParams> = {
@@ -220,7 +230,8 @@ export class TaskClient<TaskType extends string> {
   public async fail<TParams extends {} = {}>(
     task: PersistedTask,
     params: TParams,
-    error: string
+    error: string,
+    errorCode?: TaskErrorCode
   ): Promise<void> {
     this.logger.debug(`Failing task ${task.id}`);
 
@@ -231,6 +242,7 @@ export class TaskClient<TaskType extends string> {
       task: {
         params,
         error,
+        errorCode,
       },
     });
   }

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -503,7 +503,8 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                 await taskClient.fail<FeaturesIdentificationTaskParams>(
                   _task,
                   { start, end, streamName },
-                  errorMessage
+                  errorMessage,
+                  parseError(error).errorCode
                 );
 
                 if (!hasTrackedIteration) {

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -14,13 +14,19 @@ import type {
   SignificantEventsQueriesGenerationResult,
   TaskResult,
 } from '@kbn/streams-schema';
-import { OnboardingStep, TaskStatus } from '@kbn/streams-schema';
+import {
+  OnboardingStep,
+  TaskStatus,
+  CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+  type TaskErrorCode,
+} from '@kbn/streams-schema';
 import type { TaskDefinitionRegistry } from '@kbn/task-manager-plugin/server';
 import { v4 } from 'uuid';
 import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import type { LogMeta } from '@kbn/logging';
 import type { StreamsTaskType, TaskContext } from '.';
 import { getErrorMessage } from '../../streams/errors/parse_error';
+import { ConnectorNotConfiguredError } from '../../streams/errors/connector_not_configured_error';
 import { formatInferenceProviderError } from '../../../routes/utils/create_connector_sse_error';
 import { resolveConnectorId } from '../../../routes/utils/resolve_connector_id';
 import type { QueryClient } from '../../streams/assets/query/query_client';
@@ -220,6 +226,11 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                   { error } as LogMeta
                 );
 
+                const connectorErrorCode: TaskErrorCode | undefined =
+                  error instanceof ConnectorNotConfiguredError
+                    ? CONNECTOR_NOT_CONFIGURED_ERROR_CODE
+                    : undefined;
+
                 await taskClient.fail<OnboardingTaskParams>(
                   _task,
                   {
@@ -229,7 +240,8 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                     steps,
                     saveQueries,
                   },
-                  errorMessage
+                  errorMessage,
+                  connectorErrorCode
                 );
                 return getDeleteTaskRunResult();
               }

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -18,7 +18,6 @@ import {
   OnboardingStep,
   TaskStatus,
   CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
-  type TaskErrorCode,
 } from '@kbn/streams-schema';
 import type { TaskDefinitionRegistry } from '@kbn/task-manager-plugin/server';
 import { v4 } from 'uuid';
@@ -226,11 +225,6 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                   { error } as LogMeta
                 );
 
-                const connectorErrorCode: TaskErrorCode | undefined =
-                  error instanceof ConnectorNotConfiguredError
-                    ? CONNECTOR_NOT_CONFIGURED_ERROR_CODE
-                    : undefined;
-
                 await taskClient.fail<OnboardingTaskParams>(
                   _task,
                   {
@@ -241,7 +235,9 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                     saveQueries,
                   },
                   errorMessage,
-                  connectorErrorCode
+                  error instanceof ConnectorNotConfiguredError
+                    ? CONNECTOR_NOT_CONFIGURED_ERROR_CODE
+                    : undefined
                 );
                 return getDeleteTaskRunResult();
               }
@@ -274,6 +270,9 @@ async function waitForSubtask<TParams extends {} = {}, TPayload extends {} = {}>
     const result = await taskClient.getStatus<TParams, TPayload>(subtaskId);
 
     if (result.status === TaskStatus.Failed) {
+      if (result.errorCode === CONNECTOR_NOT_CONFIGURED_ERROR_CODE) {
+        throw new ConnectorNotConfiguredError();
+      }
       throw new Error(`Subtask with ID ${subtaskId} has failed. Error: ${result.error}.`);
     }
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { TaskStatus } from '@kbn/streams-schema';
+import type { TaskErrorCode, TaskStatus } from '@kbn/streams-schema';
 
 interface PersistedTaskBase<TParams extends {} = {}> {
   id: string;
@@ -52,6 +52,7 @@ interface FailedTask<TParams extends {} = {}> extends PersistedTaskBase<TParams>
   status: TaskStatus.Failed;
   task: PersistedTaskBase<TParams>['task'] & {
     error: string;
+    errorCode?: TaskErrorCode;
   };
 }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/utils/resolve_connector_id.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/utils/resolve_connector_id.ts
@@ -7,7 +7,7 @@
 
 import type { IUiSettingsClient, Logger } from '@kbn/core/server';
 import { GEN_AI_SETTINGS_DEFAULT_AI_CONNECTOR } from '@kbn/management-settings-ids';
-import { StatusError } from '../../lib/streams/errors/status_error';
+import { ConnectorNotConfiguredError } from '../../lib/streams/errors/connector_not_configured_error';
 
 /**
  * Resolves the connector ID to use for AI operations.
@@ -45,8 +45,5 @@ export async function resolveConnectorId({
     return defaultConnector;
   }
 
-  throw new StatusError(
-    'No connector ID provided and no default AI connector configured. Please provide a connectorId or configure a default AI connector in settings.',
-    400
-  );
+  throw new ConnectorNotConfiguredError();
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/connector_not_configured_callout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/connector_not_configured_callout.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
+
+const CALLOUT_TITLE = i18n.translate(
+  'xpack.streams.significantEvents.connectorNotConfigured.title',
+  { defaultMessage: 'No connector configured' }
+);
+
+const CALLOUT_DESCRIPTION = i18n.translate(
+  'xpack.streams.significantEvents.connectorNotConfigured.description',
+  {
+    defaultMessage:
+      'Configure an AI connector for this feature in the Significant events settings.',
+  }
+);
+
+const OPEN_SETTINGS_LABEL = i18n.translate(
+  'xpack.streams.significantEvents.connectorNotConfigured.openSettingsLabel',
+  { defaultMessage: 'Open settings' }
+);
+
+export function ConnectorNotConfiguredCallout() {
+  const router = useStreamsAppRouter();
+  const settingsHref = router.link('/_discovery/{tab}', { path: { tab: 'settings' } });
+
+  return (
+    <EuiCallOut title={CALLOUT_TITLE} color="warning" iconType="warning" size="s">
+      {CALLOUT_DESCRIPTION}{' '}
+      <EuiLink href={settingsHref} external>
+        {OPEN_SETTINGS_LABEL}
+      </EuiLink>
+    </EuiCallOut>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/connector_not_configured_callout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/connector_not_configured_callout.tsx
@@ -18,8 +18,7 @@ const CALLOUT_TITLE = i18n.translate(
 const CALLOUT_DESCRIPTION = i18n.translate(
   'xpack.streams.significantEvents.connectorNotConfigured.description',
   {
-    defaultMessage:
-      'Configure an AI connector for this feature in the Significant events settings.',
+    defaultMessage: 'Configure an AI connector in the Significant events settings.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
@@ -27,6 +27,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import type { Insight, InsightImpactLevel } from '@kbn/streams-schema';
 import { AssetImage } from '../../../../asset_image';
+import { ConnectorNotConfiguredCallout } from '../../../connector_not_configured_callout';
+import { useConnectorIdSettings } from '../../../../../hooks/sig_events/use_connector_id_settings';
 import { useInsightsDiscoveryApi } from '../../../../../hooks/sig_events/use_insights_discovery_api';
 import { useKibana } from '../../../../../hooks/use_kibana';
 import { useTaskPolling } from '../../../../../hooks/use_task_polling';
@@ -40,6 +42,8 @@ export function Summary({ count }: { count: number }) {
     core: { notifications },
   } = useKibana();
   const { euiTheme } = useEuiTheme();
+
+  const { isDiscoveryConnectorConfigured } = useConnectorIdSettings();
 
   const {
     scheduleInsightsDiscoveryTask,
@@ -241,7 +245,7 @@ export function Summary({ count }: { count: number }) {
                   size="s"
                   iconType="sparkles"
                   onClick={onRunDiscoveryClick}
-                  isDisabled={isSchedulingTask}
+                  isDisabled={isSchedulingTask || !isDiscoveryConnectorConfigured}
                   isLoading={isSchedulingTask}
                   data-test-subj="significant_events_run_discovery_button"
                 >
@@ -252,6 +256,11 @@ export function Summary({ count }: { count: number }) {
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
+          {!isDiscoveryConnectorConfigured && (
+            <EuiFlexItem grow={false}>
+              <ConnectorNotConfiguredCallout />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem grow={false}>
             <EuiBasicTable
               data-test-subj="streamsInsightsTable"
@@ -321,7 +330,7 @@ export function Summary({ count }: { count: number }) {
                   size="m"
                   iconType="sparkles"
                   onClick={() => scheduleTask()}
-                  isDisabled={isTaskPending}
+                  isDisabled={isTaskPending || !isDiscoveryConnectorConfigured}
                   isLoading={isTaskPending}
                   data-test-subj="significant_events_generate_insights_button"
                 >
@@ -350,6 +359,11 @@ export function Summary({ count }: { count: number }) {
                 )}
               </EuiFlexGroup>
             </EuiFlexItem>
+            {!isDiscoveryConnectorConfigured && (
+              <EuiFlexItem grow={false} css={{ width: '100%' }}>
+                <ConnectorNotConfiguredCallout />
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
         </EuiPanel>
       </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/settings/tab.tsx
@@ -52,7 +52,7 @@ export const SettingsTab = () => {
   const { signal: abortSignal } = useAbortController();
   const genAiConnectors = useGenAIConnectors({
     streamsRepositoryClient: streams.streamsRepositoryClient,
-    uiSettings: core.uiSettings,
+    uiSettings: core.settings.client,
   });
 
   const defaultConnectorFetch = useStreamsAppFetch(
@@ -379,6 +379,7 @@ export const SettingsTab = () => {
         <>
           <EuiSpacer size="m" />
           <EuiCallOut
+            announceOnMount
             title={i18n.translate(
               'xpack.streams.significantEventsDiscovery.settings.saveErrorTitle',
               { defaultMessage: 'Failed to save settings' }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -26,6 +26,7 @@ import type { TableRow } from './utils';
 import { useAIFeatures } from '../../../../../hooks/use_ai_features';
 import { useIndexPatternsConfig } from '../../../../../hooks/use_index_patterns_config';
 import { useKibana } from '../../../../../hooks/use_kibana';
+import { useConnectorIdSettings } from '../../../../../hooks/sig_events/use_connector_id_settings';
 import { useInsightsDiscoveryApi } from '../../../../../hooks/sig_events/use_insights_discovery_api';
 import { useOnboardingApi } from '../../../../../hooks/use_onboarding_api';
 import { useStreamsAppRouter } from '../../../../../hooks/use_streams_app_router';
@@ -46,6 +47,7 @@ import {
 } from './translations';
 import { StreamsTreeTable } from './tree_table';
 import { useFetchStreams } from '../../hooks/use_fetch_streams';
+import { ConnectorNotConfiguredCallout } from '../../../connector_not_configured_callout';
 
 const datePickerStyle = css`
   .euiFormControlLayout,
@@ -89,6 +91,9 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
   >({});
   const router = useStreamsAppRouter();
   const aiFeatures = useAIFeatures();
+  const { isOnboardingConnectorConfigured } = useConnectorIdSettings(
+    aiFeatures?.genAiConnectors?.defaultConnector
+  );
   const { scheduleOnboardingTask, cancelOnboardingTask } = useOnboardingApi();
   const { scheduleInsightsDiscoveryTask, getInsightsDiscoveryTaskStatus } =
     useInsightsDiscoveryApi();
@@ -291,7 +296,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
           <EuiButtonEmpty
             onClick={onBulkOnboardStreamsClick}
             iconType="radar"
-            disabled={selectedStreams.length === 0}
+            disabled={selectedStreams.length === 0 || !isOnboardingConnectorConfigured}
           >
             {RUN_BULK_STREAM_ONBOARDING_BUTTON_LABEL}
           </EuiButtonEmpty>
@@ -308,6 +313,12 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
         </EuiFlexGroup>
       </EuiFlexItem>
 
+      {!isOnboardingConnectorConfigured && (
+        <EuiFlexItem grow={false}>
+          <ConnectorNotConfiguredCallout />
+        </EuiFlexItem>
+      )}
+
       <EuiFlexItem>
         <StreamsTreeTable
           streams={streamsListFetch.data?.streams}
@@ -317,6 +328,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
           selection={{ selected: selectedStreams, onSelectionChange: setSelectedStreams }}
           onOnboardStreamActionClick={onOnboardStreamActionClick}
           onStopOnboardingActionClick={onStopOnboardingActionClick}
+          isConnectorConfigured={isOnboardingConnectorConfigured}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -147,7 +147,7 @@ export const NO_INSIGHTS_TOAST_TITLE = i18n.translate(
 );
 
 export const CONNECTOR_NOT_CONFIGURED_TOOLTIP = i18n.translate(
-  'xpack.streams.significantEventsDiscovery.streamsTree.connectorNotConfiguredTooltip',
+  'xpack.streams.significantEventsDiscovery.streamsView.connectorNotConfiguredTooltip',
   {
     defaultMessage: 'No AI connector is configured. Configure one in the settings page.',
   }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/translations.ts
@@ -145,3 +145,10 @@ export const NO_INSIGHTS_TOAST_TITLE = i18n.translate(
     defaultMessage: 'No Significant Events found',
   }
 );
+
+export const CONNECTOR_NOT_CONFIGURED_TOOLTIP = i18n.translate(
+  'xpack.streams.significantEventsDiscovery.streamsTree.connectorNotConfiguredTooltip',
+  {
+    defaultMessage: 'No AI connector is configured. Configure one in the settings page.',
+  }
+);

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/tree_table.tsx
@@ -32,6 +32,7 @@ import { QueriesColumn } from './queries_column';
 import { SignificantEventsColumn } from './significant_events_column';
 import {
   ACTIONS_COLUMN_HEADER,
+  CONNECTOR_NOT_CONFIGURED_TOOLTIP,
   KNOWLEDGE_INDICATORS_COLUMN_HEADER,
   NAME_COLUMN_HEADER,
   NO_STREAMS_MESSAGE,
@@ -60,6 +61,7 @@ export function StreamsTreeTable({
   selection,
   onOnboardStreamActionClick,
   onStopOnboardingActionClick,
+  isConnectorConfigured,
 }: {
   streams?: ListStreamDetail[];
   streamOnboardingResultMap: Record<string, TaskResult<OnboardingResult>>;
@@ -68,6 +70,7 @@ export function StreamsTreeTable({
   selection: EuiTableSelectionType<TableRow>;
   onOnboardStreamActionClick: (streamName: string) => void;
   onStopOnboardingActionClick: (streamName: string) => void;
+  isConnectorConfigured: boolean;
 }) {
   const router = useStreamsAppRouter();
   const { euiTheme } = useEuiTheme();
@@ -431,13 +434,18 @@ export function StreamsTreeTable({
                 return (
                   <EuiToolTip
                     position="top"
-                    content={RUN_STREAM_ONBOARDING_BUTTON_LABEL}
+                    content={
+                      isConnectorConfigured
+                        ? RUN_STREAM_ONBOARDING_BUTTON_LABEL
+                        : CONNECTOR_NOT_CONFIGURED_TOOLTIP
+                    }
                     display="block"
                     disableScreenReaderOutput
                   >
                     <EuiButtonIcon
                       iconType="radar"
                       aria-label={RUN_STREAM_ONBOARDING_BUTTON_LABEL}
+                      disabled={!isConnectorConfigured}
                       onClick={() => onOnboardStreamActionClick(item.stream.name)}
                     />
                   </EuiToolTip>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
@@ -34,6 +34,7 @@ import { css } from '@emotion/css';
 import { v4 } from 'uuid';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { useBoolean } from '@kbn/react-hooks';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
 import type { AIFeatures } from '../../../../hooks/use_ai_features';
@@ -334,22 +335,19 @@ export function AddSignificantEventFlyout({
                       taskError={
                         task?.status === 'failed' ? (
                           task.errorCode === CONNECTOR_NOT_CONFIGURED_ERROR_CODE ? (
-                            <>
-                              {i18n.translate(
-                                'xpack.streams.streamDetailView.addSignificantEventFlyout.connectorNotConfiguredDescription',
-                                {
-                                  defaultMessage:
-                                    'No AI connector is configured. Please configure one in the settings page.',
-                                }
-                              )}{' '}
-                              <EuiLink href={settingsHref}>{CONFIGURE_SETTINGS_LINK_LABEL}</EuiLink>
-                            </>
+                            <FormattedMessage
+                              id="xpack.streams.significantEventsDiscovery.addFlyout.connectorNotConfiguredCta"
+                              defaultMessage="No AI connector is configured. {settingsLink}"
+                              values={{
+                                settingsLink: (
+                                  <EuiLink href={settingsHref}>
+                                    {CONFIGURE_SETTINGS_LINK_LABEL}
+                                  </EuiLink>
+                                ),
+                              }}
+                            />
                           ) : (
-                            <>
-                              {task.error}
-                              <EuiSpacer size="s" />
-                              <EuiLink href={settingsHref}>{CONFIGURE_SETTINGS_LINK_LABEL}</EuiLink>
-                            </>
+                            task.error
                           )
                         ) : undefined
                       }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/add_significant_event_flyout.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiLink,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -21,7 +22,12 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { OnboardingResult, TaskResult } from '@kbn/streams-schema';
-import { TaskStatus, type StreamQuery, type Streams } from '@kbn/streams-schema';
+import {
+  TaskStatus,
+  CONNECTOR_NOT_CONFIGURED_ERROR_CODE,
+  type StreamQuery,
+  type Streams,
+} from '@kbn/streams-schema';
 import { streamQuerySchema } from '@kbn/streams-schema';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@emotion/css';
@@ -31,6 +37,7 @@ import { useBoolean } from '@kbn/react-hooks';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { useOnboardingApi } from '../../../../hooks/use_onboarding_api';
 import type { AIFeatures } from '../../../../hooks/use_ai_features';
+import { useStreamsAppRouter } from '../../../../hooks/use_streams_app_router';
 import { GeneratedFlowForm } from './generated_flow_form/generated_flow_form';
 import { ManualFlowForm } from './manual_flow_form/manual_flow_form';
 import type { Flow, SaveData } from './types';
@@ -40,6 +47,11 @@ import { validateEsqlQuery } from './common/validate_query';
 import { useStreamsAppFetch } from '../../../../hooks/use_streams_app_fetch';
 import { useTaskPolling } from '../../../../hooks/use_task_polling';
 import { SignificantEventsGenerationPanel } from '../generation_panel';
+
+const CONFIGURE_SETTINGS_LINK_LABEL = i18n.translate(
+  'xpack.streams.streamDetailView.addSignificantEventFlyout.configureSettingsLinkLabel',
+  { defaultMessage: 'Go to settings' }
+);
 
 const defaultTask: TaskResult<OnboardingResult> = {
   status: TaskStatus.NotStarted,
@@ -69,6 +81,8 @@ export function AddSignificantEventFlyout({
       start: { data },
     },
   } = useKibana();
+  const router = useStreamsAppRouter();
+  const settingsHref = router.link('/_discovery/{tab}', { path: { tab: 'settings' } });
 
   const dataViewsFetch = useStreamsAppFetch(() => {
     return data.dataViews.create({ title: definition.stream.name }).then((value) => {
@@ -252,6 +266,7 @@ export function AddSignificantEventFlyout({
                   onGenerateSuggestionsClick={generateQueries}
                   isGeneratingQueries={isGenerating}
                   isSavingManualEntry={isSubmitting}
+                  aiFeatures={aiFeatures}
                   selectedFlow={selectedFlow}
                 />
               </EuiPanel>
@@ -316,7 +331,28 @@ export function AddSignificantEventFlyout({
                       }}
                       dataViews={dataViewsFetch.value ?? []}
                       taskStatus={task?.status}
-                      taskError={task?.status === 'failed' ? task.error : undefined}
+                      taskError={
+                        task?.status === 'failed' ? (
+                          task.errorCode === CONNECTOR_NOT_CONFIGURED_ERROR_CODE ? (
+                            <>
+                              {i18n.translate(
+                                'xpack.streams.streamDetailView.addSignificantEventFlyout.connectorNotConfiguredDescription',
+                                {
+                                  defaultMessage:
+                                    'No AI connector is configured. Please configure one in the settings page.',
+                                }
+                              )}{' '}
+                              <EuiLink href={settingsHref}>{CONFIGURE_SETTINGS_LINK_LABEL}</EuiLink>
+                            </>
+                          ) : (
+                            <>
+                              {task.error}
+                              <EuiSpacer size="s" />
+                              <EuiLink href={settingsHref}>{CONFIGURE_SETTINGS_LINK_LABEL}</EuiLink>
+                            </>
+                          )
+                        ) : undefined
+                      }
                     />
                   )}
                 </EuiPanel>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/generated_flow_form/generated_flow_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/add_significant_event_flyout/generated_flow_form/generated_flow_form.tsx
@@ -28,7 +28,7 @@ interface Props {
   setCanSave: (canSave: boolean) => void;
   dataViews: DataView[];
   taskStatus?: string;
-  taskError?: string;
+  taskError?: React.ReactNode;
 }
 
 export function GeneratedFlowForm({

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/empty_state/index.tsx
@@ -9,13 +9,16 @@ import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { SignificantEventsGenerationPanel } from '../generation_panel';
+import type { AIFeatures } from '../../../../hooks/use_ai_features';
 
 export function EmptyState({
   onManualEntryClick,
   onGenerateSuggestionsClick,
+  aiFeatures,
 }: {
   onManualEntryClick: () => void;
   onGenerateSuggestionsClick: () => void;
+  aiFeatures: AIFeatures | null;
 }) {
   return (
     <EuiEmptyPrompt
@@ -44,6 +47,7 @@ export function EmptyState({
               onManualEntryClick={onManualEntryClick}
               isGeneratingQueries={false}
               isSavingManualEntry={false}
+              aiFeatures={aiFeatures}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/feature_identification_control.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/feature_identification_control.tsx
@@ -11,9 +11,11 @@ import { EuiButton, EuiButtonEmpty, EuiCallOut, EuiFlexGroup, EuiFlexItem } from
 import { useBoolean } from '@kbn/react-hooks';
 import { i18n } from '@kbn/i18n';
 import { TaskStatus, type Streams } from '@kbn/streams-schema';
-import type { AIFeatures } from '../../../hooks/use_ai_features';
 import { useStreamFeaturesApi } from '../../../hooks/sig_events/use_stream_features_api';
 import { useTaskPolling } from '../../../hooks/use_task_polling';
+import type { AIFeatures } from '../../../hooks/use_ai_features';
+import { useConnectorIdSettings } from '../../../hooks/sig_events/use_connector_id_settings';
+import { ConnectorNotConfiguredCallout } from '../connector_not_configured_callout';
 
 interface FeatureIdentificationControlProps {
   definition: Streams.all.Definition;
@@ -32,6 +34,8 @@ export function FeatureIdentificationControl({
   onTaskStart,
   onTaskEnd,
 }: FeatureIdentificationControlProps) {
+  const { isKnowledgeIndicatorExtractionConnectorConfigured: isConnectorConfigured } =
+    useConnectorIdSettings(aiFeatures?.genAiConnectors?.defaultConnector);
   const {
     getFeaturesIdentificationStatus,
     scheduleFeaturesIdentificationTask,
@@ -115,7 +119,7 @@ export function FeatureIdentificationControl({
         <TriggerButton
           isLoading={isLoading}
           onClick={handleStartIdentification}
-          aiFeatures={aiFeatures}
+          isConnectorConfigured={isConnectorConfigured}
         />
       );
 
@@ -126,7 +130,7 @@ export function FeatureIdentificationControl({
           onStartIdentification={handleStartIdentification}
           showNoResultsCallout={task.features.length === 0 && !isNoResultsDismissed}
           onDismissNoResults={dismissNoResults}
-          aiFeatures={aiFeatures}
+          isConnectorConfigured={isConnectorConfigured}
         />
       );
 
@@ -148,7 +152,7 @@ export function FeatureIdentificationControl({
           calloutTitle={TASK_FAILED_TITLE}
           calloutColor="danger"
           calloutIcon="error"
-          aiFeatures={aiFeatures}
+          isConnectorConfigured={isConnectorConfigured}
         >
           {task.error}
         </StateWithCallout>
@@ -162,7 +166,7 @@ export function FeatureIdentificationControl({
           calloutTitle={TASK_STALE_TITLE}
           calloutColor="warning"
           calloutIcon="warning"
-          aiFeatures={aiFeatures}
+          isConnectorConfigured={isConnectorConfigured}
         >
           {TASK_STALE_DESCRIPTION}
         </StateWithCallout>
@@ -187,19 +191,30 @@ const COMMON_BUTTON_PROPS = {
 interface TriggerButtonProps {
   isLoading: boolean;
   onClick: () => void;
-  aiFeatures: AIFeatures | null;
+  isConnectorConfigured: boolean;
 }
 
-function TriggerButton({ isLoading, onClick, aiFeatures }: TriggerButtonProps) {
+function TriggerButton({ isLoading, onClick, isConnectorConfigured }: TriggerButtonProps) {
   return (
-    <EuiButton
-      {...COMMON_BUTTON_PROPS}
-      isLoading={isLoading}
-      onClick={onClick}
-      isDisabled={!aiFeatures?.enabled}
-    >
-      {IDENTIFY_FEATURES_BUTTON_LABEL}
-    </EuiButton>
+    <>
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem grow={false} style={{ alignSelf: 'flex-start' }}>
+          <EuiButton
+            {...COMMON_BUTTON_PROPS}
+            isLoading={isLoading}
+            onClick={onClick}
+            isDisabled={!isConnectorConfigured}
+          >
+            {IDENTIFY_FEATURES_BUTTON_LABEL}
+          </EuiButton>
+        </EuiFlexItem>
+        {!isConnectorConfigured && (
+          <EuiFlexItem>
+            <ConnectorNotConfiguredCallout />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </>
   );
 }
 
@@ -208,7 +223,7 @@ interface CompletedStateProps {
   onStartIdentification: () => void;
   showNoResultsCallout: boolean;
   onDismissNoResults: () => void;
-  aiFeatures: AIFeatures | null;
+  isConnectorConfigured: boolean;
 }
 
 function CompletedState({
@@ -216,7 +231,7 @@ function CompletedState({
   onStartIdentification,
   showNoResultsCallout,
   onDismissNoResults,
-  aiFeatures,
+  isConnectorConfigured,
 }: CompletedStateProps) {
   if (showNoResultsCallout) {
     return (
@@ -225,7 +240,7 @@ function CompletedState({
           <TriggerButton
             isLoading={isLoading}
             onClick={onStartIdentification}
-            aiFeatures={aiFeatures}
+            isConnectorConfigured={isConnectorConfigured}
           />
         </EuiFlexItem>
         <EuiFlexItem>
@@ -244,7 +259,11 @@ function CompletedState({
   }
 
   return (
-    <TriggerButton isLoading={isLoading} onClick={onStartIdentification} aiFeatures={aiFeatures} />
+    <TriggerButton
+      isLoading={isLoading}
+      onClick={onStartIdentification}
+      isConnectorConfigured={isConnectorConfigured}
+    />
   );
 }
 
@@ -292,7 +311,7 @@ interface StateWithCalloutProps {
   calloutColor: 'danger' | 'warning' | 'primary';
   calloutIcon: 'error' | 'warning' | 'search';
   children: React.ReactNode;
-  aiFeatures: AIFeatures | null;
+  isConnectorConfigured: boolean;
 }
 
 function StateWithCallout({
@@ -302,7 +321,7 @@ function StateWithCallout({
   calloutColor,
   calloutIcon,
   children,
-  aiFeatures,
+  isConnectorConfigured,
 }: StateWithCalloutProps) {
   return (
     <EuiFlexGroup direction="column">
@@ -310,7 +329,7 @@ function StateWithCallout({
         <TriggerButton
           isLoading={isLoading}
           onClick={onStartIdentification}
-          aiFeatures={aiFeatures}
+          isConnectorConfigured={isConnectorConfigured}
         />
       </EuiFlexItem>
       <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/generation_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/generation_panel.tsx
@@ -19,20 +19,28 @@ import {
 import { i18n } from '@kbn/i18n';
 import { AssetImage } from '../../asset_image';
 import type { Flow } from './add_significant_event_flyout/types';
+import { ConnectorNotConfiguredCallout } from '../connector_not_configured_callout';
+import type { AIFeatures } from '../../../hooks/use_ai_features';
+import { useConnectorIdSettings } from '../../../hooks/sig_events/use_connector_id_settings';
 
 export function SignificantEventsGenerationPanel({
   onGenerateSuggestionsClick,
   onManualEntryClick,
   isGeneratingQueries,
   isSavingManualEntry,
+  aiFeatures,
   selectedFlow,
 }: {
   onManualEntryClick: () => void;
   onGenerateSuggestionsClick: () => void;
   isGeneratingQueries: boolean;
   isSavingManualEntry: boolean;
+  aiFeatures: AIFeatures | null;
   selectedFlow?: Flow;
 }) {
+  const { isRuleGenerationConnectorConfigured: isConnectorConfigured } = useConnectorIdSettings(
+    aiFeatures?.genAiConnectors?.defaultConnector
+  );
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
       <EuiFlexItem>
@@ -74,7 +82,7 @@ export function SignificantEventsGenerationPanel({
             <EuiButton
               iconType="sparkles"
               isLoading={isGeneratingQueries}
-              isDisabled={isGeneratingQueries || isSavingManualEntry}
+              isDisabled={isGeneratingQueries || isSavingManualEntry || !isConnectorConfigured}
               onClick={onGenerateSuggestionsClick}
               data-test-subj="significant_events_generate_suggestions_button"
             >
@@ -86,6 +94,13 @@ export function SignificantEventsGenerationPanel({
               )}
             </EuiButton>
           </EuiFlexItem>
+
+          {!isConnectorConfigured && (
+            <EuiFlexItem>
+              <EuiSpacer size="s" />
+              <ConnectorNotConfiguredCallout />
+            </EuiFlexItem>
+          )}
         </EuiPanel>
       </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/stream_detail_significant_events_view/index.tsx
@@ -96,6 +96,7 @@ export function StreamDetailSignificantEventsView({ definition }: Props) {
             setInitialFlow('ai');
             setIsEditFlyoutOpen(true);
           }}
+          aiFeatures={aiFeatures}
         />
         {editFlyout(true)}
       </>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_management/advanced_view/wired_advanced_view.test.tsx
@@ -16,10 +16,6 @@ jest.mock('@kbn/ebt-tools', () => ({
   usePerformanceContext: () => ({ onPageReady: jest.fn() }),
 }));
 
-jest.mock('../../../../../hooks/use_ai_features', () => ({
-  useAIFeatures: () => null,
-}));
-
 // Mock the useStreamsPrivileges hook
 jest.mock('../../../../../hooks/use_streams_privileges');
 
@@ -66,6 +62,19 @@ jest.mock('../../../../../hooks/sig_events/use_stream_features_api', () => ({
     cancelFeaturesIdentificationTask: jest.fn(),
     deleteFeature: jest.fn(),
     deleteFeaturesInBulk: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../../hooks/sig_events/use_connector_id_settings', () => ({
+  useConnectorIdSettings: () => ({
+    isOnboardingConnectorConfigured: true,
+    isRuleGenerationConnectorConfigured: true,
+    isKnowledgeIndicatorExtractionConnectorConfigured: true,
+    isDiscoveryConnectorConfigured: true,
+    loading: false,
+    value: undefined,
+    error: undefined,
+    refresh: jest.fn(),
   }),
 }));
 

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_connector_id_settings.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/sig_events/use_connector_id_settings.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibana } from '../use_kibana';
+import { useStreamsAppFetch } from '../use_streams_app_fetch';
+
+/**
+ * Fetches per-step connector ID settings and computes whether each step has a
+ * connector configured, falling back to the global default AI connector when a
+ * per-step connector is not set.
+ *
+ * Pass `defaultConnector` from `useAIFeatures().genAiConnectors.defaultConnector`
+ * so the calling component controls the single `useAIFeatures()` call.
+ */
+export function useConnectorIdSettings(defaultConnector: string | undefined) {
+  const {
+    dependencies: {
+      start: { streams },
+    },
+  } = useKibana();
+
+  const settingsFetch = useStreamsAppFetch(
+    ({ signal }) =>
+      streams.streamsRepositoryClient.fetch('GET /internal/streams/_significant_events/settings', {
+        signal,
+      }),
+    [streams.streamsRepositoryClient]
+  );
+
+  const isConfigured = (stepConnectorId: string | undefined): boolean =>
+    !!stepConnectorId || !!defaultConnector;
+
+  const isRuleGenerationConnectorConfigured = isConfigured(
+    settingsFetch.value?.connectorIdRuleGeneration
+  );
+  const isKnowledgeIndicatorExtractionConnectorConfigured = isConfigured(
+    settingsFetch.value?.connectorIdKnowledgeIndicatorExtraction
+  );
+  const isDiscoveryConnectorConfigured = isConfigured(settingsFetch.value?.connectorIdDiscovery);
+
+  return {
+    ...settingsFetch,
+    /** True when both onboarding sub-tasks (feature extraction + rule generation) have a connector. */
+    isOnboardingConnectorConfigured:
+      isKnowledgeIndicatorExtractionConnectorConfigured && isRuleGenerationConnectorConfigured,
+    /** "Generate suggestions" standalone step. */
+    isRuleGenerationConnectorConfigured,
+    /** "Discover Insights" step. */
+    isDiscoveryConnectorConfigured,
+    /** Knowledge Indicator Feature extraction step. */
+    isKnowledgeIndicatorExtractionConnectorConfigured,
+  };
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_ai_features.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_ai_features.tsx
@@ -37,7 +37,7 @@ export function useAIFeatures(): AIFeatures | null {
 
   const genAiConnectors = useGenAIConnectors({
     streamsRepositoryClient: streams.streamsRepositoryClient,
-    uiSettings: core.uiSettings,
+    uiSettings: core.settings.client,
   });
   const license = useObservable(licensing.license$);
   const [tourCalloutDismissed, setTourCalloutDismissed] = useElasticLlmCalloutDismissed(


### PR DESCRIPTION
## Summary

Fixes #259311

When an AI connector is not configured, users previously received either a silent failure or a generic HTTP 400 error with no guidance. This PR surfaces the issue clearly at every entry point and adds actionable callouts that link directly to the settings page.

### What changed

**Server**
- Added `ConnectorNotConfiguredError` — a typed error class thrown by `resolveConnectorId` when no connector is found
- Added `TaskErrorCode` union type and `CONNECTOR_NOT_CONFIGURED_ERROR_CODE` constant to `@kbn/streams-schema`, shared between server and client
- Extended `TaskResult<Failed>` and `FailedTask` with `errorCode?: TaskErrorCode`
- `TaskClient.fail()` now accepts an optional `errorCode` parameter, persisted alongside the error message
- `TaskClient.schedule()` now calls `removeIfExists` when the stored task is `Failed`, clearing stale Task Manager documents that would otherwise block re-scheduling
- `TaskClient.getStatus()` propagates `errorCode` from the persisted task to the returned `TaskResult`
- The onboarding task catches `ConnectorNotConfiguredError` and passes `CONNECTOR_NOT_CONFIGURED_ERROR_CODE` to `taskClient.fail()`
- Added unit tests for `TaskClient.schedule()`, `.fail()`, and `.getStatus()` covering the new behaviour

**Frontend**
- New `ConnectorNotConfiguredCallout` component — warning callout with an "Open settings" link, used wherever a connector is required but not configured
- New `useConnectorIdSettings` hook — fetches per-step connector settings and exposes `isOnboardingConnectorConfigured`, `isRuleGenerationConnectorConfigured`, `isKnowledgeIndicatorExtractionConnectorConfigured`, `isDiscoveryConnectorConfigured`
- **Streams discovery table**: bulk "Onboard Streams" and per-row action buttons are now disabled when no connector is configured; `ConnectorNotConfiguredCallout` appears above the table; per-row button shows a tooltip explaining why it is disabled
- **Add significant events flyout**: "Generate suggestions" button is disabled with inline callout when no connector is configured; `connector_not_configured` task errors show a specific message with a settings link instead of the raw error string
- **Feature identification control** (Advanced tab): "Identify features" button checks `isKnowledgeIndicatorExtractionConnectorConfigured` (the correct per-step check) and shows an inline callout below the button when disabled
- `taskError` prop on `GeneratedFlowForm` widened from `string` to `React.ReactNode` so the parent can compose rich error content
- Fix stale default AI connector setting in streams app by reading from `core.settings.client` (the same instance the gen-ai-settings management page writes to) instead of the `core.uiSettings`

<img width="800" height="526" alt="image" src="https://github.com/user-attachments/assets/e7576bff-2870-42ed-9320-8b9352a5ab98" />

<img width="800" height="824" alt="image" src="https://github.com/user-attachments/assets/832e93bd-9f92-4a8d-ad53-eb5399726b44" />

<img width="800" height="774" alt="image" src="https://github.com/user-attachments/assets/bb48f995-5923-41ae-be0d-917385e7c63e" />

<img width="800" height="819" alt="image" src="https://github.com/user-attachments/assets/c87855b9-296d-4f84-9be4-b69fc601d10b" />

<img width="800" height="812" alt="image" src="https://github.com/user-attachments/assets/572dbde9-09c1-46f8-b443-38f883490441" />



## Test plan

- [ ] With no AI connector configured, verify the "Identify features" button is disabled and shows the `ConnectorNotConfiguredCallout`
- [ ] With no AI connector configured, verify the "Generate suggestions" button in the Add flyout is disabled and shows the callout
- [ ] With no AI connector configured, verify the per-row action buttons in the Streams discovery table are disabled with the correct tooltip text and the callout appears above the table
- [ ] Configure a connector, verify all buttons become enabled and callouts disappear
- [ ] Add Significant Events
  - open 2 tabs, remove the genAI connector on tab 1
  - start the onboarding flow on tab 2 (error will happen, verify if the message will contain a link to the setttings page)
  - return to tab 1 and configure a default connector
  - return to tab 2 and start the onboarding flow again (it should work)
- [ ] Run `TaskClient` unit tests: `yarn jest task_client.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)