### PR TITLE
[Slack v2] Add createConversation and  inviteToConversation actions

### DIFF
--- a/docs/reference/connectors-kibana/slack-v2-action-type.md
+++ b/docs/reference/connectors-kibana/slack-v2-action-type.md
@@ -78,7 +78,7 @@ Use the [Action configuration settings](/reference/configuration-reference/alert
 
 ## Get API credentials [slack-v2-api-credentials]
 
-To use the Slack (v2) connector, you need a Slack app and a Slack **user token** or **bot token**.
+To use the Slack (v2) connector, you need a Slack app and a Slack **user token**.
 
 1. Create a Slack app and install it to your workspace.
 2. Add **User Token Scopes** for the actions you intend to use:

--- a/docs/reference/connectors-kibana/slack-v2-action-type.md
+++ b/docs/reference/connectors-kibana/slack-v2-action-type.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "Slack (v2)"
 type: reference
-description: "Use the Slack (v2) connector to search messages, resolve channel IDs, and send messages to Slack channels using the Slack Web API."
+description: "Use the Slack (v2) connector to search messages, resolve channel IDs, send messages, create channels, and invite users to Slack channels using the Slack Web API."
 applies_to:
   stack: preview 9.4
   serverless: preview
@@ -9,7 +9,7 @@ applies_to:
 
 # Slack (v2) connector [slack-v2-action-type]
 
-The Slack (v2) connector enables workflow-driven Slack automation: search Slack messages, resolve public channel IDs, and send messages to Slack public channels using the Slack Web API.
+The Slack (v2) connector enables workflow-driven Slack automation: search Slack messages, resolve public channel IDs, send messages, create channels, and invite users to Slack channels using the Slack Web API.
 
 ## Create connectors in {{kib}} [define-slack-v2-ui]
 
@@ -54,6 +54,16 @@ Resolve channel ID
     - `limit` (optional): Channels per page (1 to 1000). Defaults to `1000`.
     - `maxPages` (optional): Maximum pages to scan before giving up. Defaults to `10`.
 
+Create conversation
+:   Create a new Slack channel (public or private).
+    - `name` (required): Channel name. Must contain only lowercase letters, numbers, hyphens, and underscores (80 characters or fewer).
+    - `isPrivate` (optional): Whether to create a private channel. Defaults to `false`.
+
+Invite to conversation
+:   Invite users to a Slack channel.
+    - `channel` (required): The channel ID to invite users to (for example, `C123...` or `G456...`).
+    - `users` (required): Comma-separated list of user IDs to invite (for example, `U01PWE77HD2,U02ABC1234`).
+
 Send message
 :   Send a message to a Slack conversation ID.
     - `channel` (required): Conversation ID (for example, `C123...`). Use **Resolve channel ID** first if you only have a channel name.
@@ -68,11 +78,12 @@ Use the [Action configuration settings](/reference/configuration-reference/alert
 
 ## Get API credentials [slack-v2-api-credentials]
 
-To use the Slack (v2) connector, you need a Slack app and a Slack **user token**.
+To use the Slack (v2) connector, you need a Slack app and a Slack **user token** or **bot token**.
 
 1. Create a Slack app and install it to your workspace.
 2. Add **User Token Scopes** for the actions you intend to use:
    - **Resolve channel ID**: `channels:read`
    - **Send message (public channels)**: `chat:write`
+   - **Create conversation / Invite to conversation**: `groups:write`
    - **Search messages**: `search:read.public`, `search:read.private`, `search:read.im`, `search:read.mpim`, `search:read.files`
 3. Copy the **User OAuth Token** (for example, `xoxp-...`) and enter it in the **Temporary Slack user token** field when configuring the connector in {{kib}}.

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.test.ts
@@ -226,6 +226,135 @@ describe('Slack', () => {
     });
   });
 
+  describe('createConversation action', () => {
+    it('should create a public channel', async () => {
+      const mockResponse = {
+        data: {
+          ok: true,
+          channel: {
+            id: 'C123ABC',
+            name: 'incident-123',
+            is_private: false,
+          },
+        },
+      };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const result = await Slack.actions.createConversation.handler(mockContext, {
+        name: 'incident-123',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        'https://slack.com/api/conversations.create',
+        {
+          name: 'incident-123',
+          is_private: false,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+        }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should create a private channel', async () => {
+      const mockResponse = {
+        data: {
+          ok: true,
+          channel: {
+            id: 'G456DEF',
+            name: 'incident-456',
+            is_private: true,
+          },
+        },
+      };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      await Slack.actions.createConversation.handler(mockContext, {
+        name: 'incident-456',
+        isPrivate: true,
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        'https://slack.com/api/conversations.create',
+        {
+          name: 'incident-456',
+          is_private: true,
+        },
+        expect.any(Object)
+      );
+    });
+
+    it('should throw error when Slack API returns error', async () => {
+      const mockResponse = {
+        data: {
+          ok: false,
+          error: 'name_taken',
+        },
+      };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      await expect(
+        Slack.actions.createConversation.handler(mockContext, {
+          name: 'existing-channel',
+        })
+      ).rejects.toThrow('Slack createConversation error: name_taken');
+    });
+  });
+
+  describe('inviteToConversation action', () => {
+    it('should invite users to a channel', async () => {
+      const mockResponse = {
+        data: {
+          ok: true,
+          channel: {
+            id: 'C123ABC',
+            name: 'incident-123',
+          },
+        },
+      };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const result = await Slack.actions.inviteToConversation.handler(mockContext, {
+        channel: 'C123ABC',
+        users: 'U01PWE77HD2,U02ABC1234',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        'https://slack.com/api/conversations.invite',
+        {
+          channel: 'C123ABC',
+          users: 'U01PWE77HD2,U02ABC1234',
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+        }
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should throw error when Slack API returns error', async () => {
+      const mockResponse = {
+        data: {
+          ok: false,
+          error: 'channel_not_found',
+        },
+      };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      await expect(
+        Slack.actions.inviteToConversation.handler(mockContext, {
+          channel: 'INVALID',
+          users: 'U01PWE77HD2',
+        })
+      ).rejects.toThrow('Slack inviteToConversation error: channel_not_found');
+    });
+  });
+
   describe('sendMessage action', () => {
     it('should send message with required parameters', async () => {
       const mockResponse = {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/slack/slack.ts
@@ -279,6 +279,60 @@ const SlackResolveChannelIdInputSchema = z.object({
 });
 type SlackResolveChannelIdInput = z.infer<typeof SlackResolveChannelIdInputSchema>;
 
+const SlackCreateConversationInputSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.createConversation.input.name.description',
+        {
+          defaultMessage:
+            'Name of the channel to create. Channel names can only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or fewer.',
+        }
+      )
+    ),
+  isPrivate: z
+    .boolean()
+    .optional()
+    .describe(
+      i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.createConversation.input.isPrivate.description',
+        {
+          defaultMessage: 'Whether to create a private channel. Defaults to false (public).',
+        }
+      )
+    ),
+});
+type SlackCreateConversationInput = z.infer<typeof SlackCreateConversationInputSchema>;
+
+const SlackInviteToConversationInputSchema = z.object({
+  channel: z
+    .string()
+    .min(1)
+    .describe(
+      i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.inviteToConversation.input.channel.description',
+        {
+          defaultMessage: 'The ID of the channel to invite users to (e.g. C... or G...).',
+        }
+      )
+    ),
+  users: z
+    .string()
+    .min(1)
+    .describe(
+      i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.inviteToConversation.input.users.description',
+        {
+          defaultMessage:
+            'Comma-separated list of user IDs to invite to the channel (e.g. U01PWE77HD2,U02ABC1234).',
+        }
+      )
+    ),
+});
+type SlackInviteToConversationInput = z.infer<typeof SlackInviteToConversationInputSchema>;
+
 const SlackSendMessageInputSchema = z.object({
   channel: z
     .string()
@@ -458,6 +512,7 @@ async function slackRequestWithRateLimitRetry<TData>(params: {
  * - channels:read - to list channels/conversations (public/private/DMs depending on workspace + membership)
  * - chat:write - for sending messages to public channels
  * - search:read.public (and related granular scopes) - for searching messages (requires a user token)
+ * - groups:write - to create private channels and invite users
  *
  * Optional (possible future usage):
  * - groups:read - to list private channels (future)
@@ -713,6 +768,118 @@ export const Slack: ConnectorSpec = {
           pagesFetched,
           nextCursor: cursor,
         };
+      },
+    },
+
+    // https://api.slack.com/methods/conversations.create
+    createConversation: {
+      isTool: false,
+      description: i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.createConversation.description',
+        {
+          defaultMessage: 'Create a new Slack channel (public or private)',
+        }
+      ),
+      input: SlackCreateConversationInputSchema,
+      handler: async (ctx, input) => {
+        const typedInput: SlackCreateConversationInput =
+          SlackCreateConversationInputSchema.parse(input);
+
+        const payload: Record<string, unknown> = {
+          name: typedInput.name,
+          is_private: typedInput.isPrivate ?? false,
+        };
+
+        try {
+          ctx.log.debug(`Slack createConversation request: name=${typedInput.name}`);
+          const response = await slackRequestWithRateLimitRetry({
+            ctx,
+            action: 'createConversation',
+            maxRetries: SLACK_MAX_RETRIES,
+            request: () =>
+              ctx.client.post(`${SLACK_API_BASE}/conversations.create`, payload, {
+                headers: {
+                  'Content-Type': 'application/json; charset=utf-8',
+                },
+              }),
+          });
+
+          if (!response.data.ok) {
+            throw new Error(
+              formatSlackApiErrorMessage({
+                action: 'createConversation',
+                responseData: response.data,
+                responseHeaders: response.headers,
+              })
+            );
+          }
+
+          return response.data;
+        } catch (error) {
+          const err = error as AxiosError<unknown>;
+          ctx.log.error(
+            `Slack createConversation failed: ${err.message}, Status: ${
+              err.response?.status
+            }, Data: ${JSON.stringify(err.response?.data)}`
+          );
+          throw error;
+        }
+      },
+    },
+
+    // https://api.slack.com/methods/conversations.invite
+    inviteToConversation: {
+      isTool: false,
+      description: i18n.translate(
+        'core.kibanaConnectorSpecs.slack.actions.inviteToConversation.description',
+        {
+          defaultMessage: 'Invite users to a Slack channel',
+        }
+      ),
+      input: SlackInviteToConversationInputSchema,
+      handler: async (ctx, input) => {
+        const typedInput: SlackInviteToConversationInput =
+          SlackInviteToConversationInputSchema.parse(input);
+
+        const payload: Record<string, unknown> = {
+          channel: typedInput.channel,
+          users: typedInput.users,
+        };
+
+        try {
+          ctx.log.debug(`Slack inviteToConversation request: channel=${typedInput.channel}`);
+          const response = await slackRequestWithRateLimitRetry({
+            ctx,
+            action: 'inviteToConversation',
+            maxRetries: SLACK_MAX_RETRIES,
+            request: () =>
+              ctx.client.post(`${SLACK_API_BASE}/conversations.invite`, payload, {
+                headers: {
+                  'Content-Type': 'application/json; charset=utf-8',
+                },
+              }),
+          });
+
+          if (!response.data.ok) {
+            throw new Error(
+              formatSlackApiErrorMessage({
+                action: 'inviteToConversation',
+                responseData: response.data,
+                responseHeaders: response.headers,
+              })
+            );
+          }
+
+          return response.data;
+        } catch (error) {
+          const err = error as AxiosError<unknown>;
+          ctx.log.error(
+            `Slack inviteToConversation failed: ${err.message}, Status: ${
+              err.response?.status
+            }, Data: ${JSON.stringify(err.response?.data)}`
+          );
+          throw error;
+        }
       },
     },
 


### PR DESCRIPTION
## Summary

Adds two new actions to the Slack v2 (.slack2) connector:

  - createConversation — Create a Slack channel (public or private). Wraps conversations.create.
  - inviteToConversation — Invite users to a Slack channel. Wraps conversations.invite.

 Both actions are workflow-only (`isTool: false`), not exposed as agent tools as the proper guardrails aren't in place yet

Use case: Automated incident workflows that need to create a private Slack channel per incident, invite responders, and post investigation results.

Additional scope: `groups:write`.