### PR TITLE
[9.3] Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files (#259315)

### DIFF
--- a/examples/discover_customization_examples/moon.yml
+++ b/examples/discover_customization_examples/moon.yml
@@ -27,6 +27,7 @@ dependsOn:
   - '@kbn/data-plugin'
   - '@kbn/saved-search-plugin'
   - '@kbn/content-management-utils'
+  - '@kbn/i18n'
 tags:
   - plugin
   - prod

--- a/examples/discover_customization_examples/public/plugin.tsx
+++ b/examples/discover_customization_examples/public/plugin.tsx
@@ -9,6 +9,7 @@
 
 import type { IconType } from '@elastic/eui';
 import { EuiButton, EuiContextMenu, EuiFlexItem, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import type { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
 import type {
@@ -135,6 +136,10 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
           return (
             <EuiFlexItem grow={false}>
               <EuiPopover
+                aria-label={i18n.translate(
+                  'discoverCustomizationExamples.logsViewSelectorAriaLabel',
+                  { defaultMessage: 'Logs view selector' }
+                )}
                 button={
                   <EuiButton
                     iconType="arrowDown"

--- a/examples/discover_customization_examples/tsconfig.json
+++ b/examples/discover_customization_examples/tsconfig.json
@@ -15,6 +15,7 @@
     "@kbn/data-plugin",
     "@kbn/saved-search-plugin",
     "@kbn/content-management-utils",
+    "@kbn/i18n",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/badge.tsx
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/badge.tsx
@@ -30,6 +30,9 @@ export const SearchResponseWarningsBadge = (props: Props) => {
   return (
     <EuiPopover
       panelPaddingSize="none"
+      aria-label={i18n.translate('searchResponseWarnings.badgePopoverAriaLabel', {
+        defaultMessage: 'Search response warnings',
+      })}
       button={
         <EuiButton
           minWidth={0}

--- a/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/view_details_popover.tsx
+++ b/src/platform/packages/shared/kbn-search-response-warnings/src/components/search_response_warnings/view_details_popover.tsx
@@ -10,6 +10,7 @@
 import React, { useState } from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiButton, EuiIcon, EuiLink, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { viewDetailsLabel } from './i18n_utils';
 import type { SearchResponseWarning } from '../../types';
 
@@ -70,6 +71,9 @@ export const ViewDetailsPopover = (props: Props) => {
   return (
     <EuiPopover
       id="ViewDetailsPopover"
+      aria-label={i18n.translate('searchResponseWarnings.viewDetailsPopoverAriaLabel', {
+        defaultMessage: 'View details',
+      })}
       button={
         props.displayAsLink ? (
           <EuiLink

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -178,6 +178,9 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
   return (
     <EuiPopover
       id="unifiedFieldTypeFilter"
+      aria-label={i18n.translate('unifiedFieldList.fieldTypeFilter.popoverAriaLabel', {
+        defaultMessage: 'Field type filter',
+      })}
       panelProps={{ css: { width: euiTheme.base * 18 } }}
       panelPaddingSize="none"
       anchorPosition="rightUp"

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_menu/tab_menu.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_menu/tab_menu.tsx
@@ -88,6 +88,7 @@ export const TabMenu: React.FC<TabMenuProps> = ({
   return (
     <EuiPopover
       id={contextMenuPopoverId}
+      aria-label={menuButtonLabel}
       isOpen={isPopoverOpen}
       panelPaddingSize="none"
       hasArrow={false}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar_menu/tabs_bar_menu.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar_menu/tabs_bar_menu.tsx
@@ -128,6 +128,7 @@ export const TabsBarMenu: React.FC<TabsBarMenuProps> = React.memo(
       <EuiPopover
         data-test-subj="unifiedTabs_tabsBarMenu"
         id={contextMenuPopoverId}
+        aria-label={menuButtonLabel}
         isOpen={isPopoverOpen}
         closePopover={closePopover}
         panelPaddingSize="none"

--- a/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_docs_popover.tsx
+++ b/src/platform/plugins/shared/data_view_editor/public/components/form_fields/title_docs_popover.tsx
@@ -41,6 +41,9 @@ export const TitleDocsPopover: React.FC = () => {
       display="inlineBlock"
       panelPaddingSize="none"
       anchorPosition="upRight"
+      aria-label={i18n.translate('indexPatternEditor.titleDocsPopover.ariaLabel', {
+        defaultMessage: 'Index pattern examples',
+      })}
       closePopover={() => setIsOpen(false)}
     >
       <EuiPopoverTitle paddingSize="s">

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/image_preview_modal.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/image_preview_modal.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { EuiModal, EuiModalBody, type UseEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { useMemoCss } from '@kbn/css-utils/public/use_memo_css';
 
 /**
@@ -35,7 +36,12 @@ export const ImagePreviewModal = ({ imgHTML, closeModal }: Props) => {
   const styles = useMemoCss(componentStyles);
 
   return (
-    <EuiModal onClose={closeModal}>
+    <EuiModal
+      aria-label={i18n.translate('indexPatternFieldEditor.imagePreviewModal.ariaLabel', {
+        defaultMessage: 'Image preview',
+      })}
+      onClose={closeModal}
+    >
       <EuiModalBody>
         <div
           css={styles.previewImageModal}

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/index_header/index_header.tsx
@@ -94,6 +94,12 @@ export const IndexHeader: FC<PropsWithChildren<IndexHeaderProps>> = ({
         isOpen={isOpen}
         closePopover={() => setIsOpen(false)}
         panelPaddingSize="none"
+        aria-label={i18n.translate(
+          'indexPatternManagement.editDataView.moreActionsPopoverAriaLabel',
+          {
+            defaultMessage: 'More actions',
+          }
+        )}
         button={
           <EuiButtonIcon
             iconType="boxesVertical"

--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/tabs/tabs.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/tabs/tabs.tsx
@@ -315,6 +315,7 @@ export const Tabs: React.FC<TabsProps> = ({
                   <EuiPopover
                     anchorPosition="downCenter"
                     data-test-subj="indexedFieldTypeFilterDropdown-popover"
+                    aria-label={filterAriaLabel}
                     button={
                       <EuiFilterButton
                         aria-label={filterAriaLabel}
@@ -349,6 +350,7 @@ export const Tabs: React.FC<TabsProps> = ({
                   <EuiPopover
                     anchorPosition="downCenter"
                     data-test-subj="schemaFieldTypeFilterDropdown-popover"
+                    aria-label={schemaAriaLabel}
                     button={
                       <EuiFilterButton
                         aria-label={schemaAriaLabel}
@@ -429,6 +431,7 @@ export const Tabs: React.FC<TabsProps> = ({
                 <EuiPopover
                   anchorPosition="downCenter"
                   data-test-subj="scriptedFieldLanguageFilterDropdown-popover"
+                  aria-label={scriptedFieldAriaLabel}
                   button={
                     <EuiFilterButton
                       aria-label={scriptedFieldAriaLabel}

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/__snapshots__/help_flyout.test.tsx.snap
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/__snapshots__/help_flyout.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ScriptingHelpFlyout should render normally 1`] = `
 <EuiFlyout
+  aria-label="Help"
   data-test-subj="scriptedFieldsHelpFlyout"
   onClose={[Function]}
 >
@@ -43,6 +44,7 @@ exports[`ScriptingHelpFlyout should render normally 1`] = `
 
 exports[`ScriptingHelpFlyout should render nothing if not visible 1`] = `
 <EuiFlyout
+  aria-label="Help"
   data-test-subj="scriptedFieldsHelpFlyout"
   onClose={[Function]}
 >

--- a/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/help_flyout.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/field_editor/components/scripting_help/help_flyout.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { EuiFlyout, EuiFlyoutBody, EuiTabbedContent } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { ScriptingSyntax } from './scripting_syntax';
@@ -59,7 +60,14 @@ export const ScriptingHelpFlyout: React.FC<ScriptingHelpFlyoutProps> = ({
   ];
 
   return isVisible ? (
-    <EuiFlyout onClose={onClose} data-test-subj="scriptedFieldsHelpFlyout">
+    <EuiFlyout
+      onClose={onClose}
+      data-test-subj="scriptedFieldsHelpFlyout"
+      aria-label={i18n.translate(
+        'indexPatternManagement.fieldEditor.scriptingHelpFlyout.ariaLabel',
+        { defaultMessage: 'Help' }
+      )}
+    >
       <EuiFlyoutBody>
         <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />
       </EuiFlyoutBody>

--- a/src/platform/plugins/shared/discover/public/application/main/components/no_results/no_results_suggestions/syntax_suggestions_popover.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/no_results/no_results_suggestions/syntax_suggestions_popover.tsx
@@ -71,6 +71,7 @@ export const SyntaxSuggestionsPopover: React.FC<SyntaxSuggestionsPopoverProps> =
       isOpen={isOpen}
       display="inlineBlock"
       panelPaddingSize="none"
+      aria-label={title}
       closePopover={() => setIsOpen(false)}
       initialFocus="#querySyntaxBasicTableId"
     >

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/solutions_view_badge.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/solutions_view_badge.tsx
@@ -55,6 +55,7 @@ export const SolutionsViewBadge: FunctionComponent<{ badgeText: string }> = ({ b
   return (
     <EuiThemeProvider colorMode={theme.darkMode ? 'dark' : 'light'}>
       <EuiPopover
+        aria-label={badgeText}
         button={
           <EuiBadge
             color="hollow"

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout_actions.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout_actions.tsx
@@ -199,6 +199,9 @@ function FlyoutActionsPopover({
   return (
     <EuiPopover
       id="docViewerMoreFlyoutActions"
+      aria-label={i18n.translate('discover.grid.tableRow.moreFlyoutActionsPopoverAriaLabel', {
+        defaultMessage: 'More actions',
+      })}
       button={button}
       isOpen={isOpen}
       closePopover={closePopover}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/hover_popover_action.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/hover_popover_action.tsx
@@ -107,6 +107,10 @@ export const HoverActionPopover = ({
         panelPaddingSize="s"
         panelStyle={{ minWidth: '24px' }}
         display={display}
+        aria-label={i18n.translate(
+          'unifiedDocViewer.observability.traces.details.hoverPopover.ariaLabel',
+          { defaultMessage: 'Field value details' }
+        )}
       >
         {(title as string) && (
           <EuiPopoverTitle


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files (#259315)](https://github.com/elastic/kibana/pull/259315)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-25T11:57:27Z","message":"Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files (#259315)\n\nCloses: https://github.com/elastic/kibana/issues/259304\n\n20 `EuiPopover`, `EuiModal`, `EuiFlyout`, and `EuiWrappingPopover`\ncomponents were missing required `aria-label` props across 18 files\nowned by `@elastic/kibana-data-discovery`, violating WCAG 2.2 AA\naccessibility requirements.\n\n## Changes\n\n- **Added `aria-label` to 16 `EuiPopover` components** across\n`discover`, `data_view_management`, `kbn-unified-tabs`,\n`kbn-unified-field-list`, `kbn-search-response-warnings`, and\n`data_view_editor`\n- **Added `aria-label` to 1 `EuiModal`** (`image_preview_modal.tsx`)\n- **Added `aria-label` to 1 `EuiFlyout`** (`help_flyout.tsx`)\n- **Added `aria-label` to 1 `EuiWrappingPopover`**\n(`use_row_header_components.tsx`)\n- **Reused existing translated strings** where available (e.g.\n`menuButtonLabel`, `filterAriaLabel`, `badgeText`) to avoid duplicate\ncopy; added new `i18n.translate()` calls only where no suitable string\nexisted\n- **Added `i18n` imports** to the handful of files that were missing\nthem\n\nExample of the pattern applied:\n\n```tsx\n// Before\n<EuiPopover\n  id={contextMenuPopoverId}\n  isOpen={isPopoverOpen}\n  ...\n>\n\n// After — reusing an already-translated nearby string\n<EuiPopover\n  id={contextMenuPopoverId}\n  aria-label={menuButtonLabel}\n  isOpen={isPopoverOpen}\n  ...\n>\n```\n\n`use_table_header_components.tsx` was listed in the issue but was\nalready compliant; no change needed there.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Julia Rechkunova <julia.rechkunova@elastic.co>","sha":"e9d79de71a27d08e9e9f05529415bd9442f5b515","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","v9.3.3","v9.2.8","a11y:agent-pr"],"title":"Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files","number":259315,"url":"https://github.com/elastic/kibana/pull/259315","mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files (#259315)\n\nCloses: https://github.com/elastic/kibana/issues/259304\n\n20 `EuiPopover`, `EuiModal`, `EuiFlyout`, and `EuiWrappingPopover`\ncomponents were missing required `aria-label` props across 18 files\nowned by `@elastic/kibana-data-discovery`, violating WCAG 2.2 AA\naccessibility requirements.\n\n## Changes\n\n- **Added `aria-label` to 16 `EuiPopover` components** across\n`discover`, `data_view_management`, `kbn-unified-tabs`,\n`kbn-unified-field-list`, `kbn-search-response-warnings`, and\n`data_view_editor`\n- **Added `aria-label` to 1 `EuiModal`** (`image_preview_modal.tsx`)\n- **Added `aria-label` to 1 `EuiFlyout`** (`help_flyout.tsx`)\n- **Added `aria-label` to 1 `EuiWrappingPopover`**\n(`use_row_header_components.tsx`)\n- **Reused existing translated strings** where available (e.g.\n`menuButtonLabel`, `filterAriaLabel`, `badgeText`) to avoid duplicate\ncopy; added new `i18n.translate()` calls only where no suitable string\nexisted\n- **Added `i18n` imports** to the handful of files that were missing\nthem\n\nExample of the pattern applied:\n\n```tsx\n// Before\n<EuiPopover\n  id={contextMenuPopoverId}\n  isOpen={isPopoverOpen}\n  ...\n>\n\n// After — reusing an already-translated nearby string\n<EuiPopover\n  id={contextMenuPopoverId}\n  aria-label={menuButtonLabel}\n  isOpen={isPopoverOpen}\n  ...\n>\n```\n\n`use_table_header_components.tsx` was listed in the issue but was\nalready compliant; no change needed there.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Julia Rechkunova <julia.rechkunova@elastic.co>","sha":"e9d79de71a27d08e9e9f05529415bd9442f5b515"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259315","number":259315,"mergeCommit":{"message":"Fix `@elastic/eui/require-aria-label-for-modals` violations across kibana-data-discovery files (#259315)\n\nCloses: https://github.com/elastic/kibana/issues/259304\n\n20 `EuiPopover`, `EuiModal`, `EuiFlyout`, and `EuiWrappingPopover`\ncomponents were missing required `aria-label` props across 18 files\nowned by `@elastic/kibana-data-discovery`, violating WCAG 2.2 AA\naccessibility requirements.\n\n## Changes\n\n- **Added `aria-label` to 16 `EuiPopover` components** across\n`discover`, `data_view_management`, `kbn-unified-tabs`,\n`kbn-unified-field-list`, `kbn-search-response-warnings`, and\n`data_view_editor`\n- **Added `aria-label` to 1 `EuiModal`** (`image_preview_modal.tsx`)\n- **Added `aria-label` to 1 `EuiFlyout`** (`help_flyout.tsx`)\n- **Added `aria-label` to 1 `EuiWrappingPopover`**\n(`use_row_header_components.tsx`)\n- **Reused existing translated strings** where available (e.g.\n`menuButtonLabel`, `filterAriaLabel`, `badgeText`) to avoid duplicate\ncopy; added new `i18n.translate()` calls only where no suitable string\nexisted\n- **Added `i18n` imports** to the handful of files that were missing\nthem\n\nExample of the pattern applied:\n\n```tsx\n// Before\n<EuiPopover\n  id={contextMenuPopoverId}\n  isOpen={isPopoverOpen}\n  ...\n>\n\n// After — reusing an already-translated nearby string\n<EuiPopover\n  id={contextMenuPopoverId}\n  aria-label={menuButtonLabel}\n  isOpen={isPopoverOpen}\n  ...\n>\n```\n\n`use_table_header_components.tsx` was listed in the issue but was\nalready compliant; no change needed there.\n\n\n---\n\n💬 Send tasks to Copilot coding agent from\n[Slack](https://gh.io/cca-slack-docs) and\n[Teams](https://gh.io/cca-teams-docs) to turn conversations into code.\nCopilot posts an update in your thread when it's finished.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: Julia Rechkunova <julia.rechkunova@elastic.co>","sha":"e9d79de71a27d08e9e9f05529415bd9442f5b515"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->