### PR TITLE
[Scout] Stabilize dashboard create-new flow

### DIFF
--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -139,7 +139,10 @@ export class DashboardApp {
   /** Clicks "Create new dashboard" on the listing page and waits for the editor toolbar to load. */
   async openNewDashboard() {
     await this.page.waitForLoadingIndicatorHidden();
-    await this.page.testSubj.click('newItemButton', { timeout: 30_000, noWaitAfter: true });
+    const newItemButton = this.page.testSubj.locator('newItemButton');
+    await expect(newItemButton).toBeVisible({ timeout: 30_000 });
+    await expect(newItemButton).toBeEnabled({ timeout: 30_000 });
+    await newItemButton.click({ noWaitAfter: true });
     await expect(this.addTopNavButton).toBeVisible({ timeout: 30_000 });
   }
 

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -129,6 +129,10 @@ export class DashboardApp {
 
   async goto() {
     await this.page.gotoApp('dashboards');
+    // The dashboard listing performs an initial fetch; in cloud/serverless targets this can exceed Scout's default 10s.
+    await expect(this.page.testSubj.locator('dashboardLandingPage')).toBeVisible({
+      timeout: 30_000,
+    });
   }
 
   async openDashboardWithId(id: string) {
@@ -138,7 +142,6 @@ export class DashboardApp {
 
   /** Clicks "Create new dashboard" on the listing page and waits for the editor toolbar to load. */
   async openNewDashboard() {
-    await this.page.waitForLoadingIndicatorHidden();
     const newItemButton = this.page.testSubj.locator('newItemButton');
     await expect(newItemButton).toBeVisible({ timeout: 30_000 });
     await expect(newItemButton).toBeEnabled({ timeout: 30_000 });

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -138,8 +138,9 @@ export class DashboardApp {
 
   /** Clicks "Create new dashboard" on the listing page and waits for the editor toolbar to load. */
   async openNewDashboard() {
-    await this.page.testSubj.click('newItemButton');
-    await expect(this.addTopNavButton).toBeVisible();
+    await this.page.waitForLoadingIndicatorHidden();
+    await this.page.testSubj.click('newItemButton', { timeout: 30_000, noWaitAfter: true });
+    await expect(this.addTopNavButton).toBeVisible({ timeout: 30_000 });
   }
 
   private getSettingsFlyout() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -129,10 +129,7 @@ export class DashboardApp {
 
   async goto() {
     await this.page.gotoApp('dashboards');
-    // The dashboard listing performs an initial fetch and can take longer than Scout's default action timeout in CI.
-    await expect(this.page.testSubj.locator('dashboardLandingPage')).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(this.page.testSubj.locator('dashboardLandingPage')).toBeVisible();
   }
 
   async openDashboardWithId(id: string) {
@@ -143,10 +140,10 @@ export class DashboardApp {
   /** Clicks "Create new dashboard" on the listing page and waits for the editor toolbar to load. */
   async openNewDashboard() {
     const newItemButton = this.page.testSubj.locator('newItemButton');
-    await expect(newItemButton).toBeVisible({ timeout: 30_000 });
-    await expect(newItemButton).toBeEnabled({ timeout: 30_000 });
+    await expect(newItemButton).toBeVisible();
+    await expect(newItemButton).toBeEnabled();
     await newItemButton.click({ noWaitAfter: true });
-    await expect(this.addTopNavButton).toBeVisible({ timeout: 30_000 });
+    await expect(this.addTopNavButton).toBeVisible();
   }
 
   private getSettingsFlyout() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/page_objects/dashboard_app.ts
@@ -129,7 +129,7 @@ export class DashboardApp {
 
   async goto() {
     await this.page.gotoApp('dashboards');
-    // The dashboard listing performs an initial fetch; in cloud/serverless targets this can exceed Scout's default 10s.
+    // The dashboard listing performs an initial fetch and can take longer than Scout's default action timeout in CI.
     await expect(this.page.testSubj.locator('dashboardLandingPage')).toBeVisible({
       timeout: 30_000,
     });


### PR DESCRIPTION
## Summary
- Fixes flakiness where `newItemButton` click times out even though the UI navigates to the new dashboard editor.
- Uses `noWaitAfter: true` for the click to avoid Playwright waiting on scheduled navigations, then waits for the editor toolbar.
- Uses page-specific readiness signals (`dashboardLandingPage`, editor toolbar) and avoids the global loading indicator.

Fixes #259483

## Evidence (CI artifacts)
- The Scout HTML report screenshot for failing runs shows the app already on **Editing New Dashboard** while `page.click('newItemButton')` still timed out.

## Test plan
- `node scripts/check_changes.ts`
- `node scripts/scout.js run-tests --arch stateful --domain classic --testFiles src/platform/plugins/shared/dashboard/test/scout/ui/parallel_tests/dashboard_search_by_value.spec.ts`