### PR TITLE
Use filled primary button for Create rule on alerting v2 rules list

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx
@@ -58,6 +58,7 @@ export const RulesListPage = () => {
         rightSideItems={[
           <EuiButton
             key="create-rule"
+            fill
             href={basePath.prepend(paths.ruleCreate)}
             data-test-subj="createRuleButton"
           >


### PR DESCRIPTION
## Summary

Uses a filled primary `EuiButton` for the **Create rule** action in `EuiPageHeader.rightSideItems` on the Alerting V2 rules list page.

## Change

- `x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.tsx`: add `fill` to the create-rule button.

Made with [Cursor](https://cursor.com)