### PR TITLE
[inference] increase timeout for ES inference calls

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_endpoint_executor.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_endpoint_executor.test.ts
@@ -40,7 +40,7 @@ describe('createInferenceEndpointExecutor', () => {
         querystring: { timeout: '3m' },
         body,
       },
-      { asStream: true }
+      { asStream: true, requestTimeout: 180_000 }
     );
   });
 
@@ -118,13 +118,16 @@ describe('createInferenceEndpointExecutor', () => {
     );
   });
 
-  it('does not include requestTimeout when timeout is not provided', async () => {
+  it('uses the default requestTimeout when timeout is not provided', async () => {
     const stream = new PassThrough();
     mockTransportRequest.mockResolvedValue(stream);
 
     await executor.invoke({ body: {} });
 
-    expect(mockTransportRequest).toHaveBeenCalledWith(expect.anything(), { asStream: true });
+    expect(mockTransportRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requestTimeout: 180_000 })
+    );
   });
 
   it('returns the stream from the response', async () => {

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_endpoint_executor.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/inference_endpoint_executor.ts
@@ -26,28 +26,21 @@ export const createInferenceEndpointExecutor = ({
   esClient: ElasticsearchClient;
 }): InferenceEndpointExecutor => {
   return {
-    async invoke({ body, signal, timeout }): Promise<Readable> {
-      // timeout for the inference call performed by the endpoint
-      const inferenceTimeout =
-        typeof timeout === 'number' && Number.isFinite(timeout)
-          ? `${Math.ceil(timeout / 60000)}m`
-          : '3m';
-
+    async invoke({ body, signal, timeout = 180_000 }): Promise<Readable> {
       const response = await esClient.transport.request(
         {
           method: 'POST',
           path: `/_inference/chat_completion/${encodeURIComponent(inferenceId)}/_stream`,
           querystring: {
-            timeout: inferenceTimeout,
+            // timeout for the inference call performed by the endpoint
+            timeout: `${Math.ceil(timeout / 60000)}m`,
           },
           body,
         },
         {
           asStream: true,
+          requestTimeout: timeout,
           ...(signal ? { signal } : {}),
-          ...(typeof timeout === 'number' && Number.isFinite(timeout)
-            ? { requestTimeout: timeout }
-            : {}),
         }
       );
       return response as unknown as Readable;

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.test.ts
@@ -91,6 +91,7 @@ describe('InferenceConnector', () => {
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
           headers: {
             'X-Elastic-Product-Use-Case': 'security_ai_assistant',
           },
@@ -322,6 +323,7 @@ describe('InferenceConnector', () => {
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
         }
       );
     });
@@ -348,6 +350,7 @@ describe('InferenceConnector', () => {
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
           signal,
         }
       );

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.ts
@@ -209,6 +209,7 @@ export class InferenceConnector extends SubActionConnector<Config, Secrets> {
       {
         asStream: true,
         meta: true,
+        requestTimeout: 180_000,
         signal: params.signal,
         ...(params.telemetryMetadata?.pluginId
           ? {


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/elastic/kibana/pull/260267
Turns out, we also need to increase the ES call's timeout