### PR TITLE
fix flaky Synthetics API integration tests

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/create_monitor_private_location.ts
@@ -507,7 +507,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
         expect(packagePolicy.package.version).eql(lowerVersion);
         await supertestWithAuth.post('/api/fleet/setup').set('kbn-xsrf', 'true').send().expect(200);
-        await retry.tryForTime(60 * 1000, async () => {
+        await retry.tryForTime(120 * 1000, async () => {
           const policyResponseAfterUpgrade = await supertestWithAuth.get(
             '/api/fleet/package_policies?page=1&perPage=2000&kuery=ingest-package-policies.package.name%3A%20synthetics'
           );

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor_project.ts
@@ -55,7 +55,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await kibanaServer.savedObjects.clean({ types: ['synthetics-private-location'] });
+      await kibanaServer.savedObjects.clean({
+        types: ['synthetics-private-location', 'synthetics-monitor-multi-space'],
+      });
       privateLocation = await testPrivateLocationsService.addTestPrivateLocation();
       projectMonitors = setUniqueIdsAndLocations(getFixtureJson('project_browser_monitor'), [
         privateLocation,
@@ -116,22 +118,34 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           '[request body.monitors]: array size is [550], but cannot be greater than [500]'
         );
       } finally {
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(0, 250) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(250, 251) })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(0, 250) });
+        } catch (e) {
+          // best-effort cleanup
+        }
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(250, 251) });
+        } catch (e) {
+          // best-effort cleanup
+        }
       }
     });
 
@@ -191,14 +205,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(totalAfterDeletion).to.eql(1);
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
       }
     });
 
@@ -285,25 +305,34 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-              '{projectName}',
-              secondProject
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
             )
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                secondProject
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
       }
     });
 
@@ -409,26 +438,35 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            `/s/${SPACE_ID}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-              '{projectName}',
-              project
-            )}`
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              `/s/${SPACE_ID}${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )}`
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
       }
     });
 
@@ -509,14 +547,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete });
+        } catch (e) {
+          // best-effort cleanup
+        }
       }
     });
   });

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/edit_monitor_public_api_private_location.ts
@@ -80,7 +80,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     });
 
     after(async () => {
-      // await kibanaServer.savedObjects.cleanStandardList();
+      await kibanaServer.savedObjects.cleanStandardList();
     });
     let monitorId = 'test-id';
 

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
@@ -22,6 +22,7 @@ import { PrivateLocationTestService } from '../../services/synthetics_private_lo
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('GetProjectMonitors', function () {
     const supertest = getService('supertestWithoutAuth');
+    const kibanaServer = getService('kibanaServer');
     const samlAuth = getService('samlAuth');
     const retry = getService('retry');
 
@@ -60,7 +61,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       editorUser = await samlAuth.createM2mApiKeyWithRoleScope('editor');
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
+      await kibanaServer.savedObjects.clean({ types: ['synthetics-monitor-multi-space'] });
       projectMonitors = setUniqueIds(
         getFixtureJson('project_browser_monitor'),
         testPrivateLocations
@@ -152,30 +154,40 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(0, 250) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(250, 500) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(500, 600) })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(0, 250) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(250, 500) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(500, 600) });
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
 
@@ -256,30 +268,40 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(0, 250) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(250, 500) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(500, 600) })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(0, 250) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(250, 500) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(500, 600) });
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
 
@@ -360,30 +382,40 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(0, 250) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(250, 500) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(500, 600) })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(0, 250) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(250, 500) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(500, 600) });
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
 
@@ -464,30 +496,40 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       } finally {
         const monitorsToDelete = monitors.map((monitor) => monitor.id);
 
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(0, 250) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(250, 500) })
-          .expect(200);
-        await supertest
-          .delete(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete.slice(500, 600) })
-          .expect(200);
+        try {
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(0, 250) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(250, 500) });
+          await supertest
+            .delete(
+              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
+                '{projectName}',
+                project
+              )
+            )
+            .set(editorUser.apiKeyHeader)
+            .set(samlAuth.getInternalRequestHeader())
+            .send({ monitors: monitorsToDelete.slice(500, 600) });
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes 14 flaky test failures in the Synthetics API integration test suite, identified in [Buildkite build #975](https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/975#019d4bb5-84ca-44f9-87ad-3e1f117ef73b).

**Root cause:** 502 Bad Gateway during test cleanup caused a cascading failure. `.expect(200)` assertions in `finally` blocks threw on transient server errors, preventing subsequent cleanup calls from executing. This left hundreds of monitors behind, overwhelming the server and causing all downstream tests to fail with 502s or count mismatches.

**Affected test files:**
- `delete_monitor_project.ts` — count mismatches due to leftover monitors
- `edit_monitor_public_api_private_location.ts` — `before all` hook failure (server stressed)
- `get_monitor_project.ts` — 502 Bad Gateway on monitor creation (server overwhelmed)
- `create_monitor_private_location.ts` — timeout on package policy upgrade
- `migrate_legacy_policies.ts` — "backend closed connection" (downstream effect)

**Fix:**
- Add `synthetics-monitor-multi-space` to `beforeEach` cleanup in `delete_monitor_project.ts` and `get_monitor_project.ts` so each test starts with a clean state
- Wrap `finally` block deletes in `try/catch` for best-effort cleanup (prevents a single 502 from cascading)
- Uncomment the disabled `after` cleanup in `edit_monitor_public_api_private_location.ts` (was leaving monitors behind)
- Increase retry timeout for slow package policy upgrade test (60s → 120s)

**Test type:** FTR
**Config:** `x-pack/solutions/observability/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts`

## Validation

- [ ] CI flaky test runner (triggered below)