### PR TITLE
[Agent Builder] Fix sidebar error handling error

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/actions/start_new_conversation_button.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/actions/start_new_conversation_button.tsx
@@ -9,6 +9,7 @@ import React, { useCallback } from 'react';
 import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
+import { useSendMessage } from '../../../context/send_message/send_message_context';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { useLastAgentId } from '../../../hooks/use_last_agent_id';
 import { appPaths } from '../../../utils/app_paths';
@@ -23,15 +24,17 @@ const NEW_CONVERSATION_BUTTON_LABEL = i18n.translate(
 export const StartNewConversationButton: React.FC = () => {
   const { navigateToAgentBuilderUrl } = useNavigation();
   const { isEmbeddedContext, setConversationId } = useConversationContext();
+  const { removeError } = useSendMessage();
   const lastAgentId = useLastAgentId();
 
   const handleClick = useCallback(() => {
     if (isEmbeddedContext) {
+      removeError();
       setConversationId?.(undefined);
     } else {
       navigateToAgentBuilderUrl(appPaths.agent.conversations.new({ agentId: lastAgentId }));
     }
-  }, [isEmbeddedContext, setConversationId, navigateToAgentBuilderUrl, lastAgentId]);
+  }, [isEmbeddedContext, removeError, setConversationId, navigateToAgentBuilderUrl, lastAgentId]);
 
   return (
     <EuiButton

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversations_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversations_view.tsx
@@ -7,12 +7,28 @@
 
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Conversation } from './conversation';
 import { ConversationHeader } from './conversation_header/conversation_header';
 import { RoutedConversationsProvider } from '../../context/conversation/routed_conversations_provider';
-import { SendMessageProvider } from '../../context/send_message/send_message_context';
+import {
+  SendMessageProvider,
+  useSendMessage,
+} from '../../context/send_message/send_message_context';
 import { conversationBackgroundStyles, headerHeight } from './conversation.styles';
+
+// Clears error state on every navigation. Rendered inside SendMessageProvider (for context access)
+// and inside the Router (for useLocation access), so it's intentionally placed in the routed view
+// only — the embeddable/sidebar context has no navigation and doesn't need this behavior.
+const LocationErrorClearer: React.FC<{}> = () => {
+  const { key: locationKey } = useLocation();
+  const { removeError } = useSendMessage();
+  useEffect(() => {
+    removeError();
+  }, [locationKey, removeError]);
+  return null;
+};
 
 export const AgentBuilderConversationsView: React.FC<{}> = () => {
   const { euiTheme } = useEuiTheme();
@@ -45,6 +61,7 @@ export const AgentBuilderConversationsView: React.FC<{}> = () => {
   return (
     <RoutedConversationsProvider>
       <SendMessageProvider>
+        <LocationErrorClearer />
         <div css={containerStyles} data-test-subj="agentBuilderPageConversations">
           <div css={headerStyles}>
             <ConversationHeader />

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/conversations_popover_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/conversations_popover_view.tsx
@@ -19,6 +19,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
+import { useSendMessage } from '../../../context/send_message/send_message_context';
 import { useAgentBuilderAgents } from '../../../hooks/agents/use_agents';
 import { useAgentId } from '../../../hooks/use_conversation';
 import { AgentAvatar } from '../../common/agent_avatar';
@@ -55,12 +56,14 @@ export const ConversationsPopoverView: React.FC<ConversationsPopoverViewProps> =
 
   const { euiTheme } = useEuiTheme();
   const { setConversationId } = useConversationContext();
+  const { removeError } = useSendMessage();
   const { agents } = useAgentBuilderAgents();
   const agentId = useAgentId();
 
   const currentAgent = agents.find((a) => a.id === agentId);
 
   const handleNewChat = () => {
+    removeError();
     setConversationId?.(undefined);
     onClose();
   };

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/send_message_context.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/send_message_context.tsx
@@ -22,6 +22,7 @@ interface SendMessageState {
   canCancel: boolean;
   cancel: () => void;
   cleanConversation: () => void;
+  removeError: () => void;
   resumeRound: (opts: { promptId: string; confirm: boolean }) => void;
   isResuming: boolean;
   regenerate: () => void;
@@ -49,6 +50,7 @@ export const SendMessageProvider = ({ children }: { children: React.ReactNode })
     canCancel,
     cancel,
     cleanConversation,
+    removeError,
     regenerate,
     isRegenerating,
   } = useSendMessageMutation({ connectorId: connectorSelection.selectedConnector });
@@ -77,6 +79,7 @@ export const SendMessageProvider = ({ children }: { children: React.ReactNode })
         canCancel,
         cancel,
         cleanConversation,
+        removeError,
         resumeRound,
         isResuming,
         regenerate,

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/use_send_message_mutation.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/context/send_message/use_send_message_mutation.ts
@@ -6,8 +6,7 @@
  */
 
 import { useMutation } from '@kbn/react-query';
-import { useRef, useState, useMemo, useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useRef, useState, useMemo, useCallback } from 'react';
 import { toToolMetadata } from '@kbn/agent-builder-browser/tools/browser_api_tool';
 import { firstValueFrom } from 'rxjs';
 import { isEqual } from 'lodash';
@@ -120,24 +119,6 @@ export const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationPr
     setError(null);
     setErrorSteps((prev) => (prev.length === 0 ? prev : []));
   }, []);
-
-  const { key: locationKey } = useLocation();
-
-  useEffect(() => {
-    // Clear error state on every navigation. location.key is updated on every history push,
-    // including re-navigation to the same URL (e.g. clicking "New" while already on /new
-    // with an errored conversation). A conversationId-based effect was used previously but
-    // missed both that case and navigating from an errored conversation back to /new, since
-    // conversationId stays undefined for the /new route.
-    //
-    // Known gap: the old NewConversationButton (which lived inside SendMessageProvider) also
-    // cancelled any in-flight stream via cleanConversation() when clicking "New" on /new.
-    // That button was removed during the sidebar refactor and the sidebar replacement lives
-    // outside SendMessageProvider, so it cannot call cleanConversation() directly. Fixing the
-    // streaming-cancellation case properly requires a larger provider refactor —
-    // and is left as a known limitation for now.
-    removeError();
-  }, [locationKey, removeError]);
 
   const browserApiToolsMetadata = useMemo(() => {
     if (!browserApiTools) return undefined;
@@ -320,5 +301,6 @@ export const useSendMessageMutation = ({ connectorId }: UseSendMessageMutationPr
      */
     regenerate: () => mutate({ action: 'regenerate' }),
     isRegenerating: isLoading && isRegeneratingRef.current,
+    removeError,
   };
 };


### PR DESCRIPTION
## Summary

Fixes an issue where the sidebar in-chat experience was broken due to a recent merge.

<img width="1058" height="958" alt="image" src="https://github.com/user-attachments/assets/bb1a2b48-89ff-479d-86bc-0419ce43219e" />

Issue was caused by using `useLocation` in a context without a router (we don't have a router wrapping the embeddable conversation, and we shouldn't need to have one - I've removed the `useLocation` and refactored the code to avoid this.).



