### PR TITLE
[Streams] Exclude current stream's processors from failure store sample

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.test.ts
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { errors } from '@elastic/elasticsearch';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { FlattenRecord } from '@kbn/streams-schema';
+import type { Streams } from '@kbn/streams-schema';
+import type { StreamlangDSL } from '@kbn/streamlang';
+import type { StreamsClient } from '../../../../lib/streams/client';
+import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
+import { collectAncestorProcessing, getFailureStoreSamples } from './failure_store_samples_handler';
+import { simulateProcessing } from './simulation_handler';
+import type { ProcessingSimulationResponse } from '@kbn/streams-schema';
+
+jest.mock('./simulation_handler', () => ({
+  simulateProcessing: jest.fn(),
+}));
+
+const mockSimulateProcessing = simulateProcessing as jest.MockedFunction<typeof simulateProcessing>;
+
+const makeGrokStep = (field: string): StreamlangDSL['steps'][number] => ({
+  action: 'grok' as const,
+  from: field,
+  patterns: ['%{GREEDYDATA:parsed}'],
+});
+
+const makeAncestor = (
+  name: string,
+  steps: StreamlangDSL['steps'] = []
+): Streams.WiredStream.Definition =>
+  ({
+    name,
+    type: 'wired',
+    ingest: {
+      processing: { steps, updated_at: '2024-01-01T00:00:00.000Z' },
+      wired: { fields: {}, routing: [] },
+      lifecycle: { inherit: true },
+      settings: {},
+      failure_store: { enabled: false },
+    },
+  } as unknown as Streams.WiredStream.Definition);
+
+const makeEsSearchResponse = (sources: FlattenRecord[]) => ({
+  hits: {
+    hits: sources.map((source) => ({
+      _source: {
+        '@timestamp': '2024-01-01T00:00:00.000Z',
+        document: { source },
+        error: { message: 'parse error' },
+      },
+    })),
+  },
+});
+
+const makeSimulationResponse = (docs: FlattenRecord[]): ProcessingSimulationResponse => ({
+  detected_fields: [],
+  documents: docs.map((value) => ({
+    value,
+    detected_fields: [],
+    errors: [],
+    status: 'parsed' as const,
+    processed_by: [],
+  })),
+  processors_metrics: {},
+  definition_error: undefined,
+  documents_metrics: {
+    failed_rate: 0,
+    partially_parsed_rate: 0,
+    skipped_rate: 0,
+    parsed_rate: 1,
+    dropped_rate: 0,
+  },
+});
+
+const makeDeps = ({
+  searchResponse,
+  ancestors = [],
+}: {
+  searchResponse: ReturnType<typeof makeEsSearchResponse>;
+  ancestors?: Streams.WiredStream.Definition[];
+}) => ({
+  esClient: {
+    search: jest.fn().mockResolvedValue(searchResponse),
+  } as unknown as ElasticsearchClient,
+  streamsClient: {
+    getAncestors: jest.fn().mockResolvedValue(ancestors),
+  } as unknown as StreamsClient,
+  fieldsMetadataClient: {} as IFieldsMetadataClient,
+});
+
+describe('collectAncestorProcessing', () => {
+  it('returns empty steps when there are no ancestors', () => {
+    const result = collectAncestorProcessing([]);
+    expect(result.steps).toEqual([]);
+  });
+
+  it('returns steps from a single ancestor', () => {
+    const step = makeGrokStep('message');
+    const ancestor = makeAncestor('logs', [step]);
+
+    const result = collectAncestorProcessing([ancestor]);
+
+    expect(result.steps).toEqual([step]);
+  });
+
+  it('returns steps from multiple ancestors in root-to-parent order', () => {
+    const rootStep = makeGrokStep('root_field');
+    const parentStep = makeGrokStep('parent_field');
+
+    // Provide them out of order (parent before root) to verify sorting
+    const parent = makeAncestor('logs.nginx', [parentStep]);
+    const root = makeAncestor('logs', [rootStep]);
+
+    const result = collectAncestorProcessing([parent, root]);
+
+    expect(result.steps).toEqual([rootStep, parentStep]);
+  });
+
+  it('skips ancestors that have no processing steps', () => {
+    const step = makeGrokStep('message');
+    const withSteps = makeAncestor('logs', [step]);
+    const withoutSteps = makeAncestor('logs.nginx', []);
+
+    const result = collectAncestorProcessing([withoutSteps, withSteps]);
+
+    expect(result.steps).toEqual([step]);
+  });
+
+  it('does not include the current stream — regression test for the double-processing bug', () => {
+    // Simulate the bug scenario: ancestor has steps, and so does the current stream.
+    // collectAncestorProcessing should only ever receive ancestors (not the current stream),
+    // and this test verifies that the contract of the function is correctly scoped.
+    const ancestorStep = makeGrokStep('ancestor_field');
+    const ancestor = makeAncestor('logs', [ancestorStep]);
+
+    // The current stream's step — this must NOT appear in the output
+    const currentStreamStep = makeGrokStep('current_field');
+    const currentStream = makeAncestor('logs.nginx', [currentStreamStep]);
+
+    // Only pass the ancestor, not the current stream
+    const result = collectAncestorProcessing([ancestor]);
+
+    expect(result.steps).toContainEqual(ancestorStep);
+    expect(result.steps).not.toContainEqual(currentStreamStep);
+    // Also verify: if someone incorrectly passes the current stream, its step would appear
+    const buggyResult = collectAncestorProcessing([ancestor, currentStream]);
+    expect(buggyResult.steps).toContainEqual(currentStreamStep);
+  });
+});
+
+describe('getFailureStoreSamples', () => {
+  const baseDoc: FlattenRecord = { message: 'failed log line', 'log.level': 'error' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('direct child of root optimization', () => {
+    it('returns raw failure store docs without fetching ancestors for logs.child', async () => {
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+      });
+
+      const result = await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(result.documents).toEqual([baseDoc]);
+      expect(streamsClient.getAncestors).not.toHaveBeenCalled();
+      expect(mockSimulateProcessing).not.toHaveBeenCalled();
+    });
+
+    it('queries the failure store index using the ::failures selector', async () => {
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+      });
+
+      await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({ index: 'logs.nginx::failures' })
+      );
+    });
+  });
+
+  describe('empty failure store', () => {
+    it('returns empty array without fetching ancestors', async () => {
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([]),
+      });
+
+      const result = await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(result.documents).toEqual([]);
+      expect(streamsClient.getAncestors).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when failure store index does not exist (404)', async () => {
+      const notFoundError = new errors.ResponseError({
+        statusCode: 404,
+        headers: {},
+        meta: {} as never,
+        body: { error: { type: 'index_not_found_exception' } },
+        warnings: null,
+      });
+
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([]),
+      });
+      (esClient.search as jest.Mock).mockRejectedValue(notFoundError);
+
+      const result = await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(result.documents).toEqual([]);
+    });
+  });
+
+  describe('no ancestor processing', () => {
+    it('returns raw docs when ancestors have no processing steps', async () => {
+      const ancestorWithNoSteps = makeAncestor('logs', []);
+
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+        ancestors: [ancestorWithNoSteps],
+      });
+
+      const result = await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(result.documents).toEqual([baseDoc]);
+      expect(mockSimulateProcessing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ancestor processing applied', () => {
+    it('calls simulateProcessing with only the ancestor steps', async () => {
+      const ancestorStep = makeGrokStep('ancestor_field');
+      const ancestor = makeAncestor('logs', [ancestorStep]);
+      const processedDoc: FlattenRecord = { ...baseDoc, ancestor_field: 'parsed' };
+
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+        ancestors: [ancestor],
+      });
+      mockSimulateProcessing.mockResolvedValue(makeSimulationResponse([processedDoc]));
+
+      const result = await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(result.documents).toEqual([processedDoc]);
+      expect(mockSimulateProcessing).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            body: expect.objectContaining({
+              processing: { steps: [ancestorStep] },
+            }),
+          }),
+        })
+      );
+    });
+
+    it('regression: does not include the current stream processors in the pre-processing pass', async () => {
+      // This is the bug fixed by PR #260535:
+      // Before the fix, getStream(name) was called and the current stream's processors
+      // were added to the pre-processing DSL. This caused documents to appear already-parsed
+      // and then fail when the UI simulation ran those same processors a second time.
+      const ancestorStep = makeGrokStep('ancestor_field');
+      const ancestor = makeAncestor('logs', [ancestorStep]);
+
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+        ancestors: [ancestor],
+      });
+      mockSimulateProcessing.mockResolvedValue(makeSimulationResponse([baseDoc]));
+
+      await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      const call = mockSimulateProcessing.mock.calls[0][0];
+      const steps = call.params.body.processing.steps as StreamlangDSL['steps'];
+
+      // Only the ancestor step must be present — no step from 'logs.nginx.access' itself
+      expect(steps).toEqual([ancestorStep]);
+      // Confirm getAncestors was called but getStream was not
+      expect(streamsClient.getAncestors).toHaveBeenCalledWith('logs.nginx.access');
+      expect(streamsClient.getStream).toBeUndefined();
+    });
+
+    it('applies ancestors from root to closest parent when multiple ancestors exist', async () => {
+      const rootStep = makeGrokStep('root_field');
+      const midStep = makeGrokStep('mid_field');
+      // Deliberately provide them in reverse order to verify sort
+      const mid = makeAncestor('logs.nginx', [midStep]);
+      const root = makeAncestor('logs', [rootStep]);
+
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+        ancestors: [mid, root],
+      });
+      mockSimulateProcessing.mockResolvedValue(makeSimulationResponse([baseDoc]));
+
+      await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx.access' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      const call = mockSimulateProcessing.mock.calls[0][0];
+      const steps = call.params.body.processing.steps as StreamlangDSL['steps'];
+
+      expect(steps).toEqual([rootStep, midStep]);
+    });
+  });
+
+  describe('time range filtering', () => {
+    it('passes start and end to the ES query when provided', async () => {
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+      });
+
+      await getFailureStoreSamples({
+        params: {
+          path: { name: 'logs.nginx' },
+          query: { start: '2024-01-01T00:00:00.000Z', end: '2024-01-02T00:00:00.000Z' },
+        },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      expect(esClient.search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            bool: {
+              must: [
+                {
+                  range: {
+                    '@timestamp': {
+                      gte: '2024-01-01T00:00:00.000Z',
+                      lte: '2024-01-02T00:00:00.000Z',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+      );
+    });
+
+    it('omits the query entirely when no time range is provided', async () => {
+      const { esClient, streamsClient, fieldsMetadataClient } = makeDeps({
+        searchResponse: makeEsSearchResponse([baseDoc]),
+      });
+
+      await getFailureStoreSamples({
+        params: { path: { name: 'logs.nginx' } },
+        esClient,
+        streamsClient,
+        fieldsMetadataClient,
+      });
+
+      const searchCall = (esClient.search as jest.Mock).mock.calls[0][0];
+      expect(searchCall.query).toBeUndefined();
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.ts
@@ -8,7 +8,7 @@
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { IFieldsMetadataClient } from '@kbn/fields-metadata-plugin/server/services/fields_metadata/types';
 import type { FlattenRecord } from '@kbn/streams-schema';
-import { Streams } from '@kbn/streams-schema';
+import type { Streams } from '@kbn/streams-schema';
 import type { StreamlangDSL } from '@kbn/streamlang';
 import type { StreamsClient } from '../../../../lib/streams/client';
 import { FAILURE_STORE_SELECTOR } from '../../../../../common/constants';
@@ -232,7 +232,9 @@ async function fetchFailureStoreDocuments({
  * will run, and pre-applying them here would cause docs to appear already-parsed and then fail
  * the simulation on a second pass.
  */
-function collectAncestorProcessing(ancestors: Streams.WiredStream.Definition[]): StreamlangDSL {
+export function collectAncestorProcessing(
+  ancestors: Streams.WiredStream.Definition[]
+): StreamlangDSL {
   const allSteps: StreamlangDSL['steps'] = [];
 
   // Sort ancestors from root (shortest name) to closest parent

--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/failure_store_samples_handler.ts
@@ -111,14 +111,11 @@ export const getFailureStoreSamples = async ({
     return { documents: [] };
   }
 
-  // 3. Only fetch ancestors and stream definition when we have documents that need processing
-  const [ancestors, stream] = await Promise.all([
-    streamsClient.getAncestors(name),
-    streamsClient.getStream(name),
-  ]);
+  // 3. Only fetch ancestors when we have documents that need processing
+  const ancestors = await streamsClient.getAncestors(name);
 
-  // 4. Collect and combine processing steps from all ancestors (root to current stream)
-  const combinedProcessing = collectAncestorProcessing(ancestors, stream);
+  // 4. Collect and combine processing steps from all ancestors (root to closest parent)
+  const combinedProcessing = collectAncestorProcessing(ancestors);
 
   // If no processing steps are configured, return the raw documents
   if (combinedProcessing.steps.length === 0) {
@@ -226,34 +223,25 @@ async function fetchFailureStoreDocuments({
 }
 
 /**
- * Collects and combines processing steps from all ancestors in order from root to current stream.
- * This ensures processors are applied in the correct order as they would be during normal ingestion.
- * Returns a combined StreamlangDSL that can be passed to simulateProcessing.
+ * Collects and combines processing steps from all ancestors in order from root to closest parent.
+ * This brings failure store documents to the state they would be in when entering the current
+ * stream's pipeline, so the simulation can accurately show what the current stream's processors
+ * do to them.
+ *
+ * The current stream's own processors are intentionally excluded — those are what the UI simulation
+ * will run, and pre-applying them here would cause docs to appear already-parsed and then fail
+ * the simulation on a second pass.
  */
-function collectAncestorProcessing(
-  ancestors: Streams.WiredStream.Definition[],
-  currentStream: Streams.all.Definition
-): StreamlangDSL {
+function collectAncestorProcessing(ancestors: Streams.WiredStream.Definition[]): StreamlangDSL {
   const allSteps: StreamlangDSL['steps'] = [];
 
   // Sort ancestors from root (shortest name) to closest parent
   const sortedAncestors = [...ancestors].sort((a, b) => a.name.length - b.name.length);
 
-  // Add processing steps from each ancestor
+  // Add processing steps from each ancestor only
   for (const ancestor of sortedAncestors) {
     if (ancestor.ingest.processing.steps.length > 0) {
       allSteps.push(...ancestor.ingest.processing.steps);
-    }
-  }
-
-  // Add processing steps from the current stream if it's a wired or classic stream
-  if (Streams.WiredStream.Definition.is(currentStream)) {
-    if (currentStream.ingest.processing.steps.length > 0) {
-      allSteps.push(...currentStream.ingest.processing.steps);
-    }
-  } else if (Streams.ClassicStream.Definition.is(currentStream)) {
-    if (currentStream.ingest.processing.steps.length > 0) {
-      allSteps.push(...currentStream.ingest.processing.steps);
     }
   }
 


### PR DESCRIPTION
When simulating processing on failure store samples, ancestor processors are applied upfront to bring documents to the state they'd be in when entering the current stream's pipeline. Previously, the current stream's own processors were also included in this pre-processing step, causing documents to appear already-parsed — and then fail when the UI simulation ran those same processors a second time.                                                                                             
                                                                                                                                                                        
This fix removes the current stream from the pre-processing pass, so only ancestor processors are applied upfront.      

## Summary

Before: 
<img width="1588" height="920" alt="CleanShot 2026-03-31 at 18 30 37" src="https://github.com/user-attachments/assets/b6a13c2b-d4d8-4f29-a156-398aaa9caf83" />


After:

<img width="3256" height="1900" alt="CleanShot 2026-03-31 at 18 06 46@2x" src="https://github.com/user-attachments/assets/a0dec1a6-d947-4c67-8d22-42aae7aae7b8" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



