### PR TITLE
[Agent Builder] Dashboard skill: Guard with `experimental` UI setting

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
@@ -15,6 +15,7 @@ export const dashboardManagementSkill = defineSkillType({
   id: 'dashboard-management',
   name: 'dashboard-management',
   basePath: 'skills/platform/dashboard',
+  experimental: true,
   description:
     'Compose and update in-memory Kibana dashboards using ordered operations, visualization attachments, and inline visualization editing.',
   content: `## When to Use This Skill


### PR DESCRIPTION
## Summary

Adds an `experimental` flag for the dashboard skill so it doesn't get released with the next serverless release.