### PR TITLE
[9.3] fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files (#259313)

### DIFF
--- a/examples/files_example/public/components/app.tsx
+++ b/examples/files_example/public/components/app.tsx
@@ -89,7 +89,7 @@ export const FilesExampleApp = ({ files, notifications }: FilesExampleAppDeps) =
         ) : status === 'AWAITING_UPLOAD' ? (
           <EuiIcon type="clock" aria-label={status} />
         ) : (
-          <EuiIcon color="danger" type="warning" arial-label={status} />
+          <EuiIcon color="danger" type="warning" aria-label={status} />
         ),
     },
     {

--- a/src/core/packages/chrome/browser-internal/src/ui/header/__snapshots__/header.test.tsx.snap
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/__snapshots__/header.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`Header renders 1`] = `
                   class="euiHeaderSectionItemButton__content emotion-euiHeaderSectionItemButton__content"
                 >
                   <span
+                    aria-hidden="true"
                     data-euiicon-type="menu"
                   />
                 </span>

--- a/src/core/packages/chrome/browser-internal/src/ui/header/header_menu_button.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/header_menu_button.tsx
@@ -34,7 +34,7 @@ export const HeaderMenuButton = forwardRef(
         aria-controls={props['aria-controls']}
         ref={props.forwardRef}
       >
-        <EuiIcon type="menu" size="m" />
+        <EuiIcon type="menu" size="m" aria-hidden={true} />
       </EuiHeaderSectionItemButton>
     );
   }

--- a/src/core/packages/chrome/browser-internal/src/ui/header/nav_link.tsx
+++ b/src/core/packages/chrome/browser-internal/src/ui/header/nav_link.tsx
@@ -71,7 +71,9 @@ export function createEuiListItem({
       iconType: euiIconType,
       iconProps,
       icon:
-        !euiIconType && icon ? <EuiIcon type={basePath.prepend(`/${icon}`)} size="m" /> : undefined,
+        !euiIconType && icon ? (
+          <EuiIcon type={basePath.prepend(`/${icon}`)} size="m" aria-hidden={true} />
+        ) : undefined,
     }),
   };
 }

--- a/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
+++ b/src/core/packages/chrome/navigation/src/components/nested_secondary_menu/primary_menu_item.tsx
@@ -69,7 +69,15 @@ export const PrimaryMenuItem: FC<PrimaryMenuItemProps> = ({
         {...props}
       >
         {children}
-        {hasSubmenu && <EuiIcon color="textDisabled" css={arrowStyle} type="arrowRight" size="m" />}
+        {hasSubmenu && (
+          <EuiIcon
+            color="textDisabled"
+            css={arrowStyle}
+            type="arrowRight"
+            size="m"
+            aria-hidden={true}
+          />
+        )}
       </SecondaryMenu.Item>
     </div>
   );

--- a/src/platform/packages/shared/content-management/table_list_view_table/src/components/table_sort_select.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/components/table_sort_select.tsx
@@ -97,13 +97,13 @@ export function TableSortSelect({
         label: i18nText.nameAscSort,
         column: 'attributes.title',
         direction: 'asc',
-        append: <EuiIcon type="sortUp" />,
+        append: <EuiIcon type="sortUp" aria-hidden={true} />,
       },
       {
         label: i18nText.nameDescSort,
         column: 'attributes.title',
         direction: 'desc',
-        append: <EuiIcon type="sortDown" />,
+        append: <EuiIcon type="sortDown" aria-hidden={true} />,
       },
     ];
 
@@ -114,7 +114,12 @@ export function TableSortSelect({
             column: customSortingOptions.field,
             label,
             direction,
-            append: direction === 'asc' ? <EuiIcon type="sortUp" /> : <EuiIcon type="sortDown" />,
+            append:
+              direction === 'asc' ? (
+                <EuiIcon type="sortUp" aria-hidden={true} />
+              ) : (
+                <EuiIcon type="sortDown" aria-hidden={true} />
+              ),
           };
         })
       );
@@ -160,13 +165,13 @@ export function TableSortSelect({
           label: i18nText.updatedAtDescSort,
           column: 'updatedAt',
           direction: 'desc',
-          append: <EuiIcon type="sortDown" />,
+          append: <EuiIcon type="sortDown" aria-hidden={true} />,
         },
         {
           label: i18nText.updatedAtAscSort,
           column: 'updatedAt',
           direction: 'asc',
-          append: <EuiIcon type="sortUp" />,
+          append: <EuiIcon type="sortUp" aria-hidden={true} />,
         },
       ]);
     }

--- a/src/platform/packages/shared/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
+++ b/src/platform/packages/shared/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`SampleDataCard installed renders with app links 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiCard__image emotion-euiCard__image"
+        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
       >
-        <img
-          alt=""
-          src="test-file-stub"
+        <span
+          aria-hidden="true"
+          data-euiicon-type="test-file-stub"
         />
       </div>
     </div>
@@ -76,7 +76,7 @@ exports[`SampleDataCard installed renders with app links 1`] = `
                 class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate euiButtonEmpty__text"
+                  class="eui-textTruncate euiButtonEmpty__text css-13ifi6d-m"
                 >
                   Remove
                 </span>
@@ -100,13 +100,13 @@ exports[`SampleDataCard installed renders with app links 1`] = `
                   class="emotion-euiButtonDisplayContent"
                 >
                   <span
-                    class="eui-textTruncate"
+                    class="eui-textTruncate css-13ifi6d-m"
                   >
                     View data
                   </span>
                   <span
                     color="inherit"
-                    data-euiicon-type="arrowDown"
+                    data-euiicon-type="chevronSingleDown"
                   />
                 </span>
               </button>
@@ -131,11 +131,11 @@ exports[`SampleDataCard installed renders without app links 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiCard__image emotion-euiCard__image"
+        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
       >
-        <img
-          alt=""
-          src="test-file-stub"
+        <span
+          aria-hidden="true"
+          data-euiicon-type="test-file-stub"
         />
       </div>
     </div>
@@ -195,7 +195,7 @@ exports[`SampleDataCard installed renders without app links 1`] = `
                 class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate euiButtonEmpty__text"
+                  class="eui-textTruncate euiButtonEmpty__text css-13ifi6d-m"
                 >
                   Remove
                 </span>
@@ -215,7 +215,7 @@ exports[`SampleDataCard installed renders without app links 1`] = `
                 class="emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate"
+                  class="eui-textTruncate css-13ifi6d-m"
                 >
                   View data
                 </span>
@@ -241,11 +241,11 @@ exports[`SampleDataCard not installed renders 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiCard__image emotion-euiCard__image"
+        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
       >
-        <img
-          alt=""
-          src="test-file-stub"
+        <span
+          aria-hidden="true"
+          data-euiicon-type="test-file-stub"
         />
       </div>
     </div>
@@ -279,14 +279,14 @@ exports[`SampleDataCard not installed renders 1`] = `
         style="display:contents"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexEnd-stretch-row"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-m-flexStart-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button
-              aria-label="Add Sample Data Set"
-              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+              aria-label="Install Sample Data Set"
+              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-text"
               data-test-subj="addSampleDataSetsample-data-set"
               type="button"
             >
@@ -294,9 +294,13 @@ exports[`SampleDataCard not installed renders 1`] = `
                 class="emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate"
+                  color="inherit"
+                  data-euiicon-type="download"
+                />
+                <span
+                  class="eui-textTruncate css-13ifi6d-m"
                 >
-                  Add data
+                  Install data
                 </span>
               </span>
             </button>

--- a/src/platform/packages/shared/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
+++ b/src/platform/packages/shared/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`SampleDataCard installed renders with app links 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
+        class="euiCard__image emotion-euiCard__image"
       >
-        <span
-          aria-hidden="true"
-          data-euiicon-type="test-file-stub"
+        <img
+          alt=""
+          src="test-file-stub"
         />
       </div>
     </div>
@@ -76,7 +76,7 @@ exports[`SampleDataCard installed renders with app links 1`] = `
                 class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate euiButtonEmpty__text css-13ifi6d-m"
+                  class="eui-textTruncate euiButtonEmpty__text"
                 >
                   Remove
                 </span>
@@ -100,13 +100,13 @@ exports[`SampleDataCard installed renders with app links 1`] = `
                   class="emotion-euiButtonDisplayContent"
                 >
                   <span
-                    class="eui-textTruncate css-13ifi6d-m"
+                    class="eui-textTruncate"
                   >
                     View data
                   </span>
                   <span
                     color="inherit"
-                    data-euiicon-type="chevronSingleDown"
+                    data-euiicon-type="arrowDown"
                   />
                 </span>
               </button>
@@ -131,11 +131,11 @@ exports[`SampleDataCard installed renders without app links 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
+        class="euiCard__image emotion-euiCard__image"
       >
-        <span
-          aria-hidden="true"
-          data-euiicon-type="test-file-stub"
+        <img
+          alt=""
+          src="test-file-stub"
         />
       </div>
     </div>
@@ -195,7 +195,7 @@ exports[`SampleDataCard installed renders without app links 1`] = `
                 class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate euiButtonEmpty__text css-13ifi6d-m"
+                  class="eui-textTruncate euiButtonEmpty__text"
                 >
                   Remove
                 </span>
@@ -215,7 +215,7 @@ exports[`SampleDataCard installed renders without app links 1`] = `
                 class="emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate css-13ifi6d-m"
+                  class="eui-textTruncate"
                 >
                   View data
                 </span>
@@ -241,11 +241,11 @@ exports[`SampleDataCard not installed renders 1`] = `
       class="euiCard__top emotion-euiCard__top-vertical"
     >
       <div
-        class="euiFlexGroup euiCard__icon emotion-euiFlexGroup-responsive-m-center-stretch-row-euiCard__icon-vertical"
+        class="euiCard__image emotion-euiCard__image"
       >
-        <span
-          aria-hidden="true"
-          data-euiicon-type="test-file-stub"
+        <img
+          alt=""
+          src="test-file-stub"
         />
       </div>
     </div>
@@ -279,14 +279,14 @@ exports[`SampleDataCard not installed renders 1`] = `
         style="display:contents"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-responsive-m-flexStart-stretch-row"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexEnd-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button
-              aria-label="Install Sample Data Set"
-              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-text"
+              aria-label="Add Sample Data Set"
+              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
               data-test-subj="addSampleDataSetsample-data-set"
               type="button"
             >
@@ -294,13 +294,9 @@ exports[`SampleDataCard not installed renders 1`] = `
                 class="emotion-euiButtonDisplayContent"
               >
                 <span
-                  color="inherit"
-                  data-euiicon-type="download"
-                />
-                <span
-                  class="eui-textTruncate css-13ifi6d-m"
+                  class="eui-textTruncate"
                 >
-                  Install data
+                  Add data
                 </span>
               </span>
             </button>

--- a/src/platform/packages/shared/home/sample_data_card/src/footer/view_button.tsx
+++ b/src/platform/packages/shared/home/sample_data_card/src/footer/view_button.tsx
@@ -77,7 +77,7 @@ export const ViewButton = ({ id, name, overviewDashboard, appLinks }: Props) => 
   const items = sortedItems.map(({ path, label, icon, ...rest }) => {
     return {
       name: label,
-      icon: <EuiIcon type={icon} size="m" />,
+      icon: <EuiIcon type={icon} size="m" aria-hidden={true} />,
       href: addBasePath(path),
       onClick: getAppNavigationHandler(path),
       ...(rest['data-test-subj'] ? { 'data-test-subj': rest['data-test-subj'] } : {}),

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/console_error/console_error_indicator.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/console_error/console_error_indicator.tsx
@@ -146,7 +146,7 @@ export const ConsoleErrorIndicator: React.FC = () => {
               </EuiNotificationBadge>
             </EuiToolTip>
           ) : (
-            <EuiIcon type={iconType} color={iconColor} size="s" />
+            <EuiIcon type={iconType} color={iconColor} size="s" aria-hidden={true} />
           )}
         </EuiFlexItem>
         <EuiFlexItem

--- a/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/memory/memory_usage_indicator.tsx
+++ b/src/platform/packages/shared/kbn-developer-toolbar/src/toolbar_items/memory/memory_usage_indicator.tsx
@@ -60,7 +60,8 @@ export const MemoryUsageIndicator: React.FC = () => {
       <div>Threshold: {(warningThreshold / 1000).toFixed(1)}GB</div>
       {memoryInfo.leak && (
         <div>
-          <EuiIcon type="warningFilled" color={'danger'} size="s" /> Potential memory leak detected
+          <EuiIcon type="warningFilled" color={'danger'} size="s" aria-hidden={true} /> Potential
+          memory leak detected
         </div>
       )}
       <div>Samples: {memoryInfo.history.length}</div>

--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/__snapshots__/exit_full_screen_button.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/__snapshots__/exit_full_screen_button.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`<ExitFullScreenButton /> with kibana services is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <span
+          aria-hidden="true"
           data-euiicon-type="logoElastic"
         />
       </span>
@@ -32,6 +33,7 @@ exports[`<ExitFullScreenButton /> with kibana services is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <span
+          aria-hidden="true"
           data-euiicon-type="fullScreenExit"
         />
       </span>
@@ -79,6 +81,7 @@ exports[`<ExitFullScreenButton /> with kibana services renders custom logo 1`] =
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <span
+          aria-hidden="true"
           data-euiicon-type="fullScreenExit"
         />
       </span>
@@ -106,6 +109,7 @@ exports[`<ExitFullScreenButton /> with manual services is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <span
+          aria-hidden="true"
           data-euiicon-type="logoElastic"
         />
       </span>
@@ -119,6 +123,7 @@ exports[`<ExitFullScreenButton /> with manual services is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <span
+          aria-hidden="true"
           data-euiicon-type="fullScreenExit"
         />
       </span>

--- a/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/exit_full_screen_button.component.tsx
+++ b/src/platform/packages/shared/shared-ux/button/exit_full_screen/src/exit_full_screen_button.component.tsx
@@ -78,14 +78,14 @@ export const ExitFullScreenButton = ({ onClick, className, customLogo }: Props) 
             {customLogo ? (
               <EuiImage src={customLogo} size={16} alt="customLogo" />
             ) : (
-              <EuiIcon type="logoElastic" size="m" />
+              <EuiIcon type="logoElastic" size="m" aria-hidden={true} />
             )}
           </EuiFlexItem>
           <EuiFlexItem component="span" grow={false} data-test-subj="exitFullScreenModeText">
             {text}
           </EuiFlexItem>
           <EuiFlexItem component="span" grow={false}>
-            <EuiIcon type="fullScreenExit" size="s" />
+            <EuiIcon type="fullScreenExit" size="s" aria-hidden={true} />
           </EuiFlexItem>
         </EuiFlexGroup>
       </button>

--- a/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/document_data_cascade/impl/src/__stories__/data_cascade.stories.tsx
@@ -416,7 +416,7 @@ export const CascadeCustomHeaderImplementation: StoryObj<
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="database" size="xl" />
+                <EuiIcon type="database" size="xl" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem grow={true}>
                 <EuiText>
@@ -691,7 +691,7 @@ export const CascadeMultipleStatsPerRow: StoryObj<
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="database" size="xl" />
+                <EuiIcon type="database" size="xl" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem grow={true}>
                 <EuiText>
@@ -789,7 +789,7 @@ export const CascadeMultipleStatsPerRow: StoryObj<
           description={
             <EuiTextColor color="accent">
               <span>
-                <EuiIcon type="clock" color="accent" /> 70,29%
+                <EuiIcon type="clock" color="accent" aria-hidden={true} /> 70,29%
               </span>
             </EuiTextColor>
           }
@@ -799,7 +799,7 @@ export const CascadeMultipleStatsPerRow: StoryObj<
         <EuiStat title="1,554" textAlign="left" titleColor="danger" description="Good news">
           <EuiTextColor color="accent">
             <span>
-              <EuiIcon type="error" color="danger" /> 66,55%
+              <EuiIcon type="error" color="danger" aria-hidden={true} /> 66,55%
             </span>
           </EuiTextColor>
         </EuiStat>,
@@ -810,7 +810,7 @@ export const CascadeMultipleStatsPerRow: StoryObj<
           description={
             <EuiTextColor color="success">
               <span>
-                <EuiIcon type="check" color="success" /> 88,88%
+                <EuiIcon type="check" color="success" aria-hidden={true} /> 88,88%
               </span>
             </EuiTextColor>
           }
@@ -820,7 +820,7 @@ export const CascadeMultipleStatsPerRow: StoryObj<
         <EuiStat title="8,888" description="Great news" textAlign="left">
           <EuiTextColor color="success">
             <span>
-              <EuiIcon type="sortUp" /> 27,83%
+              <EuiIcon type="sortUp" aria-hidden={true} /> 27,83%
             </span>
           </EuiTextColor>
         </EuiStat>,
@@ -1012,7 +1012,7 @@ export const CascadeCustomHeaderWithCustomRowActionsImplementation: StoryObj<
       headerTitle: (
         <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="securitySignal" size="xl" />
+            <EuiIcon type="securitySignal" size="xl" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
             <EuiText>
@@ -1289,7 +1289,7 @@ export const CascadeCustomHeaderWithHiddenRowActions: StoryObj<
       headerTitle: (
         <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiIcon type="securitySignal" size="xl" />
+            <EuiIcon type="securitySignal" size="xl" aria-hidden={true} />
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
             <EuiText>
@@ -1582,7 +1582,7 @@ export const CascadeCustomHeaderWithRowSelectionActionEnabled: StoryObj<
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center" gutterSize="s">
               <EuiFlexItem grow={false}>
-                <EuiIcon type="securitySignal" size="xl" />
+                <EuiIcon type="securitySignal" size="xl" aria-hidden={true} />
               </EuiFlexItem>
               <EuiFlexItem grow={true}>
                 <EuiText>

--- a/src/platform/packages/shared/shared-ux/file/file_picker/impl/src/components/file_card.tsx
+++ b/src/platform/packages/shared/shared-ux/file/file_picker/impl/src/components/file_card.tsx
@@ -60,7 +60,7 @@ export const FileCard: FunctionComponent<Props> = ({ file }) => {
             height: ${imageHeight};
           `}
         >
-          <EuiIcon type="filebeatApp" size="xl" />
+          <EuiIcon type="filebeatApp" size="xl" aria-hidden={true} />
         </div>
       )}
     </div>

--- a/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/actions_section/action_buttons.tsx
+++ b/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/actions_section/action_buttons.tsx
@@ -127,7 +127,7 @@ export const ActionButtons = ({
             href={href}
             css={cardCss}
             layout="vertical"
-            icon={<EuiIcon type={icon} size="xxl" css={iconCss} />}
+            icon={<EuiIcon type={icon} size="xxl" css={iconCss} aria-hidden={true} />}
             title={
               <EuiText color={euiTheme.colors.textPrimary} component="span" css={titleCss}>
                 <FormattedMessage id={i18nId} defaultMessage={label} />

--- a/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/data_section/icon_type.tsx
+++ b/src/platform/plugins/private/inspect_component/public/components/inspect/flyout/data_section/icon_type.tsx
@@ -41,7 +41,7 @@ export const IconType = ({ iconType }: Props) => {
           />
         )}
       </EuiText>
-      {iconType && <EuiIcon type={iconType} size="m" />}
+      {iconType && <EuiIcon type={iconType} size="m" aria-hidden={true} />}
     </EuiFlexGroup>
   );
 };

--- a/src/platform/plugins/shared/home/public/application/components/welcome.tsx
+++ b/src/platform/plugins/shared/home/public/application/components/welcome.tsx
@@ -90,7 +90,7 @@ export const Welcome: React.FC<WelcomeProps> = ({ urlBasePath, onSkip }: Welcome
                 ${euiShadowM}
               `}
             >
-              <EuiIcon type="logoElastic" size="xxl" />
+              <EuiIcon type="logoElastic" size="xxl" aria-hidden={true} />
             </span>
             <EuiTitle size="l">
               <h1>

--- a/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/url_drilldown/components/variable_popover/index.tsx
+++ b/src/platform/plugins/shared/ui_actions_enhanced/public/drilldowns/url_drilldown/components/variable_popover/index.tsx
@@ -46,7 +46,7 @@ export const VariablePopover: React.FC<Props> = ({ variables, onSelect, variable
       button={
         <EuiText size="xs">
           <EuiLink onClick={() => setIsVariablesPopoverOpen(true)}>
-            {txtAddVariableButtonTitle} <EuiIcon type="indexOpen" />
+            {txtAddVariableButtonTitle} <EuiIcon type="indexOpen" aria-hidden={true} />
           </EuiLink>
         </EuiText>
       }

--- a/x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action/connector_selectable_footer.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant/ai-assistant-connector-selector-action/connector_selectable_footer.tsx
@@ -40,7 +40,7 @@ export const ConnectorSelectableFooter: React.FC<ConnectorSelectableFooterProps>
               aria-label={i8n.addConnectorAriaLabel}
               data-test-subj="aiAssistantAddConnectorButton"
             >
-              <EuiIcon type="plus" />
+              <EuiIcon type="plus" aria-hidden={true} />
               {i8n.addConnectorLabel}
             </EuiButton>
           </EuiFlexItem>

--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
@@ -349,7 +349,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
           setIsVisible(true);
         }}
       >
-        <EuiIcon type="search" size="m" />
+        <EuiIcon type="search" size="m" aria-hidden={true} />
       </EuiHeaderSectionItemButton>
     );
   }
@@ -433,7 +433,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
       }}
       popoverButton={
         <EuiHeaderSectionItemButton aria-label={i18nStrings.popoverButton}>
-          <EuiIcon type="search" size="m" />
+          <EuiIcon type="search" size="m" aria-hidden={true} />
         </EuiHeaderSectionItemButton>
       }
       popoverFooter={<PopoverFooter isMac={isMac} />}

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/assign_flyout/components/result_list.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/assign_flyout/components/result_list.tsx
@@ -56,6 +56,7 @@ export const AssignFlyoutResultList: FC<AssignFlyoutResultListProps> = ({
             className={`tagAssignFlyout__selectionIcon status-${overriddenStatus}`}
             type={statusIcon}
             data-test-subj="assign-result-status"
+            aria-hidden={true}
           />
           <EuiIcon type={result.icon ?? 'empty'} title={result.type} />
         </>

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/base/tag_selector.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/components/base/tag_selector.tsx
@@ -67,7 +67,7 @@ const renderCreateOption = () => {
       )}
     >
       <EuiFlexItem grow={false}>
-        <EuiIcon type="tag" />
+        <EuiIcon type="tag" aria-hidden={true} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <span>

--- a/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/action_bar.tsx
+++ b/x-pack/platform/plugins/shared/saved_objects_tagging/public/management/components/action_bar.tsx
@@ -103,7 +103,12 @@ export const ActionBar: FC<ActionBarProps> = ({
                           count: selectedCount,
                         }}
                       />
-                      <EuiIcon className="tagMgt__actionBarIcon" type="arrowDown" size="s" />
+                      <EuiIcon
+                        className="tagMgt__actionBarIcon"
+                        type="arrowDown"
+                        size="s"
+                        aria-hidden={true}
+                      />
                     </EuiLink>
                   </EuiText>
                 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files (#259313)](https://github.com/elastic/kibana/pull/259313)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-26T11:38:39Z","message":"fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files (#259313)\n\nCloses: https://github.com/elastic/kibana/issues/259306\n\nFixes 37 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 22 files — each `EuiIcon` must have a `title`, `aria-label`,\n`aria-labelledby`, or `aria-hidden={true}` if decorative.\n\n## Changes\n\n- **Typo fix** — `examples/files_example/public/components/app.tsx`:\ncorrected `arial-label` → `aria-label` on a warning status icon\n- **Decorative icons** — all other 36 instances: added\n`aria-hidden={true}` to icons that are purely decorative (inside\nlabelled buttons, alongside visible text, or as visual affordances where\nthe parent already conveys the meaning)\n\n### Example pattern applied\n\n```tsx\n// Before — no accessibility attribute\n<EuiIcon type=\"menu\" size=\"m\" />\n\n// After — explicitly decorative; parent button carries the label\n<EuiIcon type=\"menu\" size=\"m\" aria-hidden={true} />\n```\n\nAffected areas include chrome nav components, content-management sort\nselectors, sample data cards, developer toolbar indicators,\nexit-full-screen button, file picker, inspect flyout, global search bar,\nsaved objects tagging UI, AI assistant connector selector, and URL\ndrilldown variable popover.\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"7fce3923ef37329746bde52a220019405b73fe64","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","backport missing","💝community","backport:version","v9.4.0","v9.3.3","v9.2.8","a11y:agent-pr"],"title":"fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files","number":259313,"url":"https://github.com/elastic/kibana/pull/259313","mergeCommit":{"message":"fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files (#259313)\n\nCloses: https://github.com/elastic/kibana/issues/259306\n\nFixes 37 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 22 files — each `EuiIcon` must have a `title`, `aria-label`,\n`aria-labelledby`, or `aria-hidden={true}` if decorative.\n\n## Changes\n\n- **Typo fix** — `examples/files_example/public/components/app.tsx`:\ncorrected `arial-label` → `aria-label` on a warning status icon\n- **Decorative icons** — all other 36 instances: added\n`aria-hidden={true}` to icons that are purely decorative (inside\nlabelled buttons, alongside visible text, or as visual affordances where\nthe parent already conveys the meaning)\n\n### Example pattern applied\n\n```tsx\n// Before — no accessibility attribute\n<EuiIcon type=\"menu\" size=\"m\" />\n\n// After — explicitly decorative; parent button carries the label\n<EuiIcon type=\"menu\" size=\"m\" aria-hidden={true} />\n```\n\nAffected areas include chrome nav components, content-management sort\nselectors, sample data cards, developer toolbar indicators,\nexit-full-screen button, file picker, inspect flyout, global search bar,\nsaved objects tagging UI, AI assistant connector selector, and URL\ndrilldown variable popover.\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"7fce3923ef37329746bde52a220019405b73fe64"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259313","number":259313,"mergeCommit":{"message":"fix(a11y): resolve @elastic/eui/icon-accessibility-rules violations across appex-sharedux files (#259313)\n\nCloses: https://github.com/elastic/kibana/issues/259306\n\nFixes 37 ESLint violations of `@elastic/eui/icon-accessibility-rules`\nacross 22 files — each `EuiIcon` must have a `title`, `aria-label`,\n`aria-labelledby`, or `aria-hidden={true}` if decorative.\n\n## Changes\n\n- **Typo fix** — `examples/files_example/public/components/app.tsx`:\ncorrected `arial-label` → `aria-label` on a warning status icon\n- **Decorative icons** — all other 36 instances: added\n`aria-hidden={true}` to icons that are purely decorative (inside\nlabelled buttons, alongside visible text, or as visual affordances where\nthe parent already conveys the meaning)\n\n### Example pattern applied\n\n```tsx\n// Before — no accessibility attribute\n<EuiIcon type=\"menu\" size=\"m\" />\n\n// After — explicitly decorative; parent button carries the label\n<EuiIcon type=\"menu\" size=\"m\" aria-hidden={true} />\n```\n\nAffected areas include chrome nav components, content-management sort\nselectors, sample data cards, developer toolbar indicators,\nexit-full-screen button, file picker, inspect flyout, global search bar,\nsaved objects tagging UI, AI assistant connector selector, and URL\ndrilldown variable popover.\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"7fce3923ef37329746bde52a220019405b73fe64"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->