### PR TITLE
[Entity Resolution] unflatten dotted keys in bulkUpdateEntityDocs

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/resolution_client.test.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/domain/resolution/resolution_client.test.ts
@@ -111,6 +111,44 @@ describe('ResolutionClient', () => {
       );
     });
 
+    it('should pass nested doc payloads to ES bulk (not flat dotted keys)', async () => {
+      const targetDoc = createEntityDoc('target-1');
+      const entity1Doc = createEntityDoc('entity-1');
+      const entity2Doc = createEntityDoc('entity-2');
+
+      mockEsClient.search.mockResolvedValueOnce(
+        createSearchResponse([targetDoc, entity1Doc, entity2Doc]) as never
+      );
+      mockEsClient.search.mockResolvedValueOnce(createSearchResponse([]) as never);
+      mockEsClient.bulk.mockResolvedValueOnce({ errors: false, items: [] } as never);
+
+      await client.linkEntities('target-1', ['entity-1', 'entity-2']);
+
+      expect(mockEsClient.bulk).toHaveBeenCalledTimes(1);
+      const bulkPayload = mockEsClient.bulk.mock.calls[0][0];
+      const { operations } = bulkPayload;
+      if (!operations) {
+        throw new Error('expected bulk operations');
+      }
+      const docOperations = operations.filter(
+        (op: unknown): op is { doc: unknown } =>
+          op !== null && typeof op === 'object' && 'doc' in op
+      );
+      expect(docOperations).toHaveLength(2);
+      const nestedDoc = {
+        entity: {
+          relationships: {
+            resolution: {
+              resolved_to: 'target-1',
+            },
+          },
+        },
+      };
+      for (const { doc } of docOperations) {
+        expect(doc).toEqual(nestedDoc);
+      }
+    });
+
     it('should skip entities already linked to the same target', async () => {
       const targetDoc = createEntityDoc('target-1');
       const alreadyLinkedDoc = createEntityDoc('entity-1', 'user', 'target-1');
@@ -313,7 +351,15 @@ describe('ResolutionClient', () => {
           refresh: true,
           operations: expect.arrayContaining([
             expect.objectContaining({
-              doc: { 'entity.relationships.resolution.resolved_to': null },
+              doc: {
+                entity: {
+                  relationships: {
+                    resolution: {
+                      resolved_to: null,
+                    },
+                  },
+                },
+              },
             }),
           ]),
         })

--- a/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolution.ts
+++ b/x-pack/solutions/security/plugins/entity_store/server/infra/elasticsearch/resolution.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core/server';
 import type { SearchResponse, BulkResponse } from '@elastic/elasticsearch/lib/api/types';
+import { unflattenObject } from '@kbn/object-utils';
 
 const RETRY_ON_CONFLICT = 3;
 
@@ -109,7 +110,7 @@ export const bulkUpdateEntityDocs = (
         retry_on_conflict: RETRY_ON_CONFLICT,
       },
     },
-    { doc },
+    { doc: unflattenObject(doc) },
   ]);
 
   return esClient.bulk({ operations, refresh: true });

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/resolution_api.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/resolution_api.spec.ts
@@ -8,6 +8,7 @@
 import { apiTest } from '@kbn/scout-security';
 import { expect } from '@kbn/scout-security/api';
 import type { Client } from '@elastic/elasticsearch';
+import { get } from 'lodash';
 import {
   COMMON_HEADERS,
   ENTITY_STORE_ROUTES,
@@ -79,10 +80,10 @@ apiTest.describe('Entity Store Resolution API tests', { tag: ENTITY_STORE_TAGS }
 
     // Verify via ES that resolved_to is set on alias docs
     const alias1Doc = await getEntitySource(esClient, alias1);
-    expect(alias1Doc[RESOLVED_TO_FIELD]).toBe(targetId);
+    expect(get(alias1Doc, RESOLVED_TO_FIELD)).toBe(targetId);
 
     const alias2Doc = await getEntitySource(esClient, alias2);
-    expect(alias2Doc[RESOLVED_TO_FIELD]).toBe(targetId);
+    expect(get(alias2Doc, RESOLVED_TO_FIELD)).toBe(targetId);
   });
 
   apiTest('Link: should skip already-linked entities', async ({ apiClient }) => {
@@ -215,10 +216,10 @@ apiTest.describe('Entity Store Resolution API tests', { tag: ENTITY_STORE_TAGS }
 
     // Verify via ES that resolved_to is null
     const alias1Doc = await getEntitySource(esClient, alias1);
-    expect(alias1Doc[RESOLVED_TO_FIELD]).toBeNull();
+    expect(get(alias1Doc, RESOLVED_TO_FIELD)).toBeNull();
 
     const alias2Doc = await getEntitySource(esClient, alias2);
-    expect(alias2Doc[RESOLVED_TO_FIELD]).toBeNull();
+    expect(get(alias2Doc, RESOLVED_TO_FIELD)).toBeNull();
 
     // Group should show standalone
     const group = await apiClient.get(


### PR DESCRIPTION
## Summary

Fixes #260551

Entity Resolution's `bulkUpdateEntityDocs` sent flat dotted keys (for example `entity.relationships.resolution.resolved_to`) straight to Elasticsearch bulk `update`. The entity store latest index has a `dot_expander` ingest pipeline configured as `default_pipeline`, but **ES bulk partial `update` with `doc` does not run `default_pipeline`** — this is a known upstream ES bug ([elastic/elasticsearch#105804](https://github.com/elastic/elasticsearch/issues/105804), fix PR [#105805](https://github.com/elastic/elasticsearch/pull/105805) targeted for ES v9.4.0).

As a result, fields were stored as literal flat keys in `_source` next to the nested `entity` object. That dual shape could surface as `ChainResolutionError` when the automated resolution maintainer races with manual or CSV resolution.

This change runs each bulk partial `doc` through `unflattenObject` from `@kbn/object-utils` — the same pattern used by entity store CRUD routes (e.g., `bulk_update.ts` line 23) — so updates merge into the nested `entity` tree correctly. Once the upstream ES fix lands, this becomes a harmless no-op.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Regression for callers that intentionally pass flat keys:** Low severity. `unflattenObject` is the same helper used elsewhere in entity_store for API payloads; nested-only docs pass through unchanged.
- **Bulk update shape:** Low severity. ES merge behavior improves (nested merge vs literal dotted field names).