### PR TITLE
[8.19] [CI] Increase investigations cypress disks to 110G (#260423)

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -104,6 +104,7 @@ steps:
           imageProject: elastic-images-prod
           provider: gcp
           machineType: n2-standard-4
+          diskSizeGb: 110
           preemptible: true
         depends_on: build
         timeout_in_minutes: 60

--- a/.buildkite/pipelines/on_merge_fanout.yml
+++ b/.buildkite/pipelines/on_merge_fanout.yml
@@ -199,6 +199,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      diskSizeGb: 110
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     timeout_in_minutes: 60

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -116,6 +116,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      diskSizeGb: 110
       preemptible: true
     depends_on:
       - build
@@ -354,6 +355,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
+      diskSizeGb: 110
       preemptible: true
     depends_on:
       - build

--- a/.buildkite/pipelines/pull_request/security_solution/investigations.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/investigations.yml
@@ -4,6 +4,7 @@ steps:
     key: security-investigations
     agents:
       machineType: n2-standard-4
+      diskSizeGb: 110
       preemptible: true
       spotZones: us-central1-f,us-central1-c,us-central1-a
     depends_on:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Increase investigations cypress disks to 110G (#260423)](https://github.com/elastic/kibana/pull/260423)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2026-03-31T12:47:34Z","message":"[CI] Increase investigations cypress disks to 110G (#260423)\n\n## Summary\nIncrease investigations disk sizes to 110Gb across the board. We're on\nthe brink of breaching the current 100g limits.","sha":"f22bb09c0d04905038ca1e6afabb975d805e9fca","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open","v9.4.0","reviewer:skip-ai"],"title":"[CI] Increase investigations cypress disks to 110G","number":260423,"url":"https://github.com/elastic/kibana/pull/260423","mergeCommit":{"message":"[CI] Increase investigations cypress disks to 110G (#260423)\n\n## Summary\nIncrease investigations disk sizes to 110Gb across the board. We're on\nthe brink of breaching the current 100g limits.","sha":"f22bb09c0d04905038ca1e6afabb975d805e9fca"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260423","number":260423,"mergeCommit":{"message":"[CI] Increase investigations cypress disks to 110G (#260423)\n\n## Summary\nIncrease investigations disk sizes to 110Gb across the board. We're on\nthe brink of breaching the current 100g limits.","sha":"f22bb09c0d04905038ca1e6afabb975d805e9fca"}}]}] BACKPORT-->