### PR TITLE
[Agent Builder] Expose read-only conversations on plugin start contract

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/index.ts
@@ -21,7 +21,11 @@ export type {
   ToolsSetup,
   ToolsStart,
   SmlStart,
+  ConversationsStart,
+  ReadOnlyConversationClient,
 } from './types';
+
+export type { ConversationListOptions } from './services/conversation/client/types';
 
 export type {
   SmlTypeDefinition,

--- a/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/mocks.ts
@@ -68,6 +68,12 @@ const createStartContractMock = (): AgentBuilderPluginStartMock => {
     runtime: {
       createModelProvider: jest.fn(),
     },
+    conversations: {
+      getScopedClient: jest.fn().mockResolvedValue({
+        get: jest.fn(),
+        list: jest.fn(),
+      }),
+    },
     sml: {
       indexAttachment: jest.fn(),
     },

--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -273,7 +273,8 @@ export class AgentBuilderPlugin
       analyticsService: this.analyticsService,
     });
 
-    const { tools, agents, skills, runnerFactory, execution, plugins } = startServices;
+    const { tools, agents, skills, runnerFactory, execution, plugins, conversations } =
+      startServices;
     const runner = runnerFactory.getRunner();
 
     if (this.home) {
@@ -321,6 +322,15 @@ export class AgentBuilderPlugin
       },
       runtime: {
         createModelProvider: modelProviderFactory,
+      },
+      conversations: {
+        getScopedClient: async ({ request }) => {
+          const client = await conversations.getScopedClient({ request });
+          return {
+            get: client.get.bind(client),
+            list: client.list.bind(client),
+          };
+        },
       },
       sml: {
         indexAttachment: async (params) => {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/read_only_conversation_client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/read_only_conversation_client.test.ts
@@ -19,9 +19,7 @@ import type { ConversationService } from './conversation_service';
  * the same way `plugin.ts` does, so we can verify the wrapping logic in
  * isolation without booting the full plugin.
  */
-const createConversationsStart = (
-  internalService: ConversationService
-): ConversationsStart => ({
+const createConversationsStart = (internalService: ConversationService): ConversationsStart => ({
   getScopedClient: async ({ request }) => {
     const client = await internalService.getScopedClient({ request });
     return {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/read_only_conversation_client.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/conversation/read_only_conversation_client.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { KibanaRequest } from '@kbn/core-http-server';
+import type { ReadOnlyConversationClient, ConversationsStart } from '../../types';
+import {
+  createConversationClientMock,
+  createEmptyConversation,
+  type ConversationClientMock,
+} from '../../test_utils/conversations';
+import type { ConversationService } from './conversation_service';
+
+/**
+ * Builds a `ConversationsStart` that wraps the internal ConversationService
+ * the same way `plugin.ts` does, so we can verify the wrapping logic in
+ * isolation without booting the full plugin.
+ */
+const createConversationsStart = (
+  internalService: ConversationService
+): ConversationsStart => ({
+  getScopedClient: async ({ request }) => {
+    const client = await internalService.getScopedClient({ request });
+    return {
+      get: client.get.bind(client),
+      list: client.list.bind(client),
+    };
+  },
+});
+
+describe('ReadOnlyConversationClient', () => {
+  let conversationsStart: ConversationsStart;
+  let internalClient: ConversationClientMock;
+  let readOnlyClient: ReadOnlyConversationClient;
+  const request = {} as KibanaRequest;
+
+  beforeEach(async () => {
+    internalClient = createConversationClientMock();
+    const internalService: ConversationService = {
+      getScopedClient: jest.fn().mockResolvedValue(internalClient),
+    };
+    conversationsStart = createConversationsStart(internalService);
+    readOnlyClient = await conversationsStart.getScopedClient({ request });
+  });
+
+  it('delegates get() to the internal conversation client', async () => {
+    const conversation = createEmptyConversation({ id: 'conv-1', title: 'Test' });
+    internalClient.get.mockResolvedValue(conversation);
+
+    const result = await readOnlyClient.get('conv-1');
+
+    expect(internalClient.get).toHaveBeenCalledWith('conv-1');
+    expect(result).toEqual(conversation);
+  });
+
+  it('delegates list() to the internal conversation client', async () => {
+    const conversations = [
+      { ...createEmptyConversation({ id: 'conv-1' }), rounds: undefined },
+      { ...createEmptyConversation({ id: 'conv-2' }), rounds: undefined },
+    ];
+    internalClient.list.mockResolvedValue(conversations);
+
+    const result = await readOnlyClient.list({ agentId: 'agent-1' });
+
+    expect(internalClient.list).toHaveBeenCalledWith({ agentId: 'agent-1' });
+    expect(result).toEqual(conversations);
+  });
+
+  it('does not expose create, update, delete, or exists methods', () => {
+    const clientKeys = Object.keys(readOnlyClient);
+    expect(clientKeys).toEqual(expect.arrayContaining(['get', 'list']));
+    expect(clientKeys).not.toContain('create');
+    expect(clientKeys).not.toContain('update');
+    expect(clientKeys).not.toContain('delete');
+    expect(clientKeys).not.toContain('exists');
+  });
+});

--- a/x-pack/platform/plugins/shared/agent_builder/server/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KibanaRequest } from '@kbn/core-http-server';
+import type { Conversation, ConversationWithoutRounds } from '@kbn/agent-builder-common';
 import type { RunToolFn, RunAgentFn } from '@kbn/agent-builder-server';
 import type { SkillDefinition } from '@kbn/agent-builder-server/skills';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
@@ -39,6 +40,7 @@ import type { AgentExecutionService } from './services/execution';
 import type { ModelProviderFactoryFn } from './services/runner/model_provider';
 import type { SmlTypeDefinition, SmlIndexAttachmentParams } from './services/sml';
 import type { PluginsServiceSetup, PluginRegistry } from './services/plugins';
+import type { ConversationListOptions } from './services/conversation/client/types';
 
 export interface AgentBuilderSetupDependencies {
   cloud?: CloudSetup;
@@ -247,6 +249,30 @@ export interface PluginsStart {
 }
 
 /**
+ * A read-only conversation client exposing only get and list operations.
+ */
+export interface ReadOnlyConversationClient {
+  /**
+   * Retrieve a single conversation by its ID, including all rounds.
+   */
+  get(conversationId: string): Promise<Conversation>;
+  /**
+   * List conversations for the current user, optionally filtered by agent ID.
+   */
+  list(options?: ConversationListOptions): Promise<ConversationWithoutRounds[]>;
+}
+
+/**
+ * AgentBuilder conversations service's start contract (read-only).
+ */
+export interface ConversationsStart {
+  /**
+   * Returns a read-only conversation client scoped to the given request's user and space.
+   */
+  getScopedClient(opts: { request: KibanaRequest }): Promise<ReadOnlyConversationClient>;
+}
+
+/**
  * Start contract of the agentBuilder plugin.
  */
 export interface AgentBuilderPluginStart {
@@ -280,4 +306,8 @@ export interface AgentBuilderPluginStart {
    * discoverable content.
    */
   sml: SmlStart;
+  /**
+   * Conversations service (read-only), to list and retrieve conversations.
+   */
+  conversations: ConversationsStart;
 }


### PR DESCRIPTION
## Summary

- Adds `conversations` property to `AgentBuilderPluginStart` so other plugins can read conversations programmatically without going through the REST API
- Exposes a `getScopedClient({ request })` factory returning a `ReadOnlyConversationClient` with only `get` and `list` methods (no create/update/delete)
- Follows the same pattern as `agents.getRegistry`, `tools.getRegistry`, etc.

## Test plan

- [ ] Type check passes (`node scripts/type_check --project x-pack/platform/plugins/shared/agent_builder/tsconfig.json`)
- [ ] All 1989 existing jest tests pass
- [ ] Consumer plugin can import `ConversationsStart` and `ReadOnlyConversationClient` types

🤖 Generated with [Claude Code](https://claude.com/claude-code)