### PR TITLE
[9.3] Increase timeout for inference calls

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.test.ts
@@ -86,10 +86,12 @@ describe('InferenceConnector', () => {
           },
           method: 'POST',
           path: '_inference/chat_completion/test/_stream',
+          querystring: { timeout: '180s' },
         },
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
           headers: {
             'X-Elastic-Product-Use-Case': 'security_ai_assistant',
           },
@@ -298,10 +300,12 @@ describe('InferenceConnector', () => {
           },
           method: 'POST',
           path: '_inference/chat_completion/test/_stream',
+          querystring: { timeout: '180s' },
         },
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
         }
       );
     });
@@ -323,10 +327,12 @@ describe('InferenceConnector', () => {
           body: { messages: [{ content: 'Hello world', role: 'user' }], n: undefined },
           method: 'POST',
           path: '_inference/chat_completion/test/_stream',
+          querystring: { timeout: '180s' },
         },
         {
           asStream: true,
           meta: true,
+          requestTimeout: 180_000,
           signal,
         }
       );

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/inference/inference.ts
@@ -196,11 +196,15 @@ export class InferenceConnector extends SubActionConnector<Config, Secrets> {
       {
         method: 'POST',
         path: `_inference/chat_completion/${this.inferenceId}/_stream`,
+        querystring: {
+          timeout: '180s',
+        },
         body,
       },
       {
         asStream: true,
         meta: true,
+        requestTimeout: 180_000,
         signal: params.signal,
         ...(params.telemetryMetadata?.pluginId
           ? {


### PR DESCRIPTION
## Summary

Backports the stack_connectors changes from #260267 and #260382 to the 9.3 branch.

- Adds `querystring: { timeout: '180s' }` to the ES inference `chat_completion` transport request
- Adds `requestTimeout: 180_000` to the transport request options

The inference plugin changes from those PRs are not included as that code doesn't exist on 9.3.

## Test plan

- [x] Unit tests pass (`inference.test.ts`)