### PR TITLE
[Security Solution][Endpoint] Updated kibana docs to include `xpack.securitySolution.maxEndpointScriptFileSize` as configurable in cloud

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -90,6 +90,14 @@ stack: ga 9.4+
 
 You can configure the following X-Pack settings from the Kibana **User Settings** editor.
 
+### Version 9.4+ [ec_version_9_4]
+```{applies_to}
+stack: ga 9.4
+```
+
+`xpack.securitySolution.maxEndpointScriptFileSize` {applies_to}`stack: ga 9.4+`
+:    The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
+
 ### Version 9.3+ [ec_version_9_3]
 ```{applies_to}
 stack: ga 9.3

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -96,7 +96,7 @@ stack: ga 9.4
 ```
 
 `xpack.securitySolution.maxEndpointScriptFileSize`
-:    The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
+:    The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
 
 ### Version 9.3+ [ec_version_9_3]
 ```{applies_to}

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -95,7 +95,7 @@ You can configure the following X-Pack settings from the Kibana **User Settings*
 stack: ga 9.4
 ```
 
-`xpack.securitySolution.maxEndpointScriptFileSize` {applies_to}`stack: ga 9.4+`
+`xpack.securitySolution.maxEndpointScriptFileSize`
 :    The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
 
 ### Version 9.3+ [ec_version_9_3]

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -96,7 +96,7 @@ stack: ga 9.4
 ```
 
 `xpack.securitySolution.maxEndpointScriptFileSize`
-:    The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
+:    The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
 
 ### Version 9.3+ [ec_version_9_3]
 ```{applies_to}

--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -96,7 +96,7 @@ stack: ga 9.4
 ```
 
 `xpack.securitySolution.maxEndpointScriptFileSize`
-:    The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
+:    The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
 
 ### Version 9.3+ [ec_version_9_3]
 ```{applies_to}

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -589,7 +589,7 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
 `xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.4+`
-:   The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
+:   The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
 
 
 `xpack.snapshot_restore.ui.enabled`

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -588,6 +588,10 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 `xpack.securitySolution.disableEndpointRuleAutoInstall` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.2.4+`
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
+`xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+:   The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
+    It is available in {{ecloud}} 9.4.0 and later versions.
+
 
 `xpack.snapshot_restore.ui.enabled`
 :   Set this value to false to disable the Snapshot and Restore UI. **Default: true**

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -588,9 +588,8 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 `xpack.securitySolution.disableEndpointRuleAutoInstall` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.2.4+`
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
-`xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
+`xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.4+`
 :   The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
-    It is available in {{ecloud}} 9.4.0 and later versions.
 
 
 `xpack.snapshot_restore.ui.enabled`

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -589,7 +589,7 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
 `xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.4+`
-:   The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400`
+:   The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
 
 
 `xpack.snapshot_restore.ui.enabled`

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -589,7 +589,7 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
 `xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.4+`
-:   The maximum file size in bytes for scripts uploaded to the Elastic Defend script library. Default is `26214400` (25MB).
+:   The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400` (25MB).
 
 
 `xpack.snapshot_restore.ui.enabled`

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -589,7 +589,7 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
 :   Set to `true` to disable the automatic installation of Elastic Defend SIEM rules when a new Endpoint integration policy is created. Introduced with v9.2.4. Default is `false`.
 
 `xpack.securitySolution.maxEndpointScriptFileSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}") {applies_to}`stack: ga 9.4+`
-:   The maximum file size in bytes allowed for Security Solution Endpoint scripts. Default is `26214400` (25MB).
+:   The maximum file size in bytes for scripts uploaded to the {{elastic-defend}} script library. Default is `26214400`
 
 
 `xpack.snapshot_restore.ui.enabled`


### PR DESCRIPTION
## Summary

- Adds docs that indicate `xpack.securitySolution.maxEndpointScriptFileSize` is available for configuration on cloud environments
    - Feature (Script Library + `runscript` response action) will be available with `v9.4.0` of the stack

