### PR TITLE
[Significant events] Small button prop fix

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/streams_view/streams_view.tsx
@@ -292,6 +292,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
             onClick={onBulkOnboardStreamsClick}
             iconType="radar"
             disabled={selectedStreams.length === 0}
+            size="xs"
           >
             {RUN_BULK_STREAM_ONBOARDING_BUTTON_LABEL}
           </EuiButtonEmpty>
@@ -302,6 +303,7 @@ export function StreamsView({ refreshUnbackedQueriesCount }: StreamsViewProps) {
             disabled={!aiFeatures?.genAiConnectors?.connectors?.length}
             isLoading={isSchedulingInsights || isWaitingForInsightsTask}
             data-test-subj="significant_events_discover_insights_button"
+            size="xs"
           >
             {DISCOVER_INSIGHTS_BUTTON_LABEL}
           </EuiButtonEmpty>


### PR DESCRIPTION
## Summary
Super small property adjustment to make the buttons the same size for table actions, same as in KIs.


<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/31f2f747-4cae-4294-ad50-d16fd6955cda" />
