### PR TITLE
[9.3] [Security Solution] fix rule details page search bar showing up on top of full screen alert table (#260315)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -154,6 +154,7 @@ import { RuleDetailTabs, useRuleDetailsTabs } from './use_rule_details_tabs';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useRuleUpdateCallout } from '../../../rule_management/hooks/use_rule_update_callout';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
+import { FiltersGlobal } from '../../../../common/components/filters_global';
 
 const RULE_EXCEPTION_LIST_TYPES = [
   ExceptionListTypeEnum.DETECTION,
@@ -841,12 +842,14 @@ export const RuleDetailsPage = connector(
                     </Route>
                     <Route path={`/rules/id/:detailName/:tabName(${RuleDetailTabs.alerts})`}>
                       <>
-                        <SiemSearchBar
-                          dataView={experimentalDataView}
-                          pollForSignalIndex={pollForSignalIndex}
-                          id={InputsModelId.global}
-                          sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
-                        />
+                        <FiltersGlobal>
+                          <SiemSearchBar
+                            dataView={experimentalDataView}
+                            pollForSignalIndex={pollForSignalIndex}
+                            id={InputsModelId.global}
+                            sourcererDataViewSpec={oldSourcererDataViewSpec} // TODO remove when we remove the newDataViewPickerEnabled feature flag
+                          />
+                        </FiltersGlobal>
                         <EuiSpacer />
                         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
                           <EuiFlexItem grow={false}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Security Solution] fix rule details page search bar showing up on top of full screen alert table (#260315)](https://github.com/elastic/kibana/pull/260315)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-03-31T00:26:32Z","message":"[Security Solution] fix rule details page search bar showing up on top of full screen alert table (#260315)\n\n## Summary\n\nThis PR fixes a small issue introduced by this recent\n[PR](https://github.com/elastic/kibana/pull/251662), where the search\nbar of the rule details page `Alerts` tab is overlapping with the alerts\ntable when in full screen mode.\n\nYou can see in the previous PR linked above that the `FiltersGlobal` was\nremoved when the code was refactored.\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/301b5ae7-f1d5-4fec-8c0b-f825eee09c35\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ed1a14a4-9145-40b4-9bd7-d8a7f9a0b196\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/259694","sha":"7309f42f7cb018437720b0b51b6001b1ca009d80","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:version","v9.4.0","v9.3.3","v9.2.8"],"title":"[Security Solution] fix rule details page search bar showing up on top of full screen alert table","number":260315,"url":"https://github.com/elastic/kibana/pull/260315","mergeCommit":{"message":"[Security Solution] fix rule details page search bar showing up on top of full screen alert table (#260315)\n\n## Summary\n\nThis PR fixes a small issue introduced by this recent\n[PR](https://github.com/elastic/kibana/pull/251662), where the search\nbar of the rule details page `Alerts` tab is overlapping with the alerts\ntable when in full screen mode.\n\nYou can see in the previous PR linked above that the `FiltersGlobal` was\nremoved when the code was refactored.\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/301b5ae7-f1d5-4fec-8c0b-f825eee09c35\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ed1a14a4-9145-40b4-9bd7-d8a7f9a0b196\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/259694","sha":"7309f42f7cb018437720b0b51b6001b1ca009d80"}},"sourceBranch":"main","suggestedTargetBranches":["9.3","9.2"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260315","number":260315,"mergeCommit":{"message":"[Security Solution] fix rule details page search bar showing up on top of full screen alert table (#260315)\n\n## Summary\n\nThis PR fixes a small issue introduced by this recent\n[PR](https://github.com/elastic/kibana/pull/251662), where the search\nbar of the rule details page `Alerts` tab is overlapping with the alerts\ntable when in full screen mode.\n\nYou can see in the previous PR linked above that the `FiltersGlobal` was\nremoved when the code was refactored.\n\n#### Before\n\n\nhttps://github.com/user-attachments/assets/301b5ae7-f1d5-4fec-8c0b-f825eee09c35\n\nAfter\n\n\nhttps://github.com/user-attachments/assets/ed1a14a4-9145-40b4-9bd7-d8a7f9a0b196\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\nhttps://github.com/elastic/kibana/issues/259694","sha":"7309f42f7cb018437720b0b51b6001b1ca009d80"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->