### PR TITLE
[9.2] a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files (#259314)

### DIFF
--- a/examples/embeddable_examples/public/app/presentation_container_example/components/add_button.tsx
+++ b/examples/embeddable_examples/public/app/presentation_container_example/components/add_button.tsx
@@ -10,6 +10,7 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useState } from 'react';
 import { EuiButton, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { ADD_PANEL_TRIGGER } from '@kbn/ui-actions-plugin/public';
 import type { PublishingSubject, ViewMode } from '@kbn/presentation-publishing';
@@ -79,6 +80,9 @@ export function AddButton({ pageApi, uiActions }: { pageApi: unknown; uiActions:
       }}
       panelPaddingSize="none"
       anchorPosition="downLeft"
+      aria-label={i18n.translate('embeddableExamples.addPanelPopover.ariaLabel', {
+        defaultMessage: 'Add panel',
+      })}
     >
       <EuiContextMenuPanel items={items} />
     </EuiPopover>

--- a/examples/grid_example/public/grid_layout_options.tsx
+++ b/examples/grid_example/public/grid_layout_options.tsx
@@ -43,6 +43,9 @@ export const GridLayoutOptions = ({
       }
       isOpen={isSettingsPopoverOpen}
       closePopover={() => setIsSettingsPopoverOpen(false)}
+      aria-label={i18n.translate('examples.gridExample.settingsPopover.ariaLabel', {
+        defaultMessage: 'Layout settings',
+      })}
     >
       <>
         <EuiFormRow

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_section/delete_grid_section_modal.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_section/delete_grid_section_modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -32,16 +33,18 @@ export const DeleteGridSectionModal = ({
   setDeleteModalVisible: (visible: boolean) => void;
 }) => {
   const { gridLayoutStateManager } = useGridLayoutContext();
+  const modalTitleId = useGeneratedHtmlId();
 
   return (
     <EuiModal
       data-test-subj={`kbnGridLayoutDeleteSectionModal-${sectionId}`}
+      aria-labelledby={modalTitleId}
       onClose={() => {
         setDeleteModalVisible(false);
       }}
     >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
           {i18n.translate('kbnGridLayout.deleteGridSectionModal.title', {
             defaultMessage: 'Delete section',
           })}

--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/presentation_panel_hover_actions.tsx
@@ -477,6 +477,7 @@ export const PresentationPanelHoverActions = ({
                 isOpen={isContextMenuOpen}
                 className={contextMenuClasses}
                 closePopover={onClose}
+                aria-label={getContextMenuAriaLabel(title, index)}
                 data-test-subj={
                   isContextMenuOpen
                     ? 'embeddablePanelContextMenuOpen'

--- a/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_actions/filters_notification_popover.tsx
@@ -110,6 +110,7 @@ export function FiltersNotificationPopover({ api }: { api: FiltersNotificationAc
         }
       }}
       anchorPosition="upCenter"
+      aria-label={displayName}
     >
       <EuiForm
         component="div"

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -296,6 +296,7 @@ export function InternalDashboardTopNav({
               isOpen={isPopoverOpen}
               closePopover={() => setIsPopoverOpen(false)}
               panelStyle={{ maxWidth: 250 }}
+              aria-label={dashboardManagedBadge.getBadgeAriaLabel()}
             >
               <FormattedMessage
                 id="dashboard.managedContentPopoverButton"

--- a/src/platform/plugins/shared/inspector/public/ui/inspector_view_chooser.tsx
+++ b/src/platform/plugins/shared/inspector/public/ui/inspector_view_chooser.tsx
@@ -8,6 +8,7 @@
  */
 
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -117,6 +118,9 @@ export class InspectorViewChooser extends Component<Props, State> {
         panelPaddingSize="none"
         anchorPosition="downRight"
         repositionOnScroll
+        aria-label={i18n.translate('inspector.viewChooser.popover.ariaLabel', {
+          defaultMessage: 'Inspector view selector',
+        })}
       >
         <EuiContextMenuPanel items={views.map(this.renderView)} />
       </EuiPopover>

--- a/src/platform/plugins/shared/presentation_util/public/components/labs/labs_flyout.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/labs/labs_flyout.tsx
@@ -20,6 +20,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { ReactNode } from 'react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -64,6 +65,7 @@ export const getOverridenCount = (projects: Record<ProjectID, Project>) =>
 export const LabsFlyout = (props: Props) => {
   const { solutions, onEnabledCountChange = () => {}, onClose } = props;
   const labsService = useMemo(() => getPresentationLabsService(), []);
+  const flyoutTitleId = useGeneratedHtmlId();
 
   const [projects, setProjects] = useState(labsService.getProjects());
   const [overrideCount, setOverrideCount] = useState(getOverridenCount(projects));
@@ -134,10 +136,11 @@ export const LabsFlyout = (props: Props) => {
       onClose={onClose}
       hideCloseButton={true}
       maskProps={{ headerZindexLocation: 'below' }}
+      aria-labelledby={flyoutTitleId}
     >
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2>
+          <h2 id={flyoutTitleId}>
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiIcon type="beaker" size="l" />

--- a/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/minimised_actions.tsx
+++ b/src/platform/plugins/shared/unified_search/public/filters_builder/filter_item/actions/minimised_actions.tsx
@@ -33,7 +33,13 @@ export const MinimisedFilterItemActions: FC<FilterItemActionsProps> = (props) =>
   );
 
   return (
-    <EuiPopover ownFocus={false} button={button} isOpen={isPopoverOpen} closePopover={closePopover}>
+    <EuiPopover
+      ownFocus={false}
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      aria-label={strings.getMoreActionsLabel()}
+    >
       <FilterItemActions {...props} minimizePaddings={true} />
     </EuiPopover>
   );

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
@@ -92,6 +92,7 @@ const AddFilterPopoverComponent = React.memo(function AddFilterPopover({
         initialFocus=".filterEditor__hiddenItem"
         ownFocus
         repositionOnScroll
+        aria-label={strings.getAddFilterButtonLabel()}
       >
         <FilterEditorWrapper
           indexPatterns={indexPatterns}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
@@ -126,6 +126,9 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
       closePopover={() => setIsPopoverOpen(false)}
       repositionOnScroll
       panelPaddingSize="none"
+      aria-label={i18n.translate('kql.query.queryBar.syntaxOptionsPopover.ariaLabel', {
+        defaultMessage: 'Syntax options',
+      })}
     >
       <EuiPopoverTitle paddingSize="s">
         <FormattedMessage

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/language_switcher.tsx
@@ -126,7 +126,7 @@ export const QueryLanguageSwitcher = React.memo(function QueryLanguageSwitcher({
       closePopover={() => setIsPopoverOpen(false)}
       repositionOnScroll
       panelPaddingSize="none"
-      aria-label={i18n.translate('kql.query.queryBar.syntaxOptionsPopover.ariaLabel', {
+      aria-label={i18n.translate('unifiedSearch.query.queryBar.syntaxOptionsPopover.ariaLabel', {
         defaultMessage: 'Syntax options',
       })}
     >

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -269,6 +269,9 @@ function QueryBarMenuComponent({
       anchorPosition="downLeft"
       repositionOnScroll
       data-test-subj="queryBarMenuPopover"
+      aria-label={i18n.translate('unifiedSearch.queryBarMenu.popoverAriaLabel', {
+        defaultMessage: 'Query bar menu',
+      })}
     >
       {renderComponent()}
     </EuiPopover>

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error_component.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/error/components/error_component.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { EuiIcon, useResizeObserver, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { IInterpreterRenderHandlers } from '@kbn/expressions-plugin/common';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import type { ErrorRendererConfig } from '../types';
@@ -55,6 +56,9 @@ function ErrorComponent({ onLoaded, parentNode, error }: ErrorComponentProps) {
           />
         }
         isOpen={isPopoverOpen}
+        aria-label={i18n.translate('xpack.canvas.errorComponent.errorDetailsPopoverAriaLabel', {
+          defaultMessage: 'Error details',
+        })}
       >
         <Error payload={{ error }} onClose={closePopover} />
       </EuiPopover>

--- a/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset_manager.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/asset_manager/asset_manager.component.tsx
@@ -24,6 +24,7 @@ import {
   EuiProgress,
   EuiSpacer,
   EuiText,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -78,6 +79,7 @@ export interface Props {
 export const AssetManager: FC<Props> = (props) => {
   const { assets, onClose, onAddAsset } = props;
   const [isLoading, setIsLoading] = useState(false);
+  const modalTitleId = useGeneratedHtmlId();
 
   const assetsTotal = Math.round(
     assets.reduce((total, { value }) => total + value.length, 0) / 1024
@@ -112,9 +114,10 @@ export const AssetManager: FC<Props> = (props) => {
       onClose={() => onClose()}
       className="canvasAssetManager canvasModal--fixedSize"
       maxWidth="1000px"
+      aria-labelledby={modalTitleId}
     >
       <EuiModalHeader className="canvasAssetManager__modalHeader">
-        <EuiModalHeaderTitle className="canvasAssetManager__modalHeaderTitle">
+        <EuiModalHeaderTitle id={modalTitleId} className="canvasAssetManager__modalHeaderTitle">
           {strings.getModalTitle()}
         </EuiModalHeaderTitle>
         <EuiFlexGroup className="canvasAssetManager__fileUploadWrapper">

--- a/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/saved_elements_modal.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/saved_elements_modal/saved_elements_modal.component.tsx
@@ -17,6 +17,7 @@ import {
   EuiFieldSearch,
   EuiSpacer,
   EuiButton,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -116,6 +117,7 @@ export const SavedElementsModal: FunctionComponent<Props> = ({
   const [elementToDelete, setElementToDelete] = useState<CustomElement | null>(null);
   const [elementToEdit, setElementToEdit] = useState<CustomElement | null>(null);
   const [search, setSearch] = useState<string>(initialSearch);
+  const modalTitleId = useGeneratedHtmlId();
 
   useEffect(() => {
     if (!hasLoadedElements.current) {
@@ -212,9 +214,10 @@ export const SavedElementsModal: FunctionComponent<Props> = ({
         className="canvasModal--fixedSize"
         maxWidth="1000px"
         initialFocus=".canvasElements__filter input"
+        aria-labelledby={modalTitleId}
       >
         <EuiModalHeader className="canvasAssetManager__modalHeader">
-          <EuiModalHeaderTitle className="canvasAssetManager__modalHeaderTitle">
+          <EuiModalHeaderTitle id={modalTitleId} className="canvasAssetManager__modalHeaderTitle">
             {strings.getModalTitle()}
           </EuiModalHeaderTitle>
         </EuiModalHeader>

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/tile_errors_list.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/tile_errors_list.tsx
@@ -114,6 +114,9 @@ export function TileErrorsList(props: Props) {
         closePopover={() => {
           setIsPopoverOpen(false);
         }}
+        aria-label={i18n.translate('xpack.maps.tileErrorsList.popoverAriaLabel', {
+          defaultMessage: 'Tile errors',
+        })}
       >
         <EuiContextMenu initialPanelId={0} panels={panels} size="s" />
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/spatial_join_wizard/wizard_form/relationship_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/layers/wizards/spatial_join_wizard/wizard_form/relationship_expression.tsx
@@ -52,6 +52,9 @@ export function RelationshipExpression(props: Props) {
       panelPaddingSize="s"
       anchorPosition="downCenter"
       repositionOnScroll={true}
+      aria-label={i18n.translate('xpack.maps.spatialJoin.wizardForm.relationshipPopoverAriaLabel', {
+        defaultMessage: 'Spatial join relationship',
+      })}
     >
       <DistanceForm
         initialDistance={props.distance}

--- a/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/sources/es_search_source/util/scaling_documenation_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiButtonIcon, EuiLink, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getDocLinks } from '../../../../kibana_services';
 
@@ -39,6 +40,9 @@ export function ScalingDocumenationPopover(props: Props) {
       }}
       repositionOnScroll
       ownFocus
+      aria-label={i18n.translate('xpack.maps.scalingDocs.popoverAriaLabel', {
+        defaultMessage: 'Scaling documentation',
+      })}
     >
       <EuiPopoverTitle>
         <FormattedMessage id="xpack.maps.scalingDocs.title" defaultMessage="Scaling" />

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/data_mapping/data_mapping_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/data_mapping/data_mapping_popover.tsx
@@ -10,6 +10,7 @@
 import type { ReactElement } from 'react';
 import React, { Component } from 'react';
 import { EuiButtonEmpty, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 type Props = {
@@ -62,6 +63,12 @@ export class DataMappingPopover extends Component<Props, State> {
         isOpen={this.state.isPopoverOpen}
         closePopover={this._closePopover}
         ownFocus
+        aria-label={i18n.translate(
+          'xpack.maps.styles.fieldMetaOptions.dataMappingPopoverAriaLabel',
+          {
+            defaultMessage: 'Data mapping',
+          }
+        )}
       >
         {this.props.children}
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/__snapshots__/icon_select.test.js.snap
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/__snapshots__/icon_select.test.js.snap
@@ -4,6 +4,7 @@ exports[`Should render icon select 1`] = `
 <Fragment>
   <EuiPopover
     anchorPosition="downLeft"
+    aria-label="Icon selector"
     button={
       <EuiFieldText
         compressed={true}
@@ -87,6 +88,7 @@ exports[`Should render icon select with custom icons 1`] = `
 <Fragment>
   <EuiPopover
     anchorPosition="downLeft"
+    aria-label="Icon selector"
     button={
       <EuiFieldText
         compressed={true}

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/custom_icon_modal.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/custom_icon_modal.tsx
@@ -336,6 +336,7 @@ export class CustomIconModal extends Component<Props, State> {
         maxWidth={700}
         onClose={onCancel}
         initialFocus=".mapsCustomIconForm__image"
+        aria-label={title}
       >
         <EuiModalHeader>
           <EuiModalHeaderTitle component="h3">{title}</EuiModalHeaderTitle>

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/icon_select.js
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/symbol/icon_select.js
@@ -204,6 +204,9 @@ export class IconSelect extends Component {
           anchorPosition="downLeft"
           panelPaddingSize="s"
           display="block"
+          aria-label={i18n.translate('xpack.maps.styles.vector.iconSelect.popoverAriaLabel', {
+            defaultMessage: 'Icon selector',
+          })}
         >
           <EuiFocusTrap clickOutsideDisables={true}>{this._renderIconSelectable()}</EuiFocusTrap>
         </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/components/metrics_editor/mask_expression/mask_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/components/metrics_editor/mask_expression/mask_expression.tsx
@@ -7,6 +7,7 @@
 
 import React, { Component } from 'react';
 import { EuiExpression, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { DataViewField } from '@kbn/data-views-plugin/public';
 import { AGG_TYPE } from '../../../../common/constants';
 import type { AggDescriptor, FieldedAggDescriptor } from '../../../../common/descriptor_types';
@@ -92,6 +93,9 @@ export class MaskExpression extends Component<Props, State> {
         panelPaddingSize="s"
         anchorPosition="downCenter"
         repositionOnScroll={true}
+        aria-label={i18n.translate('xpack.maps.maskExpression.popoverAriaLabel', {
+          defaultMessage: 'Mask filter',
+        })}
       >
         <MaskEditor
           metric={this.props.metric}

--- a/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/__snapshots__/add_tooltip_field_popover.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/__snapshots__/add_tooltip_field_popover.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Should remove selected fields from selectable 1`] = `
 <EuiPopover
   anchorPosition="leftCenter"
+  aria-label="Add tooltip field"
   button={
     <EuiButtonEmpty
       iconType="plusInCircleFilled"
@@ -78,6 +79,7 @@ exports[`Should remove selected fields from selectable 1`] = `
 exports[`Should render 1`] = `
 <EuiPopover
   anchorPosition="leftCenter"
+  aria-label="Add tooltip field"
   button={
     <EuiButtonEmpty
       iconType="plusInCircleFilled"

--- a/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/add_tooltip_field_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/components/tooltip_selector/add_tooltip_field_popover.tsx
@@ -200,6 +200,9 @@ export class AddTooltipFieldPopover extends Component<Props, State> {
         closePopover={this._closePopover}
         panelPaddingSize="none"
         ownFocus
+        aria-label={i18n.translate('xpack.maps.tooltipSelector.addTooltipFieldPopoverAriaLabel', {
+          defaultMessage: 'Add tooltip field',
+        })}
       >
         {this._renderContent()}
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/filter_editor/filter_editor.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/filter_editor/filter_editor.tsx
@@ -126,6 +126,9 @@ export class FilterEditor extends Component<Props, State> {
         closePopover={this._close}
         anchorPosition="leftCenter"
         ownFocus
+        aria-label={i18n.translate('xpack.maps.layerPanel.filterEditor.popoverAriaLabel', {
+          defaultMessage: 'Layer filter',
+        })}
       >
         <div className="mapFilterEditor" data-test-subj="mapFilterEditor">
           <SearchBar

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/__snapshots__/metrics_expression.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/__snapshots__/metrics_expression.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Should render default props 1`] = `
 <EuiPopover
   anchorPosition="leftCenter"
+  aria-label="Configure join metrics"
   button={
     <EuiExpression
       description="and use metric"
@@ -63,6 +64,7 @@ exports[`Should render default props 1`] = `
 exports[`Should render metrics expression for metrics 1`] = `
 <EuiPopover
   anchorPosition="leftCenter"
+  aria-label="Configure join metrics"
   button={
     <EuiExpression
       description="and use metrics"

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/join_documentation_popover.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { EuiButtonIcon, EuiLink, EuiPopover, EuiPopoverTitle, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getDocLinks } from '../../../../kibana_services';
 
@@ -32,6 +33,12 @@ export function JoinDocumentationPopover() {
       }}
       repositionOnScroll
       ownFocus
+      aria-label={i18n.translate(
+        'xpack.maps.layerPanel.joinEditor.joinDocumentationPopoverAriaLabel',
+        {
+          defaultMessage: 'Join documentation',
+        }
+      )}
     >
       <EuiPopoverTitle>
         <FormattedMessage id="xpack.maps.layerPanel.joinEditor.title" defaultMessage="Joins" />

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/metrics_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/metrics_expression.tsx
@@ -117,6 +117,9 @@ export class MetricsExpression extends Component<Props, State> {
           />
         }
         repositionOnScroll={true}
+        aria-label={i18n.translate('xpack.maps.layerPanel.metricsExpression.popoverAriaLabel', {
+          defaultMessage: 'Configure join metrics',
+        })}
       >
         <div style={{ width: 400 }}>
           <EuiPopoverTitle>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/spatial_join_expression/spatial_join_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/spatial_join_expression/spatial_join_expression.tsx
@@ -53,6 +53,9 @@ export function SpatialJoinExpression(props: Props) {
         />
       }
       repositionOnScroll={true}
+      aria-label={i18n.translate('xpack.maps.spatialJoinExpression.popoverAriaLabel', {
+        defaultMessage: 'Configure spatial join',
+      })}
     >
       <SpatialJoinPopoverContent
         sourceDescriptor={props.sourceDescriptor}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/term_join_expression/term_join_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/term_join_expression/term_join_expression.tsx
@@ -74,6 +74,9 @@ export function TermJoinExpression(props: Props) {
         />
       }
       repositionOnScroll={true}
+      aria-label={i18n.translate('xpack.maps.termJoinExpression.popoverAriaLabel', {
+        defaultMessage: 'Configure term join',
+      })}
     >
       <TermJoinPopoverContent
         leftSourceName={props.leftSourceName}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/where_expression.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/join_editor/resources/where_expression.tsx
@@ -77,6 +77,9 @@ export class WhereExpression extends Component<Props, State> {
           />
         }
         repositionOnScroll={true}
+        aria-label={i18n.translate('xpack.maps.layerPanel.whereExpression.popoverAriaLabel', {
+          defaultMessage: 'Where filter',
+        })}
       >
         <div className="mapFilterEditor" data-test-subj="mapJoinWhereFilterEditor">
           <EuiFormHelpText className="mapJoinExpressionHelpText">

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/layer_settings/attribution_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/edit_layer_panel/layer_settings/attribution_popover.tsx
@@ -148,6 +148,9 @@ export class AttributionPopover extends Component<Props, State> {
         isOpen={this.state.isPopoverOpen}
         closePopover={this._closePopover}
         ownFocus
+        aria-label={i18n.translate('xpack.maps.layerSettings.attributionPopoverAriaLabel', {
+          defaultMessage: 'Attribution',
+        })}
       >
         {this._renderContent()}
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/draw_control/draw_tooltip.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/draw_control/draw_tooltip.tsx
@@ -124,6 +124,9 @@ export class DrawTooltip extends Component<Props, State> {
           pointerEvents: 'none',
           transform: `translate(${this.state.x - 13}px, ${this.state.y - 13}px)`,
         }}
+        aria-label={i18n.translate('xpack.maps.drawTooltip.popoverAriaLabel', {
+          defaultMessage: 'Draw instructions',
+        })}
       >
         <EuiText color="subdued" size="xs">
           {instructions}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/__snapshots__/tooltip_popover.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/__snapshots__/tooltip_popover.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`TooltipPopover render should render tooltip popover 1`] = `
 <EuiPopover
   anchorPosition="upCenter"
+  aria-label="Feature tooltip"
   button={
     <div
       style={
@@ -64,6 +65,7 @@ exports[`TooltipPopover render should render tooltip popover 1`] = `
 exports[`TooltipPopover render should render tooltip popover with custom tooltip content when renderTooltipContent provided 1`] = `
 <EuiPopover
   anchorPosition="upCenter"
+  aria-label="Feature tooltip"
   button={
     <div
       style={

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/tooltip_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/tooltip_popover.tsx
@@ -8,6 +8,7 @@
 import type { RefObject } from 'react';
 import React, { Component } from 'react';
 import { EuiPopover, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import type { Map as MbMap } from '@kbn/mapbox-gl';
 import type { GeoJsonProperties, Geometry } from 'geojson';
 import type { KibanaExecutionContext } from '@kbn/core/public';
@@ -162,6 +163,9 @@ export class TooltipPopover extends Component<Props, State> {
           transform: `translate(${this.state.x - 13 - offset}px, ${this.state.y - 13}px)`,
         }}
         repositionOnScroll
+        aria-label={i18n.translate('xpack.maps.tooltipPopover.popoverAriaLabel', {
+          defaultMessage: 'Feature tooltip',
+        })}
       >
         {this._renderTooltipContent()}
       </EuiPopover>

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/__snapshots__/toc_entry_actions_popover.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`TOCEntryActionsPopover is rendered 1`] = `
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"
@@ -118,6 +119,7 @@ exports[`TOCEntryActionsPopover should disable Edit features when edit mode acti
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"
@@ -232,6 +234,7 @@ exports[`TOCEntryActionsPopover should disable fit to data when supportsFitToBou
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"
@@ -346,6 +349,7 @@ exports[`TOCEntryActionsPopover should have "show layer" action when layer is no
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"
@@ -461,6 +465,7 @@ exports[`TOCEntryActionsPopover should not show edit actions in read only mode 1
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"
@@ -544,6 +549,7 @@ exports[`TOCEntryActionsPopover should show "show this layer only" action when t
 <Fragment>
   <EuiPopover
     anchorPosition="leftUp"
+    aria-label="Layer actions"
     button={
       <Memo(Connect(TOCEntryButton))
         displayName="layer 1"

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/right_side_controls/layer_control/layer_toc/toc_entry/toc_entry_actions_popover/toc_entry_actions_popover.tsx
@@ -282,6 +282,9 @@ export class TOCEntryActionsPopover extends Component<Props, State> {
           closePopover={this._closePopover}
           panelPaddingSize="none"
           anchorPosition="leftUp"
+          aria-label={i18n.translate('xpack.maps.layerToc.actionsPopoverAriaLabel', {
+            defaultMessage: 'Layer actions',
+          })}
         >
           <EuiContextMenu
             initialPanelId={0}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/set_view_control/set_view_control.tsx
@@ -69,6 +69,9 @@ export class SetViewControl extends Component<Props, State> {
         }
         isOpen={this.state.isPopoverOpen}
         closePopover={this._closePopover}
+        aria-label={i18n.translate('xpack.maps.setViewControl.popoverAriaLabel', {
+          defaultMessage: 'Set view',
+        })}
       >
         <SetViewForm
           settings={this.props.settings}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/__snapshots__/tools_control.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/__snapshots__/tools_control.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Should render cancel button when drawing 1`] = `
   <EuiFlexItem>
     <EuiPopover
       anchorPosition="leftUp"
+      aria-label="Tools"
       button={
         <EuiPanel
           className="mapToolbarOverlay__button"
@@ -109,6 +110,7 @@ exports[`Should render cancel button when drawing 1`] = `
 exports[`renders 1`] = `
 <EuiPopover
   anchorPosition="leftUp"
+  aria-label="Tools"
   button={
     <EuiPanel
       className="mapToolbarOverlay__button"

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/toolbar_overlay/tools_control/tools_control.tsx
@@ -230,6 +230,9 @@ export class ToolsControl extends Component<Props, State> {
         panelPaddingSize="none"
         anchorPosition="leftUp"
         data-test-subj="mapToolsControlPopover"
+        aria-label={i18n.translate('xpack.maps.toolbarOverlay.toolsControlPopoverAriaLabel', {
+          defaultMessage: 'Tools',
+        })}
       >
         <EuiContextMenu initialPanelId={0} panels={this._getDrawPanels()} />
       </EuiPopover>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files (#259314)](https://github.com/elastic/kibana/pull/259314)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Copilot","email":"198982749+Copilot@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T19:09:22Z","message":"a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files (#259314)\n\nCloses: https://github.com/elastic/kibana/issues/259305\n\n43 EUI overlay components (`EuiModal`, `EuiFlyout`, `EuiPopover`,\n`EuiWrappingPopover`) were missing required `aria-label` or\n`aria-labelledby` props, failing WCAG 2.2 AA screen-reader accessibility\nrequirements.\n\n## Approach\n\n**EuiModal / EuiFlyout** — preferred `aria-labelledby` pattern using\n`useGeneratedHtmlId`:\n```tsx\nconst modalTitleId = useGeneratedHtmlId();\n// ...\n<EuiModal aria-labelledby={modalTitleId} ...>\n  <EuiModalHeader>\n    <EuiModalHeaderTitle id={modalTitleId}>...</EuiModalHeaderTitle>\n```\n\n**EuiPopover / EuiWrappingPopover** — `aria-label` with i18n string:\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('xpack.maps.tileErrorsList.popoverAriaLabel', {\n    defaultMessage: 'Tile errors',\n  })}\n  ...\n>\n```\n\n## Scope\n\n- **6 modal/flyout components**: `delete_grid_section_modal`,\n`labs_flyout`, `asset_manager`, `keyboard_shortcuts_doc`,\n`saved_elements_modal`, `custom_icon_modal` (class component — used\n`aria-label` with title prop)\n- **37 popover components**: reused existing label variables\n(`displayName`, `strings.getMoreActionsLabel()`, etc.) where available;\nadded new `i18n.translate()` calls otherwise\n- Added `i18n` and `useGeneratedHtmlId` imports only where needed\n\n\n---\n\n📱 Kick off Copilot coding agent tasks wherever you are with [GitHub\nMobile](https://gh.io/cca-mobile-docs), available on iOS and Android.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>","sha":"93c442574a5ea72f599daa9ebca41a4b71601544","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","💝community","backport:version","v9.4.0","v9.3.3","v9.2.8","a11y:agent-pr"],"title":"a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files","number":259314,"url":"https://github.com/elastic/kibana/pull/259314","mergeCommit":{"message":"a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files (#259314)\n\nCloses: https://github.com/elastic/kibana/issues/259305\n\n43 EUI overlay components (`EuiModal`, `EuiFlyout`, `EuiPopover`,\n`EuiWrappingPopover`) were missing required `aria-label` or\n`aria-labelledby` props, failing WCAG 2.2 AA screen-reader accessibility\nrequirements.\n\n## Approach\n\n**EuiModal / EuiFlyout** — preferred `aria-labelledby` pattern using\n`useGeneratedHtmlId`:\n```tsx\nconst modalTitleId = useGeneratedHtmlId();\n// ...\n<EuiModal aria-labelledby={modalTitleId} ...>\n  <EuiModalHeader>\n    <EuiModalHeaderTitle id={modalTitleId}>...</EuiModalHeaderTitle>\n```\n\n**EuiPopover / EuiWrappingPopover** — `aria-label` with i18n string:\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('xpack.maps.tileErrorsList.popoverAriaLabel', {\n    defaultMessage: 'Tile errors',\n  })}\n  ...\n>\n```\n\n## Scope\n\n- **6 modal/flyout components**: `delete_grid_section_modal`,\n`labs_flyout`, `asset_manager`, `keyboard_shortcuts_doc`,\n`saved_elements_modal`, `custom_icon_modal` (class component — used\n`aria-label` with title prop)\n- **37 popover components**: reused existing label variables\n(`displayName`, `strings.getMoreActionsLabel()`, etc.) where available;\nadded new `i18n.translate()` calls otherwise\n- Added `i18n` and `useGeneratedHtmlId` imports only where needed\n\n\n---\n\n📱 Kick off Copilot coding agent tasks wherever you are with [GitHub\nMobile](https://gh.io/cca-mobile-docs), available on iOS and Android.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>","sha":"93c442574a5ea72f599daa9ebca41a4b71601544"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259314","number":259314,"mergeCommit":{"message":"a11y: Fix `@elastic/eui/require-aria-label-for-modals` violations across 43 presentation/maps/canvas files (#259314)\n\nCloses: https://github.com/elastic/kibana/issues/259305\n\n43 EUI overlay components (`EuiModal`, `EuiFlyout`, `EuiPopover`,\n`EuiWrappingPopover`) were missing required `aria-label` or\n`aria-labelledby` props, failing WCAG 2.2 AA screen-reader accessibility\nrequirements.\n\n## Approach\n\n**EuiModal / EuiFlyout** — preferred `aria-labelledby` pattern using\n`useGeneratedHtmlId`:\n```tsx\nconst modalTitleId = useGeneratedHtmlId();\n// ...\n<EuiModal aria-labelledby={modalTitleId} ...>\n  <EuiModalHeader>\n    <EuiModalHeaderTitle id={modalTitleId}>...</EuiModalHeaderTitle>\n```\n\n**EuiPopover / EuiWrappingPopover** — `aria-label` with i18n string:\n```tsx\n<EuiPopover\n  aria-label={i18n.translate('xpack.maps.tileErrorsList.popoverAriaLabel', {\n    defaultMessage: 'Tile errors',\n  })}\n  ...\n>\n```\n\n## Scope\n\n- **6 modal/flyout components**: `delete_grid_section_modal`,\n`labs_flyout`, `asset_manager`, `keyboard_shortcuts_doc`,\n`saved_elements_modal`, `custom_icon_modal` (class component — used\n`aria-label` with title prop)\n- **37 popover components**: reused existing label variables\n(`displayName`, `strings.getMoreActionsLabel()`, etc.) where available;\nadded new `i18n.translate()` calls otherwise\n- Added `i18n` and `useGeneratedHtmlId` imports only where needed\n\n\n---\n\n📱 Kick off Copilot coding agent tasks wherever you are with [GitHub\nMobile](https://gh.io/cca-mobile-docs), available on iOS and Android.\n\n---------\n\nCo-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Alexey Antonov <alexwizp@gmail.com>\nCo-authored-by: alexwizp <20072247+alexwizp@users.noreply.github.com>","sha":"93c442574a5ea72f599daa9ebca41a4b71601544"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->