### PR TITLE
[9.2] [EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents (#240082)

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/api/action_results/get_action_results_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/api/action_results/get_action_results_route.ts
@@ -16,12 +16,8 @@ export const getActionResultsRequestQuerySchema = t.type({
   sort: t.union([t.string, t.undefined]),
   sortOrder: t.union([t.literal(Direction.asc), t.literal(Direction.desc), t.undefined]),
   kuery: t.union([t.string, t.undefined]),
-  /**
-   * Optional comma-separated list of agent IDs to filter results.
-   * For external API consumers only. Limited to 100 agents max.
-   * Internal UI does not use this parameter - server fetches agents from action document.
-   */
   agentIds: t.union([t.string, t.undefined]),
+  totalAgents: t.union([toNumberRt, t.undefined]),
 });
 
 export type GetActionResultsRequestQuerySchema = t.OutputOf<

--- a/x-pack/platform/plugins/shared/osquery/common/search_strategy/osquery/actions/index.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/search_strategy/osquery/actions/index.ts
@@ -86,6 +86,7 @@ export interface ActionResultsStrategyResponse
 
 export interface ActionResultsRequestOptions extends RequestOptionsPaginated {
   actionId: string;
+  agentIds?: string[];
   startDate?: string;
   useNewDataStream?: boolean;
   integrationNamespaces?: string[];

--- a/x-pack/platform/plugins/shared/osquery/common/translations/errors.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/translations/errors.ts
@@ -21,11 +21,3 @@ export const PARAMETER_NOT_FOUND = i18n.translate(
       "This query hasn't been called due to parameter used and its value not found in the alert.",
   }
 );
-
-export const TOO_MANY_AGENT_IDS = i18n.translate(
-  'xpack.osquery.actionResults.error.tooManyAgentIds',
-  {
-    defaultMessage:
-      'Too many agent IDs in URL (max 100). Either reduce the list or omit agentIds to query all agents from the action.',
-  }
-);

--- a/x-pack/platform/plugins/shared/osquery/common/utils/agent_fields.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/utils/agent_fields.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+
+/**
+ * Extracts agent ID from Elasticsearch search hit fields.
+ * Handles both ECS formatted ['agent.id'] and legacy (agent_id) field formats.
+ *
+ * @param fields - The fields object from an Elasticsearch SearchHit
+ * @returns The agent ID string if found, undefined otherwise
+ *
+ * @example
+ * ```typescript
+ * const agentId = getAgentIdFromFields(searchHit.fields);
+ * ```
+ */
+export const getAgentIdFromFields = (fields?: estypes.SearchHit['fields']): string | undefined => {
+  if (!fields) return undefined;
+
+  // Check ECS format first (preferred), then fall back to legacy format
+  return (fields['agent.id']?.[0] as string) ?? (fields.agent_id?.[0] as string);
+};

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.test.tsx
@@ -1,0 +1,1019 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
+import type { EuiThemeComputed } from '@elastic/eui';
+import { EuiProvider } from '@elastic/eui';
+import { ThemeProvider } from '@emotion/react';
+
+import { ActionResultsSummary } from './action_results_summary';
+import * as useActionResultsHook from './use_action_results';
+import { useKibana } from '../common/lib/kibana';
+import type { estypes } from '@elastic/elasticsearch';
+
+jest.mock('./use_action_results');
+jest.mock('../common/lib/kibana');
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+const useActionResultsMock = useActionResultsHook.useActionResults as jest.MockedFunction<
+  typeof useActionResultsHook.useActionResults
+>;
+
+// Create a new QueryClient for each test to avoid cache pollution
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        cacheTime: 0,
+      },
+    },
+  });
+
+const mockHttpPost = jest.fn();
+const mockApplication = {
+  getUrlForApp: jest.fn().mockReturnValue('/app/fleet/agents/agent-1'),
+};
+const mockNotifications = {
+  toasts: {
+    addSuccess: jest.fn(),
+    addError: jest.fn(),
+    addWarning: jest.fn(),
+    addDanger: jest.fn(),
+  },
+};
+
+const mockKibanaServices = () => {
+  useKibanaMock.mockReturnValue({
+    services: {
+      http: {
+        post: mockHttpPost,
+      },
+      application: mockApplication,
+      notifications: mockNotifications,
+    },
+  } as unknown as ReturnType<typeof useKibana>);
+};
+
+const renderWithContext = (Element: React.ReactElement, queryClient = createTestQueryClient()) =>
+  render(
+    <EuiProvider>
+      <ThemeProvider
+        theme={{
+          euiTheme: {
+            colors: { success: '#00BFB3' },
+            border: { width: { thin: '1px', thick: '2px' } },
+          } as unknown as EuiThemeComputed<{}>,
+        }}
+      >
+        <IntlProvider locale="en">
+          <QueryClientProvider client={queryClient}>{Element}</QueryClientProvider>
+        </IntlProvider>
+      </ThemeProvider>
+    </EuiProvider>
+  );
+
+const createMockEdge = (agentId: string, hasResponse = false): estypes.SearchHit => ({
+  _id: hasResponse ? `result-${agentId}` : `placeholder-${agentId}`,
+  _index: '.logs-osquery_manager.action.responses-default',
+  _source: hasResponse
+    ? {
+        action_response: {
+          osquery: {
+            count: 10,
+          },
+        },
+      }
+    : {},
+  fields: {
+    agent_id: [agentId],
+    'agent.id': [agentId],
+    ...(hasResponse ? { completed_at: ['2025-01-20T00:00:00.000Z'] } : {}),
+  },
+});
+
+describe('ActionResultsSummary - Server-side Pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKibanaServices();
+  });
+
+  describe('Basic rendering and pagination state', () => {
+    it('should render EuiBasicTable with pagination controls', () => {
+      const mockAgents = ['agent-1', 'agent-2', 'agent-3'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents: 3,
+          aggregations: {
+            totalRowCount: 30,
+            totalResponded: 3,
+            successful: 3,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Verify EuiBasicTable is rendered
+      expect(container.querySelector('.euiBasicTable')).toBeInTheDocument();
+
+      // Verify pagination controls exist
+      expect(container.querySelector('.euiPagination')).toBeInTheDocument();
+    });
+
+    it('should use server totalAgents for pagination count', () => {
+      const mockAgents = ['agent-1', 'agent-2'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents: 502,
+          aggregations: {
+            totalRowCount: 30,
+            totalResponded: 2,
+            successful: 2,
+            failed: 0,
+            pending: 500,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Verify pagination uses server totalAgents (502) not agentIds.length (2)
+      expect(container.querySelector('.euiPagination')).toBeInTheDocument();
+    });
+
+    it('should fallback to agentIds.length when totalAgents is undefined', () => {
+      const mockAgents = ['agent-1', 'agent-2', 'agent-3'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 30,
+            totalResponded: 3,
+            successful: 3,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Verify pagination fallback works
+      expect(container.querySelector('.euiPagination')).toBeInTheDocument();
+    });
+
+    it('should initialize with default page index 0 and page size 20', () => {
+      const mockAgents = Array.from({ length: 100 }, (_, i) => `agent-${i}`);
+      const mockEdges = mockAgents.slice(0, 20).map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents: 100,
+          aggregations: {
+            totalRowCount: 200,
+            totalResponded: 20,
+            successful: 20,
+            failed: 0,
+            pending: 80,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Verify useActionResults was called with default pagination
+      expect(useActionResultsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activePage: 0,
+          limit: 20,
+        })
+      );
+    });
+
+    it('should handle page changes via onTableChange callback', async () => {
+      const mockAgents = Array.from({ length: 100 }, (_, i) => `agent-${i}`);
+
+      // Initial render - page 0
+      const mockEdgesPage0 = mockAgents.slice(0, 20).map((id) => createMockEdge(id, true));
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdgesPage0,
+          totalAgents: 100,
+          aggregations: {
+            totalRowCount: 1000,
+            totalResponded: 20,
+            successful: 20,
+            failed: 0,
+            pending: 80,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      const { rerender } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Simulate page change to page 2
+      const mockEdgesPage2 = mockAgents.slice(40, 60).map((id) => createMockEdge(id, true));
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdgesPage2,
+          totalAgents: 100,
+          aggregations: {
+            totalRowCount: 1000,
+            totalResponded: 20,
+            successful: 20,
+            failed: 0,
+            pending: 80,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      // Re-render with updated page
+      rerender(
+        <EuiProvider>
+          <ThemeProvider
+            theme={{
+              euiTheme: {
+                colors: { success: '#00BFB3' },
+                border: { width: { thin: '1px', thick: '2px' } },
+              } as unknown as EuiThemeComputed<{}>,
+            }}
+          >
+            <IntlProvider locale="en">
+              <QueryClientProvider client={createTestQueryClient()}>
+                <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+              </QueryClientProvider>
+            </IntlProvider>
+          </ThemeProvider>
+        </EuiProvider>
+      );
+
+      // Pagination state should update
+      await waitFor(() => {
+        expect(useActionResultsMock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            activePage: expect.any(Number),
+          })
+        );
+      });
+    });
+
+    it('should support different page sizes (10, 20, 50, 100)', () => {
+      const mockAgents = Array.from({ length: 500 }, (_, i) => `agent-${i}`);
+      const pageSizes = [10, 20, 50, 100];
+
+      pageSizes.forEach((pageSize) => {
+        jest.clearAllMocks(); // Clear mocks between iterations
+        const mockEdges = mockAgents.slice(0, pageSize).map((id) => createMockEdge(id, true));
+
+        useActionResultsMock.mockReturnValue({
+          data: {
+            edges: mockEdges,
+            totalAgents: 500,
+            aggregations: {
+              totalRowCount: pageSize * 10,
+              totalResponded: pageSize,
+              successful: pageSize,
+              failed: 0,
+              pending: mockAgents.length - pageSize,
+            },
+            inspect: { dsl: [] },
+          },
+          isLoading: false,
+          isFetching: false,
+        } as never);
+
+        mockHttpPost.mockResolvedValue({ agents: [] });
+
+        const { container } = renderWithContext(
+          <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+        );
+
+        // Verify table renders with the correct number of rows
+        const tableRows = container.querySelectorAll('.euiTableRow');
+        expect(tableRows.length).toBe(pageSize);
+
+        // Verify pagination controls exist
+        expect(container.querySelector('.euiPagination')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Bulk agent details fetching', () => {
+    it('should fetch agent details for current page agents only', async () => {
+      const mockAgents = Array.from({ length: 100 }, (_, i) => `agent-${i}`);
+      const currentPageAgents = mockAgents.slice(0, 20); // First page
+      const mockEdges = currentPageAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents: 100,
+          aggregations: {
+            totalRowCount: 1000,
+            totalResponded: 20,
+            successful: 20,
+            failed: 0,
+            pending: 80,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      const mockAgentsData = currentPageAgents.map((id) => ({
+        id,
+        local_metadata: { host: { name: `host-${id}` } },
+      }));
+
+      mockHttpPost.mockResolvedValue({ agents: mockAgentsData });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Wait for bulk fetch to be called
+      await waitFor(() => {
+        expect(mockHttpPost).toHaveBeenCalledWith(
+          '/internal/osquery/fleet_wrapper/agents/_bulk',
+          expect.objectContaining({
+            version: '1',
+            body: JSON.stringify({
+              agentIds: currentPageAgents,
+            }),
+          })
+        );
+      });
+
+      // Verify it was called only once for the current page
+      expect(mockHttpPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fetch agent details when no agents on current page', async () => {
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: [],
+          totalAgents: 0,
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={[]} />);
+
+      // Wait to ensure no fetch happens
+      await waitFor(() => {
+        expect(mockHttpPost).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should handle bulk fetch errors gracefully', async () => {
+      const mockAgents = ['agent-1', 'agent-2'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 20,
+            totalResponded: 2,
+            successful: 2,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      // Mock error response
+      mockHttpPost.mockRejectedValue(new Error('Fleet service unavailable'));
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Component should still render despite error
+      await waitFor(() => {
+        expect(container.querySelector('.euiBasicTable')).toBeInTheDocument();
+      });
+
+      // Verify error was handled (no crash)
+      expect(mockHttpPost).toHaveBeenCalled();
+    });
+
+    it('should cache bulk agent details for 1 minute', async () => {
+      const mockAgents = ['agent-1', 'agent-2'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 20,
+            totalResponded: 2,
+            successful: 2,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      const mockAgentsData = mockAgents.map((id) => ({
+        id,
+        local_metadata: { host: { name: `host-${id}` } },
+      }));
+
+      mockHttpPost.mockResolvedValue({ agents: mockAgentsData });
+
+      const queryClient = createTestQueryClient();
+
+      const { rerender } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />,
+        queryClient
+      );
+
+      // Wait for initial fetch
+      await waitFor(() => {
+        expect(mockHttpPost).toHaveBeenCalledTimes(1);
+      });
+
+      // Re-render with same agents (should use cache)
+      rerender(
+        <EuiProvider>
+          <ThemeProvider
+            theme={{
+              euiTheme: {
+                colors: { success: '#00BFB3' },
+                border: { width: { thin: '1px', thick: '2px' } },
+              } as unknown as EuiThemeComputed<{}>,
+            }}
+          >
+            <IntlProvider locale="en">
+              <QueryClientProvider client={queryClient}>
+                <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+              </QueryClientProvider>
+            </IntlProvider>
+          </ThemeProvider>
+        </EuiProvider>
+      );
+
+      // Should not fetch again (cache hit)
+      expect(mockHttpPost).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Agent name rendering with tooltips', () => {
+    it('should render agent hostname from bulk fetch', async () => {
+      const mockAgents = ['agent-1'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 10,
+            totalResponded: 1,
+            successful: 1,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: [
+          {
+            id: 'agent-1',
+            local_metadata: { host: { name: 'production-server-01' } },
+          },
+        ],
+      });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Wait for agent name to be rendered
+      await waitFor(() => {
+        expect(screen.getByText('production-server-01')).toBeInTheDocument();
+      });
+    });
+
+    it('should render agent ID as fallback when hostname not available', async () => {
+      const mockAgents = ['agent-without-hostname'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 10,
+            totalResponded: 1,
+            successful: 1,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: [
+          {
+            id: 'agent-without-hostname',
+            // No local_metadata
+          },
+        ],
+      });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Wait for fallback to agent ID
+      await waitFor(() => {
+        expect(screen.getByText('agent-without-hostname')).toBeInTheDocument();
+      });
+    });
+
+    it('should render tooltip with agent ID on hover', async () => {
+      const mockAgents = ['agent-1'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 10,
+            totalResponded: 1,
+            successful: 1,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: [
+          {
+            id: 'agent-1',
+            local_metadata: { host: { name: 'hostname-1' } },
+          },
+        ],
+      });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Wait for render
+      await waitFor(() => {
+        expect(screen.getByText('hostname-1')).toBeInTheDocument();
+      });
+
+      // Verify tooltip wrapper exists
+      expect(container.querySelector('.euiToolTipAnchor')).toBeInTheDocument();
+    });
+
+    it('should render clickable link to Fleet agent details page', async () => {
+      const mockAgents = ['agent-1'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 10,
+            totalResponded: 1,
+            successful: 1,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: [
+          {
+            id: 'agent-1',
+            local_metadata: { host: { name: 'hostname-1' } },
+          },
+        ],
+      });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Wait for link to be rendered
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: /hostname-1/i });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', expect.stringContaining('/app/fleet'));
+      });
+    });
+  });
+
+  describe('Large scale scenarios (10k+ agents)', () => {
+    it('should handle 10k agents with efficient pagination', async () => {
+      const totalAgents = 10000;
+      const mockAgents = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
+      const currentPageAgents = mockAgents.slice(0, 100); // First page
+      const mockEdges = currentPageAgents.map((id) => createMockEdge(id, false)); // Pending
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents,
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
+            failed: 0,
+            pending: totalAgents,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: currentPageAgents.map((id) => ({
+          id,
+          local_metadata: { host: { name: `host-${id}` } },
+        })),
+      });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Verify only current page data is loaded
+      await waitFor(() => {
+        expect(mockHttpPost).toHaveBeenCalledWith(
+          '/internal/osquery/fleet_wrapper/agents/_bulk',
+          expect.objectContaining({
+            body: JSON.stringify({
+              agentIds: currentPageAgents, // Only 100, not 10k
+            }),
+          })
+        );
+      });
+
+      // Verify table renders efficiently
+      expect(container.querySelector('.euiBasicTable')).toBeInTheDocument();
+    });
+
+    it('should efficiently navigate across 100+ pages', async () => {
+      const totalAgents = 15000;
+      const mockAgents = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
+
+      // Simulate navigating to page 75 (agents 7500-7599)
+      const pageIndex = 75;
+      const pageSize = 100;
+      const startIndex = pageIndex * pageSize;
+      const currentPageAgents = mockAgents.slice(startIndex, startIndex + pageSize);
+      const mockEdges = currentPageAgents.map((id) => createMockEdge(id, true));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents: 15000,
+          aggregations: {
+            totalRowCount: 10000,
+            totalResponded: 7500,
+            successful: 7500,
+            failed: 0,
+            pending: 7500,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: currentPageAgents.map((id) => ({
+          id,
+          local_metadata: { host: { name: `host-${id}` } },
+        })),
+      });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={mockAgents} />);
+
+      // Verify only current page agents fetched (exactly 100 agents from 7500-7599)
+      await waitFor(() => {
+        expect(mockHttpPost).toHaveBeenCalledWith(
+          '/internal/osquery/fleet_wrapper/agents/_bulk',
+          expect.objectContaining({
+            version: '1',
+            body: JSON.stringify({
+              agentIds: currentPageAgents,
+            }),
+          })
+        );
+      });
+
+      // Verify it was called only once for the current page
+      expect(mockHttpPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('should maintain low memory footprint with large agent sets', async () => {
+      const totalAgents = 20000;
+      const mockAgents = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
+      const currentPageAgents = mockAgents.slice(0, 100);
+      const mockEdges = currentPageAgents.map((id) => createMockEdge(id, false));
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          totalAgents,
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
+            failed: 0,
+            pending: totalAgents,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: currentPageAgents.map((id) => ({
+          id,
+          local_metadata: { host: { name: `host-${id}` } },
+        })),
+      });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('.euiBasicTable')).toBeInTheDocument();
+      });
+
+      // Verify memory-efficient rendering (only 100 rows, not 20k)
+      const tableRows = container.querySelectorAll('.euiTableRow');
+      expect(tableRows.length).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('Loading states', () => {
+    it('should show loading indicator when isLive is true', () => {
+      const mockAgents = ['agent-1'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, false)); // Pending
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
+            failed: 0,
+            pending: 1,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Verify loading state
+      expect(container.querySelector('.euiBasicTable-loading')).toBeInTheDocument();
+    });
+
+    it('should stop loading when all agents have responded', async () => {
+      const mockAgents = ['agent-1', 'agent-2'];
+      const mockEdges = mockAgents.map((id) => createMockEdge(id, true)); // All responded
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: mockEdges,
+          aggregations: {
+            totalRowCount: 20,
+            totalResponded: 2,
+            successful: 2,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({
+        agents: mockAgents.map((id) => ({
+          id,
+          local_metadata: { host: { name: `host-${id}` } },
+        })),
+      });
+
+      const { container } = renderWithContext(
+        <ActionResultsSummary actionId="test-action" agentIds={mockAgents} />
+      );
+
+      // Wait for loading to finish
+      await waitFor(() => {
+        expect(container.querySelector('.euiBasicTable-loading')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Status column rendering', () => {
+    it('should display "success" for completed agents without errors', async () => {
+      const mockEdge: estypes.SearchHit = {
+        _id: 'result-1',
+        _index: '.logs-osquery_manager.action.responses',
+        _source: {},
+        fields: {
+          agent_id: ['agent-1'],
+          'agent.id': ['agent-1'],
+          completed_at: ['2025-01-20T00:00:00.000Z'],
+        },
+      };
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: [mockEdge],
+          aggregations: {
+            totalRowCount: 10,
+            totalResponded: 1,
+            successful: 1,
+            failed: 0,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={['agent-1']} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('success')).toBeInTheDocument();
+      });
+    });
+
+    it('should display "pending" for agents without completed_at', async () => {
+      const mockEdge: estypes.SearchHit = {
+        _id: 'placeholder-1',
+        _index: '.logs-osquery_manager.action.responses',
+        _source: {},
+        fields: {
+          agent_id: ['agent-1'],
+          'agent.id': ['agent-1'],
+        },
+      };
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: [mockEdge],
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
+            failed: 0,
+            pending: 1,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={['agent-1']} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('pending')).toBeInTheDocument();
+      });
+    });
+
+    it('should display "error" for agents with error.keyword field', async () => {
+      const mockEdge: estypes.SearchHit = {
+        _id: 'result-1',
+        _index: '.logs-osquery_manager.action.responses',
+        _source: {},
+        fields: {
+          agent_id: ['agent-1'],
+          'agent.id': ['agent-1'],
+          completed_at: ['2025-01-20T00:00:00.000Z'],
+          'error.keyword': ['Query execution failed'],
+          error: ['Query execution failed'],
+        },
+      };
+
+      useActionResultsMock.mockReturnValue({
+        data: {
+          edges: [mockEdge],
+          aggregations: {
+            totalRowCount: 0,
+            totalResponded: 1,
+            successful: 0,
+            failed: 1,
+            pending: 0,
+          },
+          inspect: { dsl: [] },
+        },
+        isLoading: false,
+        isFetching: false,
+      } as never);
+
+      mockHttpPost.mockResolvedValue({ agents: [] });
+
+      renderWithContext(<ActionResultsSummary actionId="test-action" agentIds={['agent-1']} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('error')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/action_results_summary.tsx
@@ -4,14 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import { i18n } from '@kbn/i18n';
-import { EuiInMemoryTable, EuiCodeBlock } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Criteria } from '@elastic/eui';
+import { EuiBasicTable, EuiCodeBlock, EuiLink, EuiToolTip } from '@elastic/eui';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@kbn/react-query';
+import { PLUGIN_ID } from '@kbn/fleet-plugin/common';
+import { pagePathGetters } from '@kbn/fleet-plugin/public';
+import type { estypes } from '@elastic/elasticsearch';
 
-import { AgentIdToName } from '../agents/agent_id_to_name';
 import { useActionResults } from './use_action_results';
 import { Direction } from '../../common/search_strategy';
+import { useKibana } from '../common/lib/kibana';
+import { API_VERSIONS } from '../../common/constants';
+import { useErrorToast } from '../common/hooks/use_error_toast';
+import { getAgentIdFromFields } from '../../common/utils/agent_fields';
 
 interface ActionResultsSummaryProps {
   actionId: string;
@@ -21,11 +28,63 @@ interface ActionResultsSummaryProps {
   error?: string;
 }
 
+// Use Elasticsearch's native SearchHit type for result edges
+type ResultEdge = estypes.SearchHit<object>;
+
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_INDEX = 0;
+const AGENT_DETAILS_CACHE_TIME_MS = 30000;
+const TABLE_MAX_HEIGHT_PX = 500;
+const ESTIMATED_ROW_HEIGHT_PX = 41; // EUI table row default height
+const BULK_AGENT_DETAILS_ROUTE = '/internal/osquery/fleet_wrapper/agents/_bulk';
+
 const renderErrorMessage = (error: string) => (
   <EuiCodeBlock language="shell" fontSize="s" paddingSize="none" transparentBackground>
     {error}
   </EuiCodeBlock>
 );
+
+// Calculate minimum table body height based on expected rows on current page
+const calculateMinTableBodyHeight = (
+  pageSize: number,
+  pageIndex: number,
+  totalItemCount: number
+): number => {
+  const expectedItemsOnPage = Math.min(
+    pageSize,
+    Math.max(0, totalItemCount - pageIndex * pageSize)
+  );
+
+  const minHeight =
+    expectedItemsOnPage > 0
+      ? Math.min(expectedItemsOnPage * ESTIMATED_ROW_HEIGHT_PX, TABLE_MAX_HEIGHT_PX)
+      : 0;
+
+  return minHeight;
+};
+
+// CSS-in-JS styles for scrollable table with dynamic height
+const createStatusTableCss = (pageSize: number, pageIndex: number, totalItemCount: number) => ({
+  '.euiTable': {
+    display: 'block',
+  },
+  '.euiTable thead': {
+    display: 'table',
+    width: '100%',
+    tableLayout: 'fixed' as const,
+  },
+  '.euiTable tbody': {
+    display: 'block',
+    minHeight: `${calculateMinTableBodyHeight(pageSize, pageIndex, totalItemCount)}px`,
+    maxHeight: `${TABLE_MAX_HEIGHT_PX}px`,
+    overflowY: 'auto' as const,
+  },
+  '.euiTable tbody tr': {
+    display: 'table',
+    width: '100%',
+    tableLayout: 'fixed' as const,
+  },
+});
 
 const ActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> = ({
   actionId,
@@ -34,16 +93,17 @@ const ActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> = ({
   error,
   startDate,
 }) => {
-  const [pageIndex] = useState(0);
-  const [pageSize] = useState(50);
+  const { http, application } = useKibana().services;
+  const setErrorToast = useErrorToast();
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
   const expired = useMemo(
     () => (!expirationDate ? false : new Date(expirationDate) < new Date()),
     [expirationDate]
   );
   const [isLive, setIsLive] = useState(true);
-  const {
-    data: { aggregations, edges },
-  } = useActionResults({
+  const { data } = useActionResults({
     actionId,
     startDate,
     activePage: pageIndex,
@@ -54,40 +114,117 @@ const ActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> = ({
     isLive,
   });
 
-  useEffect(() => {
-    if (error) {
-      edges.forEach((edge) => {
-        if (edge.fields) {
-          edge.fields['error.skipped'] = edge.fields.error = [error];
-        }
+  // Extract agent IDs from current page edges
+  // Note: Supports both ECS formatted ['agent.id'] and legacy format (agent_id)
+  const currentPageAgentIds = useMemo(
+    () => data.edges.map((edge) => getAgentIdFromFields(edge.fields)).filter(Boolean) as string[],
+    [data.edges]
+  );
+
+  // Bulk fetch agent details for current page using POST (avoids URL length limits)
+  const { data: agentsData } = useQuery(
+    ['bulkAgentDetails', currentPageAgentIds],
+    async () => {
+      if (currentPageAgentIds.length === 0) return { agents: [] };
+
+      return http.post<{
+        agents: Array<{ id: string; local_metadata?: { host?: { name?: string } } }>;
+      }>(BULK_AGENT_DETAILS_ROUTE, {
+        version: API_VERSIONS.internal.v1,
+        body: JSON.stringify({
+          agentIds: currentPageAgentIds,
+        }),
       });
-    } else if (expired) {
-      edges.forEach((edge) => {
-        if (!edge.fields?.completed_at && edge.fields) {
-          edge.fields['error.keyword'] = edge.fields.error = [
-            i18n.translate('xpack.osquery.liveQueryActionResults.table.expiredErrorText', {
-              defaultMessage: 'The action request timed out.',
-            }),
-          ];
-        }
-      });
+    },
+    {
+      enabled: currentPageAgentIds.length > 0,
+      staleTime: AGENT_DETAILS_CACHE_TIME_MS,
+      onError: (err) => {
+        setErrorToast(err, {
+          title: i18n.translate('xpack.osquery.bulkAgentDetails.fetchError', {
+            defaultMessage: 'Error fetching agent details',
+          }),
+          toastMessage: i18n.translate('xpack.osquery.bulkAgentDetails.fetchErrorMessage', {
+            defaultMessage:
+              'Failed to load agent names. Please check your network connection and try again.',
+          }),
+        });
+      },
     }
-  }, [edges, error, expired]);
+  );
+
+  // Create agent ID to name map
+  const agentNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    agentsData?.agents?.forEach((agent) => {
+      const hostname = agent.local_metadata?.host?.name || agent.id;
+      map.set(agent.id, hostname);
+    });
+
+    return map;
+  }, [agentsData]);
+
+  // Enrich edges with error states immutably
+  const enrichedEdges = useMemo(
+    () =>
+      data.edges.map((edge) => {
+        // If edge already has error/completed state, return as-is
+        if (edge.fields?.error || edge.fields?.['error.skipped'] || edge.fields?.completed_at) {
+          return edge;
+        }
+
+        // Create new edge with error fields if needed
+        const fields = { ...(edge.fields || {}) };
+
+        if (error) {
+          fields['error.skipped'] = [error];
+          fields.error = [error];
+        } else if (expired && !edge.fields?.completed_at) {
+          const expiredMessage = i18n.translate(
+            'xpack.osquery.liveQueryActionResults.table.expiredErrorText',
+            {
+              defaultMessage: 'The action request timed out.',
+            }
+          );
+          fields['error.keyword'] = [expiredMessage];
+          fields.error = [expiredMessage];
+        }
+
+        return { ...edge, fields };
+      }),
+    [data.edges, error, expired]
+  );
 
   const renderAgentIdColumn = useCallback(
-    (agentId: any) => <AgentIdToName agentId={agentId} />,
-    []
+    (agentId: string) => {
+      const agentName = agentNameMap.get(agentId) || agentId;
+
+      return (
+        <EuiToolTip position="top" content={<p>{agentId}</p>}>
+          <EuiLink
+            className="eui-textTruncate"
+            href={application.getUrlForApp(PLUGIN_ID, {
+              path: pagePathGetters.agent_details({ agentId })[1],
+            })}
+            target="_blank"
+          >
+            {agentName}
+          </EuiLink>
+        </EuiToolTip>
+      );
+    },
+    [agentNameMap, application]
   );
-  const renderRowsColumn = useCallback((rowsCount: any) => rowsCount ?? '-', []);
+  const renderRowsColumn = useCallback((rowsCount: number | undefined) => rowsCount ?? '-', []);
   const renderStatusColumn = useCallback(
-    (_: any, item: any) => {
-      if (item.fields['error.skipped']) {
+    (_: unknown, item: ResultEdge) => {
+      if (item.fields?.['error.skipped']) {
         return i18n.translate('xpack.osquery.liveQueryActionResults.table.skippedStatusText', {
           defaultMessage: 'skipped',
         });
       }
 
-      if (!item.fields.completed_at) {
+      if (!item.fields?.completed_at) {
         return expired
           ? i18n.translate('xpack.osquery.liveQueryActionResults.table.expiredStatusText', {
               defaultMessage: 'expired',
@@ -97,7 +234,7 @@ const ActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> = ({
             });
       }
 
-      if (item.fields['error.keyword']) {
+      if (item.fields?.['error.keyword']) {
         return i18n.translate('xpack.osquery.liveQueryActionResults.table.errorStatusText', {
           defaultMessage: 'error',
         });
@@ -148,25 +285,58 @@ const ActionResultsSummaryComponent: React.FC<ActionResultsSummaryProps> = ({
     [renderAgentIdColumn, renderRowsColumn, renderStatusColumn]
   );
 
+  const onTableChange = useCallback(({ page }: Criteria<ResultEdge>) => {
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  }, []);
+
   const pagination = useMemo(
     () => ({
-      initialPageSize: 20,
+      initialPageSize: DEFAULT_PAGE_SIZE,
+      pageIndex,
+      pageSize,
+      totalItemCount: agentIds?.length ?? 0,
       pageSizeOptions: [10, 20, 50, 100],
+      showPerPageOptions: true,
     }),
-    []
+    [pageIndex, pageSize, agentIds?.length]
   );
 
+  const statusTableCss = useMemo(
+    () => createStatusTableCss(pageSize, pageIndex, agentIds?.length ?? 0),
+    [pageSize, pageIndex, agentIds?.length]
+  );
+
+  // Guard against race conditions when updating isLive
+  const currentAgentCountRef = useRef(agentIds?.length);
+
   useEffect(() => {
-    setIsLive(() => {
-      if (!agentIds?.length || expired || error) return false;
+    // Only update if agentIds length hasn't changed during render (prevents race conditions)
+    if (currentAgentCountRef.current === agentIds?.length) {
+      setIsLive(() => {
+        if (!agentIds?.length || expired || error) return false;
 
-      return aggregations.totalResponded !== agentIds?.length;
-    });
-  }, [agentIds?.length, aggregations.totalResponded, error, expired]);
+        return data.aggregations.totalResponded !== agentIds?.length;
+      });
+    }
 
-  return edges.length ? (
-    <EuiInMemoryTable loading={isLive} items={edges} columns={columns} pagination={pagination} />
-  ) : null;
+    currentAgentCountRef.current = agentIds?.length;
+  }, [agentIds?.length, data.aggregations.totalResponded, error, expired]);
+
+  return (
+    <div css={statusTableCss}>
+      <EuiBasicTable
+        loading={isLive}
+        items={enrichedEdges as ResultEdge[]}
+        columns={columns}
+        pagination={pagination}
+        onChange={onTableChange}
+        tableLayout="auto"
+      />
+    </div>
+  );
 };
 
 export const ActionResultsSummary = React.memo(ActionResultsSummaryComponent);

--- a/x-pack/platform/plugins/shared/osquery/public/action_results/use_action_results.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/action_results/use_action_results.ts
@@ -7,10 +7,12 @@
 
 import { useQuery } from '@kbn/react-query';
 import { i18n } from '@kbn/i18n';
+import { useMemo } from 'react';
 import type { InspectResponse } from '../common/helpers';
 import { useKibana } from '../common/lib/kibana';
 import type { ResultEdges, Direction } from '../../common/search_strategy';
-import { API_VERSIONS } from '../../common/constants';
+import { API_VERSIONS, ACTION_RESPONSES_INDEX } from '../../common/constants';
+import { getAgentIdFromFields } from '../../common/utils/agent_fields';
 
 import { useErrorToast } from '../common/hooks/use_error_toast';
 
@@ -41,6 +43,9 @@ export interface UseActionResults {
 interface ActionResultsResponse {
   edges: ResultEdges;
   total: number;
+  currentPage: number;
+  pageSize: number;
+  totalPages: number;
   aggregations: {
     totalRowCount: number;
     totalResponded: number;
@@ -65,6 +70,13 @@ export const useActionResults = ({
   const { http } = useKibana().services;
   const setErrorToast = useErrorToast();
 
+  const currentPageAgentIds = useMemo(() => {
+    const startIndex = activePage * limit;
+    const endIndex = startIndex + limit;
+
+    return agentIds?.slice(startIndex, endIndex) || [];
+  }, [agentIds, activePage, limit]);
+
   return useQuery<ActionResultsResponse, Error, ActionResultsArgs>(
     ['actionResults', { actionId, activePage, limit, direction, sortField }],
     () =>
@@ -77,18 +89,44 @@ export const useActionResults = ({
           sortOrder: direction,
           ...(kuery && { kuery }),
           ...(startDate && { startDate }),
-          // Note: agentIds NOT included - server fetches from action document
+          ...(currentPageAgentIds.length > 0 && {
+            agentIds: currentPageAgentIds.join(','),
+          }),
+          totalAgents: agentIds?.length ?? 0,
         },
       }),
     {
-      select: (response) => ({
-        edges: response.edges,
-        aggregations: response.aggregations,
-        inspect: response.inspect || { dsl: [], response: [] },
-      }),
+      select: (response) => {
+        // Server already filtered by agentIds - build set of responded agents
+        const respondedAgentIds = new Set(
+          response.edges
+            .map((edge) => getAgentIdFromFields(edge.fields))
+            .filter((id): id is string => id !== undefined)
+        );
+
+        const placeholderEdges = currentPageAgentIds
+          .filter((agentId) => agentId && !respondedAgentIds.has(agentId))
+          .map((agentId) => ({
+            _index: `${ACTION_RESPONSES_INDEX}-default`,
+            _id: `placeholder-${agentId}`,
+            _source: {},
+            fields: { agent_id: [agentId] },
+          }));
+
+        const mergedEdges = [...response.edges, ...placeholderEdges] as ResultEdges;
+
+        return {
+          edges: mergedEdges,
+          aggregations: response.aggregations,
+          inspect: response.inspect || { dsl: [], response: [] },
+        };
+      },
       initialData: {
         edges: [],
         total: 0,
+        currentPage: 0,
+        pageSize: limit,
+        totalPages: 0,
         aggregations: {
           totalRowCount: 0,
           totalResponded: 0,

--- a/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/results/results_table.tsx
@@ -112,9 +112,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
 }) => {
   const [isLive, setIsLive] = useState(true);
 
-  const {
-    data: { aggregations },
-  } = useActionResults({
+  const { data } = useActionResults({
     actionId,
     startDate,
     activePage: 0,
@@ -206,20 +204,20 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
       // eslint-disable-next-line react/display-name
       ({ rowIndex, columnId }) => {
         // eslint-disable-next-line react-hooks/rules-of-hooks
-        const data = useContext(DataContext);
+        const gridData = useContext(DataContext);
 
         // @ts-expect-error update types
-        const value = data[rowIndex % pagination.pageSize]?.fields[columnId];
+        const value = gridData[rowIndex % pagination.pageSize]?.fields[columnId];
 
         if (columnId === 'agent.name') {
           // @ts-expect-error update types
-          const agentIdValue = data[rowIndex % pagination.pageSize]?.fields['agent.id'];
+          const agentIdValue = gridData[rowIndex % pagination.pageSize]?.fields['agent.id'];
 
           return <EuiLink href={getFleetAppUrl(agentIdValue)}>{value}</EuiLink>;
         }
 
         if (ecsMappingColumns.includes(columnId)) {
-          const ecsFieldValue = get(columnId, data[rowIndex % pagination.pageSize]?._source);
+          const ecsFieldValue = get(columnId, gridData[rowIndex % pagination.pageSize]?._source);
 
           if (isArray(ecsFieldValue) || isObject(ecsFieldValue)) {
             try {
@@ -307,10 +305,10 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
 
     const newColumns = fields.reduce(
       (acc, fieldName) => {
-        const { data, seen } = acc;
+        const { data: accData, seen } = acc;
         if (fieldName === 'agent.name') {
           if (!seen.has(fieldName)) {
-            data.push({
+            accData.push({
               id: fieldName,
               displayAsText: i18n.translate(
                 'xpack.osquery.liveQueryResults.table.agentColumnTitle',
@@ -328,7 +326,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
 
         if (ecsMappingColumns.includes(fieldName)) {
           if (!seen.has(fieldName)) {
-            data.push({
+            accData.push({
               id: fieldName,
               displayAsText: fieldName,
               defaultSortDirection: Direction.asc,
@@ -344,7 +342,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
           const hasNumberType = fields.includes(`${fieldName}.number`);
           if (!seen.has(displayAsText)) {
             const id = hasNumberType ? fieldName + '.number' : fieldName;
-            data.push({
+            accData.push({
               id,
               displayAsText,
               display: getHeaderDisplay(displayAsText),
@@ -370,8 +368,8 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
   }, [allResultsData?.columns.length, ecsMappingColumns, getHeaderDisplay]);
 
   const leadingControlColumns: EuiDataGridControlColumn[] = useMemo(() => {
-    const data = allResultsData?.edges;
-    if (timelines && data) {
+    const edges = allResultsData?.edges;
+    if (timelines && edges) {
       return [
         {
           id: 'timeline',
@@ -381,7 +379,7 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
             const { visibleRowIndex } = actionProps as EuiDataGridCellValueElementProps & {
               visibleRowIndex: number;
             };
-            const eventId = data[visibleRowIndex]?._id;
+            const eventId = edges[visibleRowIndex]?._id;
 
             return <AddToTimelineButton field="_id" value={eventId!} isIcon={true} />;
           },
@@ -426,15 +424,14 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
         if (!agentIds?.length || expired || error) return false;
 
         return !!(
-          aggregations.totalResponded !== agentIds?.length ||
-          allResultsData?.total !== aggregations?.totalRowCount ||
+          data.aggregations.totalResponded !== agentIds?.length ||
+          allResultsData?.total !== data.aggregations?.totalRowCount ||
           (allResultsData?.total && !allResultsData?.edges.length)
         );
       }),
     [
       agentIds?.length,
-      aggregations.totalResponded,
-      aggregations?.totalRowCount,
+      data.aggregations,
       allResultsData?.edges.length,
       allResultsData?.total,
       error,
@@ -452,7 +449,10 @@ const ResultsTableComponent: React.FC<ResultsTableComponentProps> = ({
 
       {!allResultsData?.edges.length ? (
         <EuiPanel hasShadow={false} data-test-subj={'osqueryResultsPanel'}>
-          <EuiCallOut title={generateEmptyDataMessage(aggregations.totalResponded)} />
+          <EuiCallOut
+            announceOnMount
+            title={generateEmptyDataMessage(data?.aggregations.totalResponded ?? 0)}
+          />
         </EuiPanel>
       ) : (
         <DataContext.Provider value={allResultsData?.edges}>

--- a/x-pack/platform/plugins/shared/osquery/server/routes/action_results/get_action_results_route.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/action_results/get_action_results_route.test.ts
@@ -13,10 +13,8 @@ import { getActionResultsRoute } from './get_action_results_route';
 import {
   Direction,
   OsqueryQueries,
-  type ActionDetailsStrategyResponse,
   type ActionResultsStrategyResponse,
 } from '../../../common/search_strategy';
-import { TOO_MANY_AGENT_IDS } from '../../../common/translations/errors';
 import type {
   GetActionResultsRequestParamsSchema,
   GetActionResultsRequestQuerySchema,
@@ -27,7 +25,6 @@ import {
   createMockContext,
   createMockRequest,
   createMockSearchStrategy,
-  createMockActionDetailsResponse,
   createMockActionResultsResponse,
 } from './mocks';
 
@@ -65,13 +62,54 @@ describe('getActionResultsRoute', () => {
     jest.clearAllMocks();
   });
 
-  describe('Internal API - fetch agents from action document', () => {
-    it('should fetch agents from action document when no agentIds parameter provided', async () => {
+  describe('Route handler behavior', () => {
+    it('should accept agentIds in query parameter', async () => {
       const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1', 'agent-2', 'agent-3']),
         createMockActionResultsResponse(3, {
           totalResponded: 3,
           successCount: 3,
+          errorCount: 0,
+        })
+      );
+
+      const mockContext = createMockContext(mockSearchFn);
+      const mockRequest = createMockRequest({
+        actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-1,agent-2,agent-3',
+        },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(mockContext, mockRequest, mockResponse);
+
+      // Verify NO action details call
+      expect(mockSearchFn).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          factoryQueryType: OsqueryQueries.actionDetails,
+        }),
+        expect.anything()
+      );
+
+      // Verify action results called with provided agents
+      expect(mockSearchFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: 'test-action-id',
+          factoryQueryType: OsqueryQueries.actionResults,
+          agentIds: ['agent-1', 'agent-2', 'agent-3'],
+        }),
+        expectedSearchOptions
+      );
+
+      expect(mockResponse.ok).toHaveBeenCalled();
+    });
+
+    it('should handle empty agentIds parameter', async () => {
+      const mockSearchFn = createMockSearchStrategy(
+        createMockActionResultsResponse(0, {
+          totalResponded: 0,
+          totalRowCount: 0,
+          successCount: 0,
           errorCount: 0,
         })
       );
@@ -84,42 +122,141 @@ describe('getActionResultsRoute', () => {
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Verify action details was fetched
+      // Should call with empty array
       expect(mockSearchFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          actionId: 'test-action-id',
-          factoryQueryType: OsqueryQueries.actionDetails,
+          agentIds: [],
         }),
         expectedSearchOptions
       );
 
-      // Verify action results was called (without agentIds kuery since we use internal logic)
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          actionId: 'test-action-id',
-          factoryQueryType: OsqueryQueries.actionResults,
-          kuery: undefined, // No kuery when no agentIds provided
-        }),
-        expectedSearchOptions
-      );
-
-      // Verify response includes correct aggregations
       expect(mockResponse.ok).toHaveBeenCalledWith({
         body: expect.objectContaining({
+          total: 0,
+          edges: [],
           aggregations: {
-            totalRowCount: 100,
-            totalResponded: 3,
-            successful: 3,
+            totalRowCount: 0,
+            totalResponded: 0,
+            successful: 0,
             failed: 0,
-            pending: 0, // 3 agents - 3 responded = 0 pending
+            pending: 0,
           },
         }),
       });
     });
 
-    it('should calculate aggregations correctly with partial responses', async () => {
+    it('should handle single agent ID in agentIds parameter', async () => {
+      const mockSearchFn = createMockSearchStrategy(createMockActionResultsResponse(1));
+
+      const mockContext = createMockContext(mockSearchFn);
+      const mockRequest = createMockRequest({
+        actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-1',
+        },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(mockContext, mockRequest, mockResponse);
+
+      expect(mockSearchFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentIds: ['agent-1'],
+        }),
+        expectedSearchOptions
+      );
+    });
+
+    it('should trim whitespace from comma-separated agent IDs', async () => {
+      const mockSearchFn = createMockSearchStrategy(createMockActionResultsResponse(3));
+
+      const mockContext = createMockContext(mockSearchFn);
+      const mockRequest = createMockRequest({
+        actionId: 'test-action-id',
+        query: {
+          agentIds: ' agent-1 , agent-2 , agent-3 ',
+        },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(mockContext, mockRequest, mockResponse);
+
+      expect(mockSearchFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentIds: ['agent-1', 'agent-2', 'agent-3'],
+        }),
+        expectedSearchOptions
+      );
+    });
+
+    it('should combine agentIds with user-provided kuery correctly', async () => {
+      const userKuery = 'error.message: *timeout*';
+      const mockSearchFn = createMockSearchStrategy(createMockActionResultsResponse(2));
+
+      const mockContext = createMockContext(mockSearchFn);
+      const mockRequest = createMockRequest({
+        actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-1,agent-2',
+          kuery: userKuery,
+        },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(mockContext, mockRequest, mockResponse);
+
+      const actionResultsCall = mockSearchFn.mock.calls.find(
+        (call) => call[0].factoryQueryType === OsqueryQueries.actionResults
+      );
+
+      expect(actionResultsCall).toBeDefined();
+      expect(actionResultsCall![0]).toMatchObject({
+        agentIds: ['agent-1', 'agent-2'],
+        kuery: userKuery,
+      });
+    });
+
+    it('should return only real ES responses (placeholders generated client-side)', async () => {
+      const mockActionResults = createMockActionResultsResponse(2, {
+        totalResponded: 2,
+        successCount: 2,
+        errorCount: 0,
+      });
+
+      mockActionResults.edges[0].fields = { agent_id: ['agent-0'] };
+      mockActionResults.edges[1].fields = { agent_id: ['agent-1'] };
+
+      const mockSearchFn = createMockSearchStrategy(mockActionResults);
+      const mockContext = createMockContext(mockSearchFn);
+
+      const mockRequest = createMockRequest({
+        actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-0,agent-1,agent-2,agent-3,agent-4',
+        },
+      });
+      const mockResponse = httpServerMock.createResponseFactory();
+
+      await routeHandler(mockContext, mockRequest, mockResponse);
+
+      const responseBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+
+      // Server returns ONLY real ES responses (2 agents responded)
+      expect(responseBody.edges).toHaveLength(2);
+
+      // Verify NO placeholders in server response (client-side responsibility)
+      const placeholderCount = responseBody.edges.filter((edge: any) =>
+        edge._id.startsWith('placeholder-')
+      ).length;
+
+      expect(placeholderCount).toBe(0);
+
+      // Verify aggregations show pending agents (for client to generate placeholders)
+      expect(responseBody.aggregations.pending).toBe(3);
+    });
+
+    it('should calculate aggregations correctly', async () => {
       const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1', 'agent-2', 'agent-3', 'agent-4', 'agent-5']),
         createMockActionResultsResponse(3, {
           totalResponded: 3,
           totalRowCount: 150,
@@ -129,11 +266,12 @@ describe('getActionResultsRoute', () => {
       );
 
       const mockContext = createMockContext(mockSearchFn);
-
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-1,agent-2,agent-3,agent-4,agent-5',
+        },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
@@ -151,272 +289,225 @@ describe('getActionResultsRoute', () => {
       });
     });
 
-    it('should return empty results when action document has no agents', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse([]), // No agents
-        createMockActionResultsResponse(0, {
-          totalResponded: 0,
-          totalRowCount: 0,
-          successCount: 0,
-          errorCount: 0,
-        })
-      );
+    it('should handle pagination parameters correctly', async () => {
+      const mockSearchFn = createMockSearchStrategy(createMockActionResultsResponse(1));
 
       const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          total: 0,
-          edges: [],
-          aggregations: {
-            totalRowCount: 0,
-            totalResponded: 0,
-            successful: 0,
-            failed: 0,
-            pending: 0,
-          },
-        }),
-      });
-    });
-
-    it('should respect kuery filtering without agentIds', async () => {
-      const userKuery = 'agent.name: "test-agent"';
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1']),
-        createMockActionResultsResponse(1)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        query: { kuery: userKuery },
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify kuery was passed to action results search
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          factoryQueryType: OsqueryQueries.actionResults,
-          kuery: userKuery, // User kuery should be preserved
-        }),
-        expectedSearchOptions
-      );
-    });
-  });
-
-  describe('External API - agentIds parameter', () => {
-    it('should accept agentIds parameter and skip action details fetch', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        undefined, // Action details should not be fetched
-        createMockActionResultsResponse(2, {
-          totalResponded: 2,
-          successCount: 2,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
-          agentIds: 'agent-1,agent-2',
+          agentIds: 'agent-1',
+          page: 2,
+          pageSize: 50,
+          sort: 'agent.id',
+          sortOrder: Direction.asc,
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Verify action details was NOT fetched
-      expect(mockSearchFn).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          factoryQueryType: OsqueryQueries.actionDetails,
-        }),
-        expectedSearchOptions
-      );
-
-      // Verify action results was called with agent.id kuery
       expect(mockSearchFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          factoryQueryType: OsqueryQueries.actionResults,
-          kuery: 'agent.id: "agent-1" OR agent.id: "agent-2"',
+          pagination: expect.objectContaining({
+            activePage: 0,
+            querySize: 1,
+          }),
+          sort: {
+            direction: Direction.asc,
+            field: 'agent.id',
+          },
         }),
         expectedSearchOptions
       );
 
-      expect(mockResponse.ok).toHaveBeenCalled();
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          currentPage: 2,
+          pageSize: 50,
+          totalPages: 1,
+        }),
+      });
     });
 
-    it('should handle single agent ID in agentIds parameter', async () => {
-      const mockSearchFn = createMockSearchStrategy(undefined, createMockActionResultsResponse(1));
+    it('should use default pagination values when not provided', async () => {
+      const mockSearchFn = createMockSearchStrategy(createMockActionResultsResponse(1));
 
       const mockContext = createMockContext(mockSearchFn);
-
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
           agentIds: 'agent-1',
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
       expect(mockSearchFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          kuery: 'agent.id: "agent-1"',
+          pagination: expect.objectContaining({
+            activePage: 0,
+            querySize: 1,
+          }),
+          sort: {
+            direction: Direction.desc,
+            field: '@timestamp',
+          },
         }),
         expectedSearchOptions
       );
     });
 
-    it('should handle exactly 100 agent IDs (maximum allowed)', async () => {
-      const agentIds = Array.from({ length: 100 }, (_, i) => `agent-${i}`).join(',');
-      const mockSearchFn = createMockSearchStrategy(
-        undefined,
-        createMockActionResultsResponse(100)
-      );
+    it('should return only real ES responses for current page (placeholders generated client-side)', async () => {
+      const totalAgents = 1000;
+      const allAgentIds = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
 
+      // Page 2, pageSize 20: agents 40-59
+      const page = 2;
+      const pageSize = 20;
+      const startIndex = page * pageSize;
+      const currentPageAgentIds = allAgentIds.slice(startIndex, startIndex + pageSize);
+
+      const respondedAgentIds = ['agent-40', 'agent-42', 'agent-45', 'agent-50', 'agent-55'];
+      const mockActionResults = createMockActionResultsResponse(respondedAgentIds, {
+        totalResponded: 5,
+        totalRowCount: 0,
+        successCount: 5,
+        errorCount: 0,
+      });
+
+      const mockSearchFn = createMockSearchStrategy(mockActionResults);
       const mockContext = createMockContext(mockSearchFn);
 
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
-          agentIds,
+          agentIds: currentPageAgentIds.join(','),
+          page,
+          pageSize,
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Should succeed with 100 agents
-      expect(mockResponse.ok).toHaveBeenCalled();
-      expect(mockResponse.badRequest).not.toHaveBeenCalled();
+      const responseBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+
+      expect(responseBody.edges).toHaveLength(5);
+
+      const placeholderCount = responseBody.edges.filter((edge: any) =>
+        edge._id.startsWith('placeholder-')
+      ).length;
+      expect(placeholderCount).toBe(0);
+
+      const realResponses = responseBody.edges.filter(
+        (edge: any) => !edge._id.startsWith('placeholder-')
+      );
+      expect(realResponses).toHaveLength(5);
+
+      expect(responseBody.aggregations).toEqual({
+        totalRowCount: 0,
+        totalResponded: 5,
+        successful: 5,
+        failed: 0,
+        pending: 15,
+      });
+
+      expect(responseBody.totalPages).toBe(Math.ceil(currentPageAgentIds.length / pageSize));
     });
 
-    it('should trim whitespace from comma-separated agent IDs', async () => {
-      const mockSearchFn = createMockSearchStrategy(undefined, createMockActionResultsResponse(3));
+    it('should handle page 1 with large agent set efficiently (no server-side placeholders)', async () => {
+      const totalAgents = 100;
+      const allAgentIds = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
 
+      const page = 1;
+      const pageSize = 20;
+      const startIndex = page * pageSize; // 20
+      const currentPageAgentIds = allAgentIds.slice(startIndex, startIndex + pageSize); // agent-20 to agent-39
+
+      const respondedAgentIds = currentPageAgentIds.slice(0, 10); // agent-20 to agent-29
+
+      const mockActionResults = createMockActionResultsResponse(respondedAgentIds, {
+        totalResponded: 10,
+        totalRowCount: 0,
+        successCount: 10,
+        errorCount: 0,
+      });
+
+      const mockSearchFn = createMockSearchStrategy(mockActionResults);
       const mockContext = createMockContext(mockSearchFn);
 
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
-          agentIds: ' agent-1 , agent-2 , agent-3 ', // With whitespace
+          agentIds: currentPageAgentIds.join(','),
+          page,
+          pageSize,
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Verify trimmed agent IDs in kuery
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          kuery: 'agent.id: "agent-1" OR agent.id: "agent-2" OR agent.id: "agent-3"',
-        }),
-        expectedSearchOptions
-      );
+      const responseBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+
+      expect(responseBody.edges).toHaveLength(10);
+
+      const placeholderCount = responseBody.edges.filter((edge: any) =>
+        edge._id.startsWith('placeholder-')
+      ).length;
+      expect(placeholderCount).toBe(0);
+
+      expect(responseBody.aggregations.pending).toBe(10);
     });
 
-    it('should combine agentIds with user-provided kuery correctly', async () => {
-      const userKuery = 'error.message: *timeout*';
-      const mockSearchFn = createMockSearchStrategy(undefined, createMockActionResultsResponse(2));
+    it('should handle empty page (all agents responded) without creating placeholders', async () => {
+      const totalAgents = 50;
+      const allAgentIds = Array.from({ length: totalAgents }, (_, i) => `agent-${i}`);
 
+      const page = 0;
+      const pageSize = 20;
+      const currentPageAgentIds = allAgentIds.slice(0, pageSize);
+
+      const mockActionResults = createMockActionResultsResponse(currentPageAgentIds, {
+        totalResponded: 20,
+        totalRowCount: 0,
+        successCount: 20,
+        errorCount: 0,
+      });
+
+      const mockSearchFn = createMockSearchStrategy(mockActionResults);
       const mockContext = createMockContext(mockSearchFn);
 
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
-          agentIds: 'agent-1,agent-2',
-          kuery: userKuery,
+          agentIds: currentPageAgentIds.join(','),
+          page,
+          pageSize,
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Verify combined kuery: (agentIds kuery) AND (user kuery)
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          kuery: '(agent.id: "agent-1" OR agent.id: "agent-2") AND (error.message: *timeout*)',
-        }),
-        expectedSearchOptions
+      const responseBody = (mockResponse.ok as jest.Mock).mock.calls[0][0].body;
+
+      expect(responseBody.edges).toHaveLength(20);
+
+      const placeholders = responseBody.edges.filter((edge: any) =>
+        edge._id.startsWith('placeholder-')
       );
-    });
+      expect(placeholders).toHaveLength(0);
 
-    it('should handle empty string agentIds parameter', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1']), // Should fall back to fetching from action
-        createMockActionResultsResponse(1)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        query: {
-          agentIds: '', // Empty string
-        },
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Empty string should be treated as undefined, so action details should be fetched
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          factoryQueryType: OsqueryQueries.actionDetails,
-        }),
-        expectedSearchOptions
+      expect(responseBody.edges.every((edge: any) => !edge._id.startsWith('placeholder-'))).toBe(
+        true
       );
     });
   });
 
   describe('Error Handling', () => {
-    it('should return 400 error for more than 100 agent IDs', async () => {
-      const agentIds = Array.from({ length: 101 }, (_, i) => `agent-${i}`).join(',');
-      const mockSearchFn = jest.fn();
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        query: {
-          agentIds,
-        },
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify returns 400 with correct error message
-      expect(mockResponse.badRequest).toHaveBeenCalledWith({
-        body: TOO_MANY_AGENT_IDS,
-      });
-
-      // Verify search was never called
-      expect(mockSearchFn).not.toHaveBeenCalled();
-    });
-
     it('should return 500 error when search strategy throws error', async () => {
       const errorMessage = 'Elasticsearch connection failed';
       const mockSearchFn = jest.fn().mockImplementation(() => {
@@ -424,14 +515,12 @@ describe('getActionResultsRoute', () => {
       });
 
       const mockContext = createMockContext(mockSearchFn);
-
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
         query: {
           agentIds: 'agent-1',
         },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
@@ -442,91 +531,25 @@ describe('getActionResultsRoute', () => {
       });
     });
 
-    it('should handle action details returning null gracefully', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        {
-          actionDetails: undefined,
-          rawResponse: {},
-        } as Partial<ActionDetailsStrategyResponse> as ActionDetailsStrategyResponse,
-        createMockActionResultsResponse(0)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'non-existent-action-id',
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Should return successfully with empty results
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          total: 0,
-          edges: [],
-          aggregations: expect.objectContaining({
-            pending: 0,
-          }),
-        }),
-      });
-    });
-
-    it('should handle action details with missing _source', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        {
-          actionDetails: {
-            _id: 'test-action-id',
-            _index: '.logs-osquery_manager.actions',
-            // Missing _source
-          },
-          rawResponse: {},
-        } as Partial<ActionDetailsStrategyResponse> as ActionDetailsStrategyResponse,
-        createMockActionResultsResponse(0)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Should handle gracefully with empty agents array
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          aggregations: expect.objectContaining({
-            pending: 0,
-          }),
-        }),
-      });
-    });
-
     it('should handle missing aggregations in action results response', async () => {
-      const mockSearchFn = createMockSearchStrategy(createMockActionDetailsResponse(['agent-1']), {
+      const mockSearchFn = createMockSearchStrategy({
         edges: [],
         total: 0,
-        rawResponse: {
-          // Missing aggregations
-        },
+        rawResponse: {},
         inspect: { dsl: [] },
       } as unknown as ActionResultsStrategyResponse);
 
       const mockContext = createMockContext(mockSearchFn);
-
       const mockRequest = createMockRequest({
         actionId: 'test-action-id',
+        query: {
+          agentIds: 'agent-1',
+        },
       });
-
       const mockResponse = httpServerMock.createResponseFactory();
 
       await routeHandler(mockContext, mockRequest, mockResponse);
 
-      // Should return with zero values for missing aggregations
       expect(mockResponse.ok).toHaveBeenCalledWith({
         body: expect.objectContaining({
           aggregations: {
@@ -536,359 +559,6 @@ describe('getActionResultsRoute', () => {
             failed: 0,
             pending: 1, // 1 agent - 0 responded = 1 pending
           },
-        }),
-      });
-    });
-
-    it('should handle pagination and sort parameters correctly', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1']),
-        createMockActionResultsResponse(10)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        query: {
-          page: 2,
-          pageSize: 50,
-          sort: 'agent.id',
-          sortOrder: Direction.asc,
-        },
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify pagination and sort parameters were passed to search
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pagination: expect.objectContaining({
-            activePage: 2,
-            querySize: 50,
-          }),
-          sort: {
-            direction: Direction.asc,
-            field: 'agent.id',
-          },
-        }),
-        expectedSearchOptions
-      );
-
-      expect(mockResponse.ok).toHaveBeenCalled();
-    });
-
-    it('should use default pagination values when not provided', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1']),
-        createMockActionResultsResponse(10)
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        // No pagination/sort parameters
-      });
-
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify default values were used
-      expect(mockSearchFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pagination: expect.objectContaining({
-            activePage: 0, // default page
-            querySize: 100, // default pageSize
-          }),
-          sort: {
-            direction: Direction.desc, // default sortOrder
-            field: '@timestamp', // default sort
-          },
-        }),
-        expectedSearchOptions
-      );
-    });
-  });
-
-  describe('ProcessedEdges for Internal UI', () => {
-    it('should create placeholder edges for agents without results', async () => {
-      // 5 agents in action, but only 3 have results (agent-1, agent-2, agent-3)
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1', 'agent-2', 'agent-3', 'agent-4', 'agent-5']),
-        createMockActionResultsResponse(['agent-1', 'agent-2', 'agent-3'], {
-          totalResponded: 3,
-          successCount: 3,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify response contains all 5 agents (3 real + 2 placeholders)
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          edges: expect.arrayContaining([
-            expect.any(Object), // Real results
-            expect.any(Object),
-            expect.any(Object),
-            expect.any(Object), // Placeholder edges
-            expect.any(Object),
-          ]),
-          total: 5, // Total should be 5 (all agents)
-          aggregations: expect.objectContaining({
-            pending: 2, // 5 agents - 3 responded = 2 pending
-          }),
-        }),
-      });
-    });
-
-    it('should not create placeholders when agentIds parameter provided', async () => {
-      // External API usage - agentIds parameter provided
-      const mockSearchFn = createMockSearchStrategy(
-        undefined, // Action details should not be fetched
-        createMockActionResultsResponse(2, {
-          totalResponded: 2,
-          successCount: 2,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-        query: {
-          agentIds: 'agent-1,agent-2',
-        },
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify only actual ES results returned, no placeholders
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          edges: expect.any(Array),
-          total: 2, // Only actual results, no placeholders
-        }),
-      });
-    });
-
-    it('should deduplicate edges keeping real data over placeholders', async () => {
-      // Setup: 3 agents, all have results
-      const mockActionResults = createMockActionResultsResponse(3, {
-        totalResponded: 3,
-        successCount: 3,
-        errorCount: 0,
-      });
-
-      // Add agent_id fields to the edges to simulate real data
-      mockActionResults.edges = [
-        {
-          _id: 'result-1',
-          _index: '.logs-osquery_manager.action.responses',
-          _source: { status: 'success' },
-          fields: { agent_id: ['agent-1'] },
-        },
-        {
-          _id: 'result-2',
-          _index: '.logs-osquery_manager.action.responses',
-          _source: { status: 'success' },
-          fields: { agent_id: ['agent-2'] },
-        },
-        {
-          _id: 'result-3',
-          _index: '.logs-osquery_manager.action.responses',
-          _source: { status: 'success' },
-          fields: { agent_id: ['agent-3'] },
-        },
-      ] as typeof mockActionResults.edges;
-
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1', 'agent-2', 'agent-3']),
-        mockActionResults
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      const responseBody = mockResponse.ok.mock.calls[0]?.[0]?.body as {
-        edges: Array<{ _source?: object; fields?: { agent_id?: string[] } }>;
-      };
-
-      // Verify all 3 edges exist
-      expect(responseBody.edges).toHaveLength(3);
-
-      // Verify edges contain real data (have _source property), not just placeholders
-      expect(responseBody.edges[0]).toHaveProperty('_source');
-      expect(responseBody.edges[1]).toHaveProperty('_source');
-      expect(responseBody.edges[2]).toHaveProperty('_source');
-    });
-
-    it('should handle empty results with all pending agents', async () => {
-      // 10 agents, 0 results - all should be placeholders
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse([
-          'agent-1',
-          'agent-2',
-          'agent-3',
-          'agent-4',
-          'agent-5',
-          'agent-6',
-          'agent-7',
-          'agent-8',
-          'agent-9',
-          'agent-10',
-        ]),
-        createMockActionResultsResponse(0, {
-          totalResponded: 0,
-          totalRowCount: 0,
-          successCount: 0,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify 10 placeholder edges created
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          edges: expect.arrayContaining([
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-            expect.objectContaining({ fields: { agent_id: expect.any(Array) } }),
-          ]),
-          total: 10, // All placeholders
-          aggregations: expect.objectContaining({
-            pending: 10, // All pending
-          }),
-        }),
-      });
-    });
-
-    it('should handle large agent sets efficiently', async () => {
-      // Test with 100 agents to verify performance characteristics
-      const largeAgentSet = Array.from({ length: 100 }, (_, i) => `agent-${i}`);
-
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(largeAgentSet),
-        createMockActionResultsResponse(50, {
-          totalResponded: 50,
-          successCount: 50,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify all 100 agents represented in response
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          total: 100, // 50 real + 50 placeholders
-          aggregations: expect.objectContaining({
-            pending: 50, // 100 agents - 50 responded = 50 pending
-          }),
-        }),
-      });
-    });
-
-    it('should maintain proper edge structure for placeholders', async () => {
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse(['agent-1', 'agent-2']),
-        createMockActionResultsResponse(0, {
-          totalResponded: 0,
-          successCount: 0,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      const responseBody = mockResponse.ok.mock.calls[0]?.[0]?.body as {
-        edges: Array<{ _source?: object; fields: { agent_id: string[] } }>;
-      };
-
-      // Verify placeholder edges have proper fields.agent_id structure
-      expect(responseBody.edges[0]).toMatchObject({
-        fields: { agent_id: expect.arrayContaining([expect.any(String)]) },
-      });
-      expect(responseBody.edges[1]).toMatchObject({
-        fields: { agent_id: expect.arrayContaining([expect.any(String)]) },
-      });
-
-      // Verify agent IDs are preserved
-      const agentIds = responseBody.edges.map(
-        (edge: { fields: { agent_id: string[] } }) => edge.fields.agent_id[0]
-      );
-      expect(agentIds).toEqual(expect.arrayContaining(['agent-1', 'agent-2']));
-    });
-
-    it('should skip processedEdges when agentIds array is empty', async () => {
-      // Action with no agents should not attempt to create placeholders
-      const mockSearchFn = createMockSearchStrategy(
-        createMockActionDetailsResponse([]), // No agents
-        createMockActionResultsResponse(0, {
-          totalResponded: 0,
-          successCount: 0,
-          errorCount: 0,
-        })
-      );
-
-      const mockContext = createMockContext(mockSearchFn);
-      const mockRequest = createMockRequest({
-        actionId: 'test-action-id',
-      });
-      const mockResponse = httpServerMock.createResponseFactory();
-
-      await routeHandler(mockContext, mockRequest, mockResponse);
-
-      // Verify no placeholders created, just empty results
-      expect(mockResponse.ok).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          edges: [],
-          total: 0,
-          aggregations: expect.objectContaining({
-            pending: 0,
-          }),
         }),
       });
     });

--- a/x-pack/platform/plugins/shared/osquery/server/routes/action_results/get_action_results_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/action_results/get_action_results_route.ts
@@ -6,7 +6,6 @@
  */
 
 import { lastValueFrom } from 'rxjs';
-import { reverse, uniqBy, flatten } from 'lodash';
 import type { IRouter } from '@kbn/core/server';
 import type { DataRequestHandlerContext } from '@kbn/data-plugin/server';
 import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
@@ -23,12 +22,9 @@ import { API_VERSIONS } from '../../../common/constants';
 import { PLUGIN_ID, OSQUERY_INTEGRATION_NAME } from '../../../common';
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { Direction, OsqueryQueries } from '../../../common/search_strategy';
-import { TOO_MANY_AGENT_IDS } from '../../../common/translations/errors';
 import type {
   ActionResultsRequestOptions,
   ActionResultsStrategyResponse,
-  ActionDetailsRequestOptions,
-  ActionDetailsStrategyResponse,
 } from '../../../common/search_strategy';
 import { generateTablePaginationOptions } from '../../../common/utils/build_query';
 import { createInternalSavedObjectsClientForSpaceId } from '../../utils/get_internal_saved_object_client';
@@ -89,72 +85,29 @@ export const getActionResultsRoute = (
 
           const search = await context.search;
 
-          // Parse agentIds from query parameter if provided (for external API consumers)
-          const requestedAgentIds = request.query.agentIds
+          // Parse agentIds from query parameter
+          const agentIds = request.query.agentIds
             ? request.query.agentIds.split(',').map((id) => id.trim())
-            : undefined;
+            : [];
 
-          if (requestedAgentIds && requestedAgentIds.length > 100) {
-            return response.badRequest({
-              body: TOO_MANY_AGENT_IDS,
-            });
-          }
+          const page = request.query.page ?? 0;
+          const pageSize = request.query.pageSize ?? 100;
 
-          let agentIds: string[];
-          let agentIdsKuery: string | undefined;
-
-          if (requestedAgentIds) {
-            // Use provided agentIds for filtering (external API consumers)
-            agentIds = requestedAgentIds;
-
-            // Build kuery to filter results to requested agents
-            agentIdsKuery = requestedAgentIds.map((id) => `agent.id: "${id}"`).join(' OR ');
-          } else {
-            // Fetch action details to get agent IDs (internal UI usage)
-            const { actionDetails } = await lastValueFrom(
-              search.search<ActionDetailsRequestOptions, ActionDetailsStrategyResponse>(
-                {
-                  actionId: request.params.actionId,
-                  factoryQueryType: OsqueryQueries.actionDetails,
-                  spaceId:
-                    (await context.core).savedObjects.client.getCurrentNamespace() || 'default',
-                },
-                { abortSignal, strategy: 'osquerySearchStrategy' }
-              )
-            );
-
-            // Extract agent IDs from action document
-            if (actionDetails?._source) {
-              // Check if actionId is a child query action_id
-              const queries = actionDetails._source.queries || [];
-              const matchingQuery = queries.find((q) => q.action_id === request.params.actionId);
-
-              // Use query-specific agents if found, otherwise use parent action's agents
-              agentIds = matchingQuery?.agents || actionDetails._source.agents || [];
-            } else {
-              agentIds = [];
-            }
-          }
-
-          // Combine agentIds filtering with user-provided kuery
-          let combinedKuery = request.query.kuery;
-          if (agentIdsKuery) {
-            combinedKuery = combinedKuery
-              ? `(${agentIdsKuery}) AND (${combinedKuery})`
-              : agentIdsKuery;
-          }
+          const totalAgentCount = request.query.totalAgents ?? agentIds.length;
 
           const res = await lastValueFrom(
             search.search<ActionResultsRequestOptions, ActionResultsStrategyResponse>(
               {
                 actionId: request.params.actionId,
                 factoryQueryType: OsqueryQueries.actionResults,
-                kuery: combinedKuery,
+                agentIds,
+                kuery: request.query.kuery,
                 startDate: request.query.startDate,
-                pagination: generateTablePaginationOptions(
-                  request.query.page ?? 0,
-                  request.query.pageSize ?? 100
-                ),
+                // Client already sliced agents for current page, so fetch all of them (no pagination)
+                pagination:
+                  agentIds.length > 0
+                    ? generateTablePaginationOptions(0, agentIds.length)
+                    : generateTablePaginationOptions(page, pageSize),
                 sort: {
                   direction: request.query.sortOrder ?? Direction.desc,
                   field: request.query.sort ?? '@timestamp',
@@ -167,44 +120,31 @@ export const getActionResultsRoute = (
             )
           );
 
-          const totalResponded =
-            res.rawResponse?.aggregations?.aggs.responses_by_action_id?.doc_count ?? 0;
-          const totalRowCount =
-            res.rawResponse?.aggregations?.aggs.responses_by_action_id?.rows_count?.value ?? 0;
-          const aggsBuckets =
-            res.rawResponse?.aggregations?.aggs.responses_by_action_id?.responses.buckets;
+          const responseAgg = res.rawResponse?.aggregations?.aggs.responses_by_action_id;
+          const totalResponded = responseAgg?.doc_count ?? 0;
+          const totalRowCount = responseAgg?.rows_count?.value ?? 0;
+          const aggsBuckets = responseAgg?.responses.buckets;
 
           const aggregations = {
             totalRowCount,
             totalResponded,
             successful: aggsBuckets?.find((bucket) => bucket.key === 'success')?.doc_count ?? 0,
             failed: aggsBuckets?.find((bucket) => bucket.key === 'error')?.doc_count ?? 0,
-            pending: Math.max(0, agentIds.length - totalResponded),
+            pending: Math.max(0, totalAgentCount - totalResponded),
           };
 
-          let processedEdges = res.edges;
+          // Return only real responses - placeholders will be generated client-side
+          const processedEdges = res.edges;
 
-          // Only process edges for internal UI (when agentIds NOT provided in request)
-          if (!requestedAgentIds && agentIds.length > 0) {
-            // Create placeholder edges for ALL agents
-            const placeholderEdges = agentIds.map((agentId) => ({
-              _index: '.logs-osquery_manager.action.responses-default',
-              _id: `placeholder-${agentId}`,
-              _source: {},
-              fields: { agent_id: [agentId] },
-            }));
-
-            // Merge real results with placeholders, keeping real results when duplicates exist
-            // reverse() ensures proper ordering, uniqBy keeps first occurrence (real data)
-            processedEdges = reverse(
-              uniqBy(flatten([res.edges, placeholderEdges]), 'fields.agent_id[0]')
-            ) as typeof res.edges;
-          }
+          const totalPages = Math.ceil(totalAgentCount / pageSize);
 
           return response.ok({
             body: {
               edges: processedEdges,
-              total: processedEdges.length,
+              total: totalAgentCount,
+              currentPage: page,
+              pageSize,
+              totalPages,
               aggregations,
               inspect: res.inspect,
             },

--- a/x-pack/platform/plugins/shared/osquery/server/routes/action_results/mocks.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/action_results/mocks.ts
@@ -16,11 +16,7 @@ import {
 } from '@kbn/core/server/mocks';
 import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
 import { OsqueryQueries } from '../../../common/search_strategy';
-import type {
-  ActionDetailsStrategyResponse,
-  ActionResultsStrategyResponse,
-  Direction,
-} from '../../../common/search_strategy';
+import type { ActionResultsStrategyResponse, Direction } from '../../../common/search_strategy';
 
 /**
  * Creates a mock Osquery application context for testing.
@@ -70,37 +66,6 @@ export const createMockRouter = () => {
 
   return httpService.createRouter();
 };
-
-/**
- * Factory to create mock action details response.
- *
- * @param agents - Array of agent IDs
- * @param queries - Optional array of query-specific actions with their agents
- * @returns Mocked ActionDetailsStrategyResponse
- */
-export const createMockActionDetailsResponse = (
-  agents: string[],
-  queries?: Array<{ action_id: string; agents: string[] }>
-): ActionDetailsStrategyResponse =>
-  ({
-    actionDetails: {
-      _id: 'test-action-id',
-      _index: '.logs-osquery_manager.actions',
-      _source: {
-        action_id: 'test-action-id',
-        expiration: '2025-01-21T00:00:00.000Z',
-        '@timestamp': '2025-01-20T00:00:00.000Z',
-        agent_all: false,
-        agent_ids: agents,
-        agent_platforms: ['linux'],
-        agent_platforoms: [],
-        agent_policy_ids: ['policy-1'],
-        agents,
-        queries,
-      },
-    },
-    rawResponse: {},
-  } as unknown as ActionDetailsStrategyResponse);
 
 /**
  * Factory to create mock action results response.
@@ -191,25 +156,17 @@ export const createMockRequest = (params: {
   });
 
 /**
- * Helper to create mock search strategy that responds to different query types.
+ * Helper to create mock search strategy that responds to action results queries.
  *
- * @param actionDetailsResponse - Optional response for action details queries
  * @param actionResultsResponse - Optional response for action results queries
  * @returns Jest mock function that returns appropriate responses based on query type
  */
-export const createMockSearchStrategy = (
-  actionDetailsResponse?: ActionDetailsStrategyResponse,
-  actionResultsResponse?: ActionResultsStrategyResponse
-) =>
+export const createMockSearchStrategy = (actionResultsResponse?: ActionResultsStrategyResponse) =>
   jest.fn(
     (
       request: { factoryQueryType: string; [key: string]: unknown },
       options: { abortSignal?: AbortSignal; strategy: string }
     ) => {
-      if (request.factoryQueryType === OsqueryQueries.actionDetails) {
-        return of(actionDetailsResponse || createMockActionDetailsResponse(['agent-1', 'agent-2']));
-      }
-
       if (request.factoryQueryType === OsqueryQueries.actionResults) {
         return of(actionResultsResponse || createMockActionResultsResponse());
       }

--- a/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/get_bulk_agent_details.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/get_bulk_agent_details.test.ts
@@ -1,0 +1,379 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServerMock, httpServiceMock } from '@kbn/core/server/mocks';
+import type { RequestHandler } from '@kbn/core/server';
+import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
+import { getBulkAgentDetailsRoute } from './get_bulk_agent_details';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+
+interface MockContext {
+  core: Promise<{
+    logger: {
+      get: jest.Mock;
+    };
+  }>;
+}
+
+describe('getBulkAgentDetailsRoute', () => {
+  let mockOsqueryContext: OsqueryAppContext;
+  let mockRouter: ReturnType<
+    ReturnType<typeof httpServiceMock.createSetupContract>['createRouter']
+  >;
+  let routeHandler: RequestHandler<unknown, unknown, { agentIds: string[] }>;
+  let mockContext: MockContext;
+
+  const mockAgentService = {
+    asInternalScopedUser: jest.fn(),
+  };
+
+  const mockGetByIds = jest.fn();
+
+  const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createMockContext = (): MockContext => ({
+    core: Promise.resolve({
+      logger: {
+        get: jest.fn().mockReturnValue({
+          debug: jest.fn(),
+          info: jest.fn(),
+          error: jest.fn(),
+        }),
+      },
+    }),
+  });
+
+  const createMockRequest = (agentIds: string[]) =>
+    httpServerMock.createKibanaRequest({
+      body: { agentIds },
+    });
+
+  const createMockResponse = () => httpServerMock.createResponseFactory();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAgentService.asInternalScopedUser.mockReturnValue({
+      getByIds: mockGetByIds,
+    });
+
+    mockOsqueryContext = {
+      logFactory: {
+        get: jest.fn().mockReturnValue(mockLogger),
+      },
+      service: {
+        getActiveSpace: jest.fn().mockResolvedValue({ id: 'default', name: 'Default' }),
+        getAgentService: jest.fn().mockReturnValue(mockAgentService),
+      },
+    } as unknown as OsqueryAppContext;
+
+    mockContext = createMockContext();
+
+    const httpService = httpServiceMock.createSetupContract();
+    mockRouter = httpService.createRouter();
+
+    getBulkAgentDetailsRoute(mockRouter, mockOsqueryContext);
+
+    const route = mockRouter.versioned.getRoute(
+      'post',
+      '/internal/osquery/fleet_wrapper/agents/_bulk'
+    );
+    const routeVersion = route.versions['1'];
+    if (!routeVersion) {
+      throw new Error('Handler for version [1] not found!');
+    }
+
+    routeHandler = routeVersion.handler;
+  });
+
+  describe('Successful bulk agent fetch', () => {
+    it.each([
+      {
+        agentIds: ['agent-1', 'agent-2'],
+        description: 'multiple agents',
+      },
+      {
+        agentIds: ['agent-1'],
+        description: 'single agent',
+      },
+      {
+        agentIds: Array.from({ length: 1000 }, (_, i) => `agent-${i}`),
+        description: '1000 agents (maximum allowed)',
+      },
+    ])('should fetch $description and return their details', async ({ agentIds }) => {
+      const mockAgents = agentIds.map((id) => ({
+        id,
+        local_metadata: { host: { name: `host-${id}` } },
+      }));
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      const mockRequest = createMockRequest(agentIds);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockGetByIds).toHaveBeenCalledWith(agentIds, { ignoreMissing: true });
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: mockAgents,
+        },
+      });
+    });
+
+    it('should handle missing/deleted agents with ignoreMissing=true', async () => {
+      const mockAgents = [
+        { id: 'agent-1', local_metadata: { host: { name: 'host-1' } } },
+        { id: 'agent-2', local_metadata: { host: { name: 'host-2' } } },
+        { id: 'agent-5', local_metadata: { host: { name: 'host-5' } } },
+      ];
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      const mockRequest = createMockRequest([
+        'agent-1',
+        'agent-2',
+        'agent-3',
+        'agent-4',
+        'agent-5',
+      ]);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockGetByIds).toHaveBeenCalledWith(
+        ['agent-1', 'agent-2', 'agent-3', 'agent-4', 'agent-5'],
+        { ignoreMissing: true }
+      );
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: mockAgents,
+        },
+      });
+    });
+  });
+
+  describe('Space isolation', () => {
+    it('should use correct space ID for agent service', async () => {
+      const customSpaceId = 'custom-space';
+      const mockAgents = [{ id: 'agent-1', local_metadata: { host: { name: 'host-1' } } }];
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      mockOsqueryContext.service.getActiveSpace = jest
+        .fn()
+        .mockResolvedValue({ id: customSpaceId, name: 'Custom Space' });
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockAgentService.asInternalScopedUser).toHaveBeenCalledWith(customSpaceId);
+      expect(mockResponse.ok).toHaveBeenCalled();
+    });
+
+    it('should use default space when no active space returned', async () => {
+      const mockAgents = [{ id: 'agent-1', local_metadata: { host: { name: 'host-1' } } }];
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      mockOsqueryContext.service.getActiveSpace = jest.fn().mockResolvedValue(undefined);
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockAgentService.asInternalScopedUser).toHaveBeenCalledWith(DEFAULT_SPACE_ID);
+      expect(mockResponse.ok).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return empty array when agent service is unavailable', async () => {
+      mockOsqueryContext.service.getAgentService = jest.fn().mockReturnValue(null);
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: [],
+        },
+      });
+
+      expect(mockGetByIds).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 error when Fleet service throws error', async () => {
+      const errorMessage = 'Fleet service connection failed';
+      mockGetByIds.mockRejectedValue(new Error(errorMessage));
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch bulk agent details')
+      );
+
+      expect(mockResponse.customError).toHaveBeenCalledWith({
+        statusCode: 500,
+        body: {
+          message: 'Failed to fetch agent details',
+        },
+      });
+    });
+
+    it('should handle empty agent IDs array', async () => {
+      mockGetByIds.mockResolvedValue([]);
+
+      const mockRequest = createMockRequest([]);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockGetByIds).toHaveBeenCalledWith([], { ignoreMissing: true });
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: [],
+        },
+      });
+    });
+  });
+
+  describe('Agent data structure', () => {
+    it('should preserve local_metadata in agent response', async () => {
+      const mockAgents = [
+        {
+          id: 'agent-1',
+          local_metadata: {
+            host: {
+              name: 'hostname-1',
+              architecture: 'x86_64',
+              ip: ['192.168.1.10'],
+            },
+            elastic: {
+              agent: {
+                version: '8.0.0',
+              },
+            },
+          },
+        },
+      ];
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: expect.arrayContaining([
+            expect.objectContaining({
+              id: 'agent-1',
+              local_metadata: expect.objectContaining({
+                host: expect.objectContaining({
+                  name: 'hostname-1',
+                  architecture: 'x86_64',
+                }),
+              }),
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('should handle agents without local_metadata', async () => {
+      const mockAgents = [
+        {
+          id: 'agent-1',
+        },
+      ];
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      const mockRequest = createMockRequest(['agent-1']);
+      const mockResponse = createMockResponse();
+
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: [{ id: 'agent-1' }],
+        },
+      });
+    });
+  });
+
+  describe('Large scale scenarios (10k+ agents context)', () => {
+    it('should efficiently handle 100 agents (typical page size)', async () => {
+      const agentIds = Array.from({ length: 100 }, (_, i) => `agent-${i}`);
+      const mockAgents = agentIds.map((id) => ({
+        id,
+        local_metadata: { host: { name: `host-${id}` } },
+      }));
+
+      mockGetByIds.mockResolvedValue(mockAgents);
+
+      const mockRequest = createMockRequest(agentIds);
+      const mockResponse = createMockResponse();
+
+      const startTime = Date.now();
+      await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+      const duration = Date.now() - startTime;
+
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: {
+          agents: mockAgents,
+        },
+      });
+
+      expect(duration).toBeLessThan(100);
+    });
+
+    it('should support pagination across 10 pages (1000 agents)', async () => {
+      const pages = 10;
+      const pageSize = 100;
+
+      for (let page = 0; page < pages; page++) {
+        const startIndex = page * pageSize;
+        const agentIds = Array.from({ length: pageSize }, (_, i) => `agent-${startIndex + i}`);
+        const mockAgents = agentIds.map((id) => ({
+          id,
+          local_metadata: { host: { name: `host-${id}` } },
+        }));
+
+        mockGetByIds.mockResolvedValue(mockAgents);
+
+        const mockRequest = createMockRequest(agentIds);
+        const mockResponse = createMockResponse();
+
+        await routeHandler(mockContext as never, mockRequest as never, mockResponse);
+
+        expect(mockResponse.ok).toHaveBeenCalledWith({
+          body: {
+            agents: mockAgents,
+          },
+        });
+      }
+
+      expect(mockGetByIds).toHaveBeenCalledTimes(pages);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/get_bulk_agent_details.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/get_bulk_agent_details.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+import type { IRouter } from '@kbn/core/server';
+import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import { API_VERSIONS } from '../../../common/constants';
+import { PLUGIN_ID } from '../../../common';
+import type { OsqueryAppContext } from '../../lib/osquery_app_context_services';
+
+/**
+ * Request body schema for bulk agent details endpoint.
+ * Fetches agent metadata (names, IDs) for multiple agents in a single request.
+ */
+const GetBulkAgentDetailsRequestBody = z.object({
+  agentIds: z.array(z.string()).min(1).max(1000), // Limit to 1000 agents per request (supports up to 10 pages of 100)
+});
+
+export const getBulkAgentDetailsRoute = (router: IRouter, osqueryContext: OsqueryAppContext) => {
+  router.versioned
+    .post({
+      access: 'internal',
+      path: '/internal/osquery/fleet_wrapper/agents/_bulk',
+      security: {
+        authz: {
+          requiredPrivileges: [`${PLUGIN_ID}-read`],
+        },
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.internal.v1,
+        validate: {
+          request: {
+            body: buildRouteValidationWithZod(GetBulkAgentDetailsRequestBody),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const logger = osqueryContext.logFactory.get('bulkAgentDetails');
+        const space = await osqueryContext.service.getActiveSpace(request);
+
+        // Deduplicate agent IDs to prevent redundant queries
+        const agentIds = [...new Set(request.body.agentIds)];
+
+        try {
+          // Use Fleet's bulk getByIds method (with ignoreMissing to handle deleted agents)
+          const agentService = osqueryContext.service.getAgentService();
+          if (!agentService) {
+            return response.ok({ body: { agents: [] } });
+          }
+
+          const agents = await agentService
+            .asInternalScopedUser(space?.id ?? DEFAULT_SPACE_ID)
+            ?.getByIds(agentIds, { ignoreMissing: true });
+
+          return response.ok({
+            body: {
+              agents: agents || [],
+            },
+          });
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          logger.error(`Failed to fetch bulk agent details: ${errorMessage}`);
+
+          return response.customError({
+            statusCode: 500,
+            body: {
+              message: 'Failed to fetch agent details',
+            },
+          });
+        }
+      }
+    );
+};

--- a/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/index.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/fleet_wrapper/index.ts
@@ -13,9 +13,11 @@ import { getAgentStatusForAgentPolicyRoute } from './get_agent_status_for_agent_
 import { getPackagePoliciesRoute } from './get_package_policies';
 import { getAgentsRoute } from './get_agents';
 import { getAgentDetailsRoute } from './get_agent_details';
+import { getBulkAgentDetailsRoute } from './get_bulk_agent_details';
 
 export const initFleetWrapperRoutes = (router: IRouter, context: OsqueryAppContext) => {
   getAgentDetailsRoute(router, context);
+  getBulkAgentDetailsRoute(router, context);
   getAgentPoliciesRoute(router, context);
   getAgentPolicyRoute(router, context);
   getAgentStatusForAgentPolicyRoute(router, context);

--- a/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/actions/results/index.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/factory/actions/results/index.ts
@@ -22,7 +22,17 @@ export const actionResults: OsqueryFactory<OsqueryQueries.actionResults> = {
       throw new Error(`No query size above ${DEFAULT_MAX_TABLE_QUERY_SIZE}`);
     }
 
-    return buildActionResultsQuery(options);
+    // Ensure pagination defaults if not provided (match UI default pageSize: 20)
+    const optionsWithDefaults = {
+      ...options,
+      pagination: options.pagination || {
+        activePage: 0,
+        cursorStart: 0,
+        querySize: 20,
+      },
+    };
+
+    return buildActionResultsQuery(optionsWithDefaults);
   },
   // @ts-expect-error update types
   parse: async (

--- a/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/index.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/search_strategy/osquery/index.ts
@@ -53,6 +53,7 @@ export const osquerySearchStrategyProvider = <T extends FactoryQueryTypes>(
             ...('actionId' in request ? { actionId: request.actionId } : {}),
             ...('startDate' in request ? { startDate: request.startDate } : {}),
             ...('agentId' in request ? { agentId: request.agentId } : {}),
+            ...('agentIds' in request ? { agentIds: request.agentIds } : {}),
             ...('policyIds' in request ? { policyIds: request.policyIds } : {}),
             ...('spaceId' in request ? { spaceId: request.spaceId } : {}),
             ...('integrationNamespaces' in request


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents (#240082)](https://github.com/elastic/kibana/pull/240082)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2025-11-04T16:16:04Z","message":"[EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents (#240082)","sha":"1bcb51b421ba91e05724c82615278e00380402a5","branchLabelMapping":{"^v9.3.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Defend Workflows","v9.3.0"],"title":"[EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents","number":240082,"url":"https://github.com/elastic/kibana/pull/240082","mergeCommit":{"message":"[EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents (#240082)","sha":"1bcb51b421ba91e05724c82615278e00380402a5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.3.0","branchLabelMappingKey":"^v9.3.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/240082","number":240082,"mergeCommit":{"message":"[EDR Workflows] Fix Osquery Status Tab pagination to handle 10k+ agents (#240082)","sha":"1bcb51b421ba91e05724c82615278e00380402a5"}}]}] BACKPORT-->