### PR TITLE
[Observability:Streams] Fix query streams error handling test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/tests/query_streams/create_query_stream.spec.ts
@@ -38,6 +38,7 @@ test.describe('Query streams - Create query stream', { tag: tags.stateful.classi
   test('should properly handle errors for invalid query streams', async ({ pageObjects }) => {
     await pageObjects.streams.clickCreateQueryStreamButton();
     await pageObjects.streams.fillRoutingRuleName('test-query-stream');
+    await pageObjects.streams.kibanaMonacoEditor.waitCodeEditorReady('streamsEsqlEditor');
     await pageObjects.streams.kibanaMonacoEditor.setCodeEditorValue('INVALID QUERY');
     await pageObjects.streams.clickQueryStreamFlyoutSaveButton();
     await expect(pageObjects.streams.queryStreamCreateErrorToast).toBeVisible();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/258225

## Summary
The test for query stream error handling was not properly awaiting the monaco editor to be available, which led to some flaky test runs. This PR adds the necessary await to fix the test flakiness.