### PR TITLE
[One Workflow] Fix connector step icons falling back to generic plugs in YAML editor

### DIFF
--- a/src/platform/plugins/shared/workflows_management/.storybook/decorators.tsx
+++ b/src/platform/plugins/shared/workflows_management/.storybook/decorators.tsx
@@ -41,11 +41,13 @@ const createMockTriggersActionsUi = () => ({
 });
 
 const createMockWorkflowsExtensions = () => ({
-  getStepDefinition: (stepType: string) => {
-    // Return undefined for all step types in Storybook
-    // This allows the component to fall back to default icons
-    return undefined;
-  },
+  getStepDefinition: () => undefined,
+  getAllStepDefinitions: () => [],
+  hasStepDefinition: () => false,
+  getTriggerDefinition: () => undefined,
+  getAllTriggerDefinitions: () => [],
+  hasTriggerDefinition: () => false,
+  isReady: () => true,
 });
 
 /**

--- a/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/actions_menu_popover/ui/actions_menu.stories.tsx
@@ -9,10 +9,12 @@
 
 import type { Meta } from '@storybook/react';
 import { ActionsMenu } from './actions_menu';
+import { kibanaReactDecorator } from '../../../../.storybook/decorators';
 
 const meta: Meta = {
   title: 'ActionsMenu',
   component: ActionsMenu,
+  decorators: [kibanaReactDecorator],
 };
 
 export default meta;

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
@@ -15,6 +15,7 @@ import {
   getTriggerBoltFallbackDataUrl,
   resolveIconToDataUrl,
 } from './get_icon_base64';
+import { getStepIconType } from './get_step_icon_type';
 import { HardcodedIcons } from './hardcoded_icons';
 
 // Mock renderToStaticMarkup from react-dom/server
@@ -203,10 +204,10 @@ describe('getIconBase64', () => {
   });
 
   describe('step icons', () => {
-    it('returns the resolved icon when icon is provided', async () => {
+    it('returns the resolved icon when icon is provided for unknown actionTypeId', async () => {
       const dataUrl = 'data:image/svg+xml;base64,c3RlcA==';
       const result = await getIconBase64({
-        actionTypeId: '.slack',
+        actionTypeId: '.custom-connector',
         icon: dataUrl,
         kind: 'step',
       });
@@ -214,7 +215,37 @@ describe('getIconBase64', () => {
       expect(result).toBe(dataUrl);
     });
 
-    it('returns hardcoded icon when actionTypeId matches a known type', async () => {
+    it('prefers hardcoded icon over icon param for known actionTypeIds', async () => {
+      const result = await getIconBase64({
+        actionTypeId: '.slack',
+        icon: 'logoSlack',
+        kind: 'step',
+      });
+
+      expect(result).toBe(HardcodedIcons['.slack']);
+    });
+
+    it('prefers hardcoded icon for email over EUI name string', async () => {
+      const result = await getIconBase64({
+        actionTypeId: '.email',
+        icon: 'email',
+        kind: 'step',
+      });
+
+      expect(result).toBe(HardcodedIcons['.email']);
+    });
+
+    it('prefers hardcoded icon for inference over EUI name string', async () => {
+      const result = await getIconBase64({
+        actionTypeId: '.inference',
+        icon: 'sparkles',
+        kind: 'step',
+      });
+
+      expect(result).toBe(HardcodedIcons['.inference']);
+    });
+
+    it('returns hardcoded icon when actionTypeId matches a known type without icon', async () => {
       const result = await getIconBase64({
         actionTypeId: '.slack',
         kind: 'step',
@@ -223,14 +254,13 @@ describe('getIconBase64', () => {
       expect(result).toBe(HardcodedIcons['.slack']);
     });
 
-    it('returns DEFAULT_CONNECTOR_DATA_URL for unknown actionTypeId without icon', async () => {
+    it('returns plugs fallback for unknown actionTypeId without icon', async () => {
       const result = await getIconBase64({
         actionTypeId: 'unknown-action-type',
         kind: 'step',
       });
 
-      // Should be the default connector fallback (no fromRegistry)
-      expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+      expect(result).toBe(HardcodedIcons.default);
     });
 
     it('returns HardcodedIcons.kibana as fallback when fromRegistry is true', async () => {
@@ -270,5 +300,154 @@ describe('getIconBase64', () => {
 describe('getTriggerBoltFallbackDataUrl', () => {
   it('returns HardcodedIcons.trigger', () => {
     expect(getTriggerBoltFallbackDataUrl()).toBe(HardcodedIcons.trigger);
+  });
+});
+
+describe('getIconBase64 – every HardcodedIcons entry resolves to its hardcoded value', () => {
+  const NON_STEP_KEYS = ['trigger', 'flask', 'beta', 'default'];
+  const REACT_COMPONENT_KEYS = ['elasticsearch', 'kibana'];
+
+  const stepEntries = Object.entries(HardcodedIcons).filter(
+    ([key]) => !NON_STEP_KEYS.includes(key) && !REACT_COMPONENT_KEYS.includes(key)
+  );
+
+  it.each(stepEntries)(
+    'returns hardcoded icon for actionTypeId "%s"',
+    async (actionTypeId, expectedIcon) => {
+      const result = await getIconBase64({ actionTypeId, kind: 'step' });
+      expect(result).toBe(expectedIcon);
+    }
+  );
+});
+
+describe('getIconBase64 – hardcoded icon wins over EUI name strings', () => {
+  const casesWithEuiNames: Array<[string, string]> = [
+    ['.slack', 'logoSlack'],
+    ['.slack_api', 'logoSlack'],
+    ['.email', 'mail'],
+    ['.inference', 'sparkles'],
+    ['console', 'commandLine'],
+    ['if', 'branch'],
+    ['foreach', 'refresh'],
+    ['while', 'refresh'],
+    ['switch', 'productStreamsWired'],
+    ['wait', 'clock'],
+    ['waitForInput', 'user'],
+    ['alert', 'warning'],
+    ['scheduled', 'clock'],
+    ['manual', 'user'],
+    ['data.set', 'database'],
+  ];
+
+  it.each(casesWithEuiNames)(
+    'prefers hardcoded icon for "%s" over EUI icon name "%s"',
+    async (actionTypeId, euiIconName) => {
+      const result = await getIconBase64({
+        actionTypeId,
+        icon: euiIconName,
+        kind: 'step',
+      });
+      expect(result).toBe(HardcodedIcons[actionTypeId]);
+    }
+  );
+});
+
+describe('getIconBase64 – error handling', () => {
+  it('returns plugs fallback for unknown connector with non-resolvable EUI icon name', async () => {
+    const result = await getIconBase64({
+      actionTypeId: '.some-broken-connector',
+      icon: 'nonExistentEuiIcon',
+      kind: 'step',
+    });
+
+    expect(result).toBe(HardcodedIcons.default);
+  });
+
+  it('returns kibana fallback for registry step with non-resolvable icon', async () => {
+    const result = await getIconBase64({
+      actionTypeId: 'some-registry-step',
+      icon: 'nonExistentEuiIcon',
+      kind: 'step',
+      fromRegistry: true,
+    });
+
+    expect(result).toBe(HardcodedIcons.kibana);
+  });
+
+  it('returns bolt fallback for trigger with non-resolvable icon', async () => {
+    const result = await getIconBase64({
+      actionTypeId: 'broken-trigger-unique-2',
+      icon: 'nonExistentEuiIcon',
+      kind: 'trigger',
+    });
+
+    expect(result).toBe(HardcodedIcons.trigger);
+  });
+
+  it('returns plugs fallback when icon is a throwing function component', async () => {
+    renderToStaticMarkup.mockImplementation(() => {
+      throw new Error('render failed');
+    });
+
+    const BrokenComponent: React.FC<{ width: number; height: number }> = () => null;
+    const result = await getIconBase64({
+      actionTypeId: '.another-broken-connector',
+      icon: BrokenComponent,
+      kind: 'step',
+    });
+
+    expect(result).toBe(HardcodedIcons.default);
+  });
+});
+
+describe('getStepIconType and getIconBase64 consistency', () => {
+  const stepTypesInBothPaths = [
+    'console',
+    'data.set',
+    'foreach',
+    'while',
+    'switch',
+    'if',
+    'wait',
+    'waitForInput',
+    'workflow.execute',
+    'workflow.executeAsync',
+    'workflow.output',
+    'workflow.fail',
+  ];
+
+  it.each(stepTypesInBothPaths)(
+    '"%s" resolves to a non-fallback icon in both getStepIconType and getIconBase64',
+    async (stepType) => {
+      const euiIcon = getStepIconType(stepType);
+      expect(euiIcon).not.toBe('plugs');
+      expect(euiIcon).not.toBe('info');
+
+      const dataUrl = await getIconBase64({ actionTypeId: stepType, kind: 'step' });
+      expect(dataUrl).toBe(HardcodedIcons[stepType]);
+      expect(HardcodedIcons[stepType]).toBeDefined();
+    }
+  );
+
+  const triggerOnlyTypes = ['alert', 'scheduled', 'manual'];
+
+  it.each(triggerOnlyTypes)(
+    '"%s" has a hardcoded icon but is not in getStepIconType (trigger-only type)',
+    async (stepType) => {
+      expect(HardcodedIcons[stepType]).toBeDefined();
+
+      const dataUrl = await getIconBase64({ actionTypeId: stepType, kind: 'step' });
+      expect(dataUrl).toBe(HardcodedIcons[stepType]);
+    }
+  );
+
+  it('http resolves in getStepIconType but falls back in getIconBase64 (no hardcoded entry)', async () => {
+    const euiIcon = getStepIconType('http');
+    expect(euiIcon).toBe('globe');
+
+    expect(HardcodedIcons.http).toBeUndefined();
+
+    const dataUrl = await getIconBase64({ actionTypeId: 'http', kind: 'step' });
+    expect(dataUrl).toBe(HardcodedIcons.default);
   });
 });

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.test.ts
@@ -389,7 +389,7 @@ describe('getIconBase64 – error handling', () => {
       throw new Error('render failed');
     });
 
-    const BrokenComponent: React.FC<{ width: number; height: number }> = () => null;
+    const BrokenComponent: React.FC = () => null;
     const result = await getIconBase64({
       actionTypeId: '.another-broken-connector',
       icon: BrokenComponent,

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.ts
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/get_icon_base64.ts
@@ -102,11 +102,7 @@ export interface GetIconBase64Params {
   kind: 'trigger' | 'step';
 }
 
-const DEFAULT_CONNECTOR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="2"/>
-    <circle cx="8" cy="8" r="2" fill="currentColor"/>
-  </svg>`;
-const DEFAULT_CONNECTOR_DATA_URL = `data:image/svg+xml;base64,${btoa(DEFAULT_CONNECTOR_SVG)}`;
+const DEFAULT_CONNECTOR_DATA_URL = HardcodedIcons.default;
 
 const triggerIconDataUrlCache = new Map<string, string>();
 
@@ -147,10 +143,6 @@ export async function getIconBase64(params: GetIconBase64Params): Promise<string
   }
 
   try {
-    if (icon) {
-      const fallback = defaultFallbackForStep(params);
-      return resolveIconToDataUrl(icon, fallback);
-    }
     if (actionTypeId === 'elasticsearch') {
       return getDataUrlFromReactComponent(ElasticsearchLogo, DEFAULT_CONNECTOR_DATA_URL);
     }
@@ -160,6 +152,9 @@ export async function getIconBase64(params: GetIconBase64Params): Promise<string
     const hardcodedIcon = HardcodedIcons[actionTypeId];
     if (hardcodedIcon) {
       return hardcodedIcon;
+    }
+    if (icon) {
+      return resolveIconToDataUrl(icon, defaultFallbackForStep(params));
     }
     return defaultFallbackForStep(params);
   } catch {

--- a/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/shared/ui/step_icons/step_icon.stories.tsx
@@ -7,15 +7,18 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
+import { HardcodedIcons } from './hardcoded_icons';
 import { StepIcon } from './step_icon';
+import { kibanaReactDecorator } from '../../../../.storybook/decorators';
 
 export default {
   title: 'StepIcon',
+  decorators: [kibanaReactDecorator],
 };
 
-const types = [
+const builtInTypes = [
   'manual',
   'alert',
   'scheduled',
@@ -29,6 +32,9 @@ const types = [
   'elasticsearch',
   'kibana',
   'email',
+];
+
+const connectorTypes = [
   'gemini',
   'bedrock',
   'gen-ai',
@@ -43,21 +49,53 @@ const types = [
   'servicenow-itom',
 ];
 
+const hasHardcodedIcon = (type: string): boolean =>
+  type in HardcodedIcons ||
+  `.${type}` in HardcodedIcons ||
+  type === 'elasticsearch' ||
+  type === 'kibana';
+
+const IconGrid = ({ types }: { types: string[] }) => (
+  <EuiFlexGrid columns={4} gutterSize="l">
+    {types.map((type) => (
+      <EuiFlexItem key={type} grow={false}>
+        <EuiFlexGroup direction="column" gutterSize="xs">
+          <EuiFlexItem>
+            <StepIcon stepType={type} executionStatus={undefined} />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <pre>{type}</pre>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    ))}
+  </EuiFlexGrid>
+);
+
 export const Default = () => {
+  const hardcoded = builtInTypes.filter(hasHardcodedIcon);
+  const fallback = [...builtInTypes.filter((t) => !hasHardcodedIcon(t)), ...connectorTypes];
+
   return (
-    <EuiFlexGrid columns={4} gutterSize="l">
-      {types.map((type) => (
-        <EuiFlexItem key={type} grow={false}>
-          <EuiFlexGroup direction="column" gutterSize="xs">
-            <EuiFlexItem>
-              <StepIcon stepType={type} executionStatus={undefined} />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <pre>{type}</pre>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
+    <EuiFlexGroup direction="column" gutterSize="l">
+      <EuiFlexItem style={{ marginBottom: 8 }}>
+        <EuiTitle size="xxs">
+          <h3>{'Hardcoded icons (bundled SVGs)'}</h3>
+        </EuiTitle>
+      </EuiFlexItem>
+
+      <IconGrid types={hardcoded} />
+      <EuiFlexItem style={{ marginTop: 16, marginBottom: 8 }}>
+        <EuiTitle size="xxs">
+          <h3>{'Connector icons (lazy-loaded from stack_connectors in full Kibana)'}</h3>
+        </EuiTitle>
+        <EuiText size="xs" color="subdued">
+          {
+            'These show fallback icons in Storybook because the real logos are registered by stack_connectors at runtime.'
+          }
+        </EuiText>
+      </EuiFlexItem>
+      <IconGrid types={fallback} />
+    </EuiFlexGroup>
   );
 };

--- a/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_dynamic_type_icons.stories.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/widgets/workflow_yaml_editor/styles/use_dynamic_type_icons.stories.tsx
@@ -7,16 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiFlexGroup } from '@elastic/eui';
+import { EuiText } from '@elastic/eui';
+import type { Decorator } from '@storybook/react';
 import React from 'react';
+import { TypeRegistry } from '@kbn/alerts-ui-shared/lib';
+import type { CoreStart } from '@kbn/core/public';
+import { CommonGlobalAppStyles } from '@kbn/core-chrome-layout/layouts/common/global_app_styles';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import type { ActionTypeModel } from '@kbn/triggers-actions-ui-plugin/public';
 import type { ConnectorTypeInfo } from '@kbn/workflows';
 import { GlobalWorkflowEditorStyles } from './global_workflow_editor_styles';
 import { predefinedStepTypes, useDynamicTypeIcons } from './use_dynamic_type_icons';
 import type { ConnectorsResponse } from '../../../entities/connectors/model/types';
-
-export default {
-  title: 'Use Dynamic Type Icons',
-};
+import { mockUiSettingsService } from '../../../shared/mocks/mock_ui_settings_service';
+import { HardcodedIcons } from '../../../shared/ui/step_icons/hardcoded_icons';
 
 type MockConnectorTypeInfo = Pick<ConnectorTypeInfo, 'actionTypeId' | 'displayName'>;
 
@@ -92,7 +97,74 @@ const mockConnectorsResponse: MockConnectorsResponse = {
       actionTypeId: '.email',
       displayName: 'Email',
     },
+    inference: {
+      actionTypeId: '.inference',
+      displayName: 'Inference',
+    },
+    slackApi: {
+      actionTypeId: '.slack_api',
+      displayName: 'Slack API',
+    },
   },
+};
+
+// Real connector logos (gemini, bedrock, jira, etc.) are lazy React components registered by
+// stack_connectors. We use a placeholder iconClass here to avoid cross-plugin dependencies.
+// Connectors with HardcodedIcons entries (slack, email, inference) still show the correct icon.
+const createPopulatedActionTypeRegistry = () => {
+  const registry = new TypeRegistry<ActionTypeModel>();
+  for (const connector of Object.values(mockConnectorsResponse.connectorTypes)) {
+    registry.register({
+      id: connector.actionTypeId,
+      iconClass: 'plugs',
+      selectMessage: '',
+      actionConnectorFields: null,
+      actionParamsFields: null as unknown as ActionTypeModel['actionParamsFields'],
+      validateParams: async () => ({ errors: {} }),
+    } as unknown as ActionTypeModel);
+  }
+  return registry;
+};
+
+const decorator: Decorator = (story: Function) => {
+  return (
+    <I18nProvider>
+      <KibanaContextProvider
+        services={
+          {
+            application: {
+              capabilities: { workflowsManagement: {} },
+              getUrlForApp: () => '',
+            },
+            settings: { client: mockUiSettingsService() },
+            storage: {
+              storage: {},
+              set: () => {},
+              remove: () => {},
+              clear: () => {},
+              get: () => {},
+            },
+            triggersActionsUi: {
+              actionTypeRegistry: createPopulatedActionTypeRegistry(),
+              ruleTypeRegistry: new TypeRegistry(),
+            },
+            workflowsExtensions: {
+              getStepDefinition: () => undefined,
+              getAllStepDefinitions: () => [],
+            },
+          } as unknown as CoreStart
+        }
+      >
+        <CommonGlobalAppStyles />
+        {story()}
+      </KibanaContextProvider>
+    </I18nProvider>
+  );
+};
+
+export default {
+  title: 'Use Dynamic Type Icons',
+  decorators: [decorator],
 };
 
 const allTypes = [
@@ -103,19 +175,53 @@ const allTypes = [
   })),
 ];
 
-export const Default = () => {
+const hasHardcodedIcon = (actionTypeId: string): boolean =>
+  actionTypeId in HardcodedIcons ||
+  `.${actionTypeId}` in HardcodedIcons ||
+  actionTypeId === 'elasticsearch' ||
+  actionTypeId === 'kibana';
+
+const withHardcodedIcons = allTypes.filter((t) => hasHardcodedIcon(t.actionTypeId));
+const withFallbackIcons = allTypes.filter((t) => !hasHardcodedIcon(t.actionTypeId));
+
+const SectionHeading = ({ children, first }: { children: string; first?: boolean }) => (
+  <EuiText size="xs" color="subdued" style={{ margin: first ? '0 0 4px' : '16px 0 4px' }}>
+    <strong>{children}</strong>
+  </EuiText>
+);
+
+const DynamicTypeIconsDemo = () => {
   useDynamicTypeIcons(mockConnectorsResponse as ConnectorsResponse);
   return (
-    <EuiFlexGroup direction="column" gutterSize="s" alignItems="flexStart">
+    <div className="monaco-editor" style={{ fontFamily: 'monospace', fontSize: 13 }}>
       <GlobalWorkflowEditorStyles />
-      {allTypes.map((connector) => (
-        <div
-          key={connector.actionTypeId}
-          className={`type-inline-highlight type-${connector.actionTypeId.replaceAll('.', '-')}`}
-        >
-          {connector.displayName}
-        </div>
-      ))}
-    </EuiFlexGroup>
+      <div
+        className="view-line"
+        style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}
+      >
+        <SectionHeading first>{'Hardcoded icons (bundled SVGs)'}</SectionHeading>
+        {withHardcodedIcons.map((t) => (
+          <span
+            key={t.actionTypeId}
+            className={`type-inline-highlight type-${t.actionTypeId.replaceAll('.', '-')}`}
+          >
+            {t.actionTypeId}
+          </span>
+        ))}
+        <SectionHeading>
+          {'Connector icons (lazy-loaded from stack_connectors in full Kibana)'}
+        </SectionHeading>
+        {withFallbackIcons.map((t) => (
+          <span
+            key={t.actionTypeId}
+            className={`type-inline-highlight type-${t.actionTypeId.replaceAll('.', '-')}`}
+          >
+            {t.actionTypeId}
+          </span>
+        ))}
+      </div>
+    </div>
   );
 };
+
+export const Default = () => <DynamicTypeIconsDemo />;


### PR DESCRIPTION
Closes https://github.com/elastic/security-team/issues/16358

## Summary

`getIconBase64` was checking `resolveIconToDataUrl(icon)` before looking up `HardcodedIcons[actionTypeId]`. Connector icons like Slack, Email, and Inference pass an EUI icon name string (e.g. `'logoSlack'`) as `icon`, which `resolveIconToDataUrl` can't resolve to a data URL — so it fell back to the generic plugs icon for all of them.

Fix: check `HardcodedIcons[actionTypeId]` first. If a hardcoded SVG exists for the connector, return it immediately without trying to resolve the runtime icon. Also changed the default fallback from a generic circle SVG to the plugs icon (consistent with `StepIcon` component behavior).

The regression was introduced on `main` during the refactor that extracted `resolveIconToDataUrl` — on 9.3, the old code gracefully fell through EUI name strings and reached the hardcoded lookup. No backport needed.

### Before / After (Storybook `Use Dynamic Type Icons`)

| Before | After |
|--------|-------|
| <img width="1280" height="988" alt="dynamic_icons_before_full" src="https://github.com/user-attachments/assets/75f2a637-b354-40ab-833c-a73f4923d09f" /> | <img width="1280" height="988" alt="dynamic_icons_after_full" src="https://github.com/user-attachments/assets/680dcfe1-518b-4ba0-a422-2064b7ff296c" /> | 
| | Notice how `slack`, `email`, `inference`, `slack_api`, and all built-in step types now show their correct branded icons instead of the generic plugs fallback.

### Testing

- Added tests covering all `HardcodedIcons` entries, priority over EUI name strings, error handling paths, and `getStepIconType`/`getIconBase64` consistency
- Fixed Storybook stories for `StepIcon`, `Use Dynamic Type Icons`, and `ActionsMenu` (were missing Kibana context)