### PR TITLE
[One Workflow] Add more unit tests to workflows_extensions plugin

### DIFF
--- a/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_classify_step.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/common/steps/ai/ai_classify_step.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { buildStructuredOutputSchema, ConfigSchema, InputSchema } from './ai_classify_step';
+
+describe('ai_classify_step common', () => {
+  describe('schema definitions', () => {
+    it('ConfigSchema accepts optional connector-id', () => {
+      expect(ConfigSchema.safeParse({}).success).toBe(true);
+      expect(ConfigSchema.safeParse({ 'connector-id': 'abc' }).success).toBe(true);
+    });
+
+    it('InputSchema requires input and categories', () => {
+      expect(InputSchema.safeParse({}).success).toBe(false);
+      expect(InputSchema.safeParse({ input: 'text', categories: ['A', 'B'] }).success).toBe(true);
+    });
+
+    it('InputSchema rejects empty categories array', () => {
+      expect(InputSchema.safeParse({ input: 'text', categories: [] }).success).toBe(false);
+    });
+
+    it('InputSchema accepts all optional fields', () => {
+      const result = InputSchema.safeParse({
+        input: 'text',
+        categories: ['A'],
+        instructions: 'focus on severity',
+        allowMultipleCategories: true,
+        fallbackCategory: 'Other',
+        includeRationale: true,
+        temperature: 0.5,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('InputSchema rejects temperature out of range', () => {
+      expect(InputSchema.safeParse({ input: 'x', categories: ['A'], temperature: 2 }).success).toBe(
+        false
+      );
+      expect(
+        InputSchema.safeParse({ input: 'x', categories: ['A'], temperature: -0.1 }).success
+      ).toBe(false);
+    });
+
+    it('InputSchema accepts object and array inputs', () => {
+      expect(InputSchema.safeParse({ input: { key: 'val' }, categories: ['A'] }).success).toBe(
+        true
+      );
+      expect(InputSchema.safeParse({ input: [1, 2, 3], categories: ['A'] }).success).toBe(true);
+    });
+  });
+
+  describe('buildStructuredOutputSchema', () => {
+    it('returns schema with category field for single classification', () => {
+      const schema = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A', 'B'],
+      });
+
+      expect(schema.shape).toHaveProperty('category');
+      expect(schema.shape).not.toHaveProperty('categories');
+      expect(schema.shape).toHaveProperty('metadata');
+      expect(schema.shape).not.toHaveProperty('rationale');
+    });
+
+    it('returns schema with categories array for multi-label classification', () => {
+      const schema = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A', 'B'],
+        allowMultipleCategories: true,
+      });
+
+      expect(schema.shape).toHaveProperty('categories');
+      expect(schema.shape).not.toHaveProperty('category');
+    });
+
+    it('includes rationale field when includeRationale is true', () => {
+      const schema = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A'],
+        includeRationale: true,
+      });
+
+      expect(schema.shape).toHaveProperty('rationale');
+    });
+
+    it('does not include rationale field when includeRationale is false or undefined', () => {
+      const withFalse = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A'],
+        includeRationale: false,
+      });
+      expect(withFalse.shape).not.toHaveProperty('rationale');
+
+      const withUndefined = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A'],
+      });
+      expect(withUndefined.shape).not.toHaveProperty('rationale');
+    });
+
+    it('returns a valid Zod object schema that can parse data', () => {
+      const schema = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A', 'B'],
+        allowMultipleCategories: true,
+        includeRationale: true,
+      });
+
+      const result = schema.safeParse({
+        categories: ['A'],
+        rationale: 'because',
+        metadata: { model: 'test' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('returned schema rejects data missing required fields', () => {
+      const schema = buildStructuredOutputSchema({
+        input: 'text',
+        categories: ['A'],
+      });
+
+      // Missing category and metadata
+      const result = schema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/public/plugin.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/public/plugin.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+import { WorkflowsExtensionsPublicPlugin } from './plugin';
+
+jest.mock('./steps', () => ({
+  registerInternalStepDefinitions: jest.fn(),
+}));
+
+const { registerInternalStepDefinitions } = jest.requireMock('./steps');
+
+const createPlugin = () => {
+  const initContext = coreMock.createPluginInitializerContext();
+  return new WorkflowsExtensionsPublicPlugin(initContext);
+};
+
+describe('WorkflowsExtensionsPublicPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('setup', () => {
+    it('calls registerInternalStepDefinitions', () => {
+      const plugin = createPlugin();
+      plugin.setup(coreMock.createSetup(), {});
+
+      expect(registerInternalStepDefinitions).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns registerStepDefinition that delegates to step registry', () => {
+      const plugin = createPlugin();
+      const setup = plugin.setup(coreMock.createSetup(), {});
+
+      const definition = { id: 'test.step' } as any;
+      setup.registerStepDefinition(definition);
+
+      // Duplicate should throw, proving delegation to real registry
+      expect(() => setup.registerStepDefinition(definition)).toThrow(/already registered/);
+    });
+
+    it('returns registerTriggerDefinition that delegates to trigger registry', () => {
+      const plugin = createPlugin();
+      const setup = plugin.setup(coreMock.createSetup(), {});
+
+      const definition = { id: 'test.trigger' } as any;
+      setup.registerTriggerDefinition(definition);
+
+      expect(() => setup.registerTriggerDefinition(definition)).toThrow(/already registered/);
+    });
+  });
+
+  describe('start', () => {
+    it('returns step registry accessors', () => {
+      const plugin = createPlugin();
+      const setup = plugin.setup(coreMock.createSetup(), {});
+      const definition = { id: 'my.step' } as any;
+      setup.registerStepDefinition(definition);
+
+      const start = plugin.start(coreMock.createStart(), {});
+
+      expect(start.hasStepDefinition('my.step')).toBe(true);
+      expect(start.getStepDefinition('my.step')).toEqual(
+        expect.objectContaining({ id: 'my.step' })
+      );
+      expect(start.getAllStepDefinitions()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'my.step' })])
+      );
+      expect(start.hasStepDefinition('nonexistent')).toBe(false);
+    });
+
+    it('returns trigger registry accessors', () => {
+      const plugin = createPlugin();
+      const setup = plugin.setup(coreMock.createSetup(), {});
+      const definition = { id: 'my.trigger' } as any;
+      setup.registerTriggerDefinition(definition);
+
+      const start = plugin.start(coreMock.createStart(), {});
+
+      expect(start.hasTriggerDefinition('my.trigger')).toBe(true);
+      expect(start.getTriggerDefinition('my.trigger')).toEqual(
+        expect.objectContaining({ id: 'my.trigger' })
+      );
+      expect(start.getAllTriggerDefinitions()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'my.trigger' })])
+      );
+    });
+
+    it('isReady resolves when both registries have settled', async () => {
+      const plugin = createPlugin();
+      plugin.setup(coreMock.createSetup(), {});
+      const start = plugin.start(coreMock.createStart(), {});
+
+      // No async loaders registered, should resolve immediately
+      await expect(start.isReady()).resolves.toBeUndefined();
+    });
+
+    it('isReady waits for async step loaders', async () => {
+      const plugin = createPlugin();
+      const setup = plugin.setup(coreMock.createSetup(), {});
+
+      let resolveLoader!: (def: any) => void;
+      const loaderPromise = new Promise<any>((resolve) => {
+        resolveLoader = resolve;
+      });
+      setup.registerStepDefinition(() => loaderPromise);
+
+      const start = plugin.start(coreMock.createStart(), {});
+
+      let ready = false;
+      const readyPromise = start.isReady().then(() => {
+        ready = true;
+      });
+
+      // Should not be ready yet
+      expect(ready).toBe(false);
+
+      // Resolve the loader
+      resolveLoader({ id: 'async.step' });
+      await readyPromise;
+
+      expect(ready).toBe(true);
+      expect(start.hasStepDefinition('async.step')).toBe(true);
+    });
+  });
+
+  describe('stop', () => {
+    it('does not throw', () => {
+      const plugin = createPlugin();
+      expect(() => plugin.stop()).not.toThrow();
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/emit_event.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/emit_event.test.ts
@@ -164,6 +164,66 @@ describe('emitEvent', () => {
     );
   });
 
+  it('skips schema validation when eventSchema has no safeParse method', async () => {
+    const registry = new TriggerRegistry();
+    registry.register({
+      id: 'cases.updated',
+      eventSchema,
+    } as ServerTriggerDefinition);
+    // Overwrite the definition's eventSchema with an object that lacks safeParse
+    const definition = registry.get('cases.updated')!;
+    (definition as any).eventSchema = { shape: {} };
+    const handler = jest.fn().mockResolvedValue(undefined);
+    const deps = createDeps({
+      triggerRegistry: registry,
+      triggerEventHandler: handler,
+    });
+
+    await emitEvent(
+      {
+        triggerId: 'cases.updated',
+        spaceId: 'default',
+        payload: { anything: 'goes' },
+        request: mockRequest,
+      },
+      deps
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes stringified error when schema validation error is not an Error instance', async () => {
+    const registry = new TriggerRegistry();
+    registry.register({
+      id: 'cases.updated',
+      eventSchema,
+    } as ServerTriggerDefinition);
+    // Replace eventSchema with a fake that returns a non-Error failure
+    const definition = registry.get('cases.updated')!;
+    (definition as any).eventSchema = {
+      safeParse: () => ({ success: false, error: 'string-error-detail' }),
+    };
+    const handler = jest.fn();
+    const deps = createDeps({
+      triggerRegistry: registry,
+      triggerEventHandler: handler,
+    });
+
+    await expect(
+      emitEvent(
+        {
+          triggerId: 'cases.updated',
+          spaceId: 'default',
+          payload: { caseId: '123', status: 'open' },
+          request: mockRequest,
+        },
+        deps
+      )
+    ).rejects.toThrow('string-error-detail');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('throws when no handler is registered', async () => {
     const registry = new TriggerRegistry();
     registry.register({

--- a/src/platform/plugins/shared/workflows_extensions/server/event_chain_context.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/event_chain_context.test.ts
@@ -106,6 +106,34 @@ describe('event_chain_context', () => {
     expect(getEventChainContext(request)).toBeUndefined();
   });
 
+  it('returns undefined when header value is an array with null first element', () => {
+    const request = {
+      headers: { [EVENT_CHAIN_DEPTH_HEADER]: [null as any] },
+    } as unknown as KibanaRequest;
+    expect(getEventChainContext(request)).toBeUndefined();
+  });
+
+  it('returns undefined when header value is an array with non-string first element', () => {
+    const request = {
+      headers: { [EVENT_CHAIN_DEPTH_HEADER]: [42 as any] },
+    } as unknown as KibanaRequest;
+    expect(getEventChainContext(request)).toBeUndefined();
+  });
+
+  it('returns undefined when header value is an empty string', () => {
+    const request = {
+      headers: { [EVENT_CHAIN_DEPTH_HEADER]: '' },
+    } as unknown as KibanaRequest;
+    expect(getEventChainContext(request)).toBeUndefined();
+  });
+
+  it('uses first element when header value is a string array', () => {
+    const request = {
+      headers: { [EVENT_CHAIN_DEPTH_HEADER]: ['3', '5'] },
+    } as unknown as KibanaRequest;
+    expect(getEventChainContext(request)).toEqual({ depth: 3 });
+  });
+
   describe('getOutboundEventChainHeaders', () => {
     it('returns empty object when request has no event chain context', () => {
       const request = {} as KibanaRequest;

--- a/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/routes/get_step_definitions.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { httpServerMock, httpServiceMock } from '@kbn/core/server/mocks';
+import { registerGetStepDefinitionsRoute } from './get_step_definitions';
+import { ServerStepRegistry } from '../step_registry';
+
+describe('registerGetStepDefinitionsRoute', () => {
+  const router = httpServiceMock.createRouter();
+  const registry = new ServerStepRegistry();
+
+  beforeEach(() => {
+    router.get.mockClear();
+  });
+
+  it('registers a GET route at the expected path with internal access and authz disabled', () => {
+    registerGetStepDefinitionsRoute(router, registry);
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [routeConfig] = router.get.mock.calls[0];
+    expect(routeConfig.path).toBe('/internal/workflows_extensions/step_definitions');
+    expect(routeConfig.options?.access).toBe('internal');
+    expect(routeConfig.security?.authz).toHaveProperty('enabled', false);
+    expect(routeConfig.validate).toBe(false);
+  });
+
+  it('returns steps sorted alphabetically with handler hashes', async () => {
+    const stepRegistry = new ServerStepRegistry();
+    const sharedHandler = async () => ({ output: {} });
+    stepRegistry.register({ id: 'z.step', handler: sharedHandler } as any);
+    stepRegistry.register({ id: 'a.step', handler: sharedHandler } as any);
+    stepRegistry.register({ id: 'm.step', handler: sharedHandler } as any);
+
+    const testRouter = httpServiceMock.createRouter();
+    registerGetStepDefinitionsRoute(testRouter, stepRegistry);
+
+    const [, handler] = testRouter.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledTimes(1);
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { steps } = body as { steps: Array<{ id: string; handlerHash: string }> };
+
+    expect(steps.map((s) => s.id)).toEqual(['a.step', 'm.step', 'z.step']);
+    // All share the same handler, so hashes must be identical
+    expect(steps[0].handlerHash).toBe(steps[1].handlerHash);
+    expect(steps[1].handlerHash).toBe(steps[2].handlerHash);
+    // Hashes are non-empty hex strings
+    expect(steps[0].handlerHash).toMatch(/^[a-f0-9]+$/);
+  });
+
+  it('returns empty steps array when registry is empty', async () => {
+    const emptyRegistry = new ServerStepRegistry();
+    const testRouter = httpServiceMock.createRouter();
+    registerGetStepDefinitionsRoute(testRouter, emptyRegistry);
+
+    const [, handler] = testRouter.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    expect((body as { steps: unknown[] }).steps).toEqual([]);
+  });
+
+  it('produces different hashes for different handler implementations', async () => {
+    const stepRegistry = new ServerStepRegistry();
+    stepRegistry.register({ id: 'a.step', handler: async () => ({ output: 'a' }) } as any);
+    stepRegistry.register({ id: 'b.step', handler: async () => ({ output: 'b' }) } as any);
+
+    const testRouter = httpServiceMock.createRouter();
+    registerGetStepDefinitionsRoute(testRouter, stepRegistry);
+
+    const [, handler] = testRouter.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { steps } = body as { steps: Array<{ id: string; handlerHash: string }> };
+    expect(steps[0].handlerHash).not.toBe(steps[1].handlerHash);
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/routes/get_trigger_definitions.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/routes/get_trigger_definitions.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { httpServerMock, httpServiceMock } from '@kbn/core/server/mocks';
+import { z } from '@kbn/zod/v4';
+import { registerGetTriggerDefinitionsRoute } from './get_trigger_definitions';
+import { TriggerRegistry } from '../trigger_registry';
+import type { ServerTriggerDefinition } from '../types';
+
+const createTrigger = (id: string, schema: z.ZodType): ServerTriggerDefinition =>
+  ({ id, eventSchema: schema } as ServerTriggerDefinition);
+
+describe('registerGetTriggerDefinitionsRoute', () => {
+  it('registers a GET route at the expected path with internal access and authz disabled', () => {
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, new TriggerRegistry());
+
+    expect(router.get).toHaveBeenCalledTimes(1);
+    const [routeConfig] = router.get.mock.calls[0];
+    expect(routeConfig.path).toBe('/internal/workflows_extensions/trigger_definitions');
+    expect(routeConfig.options?.access).toBe('internal');
+    expect(routeConfig.security?.authz).toHaveProperty('enabled', false);
+    expect(routeConfig.validate).toBe(false);
+  });
+
+  it('returns triggers sorted alphabetically with schema hashes', async () => {
+    const registry = new TriggerRegistry();
+    registry.register(createTrigger('z.trigger', z.object({ a: z.string() })));
+    registry.register(createTrigger('a.trigger', z.object({ b: z.number() })));
+
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, registry);
+
+    const [, handler] = router.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toHaveBeenCalledTimes(1);
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { triggers } = body as { triggers: Array<{ id: string; schemaHash: string }> };
+
+    expect(triggers.map((t) => t.id)).toEqual(['a.trigger', 'z.trigger']);
+    triggers.forEach((t) => expect(t.schemaHash).toMatch(/^[a-f0-9]+$/));
+  });
+
+  it('returns empty string for schemaHash when z.toJSONSchema fails', async () => {
+    // Use a fake registry that returns a trigger with a schema that causes toJSONSchema to throw
+    const badSchema = {
+      shape: {},
+      safeParse: () => ({ success: true }),
+    } as unknown as z.ZodType;
+    const fakeRegistry = {
+      list: () => [{ id: 'bad.trigger', eventSchema: badSchema }],
+    } as unknown as TriggerRegistry;
+
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, fakeRegistry);
+
+    const [, handler] = router.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { triggers } = body as { triggers: Array<{ id: string; schemaHash: string }> };
+    expect(triggers[0].schemaHash).toBe('');
+  });
+
+  it('returns empty triggers array when registry is empty', async () => {
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, new TriggerRegistry());
+
+    const [, handler] = router.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    expect((body as { triggers: unknown[] }).triggers).toEqual([]);
+  });
+
+  it('produces identical hashes for identical schemas', async () => {
+    const registry = new TriggerRegistry();
+    registry.register(createTrigger('a.trigger', z.object({ x: z.string() })));
+    registry.register(createTrigger('b.trigger', z.object({ x: z.string() })));
+
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, registry);
+
+    const [, handler] = router.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { triggers } = body as { triggers: Array<{ id: string; schemaHash: string }> };
+    expect(triggers[0].schemaHash).toBe(triggers[1].schemaHash);
+  });
+
+  it('produces different hashes for different schemas', async () => {
+    const registry = new TriggerRegistry();
+    registry.register(createTrigger('a.trigger', z.object({ x: z.string() })));
+    registry.register(createTrigger('b.trigger', z.object({ y: z.number() })));
+
+    const router = httpServiceMock.createRouter();
+    registerGetTriggerDefinitionsRoute(router, registry);
+
+    const [, handler] = router.get.mock.calls[0];
+    const response = httpServerMock.createResponseFactory();
+    await handler({} as any, httpServerMock.createKibanaRequest(), response);
+
+    const { body } = response.ok.mock.calls[0][0]!;
+    const { triggers } = body as { triggers: Array<{ id: string; schemaHash: string }> };
+    expect(triggers[0].schemaHash).not.toBe(triggers[1].schemaHash);
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/steps/ai/ai_classify_step/build_prompts.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/steps/ai/ai_classify_step/build_prompts.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  buildClassificationRequestPart,
+  buildDataPart,
+  buildInstructionsPart,
+  buildSystemPart,
+} from './build_prompts';
+
+describe('build_prompts', () => {
+  describe('buildSystemPart', () => {
+    it('returns a system-role message with classification rules', () => {
+      const parts = buildSystemPart();
+      expect(parts).toHaveLength(1);
+      expect(parts[0].role).toBe('system');
+      expect(parts[0].content).toContain('Output ONLY valid JSON');
+      expect(parts[0].content).toContain('Categories are case-sensitive');
+    });
+  });
+
+  describe('buildDataPart', () => {
+    it('wraps object input as json', () => {
+      const parts = buildDataPart({ foo: 'bar' });
+      expect(parts).toHaveLength(1);
+      expect(parts[0].role).toBe('user');
+      expect(parts[0].content).toContain('```json');
+      expect(parts[0].content).toContain(JSON.stringify({ foo: 'bar' }));
+    });
+
+    it('wraps string input as text', () => {
+      const parts = buildDataPart('hello world');
+      expect(parts).toHaveLength(1);
+      expect(parts[0].content).toContain('```text');
+      expect(parts[0].content).toContain('hello world');
+    });
+
+    it('handles null input (typeof null === "object") by JSON stringifying it', () => {
+      const parts = buildDataPart(null);
+      expect(parts[0].content).toContain('```json');
+      expect(parts[0].content).toContain('null');
+    });
+
+    it('handles array input via the json path', () => {
+      const parts = buildDataPart([1, 2, 3]);
+      expect(parts[0].content).toContain('```json');
+      expect(parts[0].content).toContain('[1,2,3]');
+    });
+
+    it('handles number input via the text path', () => {
+      const parts = buildDataPart(42);
+      expect(parts[0].content).toContain('```text');
+      expect(parts[0].content).toContain('42');
+    });
+
+    it('handles boolean input via the text path', () => {
+      const parts = buildDataPart(true);
+      expect(parts[0].content).toContain('```text');
+      expect(parts[0].content).toContain('true');
+    });
+  });
+
+  describe('buildInstructionsPart', () => {
+    it('returns empty array for undefined instructions', () => {
+      expect(buildInstructionsPart(undefined)).toEqual([]);
+    });
+
+    it('returns empty array for empty string instructions', () => {
+      expect(buildInstructionsPart('')).toEqual([]);
+    });
+
+    it('returns a user-role message containing the instructions', () => {
+      const parts = buildInstructionsPart('focus on severity');
+      expect(parts).toHaveLength(1);
+      expect(parts[0].role).toBe('user');
+      expect(parts[0].content).toContain('focus on severity');
+    });
+  });
+
+  describe('buildClassificationRequestPart', () => {
+    it('renders all categories as list items', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['Urgent', 'Normal', 'Low'],
+        allowMultipleCategories: false,
+        includeRationale: false,
+      });
+      expect(parts[0].content).toContain('- Urgent');
+      expect(parts[0].content).toContain('- Normal');
+      expect(parts[0].content).toContain('- Low');
+    });
+
+    it('includes fallback category rule when provided', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['A', 'B'],
+        allowMultipleCategories: false,
+        fallbackCategory: 'Other',
+        includeRationale: false,
+      });
+      expect(parts[0].content).toContain('fallback category: "Other"');
+    });
+
+    it('includes single-category rules when allowMultipleCategories is false', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['A'],
+        allowMultipleCategories: false,
+        includeRationale: false,
+      });
+      expect(parts[0].content).toContain('exactly ONE category');
+      expect(parts[0].content).not.toContain('multiple categories');
+    });
+
+    it('includes multi-category rules when allowMultipleCategories is true', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['A', 'B'],
+        allowMultipleCategories: true,
+        includeRationale: false,
+      });
+      expect(parts[0].content).toContain('multiple categories');
+      expect(parts[0].content).not.toContain('exactly ONE');
+    });
+
+    it('includes rationale rule when includeRationale is true', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['A'],
+        allowMultipleCategories: false,
+        includeRationale: true,
+      });
+      expect(parts[0].content).toContain('"rationale" field');
+    });
+
+    it('does not include rationale rule when includeRationale is false', () => {
+      const parts = buildClassificationRequestPart({
+        categories: ['A'],
+        allowMultipleCategories: false,
+        includeRationale: false,
+      });
+      expect(parts[0].content).not.toContain('rationale');
+    });
+
+    it('handles category names containing special characters', () => {
+      const categories = ['Category "A"', 'Category\nB', 'Category\\C'];
+      const parts = buildClassificationRequestPart({
+        categories,
+        allowMultipleCategories: false,
+        includeRationale: false,
+      });
+      categories.forEach((cat) => {
+        expect(parts[0].content).toContain(`- ${cat}`);
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/workflows_extensions/server/steps/ai/ai_classify_step/validate_model_response.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/steps/ai/ai_classify_step/validate_model_response.test.ts
@@ -322,6 +322,53 @@ describe('validateModelResponse', () => {
     });
   });
 
+  describe('null/undefined model response', () => {
+    it('throws InvalidModelResponse when modelResponse is null', () => {
+      expect(() => {
+        validateModelResponse({
+          modelResponse: null,
+          expectedCategories: ['a'],
+          fallbackCategory: undefined,
+          responseMetadata: {},
+        });
+      }).toThrow(ExecutionError);
+
+      try {
+        validateModelResponse({
+          modelResponse: null,
+          expectedCategories: ['a'],
+          fallbackCategory: undefined,
+          responseMetadata: {},
+        });
+      } catch (error) {
+        expect((error as ExecutionError).type).toBe('InvalidModelResponse');
+        expect((error as ExecutionError).message).toBe('Model response is null or undefined.');
+      }
+    });
+
+    it('throws InvalidModelResponse when modelResponse is undefined', () => {
+      expect(() => {
+        validateModelResponse({
+          modelResponse: undefined,
+          expectedCategories: ['a'],
+          fallbackCategory: undefined,
+          responseMetadata: {},
+        });
+      }).toThrow(ExecutionError);
+
+      try {
+        validateModelResponse({
+          modelResponse: undefined,
+          expectedCategories: ['a'],
+          fallbackCategory: undefined,
+          responseMetadata: {},
+        });
+      } catch (error) {
+        expect((error as ExecutionError).type).toBe('InvalidModelResponse');
+      }
+    });
+  });
+
   describe('case sensitivity', () => {
     it('should treat category names as case-sensitive', () => {
       const modelResponse = {

--- a/src/platform/plugins/shared/workflows_extensions/server/steps/data/aggregate_utils.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/steps/data/aggregate_utils.test.ts
@@ -182,6 +182,26 @@ describe('assignBucket', () => {
     expect(assignBucket({ score: 75 }, unlabeledConfig)).toBe('50-100');
     expect(assignBucket({ score: 150 }, unlabeledConfig)).toBe('100+');
   });
+
+  it('returns null when value matches no range', () => {
+    const noMatchConfig = {
+      field: 'age',
+      ranges: [
+        { from: 0, to: 10 },
+        { from: 10, to: 20 },
+      ],
+    };
+    expect(assignBucket({ age: 999 }, noMatchConfig)).toBeNull();
+  });
+
+  it('generates wildcard label when range has no from, to, or label', () => {
+    const wildcardConfig = {
+      field: 'val',
+      ranges: [{}],
+    };
+    // A range with no from and no to matches everything
+    expect(assignBucket({ val: 42 }, wildcardConfig)).toBe('*');
+  });
 });
 
 describe('parseGroupKeyValues', () => {
@@ -208,5 +228,9 @@ describe('parseGroupKeyValues', () => {
     expect(parseGroupKeyValues('"open::urgent"', ['status'])).toEqual({
       status: 'open::urgent',
     });
+  });
+
+  it('falls back to raw string when JSON.parse fails', () => {
+    expect(parseGroupKeyValues('not-valid-json', ['key'])).toEqual({ key: 'not-valid-json' });
   });
 });

--- a/src/platform/plugins/shared/workflows_extensions/server/steps/data/data_aggregate_step.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/steps/data/data_aggregate_step.test.ts
@@ -20,7 +20,8 @@ describe('dataAggregateStepDefinition', () => {
       order_by?: string;
       order?: 'asc' | 'desc';
       limit?: number;
-    }
+    },
+    abortSignal?: AbortSignal
   ): StepHandlerContext<
     typeof dataAggregateStepDefinition.inputSchema,
     typeof dataAggregateStepDefinition.configSchema
@@ -40,7 +41,7 @@ describe('dataAggregateStepDefinition', () => {
       warn: jest.fn(),
       error: jest.fn(),
     },
-    abortSignal: new AbortController().signal,
+    abortSignal: abortSignal ?? new AbortController().signal,
     stepId: 'test-aggregate',
     stepType: 'data.aggregate',
   });
@@ -344,6 +345,58 @@ describe('dataAggregateStepDefinition', () => {
       const result = await dataAggregateStepDefinition.handler(context);
       expect(result.error).toBeDefined();
       expect(result.error?.message).toContain('exceeding the maximum');
+    });
+  });
+
+  describe('abort and error handling', () => {
+    it('returns error when abort signal fires before aggregation starts', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const context = createMockContext(
+        { items: tickets },
+        {
+          group_by: ['status'],
+          metrics: [{ name: 'count', operation: 'count' }],
+        },
+        controller.signal
+      );
+      const result = await dataAggregateStepDefinition.handler(context);
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toContain('aborted');
+    });
+
+    it('returns error when renderInputTemplate throws', async () => {
+      const context = createMockContext(
+        { items: tickets },
+        {
+          group_by: ['status'],
+          metrics: [{ name: 'count', operation: 'count' }],
+        }
+      );
+      (context.contextManager.renderInputTemplate as jest.Mock).mockImplementation(() => {
+        throw new Error('render failure');
+      });
+
+      const result = await dataAggregateStepDefinition.handler(context);
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toBe('render failure');
+    });
+
+    it('returns generic error message when non-Error value is thrown', async () => {
+      const context = createMockContext(
+        { items: tickets },
+        {
+          group_by: ['status'],
+          metrics: [{ name: 'count', operation: 'count' }],
+        }
+      );
+      (context.contextManager.renderInputTemplate as jest.Mock).mockImplementation(() => {
+        throw 'string-error'; // eslint-disable-line no-throw-literal
+      });
+
+      const result = await dataAggregateStepDefinition.handler(context);
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toBe('Failed to aggregate items');
     });
   });
 

--- a/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
+++ b/src/platform/plugins/shared/workflows_extensions/server/trigger_registry/trigger_registry.test.ts
@@ -78,6 +78,36 @@ describe('TriggerRegistry', () => {
       expect(registry.list()).toHaveLength(3);
     });
 
+    it('throws if eventSchema is null', () => {
+      expect(() => {
+        registry.register(
+          createValidDefinition({
+            eventSchema: null as unknown as ServerTriggerDefinition['eventSchema'],
+          })
+        );
+      }).toThrow('"eventSchema" must be a Zod schema');
+    });
+
+    it('throws if eventSchema is undefined', () => {
+      expect(() => {
+        registry.register(
+          createValidDefinition({
+            eventSchema: undefined as unknown as ServerTriggerDefinition['eventSchema'],
+          })
+        );
+      }).toThrow('"eventSchema" must be a Zod schema');
+    });
+
+    it('throws if eventSchema is a plain object without safeParse', () => {
+      expect(() => {
+        registry.register(
+          createValidDefinition({
+            eventSchema: { shape: {} } as unknown as ServerTriggerDefinition['eventSchema'],
+          })
+        );
+      }).toThrow('"eventSchema" must be a Zod schema');
+    });
+
     it('throws if eventSchema is not a Zod object schema', () => {
       expect(() => {
         registry.register(


### PR DESCRIPTION
## Summary

```
$ yarn test:jest --config=src/platform/plugins/shared/workflows_extensions/jest.config.js --coverage --coverageReporters=text-summary
...
=============================== Coverage summary ===============================
Statements   : 81.49% ( 837/1027 )
Branches     : 90.09% ( 473/525 )
Functions    : 61.88% ( 138/223 )
Lines        : 83.86% ( 816/973 )
================================================================================

Test Suites: 29 passed, 29 total
Tests:       530 passed, 530 total
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
