### PR TITLE
[9.2] [ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.tsx
@@ -10,7 +10,6 @@ import { openLazyFlyout } from '@kbn/presentation-util';
 import { css } from '@emotion/react';
 import type { StartServicesAccessor } from '@kbn/core/public';
 import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
-import type { TimeRange } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -18,9 +17,6 @@ import { useTimeBuckets } from '@kbn/ml-time-buckets';
 import type { PublishesUnifiedSearch } from '@kbn/presentation-publishing';
 import {
   apiHasExecutionContext,
-  apiHasParentApi,
-  apiPublishesTimeRange,
-  apiPublishesTimeslice,
   fetch$,
   initializeTimeRangeManager,
   initializeTitleManager,
@@ -31,16 +27,7 @@ import {
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
-import type { Observable } from 'rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  distinctUntilChanged,
-  map,
-  merge,
-  of,
-  Subscription,
-} from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map, merge, Subscription } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
 import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 import { dispatchRenderComplete, dispatchRenderStart } from '@kbn/kibana-utils-plugin/public';
@@ -124,8 +111,6 @@ export const getAnomalySwimLaneEmbeddableFactory = (
         ? new BehaviorSubject(initialState.rawState.filters)
         : (parentApi as Partial<PublishesUnifiedSearch>)?.filters$) ??
         new BehaviorSubject(undefined)) as PublishesUnifiedSearch['filters$'];
-
-      const refresh$ = new BehaviorSubject<void>(undefined);
 
       const titleManager = initializeTitleManager(initialState.rawState);
       const timeRangeManager = initializeTimeRangeManager(initialState.rawState);
@@ -221,39 +206,11 @@ export const getAnomalySwimLaneEmbeddableFactory = (
         dataLoading$,
         serializeState,
       });
-      const appliedTimeRange$: Observable<TimeRange | undefined> = combineLatest([
-        api.timeRange$,
-        apiHasParentApi(api) && apiPublishesTimeRange(api.parentApi)
-          ? api.parentApi.timeRange$
-          : of(null),
-        apiHasParentApi(api) && apiPublishesTimeslice(api.parentApi)
-          ? api.parentApi.timeslice$
-          : of(null),
-      ]).pipe(
-        // @ts-ignore
-        map(([timeRange, parentTimeRange, parentTimeslice]) => {
-          if (timeRange) {
-            return timeRange;
-          }
-          if (parentTimeRange) {
-            return parentTimeRange;
-          }
-          if (parentTimeslice) {
-            return parentTimeslice;
-          }
-          return undefined;
-        })
-      ) as Observable<TimeRange | undefined>;
-
       const { swimLaneData$, onDestroy } = initializeSwimLaneDataFetcher(
         api,
         chartWidth$.asObservable(),
         dataLoading$,
         blockingError$,
-        appliedTimeRange$,
-        query$,
-        filters$,
-        refresh$,
         anomalySwimLaneServices
       );
 

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/initialize_swim_lane_data_fetcher.ts
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/initialize_swim_lane_data_fetcher.ts
@@ -6,8 +6,7 @@
  */
 
 import type { estypes } from '@elastic/elasticsearch';
-import { type TimeRange } from '@kbn/es-query';
-import type { PublishesUnifiedSearch } from '@kbn/presentation-publishing';
+import { fetch$ } from '@kbn/presentation-publishing';
 import {
   BehaviorSubject,
   catchError,
@@ -21,7 +20,6 @@ import {
   of,
   shareReplay,
   skipWhile,
-  startWith,
   switchMap,
   tap,
 } from 'rxjs';
@@ -41,10 +39,6 @@ export const initializeSwimLaneDataFetcher = (
   chartWidth$: Observable<number | undefined>,
   dataLoading$: BehaviorSubject<boolean | undefined>,
   blockingError$: BehaviorSubject<Error | undefined>,
-  appliedTimeRange$: Observable<TimeRange | undefined>,
-  query$: PublishesUnifiedSearch['query$'],
-  filters$: PublishesUnifiedSearch['filters$'],
-  refresh$: Observable<void>,
   services: AnomalySwimlaneServices
 ) => {
   const { anomalyTimelineService, anomalyDetectorService } = services;
@@ -63,16 +57,20 @@ export const initializeSwimLaneDataFetcher = (
     fromPage: swimLaneApi.fromPage,
   });
 
+  const fetchContext$ = fetch$(swimLaneApi).pipe(shareReplay(1));
+
   const bucketInterval$ = combineLatest([
     selectedJobs$,
     chartWidth$.pipe(distinctUntilChanged()),
-    appliedTimeRange$,
+    fetchContext$,
   ]).pipe(
     skipWhile(([jobs, width]) => {
       return !Array.isArray(jobs) || !width;
     }),
-    tap(([, , timeRange]) => {
-      anomalyTimelineService.setTimeRange(timeRange!);
+    tap(([, , fetchContext]) => {
+      if (fetchContext.timeRange) {
+        anomalyTimelineService.setTimeRange(fetchContext.timeRange);
+      }
     }),
     map(([jobs, width]) => anomalyTimelineService.getSwimlaneBucketInterval(jobs!, width!))
   );
@@ -80,17 +78,16 @@ export const initializeSwimLaneDataFetcher = (
   const subscription = combineLatest([
     selectedJobs$,
     swimLaneInput$,
-    query$,
-    filters$,
+    fetchContext$,
     bucketInterval$,
-    refresh$.pipe(startWith(null)),
   ])
     .pipe(
       tap(() => {
         dataLoading$.next(true);
       }),
       debounceTime(FETCH_RESULTS_DEBOUNCE_MS),
-      switchMap(([explorerJobs, input, query, filters, bucketInterval]) => {
+      switchMap(([explorerJobs, input, fetchContext, bucketInterval]) => {
+        const { query, filters } = fetchContext;
         if (!explorerJobs) {
           // couldn't load the list of jobs
           return of(undefined);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Jaszczurek","email":"92210485+rbrtj@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-01T07:41:08Z","message":"[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)\n\n## Summary\n\nFixes https://github.com/elastic/sdh-kibana/issues/6159\n\nThe swim lane embeddable used a manual `refresh# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  BehaviorSubject that\nwas never triggered, and constructed `appliedTimeRange# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from raw\nobservables that don't re-emit on auto-refresh (since relative time\nrange strings like \"now-15m\" don't change). Replace these with\n`fetch$(api)` from presentation publishing, which handles time range,\nquery, filters, and reload signals in one standard mechanism, matching\nhow the anomaly charts embeddable already works.\n\nHow to test:\n\n1. Get sample data eCommerce\n2. Create Dashboard with Anomaly swim lane and Anomaly Chart\n3. Set auto-refresh or refresh it manually using Refresh ↺ button\n4. Observe that Anomaly swim lane refreshes\n\n---------\n\nCo-authored-by: Konrad Krasocki <konrad.krasocki@elastic.co>\nCo-authored-by: Konrad Krasocki <104936644+KodeRad@users.noreply.github.com>","sha":"23a10a3d7db010d3583910a6a2ce1509e3a853d8","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix",":ml","Feature:Anomaly Detection","Team:ML","backport:version","v9.4.0","v9.3.3","v9.2.8","reviewer:macroscope","v8.19.14"],"title":"[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh","number":259962,"url":"https://github.com/elastic/kibana/pull/259962","mergeCommit":{"message":"[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)\n\n## Summary\n\nFixes https://github.com/elastic/sdh-kibana/issues/6159\n\nThe swim lane embeddable used a manual `refresh# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  BehaviorSubject that\nwas never triggered, and constructed `appliedTimeRange# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from raw\nobservables that don't re-emit on auto-refresh (since relative time\nrange strings like \"now-15m\" don't change). Replace these with\n`fetch$(api)` from presentation publishing, which handles time range,\nquery, filters, and reload signals in one standard mechanism, matching\nhow the anomaly charts embeddable already works.\n\nHow to test:\n\n1. Get sample data eCommerce\n2. Create Dashboard with Anomaly swim lane and Anomaly Chart\n3. Set auto-refresh or refresh it manually using Refresh ↺ button\n4. Observe that Anomaly swim lane refreshes\n\n---------\n\nCo-authored-by: Konrad Krasocki <konrad.krasocki@elastic.co>\nCo-authored-by: Konrad Krasocki <104936644+KodeRad@users.noreply.github.com>","sha":"23a10a3d7db010d3583910a6a2ce1509e3a853d8"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2","8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259962","number":259962,"mergeCommit":{"message":"[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)\n\n## Summary\n\nFixes https://github.com/elastic/sdh-kibana/issues/6159\n\nThe swim lane embeddable used a manual `refresh# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  BehaviorSubject that\nwas never triggered, and constructed `appliedTimeRange# Backport

This will backport the following commits from `main` to `9.2`:
{{{{raw}}}} - [[ML] Anomaly Detection: Fixes anomaly swim lane embeddable refresh (#259962)](https://github.com/elastic/kibana/pull/259962){{{{/raw}}}}

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT  from raw\nobservables that don't re-emit on auto-refresh (since relative time\nrange strings like \"now-15m\" don't change). Replace these with\n`fetch$(api)` from presentation publishing, which handles time range,\nquery, filters, and reload signals in one standard mechanism, matching\nhow the anomaly charts embeddable already works.\n\nHow to test:\n\n1. Get sample data eCommerce\n2. Create Dashboard with Anomaly swim lane and Anomaly Chart\n3. Set auto-refresh or refresh it manually using Refresh ↺ button\n4. Observe that Anomaly swim lane refreshes\n\n---------\n\nCo-authored-by: Konrad Krasocki <konrad.krasocki@elastic.co>\nCo-authored-by: Konrad Krasocki <104936644+KodeRad@users.noreply.github.com>","sha":"23a10a3d7db010d3583910a6a2ce1509e3a853d8"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.14","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->