### PR TITLE
[Search] Replace aria-selected with aria-expanded on Result toggle button

### DIFF
--- a/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/components/result/result.tsx
@@ -119,7 +119,7 @@ export const Result: React.FC<ResultProps> = ({
                     tooltipRef.current?.showToolTip();
                   }}
                   aria-label={tooltipText}
-                  aria-selected={isExpanded}
+                  aria-expanded={isExpanded}
                 />
               </EuiToolTip>
             </EuiFlexItem>


### PR DESCRIPTION
## Summary

## Summary

Fixes a critical `aria-allowed-attr` accessibility violation in the `Result` component (`@kbn/search-index-documents`). 

The "Show more fields" `EuiButtonIcon` was using `aria-selected` to communicate its toggle state, but `aria-selected` is not a valid ARIA attribute for the `button` role. This was replaced with `aria-expanded`, which is the semantically correct attribute for a button that controls the visibility of related content.




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->