### PR TITLE
[kbn-code-owners] Add teams with missing area <> code owners mapping

### DIFF
--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -65,6 +65,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/obs-ux-management-team',
     'elastic/observability-design',
     'elastic/observability-ui',
+    'elastic/obs-sig-events-team',
     'elastic/observablt-robots',
     'elastic/streams-program-team',
   ],

--- a/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
+++ b/src/platform/packages/private/kbn-code-owners/src/code_owner_areas.ts
@@ -48,6 +48,7 @@ export const CODE_OWNER_AREA_MAPPINGS: { [area in CodeOwnerArea]: string[] } = {
     'elastic/ml-ui',
     'elastic/platform-docs',
     'elastic/response-ops',
+    'elastic/rna-project-team',
     'elastic/stack-monitoring',
     'elastic/workflows-eng',
   ],


### PR DESCRIPTION
This PR adds the @elastic/rna-project-team team and @elastic/obs-sig-events-team to the code owner <> area mapping. We're currently reporting an `unknown` value for the `test.file.area` field in our AppEx QA cluster for test files that belong to these teams. This PR fixes that.