### PR TITLE
[9.2] [Build] Add flag to revert to glibc 2.42 memory management (#255699)

### DIFF
--- a/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
+++ b/.buildkite/pipelines/build_pr_and_deploy_cloud.yml
@@ -59,9 +59,10 @@ steps:
           provider: gcp
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
-          machineType: n2-standard-8
-          preemptible: true
           diskSizeGb: 125
+          machineType: c4d-standard-16
+          diskType: hyperdisk-balanced
+          zones: us-central1-a,us-central1-b,us-central1-c
         if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
         timeout_in_minutes: 90
         key: build
@@ -76,8 +77,9 @@ steps:
           provider: gcp
           image: family/kibana-ubuntu-2404
           imageProject: elastic-images-prod
-          machineType: n2-standard-2
+          machineType: c2-standard-16
           preemptible: true
+          diskSizeGb: 150
         timeout_in_minutes: 30
         depends_on: build
         retry:

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -52,7 +52,7 @@ export async function runDockerGenerator(
    */
   if (flags.baseImage === 'wolfi')
     baseImageName =
-      'docker.elastic.co/wolfi/chainguard-base:latest@sha256:568df5fb0e237c3a2139399d4bd8e80994f24321fa8469aec565b8566704e83a';
+      'docker.elastic.co/wolfi/chainguard-base:latest@sha256:b2134dbfbcfb987eec9c249fc81111963de596ff76098775c2444a2869401d9c';
 
   let imageFlavor = '';
   if (flags.baseImage === 'wolfi' && !flags.serverless && !flags.cloud) imageFlavor += `-wolfi`;

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -92,8 +92,15 @@ RUN microdnf install --setopt=tsflags=nodocs -y \
       microdnf clean all
 {{/ubi}}
 {{#wolfi}}
-# TODO: Remove pinned shadow version once Wolfi image is updated. Newer releases of shadow require glibc 2.43 which is not available in the current image SHA.
-RUN apk --no-cache add bash curl fontconfig font-liberation libstdc++ libnss findutils shadow=4.19.3-r0 ca-certificates
+# Wolfi updated glibc from 2.42 to 2.43, which changed memory allocation behavior. This flag disables the new behavior.
+ENV GLIBC_TUNABLES=glibc.malloc.hugetlb=0
+
+RUN for iter in 1 2 3 4 5; do \
+      apk --no-cache add bash curl fontconfig font-liberation libstdc++ libnss findutils shadow ca-certificates{{#serverless}} libjemalloc2 mimalloc2{{/serverless}} && break; \
+      echo "apk add failed (attempt $iter/5), retrying in $((iter * 10))s..."; \
+      sleep $((iter * 10)); \
+      [ $iter -eq 5 ] && exit 1; \
+    done
 {{/wolfi}}
 
 # Bring in Kibana from the initial stage.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Build] Add flag to revert to glibc 2.42 memory management (#255699)](https://github.com/elastic/kibana/pull/255699)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T18:54:10Z","message":"[Build] Add flag to revert to glibc 2.42 memory management (#255699)\n\n## Summary\n\nReverts #255691\n\nNewer Chainguard images updated to `glibc 2.43` which changes memory\nallocation behavior. Adding this flag reverts that behavior and allows\nus to unblock Chainguard image updates.\n\nSee\nhttps://groups.google.com/a/elastic.co/g/support_team/c/RBgzGXEdyR8/m/MxtQhaAmCQAJ\nfor more details.","sha":"9f346df20cdb34f0792201cd70a5274a8f03995d","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","ci:cloud-deploy","ci:cloud-redeploy","ci:project-deploy-elasticsearch","ci:project-redeploy","v9.4.0"],"title":"[Build] Add flag to revert to glibc 2.42 memory management","number":255699,"url":"https://github.com/elastic/kibana/pull/255699","mergeCommit":{"message":"[Build] Add flag to revert to glibc 2.42 memory management (#255699)\n\n## Summary\n\nReverts #255691\n\nNewer Chainguard images updated to `glibc 2.43` which changes memory\nallocation behavior. Adding this flag reverts that behavior and allows\nus to unblock Chainguard image updates.\n\nSee\nhttps://groups.google.com/a/elastic.co/g/support_team/c/RBgzGXEdyR8/m/MxtQhaAmCQAJ\nfor more details.","sha":"9f346df20cdb34f0792201cd70a5274a8f03995d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255699","number":255699,"mergeCommit":{"message":"[Build] Add flag to revert to glibc 2.42 memory management (#255699)\n\n## Summary\n\nReverts #255691\n\nNewer Chainguard images updated to `glibc 2.43` which changes memory\nallocation behavior. Adding this flag reverts that behavior and allows\nus to unblock Chainguard image updates.\n\nSee\nhttps://groups.google.com/a/elastic.co/g/support_team/c/RBgzGXEdyR8/m/MxtQhaAmCQAJ\nfor more details.","sha":"9f346df20cdb34f0792201cd70a5274a8f03995d"}}]}] BACKPORT-->