### PR TITLE
Fix dark mode not applied in Streams enrichment diff viewer

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/doc_viewer_diff.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/doc_viewer_diff.tsx
@@ -144,6 +144,9 @@ function JsonDiffViewer({ hit, decreaseAvailableHeightBy }: DocViewRenderProps) 
         monaco.editor.defineTheme(languageId, languageThemeResolver!(euiTheme));
       }
     });
+
+    // apply the updated theme so the diff editor reflects the current color mode
+    monaco.editor.setTheme(CODE_EDITOR_DEFAULT_THEME_ID);
   }, [euiTheme]);
 
   return (


### PR DESCRIPTION
## Summary
<img width="1122" height="539" alt="Screenshot 2026-03-31 at 18 00 02" src="https://github.com/user-attachments/assets/a4b1384f-667d-432a-8212-88b30a5979c7" />

- The Monaco diff editor in the Streams enrichment simulation playground was always rendering in light mode, even when Kibana was set to dark mode
- The theme definitions were correctly re-registered when the EUI theme changed, but `monaco.editor.setTheme()` was never called afterward to apply the updated theme
- Added the missing `setTheme` call after theme re-registration

## Test plan

- [ ] Open Streams > pick a stream > Data management > Enrichment
- [ ] Open the simulation playground and trigger a diff view
- [ ] Switch Kibana to dark mode and verify the diff viewer renders with the dark theme
- [ ] Switch back to light mode and verify it renders with the light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)