### PR TITLE
[Fleet] Add name tooltip in integration cards

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -264,10 +264,19 @@ export function PackageCard({
         betaBadgeProps={quickstartBadge(isQuickstart)}
         layout="horizontal"
         title={
-          <CardTitle
-            title={wrapTitleWithDeprecated({ title, deprecated: isDeprecated })}
-            titleBadge={titleBadge}
-          />
+          titleLineClamp ? (
+            <EuiToolTip content={title} position="top" display="block">
+              <CardTitle
+                title={wrapTitleWithDeprecated({ title, deprecated: isDeprecated })}
+                titleBadge={titleBadge}
+              />
+            </EuiToolTip>
+          ) : (
+            <CardTitle
+              title={wrapTitleWithDeprecated({ title, deprecated: isDeprecated })}
+              titleBadge={titleBadge}
+            />
+          )
         }
         titleSize={titleSize}
         description={showDescription ? description : ''}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_card.tsx
@@ -223,6 +223,8 @@ export function PackageCard({
     isActive: hasDataStreams,
   });
 
+  const displayTitle = wrapTitleWithDeprecated({ title, deprecated: isDeprecated });
+
   const testid = `integration-card:${id}`;
   return (
     <TrackApplicationView viewId={testid}>
@@ -265,17 +267,11 @@ export function PackageCard({
         layout="horizontal"
         title={
           titleLineClamp ? (
-            <EuiToolTip content={title} position="top" display="block">
-              <CardTitle
-                title={wrapTitleWithDeprecated({ title, deprecated: isDeprecated })}
-                titleBadge={titleBadge}
-              />
+            <EuiToolTip content={displayTitle} position="top" display="block">
+              <CardTitle title={displayTitle} titleBadge={titleBadge} />
             </EuiToolTip>
           ) : (
-            <CardTitle
-              title={wrapTitleWithDeprecated({ title, deprecated: isDeprecated })}
-              titleBadge={titleBadge}
-            />
+            <CardTitle title={displayTitle} titleBadge={titleBadge} />
           )
         }
         titleSize={titleSize}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/255688

## Summary

Small bugfix - Add name tooltip in integration cards



# Testing

- Go to http://localhost:5601/cri/app/security/get_started
- select "ingest your data" and see the integrations
- Choose tabs "all" and search for Apache
- Hover over the integrations cards

<img width="1568" height="1236" alt="Screenshot 2026-04-01 at 12 26 25" src="https://github.com/user-attachments/assets/191faa06-7148-43b2-9552-898e3038dddc" />
<img width="1183" height="783" alt="Screenshot 2026-04-01 at 12 26 40" src="https://github.com/user-attachments/assets/e2428dc3-1753-491c-b024-2722b2ad47c7" />



