### PR TITLE
Add draft PR guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,5 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
+- Update your branch from `main` with `git merge origin/main` (after fetching). Do not rebase or reset against `main`.
+- Always open PRs as draft.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,5 +85,4 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
-- Update your branch from `main` with `git merge origin/main` (after fetching). Do not rebase or reset against `main`.
 - Always open PRs as draft.


### PR DESCRIPTION
## Summary
- ~Instruct agents to use `git merge origin/main` (not rebase/reset) to update branches~ will discuss this elsewhere
- Require agent-opened PRs to be drafts by default

<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->