### PR TITLE
Preserve inline ES|QL editor height across flyout remounts

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { EuiFlyout, EuiLoadingSpinner, EuiOverlayMask } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Provider } from 'react-redux';
@@ -182,6 +182,11 @@ const EditLensConfiguration: FC<
 }) => {
   const [currentAttributes, setCurrentAttributes] =
     useState<TypedLensSerializedState['attributes']>(attributes);
+  /**
+   * The query rerun already forces a parent rerender via `setCurrentAttributes`, so keeping the
+   * last editor height in a ref is enough to restore it on the next mount without adding resize-time rerenders.
+   */
+  const esqlEditorHeightRef = useRef<number>();
 
   /**
    * During inline editing of a by reference panel, the panel is converted to a by value one.
@@ -273,6 +278,7 @@ const EditLensConfiguration: FC<
     panelId,
     applyButtonLabel,
     hideTextBasedEditor,
+    esqlEditorHeightRef,
   };
 
   return (

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
@@ -33,6 +33,7 @@ export function LayerConfiguration({
   panelId,
   closeFlyout,
   editorContainer,
+  esqlEditorHeightRef,
   onTextBasedQueryStateChange,
 }: LayerConfigurationProps) {
   // Derive whether we're in text-based mode from the query type
@@ -76,6 +77,7 @@ export function LayerConfiguration({
     panelId,
     closeFlyout,
     editorContainer,
+    esqlEditorHeightRef,
     onTextBasedQueryStateChange,
   };
   return (

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -77,6 +77,7 @@ export function LensEditConfigurationFlyout({
   parentApi,
   panelId,
   applyButtonLabel,
+  esqlEditorHeightRef,
 }: EditConfigPanelProps) {
   const euiTheme = useEuiTheme();
   const previousAttributes = useRef<TypedLensSerializedState['attributes']>(attributes);
@@ -487,6 +488,7 @@ export function LensEditConfigurationFlyout({
             closeFlyout={closeFlyout}
             parentApi={parentApi}
             panelId={panelId}
+            esqlEditorHeightRef={esqlEditorHeightRef}
             onTextBasedQueryStateChange={onTextBasedQueryStateChange}
           />
         </FlyoutWrapper>
@@ -633,6 +635,7 @@ export function LensEditConfigurationFlyout({
                     parentApi={parentApi}
                     panelId={panelId}
                     editorContainer={editorContainer.current || undefined}
+                    esqlEditorHeightRef={esqlEditorHeightRef}
                     onTextBasedQueryStateChange={onTextBasedQueryStateChange}
                   />
                 </>

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
@@ -6,6 +6,7 @@
  */
 import type { CoreStart } from '@kbn/core/public';
 import type { PublishingSubject } from '@kbn/presentation-publishing';
+import type { MutableRefObject } from 'react';
 import type {
   TypedLensSerializedState,
   FramePublicAPI,
@@ -78,6 +79,8 @@ export interface EditConfigPanelProps {
   displayFlyoutHeader?: boolean;
   /** If true, hides the ES|QL editor in the flyout */
   hideTextBasedEditor?: boolean;
+  /** Persisted height for the inline ES|QL editor UI */
+  esqlEditorHeightRef?: MutableRefObject<number | undefined>;
   /** The flyout is used for adding a new panel by scratch */
   isNewPanel?: boolean;
   /** If set to true the layout changes to accordion and the text based query (i.e. ES|QL) can be edited */
@@ -117,6 +120,7 @@ export interface LayerConfigurationProps {
   panelId?: string;
   closeFlyout?: () => void;
   editorContainer?: HTMLElement;
+  esqlEditorHeightRef?: MutableRefObject<number | undefined>;
   /** Callback to report text-based query state changes */
   onTextBasedQueryStateChange?: (state: TextBasedQueryState) => void;
 }

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
@@ -58,6 +58,7 @@ export type ESQLEditorProps = Simplify<
     | 'updateSuggestion'
     | 'dataLoading$'
     | 'parentApi'
+    | 'esqlEditorHeightRef'
     | 'onTextBasedQueryStateChange'
   >
 >;
@@ -86,6 +87,7 @@ export function ESQLEditor({
   setCurrentAttributes,
   updateSuggestion,
   onTextBasedQueryStateChange,
+  esqlEditorHeightRef,
 }: ESQLEditorProps) {
   const prevQuery = useRef<AggregateQuery | Query>(attributes?.state.query || { esql: '' });
   const [query, setQuery] = useState<AggregateQuery | Query>(
@@ -129,6 +131,20 @@ export function ESQLEditor({
   const esqlQueryStats = useESQLQueryStats(isTextBasedLanguage, lensAdapters?.requests);
 
   const dispatch = useLensDispatch();
+
+  const handleEditorInitialStateChange = useCallback(
+    (nextState: { editorHeight?: number }) => {
+      const { editorHeight } = nextState;
+      if (editorHeight === undefined) {
+        return;
+      }
+
+      if (esqlEditorHeightRef) {
+        esqlEditorHeightRef.current = editorHeight;
+      }
+    },
+    [esqlEditorHeightRef]
+  );
 
   useEffect(() => {
     const s = dataLoading$?.subscribe((isDataLoading) => {
@@ -237,6 +253,12 @@ export function ESQLEditor({
         panelId={panelId}
         attributes={attributes}
         parentApi={parentApi}
+        editorInitialState={
+          esqlEditorHeightRef?.current === undefined
+            ? undefined
+            : { editorHeight: esqlEditorHeightRef.current }
+        }
+        onEditorInitialStateChange={handleEditorInitialStateChange}
       />
       {dataGridAttrs ? (
         <ESQLDataGridAccordion
@@ -281,6 +303,8 @@ type InnerEditorProps = Simplify<
     adHocDataViews: DataViewSpec[];
     esqlVariables: ESQLControlVariable[] | undefined;
     queryStats?: ESQLQueryStats;
+    editorInitialState?: { editorHeight?: number };
+    onEditorInitialStateChange: (nextState: { editorHeight?: number }) => void;
   } & Pick<LayerPanelProps, 'attributes' | 'parentApi' | 'panelId' | 'closeFlyout'>
 >;
 
@@ -293,6 +317,8 @@ function InnerESQLEditor({
   parentApi,
   panelId,
   closeFlyout,
+  editorInitialState,
+  onEditorInitialStateChange,
   setQuery,
   isVisualizationLoading,
   setIsVisualizationLoading,
@@ -329,6 +355,8 @@ function InnerESQLEditor({
               : undefined
           }
           editorIsInline
+          initialState={editorInitialState}
+          onInitialStateChange={onEditorInitialStateChange}
           onTextLangQuerySubmit={async (q, a) => {
             // do not run the suggestions if the query is the same as the previous one
             if (q && !isEqual(q, prevQuery.current)) {

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
@@ -10,6 +10,7 @@ import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import type { PublishingSubject } from '@kbn/presentation-publishing';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { MutableRefObject } from 'react';
 import type {
   TypedLensSerializedState,
   Visualization,
@@ -52,6 +53,7 @@ export interface LensConfigPanelBaseProps {
   panelId?: string;
   closeFlyout?: () => void;
   editorContainer?: HTMLElement;
+  esqlEditorHeightRef?: MutableRefObject<number | undefined>;
   /** Callback to report text-based query state changes */
   onTextBasedQueryStateChange?: (state: TextBasedQueryState) => void;
 }


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/171830

At the moment I'm holding off on bugfixes, before venturing into things that may not be needed. (see note section)

When the user resizes the ES|QL editor and then reruns the query, the flyout rerenders and remounts the editor subtree. Before this change, the editor would come back with its default inline height. 

- keep the latest ES|QL editor height in `EditLensConfiguration`
- pass it through the flyout/config panel path
- restore (across remount) it through `ESQLLangEditor ` `initialState`

**Why ref**
We use a ref instead of React state because editor resize is a hot path.
The ES|QL editor updates `editorHeight `during resize. If we lifted that value into React state in Lens, we would trigger extra flyout rerenders while dragging, which causes visible lag. A ref lets us retain the latest height without rerendering the Lens flyout on resize updates.
**This is sufficient in the current flow because rerunning the query already triggers a parent rerender via `setCurrentAttributes`.** 
On the next mount, the editor reads the latest height from that ref through `initialState`.


**Note:** 
A broader consideration  is that inline Lens editing recreates the flyout store during the rerun flow. Fixing that properly means changing the flyout/store lifecycle and separating structural reinitialization from normal ES|QL reruns.
That is a larger architectural change with broader behavioral risk 