### PR TITLE
fix: Lens gauge default palette and band colors editor

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/dimension_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/dimension_editor.test.tsx
@@ -97,6 +97,21 @@ describe('GaugeDimensionEditor', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('shows band colors on when colorMode and palette are omitted (implicit defaults)', () => {
+    const implicitState: GaugeVisualizationState = {
+      layerId: 'first',
+      layerType: LayerTypes.DATA,
+      metricAccessor: 'metric-col-id',
+      ticksPosition: GaugeTicksPositions.AUTO,
+      labelMajorMode: 'auto',
+      shape: 'horizontalBullet',
+    };
+
+    renderGaugeDimensionEditor({ state: implicitState });
+
+    expect(screen.getByTestId('lnsDynamicColoringGaugeSwitch')).toBeChecked();
+  });
+
   it('toggles dynamic coloring when the band colors switch is clicked', async () => {
     const user = userEvent.setup();
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/dimension_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/dimension_editor.tsx
@@ -20,7 +20,7 @@ import { isNumericFieldForDatatable } from '../../../common/expressions/impl/dat
 import { PalettePanelContainer } from '../../shared_components';
 import type { GaugeVisualizationState } from './constants';
 import { defaultPaletteParams } from './palette_config';
-import { getAccessorsFromState } from './utils';
+import { getAccessorsFromState, resolveGaugePaletteForExpression } from './utils';
 
 export function GaugeDimensionEditor(
   props: VisualizationDimensionEditorProps<GaugeVisualizationState> & {
@@ -40,7 +40,10 @@ export function GaugeDimensionEditor(
 
   const accessors = getAccessorsFromState(state);
 
-  const hasDynamicColoring = state?.colorMode === 'palette';
+  const { colorMode: effectiveColorMode, palette: resolvedPalette } =
+    resolveGaugePaletteForExpression(props.paletteService, state);
+
+  const hasDynamicColoring = effectiveColorMode !== 'none';
 
   const currentMinMax = {
     min: getMinValue(firstRow, accessors),
@@ -48,7 +51,8 @@ export function GaugeDimensionEditor(
   };
 
   const activePalette =
-    state?.palette ||
+    resolvedPalette ??
+    state?.palette ??
     ({
       type: 'palette',
       name: defaultPaletteParams.name,

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/utils.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/utils.ts
@@ -28,3 +28,23 @@ export const getDefaultPalette = (
     stops: applyPaletteParams(paletteService, DEFAULT_PALETTE, { min: 0, max: 100 }),
   },
 });
+
+/**
+ * Aligns persisted state with rendering: when `colorMode` / `palette` are omitted (e.g. API-built
+ * configs), Lens uses the same defaults as `initialize()` and `toExpression`.
+ */
+export const resolveGaugePaletteForExpression = (
+  paletteService: PaletteRegistry,
+  state: GaugeVisualizationState
+): {
+  colorMode: 'palette' | 'none';
+  palette: PaletteOutput<CustomPaletteParams> | undefined;
+} => {
+  if (state.colorMode === 'none') {
+    return { colorMode: 'none', palette: undefined };
+  }
+
+  const palette = state.palette?.params != null ? state.palette : getDefaultPalette(paletteService);
+
+  return { colorMode: 'palette', palette };
+};

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/visualization.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/visualization.test.ts
@@ -131,7 +131,13 @@ describe('gauge', () => {
             groupId: GROUP_ID.METRIC,
             groupLabel: 'Metric',
             isMetricDimension: true,
-            accessors: [{ columnId: 'metric-accessor', triggerIconType: 'none' }],
+            accessors: [
+              {
+                columnId: 'metric-accessor',
+                triggerIconType: 'colorBy',
+                palette: ['blue', 'red', 'yellow', 'green'],
+              },
+            ],
             filterOperations: isNumericDynamicMetric,
             supportsMoreColumns: false,
             requiredMinDimensionCount: 1,
@@ -481,7 +487,21 @@ describe('gauge', () => {
               min: ['min-accessor'],
               max: ['max-accessor'],
               goal: ['goal-accessor'],
-              colorMode: ['none'],
+              colorMode: ['palette'],
+              palette: [
+                {
+                  type: 'expression',
+                  chain: [
+                    {
+                      type: 'function',
+                      function: 'system_palette',
+                      arguments: {
+                        name: ['mocked'],
+                      },
+                    },
+                  ],
+                },
+              ],
               ticksPosition: ['auto'],
               labelMajorMode: ['auto'],
               labelMinor: ['Subtitle'],
@@ -498,6 +518,35 @@ describe('gauge', () => {
         minAccessor: 'min-accessor',
       };
       expect(getGaugeVisualization(deps).toExpression(state, datasourceLayers)).toEqual(null);
+    });
+
+    test('respects explicit colorMode none (no palette)', () => {
+      const state: GaugeVisualizationState = {
+        ...exampleState(),
+        layerId: 'first',
+        metricAccessor: 'metric-accessor',
+        minAccessor: 'min-accessor',
+        maxAccessor: 'max-accessor',
+        colorMode: 'none',
+      };
+      expect(getGaugeVisualization(deps).toExpression(state, datasourceLayers)).toEqual({
+        type: 'expression',
+        chain: [
+          {
+            type: 'function',
+            function: 'gauge',
+            arguments: {
+              metric: ['metric-accessor'],
+              min: ['min-accessor'],
+              max: ['max-accessor'],
+              colorMode: ['none'],
+              ticksPosition: ['auto'],
+              labelMajorMode: ['auto'],
+              shape: ['horizontalBullet'],
+            },
+          },
+        ],
+      });
     });
   });
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/visualization.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/gauge/visualization.tsx
@@ -40,7 +40,11 @@ import type { GaugeVisualizationState } from './constants';
 import { GROUP_ID, LENS_GAUGE_ID } from './constants';
 import { GaugeDimensionEditor } from './dimension_editor';
 import { generateId } from '../../id_generator';
-import { getAccessorsFromState, getDefaultPalette } from './utils';
+import {
+  getAccessorsFromState,
+  getDefaultPalette,
+  resolveGaugePaletteForExpression,
+} from './utils';
 import {
   GAUGE_GOAL_GT_MAX,
   GAUGE_METRIC_GT_MAX,
@@ -142,17 +146,20 @@ const toExpression = (
     return null;
   }
 
+  const { colorMode: resolvedColorMode, palette: resolvedPalette } =
+    resolveGaugePaletteForExpression(paletteService, state);
+
   const gaugeFn = buildExpressionFunction<GaugeExpressionFunctionDefinition>('gauge', {
     metric: state.metricAccessor,
     min: state.minAccessor,
     max: state.maxAccessor,
     goal: state.goalAccessor,
     shape: state.shape ?? GaugeShapes.HORIZONTAL_BULLET,
-    colorMode: state?.colorMode ?? 'none',
-    palette: state.palette?.params
+    colorMode: resolvedColorMode,
+    palette: resolvedPalette
       ? paletteService
           .get(CUSTOM_PALETTE)
-          .toExpression(computePaletteParams(paletteService, state.palette))
+          .toExpression(computePaletteParams(paletteService, resolvedPalette))
       : undefined,
     ticksPosition: state.ticksPosition ?? 'auto',
     labelMinor: state.labelMinor,
@@ -672,7 +679,12 @@ function getConfigurationAccessorsAndPalette(
   paletteService: PaletteRegistry,
   activeData?: FramePublicAPI['activeData']
 ) {
-  const hasColoring = Boolean(state.colorMode !== 'none' && state.palette?.params?.stops);
+  const { colorMode: effectiveColorMode, palette: effectivePalette } =
+    resolveGaugePaletteForExpression(paletteService, state);
+
+  const hasColoring = Boolean(
+    effectiveColorMode !== 'none' && effectivePalette != null && effectivePalette.params?.stops
+  );
 
   const row = getActiveDataForLayer(state?.layerId, activeData)?.rows?.[0];
   const { metricAccessor } = state ?? {};
@@ -680,12 +692,12 @@ function getConfigurationAccessorsAndPalette(
   const accessors = getAccessorsFromState(state);
 
   let palette;
-  if (row != null && metricAccessor != null && state?.palette != null && hasColoring) {
+  if (row != null && metricAccessor != null && effectivePalette != null && hasColoring) {
     const currentMinMax = {
       min: getMinValue(row, accessors),
       max: getMaxValue(row, accessors),
     };
-    const displayStops = applyPaletteParams(paletteService, state?.palette, currentMinMax);
+    const displayStops = applyPaletteParams(paletteService, effectivePalette, currentMinMax);
     palette = displayStops.map(({ color }) => color);
   }
   return { metricAccessor, accessors, palette };


### PR DESCRIPTION
Apply the same implicit color defaults as gauge initialize() when colorMode/palette are omitted (e.g. API-built configs): resolve palette in toExpression, getConfiguration, and GaugeDimensionEditor via shared resolveGaugePaletteForExpression.

Band colors switch and metric dimension colorBy now reflect implicit defaults.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



