### PR TITLE
[Docs] Add running_queries:minRunningTime to advanced settings reference

### DIFF
--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -495,6 +495,9 @@ $$$rollups-enableindexpatterns$$$`rollups:enableIndexPatterns` {applies_to}`stac
 
 ### {{product.elasticsearch}} [kibana-search-settings]
 
+$$$query-activity-minrunningtime$$$`query_activity:minRunningTime` {applies_to}`stack: preview 9.4` {applies_to}`serverless: unavailable`
+:   The minimum time in milliseconds that a query must be running before it appears on the [Query activity](docs-content://deploy-manage/monitor/query-activity.md) page. Increase this value to filter out fast-completing queries and focus on long-running ones. `100` by default.
+
 $$$courier-ignorefilteriffieldnotinindex$$$`courier:ignoreFilterIfFieldNotInIndex` {applies_to}`stack: ga` {applies_to}`elasticsearch: ga`
 :   Enhances support for dashboards containing visualizations accessing several dissimilar {{data-sources}}. When activated, filters are ignored for a visualization when the visualization's data view does not contain the filtering field. When deactivated, all filters are applied to all visualizations. `false` by default.
 


### PR DESCRIPTION
## Summary

Documents the new `running_queries:minRunningTime` advanced setting introduced by the Query activity plugin (#253216). This setting controls the minimum running time threshold (in ms) for queries to appear on the Query activity page. Default: `100` ms.

### Related

- https://github.com/elastic/docs-content/issues/5451
- Feature PR: https://github.com/elastic/kibana/pull/253216
- Docs-content PR: https://github.com/elastic/docs-content/pull/5739

> [!NOTE]
> This is a docs-only change. Should be merged after or alongside the Query activity feature PR (#253216).


Made with [Cursor](https://cursor.com)