### PR TITLE
[Dashboard] Unskip full screen mode tests

### DIFF
--- a/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
+++ b/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const { dashboard, common } = getPageObjects(['dashboard', 'common']);
   const filterBar = getService('filterBar');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/258163
-  describe.skip('full screen mode', () => {
+  describe('full screen mode', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(

--- a/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
+++ b/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const { dashboard, common } = getPageObjects(['dashboard', 'common']);
   const filterBar = getService('filterBar');
 
-  describe.only('full screen mode', () => {
+  describe('full screen mode', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(

--- a/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
+++ b/src/platform/test/functional/apps/dashboard/group2/full_screen_mode.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const { dashboard, common } = getPageObjects(['dashboard', 'common']);
   const filterBar = getService('filterBar');
 
-  describe('full screen mode', () => {
+  describe.only('full screen mode', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/258163

## Summary

This PR unskips the full screen Dashboard tests - it seems like the failures were cluster of one-offs based on a bad CI environment (the failure screenshots are all empty) and the flaky test runner no longer shows any failures after 200 tries (including [this run](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11338/) on a different test branch).

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.



