### PR TITLE
[9.3] Fix decorative `EuiIcon` accessibility violations in kibana-core components (#259749)

### DIFF
--- a/src/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx
+++ b/src/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx
@@ -35,7 +35,7 @@ export const FancySelect: React.FC<FancySelectProps> = ({
         inputDisplay: (
           <EuiFlexGroup justifyContent={'spaceBetween'} alignItems={'center'} gutterSize={'s'}>
             <EuiFlexItem grow={false}>
-              <EuiIcon type={option.icon} />
+              <EuiIcon type={option.icon} aria-hidden={true} />
             </EuiFlexItem>
             <EuiFlexItem grow={true}>
               <EuiText size={'s'} textAlign={'left'}>

--- a/src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx
+++ b/src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx
@@ -75,7 +75,7 @@ export const NewsfeedNavButton = ({ newsfeedApi, hasCustomBranding$, isServerles
           notification={hasNew ? true : null}
           onClick={showFlyout}
         >
-          <EuiIcon type="cheer" size="m" />
+          <EuiIcon type="cheer" size="m" aria-hidden={true} />
         </EuiHeaderSectionItemButton>
         {flyoutVisible ? (
           <NewsfeedFlyout

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx
@@ -57,7 +57,7 @@ export function ValuesGroup<T extends string = string>({
             }}
             data-test-subj={`colorModeKeyPadItem${id}`}
           >
-            <EuiIcon type={icon} size="l" />
+            <EuiIcon type={icon} size="l" aria-hidden={true} />
           </EuiKeyPadMenuItem>
         ))}
       </EuiKeyPadMenu>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix decorative `EuiIcon` accessibility violations in kibana-core components (#259749)](https://github.com/elastic/kibana/pull/259749)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T19:08:56Z","message":"Fix decorative `EuiIcon` accessibility violations in kibana-core components (#259749)\n\nCloses: https://github.com/elastic/kibana/issues/259746\n\nThis addresses the reported `@elastic/eui/icon-accessibility-rules`\nviolations across the three `@elastic/kibana-core` files in the backlog\nitem. The affected icons are decorative within already-labeled controls,\nso they should be hidden from assistive technology rather than announced\nindependently.\n\n- **Scope**\n-\n`src/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx`\n-\n`src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx`\n-\n`x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n\n- **What changed**\n- Marked the reported `EuiIcon` usages as decorative with\n`aria-hidden={true}`.\n  - Left the surrounding control semantics unchanged:\n- `FancySelect` continues to expose the option title as visible text.\n- `NewsfeedNavButton` continues to use the button’s existing\n`aria-label`.\n- `ValuesGroup` continues to use each keypad item’s existing `label`.\n\n- **Why this shape**\n- These icons do not carry unique user-facing meaning beyond adjacent\ntext or parent control labels.\n- Hiding them from screen readers resolves the lint issue without\nchanging interaction or visible UI.\n\n- **Example**\n  ```tsx\n  <EuiIcon type={icon} size=\"l\" aria-hidden={true} />\n  ```\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/yarn_install_scripts.js run ldd\n0.8.2` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/kbn bootstrap` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node node\nscripts/eslint\nsrc/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx\nsrc/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx\nx-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"ea6aeb5313794b87a91ac8da73a50a9ed3f4c64b","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Project:Accessibility","release_note:skip","💝community","backport:version","v9.4.0","v9.3.3","v9.2.8","a11y:agent-pr"],"title":"Fix decorative `EuiIcon` accessibility violations in kibana-core components","number":259749,"url":"https://github.com/elastic/kibana/pull/259749","mergeCommit":{"message":"Fix decorative `EuiIcon` accessibility violations in kibana-core components (#259749)\n\nCloses: https://github.com/elastic/kibana/issues/259746\n\nThis addresses the reported `@elastic/eui/icon-accessibility-rules`\nviolations across the three `@elastic/kibana-core` files in the backlog\nitem. The affected icons are decorative within already-labeled controls,\nso they should be hidden from assistive technology rather than announced\nindependently.\n\n- **Scope**\n-\n`src/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx`\n-\n`src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx`\n-\n`x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n\n- **What changed**\n- Marked the reported `EuiIcon` usages as decorative with\n`aria-hidden={true}`.\n  - Left the surrounding control semantics unchanged:\n- `FancySelect` continues to expose the option title as visible text.\n- `NewsfeedNavButton` continues to use the button’s existing\n`aria-label`.\n- `ValuesGroup` continues to use each keypad item’s existing `label`.\n\n- **Why this shape**\n- These icons do not carry unique user-facing meaning beyond adjacent\ntext or parent control labels.\n- Hiding them from screen readers resolves the lint issue without\nchanging interaction or visible UI.\n\n- **Example**\n  ```tsx\n  <EuiIcon type={icon} size=\"l\" aria-hidden={true} />\n  ```\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/yarn_install_scripts.js run ldd\n0.8.2` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/kbn bootstrap` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node node\nscripts/eslint\nsrc/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx\nsrc/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx\nx-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"ea6aeb5313794b87a91ac8da73a50a9ed3f4c64b"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259749","number":259749,"mergeCommit":{"message":"Fix decorative `EuiIcon` accessibility violations in kibana-core components (#259749)\n\nCloses: https://github.com/elastic/kibana/issues/259746\n\nThis addresses the reported `@elastic/eui/icon-accessibility-rules`\nviolations across the three `@elastic/kibana-core` files in the backlog\nitem. The affected icons are decorative within already-labeled controls,\nso they should be hidden from assistive technology rather than announced\nindependently.\n\n- **Scope**\n-\n`src/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx`\n-\n`src/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx`\n-\n`x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n\n- **What changed**\n- Marked the reported `EuiIcon` usages as decorative with\n`aria-hidden={true}`.\n  - Left the surrounding control semantics unchanged:\n- `FancySelect` continues to expose the option title as visible text.\n- `NewsfeedNavButton` continues to use the button’s existing\n`aria-label`.\n- `ValuesGroup` continues to use each keypad item’s existing `label`.\n\n- **Why this shape**\n- These icons do not carry unique user-facing meaning beyond adjacent\ntext or parent control labels.\n- Hiding them from screen readers resolves the lint issue without\nchanging interaction or visible UI.\n\n- **Example**\n  ```tsx\n  <EuiIcon type={icon} size=\"l\" aria-hidden={true} />\n  ```\n\n> [!WARNING]\n>\n> <details>\n> <summary>Firewall rules blocked me from connecting to one or more\naddresses (expand for details)</summary>\n>\n> #### I tried to connect to the following addresses, but was blocked by\nfirewall rules:\n>\n> - `ci-stats.kibana.dev`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/yarn_install_scripts.js run ldd\n0.8.2` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node scripts/kbn bootstrap` (dns block)\n> - Triggering command: `/tmp/node_modules/node/bin/node node\nscripts/eslint\nsrc/platform/packages/shared/cloud/connection_details/components/fancy_select/fancy_select.tsx\nsrc/platform/plugins/shared/newsfeed/public/components/newsfeed_header_nav_button.tsx\nx-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/appearance_selector/values_group.tsx`\n(dns block)\n> - `clients3.google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `detectportal.firefox.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `google.com`\n> - Triggering command:\n`/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\n/home/REDACTED/work/kibana/kibana/node_modules/@moonrepo/core-linux-x64-gnu/moon\nrun :extract-version-dependencies :build-webpack 0.so.0` (dns block)\n> - `googlechromelabs.github.io`\n> - Triggering command: `/tmp/node_modules/node/bin/node\n/tmp/node_modules/node/bin/node install.js` (dns block)\n>\n> If you need me to access, download, or install something from one of\nthese locations, you can either:\n>\n> - Configure [Actions setup\nsteps](https://gh.io/copilot/actions-setup-steps) to set up my\nenvironment, which run before the firewall is enabled\n> - Add the appropriate URLs or hosts to the custom allowlist in this\nrepository's [Copilot coding agent\nsettings](https://github.com/elastic/kibana/settings/copilot/coding_agent)\n(admins only)\n>\n> </details>\n\n\n---\n\n💡 You can make Copilot smarter by setting up custom instructions,\ncustomizing its development environment and configuring Model Context\nProtocol (MCP) servers. Learn more [Copilot coding agent\ntips](https://gh.io/copilot-coding-agent-tips) in the docs.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>","sha":"ea6aeb5313794b87a91ac8da73a50a9ed3f4c64b"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->