### PR TITLE
[Discover][Flyout] Update overview fields table with new prop headerVisibility set to false

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/content_framework/table/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/content_framework/table/index.tsx
@@ -231,6 +231,7 @@ export function ContentFrameworkTable({
         customRenderCellValue={cellValueRenderer}
         customRenderCellPopover={cellPopoverRenderer}
         gridStyle={{ stripes: false, rowHover: 'none', header: 'shade' }}
+        headerVisibility={false}
       />
     </div>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
@@ -77,6 +77,7 @@ export interface TableGridProps {
   customRenderCellValue?: RenderCellValue;
   customRenderCellPopover?: React.JSXElementConstructor<EuiDataGridCellPopoverElementProps>;
   gridStyle?: EuiDataGridStyle;
+  headerVisibility?: boolean;
   hideFilteringOnComputedColumns?: boolean;
 }
 
@@ -107,6 +108,7 @@ export function TableGrid({
   customRenderCellValue,
   customRenderCellPopover,
   gridStyle,
+  headerVisibility,
   hideFilteringOnComputedColumns,
 }: TableGridProps) {
   const styles = useMemoCss(componentStyles);
@@ -299,6 +301,7 @@ export function TableGrid({
       className="kbnDocViewer__fieldsGrid"
       css={styles.fieldsGrid}
       columns={gridColumns}
+      headerVisibility={headerVisibility}
       toolbarVisibility={false}
       rowCount={rows.length}
       renderCellValue={customRenderCellValue ? customRenderCellValue : renderCellValue}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_grid.tsx
@@ -324,6 +324,22 @@ const componentStyles = {
         borderTop: 'none',
       },
 
+      '&.euiDataGrid--noHeader': {
+        overflow: 'visible',
+      },
+
+      '&.euiDataGrid--noHeader .euiDataGrid__content': {
+        overflow: 'visible',
+      },
+
+      '&.euiDataGrid--noHeader .euiDataGrid__virtualized': {
+        overflow: 'visible !important',
+      },
+
+      '&.euiDataGrid--noHeader .euiDataGridRow:first-of-type .euiDataGridRowCell': {
+        borderBlockStart: 'none',
+      },
+
       '&.euiDataGrid--headerUnderline .euiDataGridHeader': {
         borderBottom: euiTheme.border.thin,
       },

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/about/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/about/index.tsx
@@ -28,9 +28,8 @@ import {
   USER_AGENT_NAME,
   USER_AGENT_VERSION,
 } from '@kbn/apm-types';
-import { EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiPanel } from '@elastic/eui';
 import { Duration } from '@kbn/apm-ui-shared';
-import { css } from '@emotion/react';
 import { ContentFrameworkTable } from '../../../../content_framework';
 import { isTransaction } from '../../helpers';
 import {
@@ -72,7 +71,6 @@ export interface AboutProps
 }
 
 export const About = ({ hit, dataView, filter, onAddColumn, onRemoveColumn }: AboutProps) => {
-  const { euiTheme } = useEuiTheme();
   const isSpan = !isTransaction(hit);
   const flattenedHit = getFlattenedTraceDocumentOverview(hit);
   const traceRootSpan = useFetchTraceRootSpanContext();
@@ -104,14 +102,7 @@ export const About = ({ hit, dataView, filter, onAddColumn, onRemoveColumn }: Ab
   };
 
   return (
-    <EuiPanel
-      hasBorder={true}
-      hasShadow={false}
-      paddingSize="s"
-      css={css`
-        padding-bottom: ${euiTheme.base / 4}px;
-      `}
-    >
+    <EuiPanel hasBorder={true} hasShadow={false} paddingSize="s">
       <ContentFrameworkTable
         fieldNames={isSpan ? spanFieldNames : transactionFieldNames}
         id={'aboutTable'}


### PR DESCRIPTION
## Summary

Closes #248314

Removes the header row from the `EuiDataGrid` used in the Discover flyout Overview tab for both Traces and Logs documents.

### Context

The original design for the Overview tab key fields table didn't include a column header, but we shipped with it visible because `EuiDataGrid` didn't support hiding it at the time. Now that EUI supports the `headerVisibility` prop ([EuiDataGrid: Support rendering the header optionally](https://github.com/elastic/eui/pull/8386)), we can set it to `false` to match the original intended design.

### Changes
- Added an optional `headerVisibility` prop to `TableGrid`, passing it through to `EuiDataGrid`
- Set `headerVisibility={false}` in `ContentFrameworkTable`, which is the shared component used by both the Traces and Logs overview
- Added CSS overrides scoped to `.euiDataGrid--noHeader` in `TableGrid` to handle visual adjustments when the header is hidden:
  - Removed the top border on the first data row (previously adjacent to the header)
  - Set `overflow: visible` on the grid root, content wrapper, and virtualized container so that the first row's cell actions popover toolbar (positioned above each cell) is not clipped
- Simplified the Traces table panel by removing the custom `padding-bottom` override (matching Logs overview table panel)

### Demo

https://github.com/user-attachments/assets/b111051e-0e53-4d23-82fa-f71b5dba26ce
