### PR TITLE
Fix YAML/GUI toggle alignment in rule form

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_create_rule.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/app_menu_actions/get_create_rule.tsx
@@ -59,7 +59,7 @@ export function CreateESQLRuleFlyout({
     };
   }, [history, core.application.currentAppId$]);
 
-  return <RuleFormFlyout query={query} onClose={onClose} />;
+  return <RuleFormFlyout query={query} onClose={onClose} includeYaml />;
 }
 
 export const getCreateRuleMenuItem = ({

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/dynamic_rule_form_flyout.tsx
@@ -22,6 +22,8 @@ export interface DynamicRuleFormFlyoutProps {
   query: string;
   /** Required services */
   services: RuleFormServices;
+  /** Whether to include YAML editor toggle (default: false) */
+  includeYaml?: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ const DynamicRuleFormFlyoutInner = ({
   onClose,
   query,
   services,
+  includeYaml = false,
 }: DynamicRuleFormFlyoutProps) => {
   const { createRule, isLoading } = useCreateRule({
     http: services.http,
@@ -57,6 +60,7 @@ const DynamicRuleFormFlyoutInner = ({
         query={query}
         services={services}
         layout="flyout"
+        includeYaml={includeYaml}
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/flyout_header_portal_context.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/flyout_header_portal_context.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext, useContext } from 'react';
+
+/**
+ * Allows descendants to portal content into a header area (flyout header
+ * or page header).
+ *
+ * The parent creates a target `<div>` inside its header and exposes the
+ * DOM element via this context. Form components deeper in the tree can use
+ * `useHeaderActionPortal()` to obtain the element and render into it with
+ * `createPortal`.
+ *
+ * Uses a state-based callback ref (not useRef) so that a re-render is
+ * triggered when the element mounts, ensuring the portal is available on
+ * the first meaningful paint.
+ */
+const HeaderActionPortalContext = createContext<HTMLDivElement | null>(null);
+
+export const HeaderActionPortalProvider = HeaderActionPortalContext.Provider;
+
+/**
+ * Returns the header portal target element, or `null` when no portal
+ * target has been provided by a parent.
+ */
+export const useHeaderActionPortal = (): HTMLDivElement | null =>
+  useContext(HeaderActionPortalContext);

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/rule_form_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
   EuiFlyout,
@@ -19,6 +19,7 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { RULE_FORM_ID } from '../form/constants';
+import { HeaderActionPortalProvider } from './flyout_header_portal_context';
 
 const FLYOUT_TITLE_ID = 'ruleV2FormFlyoutTitle';
 
@@ -34,6 +35,9 @@ export interface RuleFormFlyoutProps {
  *
  * Use DynamicRuleFormFlyout or StandaloneRuleFormFlyout for pre-composed
  * flyouts that handle form submission and state management.
+ *
+ * Exposes a portal target in the header via FlyoutHeaderPortalContext so
+ * descendants can render actions (e.g. a GUI/YAML toggle) next to the title.
  */
 export const RuleFormFlyout = ({
   push = true,
@@ -41,6 +45,11 @@ export const RuleFormFlyout = ({
   isLoading = false,
   children,
 }: RuleFormFlyoutProps) => {
+  const [headerActionEl, setHeaderActionEl] = useState<HTMLDivElement | null>(null);
+  const headerActionCallbackRef = useCallback((node: HTMLDivElement | null) => {
+    setHeaderActionEl(node);
+  }, []);
+
   return (
     <EuiFlyout
       session="start"
@@ -55,16 +64,25 @@ export const RuleFormFlyout = ({
       maxWidth={600}
     >
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m" id={FLYOUT_TITLE_ID}>
-          <h2>
-            <FormattedMessage
-              id="xpack.alertingV2.ruleForm.flyoutTitle"
-              defaultMessage="Create Alert Rule"
-            />
-          </h2>
-        </EuiTitle>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="m" id={FLYOUT_TITLE_ID}>
+              <h2>
+                <FormattedMessage
+                  id="xpack.alertingV2.ruleForm.flyoutTitle"
+                  defaultMessage="Create Alert Rule"
+                />
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <div ref={headerActionCallbackRef} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlyoutHeader>
-      <EuiFlyoutBody>{children}</EuiFlyoutBody>
+      <EuiFlyoutBody>
+        <HeaderActionPortalProvider value={headerActionEl}>{children}</HeaderActionPortalProvider>
+      </EuiFlyoutBody>
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/flyout/standalone_rule_form_flyout.tsx
@@ -22,6 +22,8 @@ export interface StandaloneRuleFormFlyoutProps {
   query: string;
   /** Required services */
   services: RuleFormServices;
+  /** Whether to include YAML editor toggle (default: false) */
+  includeYaml?: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ const StandaloneRuleFormFlyoutInner = ({
   onClose,
   query,
   services,
+  includeYaml = false,
 }: StandaloneRuleFormFlyoutProps) => {
   const { createRule, isLoading } = useCreateRule({
     http: services.http,
@@ -57,6 +60,7 @@ const StandaloneRuleFormFlyoutInner = ({
         query={query}
         services={services}
         layout="flyout"
+        includeYaml={includeYaml}
       />
     </RuleFormFlyout>
   );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useRef, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -19,6 +20,7 @@ import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { FormValues } from './types';
 import { EditModeToggle, type EditMode } from './components/edit_mode_toggle';
+import { useHeaderActionPortal } from '../flyout/flyout_header_portal_context';
 import {
   RuleFormProvider,
   useRuleFormServices,
@@ -190,33 +192,20 @@ const RuleFormContent = ({
   );
 
   const isYamlMode = editMode === 'yaml';
+  const headerPortalEl = useHeaderActionPortal();
+
+  const editModeToggle = includeYaml ? (
+    <EditModeToggle
+      editMode={editMode}
+      onChange={handleModeChange}
+      disabled={isDisabled || isSubmitting}
+    />
+  ) : null;
 
   const formContent = (
     <>
-      {isYamlMode ? (
-        includeYaml && (
-          <EditModeToggle
-            editMode={editMode}
-            onChange={handleModeChange}
-            disabled={isDisabled || isSubmitting}
-          />
-        )
-      ) : (
-        <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-          <EuiFlexItem>
-            <NameField />
-          </EuiFlexItem>
-          {includeYaml && (
-            <EuiFlexItem grow={false}>
-              <EditModeToggle
-                editMode={editMode}
-                onChange={handleModeChange}
-                disabled={isDisabled || isSubmitting}
-              />
-            </EuiFlexItem>
-          )}
-        </EuiFlexGroup>
-      )}
+      {headerPortalEl && editModeToggle ? createPortal(editModeToggle, headerPortalEl) : null}
+      <NameField />
       <EuiSpacer size="m" />
 
       {isYamlMode && includeYaml ? (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/index.ts
@@ -27,6 +27,9 @@ export { RuleResultsPreview } from './form';
 // Context - for consumers who need custom integrations
 export { RuleFormProvider, useRuleFormServices, useRuleFormMeta } from './form';
 
+// Portal — lets a parent header host the GUI/YAML toggle rendered by the form
+export { HeaderActionPortalProvider } from './flyout/flyout_header_portal_context';
+
 // Mappers
 export {
   mapFormValuesToRuleRequest,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/create_rule_form_flyout.tsx
@@ -14,6 +14,8 @@ export interface CreateRuleFormFlyoutProps {
   query: string;
   onClose?: () => void;
   push?: boolean;
+  /** Whether to include YAML editor toggle (default: false) */
+  includeYaml?: boolean;
 }
 
 export const DynamicRuleFormFlyout = (props: CreateRuleFormFlyoutProps) => {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rule_form_page/rule_form_page.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   EuiCallOut,
   EuiLoadingSpinner,
@@ -21,7 +21,11 @@ import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useParams, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@kbn/react-query';
-import { StandaloneRuleForm, mapRuleResponseToFormValues } from '@kbn/alerting-v2-rule-form';
+import {
+  StandaloneRuleForm,
+  mapRuleResponseToFormValues,
+  HeaderActionPortalProvider,
+} from '@kbn/alerting-v2-rule-form';
 import type { FormValues } from '@kbn/alerting-v2-rule-form';
 import { i18n } from '@kbn/i18n';
 import { useFetchRule } from '../../hooks/use_fetch_rule';
@@ -169,22 +173,29 @@ const RuleFormPageContent = ({ ruleId, initialQuery, initialValues }: RuleFormPa
     <FormattedMessage id="xpack.alertingV2.createRule.submitLabel" defaultMessage="Create rule" />
   );
 
+  const [headerActionEl, setHeaderActionEl] = useState<HTMLDivElement | null>(null);
+
   return (
     <>
-      <EuiPageHeader pageTitle={pageTitle} />
-      <EuiSpacer size="m" />
-      <StandaloneRuleForm
-        query={initialQuery ?? DEFAULT_QUERY}
-        services={ruleFormServices}
-        includeYaml
-        isDisabled={false}
-        includeSubmission
-        onSuccess={onSuccess}
-        onCancel={onCancel}
-        ruleId={ruleId}
-        initialValues={initialValues}
-        submitLabel={submitLabel}
+      <EuiPageHeader
+        pageTitle={pageTitle}
+        rightSideItems={[<div ref={setHeaderActionEl} key="header-action-portal" />]}
       />
+      <EuiSpacer size="m" />
+      <HeaderActionPortalProvider value={headerActionEl}>
+        <StandaloneRuleForm
+          query={initialQuery ?? DEFAULT_QUERY}
+          services={ruleFormServices}
+          includeYaml
+          isDisabled={false}
+          includeSubmission
+          onSuccess={onSuccess}
+          onCancel={onCancel}
+          ruleId={ruleId}
+          initialValues={initialValues}
+          submitLabel={submitLabel}
+        />
+      </HeaderActionPortalProvider>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Moves the GUI/YAML edit mode toggle to the page/flyout header level so it appears next to the "Create rule" / "Create Alert Rule" heading, and stays in a consistent position regardless of which mode is active.

Closes https://github.com/elastic/rna-program/issues/254

### Changes

- **Portal-based toggle placement**: Introduced a `HeaderActionPortalProvider` context that lets `RuleFormContent` portal the `EditModeToggle` into whatever header the parent provides — flyout header or page header
- **Flyout support**: `RuleFormFlyout` creates a portal target `<div>` right-aligned next to the title in `EuiFlyoutHeader` and wraps children with the provider
- **Page support**: `RuleFormPage` creates a portal target via `EuiPageHeader.rightSideItems` and wraps `StandaloneRuleForm` with the provider
- **`includeYaml` passthrough**: Wired `includeYaml` prop through the flyout wrapper components (`DynamicRuleFormFlyout`, `StandaloneRuleFormFlyout`, `CreateRuleFormFlyoutProps`) and enabled it in the Discover integration
- **Consistent layout**: `NameField` always renders on its own row; the toggle no longer shifts position when switching between GUI and YAML modes

## Test plan

- [ ] Open Discover, create a v2 ES|QL rule via the flyout — toggle should appear in the flyout header next to "Create Alert Rule"
- [ ] Toggle between GUI and YAML — toggle stays in the header, form body switches correctly
- [ ] Open Stack Management > Rules V2 > Create rule — toggle should appear next to the "Create rule" page header
- [ ] Toggle between GUI and YAML on the page — toggle stays in the header
- [ ] Verify v1 alerting navigation is unaffected