### PR TITLE
[alerting_v2] Convert notification policy and alert action endpoints from internal to public (experimental)

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-constants/index.ts
@@ -6,3 +6,6 @@
  */
 
 export const ALERTING_V2_RULE_API_PATH = '/api/alerting/v2/rules' as const;
+export const ALERTING_V2_ALERT_API_PATH = '/api/alerting/v2/alerts' as const;
+export const ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
+  '/api/alerting/v2/notification_policies' as const;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/constants.ts
@@ -11,9 +11,10 @@ export const ALERTING_V2_APP_ROUTE = '/alerting_v2';
 export const ALERTING_V2_MANAGEMENT_PATH = 'insightsAndAlerting/alerting_v2';
 export const MANAGEMENT_APP_ID = 'management';
 export const ALERTING_V2_NOTIFICATION_POLICIES_PATH = `${ALERTING_V2_BASE_PATH}/notification_policies`;
-export { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
-export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
-  '/internal/alerting/v2/notification_policies' as const;
+export {
+  ALERTING_V2_RULE_API_PATH,
+  ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
+} from '@kbn/alerting-v2-constants';
 
 export const paths = {
   ruleCreate: `${ALERTING_V2_BASE_PATH}/create`,

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/notification_policies_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/notification_policies_api.ts
@@ -63,10 +63,9 @@ export class NotificationPoliciesApi {
   }
 
   public async createNotificationPolicy(data: CreateNotificationPolicyData) {
-    return this.http.post<NotificationPolicyResponse>(
-      ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
-      { body: JSON.stringify(data) }
-    );
+    return this.http.post<NotificationPolicyResponse>(ALERTING_V2_NOTIFICATION_POLICY_API_PATH, {
+      body: JSON.stringify(data),
+    });
   }
 
   public async updateNotificationPolicy(id: string, data: UpdateNotificationPolicyBody) {
@@ -106,9 +105,7 @@ export class NotificationPoliciesApi {
   }
 
   public async updateNotificationPolicyApiKey(id: string) {
-    await this.http.post(
-      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_update_api_key`
-    );
+    await this.http.post(`${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_update_api_key`);
   }
 
   public async bulkActionNotificationPolicies(body: BulkActionNotificationPoliciesBody) {

--- a/x-pack/platform/plugins/shared/alerting_v2/public/services/notification_policies_api.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/services/notification_policies_api.ts
@@ -14,7 +14,7 @@ import type {
   NotificationPolicyResponse,
   UpdateNotificationPolicyBody,
 } from '@kbn/alerting-v2-schemas';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 
 export interface BulkActionNotificationPoliciesResponse {
   processed: number;
@@ -35,7 +35,7 @@ export class NotificationPoliciesApi {
 
   public async getNotificationPolicy(id: string) {
     return this.http.get<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`
     );
   }
 
@@ -48,7 +48,7 @@ export class NotificationPoliciesApi {
     sortOrder?: 'asc' | 'desc';
   }) {
     return this.http.get<FindNotificationPoliciesResponse>(
-      INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
+      ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
       {
         query: {
           page: params.page,
@@ -64,56 +64,56 @@ export class NotificationPoliciesApi {
 
   public async createNotificationPolicy(data: CreateNotificationPolicyData) {
     return this.http.post<NotificationPolicyResponse>(
-      INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
+      ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
       { body: JSON.stringify(data) }
     );
   }
 
   public async updateNotificationPolicy(id: string, data: UpdateNotificationPolicyBody) {
     return this.http.put<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`,
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`,
       { body: JSON.stringify(data) }
     );
   }
 
   public async deleteNotificationPolicy(id: string) {
-    await this.http.delete(`${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`);
+    await this.http.delete(`${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}`);
   }
 
   public async enableNotificationPolicy(id: string) {
     return this.http.post<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_enable`
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_enable`
     );
   }
 
   public async disableNotificationPolicy(id: string) {
     return this.http.post<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_disable`
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_disable`
     );
   }
 
   public async snoozeNotificationPolicy(id: string, snoozedUntil: string) {
     return this.http.post<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_snooze`,
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_snooze`,
       { body: JSON.stringify({ snoozedUntil }) }
     );
   }
 
   public async unsnoozeNotificationPolicy(id: string) {
     return this.http.post<NotificationPolicyResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_unsnooze`
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_unsnooze`
     );
   }
 
   public async updateNotificationPolicyApiKey(id: string) {
     await this.http.post(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_update_api_key`
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/${id}/_update_api_key`
     );
   }
 
   public async bulkActionNotificationPolicies(body: BulkActionNotificationPoliciesBody) {
     return this.http.post<BulkActionNotificationPoliciesResponse>(
-      `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/_bulk`,
+      `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/_bulk`,
       { body: JSON.stringify(body) }
     );
   }

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/bulk_create_alert_action_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/bulk_create_alert_action_route.ts
@@ -16,18 +16,24 @@ import {
 } from '@kbn/alerting-v2-schemas';
 import { AlertActionsClient } from '../../lib/alert_actions_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_ALERT_API_PATH } from '../constants';
+import { ALERTING_V2_ALERT_API_PATH } from '../constants';
 
 @injectable()
 export class BulkCreateAlertActionRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_ALERT_API_PATH}/action/_bulk`;
+  static path = `${ALERTING_V2_ALERT_API_PATH}/action/_bulk`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.alerts.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Bulk create alert actions',
+    description: 'Create actions for multiple alert groups in a single request.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       body: buildRouteValidationWithZod(bulkCreateAlertActionBodySchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/bulk_get_alert_actions_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/bulk_get_alert_actions_route.ts
@@ -16,18 +16,24 @@ import {
 } from '@kbn/alerting-v2-schemas';
 import { AlertActionsClient } from '../../lib/alert_actions_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_ALERT_API_PATH } from '../constants';
+import { ALERTING_V2_ALERT_API_PATH } from '../constants';
 
 @injectable()
 export class BulkGetAlertActionsRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_ALERT_API_PATH}/action/_bulk_get`;
+  static path = `${ALERTING_V2_ALERT_API_PATH}/action/_bulk_get`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.alerts.read],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Bulk get alert actions',
+    description: 'Get actions for multiple episodes in a single request.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       body: buildRouteValidationWithZod(bulkGetAlertActionsBodySchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/create_alert_action_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/alert_actions/create_alert_action_route.ts
@@ -18,18 +18,24 @@ import { buildRouteValidationWithZod } from '@kbn/zod-helpers/v4';
 import { inject, injectable } from 'inversify';
 import { AlertActionsClient } from '../../lib/alert_actions_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_ALERT_API_PATH } from '../constants';
+import { ALERTING_V2_ALERT_API_PATH } from '../constants';
 
 @injectable()
 export class CreateAlertActionRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_ALERT_API_PATH}/{group_hash}/action`;
+  static path = `${ALERTING_V2_ALERT_API_PATH}/{group_hash}/action`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.alerts.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Create an alert action',
+    description: 'Create an action for a specific alert group.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(createAlertActionParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/constants.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-export { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
-export const INTERNAL_ALERTING_V2_ALERT_API_PATH = '/internal/alerting/v2/alerts' as const;
-export const INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH =
-  '/internal/alerting/v2/notification_policies' as const;
+export {
+  ALERTING_V2_RULE_API_PATH,
+  ALERTING_V2_ALERT_API_PATH,
+  ALERTING_V2_NOTIFICATION_POLICY_API_PATH,
+} from '@kbn/alerting-v2-constants';

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/bulk_action_notification_policies_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/bulk_action_notification_policies_route.ts
@@ -18,19 +18,25 @@ import type { Logger as KibanaLogger } from '@kbn/logging';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 @injectable()
 export class BulkActionNotificationPoliciesRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/_bulk`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/_bulk`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Bulk action notification policies',
+    description: 'Perform bulk actions on notification policies.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       body: buildRouteValidationWithZod(bulkActionNotificationPoliciesBodySchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/create_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/create_notification_policy_route.ts
@@ -19,7 +19,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const createNotificationPolicyParamsSchema = z.object({
@@ -29,13 +29,19 @@ const createNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class CreateNotificationPolicyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id?}`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id?}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Create a notification policy',
+    description: 'Create a new notification policy with an optional custom identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       body: buildRouteValidationWithZod(createNotificationPolicyDataSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/delete_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/delete_notification_policy_route.ts
@@ -12,7 +12,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const deleteNotificationPolicyParamsSchema = z.object({
@@ -22,13 +22,19 @@ const deleteNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class DeleteNotificationPolicyRoute {
   static method = 'delete' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Delete a notification policy',
+    description: 'Delete a notification policy by identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(deleteNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/disable_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/disable_notification_policy_route.ts
@@ -15,7 +15,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const disableNotificationPolicyParamsSchema = z.object({
@@ -25,13 +25,19 @@ const disableNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class DisableNotificationPolicyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_disable`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_disable`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Disable a notification policy',
+    description: 'Disable a notification policy by identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(disableNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/enable_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/enable_notification_policy_route.ts
@@ -15,7 +15,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const enableNotificationPolicyParamsSchema = z.object({
@@ -25,13 +25,19 @@ const enableNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class EnableNotificationPolicyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_enable`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_enable`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Enable a notification policy',
+    description: 'Enable a notification policy by identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(enableNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/get_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/get_notification_policy_route.ts
@@ -12,7 +12,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const getNotificationPolicyParamsSchema = z.object({
@@ -22,13 +22,19 @@ const getNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class GetNotificationPolicyRoute {
   static method = 'get' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.read],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Get a notification policy',
+    description: 'Get a notification policy by identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(getNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/list_notification_policies_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/list_notification_policies_route.ts
@@ -13,7 +13,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 
 const sortFieldSchema = z.enum([
   'name',
@@ -40,13 +40,19 @@ const listNotificationPoliciesQuerySchema = z.object({
 @injectable()
 export class ListNotificationPoliciesRoute {
   static method = 'get' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.read],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'List notification policies',
+    description: 'Get a paginated list of notification policies with optional filtering and sorting.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       query: buildRouteValidationWithZod(listNotificationPoliciesQuerySchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/list_notification_policies_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/list_notification_policies_route.ts
@@ -49,7 +49,8 @@ export class ListNotificationPoliciesRoute {
   static options = {
     access: 'public',
     summary: 'List notification policies',
-    description: 'Get a paginated list of notification policies with optional filtering and sorting.',
+    description:
+      'Get a paginated list of notification policies with optional filtering and sorting.',
     tags: ['oas-tag:alerting-v2'],
     availability: { stability: 'experimental' },
   } as const;

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/snooze_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/snooze_notification_policy_route.ts
@@ -19,7 +19,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const snoozeNotificationPolicyParamsSchema = z.object({
@@ -29,13 +29,19 @@ const snoozeNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class SnoozeNotificationPolicyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_snooze`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_snooze`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Snooze a notification policy',
+    description: 'Snooze a notification policy until a specified time.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(snoozeNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/unsnooze_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/unsnooze_notification_policy_route.ts
@@ -15,7 +15,7 @@ import { z } from '@kbn/zod/v4';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const unsnoozeNotificationPolicyParamsSchema = z.object({
@@ -25,13 +25,19 @@ const unsnoozeNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class UnsnoozeNotificationPolicyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_unsnooze`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_unsnooze`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Unsnooze a notification policy',
+    description: 'Remove the snooze from a notification policy.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(unsnoozeNotificationPolicyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/update_notification_policy_api_key_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/update_notification_policy_api_key_route.ts
@@ -15,7 +15,7 @@ import { z } from '@kbn/zod';
 import { inject, injectable } from 'inversify';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const updateNotificationPolicyApiKeyParamsSchema = z.object({
@@ -25,13 +25,19 @@ const updateNotificationPolicyApiKeyParamsSchema = z.object({
 @injectable()
 export class UpdateNotificationPolicyApiKeyRoute implements RouteHandler {
   static method = 'post' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_update_api_key`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}/_update_api_key`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Update a notification policy API key',
+    description: 'Rotate the API key for a notification policy.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       params: buildRouteValidationWithZod(updateNotificationPolicyApiKeyParamsSchema),

--- a/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/update_notification_policy_route.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/server/routes/notification_policies/update_notification_policy_route.ts
@@ -16,7 +16,7 @@ import {
 } from '@kbn/alerting-v2-schemas';
 import { NotificationPolicyClient } from '../../lib/notification_policy_client';
 import { ALERTING_V2_API_PRIVILEGES } from '../../lib/security/privileges';
-import { INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
+import { ALERTING_V2_NOTIFICATION_POLICY_API_PATH } from '../constants';
 import { buildRouteValidationWithZod } from '../route_validation';
 
 const updateNotificationPolicyParamsSchema = z.object({
@@ -26,13 +26,19 @@ const updateNotificationPolicyParamsSchema = z.object({
 @injectable()
 export class UpdateNotificationPolicyRoute {
   static method = 'put' as const;
-  static path = `${INTERNAL_ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
+  static path = `${ALERTING_V2_NOTIFICATION_POLICY_API_PATH}/{id}`;
   static security: RouteSecurity = {
     authz: {
       requiredPrivileges: [ALERTING_V2_API_PRIVILEGES.notificationPolicies.write],
     },
   };
-  static options = { access: 'internal' } as const;
+  static options = {
+    access: 'public',
+    summary: 'Update a notification policy',
+    description: 'Update an existing notification policy by identifier.',
+    tags: ['oas-tag:alerting-v2'],
+    availability: { stability: 'experimental' },
+  } as const;
   static validate = {
     request: {
       body: buildRouteValidationWithZod(updateNotificationPolicyBodySchema),

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/bulk_create_alert_action.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/bulk_create_alert_action.ts
@@ -10,7 +10,7 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_co
 import type { RoleCredentials } from '../../services';
 import { createAlertEvent, indexAlertEvents } from './fixtures';
 
-const BULK_ALERT_ACTION_API_PATH = '/internal/alerting/v2/alerts/action/_bulk';
+const BULK_ALERT_ACTION_API_PATH = '/api/alerting/v2/alerts/action/_bulk';
 const ALERTING_EVENTS_INDEX = '.rule-events';
 const ALERTING_ACTIONS_INDEX = '.alert-actions';
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/create_alert_action.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/create_alert_action.ts
@@ -10,7 +10,7 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_co
 import type { RoleCredentials } from '../../services';
 import { createAlertEvent, indexAlertEvents } from './fixtures';
 
-const ALERT_ACTION_API_PATH = '/internal/alerting/v2/alerts';
+const ALERT_ACTION_API_PATH = '/api/alerting/v2/alerts';
 const ALERTING_EVENTS_INDEX = '.rule-events';
 const ALERTING_ACTIONS_INDEX = '.alert-actions';
 

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/bulk_action_notification_policies.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/bulk_action_notification_policies.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/create_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/create_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/delete_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/delete_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/disable_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/disable_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/enable_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/enable_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/get_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/get_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/list_notification_policies.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/list_notification_policies.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/snooze_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/snooze_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/unsnooze_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/unsnooze_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/update_notification_policy.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/update_notification_policy.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/update_notification_policy_api_key.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/alerting_v2/notification_policy/update_notification_policy_api_key.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 import type { RoleCredentials } from '../../../services';
 
-const NOTIFICATION_POLICY_API_PATH = '/internal/alerting/v2/notification_policies';
+const NOTIFICATION_POLICY_API_PATH = '/api/alerting/v2/notification_policies';
 const NOTIFICATION_POLICY_SO_TYPE = 'alerting_notification_policy';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/259139
Closes https://github.com/elastic/kibana/issues/259140

## Summary

Convert the 11 notification policy API routes and 3 alert action API routes from `access: 'internal'` to `access: 'public'` with `stability: 'experimental'`, add OAS metadata, and update paths from `/internal/` to `/api/`.

Follows the same pattern as #260148 (rules API conversion).

### Changes

- Add `ALERTING_V2_ALERT_API_PATH` and `ALERTING_V2_NOTIFICATION_POLICY_API_PATH` to `@kbn/alerting-v2-constants`
- Convert 11 notification policy routes: create, delete, disable, enable, get, list, snooze, unsnooze, update, update API key, bulk action
- Convert 3 alert action routes: create, bulk create, bulk get
- Update paths from `/internal/alerting/v2/...` to `/api/alerting/v2/...`
- Set `access: 'public'`, `tags: ['oas-tag:alerting-v2']`, `availability: { stability: 'experimental' }`
- Add `summary` and `description` to all 14 route classes for OAS docs
- Update `server/routes/constants.ts` and `public/constants.ts` to re-export from shared package
- Update all hardcoded path references in integration tests and UI services

Made with [Cursor](https://cursor.com)