### PR TITLE
[Automatic Import V2] Provide user tooltips

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/index.ts
@@ -70,7 +70,6 @@ export {
   type ReviewApproveMenuClickedPayload,
   type ApproveModalCancelClickedPayload,
   type ApproveModalApproveClickedPayload,
-  type IntegrationDeleteConfirmedPayload,
   type DataStreamDeleteConfirmedPayload,
   type DataStreamRefreshConfirmedPayload,
   type PipelineEditedPayload,

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/telemetry/types.ts
@@ -40,34 +40,34 @@ export enum AIV2TelemetryEventType {
 }
 
 export interface CreateIntegrationPageLoadedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface DataStreamFlyoutOpenedPayload {
-  sessionId: string;
+  sessionId?: string;
   /** Boolean flag if this is the first data stream being created for a new integration */
   isFirstDataStream: boolean;
 }
 
 export interface EditDataStreamFlyoutOpenedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface AnalyzeLogsTriggeredPayload {
-  sessionId: string;
+  sessionId?: string;
   logsSource: LogsSource;
 }
 
 export interface EditPipelineTabOpenedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface CodeEditorCopyClickedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface DataStreamCreationCompletePayload {
-  sessionId: string;
+  sessionId?: string;
   integrationId: string;
   integrationName: string;
   dataStreamId: string;
@@ -78,7 +78,7 @@ export interface DataStreamCreationCompletePayload {
 }
 
 export interface IntegrationInstalledPayload {
-  sessionId: string;
+  sessionId?: string;
   integrationName: string;
   version: string;
   dataStreamCount: number;
@@ -89,11 +89,11 @@ export type ManageIntegrationsTableViewedPayload = Record<string, never>;
 export type UploadIntegrationClickedPayload = Record<string, never>;
 
 export interface CancelButtonClickedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface DoneButtonClickedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export type ReviewApproveMenuClickedPayload = Record<string, never>;
@@ -101,19 +101,19 @@ export type IntegrationDownloadZipClickedPayload = Record<string, never>;
 export type ApproveModalCancelClickedPayload = Record<string, never>;
 export type ApproveModalApproveClickedPayload = Record<string, never>;
 export interface IntegrationDeleteConfirmedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface DataStreamDeleteConfirmedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface DataStreamRefreshConfirmedPayload {
-  sessionId: string;
+  sessionId?: string;
 }
 
 export interface PipelineEditedPayload {
-  sessionId: string;
+  sessionId?: string;
   linesAdded: number;
   linesRemoved: number;
   netLineChange: number;

--- a/x-pack/platform/plugins/shared/automatic_import_v2/common/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/common/telemetry/types.ts
@@ -32,7 +32,6 @@ export enum AIV2TelemetryEventType {
   // Fleet Events
   ManageIntegrationsTableViewed = 'aiv2_manage_integrations_table_viewed',
   UploadIntegrationClicked = 'aiv2_upload_integration_clicked',
-  IntegrationDeleteConfirmed = 'aiv2_integration_delete_confirmed',
   ReviewApproveMenuClicked = 'aiv2_review_approve_menu_clicked',
   IntegrationDownloadZipClicked = 'aiv2_integration_download_zip_clicked',
   ApproveModalCancelClicked = 'aiv2_approve_modal_cancel_clicked',
@@ -100,9 +99,6 @@ export type ReviewApproveMenuClickedPayload = Record<string, never>;
 export type IntegrationDownloadZipClickedPayload = Record<string, never>;
 export type ApproveModalCancelClickedPayload = Record<string, never>;
 export type ApproveModalApproveClickedPayload = Record<string, never>;
-export interface IntegrationDeleteConfirmedPayload {
-  sessionId?: string;
-}
 
 export interface DataStreamDeleteConfirmedPayload {
   sessionId?: string;
@@ -152,8 +148,6 @@ export type AIV2EventPayload<T extends AIV2TelemetryEventType> =
     ? ApproveModalCancelClickedPayload
     : T extends AIV2TelemetryEventType.ApproveModalApproveClicked
     ? ApproveModalApproveClickedPayload
-    : T extends AIV2TelemetryEventType.IntegrationDeleteConfirmed
-    ? IntegrationDeleteConfirmedPayload
     : T extends AIV2TelemetryEventType.DataStreamDeleteConfirmed
     ? DataStreamDeleteConfirmedPayload
     : T extends AIV2TelemetryEventType.DataStreamRefreshConfirmed

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/integration_management.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/integration_management.test.tsx
@@ -17,7 +17,6 @@ const mockNavigateToUrl = jest.fn();
 const mockGetUrlForApp = jest.fn(() => '/mock-integrations-url');
 const mockReportCancelButtonClicked = jest.fn();
 const mockReportDoneButtonClicked = jest.fn();
-const mockReportIntegrationDeleteConfirmed = jest.fn();
 const mockUseGetIntegrationById = jest.fn();
 const mockDeleteIntegrationMutateAsync = jest.fn().mockResolvedValue(undefined);
 
@@ -77,7 +76,6 @@ jest.mock('../telemetry_context', () => ({
   useTelemetry: () => ({
     reportCancelButtonClicked: mockReportCancelButtonClicked,
     reportDoneButtonClicked: mockReportDoneButtonClicked,
-    reportIntegrationDeleteConfirmed: mockReportIntegrationDeleteConfirmed,
   }),
 }));
 
@@ -271,7 +269,6 @@ describe('IntegrationManagement telemetry', () => {
       });
     });
 
-    expect(mockReportIntegrationDeleteConfirmed).toHaveBeenCalledTimes(1);
     expect(mockNavigateToApp).toHaveBeenCalledWith('integrations', expect.any(Object));
   });
 });

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/integration_management.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/integration_management.tsx
@@ -42,8 +42,7 @@ const IntegrationManagementContents: React.FC = () => {
   );
   const [isDeleteIntegrationModalVisible, setIsDeleteIntegrationModalVisible] = useState(false);
   const deleteIntegrationModalTitleId = useGeneratedHtmlId();
-  const { reportCancelButtonClicked, reportDoneButtonClicked, reportIntegrationDeleteConfirmed } =
-    useTelemetry();
+  const { reportCancelButtonClicked, reportDoneButtonClicked } = useTelemetry();
 
   const navigateToManage = useCallback(() => {
     application.navigateToApp(INTEGRATIONS_APP_ID, { path: INTEGRATIONS_MANAGE_PATH });
@@ -77,17 +76,11 @@ const IntegrationManagementContents: React.FC = () => {
     try {
       await deleteIntegrationMutation.mutateAsync({ integrationId });
       setIsDeleteIntegrationModalVisible(false);
-      reportIntegrationDeleteConfirmed();
       navigateToManage();
     } catch {
       // Error toast is shown by useDeleteIntegration
     }
-  }, [
-    deleteIntegrationMutation,
-    integrationId,
-    navigateToManage,
-    reportIntegrationDeleteConfirmed,
-  ]);
+  }, [deleteIntegrationMutation, integrationId, navigateToManage]);
 
   const handleDone = useCallback(() => {
     reportDoneButtonClicked();

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.test.tsx
@@ -209,6 +209,29 @@ describe('CreateDataStreamFlyout', () => {
 
       expect(getByTestId('analyzeLogsButton')).toBeDisabled();
     });
+
+    it('should keep analyze button disabled when data stream description is empty', async () => {
+      const Wrapper = createWrapper({
+        title: 'Integration',
+        description: 'Integration description',
+        connectorId: 'connector-1',
+        dataStreamTitle: 'My stream',
+        dataStreamDescription: '',
+        dataCollectionMethod: ['filestream'],
+        logSample: '2024-01-01 level=info msg=test',
+      });
+      const { getByTestId } = render(
+        <Wrapper>
+          <CreateDataStreamFlyout onClose={mockOnClose} />
+        </Wrapper>
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('analyzeLogsButton')).toBeInTheDocument();
+      });
+
+      expect(getByTestId('analyzeLogsButton')).toBeDisabled();
+    });
   });
 
   describe('log source selection', () => {

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/create_data_stream_flyout.tsx
@@ -25,6 +25,7 @@ import {
   EuiCallOut,
   EuiCheckableCard,
   EuiFilePicker,
+  EuiToolTip,
   useEuiTheme,
 } from '@elastic/eui';
 import { UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
@@ -39,6 +40,7 @@ import {
 import { PLUGIN_ID } from '../../../../../common/constants';
 import type { LogsSourceOption } from '../../forms/types';
 import { useIntegrationForm } from '../../forms/integration_form';
+import * as formI18n from '../../forms/translations';
 import * as i18n from './translations';
 import { FormStyledLabel } from '../../../../common/components/form_styled_label';
 import {
@@ -132,6 +134,7 @@ const dataCollectionMethodOptions: Array<EuiComboBoxOptionOption<string>> = [
 ];
 
 export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ onClose }) => {
+  const { euiTheme } = useEuiTheme();
   const styles = useLayoutStyles();
   const { integrationId: currentIntegrationId } = useParams<{ integrationId?: string }>();
   const { reportAnalyzeLogsTriggered } = useTelemetry();
@@ -225,7 +228,6 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
     [validateIndex, clearIndexValidationError]
   );
 
-  // Check if integration-level required fields are filled (only when creating new integration)
   const isIntegrationFieldsValid =
     !!formData?.title?.trim() && !!formData?.description?.trim() && !!formData?.connectorId?.trim();
 
@@ -240,6 +242,7 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
 
   const isDataStreamFieldsValid =
     !!formData?.dataStreamTitle?.trim() &&
+    !!formData?.dataStreamDescription?.trim() &&
     !hasDuplicateDataStreamName &&
     formData?.dataCollectionMethod != null &&
     formData.dataCollectionMethod.length > 0;
@@ -256,6 +259,87 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
     isValidatingIndex ||
     isLoading ||
     isUploadingSamples;
+
+  const analyzeLogsValidationReasons = useMemo(() => {
+    const reasons: string[] = [];
+    if (!formData?.title?.trim()) {
+      reasons.push(formI18n.TITLE_REQUIRED);
+    }
+    if (!formData?.description?.trim()) {
+      reasons.push(formI18n.DESCRIPTION_REQUIRED);
+    }
+    if (!formData?.connectorId?.trim()) {
+      reasons.push(formI18n.CONNECTOR_REQUIRED);
+    }
+    if (!formData?.dataStreamTitle?.trim()) {
+      reasons.push(formI18n.DATA_STREAM_TITLE_REQUIRED);
+    } else if (hasDuplicateDataStreamName) {
+      reasons.push(formI18n.DATA_STREAM_TITLE_ALREADY_EXISTS);
+    }
+    if (!formData?.dataStreamDescription?.trim()) {
+      reasons.push(formI18n.DATA_STREAM_DESCRIPTION_REQUIRED);
+    }
+    if (!formData?.dataCollectionMethod?.length) {
+      reasons.push(formI18n.DATA_COLLECTION_METHOD_REQUIRED);
+    }
+    if (logsSourceOption === 'file' && !logSample) {
+      reasons.push(formI18n.LOG_SAMPLE_REQUIRED);
+    }
+    if (logsSourceOption === 'index') {
+      if (!selectedIndex) {
+        reasons.push(formI18n.SELECTED_INDEX_REQUIRED);
+      } else if (indexValidationError) {
+        reasons.push(indexValidationError);
+      }
+    }
+    return reasons;
+  }, [
+    formData?.title,
+    formData?.description,
+    formData?.connectorId,
+    formData?.dataStreamTitle,
+    formData?.dataStreamDescription,
+    formData?.dataCollectionMethod,
+    hasDuplicateDataStreamName,
+    logsSourceOption,
+    logSample,
+    selectedIndex,
+    indexValidationError,
+  ]);
+
+  const analyzeLogsDisabledTooltipContent = useMemo(() => {
+    if (!isAnalyzeDisabled) {
+      return null;
+    }
+    if (analyzeLogsValidationReasons.length > 0) {
+      return (
+        <EuiText size="xs" component="div">
+          <ul
+            css={css`
+              margin-block: 0;
+              padding-inline-start: ${euiTheme.size.base};
+            `}
+          >
+            {analyzeLogsValidationReasons.map((reason, index) => (
+              <li key={`${reason}-${index}`}>{reason}</li>
+            ))}
+          </ul>
+        </EuiText>
+      );
+    }
+    if (isParsing || isValidatingIndex || isLoading || isUploadingSamples) {
+      return i18n.ANALYZE_LOGS_DISABLED_LOADING;
+    }
+    return null;
+  }, [
+    analyzeLogsValidationReasons,
+    euiTheme.size.base,
+    isAnalyzeDisabled,
+    isLoading,
+    isParsing,
+    isUploadingSamples,
+    isValidatingIndex,
+  ]);
 
   const handleAnalyzeLogs = useCallback(async () => {
     if (!formData) return;
@@ -447,6 +531,8 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
         <EuiText size="s" color="subdued">
           {i18n.LOGS_SECTION_DESCRIPTION}
         </EuiText>
+        <EuiSpacer size="xs" />
+        <EuiText size="s">{i18n.LOG_SAMPLE_REQUIRED_FOR_ANALYSIS}</EuiText>
 
         <EuiSpacer size="m" />
 
@@ -530,15 +616,31 @@ export const CreateDataStreamFlyout: React.FC<CreateDataStreamFlyoutProps> = ({ 
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              onClick={handleAnalyzeLogs}
-              disabled={isAnalyzeDisabled}
-              isLoading={isParsing || isLoading || isUploadingSamples}
-              data-test-subj="analyzeLogsButton"
-            >
-              {i18n.ANALYZE_LOGS_BUTTON}
-            </EuiButton>
+            {isAnalyzeDisabled && analyzeLogsDisabledTooltipContent != null ? (
+              <EuiToolTip content={analyzeLogsDisabledTooltipContent} position="top">
+                <span tabIndex={0}>
+                  <EuiButton
+                    fill
+                    onClick={handleAnalyzeLogs}
+                    disabled={isAnalyzeDisabled}
+                    isLoading={isParsing || isLoading || isUploadingSamples}
+                    data-test-subj="analyzeLogsButton"
+                  >
+                    {i18n.ANALYZE_LOGS_BUTTON}
+                  </EuiButton>
+                </span>
+              </EuiToolTip>
+            ) : (
+              <EuiButton
+                fill
+                onClick={handleAnalyzeLogs}
+                disabled={isAnalyzeDisabled}
+                isLoading={isParsing || isLoading || isUploadingSamples}
+                data-test-subj="analyzeLogsButton"
+              >
+                {i18n.ANALYZE_LOGS_BUTTON}
+              </EuiButton>
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/data_streams.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/data_streams.test.tsx
@@ -12,6 +12,7 @@ import { MemoryRouter, Route } from '@kbn/shared-ux-router';
 import { DataStreams } from './data_streams';
 import { UIStateProvider } from '../../contexts';
 import { useGetIntegrationById } from '../../../../common';
+import { useIntegrationForm } from '../../forms/integration_form';
 
 jest.mock('../../../../common', () => ({
   useGetIntegrationById: jest.fn(),
@@ -24,6 +25,11 @@ jest.mock('../../../../common', () => ({
   })),
 }));
 const mockUseGetIntegrationById = useGetIntegrationById as jest.Mock;
+
+jest.mock('../../forms/integration_form', () => ({
+  useIntegrationForm: jest.fn(),
+}));
+const mockUseIntegrationForm = useIntegrationForm as jest.Mock;
 
 const mockReportDataStreamFlyoutOpened = jest.fn();
 jest.mock('../../../telemetry_context', () => ({
@@ -73,6 +79,9 @@ describe('DataStreams', () => {
       isError: false,
       error: null,
       refetch: jest.fn(),
+    });
+    mockUseIntegrationForm.mockReturnValue({
+      formData: { title: 'Integration title', description: 'Integration description' },
     });
   });
 
@@ -217,6 +226,63 @@ describe('DataStreams', () => {
 
       // Zero-state description should NOT be visible
       expect(queryByText(/No data streams have been configured/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('create integration page', () => {
+    it('disables add data stream when integration name is empty', () => {
+      mockUseIntegrationForm.mockReturnValue({
+        formData: { title: '', description: 'Has description' },
+      });
+      mockUseGetIntegrationById.mockReturnValue({
+        integration: undefined,
+        isLoading: false,
+      });
+
+      const { getByTestId } = renderDataStreams();
+      expect(getByTestId('addDataStreamButton')).toBeDisabled();
+    });
+
+    it('disables add data stream when description is empty', () => {
+      mockUseIntegrationForm.mockReturnValue({
+        formData: { title: 'Has title', description: '   ' },
+      });
+      mockUseGetIntegrationById.mockReturnValue({
+        integration: undefined,
+        isLoading: false,
+      });
+
+      const { getByTestId } = renderDataStreams();
+      expect(getByTestId('addDataStreamButton')).toBeDisabled();
+    });
+
+    it('enables add data stream when name and description are set', () => {
+      mockUseIntegrationForm.mockReturnValue({
+        formData: { title: 'My integration', description: 'A description' },
+      });
+      mockUseGetIntegrationById.mockReturnValue({
+        integration: undefined,
+        isLoading: false,
+      });
+
+      const { getByTestId } = renderDataStreams();
+      expect(getByTestId('addDataStreamButton')).not.toBeDisabled();
+    });
+
+    it('does not open flyout when add button is disabled on create page', () => {
+      mockUseIntegrationForm.mockReturnValue({
+        formData: { title: '', description: '' },
+      });
+      mockUseGetIntegrationById.mockReturnValue({
+        integration: undefined,
+        isLoading: false,
+      });
+
+      const { getByTestId, queryByTestId } = renderDataStreams();
+
+      fireEvent.click(getByTestId('addDataStreamButton'));
+      expect(queryByTestId('createDataStreamFlyoutMock')).not.toBeInTheDocument();
+      expect(mockReportDataStreamFlyoutOpened).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/data_streams.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/data_streams.tsx
@@ -11,8 +11,9 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useUIState } from '../../contexts';
 import { CreateDataStreamFlyout } from './create_data_stream_flyout';
@@ -21,6 +22,7 @@ import { useGetIntegrationById } from '../../../../common';
 import { DataStreamsTable } from './data_streams_table/data_steams_table';
 import { EditPipelineFlyout } from './edit_pipeline_flyout';
 import { useTelemetry } from '../../../telemetry_context';
+import { useIntegrationForm } from '../../forms/integration_form';
 
 export const DataStreams = React.memo<{ integrationId?: string }>(() => {
   const {
@@ -34,8 +36,18 @@ export const DataStreams = React.memo<{ integrationId?: string }>(() => {
   const { integrationId } = useParams<{ integrationId?: string }>();
   const { integration } = useGetIntegrationById(integrationId);
   const { reportDataStreamFlyoutOpened } = useTelemetry();
+  const { formData } = useIntegrationForm();
 
   const hasDataStreams = (integration?.dataStreams?.length ?? 0) > 0;
+
+  const isCreateIntegrationPage = !integrationId;
+
+  const canAddDataStream = useMemo(() => {
+    if (!isCreateIntegrationPage) {
+      return true;
+    }
+    return Boolean(formData?.title?.trim()) && Boolean(formData?.description?.trim());
+  }, [formData?.description, formData?.title, isCreateIntegrationPage]);
 
   const handleOpenCreateDataStreamFlyout = useCallback(() => {
     openCreateDataStreamFlyout();
@@ -43,6 +55,34 @@ export const DataStreams = React.memo<{ integrationId?: string }>(() => {
       isFirstDataStream: !hasDataStreams,
     });
   }, [hasDataStreams, reportDataStreamFlyoutOpened, openCreateDataStreamFlyout]);
+
+  const renderAddDataStreamButton = useCallback(
+    (layout: 'header' | 'zeroState') => {
+      const button = (
+        <EuiButton
+          iconType="plusCircle"
+          onClick={handleOpenCreateDataStreamFlyout}
+          data-test-subj="addDataStreamButton"
+          isDisabled={!canAddDataStream}
+        >
+          {i18n.ADD_DATA_STREAM_BUTTON}
+        </EuiButton>
+      );
+
+      if (canAddDataStream) {
+        return layout === 'zeroState' ? <EuiFlexItem grow={false}>{button}</EuiFlexItem> : button;
+      }
+
+      const wrapped = (
+        <EuiToolTip content={i18n.ADD_DATA_STREAM_DISABLED_TOOLTIP} position="top">
+          <span tabIndex={0}>{button}</span>
+        </EuiToolTip>
+      );
+
+      return layout === 'zeroState' ? <EuiFlexItem grow={false}>{wrapped}</EuiFlexItem> : wrapped;
+    },
+    [canAddDataStream, handleOpenCreateDataStreamFlyout]
+  );
 
   return (
     <>
@@ -60,15 +100,7 @@ export const DataStreams = React.memo<{ integrationId?: string }>(() => {
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {hasDataStreams && (
-                <EuiButton
-                  iconType="plusCircle"
-                  onClick={handleOpenCreateDataStreamFlyout}
-                  data-test-subj="addDataStreamButton"
-                >
-                  {i18n.ADD_DATA_STREAM_BUTTON}
-                </EuiButton>
-              )}
+              {hasDataStreams && renderAddDataStreamButton('header')}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
@@ -81,15 +113,7 @@ export const DataStreams = React.memo<{ integrationId?: string }>(() => {
           <EuiText size="s" color="subdued">
             {i18n.ZERO_STATE_DESCRIPTION}
           </EuiText>
-          <EuiFlexItem grow={false}>
-            <EuiButton
-              iconType="plusCircle"
-              onClick={handleOpenCreateDataStreamFlyout}
-              data-test-subj="addDataStreamButton"
-            >
-              {i18n.ADD_DATA_STREAM_BUTTON}
-            </EuiButton>
-          </EuiFlexItem>
+          {renderAddDataStreamButton('zeroState')}
         </EuiFlexGroup>
       )}
 

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
@@ -14,6 +14,13 @@ export const ADD_DATA_STREAM_BUTTON = i18n.translate(
   }
 );
 
+export const ADD_DATA_STREAM_DISABLED_TOOLTIP = i18n.translate(
+  'xpack.automaticImportV2.dataStreams.addDataStreamDisabledTooltip',
+  {
+    defaultMessage: 'Enter an integration name and description before adding a data stream.',
+  }
+);
+
 export const DATA_STREAMS_TITLE = i18n.translate(
   'xpack.automaticImportV2.dataStreams.dataStreamsTitle',
   {

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/integration_management/management_contents/data_streams/translations.ts
@@ -85,6 +85,13 @@ export const LOGS_SECTION_DESCRIPTION = i18n.translate(
   }
 );
 
+export const LOG_SAMPLE_REQUIRED_FOR_ANALYSIS = i18n.translate(
+  'xpack.automaticImportV2.dataStreams.logSampleRequiredForAnalysis',
+  {
+    defaultMessage: 'Log sample is required for analysis',
+  }
+);
+
 export const AI_ANALYSIS_CALLOUT = i18n.translate(
   'xpack.automaticImportV2.dataStreams.aiAnalysisCallout',
   {
@@ -122,6 +129,13 @@ export const ANALYZE_LOGS_BUTTON = i18n.translate(
   'xpack.automaticImportV2.dataStreams.analyzeLogsButton',
   {
     defaultMessage: 'Analyze logs',
+  }
+);
+
+export const ANALYZE_LOGS_DISABLED_LOADING = i18n.translate(
+  'xpack.automaticImportV2.dataStreams.analyzeLogsDisabledLoading',
+  {
+    defaultMessage: 'Please wait for the current operation to finish.',
   }
 );
 

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/telemetry_context.test.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/telemetry_context.test.tsx
@@ -195,19 +195,6 @@ describe('useTelemetry', () => {
     );
   });
 
-  it('reportIntegrationDeleteConfirmed calls reportEvent', () => {
-    const { result } = renderHook(() => useTelemetry(), { wrapper });
-
-    act(() => {
-      result.current.reportIntegrationDeleteConfirmed();
-    });
-
-    expect(mockReportEvent).toHaveBeenCalledWith(
-      AIV2TelemetryEventType.IntegrationDeleteConfirmed,
-      expect.objectContaining({ sessionId: expect.any(String) })
-    );
-  });
-
   it('reportDataStreamRefreshConfirmed calls reportEvent', () => {
     const { result } = renderHook(() => useTelemetry(), { wrapper });
 

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/components/telemetry_context.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/components/telemetry_context.tsx
@@ -26,8 +26,6 @@ type ReportDoneButtonClicked = () => void;
 
 type ReportDataStreamDeleteConfirmed = () => void;
 
-type ReportIntegrationDeleteConfirmed = () => void;
-
 type ReportDataStreamRefreshConfirmed = () => void;
 
 type ReportPipelineEdited = (params: {
@@ -46,7 +44,6 @@ interface TelemetryContextProps {
   reportCancelButtonClicked: ReportCancelButtonClicked;
   reportDoneButtonClicked: ReportDoneButtonClicked;
   reportDataStreamDeleteConfirmed: ReportDataStreamDeleteConfirmed;
-  reportIntegrationDeleteConfirmed: ReportIntegrationDeleteConfirmed;
   reportDataStreamRefreshConfirmed: ReportDataStreamRefreshConfirmed;
   reportPipelineEdited: ReportPipelineEdited;
 }
@@ -61,7 +58,6 @@ const defaultTelemetryContext: TelemetryContextProps = {
   reportCancelButtonClicked: () => {},
   reportDoneButtonClicked: () => {},
   reportDataStreamDeleteConfirmed: () => {},
-  reportIntegrationDeleteConfirmed: () => {},
   reportDataStreamRefreshConfirmed: () => {},
   reportPipelineEdited: () => {},
 };
@@ -144,12 +140,6 @@ export const TelemetryContextProvider = React.memo<PropsWithChildren<{}>>(({ chi
     });
   }, [telemetry]);
 
-  const reportIntegrationDeleteConfirmed = useCallback<ReportIntegrationDeleteConfirmed>(() => {
-    telemetry?.reportEvent(AIV2TelemetryEventType.IntegrationDeleteConfirmed, {
-      sessionId: sessionData.current.sessionId,
-    });
-  }, [telemetry]);
-
   const reportDataStreamRefreshConfirmed = useCallback<ReportDataStreamRefreshConfirmed>(() => {
     telemetry?.reportEvent(AIV2TelemetryEventType.DataStreamRefreshConfirmed, {
       sessionId: sessionData.current.sessionId,
@@ -179,7 +169,6 @@ export const TelemetryContextProvider = React.memo<PropsWithChildren<{}>>(({ chi
       reportCancelButtonClicked,
       reportDoneButtonClicked,
       reportDataStreamDeleteConfirmed,
-      reportIntegrationDeleteConfirmed,
       reportDataStreamRefreshConfirmed,
       reportPipelineEdited,
     }),
@@ -192,7 +181,6 @@ export const TelemetryContextProvider = React.memo<PropsWithChildren<{}>>(({ chi
       reportCancelButtonClicked,
       reportDoneButtonClicked,
       reportDataStreamDeleteConfirmed,
-      reportIntegrationDeleteConfirmed,
       reportDataStreamRefreshConfirmed,
       reportPipelineEdited,
     ]

--- a/x-pack/platform/plugins/shared/automatic_import_v2/public/services/telemetry/events.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/public/services/telemetry/events.ts
@@ -115,15 +115,6 @@ export const telemetryEventsSchemas: Partial<Record<AIV2TelemetryEventType, Root
   [AIV2TelemetryEventType.IntegrationDownloadZipClicked]: {},
   [AIV2TelemetryEventType.ApproveModalCancelClicked]: {},
   [AIV2TelemetryEventType.ApproveModalApproveClicked]: {},
-  [AIV2TelemetryEventType.IntegrationDeleteConfirmed]: {
-    sessionId: {
-      type: 'keyword',
-      _meta: {
-        description: 'The ID to identify all the events in the same session',
-        optional: false,
-      },
-    },
-  },
   [AIV2TelemetryEventType.DataStreamDeleteConfirmed]: {
     sessionId: {
       type: 'keyword',

--- a/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/ui/fixtures/page_objects/integration_management_page.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/ui/fixtures/page_objects/integration_management_page.ts
@@ -62,6 +62,10 @@ export class IntegrationManagementPage {
     return this.page.testSubj.locator('dataStreamTitleInputV2');
   }
 
+  getDataStreamDescriptionInput() {
+    return this.page.testSubj.locator('dataStreamDescriptionInputV2');
+  }
+
   getDataCollectionMethodSelect() {
     return this.page.testSubj.locator('dataCollectionMethodSelect');
   }

--- a/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/ui/tests/create_data_stream_flyout.spec.ts
+++ b/x-pack/platform/plugins/shared/automatic_import_v2/test/scout_automatic_import_v2/ui/tests/create_data_stream_flyout.spec.ts
@@ -102,6 +102,9 @@ test.describe(
       await pageObjects.integrationManagement
         .getDataStreamTitleInput()
         .fill('Audit Logs Data Stream');
+      await pageObjects.integrationManagement
+        .getDataStreamDescriptionInput()
+        .fill('Audit log events from security appliances');
 
       const comboInput = pageObjects.integrationManagement
         .getDataCollectionMethodSelect()
@@ -164,6 +167,9 @@ test.describe(
       const flyout = pageObjects.integrationManagement.getCreateDataStreamFlyout();
 
       await pageObjects.integrationManagement.getDataStreamTitleInput().fill('Audit Logs');
+      await pageObjects.integrationManagement
+        .getDataStreamDescriptionInput()
+        .fill('Audit log sample stream');
 
       const comboInput = pageObjects.integrationManagement
         .getDataCollectionMethodSelect()

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import {
   EuiButtonIcon,
   EuiButtonEmpty,
@@ -106,7 +107,7 @@ export const ManageIntegrationActions: React.FC<{
     setIsDeleting(true);
     (automaticImportVTwo?.telemetry as AIV2Telemetry)?.reportEvent(
       'aiv2_integration_delete_confirmed',
-      {}
+      { sessionId: uuidv4() }
     );
     try {
       await onDelete(integration.integrationId);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integration_actions.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import {
   EuiButtonIcon,
   EuiButtonEmpty,
@@ -105,17 +104,13 @@ export const ManageIntegrationActions: React.FC<{
 
   const handleConfirmDelete = useCallback(async () => {
     setIsDeleting(true);
-    (automaticImportVTwo?.telemetry as AIV2Telemetry)?.reportEvent(
-      'aiv2_integration_delete_confirmed',
-      { sessionId: uuidv4() }
-    );
     try {
       await onDelete(integration.integrationId);
     } finally {
       setIsDeleting(false);
       setShowDeleteConfirm(false);
     }
-  }, [onDelete, integration.integrationId, automaticImportVTwo]);
+  }, [onDelete, integration.integrationId]);
 
   const openReviewModal = useCallback(() => {
     setIsPopoverOpen(false);

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { css } from '@emotion/react';
 import {
   EuiBadge,
@@ -224,7 +225,7 @@ export const ManageIntegrationsTable: React.FC<{
         );
         (automaticImportVTwo?.telemetry as AIV2Telemetry)?.reportEvent(
           'aiv2_integration_delete_confirmed',
-          {}
+          { sessionId: uuidv4() }
         );
         notifications.toasts.addSuccess({
           title: i18n.translate(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/browse_integrations/components/manage_integrations_table.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { css } from '@emotion/react';
 import {
   EuiBadge,
@@ -223,10 +222,6 @@ export const ManageIntegrationsTable: React.FC<{
           `/api/automatic_import_v2/integrations/${encodeURIComponent(integrationId)}`,
           { version: '1' }
         );
-        (automaticImportVTwo?.telemetry as AIV2Telemetry)?.reportEvent(
-          'aiv2_integration_delete_confirmed',
-          { sessionId: uuidv4() }
-        );
         notifications.toasts.addSuccess({
           title: i18n.translate(
             'xpack.fleet.epmList.manageIntegrations.actions.deleteSuccessTitle',
@@ -243,7 +238,7 @@ export const ManageIntegrationsTable: React.FC<{
         throw error;
       }
     },
-    [http, notifications, onRefetch, automaticImportVTwo]
+    [http, notifications, onRefetch]
   );
 
   const fetchIntegrationReviewDetails = useCallback(


### PR DESCRIPTION
## Summary

Improves **Automatic Import v2** create-integration UX by gating actions until required fields are set, surfacing **why** Analyze logs is disabled via a tooltip.

## Changes

### Create integration — Data streams

- **Add data stream**: On the **new integration** flow (no `integrationId`), **Add data stream** is disabled until **integration name** and **description** are non-empty. A tooltip explains: *Enter an integration name and description before adding a data stream.* Edit flow unchanged.
- **Create data stream flyout**:
  - **Analyze logs** stays disabled until all requirements are met (integration name, description, connector, data stream title & **description**, data collection method, and log source — file upload or index — including index validation errors when applicable).
  - When disabled for validation, hovering **Analyze logs** shows a tooltip listing the **same messages** as form validation (reused from integration form i18n). When disabled only for in-flight work (parsing file, validating index, create/upload), tooltip: *Please wait for the current operation to finish.*
  - **Data stream description** is required for Analyze logs (aligned with existing form schema).
  - **Logs** section: added copy *Log sample is required for analysis* (applies to file or index source).

### Telemetry

- **AIV2 event payloads**: `sessionId` is **optional** on telemetry payload types where callers may omit it.

### Tests

- Unit tests: `create_data_stream_flyout.test.tsx`, `data_streams.test.tsx`.
- Scout: `create_data_stream_flyout.spec.ts` (data stream description helper / scenarios as updated).

## How to test

1. **Create integration** (no data streams yet): leave name/description empty → **Add data stream** disabled + tooltip; fill both → button enables.
2. Open **Add data stream** flyout: leave fields incomplete → **Analyze logs** disabled + tooltip lists missing items; complete all including **data stream description** and log sample (file or index) → button enables.
3. From **Integrations → Manage**, delete an Automatic Import integration and confirm telemetry still fires (no functional change beyond payload shape).


https://github.com/user-attachments/assets/9425d1fa-caf1-4338-a082-7776c94c565c


