### PR TITLE
[Alerting v2] Fix rule results preview chart responsiveness

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -244,8 +244,10 @@ const RuleFormContent = ({
   if (layout === 'page') {
     return (
       <EuiFlexGroup gutterSize="l" alignItems="flexStart">
-        <EuiFlexItem grow={1}>{formContent}</EuiFlexItem>
-        <EuiFlexItem grow={1}>
+        <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
+          {formContent}
+        </EuiFlexItem>
+        <EuiFlexItem grow={1} style={{ minWidth: 0 }}>
           <RulePreviewPanel />
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Fixes the rule results preview chart not responding to window width changes in the alerting v2 rule form page layout.

Recreates #259791

### Before

<img width="990" height="243" alt="image" src="https://github.com/user-attachments/assets/7f7253e1-477e-4b14-8cb6-b445c0482bd1" />

### After

<img width="894" height="250" alt="image" src="https://github.com/user-attachments/assets/87b31a67-1ffe-4d83-8124-8240400a11ef" />

## Problem

The page layout renders the rule form and the results preview panel side by side using `EuiFlexGroup`. Without `min-width: 0` on the `EuiFlexItem` elements, the browser's flexbox algorithm refuses to shrink a flex child below its content's natural minimum width. The `EuiDataGrid` and Lens chart inside the preview panel have non-trivial intrinsic minimum widths, so reducing the viewport caused the panel to overflow rather than reflow.

## Fix

Add `style={{ minWidth: 0 }}` to both `EuiFlexItem` elements in the two-column page layout. This is the standard CSS fix for flex children that need to shrink below their content size — it overrides the default `min-width: auto` that flexbox applies to items.

## Testing

1. Open the alerting v2 rule form in page layout
2. Configure a base query so the results preview chart renders
3. Reduce the browser window width — the chart should now scale down responsively alongside the form