### PR TITLE
[Agent Builder] Sidebar navigation updates

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/conversation_list.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/conversation_list.tsx
@@ -15,23 +15,30 @@ import {
   EuiTextTruncate,
   useEuiTheme,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { appPaths } from '../../../../../utils/app_paths';
 import { useConversationList } from '../../../../../hooks/use_conversation_list';
 import {
   createConversationListItemStyles,
   createActiveConversationListItemStyles,
 } from '../../../../conversations/conversation_list_item_styles';
-import { NoConversationsPrompt } from '../../../../conversations/embeddable_conversation_header/no_conversations_prompt';
+
+const newConversationLabel = i18n.translate(
+  'xpack.agentBuilder.sidebar.conversation.newConversation',
+  { defaultMessage: 'New conversation' }
+);
 
 interface ConversationListProps {
   agentId: string;
   currentConversationId: string | undefined;
+  isNewConversationRoute: boolean;
   onItemClick?: () => void;
 }
 
 export const ConversationList: React.FC<ConversationListProps> = ({
   agentId,
   currentConversationId,
+  isNewConversationRoute,
   onItemClick,
 }) => {
   const { euiTheme } = useEuiTheme();
@@ -58,8 +65,22 @@ export const ConversationList: React.FC<ConversationListProps> = ({
     );
   }
 
+  // If there are no conversations, show 1 mock conversation item that links to the new conversation route
   if (sortedConversations.length === 0) {
-    return <NoConversationsPrompt isFiltered={false} />;
+    return (
+      <EuiFlexGroup direction="column" gutterSize="xs">
+        <EuiFlexItem grow={false}>
+          <Link
+            to={appPaths.agent.conversations.new({ agentId })}
+            css={isNewConversationRoute ? activeLinkStyles : linkStyles}
+            data-test-subj="agentBuilderSidebarConversation-new"
+            onClick={onItemClick}
+          >
+            <EuiTextTruncate text={newConversationLabel} />
+          </Link>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
   }
 
   return (

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
@@ -11,7 +11,6 @@ import { useLocation } from 'react-router-dom';
 import {
   EuiAccordion,
   EuiButton,
-  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -24,6 +23,7 @@ import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { agentBuilderDefaultAgentId } from '@kbn/agent-builder-common';
 import { appPaths } from '../../../../../utils/app_paths';
+import { newConversationId } from '../../../../../utils/new_conversation';
 import {
   getAgentIdFromPath,
   getAgentSettingsNavItems,
@@ -47,6 +47,10 @@ const customizeLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.c
 
 const newLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.new', {
   defaultMessage: 'New',
+});
+
+const searchLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.search', {
+  defaultMessage: 'Search',
 });
 
 const searchChatsAriaLabel = i18n.translate('xpack.agentBuilder.sidebar.conversation.searchChats', {
@@ -102,6 +106,9 @@ export const ConversationSidebarView: React.FC = () => {
   const { conversations = [] } = useConversationList({ agentId });
   const hasConversations = conversations.length > 0;
 
+  const isNewConversationRoute =
+    conversationId === newConversationId || pathname === appPaths.agent.root({ agentId });
+
   const navItems = useMemo(
     () => getAgentSettingsNavItems(agentId, featureFlags),
     [agentId, featureFlags]
@@ -154,7 +161,7 @@ export const ConversationSidebarView: React.FC = () => {
     padding: ${euiTheme.size.s} ${euiTheme.size.base};
 
     .euiAccordion__triggerWrapper {
-      padding: 0;
+      padding: 0 0 0 ${euiTheme.size.s};
     }
 
     .euiAccordion__iconButton {
@@ -171,6 +178,7 @@ export const ConversationSidebarView: React.FC = () => {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    padding-top: ${euiTheme.size.base};
   `;
 
   return (
@@ -186,7 +194,7 @@ export const ConversationSidebarView: React.FC = () => {
             {customizeLabel}
           </EuiText>
         }
-        arrowDisplay="left"
+        arrowDisplay="right"
         forceState={isCustomizeOpen ? 'open' : 'closed'}
         onToggle={() => setIsCustomizeOpen((prev) => !prev)}
         paddingSize="none"
@@ -213,10 +221,18 @@ export const ConversationSidebarView: React.FC = () => {
             {chatsLabel}
           </EuiText>
         }
-        extraAction={
-          <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
-            <EuiFlexItem grow={false}>
+        arrowDisplay="right"
+        forceState={isChatsOpen ? 'open' : 'closed'}
+        onToggle={() => setIsChatsOpen((prev) => !prev)}
+        buttonProps={{ 'data-test-subj': 'agentBuilderSidebarChatsToggle' }}
+        paddingSize="none"
+        css={[accordionButtonStyles, chatsAccordionStyles]}
+      >
+        <div css={conversationListStyles}>
+          <EuiFlexGroup gutterSize="xs" responsive={false}>
+            <EuiFlexItem grow={true}>
               <EuiButton
+                fullWidth
                 iconType="plus"
                 size="s"
                 color="text"
@@ -228,9 +244,9 @@ export const ConversationSidebarView: React.FC = () => {
                 {newLabel}
               </EuiButton>
             </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                display="base"
+            <EuiFlexItem grow={true}>
+              <EuiButton
+                fullWidth
                 iconType="search"
                 size="s"
                 color="text"
@@ -238,22 +254,16 @@ export const ConversationSidebarView: React.FC = () => {
                 onClick={() => setIsSearchModalOpen(true)}
                 disabled={!hasConversations}
                 data-test-subj="agentBuilderSidebarSearchChatsButton"
-              />
+              >
+                {searchLabel}
+              </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
-        }
-        arrowDisplay="left"
-        forceState={isChatsOpen ? 'open' : 'closed'}
-        onToggle={() => setIsChatsOpen((prev) => !prev)}
-        buttonProps={{ 'data-test-subj': 'agentBuilderSidebarChatsToggle' }}
-        paddingSize="none"
-        css={[accordionButtonStyles, chatsAccordionStyles]}
-      >
-        <div css={conversationListStyles}>
           <EuiSpacer size="m" />
           <ConversationList
             agentId={agentId}
             currentConversationId={conversationId}
+            isNewConversationRoute={isNewConversationRoute}
             onItemClick={() => setIsCustomizeOpen(false)}
           />
         </div>

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/layout/unified_sidebar/views/conversation_view/index.tsx
@@ -181,6 +181,11 @@ export const ConversationSidebarView: React.FC = () => {
     padding-top: ${euiTheme.size.base};
   `;
 
+  const handlePressNewConversation = () => {
+    setIsCustomizeOpen(false);
+    navigateToAgentBuilderUrl(appPaths.agent.conversations.new({ agentId }));
+  };
+
   return (
     <div css={containerStyles} data-test-subj="agentBuilderSidebar-conversation">
       <EuiHorizontalRule margin="none" />
@@ -236,9 +241,7 @@ export const ConversationSidebarView: React.FC = () => {
                 iconType="plus"
                 size="s"
                 color="text"
-                onClick={() =>
-                  navigateToAgentBuilderUrl(appPaths.agent.conversations.new({ agentId }))
-                }
+                onClick={handlePressNewConversation}
                 data-test-subj="agentBuilderSidebarNewConversationButton"
               >
                 {newLabel}
@@ -277,6 +280,7 @@ export const ConversationSidebarView: React.FC = () => {
           currentConversationId={conversationId}
           onClose={() => setIsSearchModalOpen(false)}
           onSelectConversation={(id) => {
+            setIsCustomizeOpen(false);
             navigateToAgentBuilderUrl(
               appPaths.agent.conversations.byId({ agentId, conversationId: id })
             );


### PR DESCRIPTION
closes https://github.com/elastic/search-team/issues/13636

Designs:
<img width="1358" height="825" alt="image" src="https://github.com/user-attachments/assets/dd62514d-0478-4a03-b394-aafaeb3031f7" />

- Moves accordion chevrons to the right hand side
- Moves the actions: "search" + "new" inside the accordion body
- Adds 1 "new conversation" list item when there are no conversations


https://github.com/user-attachments/assets/163e8dc0-4fe2-4c83-946c-a03f39b5d18e




