### PR TITLE
[Sig Events] Fix total events count for the sig events tab

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/tab.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/tab.tsx
@@ -31,7 +31,7 @@ export function InsightsTab() {
 
   const queriesFetch = useStreamsAppFetch(
     async ({ signal }) =>
-      streamsRepositoryClient.fetch('GET /internal/streams/_queries', {
+      streamsRepositoryClient.fetch('GET /internal/streams/_significant_events', {
         params: {
           query: {
             from: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
@@ -48,7 +48,10 @@ export function InsightsTab() {
     return <EuiLoadingElastic />;
   }
 
-  const totalEvents = queriesFetch.value?.total ?? 0;
+  const totalEvents = queriesFetch.value?.aggregated_occurrences.reduce(
+    (acc, current) => acc + current.count,
+    0
+  );
 
   if (totalEvents === 0 || totalEvents === undefined) {
     return (


### PR DESCRIPTION
When introducing the `_queries` endpoint I accidentally changed Sig Events tab to use instead of `_significant_events`. As a result the tab was using queries count instead of occurrences count inside the summary callout. This fixes the issue.