### PR TITLE
[ResponseOps] Convert event log duration and schedule_delay to nanoseconds

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/millis_to_nanos.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/millis_to_nanos.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { millisToNanos } from './millis_to_nanos';
+
+describe('millisToNanos', () => {
+  test('should return "0" when passing 0 millis', () => {
+    expect(millisToNanos(0)).toEqual('0');
+  });
+
+  test('should return "1000000" when passing in 1 millis', () => {
+    expect(millisToNanos(1)).toEqual('1000000');
+  });
+
+  test('should return "9007199254740991000000" when passing in 9007199254740991 (Number.MAX_SAFE_INTEGER)', () => {
+    expect(millisToNanos(9007199254740991)).toEqual('9007199254740991000000');
+  });
+
+  test('should round to "1000000" wheen passing in 0.75 millis', () => {
+    expect(millisToNanos(0.75)).toEqual('1000000');
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/millis_to_nanos.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/millis_to_nanos.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function millisToNanos(millis: number): string {
+  const roundedMillis = Math.round(millis);
+  if (roundedMillis === 0) {
+    return '0';
+  }
+  return `${roundedMillis}000000`;
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -2725,7 +2725,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'success',
             start: expect.stringMatching(dateRegExp),
@@ -2734,7 +2734,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -2774,7 +2774,7 @@ describe('TaskManagerRunner', () => {
           error: expect.any(Object),
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'failure',
             start: expect.stringMatching(dateRegExp),
@@ -2783,7 +2783,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -2817,7 +2817,7 @@ describe('TaskManagerRunner', () => {
           error: expect.any(Object),
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'failure',
             start: expect.stringMatching(dateRegExp),
@@ -2826,7 +2826,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -2876,7 +2876,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-cancel',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             start: expect.stringMatching(dateRegExp),
           },
@@ -2890,7 +2890,7 @@ describe('TaskManagerRunner', () => {
           error: expect.any(Object),
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'failure',
             start: expect.stringMatching(dateRegExp),
@@ -2900,7 +2900,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -2948,7 +2948,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-cancel',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             start: expect.stringMatching(dateRegExp),
           },
@@ -2961,7 +2961,7 @@ describe('TaskManagerRunner', () => {
           error: expect.any(Object),
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'failure',
             start: expect.stringMatching(dateRegExp),
@@ -2971,7 +2971,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -3014,7 +3014,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-cancel',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             start: expect.stringMatching(dateRegExp),
           },
@@ -3026,7 +3026,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'success',
             start: expect.stringMatching(dateRegExp),
@@ -3035,7 +3035,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },
@@ -3075,7 +3075,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-cancel',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             start: expect.stringMatching(dateRegExp),
           },
@@ -3087,7 +3087,7 @@ describe('TaskManagerRunner', () => {
         expect(eventLoggerMock.logEvent).toHaveBeenCalledWith({
           event: {
             action: 'task-run',
-            duration: expect.any(Number),
+            duration: expect.any(String),
             end: expect.stringMatching(dateRegExp),
             outcome: 'success',
             start: expect.stringMatching(dateRegExp),
@@ -3096,7 +3096,7 @@ describe('TaskManagerRunner', () => {
             task: {
               id,
               type: 'bar',
-              schedule_delay: expect.any(Number),
+              schedule_delay: expect.any(String),
               scheduled: expect.any(String),
             },
           },

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -74,6 +74,7 @@ import { getNextRunAt } from '../lib/get_next_run_at';
 import { TaskErrorSource } from '../../common/constants';
 import { getExecutionId } from '../lib/get_execution_id';
 import { EVENT_LOG_ACTIONS, EventLogOutcomes } from '../constants';
+import { millisToNanos } from '../lib/millis_to_nanos';
 
 export const EMPTY_RUN_RESULT: SuccessfulRunResult = { state: {} };
 
@@ -1092,10 +1093,10 @@ export class TaskManagerRunner implements TaskRunner {
     message: string,
     error?: Error | DecoratedError
   ): void {
-    const runDurationMs = taskTiming.stop - taskTiming.start;
-    const scheduleDelayMs =
+    const runDurationNs = millisToNanos(taskTiming.stop - taskTiming.start);
+    const scheduleDelayNs =
       task.startedAt && task.scheduledAt
-        ? task.startedAt.getTime() - task.scheduledAt.getTime()
+        ? millisToNanos(task.startedAt.getTime() - task.scheduledAt.getTime())
         : undefined;
     const errorDetails = error
       ? {
@@ -1107,7 +1108,7 @@ export class TaskManagerRunner implements TaskRunner {
       event: {
         action: EVENT_LOG_ACTIONS.taskRun,
         outcome,
-        duration: runDurationMs,
+        duration: runDurationNs,
         start: new Date(taskTiming.start).toISOString(),
         end: new Date(taskTiming.stop).toISOString(),
         ...(error && this.isCancelled ? { reason: `Task "${this.id}" was cancelled.` } : {}),
@@ -1117,7 +1118,7 @@ export class TaskManagerRunner implements TaskRunner {
           id: this.id,
           type: this.taskType,
           scheduled: task.scheduledAt.toISOString(),
-          ...(scheduleDelayMs != null ? { schedule_delay: scheduleDelayMs } : {}),
+          ...(scheduleDelayNs != null ? { schedule_delay: scheduleDelayNs } : {}),
         },
       },
       message,
@@ -1126,11 +1127,11 @@ export class TaskManagerRunner implements TaskRunner {
   }
 
   private logTaskCancelEvent(task: ConcreteTaskInstance, taskTiming: TaskTiming): void {
-    const runDurationMs = taskTiming.stop - taskTiming.start;
+    const runDurationNs = millisToNanos(taskTiming.stop - taskTiming.start);
     this.eventLogger.logEvent({
       event: {
         action: EVENT_LOG_ACTIONS.taskCancel,
-        duration: runDurationMs,
+        duration: runDurationNs,
         start: new Date(taskTiming.start).toISOString(),
         end: new Date(taskTiming.stop).toISOString(),
       },


### PR DESCRIPTION
## Summary

This PR updates the unit of the event log duration and schedule_delay values from milliseconds nanoseconds.

Bc of the circular dependency issues with TM and the EventLog I just copied `millisToNanos` instead of importing it from the EventLog plugin