### PR TITLE
[8.19] [APM] Remove unprocessed OTEL documents from service view infra tab (#259970)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/infrastructure/get_infrastructure_data.ts
@@ -39,49 +39,45 @@ export const getInfrastructureData = async ({
   const isOtel = Boolean(agentName && hasOpenTelemetryPrefix(agentName));
   const k8sFilterField = isOtel ? KUBERNETES_POD_NAME_OTEL : KUBERNETES_POD_NAME;
 
-  const response = await apmEventClient.search(
-    'get_service_infrastructure',
-    {
-      apm: {
-        events: [ProcessorEvent.metric],
+  const response = await apmEventClient.search('get_service_infrastructure', {
+    apm: {
+      events: [ProcessorEvent.metric],
+    },
+    body: {
+      track_total_hits: false,
+      size: 0,
+      query: {
+        bool: {
+          filter: [
+            ...termQuery(SERVICE_NAME, serviceName),
+            ...rangeQuery(start, end),
+            ...environmentQuery(environment),
+            ...kqlQuery(kuery),
+          ],
+        },
       },
-      body: {
-        track_total_hits: false,
-        size: 0,
-        query: {
-          bool: {
-            filter: [
-              ...termQuery(SERVICE_NAME, serviceName),
-              ...rangeQuery(start, end),
-              ...environmentQuery(environment),
-              ...kqlQuery(kuery),
-            ],
+      aggs: {
+        containerIds: {
+          terms: {
+            field: CONTAINER_ID,
+            size: 500,
           },
         },
-        aggs: {
-          containerIds: {
-            terms: {
-              field: CONTAINER_ID,
-              size: 500,
-            },
+        hostNames: {
+          terms: {
+            field: HOST_NAME,
+            size: 500,
           },
-          hostNames: {
-            terms: {
-              field: HOST_NAME,
-              size: 500,
-            },
-          },
-          podNames: {
-            terms: {
-              field: k8sFilterField,
-              size: 500,
-            },
+        },
+        podNames: {
+          terms: {
+            field: k8sFilterField,
+            size: 500,
           },
         },
       },
     },
-    { skipProcessorEventFilter: true }
-  );
+  });
 
   let containerIds: string[] =
     response.aggregations?.containerIds?.buckets.map((bucket) => bucket.key as string) ?? [];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM] Remove unprocessed OTEL documents from service view infra tab (#259970)](https://github.com/elastic/kibana/pull/259970)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T19:54:52Z","message":"[APM] Remove unprocessed OTEL documents from service view infra tab (#259970)\n\n## Summary\n\nCloses #257873\n\nAs described in #257873, the service views infra tab is currently\nincluding raw OTEL documents in it's results. The problem is most APM\nfeatures today do not support unprocessed OTEL. One of those features is\nthe environment selector, which is visible from the tab, and as\ndescribed in the issue is leading to inconsistencies when an environment\nfilter is applied vs viewing data for all envs.\n\nAs agreed by the team and product, this PR removes support for\nunprocessed OTEL in the infrastructure tab. Given that raw OTEL is not\nsupported for now in APM, trying to support it here while the rest of\nthe features break creates more disadvantages than advantages.\n\n> [!IMPORTANT]  \n> When dealing with OTEL instrumented k8s, there is a known issue with\nhow container id is set:\n> \n> Kubernetes runs a hidden **pause container** alongside every\napplication container in a pod. Its purpose is to hold the pod's network\nnamespace for the lifetime of the pod — it starts first and is never\nvisible in `kubectl get pods`.\n> When an OTel SDK starts up and auto-detects `container.id`, it reads\n`/proc/self/mountinfo` (the cgroup v2 fallback introduced because\n`/proc/self/cgroup` does not expose container IDs on cgroup v2 kernels).\nThe cgroup hierarchy under containerd looks like:\n> ```\n> /sys/fs/cgroup/kubepods/pod<uid>/\n> ├── <sandbox-container-id>/   ← pause container, created first\n> └── <app-container-id>/       ← actual service container\n> ```\n> The sandbox entry appears first because it was created first. The\nSDK's regex matches it before reaching the application container's\nentry, so all telemetry from the service is tagged with the sandbox ID.\n> This is a cross-SDK, cross-language problem rooted in the fact that\nthere is no portable mechanism for a process inside a container to\nobtain its own container ID:\n> -\n[java-instrumentation#8462](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8462)\n— Java agent picks up sandbox ID from `mountinfo`\n> -\n[opentelemetry-php#1114](https://github.com/open-telemetry/opentelemetry-php/issues/1114)\n— PHP SDK reports sandbox container ID\n> -\n[js-contrib#1408](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1408)\n— JS SDK on EKS picks up wrong ID from cgroup v2 path\n> -\n[containerd#8185](https://github.com/containerd/containerd/issues/8185)\n— upstream root cause: no standard mechanism exists for a process to\nobtain its own container ID from within a container\n>\n> In order to combat this problem, the `get_container_ids_by_pod_names`\nwill still use `skipProcessorEventFilter: true` The intent behind this\nis to be able to pick up raw container metrics stored under the\n`kubeletstatsreceiver.otel` dataset. While these metrics documents\naren't augmented for APM, they will contain the proper container ids.\nAnd, because this query is filtered by pod names that come from an\nenvironment-aware and thus APM augmented only query, we can ensure they\nwill only display for EDOT augmented services\n\n## Evidence\n\nUsing minikube, I've setup 3 different clusters in my local dev machine.\nThey're configured as follows:\n\n- All of them are built on top of the `opentelemetry-demo` repository\nand are thus instrumented with OTEL\n- 2 of them, `minikube-edot-qa` and `minikube-edot-prod`, have an EDOT\ncollector configured. This component is tasked with writing the data to\nES and ensure APM enrichment happens\n- The other one, `minikube-otel`, does not have an EDOT collector.\nInstead, the otel collector writes data directly to ES without APM\nenrichment\n\nKnowing this setup, the visual comparison below will walkthrough the\ninfra tab with and without the updates in this PR and will explain the\ndifferences between each scenario and why they happen\n\n### Visual Comparison\n\n#### Before (k8s)\n\n\nhttps://github.com/user-attachments/assets/be031bff-8215-4dcd-82fa-920f5438bbda\n\nWhy doesn't the `minikube-otel` environment show in the environment\nselector and why do the resources (container, pod and host) linked to it\n\"vanish\" when filtering by environments? The answer is in the result of\nthis query:\n\n\n<img width=\"2558\" height=\"1367\" alt=\"Screenshot 2026-03-31 at 15 01 52\"\nsrc=\"https://github.com/user-attachments/assets/d1564838-e327-4659-a861-ee30cd74d772\"\n/>\n\nNotice how even though `deployment.environment.name` (the field for\nenvironment in SemConv) is set, `service.environment` (the ECS field)\nisn't. This means this documents weren't properly enriched for APM use\nand thus aren't properly supported in the APM UIs. But, because the\ninfra data query is configured to include raw OTEL when no environment\nquery is selected this documents leak into this view when they really\nshouldn't be supported. This is the exact issue the changes in this PR\nare tackling\n\n#### After (k8s)\n\n\nhttps://github.com/user-attachments/assets/b8c8adcd-e172-4275-867f-ed8ec13ce625\n\nNow, no infrastructure is shown for `minikube-otel` at all, because the\ndata coming from the environment as we saw before isn't properly enrich.\nWith the update, this unsupported documents no longer leak into the view\nin this tab and thus we no longer have the problem of the sum of\nfiltered views not matching what \"environment: all\" show\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fbfec083d5ec8e637239210d7d9ae12321f4799","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","v9.4.0","Team:obs-presentation","v9.3.3","v9.2.8"],"title":"[APM] Remove unprocessed OTEL documents from service view infra tab","number":259970,"url":"https://github.com/elastic/kibana/pull/259970","mergeCommit":{"message":"[APM] Remove unprocessed OTEL documents from service view infra tab (#259970)\n\n## Summary\n\nCloses #257873\n\nAs described in #257873, the service views infra tab is currently\nincluding raw OTEL documents in it's results. The problem is most APM\nfeatures today do not support unprocessed OTEL. One of those features is\nthe environment selector, which is visible from the tab, and as\ndescribed in the issue is leading to inconsistencies when an environment\nfilter is applied vs viewing data for all envs.\n\nAs agreed by the team and product, this PR removes support for\nunprocessed OTEL in the infrastructure tab. Given that raw OTEL is not\nsupported for now in APM, trying to support it here while the rest of\nthe features break creates more disadvantages than advantages.\n\n> [!IMPORTANT]  \n> When dealing with OTEL instrumented k8s, there is a known issue with\nhow container id is set:\n> \n> Kubernetes runs a hidden **pause container** alongside every\napplication container in a pod. Its purpose is to hold the pod's network\nnamespace for the lifetime of the pod — it starts first and is never\nvisible in `kubectl get pods`.\n> When an OTel SDK starts up and auto-detects `container.id`, it reads\n`/proc/self/mountinfo` (the cgroup v2 fallback introduced because\n`/proc/self/cgroup` does not expose container IDs on cgroup v2 kernels).\nThe cgroup hierarchy under containerd looks like:\n> ```\n> /sys/fs/cgroup/kubepods/pod<uid>/\n> ├── <sandbox-container-id>/   ← pause container, created first\n> └── <app-container-id>/       ← actual service container\n> ```\n> The sandbox entry appears first because it was created first. The\nSDK's regex matches it before reaching the application container's\nentry, so all telemetry from the service is tagged with the sandbox ID.\n> This is a cross-SDK, cross-language problem rooted in the fact that\nthere is no portable mechanism for a process inside a container to\nobtain its own container ID:\n> -\n[java-instrumentation#8462](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8462)\n— Java agent picks up sandbox ID from `mountinfo`\n> -\n[opentelemetry-php#1114](https://github.com/open-telemetry/opentelemetry-php/issues/1114)\n— PHP SDK reports sandbox container ID\n> -\n[js-contrib#1408](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1408)\n— JS SDK on EKS picks up wrong ID from cgroup v2 path\n> -\n[containerd#8185](https://github.com/containerd/containerd/issues/8185)\n— upstream root cause: no standard mechanism exists for a process to\nobtain its own container ID from within a container\n>\n> In order to combat this problem, the `get_container_ids_by_pod_names`\nwill still use `skipProcessorEventFilter: true` The intent behind this\nis to be able to pick up raw container metrics stored under the\n`kubeletstatsreceiver.otel` dataset. While these metrics documents\naren't augmented for APM, they will contain the proper container ids.\nAnd, because this query is filtered by pod names that come from an\nenvironment-aware and thus APM augmented only query, we can ensure they\nwill only display for EDOT augmented services\n\n## Evidence\n\nUsing minikube, I've setup 3 different clusters in my local dev machine.\nThey're configured as follows:\n\n- All of them are built on top of the `opentelemetry-demo` repository\nand are thus instrumented with OTEL\n- 2 of them, `minikube-edot-qa` and `minikube-edot-prod`, have an EDOT\ncollector configured. This component is tasked with writing the data to\nES and ensure APM enrichment happens\n- The other one, `minikube-otel`, does not have an EDOT collector.\nInstead, the otel collector writes data directly to ES without APM\nenrichment\n\nKnowing this setup, the visual comparison below will walkthrough the\ninfra tab with and without the updates in this PR and will explain the\ndifferences between each scenario and why they happen\n\n### Visual Comparison\n\n#### Before (k8s)\n\n\nhttps://github.com/user-attachments/assets/be031bff-8215-4dcd-82fa-920f5438bbda\n\nWhy doesn't the `minikube-otel` environment show in the environment\nselector and why do the resources (container, pod and host) linked to it\n\"vanish\" when filtering by environments? The answer is in the result of\nthis query:\n\n\n<img width=\"2558\" height=\"1367\" alt=\"Screenshot 2026-03-31 at 15 01 52\"\nsrc=\"https://github.com/user-attachments/assets/d1564838-e327-4659-a861-ee30cd74d772\"\n/>\n\nNotice how even though `deployment.environment.name` (the field for\nenvironment in SemConv) is set, `service.environment` (the ECS field)\nisn't. This means this documents weren't properly enriched for APM use\nand thus aren't properly supported in the APM UIs. But, because the\ninfra data query is configured to include raw OTEL when no environment\nquery is selected this documents leak into this view when they really\nshouldn't be supported. This is the exact issue the changes in this PR\nare tackling\n\n#### After (k8s)\n\n\nhttps://github.com/user-attachments/assets/b8c8adcd-e172-4275-867f-ed8ec13ce625\n\nNow, no infrastructure is shown for `minikube-otel` at all, because the\ndata coming from the environment as we saw before isn't properly enrich.\nWith the update, this unsupported documents no longer leak into the view\nin this tab and thus we no longer have the problem of the sum of\nfiltered views not matching what \"environment: all\" show\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fbfec083d5ec8e637239210d7d9ae12321f4799"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259970","number":259970,"mergeCommit":{"message":"[APM] Remove unprocessed OTEL documents from service view infra tab (#259970)\n\n## Summary\n\nCloses #257873\n\nAs described in #257873, the service views infra tab is currently\nincluding raw OTEL documents in it's results. The problem is most APM\nfeatures today do not support unprocessed OTEL. One of those features is\nthe environment selector, which is visible from the tab, and as\ndescribed in the issue is leading to inconsistencies when an environment\nfilter is applied vs viewing data for all envs.\n\nAs agreed by the team and product, this PR removes support for\nunprocessed OTEL in the infrastructure tab. Given that raw OTEL is not\nsupported for now in APM, trying to support it here while the rest of\nthe features break creates more disadvantages than advantages.\n\n> [!IMPORTANT]  \n> When dealing with OTEL instrumented k8s, there is a known issue with\nhow container id is set:\n> \n> Kubernetes runs a hidden **pause container** alongside every\napplication container in a pod. Its purpose is to hold the pod's network\nnamespace for the lifetime of the pod — it starts first and is never\nvisible in `kubectl get pods`.\n> When an OTel SDK starts up and auto-detects `container.id`, it reads\n`/proc/self/mountinfo` (the cgroup v2 fallback introduced because\n`/proc/self/cgroup` does not expose container IDs on cgroup v2 kernels).\nThe cgroup hierarchy under containerd looks like:\n> ```\n> /sys/fs/cgroup/kubepods/pod<uid>/\n> ├── <sandbox-container-id>/   ← pause container, created first\n> └── <app-container-id>/       ← actual service container\n> ```\n> The sandbox entry appears first because it was created first. The\nSDK's regex matches it before reaching the application container's\nentry, so all telemetry from the service is tagged with the sandbox ID.\n> This is a cross-SDK, cross-language problem rooted in the fact that\nthere is no portable mechanism for a process inside a container to\nobtain its own container ID:\n> -\n[java-instrumentation#8462](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8462)\n— Java agent picks up sandbox ID from `mountinfo`\n> -\n[opentelemetry-php#1114](https://github.com/open-telemetry/opentelemetry-php/issues/1114)\n— PHP SDK reports sandbox container ID\n> -\n[js-contrib#1408](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1408)\n— JS SDK on EKS picks up wrong ID from cgroup v2 path\n> -\n[containerd#8185](https://github.com/containerd/containerd/issues/8185)\n— upstream root cause: no standard mechanism exists for a process to\nobtain its own container ID from within a container\n>\n> In order to combat this problem, the `get_container_ids_by_pod_names`\nwill still use `skipProcessorEventFilter: true` The intent behind this\nis to be able to pick up raw container metrics stored under the\n`kubeletstatsreceiver.otel` dataset. While these metrics documents\naren't augmented for APM, they will contain the proper container ids.\nAnd, because this query is filtered by pod names that come from an\nenvironment-aware and thus APM augmented only query, we can ensure they\nwill only display for EDOT augmented services\n\n## Evidence\n\nUsing minikube, I've setup 3 different clusters in my local dev machine.\nThey're configured as follows:\n\n- All of them are built on top of the `opentelemetry-demo` repository\nand are thus instrumented with OTEL\n- 2 of them, `minikube-edot-qa` and `minikube-edot-prod`, have an EDOT\ncollector configured. This component is tasked with writing the data to\nES and ensure APM enrichment happens\n- The other one, `minikube-otel`, does not have an EDOT collector.\nInstead, the otel collector writes data directly to ES without APM\nenrichment\n\nKnowing this setup, the visual comparison below will walkthrough the\ninfra tab with and without the updates in this PR and will explain the\ndifferences between each scenario and why they happen\n\n### Visual Comparison\n\n#### Before (k8s)\n\n\nhttps://github.com/user-attachments/assets/be031bff-8215-4dcd-82fa-920f5438bbda\n\nWhy doesn't the `minikube-otel` environment show in the environment\nselector and why do the resources (container, pod and host) linked to it\n\"vanish\" when filtering by environments? The answer is in the result of\nthis query:\n\n\n<img width=\"2558\" height=\"1367\" alt=\"Screenshot 2026-03-31 at 15 01 52\"\nsrc=\"https://github.com/user-attachments/assets/d1564838-e327-4659-a861-ee30cd74d772\"\n/>\n\nNotice how even though `deployment.environment.name` (the field for\nenvironment in SemConv) is set, `service.environment` (the ECS field)\nisn't. This means this documents weren't properly enriched for APM use\nand thus aren't properly supported in the APM UIs. But, because the\ninfra data query is configured to include raw OTEL when no environment\nquery is selected this documents leak into this view when they really\nshouldn't be supported. This is the exact issue the changes in this PR\nare tackling\n\n#### After (k8s)\n\n\nhttps://github.com/user-attachments/assets/b8c8adcd-e172-4275-867f-ed8ec13ce625\n\nNow, no infrastructure is shown for `minikube-otel` at all, because the\ndata coming from the environment as we saw before isn't properly enrich.\nWith the update, this unsupported documents no longer leak into the view\nin this tab and thus we no longer have the problem of the sum of\nfiltered views not matching what \"environment: all\" show\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7fbfec083d5ec8e637239210d7d9ae12321f4799"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260572","number":260572,"state":"MERGED","mergeCommit":{"sha":"efbce83bec2b7956ffc1fa741e8735379898d979","message":"[9.3] [APM] Remove unprocessed OTEL documents from service view infra tab (#259970) (#260572)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[APM] Remove unprocessed OTEL documents from service view infra tab\n(#259970)](https://github.com/elastic/kibana/pull/259970)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Fernandez <47327793+AlejandroFrndz@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260571","number":260571,"state":"MERGED","mergeCommit":{"sha":"5ae0658e84f057be2140272634f3a258d4afa716","message":"[9.2] [APM] Remove unprocessed OTEL documents from service view infra tab (#259970) (#260571)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[APM] Remove unprocessed OTEL documents from service view infra tab\n(#259970)](https://github.com/elastic/kibana/pull/259970)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Fernandez <47327793+AlejandroFrndz@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->