### PR TITLE
[Significant events] Significant events tab and flyout improvements

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/feedback_buttons.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/feedback_buttons.tsx
@@ -7,15 +7,30 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiFlexGroup, EuiFlexItem, EuiButtonIcon } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 
 export function FeedbackButtons() {
   const [hasReacted, setHasReacted] = React.useState(false);
 
-  if (hasReacted) return null;
+  if (hasReacted) {
+    return (
+      <EuiText size="s" color="subdued">
+        {i18n.translate('xpack.streams.significantEventsSummary.thankYouLabel', {
+          defaultMessage: 'Thank you!',
+        })}
+      </EuiText>
+    );
+  }
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiText size="s" color="subdued">
+          {i18n.translate('xpack.streams.significantEventsSummary.shareYourFeedbackLabel', {
+            defaultMessage: 'Share your feedback:',
+          })}
+        </EuiText>
+      </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiButtonIcon
           iconType="thumbUp"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/insight_flyout.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/insight_flyout.tsx
@@ -14,9 +14,10 @@ import {
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
+  EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiHealth,
   EuiHorizontalRule,
-  EuiPanel,
   EuiText,
   EuiTitle,
   useGeneratedHtmlId,
@@ -25,6 +26,8 @@ import { i18n } from '@kbn/i18n';
 import type { Insight } from '@kbn/streams-schema';
 import { InfoPanel } from '../../../../info_panel';
 import { impactBadgeColors, impactLabels } from './insight_constants';
+import { FeedbackButtons } from './feedback_buttons';
+import { formatGeneratedAt } from './utils';
 
 interface InsightFlyoutProps {
   insight: Insight;
@@ -33,6 +36,29 @@ interface InsightFlyoutProps {
 
 export const InsightFlyout = ({ insight, onClose }: InsightFlyoutProps) => {
   const flyoutTitleId = useGeneratedHtmlId({ prefix: 'insightFlyoutTitle' });
+
+  const detailItems = [
+    {
+      title: i18n.translate('xpack.streams.insightFlyout.impactLabel', {
+        defaultMessage: 'Severity',
+      }),
+      description: (
+        <EuiBadge color={impactBadgeColors[insight.impact]}>
+          {impactLabels[insight.impact]}
+        </EuiBadge>
+      ),
+    },
+    {
+      title: i18n.translate('xpack.streams.insightFlyout.discoveredAtLabel', {
+        defaultMessage: 'Discovered at',
+      }),
+      description: (
+        <EuiText size="s" color="subdued">
+          {formatGeneratedAt(insight.generated_at)}
+        </EuiText>
+      ),
+    },
+  ];
 
   return (
     <EuiFlyout
@@ -72,37 +98,27 @@ export const InsightFlyout = ({ insight, onClose }: InsightFlyoutProps) => {
                 defaultMessage: 'Significant event details',
               })}
             >
-              <EuiDescriptionList
-                type="column"
-                columnWidths={[1, 2]}
-                compressed
-                listItems={[
-                  {
-                    title: i18n.translate('xpack.streams.insightFlyout.impactLabel', {
-                      defaultMessage: 'Severity',
-                    }),
-                    description: (
-                      <EuiBadge color={impactBadgeColors[insight.impact]}>
-                        {impactLabels[insight.impact]}
-                      </EuiBadge>
-                    ),
-                  },
-                ]}
-              />
-              <EuiHorizontalRule margin="m" />
-              <EuiDescriptionList
-                type="column"
-                columnWidths={[1, 2]}
-                compressed
-                listItems={[
-                  {
-                    title: i18n.translate('xpack.streams.insightFlyout.summaryLabel', {
-                      defaultMessage: 'Summary',
-                    }),
-                    description: <EuiText size="s">{insight.description}</EuiText>,
-                  },
-                ]}
-              />
+              {detailItems.map((item, index) => (
+                <React.Fragment key={item.title}>
+                  <EuiDescriptionList
+                    type="column"
+                    columnWidths={[1, 2]}
+                    compressed
+                    listItems={[item]}
+                  />
+                  {index < detailItems.length - 1 && <EuiHorizontalRule margin="m" />}
+                </React.Fragment>
+              ))}
+            </InfoPanel>
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <InfoPanel
+              title={i18n.translate('xpack.streams.insightFlyout.summaryTitle', {
+                defaultMessage: 'Summary',
+              })}
+            >
+              <EuiText size="s">{insight.description}</EuiText>
             </InfoPanel>
           </EuiFlexItem>
 
@@ -113,16 +129,16 @@ export const InsightFlyout = ({ insight, onClose }: InsightFlyoutProps) => {
                   defaultMessage: 'Evidence',
                 })}
               >
-                <EuiFlexGroup direction="column" gutterSize="xs">
-                  {insight.evidence.map((ev, idx) => (
-                    <EuiFlexItem key={idx}>
-                      <EuiPanel color="subdued" paddingSize="s" hasShadow={false}>
-                        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                {insight.evidence.map((ev, idx) => (
+                  <React.Fragment key={idx}>
+                    <EuiFlexGroup gutterSize="s" alignItems="flexStart" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        <EuiHealth color="subdued" />
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
                           <EuiFlexItem grow={false}>
-                            <EuiBadge color="hollow">{ev.stream_name}</EuiBadge>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <EuiText size="xs">
+                            <EuiText size="s">
                               {i18n.translate('xpack.streams.insightFlyout.evidenceDescription', {
                                 defaultMessage: '{queryTitle} ({eventCount} events)',
                                 values: {
@@ -132,11 +148,15 @@ export const InsightFlyout = ({ insight, onClose }: InsightFlyoutProps) => {
                               })}
                             </EuiText>
                           </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiBadge color="hollow">{ev.stream_name}</EuiBadge>
+                          </EuiFlexItem>
                         </EuiFlexGroup>
-                      </EuiPanel>
-                    </EuiFlexItem>
-                  ))}
-                </EuiFlexGroup>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                    {idx < insight.evidence.length - 1 && <EuiHorizontalRule margin="m" />}
+                  </React.Fragment>
+                ))}
               </InfoPanel>
             </EuiFlexItem>
           )}
@@ -160,6 +180,10 @@ export const InsightFlyout = ({ insight, onClose }: InsightFlyoutProps) => {
           )}
         </EuiFlexGroup>
       </EuiFlyoutBody>
+
+      <EuiFlyoutFooter>
+        <FeedbackButtons />
+      </EuiFlyoutFooter>
     </EuiFlyout>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
@@ -21,7 +21,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
 import { TaskStatus } from '@kbn/streams-schema';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
@@ -31,9 +30,9 @@ import { useInsightsDiscoveryApi } from '../../../../../hooks/sig_events/use_ins
 import { useKibana } from '../../../../../hooks/use_kibana';
 import { useTaskPolling } from '../../../../../hooks/use_task_polling';
 import { getFormattedError } from '../../../../../util/errors';
-import { FeedbackButtons } from './feedback_buttons';
 import { impactBadgeColors, impactLabels } from './insight_constants';
 import { InsightFlyout } from './insight_flyout';
+import { formatGeneratedAt } from './utils';
 
 export function Summary({ count }: { count: number }) {
   const {
@@ -211,10 +210,10 @@ export function Summary({ count }: { count: number }) {
         name: i18n.translate('xpack.streams.insights.table.generatedAtColumn', {
           defaultMessage: 'Discovered',
         }),
-        width: '150px',
+        width: '180px',
         render: (generatedAt: string) => (
           <EuiText size="s" color="subdued">
-            {moment(generatedAt).fromNow()}
+            {formatGeneratedAt(generatedAt)}
           </EuiText>
         ),
       },
@@ -227,15 +226,7 @@ export function Summary({ count }: { count: number }) {
       <>
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              justifyContent="flexEnd"
-              alignItems="center"
-              gutterSize="s"
-              responsive={false}
-            >
-              <EuiFlexItem grow={false}>
-                <FeedbackButtons />
-              </EuiFlexItem>
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiButton
                   size="s"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/utils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function formatGeneratedAt(isoString: string): string {
+  const date = new Date(isoString);
+  const formattedDate = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const formattedTime = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  return `${formattedDate}, ${formattedTime}`;
+}


### PR DESCRIPTION
## Summary

Small PR with few visual and structural adjustments of the significant events tab and flyout. This make sure we are moving in the right design direction. List of improvements:

- "Discovered" column in the table now shows a full timestamp instead of relative time ("a day ago")
- Added "Discovered at" field and moved "Summary" into its own panel in the flyout
- Aligned flyout panels (details, evidence) visually with the Query and Knowledge Indicator flyouts
- Moved feedback buttons from the table toolbar into the flyout footer, scoped to the individual insight; added a label and "Thank you!" confirmation on click

<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/0c3c5856-0094-485b-94d6-86d22fc681e8" />


