### PR TITLE
[Entity Analytics][Risk Score Maintainer] Add telemetry events for maintainer execution

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -314,6 +314,145 @@ export const RISK_SCORE_EXECUTION_CANCELLATION_EVENT: EventTypeOpts<{
   },
 };
 
+export type RiskScoreMaintainerStatus = 'success' | 'error' | 'skipped' | 'aborted';
+export type RiskScoreMaintainerSkipReason =
+  | 'license_insufficient'
+  | 'feature_disabled'
+  | 'risk_engine_disabled'
+  | 'reset_to_zero_disabled'
+  | 'phase_not_available';
+export type RiskScoreMaintainerErrorKind =
+  | 'esql_query_failed'
+  | 'bulk_write_failed'
+  | 'entity_store_write_failed'
+  | 'entity_fetch_failed'
+  | 'unexpected';
+export type RiskScoreMaintainerStage = 'phase1_base_scoring' | 'reset_to_zero';
+
+export const RISK_SCORE_MAINTAINER_RUN_SUMMARY_EVENT: EventTypeOpts<{
+  namespace: string;
+  entityType: string;
+  status: RiskScoreMaintainerStatus;
+  skipReason?: RiskScoreMaintainerSkipReason;
+  errorKind?: RiskScoreMaintainerErrorKind;
+  durationMs: number;
+  scoresWrittenTotal: number;
+  scoresWrittenBase: number;
+  scoresWrittenResetToZero: number;
+  pagesProcessed: number;
+  deferToPhase2Count: number;
+  notInStoreCount: number;
+  idBasedRiskScoringEnabled: boolean;
+  pipelineVersion: string;
+}> = {
+  eventType: 'risk_score_maintainer_run_summary',
+  schema: {
+    namespace: { type: 'keyword', _meta: { description: 'Kibana space where scoring ran' } },
+    entityType: { type: 'keyword', _meta: { description: 'Entity type scored (e.g. host, user)' } },
+    status: { type: 'keyword', _meta: { description: 'Run outcome status' } },
+    skipReason: {
+      type: 'keyword',
+      _meta: { optional: true, description: 'Bounded reason when status is skipped' },
+    },
+    errorKind: {
+      type: 'keyword',
+      _meta: { optional: true, description: 'Bounded error category when status is error' },
+    },
+    durationMs: { type: 'long', _meta: { description: 'Run duration in milliseconds' } },
+    scoresWrittenTotal: { type: 'long', _meta: { description: 'Total risk score docs written' } },
+    scoresWrittenBase: {
+      type: 'long',
+      _meta: { description: 'Risk score docs written during base scoring stage' },
+    },
+    scoresWrittenResetToZero: {
+      type: 'long',
+      _meta: { description: 'Risk score docs written during reset-to-zero stage' },
+    },
+    pagesProcessed: {
+      type: 'long',
+      _meta: { description: 'Number of base-scoring pages processed' },
+    },
+    deferToPhase2Count: {
+      type: 'long',
+      _meta: { description: 'Entities classified as defer_to_phase_2' },
+    },
+    notInStoreCount: {
+      type: 'long',
+      _meta: { description: 'Entities classified as not_in_store' },
+    },
+    idBasedRiskScoringEnabled: {
+      type: 'boolean',
+      _meta: { description: 'Whether Entity Store dual-write was enabled' },
+    },
+    pipelineVersion: {
+      type: 'keyword',
+      _meta: { description: 'Version identifier for V2 telemetry evolution' },
+    },
+  },
+};
+
+export const RISK_SCORE_MAINTAINER_STAGE_SUMMARY_EVENT: EventTypeOpts<{
+  namespace: string;
+  entityType: string;
+  stage: RiskScoreMaintainerStage;
+  status: RiskScoreMaintainerStatus;
+  skipReason?: RiskScoreMaintainerSkipReason;
+  errorKind?: RiskScoreMaintainerErrorKind;
+  durationMs: number;
+  pagesProcessed?: number;
+  scoresWritten?: number;
+  deferToPhase2Count?: number;
+  notInStoreCount?: number;
+  resetBatchLimitHit?: boolean;
+  idBasedRiskScoringEnabled: boolean;
+  pipelineVersion: string;
+}> = {
+  eventType: 'risk_score_maintainer_stage_summary',
+  schema: {
+    namespace: { type: 'keyword', _meta: { description: 'Kibana space where scoring ran' } },
+    entityType: { type: 'keyword', _meta: { description: 'Entity type scored (e.g. host, user)' } },
+    stage: { type: 'keyword', _meta: { description: 'Phase-1 stage identifier' } },
+    status: { type: 'keyword', _meta: { description: 'Stage outcome status' } },
+    skipReason: {
+      type: 'keyword',
+      _meta: { optional: true, description: 'Bounded reason when status is skipped' },
+    },
+    errorKind: {
+      type: 'keyword',
+      _meta: { optional: true, description: 'Bounded error category when status is error' },
+    },
+    durationMs: { type: 'long', _meta: { description: 'Stage duration in milliseconds' } },
+    pagesProcessed: {
+      type: 'long',
+      _meta: { optional: true, description: 'Number of pages processed in this stage' },
+    },
+    scoresWritten: {
+      type: 'long',
+      _meta: { optional: true, description: 'Risk score docs written in this stage' },
+    },
+    deferToPhase2Count: {
+      type: 'long',
+      _meta: { optional: true, description: 'Entities classified as defer_to_phase_2' },
+    },
+    notInStoreCount: {
+      type: 'long',
+      _meta: { optional: true, description: 'Entities classified as not_in_store' },
+    },
+    resetBatchLimitHit: {
+      type: 'boolean',
+      _meta: { optional: true, description: 'Whether reset-to-zero hit per-run batch limit' },
+    },
+    idBasedRiskScoringEnabled: {
+      type: 'boolean',
+      _meta: { description: 'Whether Entity Store dual-write was enabled' },
+    },
+    pipelineVersion: {
+      type: 'keyword',
+      _meta: { description: 'Version identifier for V2 telemetry evolution' },
+    },
+  },
+};
+
 interface AssetCriticalitySystemProcessedAssignmentFileEvent {
   processing: {
     startTime: string;
@@ -1798,6 +1937,8 @@ export const events = [
   RISK_SCORE_EXECUTION_SUCCESS_EVENT,
   RISK_SCORE_EXECUTION_ERROR_EVENT,
   RISK_SCORE_EXECUTION_CANCELLATION_EVENT,
+  RISK_SCORE_MAINTAINER_RUN_SUMMARY_EVENT,
+  RISK_SCORE_MAINTAINER_STAGE_SUMMARY_EVENT,
   ASSET_CRITICALITY_SYSTEM_PROCESSED_ASSIGNMENT_FILE_EVENT,
   ALERT_SUPPRESSION_EVENT,
   ENDPOINT_RESPONSE_ACTION_SENT_EVENT,

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -105,7 +105,6 @@ export interface SecuritySolutionPluginStartDependencies {
   anonymization: AnonymizationPluginStart;
   llmTasks?: LlmTasksPluginStart;
   agentBuilder?: AgentBuilderPluginStart;
-  entityStore?: EntityStoreStartContract;
 }
 
 export interface SecuritySolutionPluginSetup {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -105,6 +105,7 @@ export interface SecuritySolutionPluginStartDependencies {
   anonymization: AnonymizationPluginStart;
   llmTasks?: LlmTasksPluginStart;
   agentBuilder?: AgentBuilderPluginStart;
+  entityStore?: EntityStoreStartContract;
 }
 
 export interface SecuritySolutionPluginSetup {


### PR DESCRIPTION
## Summary

note: recreated from https://github.com/elastic/kibana/pull/260298 as it had to be reverted

Splitting this out from the main risk score maintainer PR to reduce its size and make reviews easier. 

This PR simply adds the Event-Based Telemetry (EBT) event schemas for the new Risk Score Maintainer and registers them. It does not yet emit them.

The two new events are:
- `risk_score_maintainer_run_summary`: Tracks the overall outcome of a maintainer execution for a specific entity type (e.g., host, user). It records the total duration, total scores written, overall status, and any high-level errors or skip reasons.
- `risk_score_maintainer_stage_summary`: Tracks the performance and outcome of individual stages within the maintainer run (e.g., the `phase1_base_scoring` stage vs the `reset_to_zero` stage). It includes granular metrics like pages processed, scores written in that specific stage, and stage-specific errors.