### PR TITLE
[Inference UI] Beta/Tech Preview status to registry and settings

### DIFF
--- a/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/common/types.ts
@@ -59,6 +59,8 @@ export interface InferenceFeatureResponse {
   taskType: string;
   maxNumberOfEndpoints?: number;
   recommendedEndpoints: string[];
+  isBeta?: boolean;
+  isTechPreview?: boolean;
 }
 
 export type InferenceEndpointWithMetadata = InferenceAPIConfigResponse & {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/feature_section.tsx
@@ -6,7 +6,16 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiPanel, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiBadgeGroup,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiPanel,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import * as translations from '../../../common/translations';
 import type { InferenceFeatureResponse as InferenceFeatureConfig } from '../../../common/types';
@@ -23,6 +32,8 @@ interface FeatureSectionProps {
   features: FeatureSettingItem[];
   onReset: () => void;
   onEndpointsChange: (featureId: string, newEndpointIds: string[]) => void;
+  isTechPreview?: boolean;
+  isBeta?: boolean;
 }
 
 export const FeatureSection: React.FC<FeatureSectionProps> = ({
@@ -31,6 +42,8 @@ export const FeatureSection: React.FC<FeatureSectionProps> = ({
   features,
   onReset,
   onEndpointsChange,
+  isTechPreview = false,
+  isBeta = false,
 }) => {
   return (
     <EuiFlexGroup gutterSize="m" direction="column">
@@ -40,9 +53,33 @@ export const FeatureSection: React.FC<FeatureSectionProps> = ({
         data-test-subj={`featureSection-${parentName}`}
       >
         <EuiFlexItem grow={false}>
-          <EuiTitle size="s">
-            <h3>{parentName}</h3>
-          </EuiTitle>
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="s">
+                <h3>{parentName}</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+            {isTechPreview || isBeta ? (
+              <EuiFlexItem grow={false}>
+                <EuiBadgeGroup>
+                  {isTechPreview && (
+                    <EuiBadge>
+                      {i18n.translate('xpack.searchInferenceEndpoints.settings.techPreview', {
+                        defaultMessage: 'Technical Preview',
+                      })}
+                    </EuiBadge>
+                  )}
+                  {isBeta && (
+                    <EuiBadge>
+                      {i18n.translate('xpack.searchInferenceEndpoints.settings.betaBadge', {
+                        defaultMessage: 'Beta',
+                      })}
+                    </EuiBadge>
+                  )}
+                </EuiBadgeGroup>
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
           <EuiText size="s" color="subdued">
             <p>{parentDescription}</p>
           </EuiText>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/model_settings.tsx
@@ -124,6 +124,8 @@ export const ModelSettings: React.FC = () => {
                 }))}
                 onReset={() => setResetParentKey(section.featureId)}
                 onEndpointsChange={updateEndpoints}
+                isBeta={section.isBeta}
+                isTechPreview={section.isTechPreview}
               />
               <EuiSpacer size="xl" />
             </React.Fragment>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.test.tsx
@@ -77,6 +77,12 @@ const mockEndpoints = [
     task_type: 'text_embedding',
     service_settings: { model_id: 'e5' },
   },
+  {
+    inference_id: 'ep-beta-tech-preview',
+    service: 'elastic',
+    task_type: 'chat_completion',
+    service_settings: { model_id: 'claude' },
+  },
 ];
 
 const feature: InferenceFeatureConfig = {
@@ -86,6 +92,8 @@ const feature: InferenceFeatureConfig = {
   featureDescription: 'A test feature',
   taskType: 'chat_completion',
   recommendedEndpoints: ['ep-1'],
+  isBeta: false,
+  isTechPreview: false,
 };
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => {
@@ -126,6 +134,40 @@ describe('SubFeatureCard', () => {
     expect(screen.getByText('Test Feature')).toBeInTheDocument();
     expect(screen.getByText('A test feature')).toBeInTheDocument();
     expect(screen.getByText('chat_completion')).toBeInTheDocument();
+  });
+
+  describe('feature status badges', () => {
+    it.each([
+      {
+        scenario: 'renders beta',
+        setup: {
+          ids: ['ep-beta-technical-preview'],
+          overrides: { isBeta: true },
+        },
+        expected: ['Beta'],
+      },
+      {
+        scenario: 'renders technical preview',
+        setup: {
+          ids: ['ep-beta-technical-preview'],
+          overrides: { isTechPreview: true },
+        },
+        expected: ['Technical Preview'],
+      },
+      {
+        scenario: 'renders both beta and technical preview',
+        setup: {
+          ids: ['ep-beta-technical-preview'],
+          overrides: { isBeta: true, isTechPreview: true },
+        },
+        expected: ['Beta', 'Technical Preview'],
+      },
+    ])('$scenario', ({ setup, expected }) => {
+      const { ids, overrides } = setup;
+
+      renderCard(ids, overrides);
+      expected.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+    });
   });
 
   it('renders all endpoint rows within collapsed count', () => {

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/public/components/settings/sub_feature_card.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   EuiBadge,
+  EuiBadgeGroup,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiDragDropContext,
@@ -58,6 +59,7 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
   const [isCopyModalOpen, setIsCopyModalOpen] = useState(false);
   const [listWidth, setListWidth] = useState<number | undefined>(undefined);
   const listRef = useRef<HTMLDivElement>(null);
+  const { isTechPreview, isBeta } = feature;
 
   useEffect(() => {
     const el = listRef.current;
@@ -148,9 +150,33 @@ export const SubFeatureCard: React.FC<SubFeatureCardProps> = ({
             min-inline-size: min(20rem, 50%);
           `}
         >
-          <EuiTitle size="s">
-            <h4>{feature.featureName}</h4>
-          </EuiTitle>
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="s">
+                <h4>{feature.featureName}</h4>
+              </EuiTitle>
+            </EuiFlexItem>
+            {isTechPreview || isBeta ? (
+              <EuiFlexItem grow={false}>
+                <EuiBadgeGroup>
+                  {isTechPreview && (
+                    <EuiBadge>
+                      {i18n.translate('xpack.searchInferenceEndpoints.settings.techPreview', {
+                        defaultMessage: 'Technical Preview',
+                      })}
+                    </EuiBadge>
+                  )}
+                  {isBeta && (
+                    <EuiBadge>
+                      {i18n.translate('xpack.searchInferenceEndpoints.settings.betaBadge', {
+                        defaultMessage: 'Beta',
+                      })}
+                    </EuiBadge>
+                  )}
+                </EuiBadgeGroup>
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
           <EuiSpacer size="s" />
           <EuiText size="s" color="subdued">
             <p>{feature.featureDescription}</p>

--- a/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
+++ b/x-pack/platform/plugins/shared/search_inference_endpoints/server/types.ts
@@ -22,6 +22,8 @@ export interface InferenceFeatureConfig {
   taskType: InferenceTaskType;
   maxNumberOfEndpoints?: number;
   recommendedEndpoints: string[];
+  isTechPreview?: boolean;
+  isBeta?: boolean;
 }
 
 export type RegisterResult = { ok: true } | { ok: false; error: string };


### PR DESCRIPTION
## Summary

Adds a Beta/Tech Preview status to registry and settings.



<img width="2512" height="1256" alt="Screenshot 2026-03-31 at 13 08 53" src="https://github.com/user-attachments/assets/97e3d021-6d0b-4d91-956d-a48dbed53f50" />
<img width="2364" height="637" alt="Screenshot 2026-03-31 at 14 18 39" src="https://github.com/user-attachments/assets/44962495-ee05-430b-b6a1-86f1ca76b32e" />

The screenshots are taken while testing and does not actually reflect the Status of those features. The feature owner should Update the registry to add/get this information.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Low risk. Feature not released yet.