### PR TITLE
[CI] Avoid Moon sync actions centrally

### DIFF
--- a/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
+++ b/.buildkite/pipeline-utils/affected-packages/strategy_moon.ts
@@ -26,7 +26,6 @@ export function getAffectedProjectsMoon(
     env: {
       ...process.env,
       MOON_BASE: mergeBase,
-      MOON_NO_ACTIONS: 'true',
     },
     timeout: 30000, // 30 seconds
   });

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -13,6 +13,9 @@ vcs:
 
 pipeline:
   installDependencies: false
+  syncWorkspace: false
+  syncProjectDependencies: false
+  syncProjects: false
 
 # https://moonrepo.dev/docs/guides/remote-cache
 # Auth credentials will be missing on local environments, but that's OK.


### PR DESCRIPTION
## Summary
We currently don't use any of the moon sync operations, but even the no-op sync for this amount of packages does stalls big runs, like `:jest` with no benefit.

In other Moon related wrappers, we'd set `MOON_NO_ACTIONS` but since Moon 2 it seems setting these fields to false in the workspace config works the same wonders.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->