### PR TITLE
[9.2] [Infra] Post-enrichment filtering for Hosts exclusion filters (#260426)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/constants.ts
@@ -76,3 +76,5 @@ export const DEFAULT_METRICS_VIEW_ATTRIBUTES = {
 export const SNAPSHOT_API_MAX_METRICS = 20;
 
 export const SCHEMA_SELECTOR_DOCS_LINK = 'https://ela.st/schema-selector-hosts';
+
+export const MAX_HOST_COUNT_LIMIT = 10000;

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
@@ -21,7 +21,7 @@ export const getFilteredHostNames = async ({
   schema,
 }: Required<Pick<GetHostParameters, 'infraMetricsClient' | 'from' | 'to' | 'limit' | 'schema'>> & {
   query?: estypes.QueryDslQueryContainer;
-}) => {
+}): Promise<string[]> => {
   const inventoryModel = findInventoryModel('host');
 
   const response = await infraMetricsClient.search({
@@ -31,27 +31,24 @@ export const getFilteredHostNames = async ({
     query: {
       bool: {
         filter: [
-          ...castArray(query),
           ...rangeQuery(from, to),
           ...(inventoryModel.nodeFilter?.({ schema }) ?? []),
+          ...(query ? [query] : []),
         ],
       },
     },
     aggs: {
-      uniqueHostNames: {
+      filteredHosts: {
         terms: {
           field: HOST_NAME_FIELD,
           size: limit,
-          order: {
-            _key: 'asc',
-          },
+          order: { _key: 'asc' },
         },
       },
     },
   });
 
-  const { uniqueHostNames } = response.aggregations ?? {};
-  return uniqueHostNames?.buckets?.map((p) => p.key as string) ?? [];
+  return response.aggregations?.filteredHosts?.buckets?.map((p) => p.key as string) ?? [];
 };
 
 export const getHasDataFromSystemIntegration = async ({

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getHosts } from './get_hosts';
+import type { GetHostParameters } from '../types';
+
+jest.mock('./get_filtered_hosts', () => ({
+  getFilteredHostNames: jest.fn(),
+}));
+
+jest.mock('./get_apm_hosts', () => ({
+  getApmHostNames: jest.fn(),
+}));
+
+jest.mock('./get_all_hosts', () => ({
+  getAllHosts: jest.fn(),
+}));
+
+jest.mock('./get_hosts_alerts_count', () => ({
+  getHostsAlertsCount: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  assertQueryStructure: jest.fn(),
+}));
+
+const { getFilteredHostNames } = jest.requireMock('./get_filtered_hosts');
+const { getApmHostNames } = jest.requireMock('./get_apm_hosts');
+const { getAllHosts } = jest.requireMock('./get_all_hosts');
+const { getHostsAlertsCount } = jest.requireMock('./get_hosts_alerts_count');
+
+const mockInfraMetricsClient = {} as GetHostParameters['infraMetricsClient'];
+const mockAlertsClient = {} as GetHostParameters['alertsClient'];
+const mockApmDataAccessServices = {
+  getDocumentSources: jest.fn().mockResolvedValue([{ source: 'mock' }]),
+  getHostNames: jest.fn(),
+} as unknown as GetHostParameters['apmDataAccessServices'];
+
+const host = (name: string, metadata: Array<{ name: string; value: string | null }> = []) => ({
+  name,
+  metadata,
+});
+
+const baseParams: GetHostParameters = {
+  metrics: [],
+  from: 0,
+  to: 1000,
+  limit: 100,
+  query: { bool: { filter: [] } },
+  alertsClient: mockAlertsClient,
+  apmDataAccessServices: mockApmDataAccessServices,
+  infraMetricsClient: mockInfraMetricsClient,
+  schema: 'ecs',
+};
+
+describe('getHosts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAllHosts.mockResolvedValue([]);
+    getHostsAlertsCount.mockResolvedValue([]);
+  });
+
+  describe('host name union', () => {
+    it('returns union of infra and APM hosts', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1', 'host-2']);
+      getApmHostNames.mockResolvedValue(['host-2', 'host-3']);
+
+      getAllHosts.mockResolvedValue([host('host-1'), host('host-2'), host('host-3')]);
+
+      const result = await getHosts(baseParams);
+
+      expect(result.nodes.map((n) => n.name).sort()).toEqual(['host-1', 'host-2', 'host-3']);
+    });
+
+    it('returns empty when no hosts match from either source', async () => {
+      getFilteredHostNames.mockResolvedValue([]);
+      getApmHostNames.mockResolvedValue([]);
+
+      const result = await getHosts(baseParams);
+
+      expect(result.nodes).toEqual([]);
+    });
+
+    it('works without APM data access services', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1']);
+
+      getAllHosts.mockResolvedValue([host('host-1')]);
+
+      const result = await getHosts({ ...baseParams, apmDataAccessServices: undefined });
+
+      expect(result.nodes.map((n) => n.name)).toEqual(['host-1']);
+    });
+  });
+
+  describe('post-enrichment filtering', () => {
+    it('removes hosts whose enriched metadata matches must_not exclusion', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1']);
+      getApmHostNames.mockResolvedValue(['host-1', 'apm-only-host']);
+
+      getAllHosts.mockResolvedValue([
+        host('host-1', [{ name: 'cloud.provider', value: 'aws' }]),
+        host('apm-only-host', [{ name: 'cloud.provider', value: 'gcp' }]),
+      ]);
+
+      const result = await getHosts({
+        ...baseParams,
+        query: {
+          bool: {
+            must_not: [{ match_phrase: { 'cloud.provider': 'gcp' } }],
+          },
+        },
+      });
+
+      expect(result.nodes.map((n) => n.name)).toEqual(['host-1']);
+    });
+
+    it('removes APM-only host enriched with excluded cloud.provider (rnqx scenario)', async () => {
+      getFilteredHostNames.mockResolvedValue([]);
+      getApmHostNames.mockResolvedValue(['infra-gcp-1', 'infra-gcp-2', 'rnqx']);
+
+      getAllHosts.mockResolvedValue([
+        host('infra-gcp-1', [{ name: 'cloud.provider', value: 'gcp' }]),
+        host('infra-gcp-2', [{ name: 'cloud.provider', value: 'gcp' }]),
+        host('rnqx', [{ name: 'cloud.provider', value: 'gcp' }]),
+      ]);
+
+      const result = await getHosts({
+        ...baseParams,
+        query: {
+          bool: {
+            must_not: [{ match_phrase: { 'cloud.provider': 'gcp' } }],
+          },
+        },
+      });
+
+      expect(result.nodes).toEqual([]);
+    });
+
+    it('keeps hosts with null metadata value even when field is excluded', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1']);
+      getApmHostNames.mockResolvedValue(['host-1', 'apm-only']);
+
+      getAllHosts.mockResolvedValue([
+        host('host-1', [{ name: 'cloud.provider', value: 'aws' }]),
+        host('apm-only', [{ name: 'cloud.provider', value: null }]),
+      ]);
+
+      const result = await getHosts({
+        ...baseParams,
+        query: {
+          bool: {
+            must_not: [{ match_phrase: { 'cloud.provider': 'gcp' } }],
+          },
+        },
+      });
+
+      expect(result.nodes.map((n) => n.name).sort()).toEqual(['apm-only', 'host-1']);
+    });
+
+    it('does not filter when query has no must_not clauses', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1']);
+      getApmHostNames.mockResolvedValue(['host-1', 'host-2']);
+
+      getAllHosts.mockResolvedValue([
+        host('host-1', [{ name: 'cloud.provider', value: 'gcp' }]),
+        host('host-2', [{ name: 'cloud.provider', value: 'gcp' }]),
+      ]);
+
+      const result = await getHosts(baseParams);
+
+      expect(result.nodes.map((n) => n.name).sort()).toEqual(['host-1', 'host-2']);
+    });
+
+    it('does not filter on non-metadata fields', async () => {
+      getFilteredHostNames.mockResolvedValue(['host-1']);
+      getApmHostNames.mockResolvedValue(['host-1']);
+
+      getAllHosts.mockResolvedValue([host('host-1', [{ name: 'cloud.provider', value: 'gcp' }])]);
+
+      const result = await getHosts({
+        ...baseParams,
+        query: {
+          bool: {
+            must_not: [{ match_phrase: { 'service.name': 'my-service' } }],
+          },
+        },
+      });
+
+      expect(result.nodes.map((n) => n.name)).toEqual(['host-1']);
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts.ts
@@ -7,11 +7,11 @@
 
 import type { TimeRangeMetadata } from '@kbn/apm-data-access-plugin/common';
 import type { GetInfraMetricsResponsePayload } from '../../../../../common/http_api/infra';
-import { getFilteredHostNames, getHasDataFromSystemIntegration } from './get_filtered_hosts';
+import { getFilteredHostNames } from './get_filtered_hosts';
 import type { GetHostParameters } from '../types';
 import { getAllHosts } from './get_all_hosts';
 import { getHostsAlertsCount } from './get_hosts_alerts_count';
-import { assertQueryStructure } from '../utils';
+import { assertQueryStructure, extractExcludedMetadataValues } from '../utils';
 import { getApmHostNames } from './get_apm_hosts';
 
 export const getHosts = async ({
@@ -68,12 +68,24 @@ export const getHosts = async ({
     }),
   ]);
 
+  const excludedValues = extractExcludedMetadataValues(query);
+  const filteredHostMetrics = hostMetricsResponse.filter((host) =>
+    host.metadata.every((meta) => {
+      const excluded = excludedValues.get(meta.name);
+      if (!excluded || meta.value === null) return true;
+      if (Array.isArray(meta.value)) {
+        return meta.value.every((v) => !excluded.has(String(v)));
+      }
+      return !excluded.has(String(meta.value));
+    })
+  );
+
   const alertsByHostName = alertsCountResponse.reduce((acc, { name, alertsCount }) => {
     acc[name] = { alertsCount };
     return acc;
   }, {} as Record<string, { alertsCount: number }>);
 
-  const hosts = hostMetricsResponse.map((host) => {
+  const hosts = filteredHostMetrics.map((host) => {
     const { alertsCount } = alertsByHostName[host.name] ?? {};
     return {
       ...host,
@@ -104,25 +116,15 @@ const getHostNames = async ({
 }) => {
   assertQueryStructure(query);
 
-  const hasSystemIntegrationData = await getHasDataFromSystemIntegration({
-    infraMetricsClient,
-    from,
-    to,
-    query,
-    schema,
-  });
-
-  const [monitoredHosts, apmHosts] = await Promise.all([
-    hasSystemIntegrationData
-      ? getFilteredHostNames({
-          infraMetricsClient,
-          query,
-          from,
-          to,
-          limit,
-          schema,
-        })
-      : undefined,
+  const [filteredHosts, apmHosts] = await Promise.all([
+    getFilteredHostNames({
+      infraMetricsClient,
+      query,
+      from,
+      to,
+      limit,
+      schema,
+    }),
     apmDataAccessServices && apmDocumentSources
       ? getApmHostNames({
           apmDataAccessServices,
@@ -136,5 +138,5 @@ const getHostNames = async ({
       : undefined,
   ]);
 
-  return [...new Set([...(monitoredHosts ?? []), ...(apmHosts ?? [])])];
+  return [...new Set([...filteredHosts, ...(apmHosts ?? [])])];
 };

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts_count.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts_count.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import { rangeQuery } from '@kbn/observability-plugin/server';
+import { rangeQuery, termsQuery } from '@kbn/observability-plugin/server';
 import type { ApmDataAccessServicesWrapper } from '../../../../lib/helpers/get_apm_data_access_client';
 import type { GetInfraEntityCountRequestBodyPayload } from '../../../../../common/http_api';
 import type { InfraMetricsClient } from '../../../../lib/helpers/get_infra_metrics_client';
-import { HOST_NAME_FIELD } from '../../../../../common/constants';
-import { assertQueryStructure } from '../utils';
+import { HOST_NAME_FIELD, MAX_HOST_COUNT_LIMIT } from '../../../../../common/constants';
+import { assertQueryStructure, extractExcludedMetadataValues } from '../utils';
 import { getDocumentsFilter } from '../helpers/query';
+import { getFilteredHostNames } from './get_filtered_hosts';
+import { getApmHostNames } from './get_apm_hosts';
 
 export async function getHostsCount({
   infraMetricsClient,
@@ -31,6 +33,35 @@ export async function getHostsCount({
     end: to,
   });
 
+  const [filteredHosts, apmHosts] = await Promise.all([
+    getFilteredHostNames({
+      infraMetricsClient,
+      query,
+      from,
+      to,
+      limit: MAX_HOST_COUNT_LIMIT,
+      schema,
+    }),
+    apmDataAccessServices && apmDocumentSources
+      ? getApmHostNames({
+          apmDataAccessServices,
+          apmDocumentSources,
+          query,
+          from,
+          to,
+          limit: MAX_HOST_COUNT_LIMIT,
+          schema,
+        })
+      : undefined,
+  ]);
+
+  const hostNames = [...new Set([...filteredHosts, ...(apmHosts ?? [])])];
+
+  if (hostNames.length === 0) return 0;
+
+  const excludedValues = extractExcludedMetadataValues(query);
+  if (excludedValues.size === 0) return hostNames.length;
+
   const documentsFilter = await getDocumentsFilter({
     apmDataAccessServices,
     apmDocumentSources,
@@ -39,6 +70,18 @@ export async function getHostsCount({
     schema,
   });
 
+  const metadataAggs: Record<string, object> = {};
+  for (const field of excludedValues.keys()) {
+    metadataAggs[field] = {
+      filter: { exists: { field } },
+      aggs: {
+        latest: {
+          top_metrics: { metrics: [{ field }], size: 1, sort: { '@timestamp': 'desc' } },
+        },
+      },
+    };
+  }
+
   const response = await infraMetricsClient.search({
     allow_no_indices: true,
     size: 0,
@@ -46,24 +89,30 @@ export async function getHostsCount({
     query: {
       bool: {
         filter: [
-          query,
+          ...termsQuery(HOST_NAME_FIELD, ...hostNames),
           ...rangeQuery(from, to),
-          {
-            bool: {
-              should: [...documentsFilter],
-            },
-          },
+          { bool: { should: [...documentsFilter] } },
         ],
       },
     },
     aggs: {
-      totalCount: {
-        cardinality: {
-          field: HOST_NAME_FIELD,
-        },
+      hosts: {
+        terms: { field: HOST_NAME_FIELD, size: MAX_HOST_COUNT_LIMIT, order: { _key: 'asc' } },
+        aggs: metadataAggs,
       },
     },
   });
 
-  return response.aggregations?.totalCount.value ?? 0;
+  const buckets = response.aggregations?.hosts?.buckets ?? [];
+
+  return buckets.filter((bucket: Record<string, any>) =>
+    [...excludedValues.entries()].every(([field, values]) => {
+      const metaValue = bucket[field]?.latest?.top?.[0]?.metrics?.[field];
+      if (metaValue == null) return true;
+      if (Array.isArray(metaValue)) {
+        return metaValue.every((v: unknown) => !values.has(String(v)));
+      }
+      return !values.has(String(metaValue));
+    })
+  ).length;
 }

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/utils.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/utils.test.ts
@@ -5,11 +5,103 @@
  * 2.0.
  */
 
-import { assertQueryStructure } from './utils';
+import { assertQueryStructure, extractExcludedMetadataValues } from './utils';
 
 const query = { bool: { must_not: [], filter: [], should: [], must: [] } };
 
 describe('utils', () => {
+  describe('extractExcludedMetadataValues', () => {
+    test('returns empty map for undefined query', () => {
+      expect(extractExcludedMetadataValues(undefined).size).toBe(0);
+    });
+
+    test('returns empty map for query without must_not', () => {
+      expect(extractExcludedMetadataValues({ bool: { filter: [] } }).size).toBe(0);
+    });
+
+    test('extracts match_phrase values for metadata fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: { must_not: [{ match_phrase: { 'cloud.provider': 'gcp' } }] },
+      });
+      expect(result.get('cloud.provider')).toEqual(new Set(['gcp']));
+    });
+
+    test('extracts match values for metadata fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: { must_not: [{ match: { 'host.os.name': 'Linux' } }] },
+      });
+      expect(result.get('host.os.name')).toEqual(new Set(['Linux']));
+    });
+
+    test('extracts term values for metadata fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: { must_not: [{ term: { 'cloud.provider': { value: 'aws' } } }] },
+      });
+      expect(result.get('cloud.provider')).toEqual(new Set(['aws']));
+    });
+
+    test('extracts terms values for metadata fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: { must_not: [{ terms: { 'cloud.provider': ['aws', 'gcp'] } }] },
+      });
+      expect(result.get('cloud.provider')).toEqual(new Set(['aws', 'gcp']));
+    });
+
+    test('ignores non-metadata fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: { must_not: [{ match_phrase: { 'service.name': 'my-service' } }] },
+      });
+      expect(result.size).toBe(0);
+    });
+
+    test('handles multiple must_not clauses across fields', () => {
+      const result = extractExcludedMetadataValues({
+        bool: {
+          must_not: [
+            { match_phrase: { 'cloud.provider': 'gcp' } },
+            { match_phrase: { 'host.os.name': 'Windows' } },
+          ],
+        },
+      });
+      expect(result.get('cloud.provider')).toEqual(new Set(['gcp']));
+      expect(result.get('host.os.name')).toEqual(new Set(['Windows']));
+    });
+
+    test('handles bool.should inside must_not', () => {
+      const result = extractExcludedMetadataValues({
+        bool: {
+          must_not: [
+            {
+              bool: {
+                should: [
+                  { match_phrase: { 'cloud.provider': 'gcp' } },
+                  { match_phrase: { 'cloud.provider': 'aws' } },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(result.get('cloud.provider')).toEqual(new Set(['gcp', 'aws']));
+    });
+
+    test('skips bool.should when must/filter are present (msm defaults to 0)', () => {
+      const result = extractExcludedMetadataValues({
+        bool: {
+          must_not: [
+            {
+              bool: {
+                must: [{ exists: { field: 'host.name' } }],
+                should: [{ match_phrase: { 'host.os.name': 'Windows' } }],
+              },
+            },
+          ],
+        },
+      });
+      expect(result.size).toBe(0);
+    });
+  });
+
   describe('assertQueryStructure', () => {
     test('should successfully parse a partial query object', () => {
       const partialQuery = {

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/utils.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/utils.ts
@@ -29,3 +29,82 @@ export const assertQueryStructure: (query?: any) => asserts query is BoolQuery =
     throw Boom.badRequest('Invalid query');
   }
 };
+
+const METADATA_FIELDS = new Set(['cloud.provider', 'host.os.name', 'host.ip']);
+
+/**
+ * Extracts excluded field/value pairs from must_not clauses in the query,
+ * limited to fields that getAllHosts enriches as host metadata.
+ * Used for post-enrichment filtering: hosts whose enriched metadata matches
+ * an excluded value are removed from the final results.
+ */
+export const extractExcludedMetadataValues = (
+  query?: estypes.QueryDslQueryContainer
+): Map<string, Set<string>> => {
+  const excluded = new Map<string, Set<string>>();
+  if (!query?.bool?.must_not) return excluded;
+
+  const mustNot = Array.isArray(query.bool.must_not) ? query.bool.must_not : [query.bool.must_not];
+
+  const addExcludedValue = (field: string, value: string) => {
+    if (!METADATA_FIELDS.has(field)) return;
+    if (!excluded.has(field)) excluded.set(field, new Set());
+    excluded.get(field)!.add(value);
+  };
+
+  const extractFromClause = (clause: estypes.QueryDslQueryContainer) => {
+    if (clause?.match_phrase) {
+      for (const [field, val] of Object.entries(clause.match_phrase)) {
+        const str = typeof val === 'string' ? val : (val as { query: string })?.query;
+        if (str) addExcludedValue(field, str);
+      }
+    }
+
+    if (clause?.match) {
+      for (const [field, val] of Object.entries(clause.match)) {
+        const str = typeof val === 'string' ? val : (val as { query: string })?.query;
+        if (str) addExcludedValue(field, String(str));
+      }
+    }
+
+    if (clause?.term) {
+      for (const [field, val] of Object.entries(clause.term)) {
+        const str =
+          typeof val === 'object' && val !== null ? (val as { value: unknown }).value : val;
+        if (str != null) addExcludedValue(field, String(str));
+      }
+    }
+
+    if (clause?.terms) {
+      for (const [field, values] of Object.entries(clause.terms)) {
+        if (Array.isArray(values)) {
+          for (const v of values) addExcludedValue(field, String(v));
+        }
+      }
+    }
+
+    if (clause?.bool?.should) {
+      const { minimum_should_match: msm, must, filter } = clause.bool;
+      const hasMustOrFilter =
+        (Array.isArray(must) ? must.length > 0 : !!must) ||
+        (Array.isArray(filter) ? filter.length > 0 : !!filter);
+      // ES defaults minimum_should_match to 0 when must/filter are present,
+      // making should clauses optional. Only extract when should is required.
+      const shouldIsRequired = msm === 1 || msm === '1' || (msm === undefined && !hasMustOrFilter);
+      if (shouldIsRequired) {
+        const shouldClauses = Array.isArray(clause.bool.should)
+          ? clause.bool.should
+          : [clause.bool.should];
+        for (const shouldClause of shouldClauses) {
+          extractFromClause(shouldClause as estypes.QueryDslQueryContainer);
+        }
+      }
+    }
+  };
+
+  for (const clause of mustNot) {
+    extractFromClause(clause as estypes.QueryDslQueryContainer);
+  }
+
+  return excluded;
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Infra] Post-enrichment filtering for Hosts exclusion filters (#260426)](https://github.com/elastic/kibana/pull/260426)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-01T09:11:10Z","message":"[Infra] Post-enrichment filtering for Hosts exclusion filters (#260426)","sha":"705ddb99317ff5143909e5c8352db962affac98b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","v9.4.0","Team:obs-presentation","v9.3.3","v9.2.8"],"title":"[Infra] Post-enrichment filtering for Hosts exclusion filters","number":260426,"url":"https://github.com/elastic/kibana/pull/260426","mergeCommit":{"message":"[Infra] Post-enrichment filtering for Hosts exclusion filters (#260426)","sha":"705ddb99317ff5143909e5c8352db962affac98b"}},"sourceBranch":"main","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260426","number":260426,"mergeCommit":{"message":"[Infra] Post-enrichment filtering for Hosts exclusion filters (#260426)","sha":"705ddb99317ff5143909e5c8352db962affac98b"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260649","number":260649,"state":"OPEN"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->