### PR TITLE
fix(sync_logs): eliminate older-data bias in random sampling

### DIFF
--- a/scripts/sync_logs.js
+++ b/scripts/sync_logs.js
@@ -313,7 +313,7 @@ function search(sourceClient, config, cycleNumber, log, startTime, endTime) {
 
   var query = {
     bool: {
-      must: [{ match_all: {} }, { range: { '@timestamp': timeRange } }],
+      filter: [{ range: { '@timestamp': timeRange } }],
     },
   };
 
@@ -332,7 +332,7 @@ function search(sourceClient, config, cycleNumber, log, startTime, endTime) {
         function_score: {
           query: query,
           functions: [{ random_score: { seed: seed } }],
-          score_mode: 'sum',
+          boost_mode: 'replace',
         },
       },
       size: size,


### PR DESCRIPTION
During fetching data for testing, I realised there is is much more older then "recent" data which was odd. This should fix this biasing in the sync_logs script.

The random sample mode used `score_mode: 'sum'` which added the random_score (0–1) to the base query score (1.0), compressing all documents into a narrow 1.0–2.0 band. With many near-identical scores, Elasticsearch broke ties by internal Lucene doc ID, systematically favouring older (earlier-indexed) documents.

Additionally, the @timestamp range filter sat inside `bool.must`, contributing to document scoring when it should be a zero-score filter.

Fixes:
- Change to `boost_mode` from `'sum'` to `'replace'` so random_score is the sole ranking factor.
- Move the @timestamp range from `bool.must` to `bool.filter` so it no longer influences scoring in either sample mode.
