### PR TITLE
Bump default container heap from 60% to 75%

### DIFF
--- a/src/dev/build/tasks/bin/scripts/kibana
+++ b/src/dev/build/tasks/bin/scripts/kibana
@@ -65,7 +65,7 @@ ALL_NODE_OPTIONS="$BASE_NODE_OPTIONS $NODE_OPTIONS_HEAPSNAPSHOT_DEFAULT $KBN_NOD
 
 if [ "$ELASTIC_CONTAINER" = "true" ] && ! printf '%s' "$ALL_NODE_OPTIONS" | grep -q -- '--max-old-space-size'; then
   heap_mb=
-  target_heap_percent=60
+  target_heap_percent=75
   min_heap_mb=512
   max_heap_mb=4096
   cgroup_max_bytes=$((1024 * 1024 * 1024 * 1024)) # 1TB


### PR DESCRIPTION
We previously decided to gradually increase up to our target heap of 75%.  This bumps the heap to our final target percent.

https://github.com/elastic/kibana/issues/245742