### PR TITLE
feat(agent-builder): prettier graph attachment defaults with icons, step edges, and group nodes

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_platform/common/attachments/graph.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/common/attachments/graph.ts
@@ -12,13 +12,22 @@ export const GRAPH_ATTACHMENT_TYPE = 'graph' as const;
 
 const graphNodeSchema = z.looseObject({
   id: z.string().min(1),
+  type: z.string().optional(),
+  parentId: z.string().optional(),
   position: z.object({
     x: z.number(),
     y: z.number(),
   }),
   data: z.looseObject({
     label: z.string(),
+    icon: z.string().optional(),
   }),
+  style: z
+    .object({
+      width: z.number().optional(),
+      height: z.number().optional(),
+    })
+    .optional(),
 });
 
 const graphEdgeSchema = z.looseObject({

--- a/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/graph_attachment/graph_flow_canvas.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/public/attachment_types/graph_attachment/graph_flow_canvas.tsx
@@ -5,18 +5,100 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
+import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import {
   Background,
   Controls,
+  Handle,
+  Position,
   ReactFlow,
   ReactFlowProvider,
   type ColorMode,
   type Edge,
   type Node,
+  type NodeProps,
 } from '@xyflow/react';
 
 import '@xyflow/react/dist/style.css';
+
+interface GraphNodeData {
+  label: string;
+  icon?: string;
+  [key: string]: unknown;
+}
+
+const IconNode: React.FC<NodeProps<Node<GraphNodeData>>> = ({ data }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        gap: ${euiTheme.size.s};
+        padding: ${euiTheme.size.xs} ${euiTheme.size.m};
+        background: ${euiTheme.colors.backgroundBasePlain};
+        border: 2px solid ${euiTheme.colors.borderBaseSubdued};
+        border-radius: ${euiTheme.border.radius.medium};
+        font-size: ${euiTheme.size.m};
+        font-weight: ${euiTheme.font.weight.medium};
+        color: ${euiTheme.colors.textParagraph};
+        min-width: 100px;
+        white-space: nowrap;
+      `}
+    >
+      <Handle type="target" position={Position.Left} css={handleStyle} />
+      {data.icon && <EuiIcon type={data.icon} size="m" color="subdued" aria-hidden={true} />}
+      <span>{data.label}</span>
+      <Handle type="source" position={Position.Right} css={handleStyle} />
+    </div>
+  );
+};
+
+const GroupNode: React.FC<NodeProps<Node<GraphNodeData>>> = ({ data }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      css={css`
+        width: 100%;
+        height: 100%;
+        background: ${euiTheme.colors.backgroundBaseSubdued};
+        border: 2px dashed ${euiTheme.colors.borderBaseSubdued};
+        border-radius: ${euiTheme.border.radius.medium};
+        padding: ${euiTheme.size.s};
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          gap: ${euiTheme.size.xs};
+          font-size: ${euiTheme.size.m};
+          font-weight: ${euiTheme.font.weight.semiBold};
+          color: ${euiTheme.colors.textSubdued};
+          padding-bottom: ${euiTheme.size.xs};
+        `}
+      >
+        {data.icon && <EuiIcon type={data.icon} size="s" color="subdued" aria-hidden={true} />}
+        <span>{data.label}</span>
+      </div>
+    </div>
+  );
+};
+
+const handleStyle = css`
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+`;
+
+const nodeTypes = {
+  default: IconNode,
+  group: GroupNode,
+};
 
 interface GraphFlowCanvasProps {
   nodes: Node[];
@@ -25,14 +107,25 @@ interface GraphFlowCanvasProps {
 }
 
 export const GraphFlowCanvas: React.FC<GraphFlowCanvasProps> = ({ nodes, edges, colorMode }) => {
+  const styledEdges = useMemo(
+    () =>
+      edges.map((edge) => ({
+        ...edge,
+        style: { strokeWidth: 1.5, ...edge.style },
+      })),
+    [edges]
+  );
+
   return (
     <ReactFlowProvider>
       <ReactFlow
         nodes={nodes}
-        edges={edges}
+        edges={styledEdges}
+        nodeTypes={nodeTypes}
         fitView
         fitViewOptions={{
           nodes,
+          padding: 0.2,
         }}
         minZoom={0.1}
         nodesDraggable={false}

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/graph_creation_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/graph_creation_skill.ts
@@ -21,6 +21,7 @@ Use this skill when:
 - A user asks for relationship/dependency/topology/entity-link visualization.
 - You need to represent raw records as nodes and edges and render them in-chat.
 - You need a reusable graph attachment id for follow-up updates or comparisons.
+- A user asks for an architecture diagram (e.g. services inside a K8s cluster, components in a VPC).
 
 Do **not** use this skill when:
 - A chart/table/metric is more appropriate than a graph.
@@ -38,7 +39,11 @@ Do **not** use this skill when:
     - each node must include:
       - \`id\`: non-empty string
       - \`position\`: object with numeric \`x\` and \`y\`
-      - \`data\`: object with required string \`label\`
+      - \`data\`: object with required string \`label\` and optional string \`icon\`
+    - optional fields:
+      - \`type\`: set to \`"group"\` for container/grouping nodes
+      - \`parentId\`: id of a group node this node belongs to (positions become relative to the parent)
+      - \`style\`: object with optional \`width\` and \`height\` numbers (use for group nodes to set bounding area)
   - \`edges\`: array of edge objects (required)
     - each edge must include:
       - \`id\`: non-empty string
@@ -54,6 +59,7 @@ Do **not** use this skill when:
 1. **Identify entities and relationships**
    - Decide what becomes a node (service, host, user, process, endpoint, etc.).
    - Decide what becomes an edge (depends_on, calls, owns, connects_to, etc.).
+   - Identify natural groupings (services in a namespace, components in a cluster, stages in a pipeline).
 
 2. **Build valid nodes**
    - Create stable string ids (prefer canonical keys from raw data).
@@ -61,23 +67,77 @@ Do **not** use this skill when:
    - Always include required fields:
      - \`position\`: provide numeric coordinates for every node.
      - \`data.label\`: provide a readable string label for every node.
-   - You may include additional React Flow fields (for example \`type\`) when useful.
+   - Always include \`data.icon\` with an EUI icon name that matches the entity type (see Icon Reference below).
+   - You may include additional React Flow fields when useful.
 
 3. **Build valid edges**
    - Ensure every edge has non-empty string \`id\`, \`source\`, \`target\`, and \`type\`.
    - Use deterministic edge ids (for example \`\${source}-\${target}\` or \`\${source}-\${target}-\${relation}\`).
-   - Use \`type: 'simplebezier'\` by default unless the user explicitly asks for a different edge type.
+   - Use \`type: 'step'\` by default. This produces clean right-angle connectors. Only use \`'simplebezier'\` or \`'straight'\` if the user explicitly requests curved or straight edges.
    - Use \`markerEnd: 'arrow'\` when edge direction should be explicit.
    - Only emit edges where both endpoint node ids exist.
    - Include \`label\` when relationship meaning or weight should be visible (for example \`"calls"\`, \`"depends_on"\`, or counts).
    - Optionally include \`data\`.
+
+## Icon Reference
+
+Always set \`data.icon\` on every node. Pick the best match from this curated list:
+
+| Entity type | Icon name |
+|---|---|
+| Generic service / microservice | \`compute\` |
+| Web frontend / UI | \`globe\` |
+| API / gateway | \`endpoint\` |
+| Database / data store | \`database\` |
+| Message queue / broker | \`logstashQueue\` |
+| Cache (Redis, Memcached) | \`bolt\` |
+| Authentication / security | \`lock\` |
+| User / identity | \`user\` |
+| Host / server / VM | \`compute\` |
+| Container | \`container\` |
+| Kubernetes / orchestration | \`kubernetesNode\` |
+| Cloud provider / region | \`cloudSunny\` |
+| Network / load balancer | \`network\` |
+| Storage / disk / S3 | \`storage\` |
+| Monitoring / observability | \`eye\` |
+| Logging | \`document\` |
+| Email / notification | \`email\` |
+| Search / Elasticsearch | \`search\` |
+| Package / module / library | \`package\` |
+| Pipeline / workflow | \`pipelineApp\` |
+| Alert / warning | \`warning\` |
+| Error / failure | \`error\` |
+| Success / healthy | \`checkInCircleFilled\` |
+| Unknown / generic | \`node\` |
+
+If none of the above match, use \`node\` as a safe fallback.
+
+## Group Nodes (Architecture Views)
+
+When the data has a natural containment hierarchy (e.g. services inside a Kubernetes namespace, components inside a VPC, stages in a deployment pipeline), use group nodes to visually enclose related nodes:
+
+1. Create a parent node with \`type: "group"\` and a \`style\` with explicit \`width\` and \`height\` to define the bounding area.
+2. Set \`parentId\` on child nodes to the group node's id.
+3. Child node positions become **relative to the parent's origin** (top-left corner of the group).
+4. Leave enough padding inside the group (at least 40px on each side) so children are not clipped.
+5. Group nodes should have \`data.label\` set to the group name and an appropriate \`data.icon\`.
+
+Example group node:
+\`\`\`json
+{ "id": "k8s-cluster", "type": "group", "position": { "x": 0, "y": 0 }, "style": { "width": 560, "height": 300 }, "data": { "label": "K8s Cluster", "icon": "kubernetesNode" } }
+\`\`\`
+
+Example child node inside the group:
+\`\`\`json
+{ "id": "api-svc", "parentId": "k8s-cluster", "position": { "x": 40, "y": 60 }, "data": { "label": "API Service", "icon": "endpoint" } }
+\`\`\`
 
 ## Node Positioning Guidelines
 
 - Use a clear layered layout based on edge direction:
   - left-to-right flow: increase \`x\` by layer, keep related nodes near each other on \`y\`
   - top-to-bottom flow: increase \`y\` by layer, keep related nodes near each other on \`x\`
-- Keep layers visually separated with consistent spacing (for example, 200-300px between layers).
+- Keep layers visually separated with consistent spacing (200-300px between layers).
 - Keep nodes within the same layer aligned on one axis to make structure easy to scan.
 - Order nodes within a layer to reduce edge crossings:
   - place nodes with shared parents/children next to each other
@@ -85,13 +145,17 @@ Do **not** use this skill when:
 - Place hub nodes (high degree) near the center of their layer to reduce long diagonal edges.
 - Prefer orthogonal progression of coordinates (monotonic x or y across layers) over random placement.
 - Ensure positions are deterministic for the same input data so repeated runs produce stable layouts.
+- For peer services at the same level, use a grid layout rather than forcing a tree structure.
 
 4. **Validate before creating attachment**
    - \`nodes\` and \`edges\` are arrays.
    - Every node has non-empty string \`id\`.
    - Every node has \`position.x\` and \`position.y\` as numbers.
    - Every node has \`data.label\` as a non-empty string.
+   - Every node has \`data.icon\` as a non-empty string.
    - Every edge has non-empty string \`id\`, \`source\`, \`target\`, and \`type\`.
+   - Group nodes have \`type: "group"\` and \`style.width\`/\`style.height\`.
+   - Child nodes with \`parentId\` reference an existing group node.
    - Remove invalid/partial records instead of emitting broken graph objects.
 
 5. **Create graph attachment**
@@ -106,6 +170,7 @@ Do **not** use this skill when:
 ## Quality Rules
 
 - Prefer semantic labels over opaque ids where possible.
+- Always include an icon on every node for visual clarity.
 - Keep graph readable: avoid excessive low-value edges.
 - If raw data is too large, summarize:
   - top entities by importance
@@ -141,15 +206,15 @@ Attachment add payload:
     "title": "Service Dependencies",
     "description": "Derived from service call counts",
     "nodes": [
-      { "id": "frontend", "position": { "x": 0, "y": 0 }, "data": { "label": "frontend" } },
-      { "id": "api", "position": { "x": 240, "y": 0 }, "data": { "label": "api" } },
-      { "id": "auth", "position": { "x": 480, "y": 0 }, "data": { "label": "auth" } },
-      { "id": "orders", "position": { "x": 480, "y": 180 }, "data": { "label": "orders" } }
+      { "id": "frontend", "position": { "x": 0, "y": 0 }, "data": { "label": "Frontend", "icon": "globe" } },
+      { "id": "api", "position": { "x": 280, "y": 0 }, "data": { "label": "API", "icon": "endpoint" } },
+      { "id": "auth", "position": { "x": 560, "y": -90 }, "data": { "label": "Auth", "icon": "lock" } },
+      { "id": "orders", "position": { "x": 560, "y": 90 }, "data": { "label": "Orders", "icon": "package" } }
     ],
     "edges": [
-      { "id": "frontend-api", "source": "frontend", "target": "api", "type": "simplebezier", "markerEnd": "arrow", "label": "1200" },
-      { "id": "api-auth", "source": "api", "target": "auth", "type": "simplebezier", "markerEnd": "arrow", "label": "900" },
-      { "id": "api-orders", "source": "api", "target": "orders", "type": "simplebezier", "markerEnd": "arrow", "label": "700" }
+      { "id": "frontend-api", "source": "frontend", "target": "api", "type": "step", "markerEnd": "arrow", "label": "1,200 calls" },
+      { "id": "api-auth", "source": "api", "target": "auth", "type": "step", "markerEnd": "arrow", "label": "900 calls" },
+      { "id": "api-orders", "source": "api", "target": "orders", "type": "step", "markerEnd": "arrow", "label": "700 calls" }
     ]
   }
 }
@@ -162,6 +227,32 @@ Attachment add payload:
 
 \`\`\`xml
 <render_attachment id="att-graph-123" />
+\`\`\`
+
+## Example: Architecture diagram with group nodes
+
+\`\`\`json
+{
+  "type": "graph",
+  "description": "K8s cluster architecture",
+  "data": {
+    "title": "Production Architecture",
+    "nodes": [
+      { "id": "k8s", "type": "group", "position": { "x": 100, "y": 0 }, "style": { "width": 560, "height": 260 }, "data": { "label": "K8s Cluster", "icon": "kubernetesNode" } },
+      { "id": "api", "parentId": "k8s", "position": { "x": 40, "y": 60 }, "data": { "label": "API Service", "icon": "endpoint" } },
+      { "id": "worker", "parentId": "k8s", "position": { "x": 300, "y": 60 }, "data": { "label": "Worker", "icon": "compute" } },
+      { "id": "cache", "parentId": "k8s", "position": { "x": 40, "y": 170 }, "data": { "label": "Redis Cache", "icon": "bolt" } },
+      { "id": "lb", "position": { "x": 0, "y": 60 }, "data": { "label": "Load Balancer", "icon": "network" } },
+      { "id": "db", "position": { "x": 760, "y": 60 }, "data": { "label": "PostgreSQL", "icon": "database" } }
+    ],
+    "edges": [
+      { "id": "lb-api", "source": "lb", "target": "api", "type": "step", "markerEnd": "arrow" },
+      { "id": "api-worker", "source": "api", "target": "worker", "type": "step", "markerEnd": "arrow", "label": "enqueue" },
+      { "id": "api-cache", "source": "api", "target": "cache", "type": "step", "markerEnd": "arrow" },
+      { "id": "worker-db", "source": "worker", "target": "db", "type": "step", "markerEnd": "arrow", "label": "write" }
+    ]
+  }
+}
 \`\`\`
 
 ## Example: Mermaid graph to graph attachment
@@ -184,15 +275,15 @@ Converted attachment payload:
   "data": {
     "title": "Service Dependencies (Mermaid)",
     "nodes": [
-      { "id": "Frontend", "position": { "x": 0, "y": 0 }, "data": { "label": "Frontend" } },
-      { "id": "API", "position": { "x": 240, "y": 0 }, "data": { "label": "API Service" } },
-      { "id": "Auth", "position": { "x": 480, "y": -80 }, "data": { "label": "Auth Service" } },
-      { "id": "Orders", "position": { "x": 480, "y": 80 }, "data": { "label": "Orders Service" } }
+      { "id": "Frontend", "position": { "x": 0, "y": 0 }, "data": { "label": "Frontend", "icon": "globe" } },
+      { "id": "API", "position": { "x": 280, "y": 0 }, "data": { "label": "API Service", "icon": "endpoint" } },
+      { "id": "Auth", "position": { "x": 560, "y": -90 }, "data": { "label": "Auth Service", "icon": "lock" } },
+      { "id": "Orders", "position": { "x": 560, "y": 90 }, "data": { "label": "Orders Service", "icon": "package" } }
     ],
     "edges": [
-      { "id": "Frontend-API", "source": "Frontend", "target": "API", "type": "simplebezier", "markerEnd": "arrow", "label": "calls" },
-      { "id": "API-Auth", "source": "API", "target": "Auth", "type": "simplebezier", "markerEnd": "arrow", "label": "calls" },
-      { "id": "API-Orders", "source": "API", "target": "Orders", "type": "simplebezier", "markerEnd": "arrow", "label": "calls" }
+      { "id": "Frontend-API", "source": "Frontend", "target": "API", "type": "step", "markerEnd": "arrow" },
+      { "id": "API-Auth", "source": "API", "target": "Auth", "type": "step", "markerEnd": "arrow" },
+      { "id": "API-Orders", "source": "API", "target": "Orders", "type": "step", "markerEnd": "arrow" }
     ]
   }
 }
@@ -204,5 +295,6 @@ Mermaid conversion notes:
 - Preserve edge direction from Mermaid arrows.
 - If Mermaid omits positions, generate deterministic coordinates for all nodes.
 - Apply layered placement so dependency depth is visually separated and edge intersections are minimized.
+- Always assign an appropriate \`data.icon\` based on the entity type.
 `,
 });


### PR DESCRIPTION
## Summary

- **Custom node rendering**: Replace default React Flow nodes with styled nodes featuring 2px rounded borders, EUI icons, and proper theming via Emotion/EUI tokens
- **Group node support**: Add `type: "group"` and `parentId` to the schema and renderer, enabling architecture-style diagrams where nodes are visually enclosed in container boxes (e.g. K8s clusters, VPCs)
- **Improved LLM skill prompt**: Default edge type changed from `simplebezier` to `step` (right-angle connectors), added a curated 24-icon reference table for the LLM, added group node instructions with examples, and improved layout guidance for non-tree topologies

Addresses https://github.com/elastic/nightshift-program/issues/110

## Test plan

- [ ] Create a graph attachment via Agent Builder and verify nodes render with icons and rounded borders
- [ ] Verify edges use right-angle (`step`) connectors by default
- [ ] Test group node rendering by asking for an architecture diagram (e.g. "show me a K8s cluster with services")
- [ ] Verify dark mode renders correctly (colors adapt via EUI theme tokens)
- [ ] Verify graphs without icons still render gracefully (icon is optional)