### PR TITLE
[9.3] [Fleet] Update doc links in agent policy settings (#260245)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -939,6 +939,12 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       agentReleaseProcess: `${ELASTIC_DOCS}reference/fleet/fleet-agent-release-process`,
       fipsIngest: `${ELASTIC_DOCS}deploy-manage/security/fips-ingest`,
       edotCollector: `${ELASTIC_DOCS}reference/edot-collector`,
+      agentPolicyLimitCpu: `${ELASTIC_DOCS}reference/fleet/agent-policy#agent-policy-limit-cpu`,
+      agentDownloadTimeout: `${ELASTIC_DOCS}reference/fleet/enable-custom-policy-settings#configure-agent-download-timeout`,
+      elasticAgentStandaloneDownload: `${ELASTIC_DOCS}reference/fleet/elastic-agent-standalone-download`,
+      elasticAgentStandaloneLoggingConfig: `${ELASTIC_DOCS}reference/fleet/elastic-agent-standalone-logging-config#elastic-agent-standalone-logging-settings`,
+      agentPolicyLogLevel: `${ELASTIC_DOCS}reference/fleet/agent-policy#agent-policy-log-level`,
+      elasticAgentLogFileRetention: `${ELASTIC_DOCS}reference/fleet/agent-policy#agent-policy-log-file-rotation-retention`,
     },
     integrationDeveloper: {
       upload: `${ELASTIC_DOCS}extend/integrations/upload-new-integration`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -581,6 +581,12 @@ export interface DocLinks {
     agentReleaseProcess: string;
     fipsIngest: string;
     edotCollector: string;
+    agentPolicyLimitCpu: string;
+    agentDownloadTimeout: string;
+    elasticAgentStandaloneDownload: string;
+    elasticAgentStandaloneLoggingConfig: string;
+    agentPolicyLogLevel: string;
+    elasticAgentLogFileRetention: string;
   }>;
   readonly integrationDeveloper: {
     upload: string;

--- a/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.test.tsx
@@ -6,9 +6,12 @@
  */
 
 import {
+  getAgentPolicyAdvancedSettings,
   zodStringWithDurationValidation,
   zodStringWithYamlValidation,
 } from './agent_policy_settings';
+
+const AGENT_POLICY_ADVANCED_SETTINGS = getAgentPolicyAdvancedSettings();
 
 describe('agent_policy_settings', () => {
   describe('zodStringWithDurationValidation', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.test.tsx
@@ -6,12 +6,9 @@
  */
 
 import {
-  getAgentPolicyAdvancedSettings,
   zodStringWithDurationValidation,
   zodStringWithYamlValidation,
 } from './agent_policy_settings';
-
-const AGENT_POLICY_ADVANCED_SETTINGS = getAgentPolicyAdvancedSettings();
 
 describe('agent_policy_settings', () => {
   describe('zodStringWithDurationValidation', () => {

--- a/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/agent_policy_settings.tsx
@@ -10,6 +10,8 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { z } from '@kbn/zod';
 
+import type { DocLinks } from '@kbn/doc-links';
+
 import { AGENT_LOG_LEVELS, DEFAULT_LOG_LEVEL } from '../constants';
 
 import type { SettingsConfig } from './types';
@@ -41,7 +43,7 @@ export const zodStringWithYamlValidation = z.string().refine(
   }
 );
 
-export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
+export const getAgentPolicyAdvancedSettings = (docLinks?: DocLinks['fleet']): SettingsConfig[] => [
   {
     name: 'agent.limits.go_max_procs',
     title: i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.goMaxProcsTitle', {
@@ -51,8 +53,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
       i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.goMaxProcsDescription', {
         defaultMessage: 'Limits the maximum number of CPUs that can be executing simultaneously.',
       }),
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-limit-cpu',
+    learnMoreLink: docLinks?.agentPolicyLimitCpu,
     api_field: {
       name: 'agent_limits_go_max_procs',
     },
@@ -69,8 +70,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
       i18n.translate('xpack.fleet.settings.agentPolicyAdvanced.downloadTimeoutDescription', {
         defaultMessage: 'Timeout for downloading the agent binary.',
       }),
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/enable-custom-policy-settings.html#configure-agent-download-timeout',
+    learnMoreLink: docLinks?.agentDownloadTimeout,
     api_field: {
       name: 'agent_download_timeout',
     },
@@ -96,8 +96,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
           defaultMessage: 'The disk path to which the agent binary will be downloaded.',
         }
       ),
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-download.html',
+    learnMoreLink: docLinks?.elasticAgentStandaloneDownload,
     schema: z.string(),
     example_value: '/tmp/test',
   },
@@ -120,8 +119,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
           defaultMessage: 'The frequency of logging the internal Elastic Agent metrics.',
         }
       ),
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
+    learnMoreLink: docLinks?.elasticAgentLogFileRetention,
     schema: zodStringWithDurationValidation,
     example_value: '10m',
   },
@@ -140,8 +138,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     api_field: {
       name: 'agent_logging_level',
     },
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-log-level',
+    learnMoreLink: docLinks?.agentPolicyLogLevel,
     schema: z.enum(AGENT_LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
     example_value: 'info',
   },
@@ -159,8 +156,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     api_field: {
       name: 'agent_logging_to_files',
     },
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
+    learnMoreLink: docLinks?.elasticAgentLogFileRetention,
     schema: z.boolean().default(true),
     example_value: true,
   },
@@ -178,8 +174,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     api_field: {
       name: 'agent_logging_files_rotateeverybytes',
     },
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
+    learnMoreLink: docLinks?.elasticAgentLogFileRetention,
     schema: z.number().int().min(0),
     example_value: 10,
   },
@@ -197,8 +192,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     api_field: {
       name: 'agent_logging_files_keepfiles',
     },
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
+    learnMoreLink: docLinks?.elasticAgentLogFileRetention,
     schema: z.number().int().min(0),
     example_value: 10,
   },
@@ -219,8 +213,7 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     api_field: {
       name: 'agent_logging_files_interval',
     },
-    learnMoreLink:
-      'https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-logging-config.html#elastic-agent-standalone-logging-settings',
+    learnMoreLink: docLinks?.elasticAgentLogFileRetention,
     schema: zodStringWithDurationValidation,
     example_value: '10m',
   },

--- a/x-pack/platform/plugins/shared/fleet/common/settings/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/settings/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { AGENT_POLICY_ADVANCED_SETTINGS } from './agent_policy_settings';
+export { getAgentPolicyAdvancedSettings } from './agent_policy_settings';

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_form.tsx
@@ -17,9 +17,9 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import styled from 'styled-components';
 
-import { AGENT_POLICY_ADVANCED_SETTINGS } from '../../../../../../common/settings';
+import { getAgentPolicyAdvancedSettings } from '../../../../../../common/settings';
 import type { NewAgentPolicy, AgentPolicy } from '../../../types';
-import { useAuthz } from '../../../../../hooks';
+import { useAuthz, useStartServices } from '../../../../../hooks';
 
 import { ConfiguredSettings } from '../../../components/form_settings';
 
@@ -70,7 +70,9 @@ export const AgentPolicyForm: React.FunctionComponent<Props> = ({
   setInvalidSpaceError,
 }) => {
   const authz = useAuthz();
+  const { docLinks } = useStartServices();
   const isDisabled = !authz.fleet.allAgentPolicies;
+  const agentPolicyAdvancedSettings = getAgentPolicyAdvancedSettings(docLinks.links.fleet);
 
   const generalSettingsWrapper = (children: JSX.Element[]) => (
     <EuiDescribedFormGroup
@@ -162,7 +164,7 @@ export const AgentPolicyForm: React.FunctionComponent<Props> = ({
                 </EuiTitle>
                 <EuiSpacer size="m" />
                 <ConfiguredSettings
-                  configuredSettings={AGENT_POLICY_ADVANCED_SETTINGS}
+                  configuredSettings={agentPolicyAdvancedSettings}
                   disabled={isDisabled}
                 />
               </>
@@ -190,7 +192,7 @@ export const AgentPolicyForm: React.FunctionComponent<Props> = ({
               </EuiTitle>
               <EuiSpacer size="m" />
               <ConfiguredSettings
-                configuredSettings={AGENT_POLICY_ADVANCED_SETTINGS}
+                configuredSettings={agentPolicyAdvancedSettings}
                 disabled={
                   isDisabled || !!agentPolicy?.supports_agentless || !!agentPolicy?.is_managed
                 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/form_settings/form_settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/form_settings/form_settings.ts
@@ -10,7 +10,7 @@ import { type Props, schema } from '@kbn/config-schema';
 import { stringifyZodError } from '@kbn/zod-helpers';
 
 import type { SettingsConfig, SettingsSection } from '../../../common/settings/types';
-import { AGENT_POLICY_ADVANCED_SETTINGS } from '../../../common/settings';
+import { getAgentPolicyAdvancedSettings } from '../../../common/settings';
 import type { AgentPolicy } from '../../types';
 
 export function getSettingsAPISchema(settingSection: SettingsSection) {
@@ -91,7 +91,7 @@ function convertValue(val: any, type?: string) {
 
 export function getSettings(settingSection: SettingsSection) {
   if (settingSection === 'AGENT_POLICY_ADVANCED_SETTINGS') {
-    return AGENT_POLICY_ADVANCED_SETTINGS;
+    return getAgentPolicyAdvancedSettings();
   }
 
   throw new Error(`Invalid settings section ${settingSection}`);

--- a/x-pack/platform/plugins/shared/fleet/tsconfig.json
+++ b/x-pack/platform/plugins/shared/fleet/tsconfig.json
@@ -126,6 +126,7 @@
     "@kbn/spaces-utils",
     "@kbn/setup-node-env",
     "@kbn/react-query",
-    "@kbn/fs"
+    "@kbn/fs",
+    "@kbn/doc-links"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Fleet] Update doc links in agent policy settings (#260245)](https://github.com/elastic/kibana/pull/260245)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T13:44:38Z","message":"[Fleet] Update doc links in agent policy settings (#260245)\n\n## Summary\nRelated to https://github.com/elastic/docs-content/pull/5654\n\nUpdate the doc links in agent policy settings. This\n[PR](https://github.com/elastic/kibana/pull/200274) added granular\nsettings for agent logging - now updated the doc links to point to the\nnew docs merged with https://github.com/elastic/docs-content/pull/5654.\n\n### Testing\nCheck the links in this advanced section of agent policies:\n\n<img width=\"1398\" height=\"638\" alt=\"Screenshot 2026-03-30 at 14 39 18\"\nsrc=\"https://github.com/user-attachments/assets/5d459dde-7b7d-4bfd-bf4d-8b69660353aa\"\n/>\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3dd2dc037731ccebc5169522e7c66e8c7dea3875","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:version","v9.4.0","v9.3.3","v9.2.8","v8.19.14"],"title":"[Fleet] Update doc links in agent policy settings","number":260245,"url":"https://github.com/elastic/kibana/pull/260245","mergeCommit":{"message":"[Fleet] Update doc links in agent policy settings (#260245)\n\n## Summary\nRelated to https://github.com/elastic/docs-content/pull/5654\n\nUpdate the doc links in agent policy settings. This\n[PR](https://github.com/elastic/kibana/pull/200274) added granular\nsettings for agent logging - now updated the doc links to point to the\nnew docs merged with https://github.com/elastic/docs-content/pull/5654.\n\n### Testing\nCheck the links in this advanced section of agent policies:\n\n<img width=\"1398\" height=\"638\" alt=\"Screenshot 2026-03-30 at 14 39 18\"\nsrc=\"https://github.com/user-attachments/assets/5d459dde-7b7d-4bfd-bf4d-8b69660353aa\"\n/>\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3dd2dc037731ccebc5169522e7c66e8c7dea3875"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260245","number":260245,"mergeCommit":{"message":"[Fleet] Update doc links in agent policy settings (#260245)\n\n## Summary\nRelated to https://github.com/elastic/docs-content/pull/5654\n\nUpdate the doc links in agent policy settings. This\n[PR](https://github.com/elastic/kibana/pull/200274) added granular\nsettings for agent logging - now updated the doc links to point to the\nnew docs merged with https://github.com/elastic/docs-content/pull/5654.\n\n### Testing\nCheck the links in this advanced section of agent policies:\n\n<img width=\"1398\" height=\"638\" alt=\"Screenshot 2026-03-30 at 14 39 18\"\nsrc=\"https://github.com/user-attachments/assets/5d459dde-7b7d-4bfd-bf4d-8b69660353aa\"\n/>\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3dd2dc037731ccebc5169522e7c66e8c7dea3875"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->