### PR TITLE
[Entity Store] Fix hook to install in non-default namespaces if v1 is installed there

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
+++ b/x-pack/solutions/security/plugins/entity_store/public/hooks/useInstallEntityStoreV2.tsx
@@ -68,17 +68,14 @@ export const useInstallEntityStoreV2 = (services: Services) => {
           getStatusRequest
         );
         const isEntityStoreV2Installed = isEntityStoreInstalled(statusResponse.status);
-        // Entity store already installed → init entity maintainers only (any space).
+        // Entity store already installed → init entity maintainers only.
         if (isEntityStoreV2Installed) {
           await services.http.post(initEntityMaintainersRequest);
           return;
         }
-        // Entity store not installed and default space → install entity store, then init entity maintainers.
-        if (space.id === 'default') {
-          await services.http.post(installAllEntitiesRequest);
-          await services.http.post(initEntityMaintainersRequest);
-        }
-        // Entity store not installed and non-default space → do nothing.
+        // Entity store not installed → install entity store, then init entity maintainers.
+        await services.http.post(installAllEntitiesRequest);
+        await services.http.post(initEntityMaintainersRequest);
       } catch (e) {
         services.logger.error('Failed to initialize Entity Store V2');
         services.logger.error(e);


### PR DESCRIPTION
## Summary

Fixes the `useInstallEntityStoreV2` hook to restore the logic introduced by #255966.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
