### PR TITLE
[Agent Builder] FTR tests for Agent Builder sidebar

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/common/agent_selector/use_agent_options.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/common/agent_selector/use_agent_options.tsx
@@ -91,6 +91,7 @@ export const useAgentOptions = ({
         prepend: <AgentOptionPrepend agent={agent} />,
         textWrap: 'wrap',
         data: { agent },
+        'data-test-subj': `agentBuilderAgentOption-${agent.id}`,
       };
       return option;
     });

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/agents_popover_view.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/agents_popover_view.tsx
@@ -20,6 +20,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import type { AgentDefinition } from '@kbn/agent-builder-common';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
+import { useSendMessage } from '../../../context/send_message/send_message_context';
 import { useAgentBuilderAgents } from '../../../hooks/agents/use_agents';
 import { useNavigation } from '../../../hooks/use_navigation';
 import { appPaths } from '../../../utils/app_paths';
@@ -55,6 +56,7 @@ export const AgentsPopoverView: React.FC<AgentsPopoverViewProps> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const { agentId, setAgentId } = useConversationContext();
+  const { removeError } = useSendMessage();
   const { agents } = useAgentBuilderAgents();
   const { agentOptions, renderAgentOption } = useAgentOptions({ agents, selectedAgentId: agentId });
 
@@ -77,6 +79,7 @@ export const AgentsPopoverView: React.FC<AgentsPopoverViewProps> = ({
   ) => {
     const { checked, key: newAgentId } = changedOption;
     if (checked === 'on' && newAgentId) {
+      removeError();
       setAgentId?.(newAgentId);
       onClose();
     }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/embeddable_conversation_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/embeddable_conversation_header/embeddable_conversation_list.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useConversationContext } from '../../../context/conversation/conversation_context';
+import { useSendMessage } from '../../../context/send_message/send_message_context';
 import { useConversationList } from '../../../hooks/use_conversation_list';
 import {
   createConversationListItemStyles,
@@ -33,6 +34,7 @@ export const EmbeddableConversationList: React.FC<EmbeddableConversationListProp
 }) => {
   const { euiTheme } = useEuiTheme();
   const { agentId, conversationId, setConversationId } = useConversationContext();
+  const { removeError } = useSendMessage();
   const { conversations = [], isLoading } = useConversationList({ agentId });
 
   const sortedConversations = useMemo(
@@ -81,6 +83,7 @@ export const EmbeddableConversationList: React.FC<EmbeddableConversationListProp
             <button
               css={isActive ? activeItemStyles : itemStyles}
               onClick={() => {
+                removeError();
                 setConversationId?.(conversation.id);
                 onClose();
               }}

--- a/x-pack/platform/test/agent_builder_functional/config.ts
+++ b/x-pack/platform/test/agent_builder_functional/config.ts
@@ -18,5 +18,7 @@ export default createStatefulTestConfig({
     `--logging.loggers=${JSON.stringify([
       { name: 'plugins.agentBuilder', level: 'debug', appenders: ['console'] },
     ])}`,
+    '--feature_flags.overrides.aiAssistant.aiAgents.enabled=true',
+    '--uiSettings.overrides.aiAssistant:preferredChatExperience=agent',
   ],
 });

--- a/x-pack/platform/test/agent_builder_functional/tests/index.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/index.ts
@@ -44,5 +44,12 @@ export default function ({ loadTestFile, getService }: AgentBuilderUiFtrProvider
       loadTestFile(require.resolve('./agents/create_agent.ts'));
       loadTestFile(require.resolve('./agents/edit_agent.ts'));
     });
+
+    describe('sidebar', function () {
+      loadTestFile(require.resolve('./sidebar/sidebar_conversation_flow.ts'));
+      loadTestFile(require.resolve('./sidebar/sidebar_conversation_history.ts'));
+      loadTestFile(require.resolve('./sidebar/sidebar_agent_switch.ts'));
+      loadTestFile(require.resolve('./sidebar/sidebar_error_handling.ts'));
+    });
   });
 }

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_agent_switch.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_agent_switch.ts
@@ -57,9 +57,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('starts with the default agent selected', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.prepareEmbeddableSidebar();
       await agentBuilder.openEmbeddableMenu();
 
       const agentRow = await testSubjects.find('agentBuilderEmbeddableAgentRow');
@@ -71,11 +69,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('switching agent resets to a new conversation', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
-      await agentBuilder.openEmbeddableMenu();
-      await agentBuilder.clickEmbeddableNewChatButton();
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
 
       // Switch to the custom agent
       await agentBuilder.openEmbeddableMenu();
@@ -103,11 +97,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const MOCKED_RESPONSE = 'response from the custom agent';
       const MOCKED_TITLE = 'Custom Agent Conversation';
 
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
-      await agentBuilder.openEmbeddableMenu();
-      await agentBuilder.clickEmbeddableNewChatButton();
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
 
       // Switch to the custom agent
       await agentBuilder.openEmbeddableMenu();
@@ -148,11 +138,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('can switch back to the default agent', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
-      await agentBuilder.openEmbeddableMenu();
-      await agentBuilder.clickEmbeddableNewChatButton();
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
 
       // Switch to the custom agent first
       await agentBuilder.openEmbeddableMenu();

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_agent_switch.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_agent_switch.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
+import type { LlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { createLlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { setupAgentDirectAnswer } from '../../../agent_builder_api_integration/utils/proxy_scenario';
+import { createAgent, deleteAgent } from '../../../agent_builder_api_integration/utils/agents';
+import { createConnector, deleteConnectors } from '../../utils/connector_helpers';
+import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+const CUSTOM_AGENT_ID = 'sidebar-test-agent';
+const CUSTOM_AGENT_NAME = 'Sidebar Test Agent';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { agentBuilder } = getPageObjects(['agentBuilder']);
+  const testSubjects = getService('testSubjects');
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const es = getService('es');
+
+  describe('Sidebar Agent Switch', function () {
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+
+      await createAgent(
+        {
+          id: CUSTOM_AGENT_ID,
+          name: CUSTOM_AGENT_NAME,
+          description: 'A custom agent for sidebar switch testing',
+        },
+        { supertest }
+      );
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteConnectors(supertest);
+      await deleteAgent(CUSTOM_AGENT_ID, { supertest });
+      await es.deleteByQuery({
+        index: '.chat-conversations',
+        query: { match_all: {} },
+        wait_for_completion: true,
+        refresh: true,
+        conflicts: 'proceed',
+        ignore_unavailable: true,
+      });
+    });
+
+    it('starts with the default agent selected', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+
+      const agentRow = await testSubjects.find('agentBuilderEmbeddableAgentRow');
+      const agentRowText = await agentRow.getVisibleText();
+      expect(agentRowText).to.contain('Elastic AI Agent');
+
+      const browser = getService('browser');
+      await browser.pressKeys(browser.keys.ESCAPE);
+    });
+
+    it('switching agent resets to a new conversation', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      // Switch to the custom agent
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableAgentRow();
+
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderAgentOption-${CUSTOM_AGENT_ID}`);
+      });
+
+      await agentBuilder.selectEmbeddableAgent(CUSTOM_AGENT_ID);
+
+      // Agent options list should close after selection
+      await retry.try(async () => {
+        await testSubjects.missingOrFail(`agentBuilderAgentOption-${CUSTOM_AGENT_ID}`);
+      });
+
+      // Conversation should be reset — no prior response, input form ready
+      const hasResponse = await testSubjects.exists('agentBuilderRoundResponse');
+      expect(hasResponse).to.be(false);
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+    });
+
+    it('new conversation uses the switched agent', async () => {
+      const MOCKED_INPUT = 'message with the custom agent';
+      const MOCKED_RESPONSE = 'response from the custom agent';
+      const MOCKED_TITLE = 'Custom Agent Conversation';
+
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      // Switch to the custom agent
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableAgentRow();
+
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderAgentOption-${CUSTOM_AGENT_ID}`);
+      });
+
+      await agentBuilder.selectEmbeddableAgent(CUSTOM_AGENT_ID);
+
+      // Send a message and verify response
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_TITLE,
+        response: MOCKED_RESPONSE,
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_RESPONSE);
+      });
+
+      // The custom agent should still be shown in the menu
+      await agentBuilder.openEmbeddableMenu();
+      const agentRow = await testSubjects.find('agentBuilderEmbeddableAgentRow');
+      const agentRowText = await agentRow.getVisibleText();
+      expect(agentRowText).to.contain(CUSTOM_AGENT_NAME);
+
+      const browser = getService('browser');
+      await browser.pressKeys(browser.keys.ESCAPE);
+    });
+
+    it('can switch back to the default agent', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      // Switch to the custom agent first
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableAgentRow();
+
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderAgentOption-${CUSTOM_AGENT_ID}`);
+      });
+
+      await agentBuilder.selectEmbeddableAgent(CUSTOM_AGENT_ID);
+
+      // Now switch back to the default agent
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableAgentRow();
+
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderAgentOption-${agentBuilderDefaultAgentId}`);
+      });
+
+      await agentBuilder.selectEmbeddableAgent(agentBuilderDefaultAgentId);
+
+      // Agent options list should close after selection
+      await retry.try(async () => {
+        await testSubjects.missingOrFail(`agentBuilderAgentOption-${agentBuilderDefaultAgentId}`);
+      });
+
+      // Conversation should reset to new state
+      await retry.try(async () => {
+        const hasResponse = await testSubjects.exists('agentBuilderRoundResponse');
+        expect(hasResponse).to.be(false);
+      });
+
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+    });
+  });
+}

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_flow.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_flow.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { LlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { createLlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { setupAgentDirectAnswer } from '../../../agent_builder_api_integration/utils/proxy_scenario';
+import { createConnector, deleteConnectors } from '../../utils/connector_helpers';
+import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { agentBuilder } = getPageObjects(['agentBuilder']);
+  const testSubjects = getService('testSubjects');
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const es = getService('es');
+
+  describe('Sidebar Conversation Flow', function () {
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+      // Navigate to home — sidebar tests must NOT be on the agent builder app
+      // to avoid clashing with full-screen conversation components sharing the same data-test-subj
+      await agentBuilder.navigateToHome();
+      // Open the sidebar and reset to a fresh conversation — the sidebar persists
+      // the last agent and conversation ID so we always clear state before starting
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteConnectors(supertest);
+      await es.deleteByQuery({
+        index: '.chat-conversations',
+        query: { match_all: {} },
+        wait_for_completion: true,
+        refresh: true,
+        conflicts: 'proceed',
+        ignore_unavailable: true,
+      });
+    });
+
+    it('shows initial state', async () => {
+      // The menu button should be visible (part of the embeddable header)
+      await testSubjects.existOrFail('agentBuilderEmbeddableMenuButton');
+
+      // The conversation input form should be visible
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+    });
+
+    it('sends a message and receives a response', async () => {
+      const MOCKED_INPUT = 'hello from the sidebar';
+      const MOCKED_RESPONSE = 'This is the sidebar response';
+      const MOCKED_TITLE = 'Sidebar Flow Test';
+
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_TITLE,
+        response: MOCKED_RESPONSE,
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Wait for the response to appear in the sidebar
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_RESPONSE);
+      });
+    });
+
+    it('can start a new chat from the menu', async () => {
+      // Open the menu popover
+      await agentBuilder.openEmbeddableMenu();
+
+      // Click "New chat"
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      // Input form should still be visible (new empty conversation)
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+
+      // No response should be visible (new conversation)
+      const hasResponse = await testSubjects.exists('agentBuilderRoundResponse');
+      expect(hasResponse).to.be(false);
+    });
+
+    it('can send a message after starting a new conversation from the menu', async () => {
+      const MOCKED_INPUT = 'message after new chat';
+      const MOCKED_RESPONSE = 'Response after new chat';
+      const MOCKED_TITLE = 'Post New Chat Conversation';
+
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_TITLE,
+        response: MOCKED_RESPONSE,
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_RESPONSE);
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_flow.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_flow.ts
@@ -26,15 +26,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     before(async () => {
       llmProxy = await createLlmProxy(log);
       await createConnector(llmProxy, supertest);
-      // Navigate to home — sidebar tests must NOT be on the agent builder app
-      // to avoid clashing with full-screen conversation components sharing the same data-test-subj
-      await agentBuilder.navigateToHome();
-      // Open the sidebar and reset to a fresh conversation — the sidebar persists
-      // the last agent and conversation ID so we always clear state before starting
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
-      await agentBuilder.openEmbeddableMenu();
-      await agentBuilder.clickEmbeddableNewChatButton();
     });
 
     after(async () => {
@@ -51,6 +42,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('shows initial state', async () => {
+      await agentBuilder.prepareEmbeddableSidebar();
+
       // The menu button should be visible (part of the embeddable header)
       await testSubjects.existOrFail('agentBuilderEmbeddableMenuButton');
 
@@ -62,6 +55,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const MOCKED_INPUT = 'hello from the sidebar';
       const MOCKED_RESPONSE = 'This is the sidebar response';
       const MOCKED_TITLE = 'Sidebar Flow Test';
+
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
 
       await setupAgentDirectAnswer({
         proxy: llmProxy,
@@ -83,6 +78,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('can start a new chat from the menu', async () => {
+      await agentBuilder.prepareEmbeddableSidebar();
+
       // Open the menu popover
       await agentBuilder.openEmbeddableMenu();
 
@@ -102,8 +99,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const MOCKED_RESPONSE = 'Response after new chat';
       const MOCKED_TITLE = 'Post New Chat Conversation';
 
-      await agentBuilder.openEmbeddableMenu();
-      await agentBuilder.clickEmbeddableNewChatButton();
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
 
       await setupAgentDirectAnswer({
         proxy: llmProxy,

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_history.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_history.ts
@@ -66,9 +66,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('shows existing conversations in the menu', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.prepareEmbeddableSidebar();
       await agentBuilder.openEmbeddableMenu();
 
       // Both conversations should appear in the list
@@ -83,9 +81,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('can switch to an existing conversation and see its messages', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.prepareEmbeddableSidebar();
 
       // Select the first conversation by ID
       await agentBuilder.openEmbeddableMenu();
@@ -109,9 +105,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('search filters the conversation list', async () => {
-      await agentBuilder.navigateToHome();
-      await agentBuilder.openEmbeddableSidebar();
-      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.prepareEmbeddableSidebar();
       await agentBuilder.openEmbeddableMenu();
 
       // Type part of the first conversation's title in the search box

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_history.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_conversation_history.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { LlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { createLlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { createConnector, deleteConnectors } from '../../utils/connector_helpers';
+import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+const CONVERSATION_DATA = [
+  {
+    title: 'Sidebar History Conversation 1',
+    userMessage: 'Hello, this is sidebar conversation 1',
+    expectedResponse: 'Sidebar response for conversation 1',
+  },
+  {
+    title: 'Sidebar History Conversation 2',
+    userMessage: 'Hello, this is sidebar conversation 2',
+    expectedResponse: 'Sidebar response for conversation 2',
+  },
+];
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { agentBuilder } = getPageObjects(['agentBuilder']);
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const es = getService('es');
+  const log = getService('log');
+  const supertest = getService('supertest');
+
+  describe('Sidebar Conversation History', function () {
+    let llmProxy: LlmProxy;
+    const conversationIds: string[] = [];
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+
+      // Use full-screen experience helper method to create conversations (this test suite is only testing the history navigation of the sidebar, not the 'creating' of conversations)
+      for (const conv of CONVERSATION_DATA) {
+        const conversationId = await agentBuilder.createConversationViaUI(
+          conv.title,
+          conv.userMessage,
+          conv.expectedResponse,
+          llmProxy
+        );
+        conversationIds.push(conversationId);
+      }
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteConnectors(supertest);
+      await es.deleteByQuery({
+        index: '.chat-conversations',
+        query: { match_all: {} },
+        wait_for_completion: true,
+        refresh: true,
+        conflicts: 'proceed',
+        ignore_unavailable: true,
+      });
+    });
+
+    it('shows existing conversations in the menu', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+
+      // Both conversations should appear in the list
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderEmbeddableConversation-${conversationIds[0]}`);
+        await testSubjects.existOrFail(`agentBuilderEmbeddableConversation-${conversationIds[1]}`);
+      });
+
+      // Close the menu
+      const browser = getService('browser');
+      await browser.pressKeys(browser.keys.ESCAPE);
+    });
+
+    it('can switch to an existing conversation and see its messages', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+
+      // Select the first conversation by ID
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.selectEmbeddableConversation(conversationIds[0]);
+
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(CONVERSATION_DATA[0].expectedResponse);
+      });
+
+      // Switch to the second conversation by ID
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.selectEmbeddableConversation(conversationIds[1]);
+
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(CONVERSATION_DATA[1].expectedResponse);
+      });
+    });
+
+    it('search filters the conversation list', async () => {
+      await agentBuilder.navigateToHome();
+      await agentBuilder.openEmbeddableSidebar();
+      await agentBuilder.waitForEmbeddableSidebarOpen();
+      await agentBuilder.openEmbeddableMenu();
+
+      // Type part of the first conversation's title in the search box
+      const searchInput = await testSubjects.find('agentBuilderEmbeddableConversationSearch');
+      await searchInput.type('Conversation 1');
+
+      // First conversation should still be visible
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderEmbeddableConversation-${conversationIds[0]}`);
+      });
+
+      // Second conversation should be hidden (filtered out)
+      await retry.try(async () => {
+        await testSubjects.missingOrFail(
+          `agentBuilderEmbeddableConversation-${conversationIds[1]}`
+        );
+      });
+
+      // Clear the search
+      await searchInput.clearValueWithKeyboard();
+
+      // Both conversations should be visible again
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`agentBuilderEmbeddableConversation-${conversationIds[0]}`);
+        await testSubjects.existOrFail(`agentBuilderEmbeddableConversation-${conversationIds[1]}`);
+      });
+
+      // Close menu
+      const browser = getService('browser');
+      await browser.pressKeys(browser.keys.ESCAPE);
+    });
+  });
+}

--- a/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_error_handling.ts
+++ b/x-pack/platform/test/agent_builder_functional/tests/sidebar/sidebar_error_handling.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import type { LlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import { createLlmProxy } from '../../../agent_builder_api_integration/utils/llm_proxy';
+import {
+  setupAgentDirectAnswer,
+  setupAgentDirectError,
+} from '../../../agent_builder_api_integration/utils/proxy_scenario';
+import { createConnector, deleteConnectors } from '../../utils/connector_helpers';
+import type { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const { agentBuilder } = getPageObjects(['agentBuilder']);
+  const testSubjects = getService('testSubjects');
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+  const es = getService('es');
+
+  describe('Sidebar Error Handling', function () {
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await deleteConnectors(supertest);
+      await es.deleteByQuery({
+        index: '.chat-conversations',
+        query: { match_all: {} },
+        wait_for_completion: true,
+        refresh: true,
+        conflicts: 'proceed',
+        ignore_unavailable: true,
+      });
+    });
+
+    it('shows an error message and allows the user to retry', async () => {
+      const MOCKED_INPUT = 'sidebar error test message';
+      const MOCKED_RESPONSE = 'Successful response after retry';
+      const MOCKED_TITLE = 'Sidebar Error Retry Test';
+
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
+
+      // Setup the LLM proxy to return an error
+      await setupAgentDirectError({
+        proxy: llmProxy,
+        error: { type: 'error', statusCode: 400, errorMsg: 'Some test error' },
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Error should be visible
+      const isErrorVisible = await agentBuilder.isErrorVisible();
+      expect(isErrorVisible).to.be(true);
+
+      await testSubjects.find('agentBuilderRoundError');
+      await testSubjects.existOrFail('agentBuilderRoundErrorRetryButton');
+
+      // Setup a successful response for the retry
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_TITLE,
+        response: MOCKED_RESPONSE,
+      });
+
+      // Click retry
+      await agentBuilder.clickRetryButton();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Wait for the successful response
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_RESPONSE);
+      });
+
+      // Error should no longer be visible
+      await retry.try(async () => {
+        const isErrorStillVisible = await agentBuilder.isErrorVisible();
+        expect(isErrorStillVisible).to.be(false);
+      });
+    });
+
+    it('can start a new chat when there is an error', async () => {
+      const MOCKED_INPUT = 'sidebar error before new chat';
+      const MOCKED_RESPONSE = 'Successful response in new chat';
+      const MOCKED_TITLE = 'Sidebar New Chat After Error';
+
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
+
+      // Setup error
+      await setupAgentDirectError({
+        proxy: llmProxy,
+        error: { type: 'error', statusCode: 400, errorMsg: 'Some test error' },
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Error should be visible
+      const isErrorVisible = await agentBuilder.isErrorVisible();
+      expect(isErrorVisible).to.be(true);
+
+      // Open menu and click "New chat"
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.clickEmbeddableNewChatButton();
+
+      // Should be back to the initial state (no error, input form ready)
+      await retry.try(async () => {
+        const hasError = await agentBuilder.isErrorVisible();
+        expect(hasError).to.be(false);
+      });
+
+      await testSubjects.existOrFail('agentBuilderConversationInputForm');
+
+      // Send a successful message in the new chat
+      await setupAgentDirectAnswer({
+        proxy: llmProxy,
+        title: MOCKED_TITLE,
+        response: MOCKED_RESPONSE,
+      });
+
+      await agentBuilder.typeMessage(MOCKED_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(MOCKED_RESPONSE);
+      });
+    });
+
+    it('an error does not persist when switching to another conversation', async () => {
+      const SUCCESSFUL_INPUT = 'successful sidebar message';
+      const SUCCESSFUL_RESPONSE = 'Successful sidebar response';
+      const SUCCESSFUL_TITLE = 'Successful Sidebar Conversation';
+
+      const ERROR_INPUT = 'error message in sidebar';
+
+      // Create a successful conversation via the full-screen experience
+      const successfulConversationId = await agentBuilder.createConversationViaUI(
+        SUCCESSFUL_TITLE,
+        SUCCESSFUL_INPUT,
+        SUCCESSFUL_RESPONSE,
+        llmProxy
+      );
+
+      // Navigate to home and open the sidebar to continue the test there
+      await agentBuilder.prepareEmbeddableSidebarWithNewChat();
+
+      await retry.try(async () => {
+        const hasError = await agentBuilder.isErrorVisible();
+        expect(hasError).to.be(false);
+      });
+
+      // Trigger an error in the new conversation
+      await setupAgentDirectError({
+        proxy: llmProxy,
+        error: { type: 'error', statusCode: 400, errorMsg: 'Some test error' },
+      });
+
+      await agentBuilder.typeMessage(ERROR_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Error should be visible in the current conversation
+      const isErrorVisible = await agentBuilder.isErrorVisible();
+      expect(isErrorVisible).to.be(true);
+
+      await testSubjects.existOrFail('agentBuilderRoundErrorRetryButton');
+
+      // Switch back to the successful conversation by ID
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.selectEmbeddableConversation(successfulConversationId);
+
+      // Error should not be visible in the successful conversation
+      await retry.try(async () => {
+        const isErrorVisibleInSuccessful = await agentBuilder.isErrorVisible();
+        expect(isErrorVisibleInSuccessful).to.be(false);
+      });
+
+      // The successful response should still be visible
+      await retry.try(async () => {
+        const responseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const responseText = await responseElement.getVisibleText();
+        expect(responseText).to.contain(SUCCESSFUL_RESPONSE);
+      });
+    });
+
+    it('keeps previous conversation rounds visible when there is an error', async () => {
+      const FIRST_INPUT = 'first successful sidebar message';
+      const FIRST_RESPONSE = 'First successful sidebar response';
+      const FIRST_TITLE = 'Previous Rounds Sidebar Test';
+
+      const ERROR_INPUT = 'error message after success';
+
+      // Create the first conversation via the full-screen experience
+      const firstConversationId = await agentBuilder.createConversationViaUI(
+        FIRST_TITLE,
+        FIRST_INPUT,
+        FIRST_RESPONSE,
+        llmProxy
+      );
+
+      // Navigate to home, open the sidebar, and switch to the created conversation
+      await agentBuilder.prepareEmbeddableSidebar();
+      await agentBuilder.openEmbeddableMenu();
+      await agentBuilder.selectEmbeddableConversation(firstConversationId);
+
+      // Assert the first round is visible
+      await retry.try(async () => {
+        const firstResponseElement = await testSubjects.find('agentBuilderRoundResponse');
+        const firstResponseText = await firstResponseElement.getVisibleText();
+        expect(firstResponseText).to.contain(FIRST_RESPONSE);
+      });
+
+      // Trigger an error in the same conversation
+      await setupAgentDirectError({
+        proxy: llmProxy,
+        continueConversation: true,
+        error: { type: 'error', statusCode: 400, errorMsg: 'Some test error' },
+      });
+
+      await agentBuilder.typeMessage(ERROR_INPUT);
+      await agentBuilder.sendMessage();
+
+      await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+
+      // Error should be visible
+      const isErrorVisible = await agentBuilder.isErrorVisible();
+      expect(isErrorVisible).to.be(true);
+
+      await testSubjects.existOrFail('agentBuilderRoundErrorRetryButton');
+
+      // The previous successful round should still be visible
+      const previousResponseElement = await testSubjects.find('agentBuilderRoundResponse');
+      const previousResponseText = await previousResponseElement.getVisibleText();
+      expect(previousResponseText).to.contain(FIRST_RESPONSE);
+    });
+  });
+}

--- a/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
+++ b/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
@@ -740,6 +740,71 @@ export class AgentBuilderPageObject extends FtrService {
     };
   }
 
+  /*
+   * ==========================
+   * Embeddable sidebar helpers
+   * ==========================
+   */
+
+  /**
+   * Navigate to the Kibana home page — use this as the starting point for sidebar tests
+   * so the sidebar components don't clash with the full-screen agent builder components.
+   */
+  async navigateToHome() {
+    await this.common.navigateToApp('home');
+  }
+
+  /**
+   * Open the embeddable conversation sidebar by clicking the nav control button
+   */
+  async openEmbeddableSidebar() {
+    await this.testSubjects.click('AgentBuilderNavControlButton');
+  }
+
+  /**
+   * Wait for the embeddable sidebar to be open (menu button visible)
+   */
+  async waitForEmbeddableSidebarOpen() {
+    await this.retry.try(async () => {
+      await this.testSubjects.existOrFail('agentBuilderEmbeddableMenuButton');
+    });
+  }
+
+  /**
+   * Open the embeddable menu (hamburger button)
+   */
+  async openEmbeddableMenu() {
+    await this.testSubjects.click('agentBuilderEmbeddableMenuButton');
+  }
+
+  /**
+   * Click "New chat" button inside the embeddable menu popover
+   */
+  async clickEmbeddableNewChatButton() {
+    await this.testSubjects.click('agentBuilderEmbeddableNewChatButton');
+  }
+
+  /**
+   * Select an existing conversation from the embeddable menu popover
+   */
+  async selectEmbeddableConversation(conversationId: string) {
+    await this.testSubjects.click(`agentBuilderEmbeddableConversation-${conversationId}`);
+  }
+
+  /**
+   * Click the agent row in the conversations popover to navigate to agents view
+   */
+  async clickEmbeddableAgentRow() {
+    await this.testSubjects.click('agentBuilderEmbeddableAgentRow');
+  }
+
+  /**
+   * Select an agent from the agents popover view
+   */
+  async selectEmbeddableAgent(agentId: string) {
+    await this.testSubjects.click(`agentBuilderAgentOption-${agentId}`);
+  }
+
   async getAgentFormDisplayName() {
     const displayNameInputValue = await this.testSubjects.getAttribute(
       'agentSettingsDisplayNameInput',

--- a/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
+++ b/x-pack/platform/test/functional/page_objects/agent_builder_page.ts
@@ -755,6 +755,28 @@ export class AgentBuilderPageObject extends FtrService {
   }
 
   /**
+   * Standard starting point for all embeddable sidebar tests.
+   * Navigates to home, opens the sidebar, and waits for it to be ready.
+   * Must be called from any page except the agent builder app, to avoid
+   * data-test-subj clashes with full-screen components.
+   */
+  async prepareEmbeddableSidebar() {
+    await this.navigateToHome();
+    await this.openEmbeddableSidebar();
+    await this.waitForEmbeddableSidebarOpen();
+  }
+
+  /**
+   * Opens the sidebar and resets it to a blank new chat.
+   * Use when the test needs a clean empty conversation ready for input.
+   */
+  async prepareEmbeddableSidebarWithNewChat() {
+    await this.prepareEmbeddableSidebar();
+    await this.openEmbeddableMenu();
+    await this.clickEmbeddableNewChatButton();
+  }
+
+  /**
    * Open the embeddable conversation sidebar by clicking the nav control button
    */
   async openEmbeddableSidebar() {


### PR DESCRIPTION
## Add FTR tests for the embeddable conversation sidebar

Adds 15 functional tests covering the embeddable conversation sidebar widget (opened via the Kibana nav bar), organised into four suites:

### Sidebar Conversation Flow — basic interaction with the sidebar
- shows initial state
- sends a message and receives a response
- can start a new chat from the menu
- can send a message after starting a new conversation from the menu

### Sidebar Conversation History — conversation list and navigation
- shows existing conversations in the menu
- can switch to an existing conversation and see its messages
- search filters the conversation list

### Sidebar Agent Switch — switching between agents
- starts with the default agent selected
- switching agent resets to a new conversation
- new conversation uses the switched agent
- can switch back to the default agent

### Sidebar Error Handling — error states and recovery
- shows an error message and allows the user to retry
- can start a new chat when there is an error
- an error does not persist when switching to another conversation
- keeps previous conversation rounds visible when there is an error


