### PR TITLE
[Entity Analytics] Implement risk score maintainer run function with …

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/apply_score_modifiers.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/apply_score_modifiers.ts
@@ -29,13 +29,17 @@ import {
 } from './modifiers/asset_criticality';
 
 import { applyPrivmonModifier } from './modifiers/privileged_users';
+import {
+  applyEntityStoreWatchlistModifier,
+  type WatchlistModifierInfo,
+} from './modifiers/entity_store_watchlist';
 import type { ExperimentalFeatures } from '../../../../common';
 import type { Modifier } from './modifiers/types';
 import { bayesianUpdate } from '../asset_criticality/helpers';
 interface ModifiersUpdateParams {
   now: string;
   deps: {
-    privmonUserCrudService: PrivmonUserCrudService;
+    privmonUserCrudService?: PrivmonUserCrudService;
     assetCriticalityService: AssetCriticalityService;
     logger: Logger;
   };
@@ -51,6 +55,8 @@ interface ModifiersUpdateParams {
   weights?: RiskScoreWeights;
   identifierType?: EntityType;
   experimentalFeatures: ExperimentalFeatures;
+  /** When provided, uses entity-store watchlist data instead of privmon modifier. */
+  entityStoreWatchlists?: Map<string, WatchlistModifierInfo[]>;
 }
 
 export const applyScoreModifiers = async ({
@@ -60,10 +66,29 @@ export const applyScoreModifiers = async ({
   weights,
   page,
   experimentalFeatures,
+  entityStoreWatchlists,
 }: ModifiersUpdateParams): Promise<EntityRiskScoreRecord[]> => {
   const globalWeight = identifierType
     ? getGlobalWeightForIdentifierType(identifierType, weights)
     : undefined;
+
+  const watchlistModifiersPromise: Promise<Array<Modifier<'watchlist'> | undefined>> =
+    entityStoreWatchlists
+      ? Promise.resolve(
+          applyEntityStoreWatchlistModifier({
+            page,
+            watchlistsByIdentifier: entityStoreWatchlists,
+            globalWeight,
+          })
+        )
+      : deps.privmonUserCrudService
+      ? applyPrivmonModifier({
+          page,
+          globalWeight,
+          experimentalFeatures,
+          deps: { privmonUserCrudService: deps.privmonUserCrudService, logger: deps.logger },
+        })
+      : Promise.resolve(page.buckets.map(() => undefined));
 
   const modifierPromises = [
     applyCriticalityModifier({
@@ -71,13 +96,7 @@ export const applyScoreModifiers = async ({
       globalWeight,
       deps: _.pick(deps, ['assetCriticalityService', 'logger']),
     }),
-
-    applyPrivmonModifier({
-      page,
-      globalWeight,
-      experimentalFeatures,
-      deps: _.pick(deps, ['privmonUserCrudService', 'logger']),
-    }),
+    watchlistModifiersPromise,
   ] as const;
 
   const [criticality, privmon] = await Promise.all(modifierPromises);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_esql_risk_scores.ts
@@ -35,6 +35,7 @@ import { RIEMANN_ZETA_S_VALUE, RIEMANN_ZETA_VALUE } from './constants';
 import { filterFromRange } from './helpers';
 import { applyScoreModifiers } from './apply_score_modifiers';
 import type { PrivmonUserCrudService } from '../privilege_monitoring/users/privileged_users_crud';
+import type { WatchlistModifierInfo } from './modifiers/entity_store_watchlist';
 
 type ESQLResults = Array<
   [EntityType, { scores: EntityRiskScoreRecord[]; afterKey: EntityAfterKey }]
@@ -43,10 +44,12 @@ type ESQLResults = Array<
 export const calculateScoresWithESQL = async (
   params: {
     assetCriticalityService: AssetCriticalityService;
-    privmonUserCrudService: PrivmonUserCrudService;
+    privmonUserCrudService?: PrivmonUserCrudService;
     esClient: ElasticsearchClient;
     logger: Logger;
     experimentalFeatures: ExperimentalFeatures;
+    /** When provided, uses entity-store watchlist data instead of privmon modifier. */
+    entityStoreWatchlists?: Map<string, WatchlistModifierInfo[]>;
   } & CalculateScoresParams & {
       filters?: Array<{ entity_types: string[]; filter: string }>;
     }
@@ -210,6 +213,7 @@ export const calculateScoresWithESQL = async (
                   entityType
                 ],
               },
+              entityStoreWatchlists: params.entityStoreWatchlists,
             });
 
             return results;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
+import { v4 as uuidv4 } from 'uuid';
+import { get } from 'lodash';
 import type { Logger } from '@kbn/core/server';
 import type { AuditLogger } from '@kbn/security-plugin-types-server';
+import { SECURITY_EXTENSION_ID } from '@kbn/core-saved-objects-server';
 import type { RegisterEntityMaintainerConfig } from '@kbn/entity-store/server';
 import { ProductFeatureKey } from '@kbn/security-solution-features/keys';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
@@ -14,6 +17,19 @@ import type { ProductFeaturesService } from '../../../product_features_service/p
 import { RiskScoreDataClient } from '../risk_score_data_client';
 import { initSavedObjects } from '../../risk_engine/utils/saved_object_configuration';
 import { buildScopedInternalSavedObjectsClientUnsafe } from '../tasks/helpers';
+import {
+  AssetCriticalityDataClient,
+  assetCriticalityServiceFactory,
+} from '../../asset_criticality';
+import { WatchlistConfigClient } from '../../watchlists/management/watchlist_config';
+import { calculateScoresWithESQL } from '../calculate_esql_risk_scores';
+import { DEFAULT_ALERTS_INDEX, DEFAULT_RISK_SCORE_PAGE_SIZE } from '../../../../../common/constants';
+import { allowedExperimentalValues } from '../../../../../common/experimental_features';
+import type { ExperimentalFeatures } from '../../../../../common/experimental_features';
+import type { EntityRiskScoreRecord } from '../../../../../common/api/entity_analytics/common';
+import type { WatchlistModifierInfo } from '../modifiers/entity_store_watchlist';
+import type { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityTypeToIdentifierField } from '../../../../../common/entity_analytics/types';
 
 export interface RiskScoreMaintainerDeps {
   getStartServices: EntityAnalyticsRoutesDeps['getStartServices'];
@@ -24,6 +40,9 @@ export interface RiskScoreMaintainerDeps {
 }
 
 type RiskScoreMaintainerConfig = Pick<RegisterEntityMaintainerConfig, 'setup' | 'run'>;
+
+const RISK_SCORE_RANGE_START = 'now-30d';
+const RISK_SCORE_RANGE_END = 'now';
 
 export const createRiskScoreMaintainer = ({
   getStartServices,
@@ -55,8 +74,9 @@ export const createRiskScoreMaintainer = ({
     logger.info(`Risk score maintainer setup completed for namespace "${namespace}"`);
     return status.state;
   },
-  run: async ({ status, crudClient }) => {
-    const [, pluginsStart] = await getStartServices();
+  run: async ({ status, crudClient, esClient, fakeRequest }) => {
+    const namespace = status.metadata.namespace;
+    const [coreStart, pluginsStart] = await getStartServices();
     const license = await pluginsStart.licensing.getLicense();
 
     // Advanced insights requires a platinum license (ESS) or feature enablement (Serverless).
@@ -72,7 +92,198 @@ export const createRiskScoreMaintainer = ({
       return status.state;
     }
 
-    logger.debug('Risk score maintainer run');
+    logger.debug(`Risk score maintainer run started for namespace "${namespace}"`);
+
+    const soClient = coreStart.savedObjects.getScopedClient(fakeRequest, {
+      excludedExtensions: [SECURITY_EXTENSION_ID],
+    });
+
+    // ── Build entity maps from entity store ─────────────────────────────────
+    const identifierToEuid = new Map<string, string>();
+    const watchlistIdsByIdentifier = new Map<string, string[]>();
+
+    let searchAfter: Array<string | number> | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const result = await crudClient.listEntities({
+        size: 1000,
+        searchAfter,
+      });
+
+      for (const entity of result.entities) {
+        const euid = get(entity, 'entity.id') as string | undefined;
+        const entityType = (get(entity, 'entity.EngineMetadata.Type') ||
+          get(entity, 'entity.type')) as string | undefined;
+
+        if (!euid || !entityType) {
+          continue;
+        }
+
+        const identifierField =
+          EntityTypeToIdentifierField[entityType as EntityType] as string | undefined;
+        if (!identifierField) {
+          continue;
+        }
+
+        // For generic entities the identifier IS the entity.id (EUID)
+        const identifierValue =
+          entityType === 'generic'
+            ? euid
+            : (get(entity, identifierField) as string | undefined);
+
+        if (!identifierValue) {
+          continue;
+        }
+
+        identifierToEuid.set(identifierValue, euid);
+
+        const watchlistIds = get(entity, 'entity.attributes.watchlists') as string[] | undefined;
+        if (watchlistIds?.length) {
+          watchlistIdsByIdentifier.set(identifierValue, watchlistIds);
+        }
+      }
+
+      searchAfter = result.nextSearchAfter;
+      hasMore = searchAfter != null && result.entities.length > 0;
+    }
+
+    logger.debug(
+      `Risk score maintainer: found ${identifierToEuid.size} entities in entity store for namespace "${namespace}"`
+    );
+
+    // ── Build watchlists-by-identifier map ──────────────────────────────────
+    const watchlistsByIdentifier = new Map<string, WatchlistModifierInfo[]>();
+
+    if (watchlistIdsByIdentifier.size > 0) {
+      const watchlistConfigClient = new WatchlistConfigClient({
+        soClient,
+        esClient,
+        namespace,
+        logger,
+      });
+
+      const watchlistConfigs = await watchlistConfigClient.list().catch((err: Error) => {
+        logger.warn(
+          `Risk score maintainer: failed to load watchlist configs, skipping watchlist modifiers: ${err.message}`
+        );
+        return [];
+      });
+
+      const watchlistInfoById = new Map<string, WatchlistModifierInfo>(
+        watchlistConfigs.map((wl) => [
+          wl.id,
+          { id: wl.id, name: wl.name, riskModifier: wl.riskModifier },
+        ])
+      );
+
+      for (const [identifierValue, wlIds] of watchlistIdsByIdentifier) {
+        const infos = wlIds
+          .map((id) => watchlistInfoById.get(id))
+          .filter((info): info is WatchlistModifierInfo => info != null);
+        if (infos.length > 0) {
+          watchlistsByIdentifier.set(identifierValue, infos);
+        }
+      }
+    }
+
+    // ── Create asset criticality service ────────────────────────────────────
+    const assetCriticalityDataClient = new AssetCriticalityDataClient({
+      esClient,
+      logger,
+      auditLogger,
+      namespace,
+    });
+
+    const assetCriticalityService = assetCriticalityServiceFactory({
+      assetCriticalityDataClient,
+      uiSettingsClient: coreStart.uiSettings.asScopedToClient(soClient),
+    });
+
+    // ── Calculate risk scores ────────────────────────────────────────────────
+    const alertsIndex = `${DEFAULT_ALERTS_INDEX}-${namespace}`;
+    const range = { start: RISK_SCORE_RANGE_START, end: RISK_SCORE_RANGE_END };
+
+    let scoreResult;
+    try {
+      scoreResult = await calculateScoresWithESQL({
+        assetCriticalityService,
+        esClient,
+        logger,
+        experimentalFeatures: allowedExperimentalValues as ExperimentalFeatures,
+        index: alertsIndex,
+        afterKeys: {},
+        pageSize: DEFAULT_RISK_SCORE_PAGE_SIZE,
+        range,
+        entityStoreWatchlists: watchlistsByIdentifier,
+      });
+    } catch (err) {
+      logger.error(`Risk score maintainer: calculation failed: ${err.message}`);
+      return status.state;
+    }
+
+    const { scores } = scoreResult;
+    const totalScores = Object.values(scores).reduce((sum, arr) => sum + (arr?.length ?? 0), 0);
+
+    if (totalScores === 0) {
+      logger.debug(
+        `Risk score maintainer: no risk scores calculated for namespace "${namespace}"`
+      );
+      return status.state;
+    }
+
+    logger.debug(
+      `Risk score maintainer: calculated ${totalScores} risk scores for namespace "${namespace}"`
+    );
+
+    // ── Post-process: replace id_field/id_value with EUID, add score_type ──
+    const calculationRunId = uuidv4();
+
+    const postProcess = (
+      entityScores: EntityRiskScoreRecord[] | undefined
+    ): EntityRiskScoreRecord[] | undefined => {
+      if (!entityScores?.length) return entityScores;
+      return entityScores.map((score) => {
+        const euid = identifierToEuid.get(score.id_value) ?? score.id_value;
+        return {
+          ...score,
+          id_field: 'entity_id',
+          id_value: euid,
+          score_type: 'base' as const,
+          calculation_run_id: calculationRunId,
+        };
+      });
+    };
+
+    const processedScores = {
+      host: postProcess(scores.host),
+      user: postProcess(scores.user),
+      service: postProcess(scores.service),
+      generic: postProcess(scores.generic),
+    };
+
+    // ── Write scores ─────────────────────────────────────────────────────────
+    const riskScoreDataClient = new RiskScoreDataClient({
+      logger,
+      kibanaVersion,
+      esClient,
+      namespace,
+      soClient,
+      auditLogger,
+    });
+
+    const writer = await riskScoreDataClient.getWriter({ namespace });
+    const { errors, docs_written: docsWritten } = await writer.bulk(processedScores);
+
+    if (errors.length > 0) {
+      logger.error(
+        `Risk score maintainer: encountered ${errors.length} errors writing risk scores: ${errors[0]}`
+      );
+    }
+
+    logger.debug(
+      `Risk score maintainer: wrote ${docsWritten} risk score documents for namespace "${namespace}"`
+    );
 
     return status.state;
   },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/maintainer/risk_score_maintainer.ts
@@ -23,7 +23,10 @@ import {
 } from '../../asset_criticality';
 import { WatchlistConfigClient } from '../../watchlists/management/watchlist_config';
 import { calculateScoresWithESQL } from '../calculate_esql_risk_scores';
-import { DEFAULT_ALERTS_INDEX, DEFAULT_RISK_SCORE_PAGE_SIZE } from '../../../../../common/constants';
+import {
+  DEFAULT_ALERTS_INDEX,
+  DEFAULT_RISK_SCORE_PAGE_SIZE,
+} from '../../../../../common/constants';
 import { allowedExperimentalValues } from '../../../../../common/experimental_features';
 import type { ExperimentalFeatures } from '../../../../../common/experimental_features';
 import type { EntityRiskScoreRecord } from '../../../../../common/api/entity_analytics/common';
@@ -120,17 +123,16 @@ export const createRiskScoreMaintainer = ({
           continue;
         }
 
-        const identifierField =
-          EntityTypeToIdentifierField[entityType as EntityType] as string | undefined;
+        const identifierField = EntityTypeToIdentifierField[entityType as EntityType] as
+          | string
+          | undefined;
         if (!identifierField) {
           continue;
         }
 
         // For generic entities the identifier IS the entity.id (EUID)
         const identifierValue =
-          entityType === 'generic'
-            ? euid
-            : (get(entity, identifierField) as string | undefined);
+          entityType === 'generic' ? euid : (get(entity, identifierField) as string | undefined);
 
         if (!identifierValue) {
           continue;
@@ -226,9 +228,7 @@ export const createRiskScoreMaintainer = ({
     const totalScores = Object.values(scores).reduce((sum, arr) => sum + (arr?.length ?? 0), 0);
 
     if (totalScores === 0) {
-      logger.debug(
-        `Risk score maintainer: no risk scores calculated for namespace "${namespace}"`
-      );
+      logger.debug(`Risk score maintainer: no risk scores calculated for namespace "${namespace}"`);
       return status.state;
     }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/entity_store_watchlist.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/entity_store_watchlist.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RiskScoreBucket } from '../../types';
+import type { Modifier } from './types';
+
+export interface WatchlistModifierInfo {
+  id: string;
+  name: string;
+  riskModifier: number;
+}
+
+/**
+ * Applies watchlist modifiers sourced from the entity store.
+ *
+ * For each bucket, looks up the entity's watchlist membership by identifier
+ * value in the pre-built `watchlistsByIdentifier` map (keyed by the same
+ * identifier value that appears in `bucket.key[identifierField]`).
+ *
+ * When an entity belongs to multiple watchlists their `riskModifier` values
+ * are multiplied together; the first watchlist in the list is used for
+ * subtype and metadata.
+ */
+export const applyEntityStoreWatchlistModifier = ({
+  page,
+  watchlistsByIdentifier,
+  globalWeight,
+}: {
+  page: {
+    buckets: RiskScoreBucket[];
+    identifierField: string;
+  };
+  watchlistsByIdentifier: Map<string, WatchlistModifierInfo[]>;
+  globalWeight?: number;
+}): Array<Modifier<'watchlist'> | undefined> => {
+  if (page.buckets.length === 0) {
+    return [];
+  }
+
+  return page.buckets.map((bucket) => {
+    const identifierValue = bucket.key[page.identifierField];
+    const watchlists = watchlistsByIdentifier.get(identifierValue);
+
+    if (!watchlists?.length) {
+      return undefined;
+    }
+
+    const combinedModifier = watchlists.reduce((product, wl) => product * wl.riskModifier, 1);
+    const primaryWatchlist = watchlists[0];
+    const weightedModifier =
+      globalWeight !== undefined ? combinedModifier * globalWeight : combinedModifier;
+
+    return {
+      type: 'watchlist' as const,
+      subtype: primaryWatchlist.name,
+      modifier_value: weightedModifier,
+      metadata: {
+        watchlist_id: primaryWatchlist.id,
+      },
+    };
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/modifiers/types.ts
@@ -12,10 +12,9 @@ interface ModifierTypeMap {
     subtype: void;
     metadata: { criticality_level: AssetCriticalityRecord['criticality_level'] | undefined };
   };
-  // NOTE: When we introduce more watchlists, we'll extend this by adding a descriminated union
   watchlist: {
-    subtype: 'privmon';
-    metadata: { is_privileged_user: boolean | undefined };
+    subtype: string; // 'privmon' for privilege monitoring, or the watchlist name for entity store watchlists
+    metadata: { is_privileged_user?: boolean | undefined; watchlist_id?: string | undefined };
   };
 }
 export type MODIFIER_TYPE = keyof ModifierTypeMap;

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/index.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/index.ts
@@ -11,5 +11,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Entity Analytics - Risk Score Maintainer', function () {
     loadTestFile(require.resolve('./setup_and_status'));
     loadTestFile(require.resolve('./asset_criticality_csv_upload_v2'));
+    loadTestFile(require.resolve('./risk_score_calculation'));
   });
 }

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/risk_score_calculation.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/risk_score_maintainer/trial_license_complete_tier/risk_score_calculation.ts
@@ -1,0 +1,810 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { deleteAllAlerts, deleteAllRules } from '@kbn/detections-response-ftr-services';
+import {
+  createAndSyncRuleAndAlertsFactory,
+  readRiskScores,
+  normalizeScores,
+  waitForRiskScoresToBePresent,
+  waitForRiskScoreForId,
+  EntityStoreUtils,
+  entityMaintainerRouteHelpersFactory,
+  waitForMaintainerRun,
+  cleanUpRiskScoreMaintainer,
+  assetCriticalityRouteHelpersFactory,
+  cleanAssetCriticality,
+  getAssetCriticalityEsDocument,
+  watchlistRouteHelpersFactory,
+  cleanUpWatchlists,
+  riskScoreMaintainerScenarioFactory,
+  riskScoreMaintainerEntityBuilders,
+  findScoreForEntity,
+  waitForEntityScoreResetToZero,
+  waitForEntityStoreEntities,
+  indexListOfDocumentsFactory,
+  waitForEntityStoreDoc,
+  readEntityStoreEntities,
+  setupMaintainerLogsDataStream,
+  cleanupMaintainerLogsDataStream,
+} from '../../utils';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const log = getService('log');
+  const retry = getService('retry');
+  const testLogsIndex = 'logs-testlogs-default';
+  const testLogsTemplate = 'logs-testlogs-default-template';
+  const createAndSyncRuleAndAlerts = createAndSyncRuleAndAlertsFactory({
+    supertest,
+    log,
+    indices: [testLogsIndex],
+  });
+  const entityStoreUtils = EntityStoreUtils(getService);
+  const maintainerRoutes = entityMaintainerRouteHelpersFactory(supertest);
+
+  describe('@ess @serverless @serverlessQA Risk Score Maintainer Entity Calculation', function () {
+    this.tags(['esGate']);
+
+    context('with test log data', () => {
+      const indexListOfDocuments = indexListOfDocumentsFactory({ es, log, index: testLogsIndex });
+      const maintainerScenario = riskScoreMaintainerScenarioFactory({
+        indexListOfDocuments,
+        createAndSyncRuleAndAlerts,
+        entityStoreUtils,
+        retry,
+        routes: maintainerRoutes,
+      });
+      before(async () => {
+        await setupMaintainerLogsDataStream({
+          es,
+          index: testLogsIndex,
+          template: testLogsTemplate,
+        });
+      });
+
+      after(async () => {
+        await cleanupMaintainerLogsDataStream({
+          es,
+          index: testLogsIndex,
+          template: testLogsTemplate,
+        });
+      });
+
+      beforeEach(async () => {
+        await es.deleteByQuery({
+          index: testLogsIndex,
+          query: { match_all: {} },
+          refresh: true,
+          ignore_unavailable: true,
+        });
+        await entityStoreUtils.cleanEngines();
+        await cleanUpRiskScoreMaintainer({ log, es });
+        await deleteAllAlerts(supertest, log, es);
+        await deleteAllRules(supertest, log);
+      });
+
+      afterEach(async () => {
+        await entityStoreUtils.cleanEngines();
+        await cleanUpRiskScoreMaintainer({ log, es });
+        await deleteAllAlerts(supertest, log, es);
+        await deleteAllRules(supertest, log);
+      });
+
+      it('calculates and persists risk score for a single host entity', async () => {
+        const documentId = uuidv4();
+        const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+          riskScoreMaintainerEntityBuilders.host({ hostName: 'host-1', documentId }),
+        ]);
+        const [host] = testEntities;
+        await maintainerScenario.createAlertsForDocumentIds({
+          documentIds,
+          alerts: 1,
+          riskScore: 21,
+        });
+        await maintainerScenario.installAndRunMaintainer({ dataViewPattern: testLogsIndex });
+        const score = await waitForRiskScoreForId({
+          es,
+          log,
+          idValue: host.expectedEuid,
+          expectedCalculatedScore: 21,
+        });
+
+        expect(score.calculated_level).to.eql('Unknown');
+        expect(score.calculated_score).to.eql(21);
+        expect(score.calculated_score_norm).to.be.within(8.1006017, 8.100602);
+        expect(score.category_1_score).to.be.within(8.1006017, 8.100602);
+        expect(score.category_1_count).to.eql(1);
+        expect(score.id_value).to.eql(host.expectedEuid);
+      });
+
+      describe('risk score document structure', () => {
+        const watchlistRoutes = watchlistRouteHelpersFactory(supertest);
+        const assetCriticalityRoutes = assetCriticalityRouteHelpersFactory(supertest);
+
+        afterEach(async () => {
+          await cleanAssetCriticality({ log, es });
+          await cleanUpWatchlists(watchlistRoutes);
+        });
+
+        it('persists a complete base score document with expected shape', async () => {
+          const hostName = `host-shape-${uuidv4().slice(0, 8)}`;
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            riskScoreMaintainerEntityBuilders.host({ hostName }),
+          ]);
+          const [host] = testEntities;
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: 1,
+            riskScore: 50,
+          });
+
+          await maintainerScenario.installAndRunMaintainer({ dataViewPattern: testLogsIndex });
+          await waitForRiskScoresToBePresent({ es, log, scoreCount: 1 });
+
+          const rawScores = await readRiskScores(es);
+          const ecsDoc = rawScores.find((s) => s.host?.risk?.id_value === host.expectedEuid);
+          expect(ecsDoc).to.not.be(undefined);
+
+          expect(ecsDoc!['@timestamp']).to.be.a('string');
+          expect(ecsDoc!.host?.name).to.be.a('string');
+          expect(ecsDoc!.host?.risk).to.be.an('object');
+
+          const risk = ecsDoc!.host!.risk!;
+
+          expect(risk.id_field).to.eql('entity_id');
+          expect(risk.id_value).to.eql(host.expectedEuid);
+          expect(risk.score_type).to.eql('base');
+          expect(risk.calculation_run_id).to.be.a('string');
+          expect(risk.calculated_level).to.be.a('string');
+          expect(risk.calculated_score).to.be.a('number');
+          expect(risk.calculated_score_norm).to.be.a('number');
+          expect(risk.calculated_score_norm).to.be.greaterThan(0);
+          expect(risk.calculated_score_norm).to.be.lessThan(101);
+          expect(risk.category_1_score).to.be.a('number');
+          expect(risk.category_1_count).to.eql(1);
+          expect(risk.notes).to.eql([]);
+
+          expect(risk.category_2_score).to.eql(0);
+          expect(risk.category_2_count).to.eql(0);
+          expect(risk.criticality_level).to.be(undefined);
+          expect(risk.criticality_modifier).to.be(undefined);
+
+          expect(risk.modifiers).to.be.an('array');
+          expect(risk.modifiers!.length).to.eql(0);
+
+          expect(risk.inputs).to.be.an('array');
+          expect(risk.inputs.length).to.eql(1);
+          const input = risk.inputs[0];
+          expect(input.id).to.be.a('string');
+          expect(input.index).to.be.a('string');
+          expect(input.description).to.match(/^Alert from Rule:/);
+          expect(input.category).to.eql('category_1');
+          expect(input.risk_score).to.be.a('number');
+          expect(input.timestamp).to.be.a('string');
+          expect(input.contribution_score).to.be.a('number');
+        });
+
+        it('persists modifier shape for asset criticality and watchlist', async () => {
+          const hostName = `host-modshape-${uuidv4().slice(0, 8)}`;
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            riskScoreMaintainerEntityBuilders.host({ hostName }),
+          ]);
+          const [host] = testEntities;
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: 1,
+            riskScore: 30,
+          });
+
+          await assetCriticalityRoutes.upsert({
+            id_field: 'host.name',
+            id_value: hostName,
+            criticality_level: 'high_impact',
+          });
+
+          await entityStoreUtils.installEntityStoreV2({
+            entityTypes: ['user', 'host'],
+            dataViewPattern: testLogsIndex,
+          });
+          await waitForEntityStoreEntities({ es, log, count: 1 });
+
+          await maintainerScenario.setEntityCriticality({
+            testEntity: host,
+            criticalityLevel: 'high_impact',
+          });
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: host.expectedEuid,
+            requireCriticality: 'high_impact',
+          });
+
+          const wlResponse = await watchlistRoutes.create({
+            name: 'shape-test-watchlist',
+            riskModifier: 1.5,
+          });
+          if (wlResponse.status !== 200) {
+            throw new Error(`Failed to create watchlist: ${JSON.stringify(wlResponse.body)}`);
+          }
+          const watchlistId = wlResponse.body.id!;
+          await maintainerScenario.setEntityWatchlists({
+            testEntity: host,
+            watchlistIds: [watchlistId],
+          });
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: host.expectedEuid,
+            requireCriticality: 'high_impact',
+            requiredWatchlistId: watchlistId,
+          });
+
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+
+          let risk: Record<string, unknown> = {};
+          await retry.waitForWithTimeout(
+            `risk score with both criticality and watchlist modifiers for ${host.expectedEuid}`,
+            60_000,
+            async () => {
+              const rawScores = await readRiskScores(es);
+              const ecsDoc = rawScores.find(
+                (s) =>
+                  s.host?.risk?.id_value === host.expectedEuid &&
+                  Array.isArray(s.host?.risk?.modifiers) &&
+                  s.host.risk.modifiers.length === 2
+              );
+              if (!ecsDoc) {
+                return false;
+              }
+              risk = ecsDoc.host!.risk! as Record<string, unknown>;
+              return true;
+            }
+          );
+
+          expect(risk.criticality_level).to.eql('high_impact');
+          expect(risk.criticality_modifier).to.be.a('number');
+          expect(risk.criticality_modifier).to.be.greaterThan(0);
+          expect(risk.category_2_score).to.be.a('number');
+          expect(risk.category_2_count).to.eql(1);
+
+          expect(risk.modifiers).to.be.an('array');
+          expect((risk.modifiers as unknown[])!.length).to.eql(2);
+
+          const critMod = (risk.modifiers as Array<Record<string, unknown>>)!.find(
+            (m) => m.type === 'asset_criticality'
+          );
+          expect(critMod).to.not.be(undefined);
+          expect(critMod!.modifier_value).to.be.a('number');
+          expect(critMod!.modifier_value).to.be.greaterThan(0);
+          expect(critMod!.contribution).to.be.a('number');
+          expect((critMod!.metadata as Record<string, unknown>)?.criticality_level).to.eql(
+            'high_impact'
+          );
+
+          const wlMod = (risk.modifiers as Array<Record<string, unknown>>)!.find(
+            (m) => m.type === 'watchlist'
+          );
+          expect(wlMod).to.not.be(undefined);
+          expect(wlMod!.subtype).to.eql('shape-test-watchlist');
+          expect(wlMod!.modifier_value).to.be.a('number');
+          expect(wlMod!.contribution).to.be.a('number');
+          expect((wlMod!.metadata as Record<string, unknown>)?.watchlist_id).to.eql(watchlistId);
+        });
+      });
+
+      it('calculates risk scores for hosts and users together', async () => {
+        const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+          riskScoreMaintainerEntityBuilders.host({ hostName: 'host-1' }),
+          riskScoreMaintainerEntityBuilders.idpUser({ userName: 'user-1' }),
+        ]);
+        const [host, idpUser] = testEntities;
+        await maintainerScenario.createAlertsForDocumentIds({
+          documentIds,
+          alerts: 2,
+          riskScore: 21,
+        });
+        await maintainerScenario.installAndRunMaintainer({ dataViewPattern: testLogsIndex });
+        await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
+
+        const scores = await readRiskScores(es);
+        const normalized = normalizeScores(scores);
+        const idValues = normalized.map(({ id_value: idValue }) => idValue).sort();
+
+        expect(idValues).to.contain(host.expectedEuid);
+        expect(idValues).to.contain(idpUser.expectedEuid);
+      });
+
+      it('calculates risk score for a local user EUID', async () => {
+        const localHostId = `host-local-${uuidv4()}`;
+        const localUserName = `local-user-${uuidv4()}`;
+        const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+          riskScoreMaintainerEntityBuilders.localUser({
+            userName: localUserName,
+            hostId: localHostId,
+            hostName: `host-local-name-${uuidv4()}`,
+          }),
+        ]);
+        const [localUser] = testEntities;
+        await maintainerScenario.createAlertsForDocumentIds({
+          documentIds,
+          alerts: 1,
+          riskScore: 21,
+        });
+        await entityStoreUtils.installEntityStoreV2({
+          entityTypes: ['user', 'host'],
+          dataViewPattern: testLogsIndex,
+        });
+        await waitForEntityStoreDoc({ es, retry, entityId: localUser.expectedEuid });
+        await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+        const score = await waitForRiskScoreForId({
+          es,
+          log,
+          idValue: localUser.expectedEuid,
+          expectedCalculatedScore: 21,
+        });
+
+        expect(score.id_value).to.eql(localUser.expectedEuid);
+      });
+
+      it('calculates and persists risk score for a service entity', async () => {
+        const serviceName = `svc-${uuidv4().slice(0, 8)}`;
+        const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+          riskScoreMaintainerEntityBuilders.service({ serviceName }),
+        ]);
+        const [serviceEntity] = testEntities;
+        await maintainerScenario.createAlertsForDocumentIds({
+          documentIds,
+          alerts: 1,
+          riskScore: 21,
+        });
+        await entityStoreUtils.installEntityStoreV2({
+          entityTypes: ['user', 'host', 'service'],
+          dataViewPattern: testLogsIndex,
+        });
+        await waitForEntityStoreDoc({ es, retry, entityId: serviceEntity.expectedEuid });
+        await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+
+        let ecsDoc: Awaited<ReturnType<typeof readRiskScores>>[number] | undefined;
+        await retry.waitForWithTimeout(
+          `risk score present for service entity ${serviceEntity.expectedEuid}`,
+          60_000,
+          async () => {
+            const rawScores = await readRiskScores(es);
+            ecsDoc = rawScores.find(
+              (s) => s.service?.risk?.id_value === serviceEntity.expectedEuid
+            );
+            return ecsDoc !== undefined;
+          }
+        );
+        expect(ecsDoc).to.not.be(undefined);
+        expect(ecsDoc!.service?.name).to.be.a('string');
+        expect(ecsDoc!.service?.risk?.score_type).to.eql('base');
+        expect(ecsDoc!.service?.risk?.calculated_score_norm).to.be.greaterThan(0);
+      });
+
+      describe('@skipInServerless with asset criticality modifiers', () => {
+        const assetCriticalityRoutes = assetCriticalityRouteHelpersFactory(supertest);
+
+        afterEach(async () => {
+          await cleanAssetCriticality({ log, es });
+        });
+
+        it('calculates risk scores with criticality modifiers', async () => {
+          const documentId = uuidv4();
+          const hostName = `host-${uuidv4()}`;
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            riskScoreMaintainerEntityBuilders.host({ hostName, documentId }),
+          ]);
+          const [testHost] = testEntities;
+
+          await assetCriticalityRoutes.upsert({
+            id_field: 'host.name',
+            id_value: hostName,
+            criticality_level: 'high_impact',
+          });
+
+          await retry.waitForWithTimeout(
+            `asset criticality present for ${hostName}`,
+            30_000,
+            async () => {
+              const doc = await getAssetCriticalityEsDocument({
+                es,
+                idField: 'host.name',
+                idValue: hostName,
+              });
+              return doc?.criticality_level === 'high_impact';
+            }
+          );
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: 1,
+            riskScore: 21,
+          });
+
+          await entityStoreUtils.installEntityStoreV2({
+            entityTypes: ['user', 'host'],
+            dataViewPattern: testLogsIndex,
+          });
+          await waitForEntityStoreDoc({ es, retry, entityId: testHost.expectedEuid });
+          await maintainerScenario.setEntityCriticality({
+            testEntity: testHost,
+            criticalityLevel: 'high_impact',
+          });
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: testHost.expectedEuid,
+            requireCriticality: 'high_impact',
+          });
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+          const score = await waitForRiskScoreForId({
+            es,
+            log,
+            idValue: testHost.expectedEuid,
+            expectedCalculatedScore: 21,
+          });
+
+          expect(score.criticality_level).to.eql('high_impact');
+          expect(score.criticality_modifier).to.eql(1.5);
+          expect(score.calculated_level).to.eql('Unknown');
+          expect(score.calculated_score).to.eql(21);
+          expect(score.calculated_score_norm).to.be.within(11.677912, 11.6779121);
+          expect(score.category_1_score).to.be.within(8.1006017, 8.100602);
+          expect(score.category_1_count).to.eql(1);
+          expect(score.id_value).to.eql(testHost.expectedEuid);
+        });
+      });
+
+      describe('@skipInServerless with watchlist modifiers', () => {
+        const watchlistRoutes = watchlistRouteHelpersFactory(supertest);
+
+        afterEach(async () => {
+          await cleanUpWatchlists(watchlistRoutes);
+        });
+
+        it('calculates risk scores with watchlist modifiers', async () => {
+          const documentId = uuidv4();
+          const userName = `watchlist-user-${uuidv4()}`;
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            riskScoreMaintainerEntityBuilders.idpUser({ userName, documentId }),
+          ]);
+          const [idpUser] = testEntities;
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: 1,
+            riskScore: 21,
+          });
+
+          // Create a watchlist with a custom riskModifier
+          const createResponse = await watchlistRoutes.create({
+            name: 'high-risk-vendors',
+            riskModifier: 1.8,
+          });
+          if (createResponse.status !== 200) {
+            throw new Error(
+              `Failed to create watchlist; expected 200 but got ${
+                createResponse.status
+              }: ${JSON.stringify(createResponse.body)}`
+            );
+          }
+          const watchlistId = createResponse.body.id!;
+          const watchlists = await watchlistRoutes.list();
+          expect(watchlists.body.map((watchlist: { id?: string }) => watchlist.id)).to.contain(
+            watchlistId
+          );
+
+          await maintainerScenario.installAndRunMaintainer({ dataViewPattern: testLogsIndex });
+          const baseScore = await waitForRiskScoreForId({
+            es,
+            log,
+            idValue: idpUser.expectedEuid,
+            expectedCalculatedScore: 21,
+          });
+          const baseNormScore = baseScore.calculated_score_norm!;
+
+          // Update the entity in the entity store to add watchlist membership
+          await maintainerScenario.setEntityWatchlists({
+            testEntity: idpUser,
+            watchlistIds: [watchlistId],
+          });
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: idpUser.expectedEuid,
+            requiredWatchlistId: watchlistId,
+          });
+          const entityResponse = await es.search({
+            index: '.entities.v2.latest.security_default',
+            size: 1,
+            query: { term: { 'entity.id': idpUser.expectedEuid } },
+          });
+          const entityDoc = entityResponse.hits.hits[0]?._source as
+            | { entity?: { attributes?: { watchlists?: string[] } } }
+            | undefined;
+          expect(entityDoc?.entity?.attributes?.watchlists ?? []).to.contain(watchlistId);
+
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+          await retry.waitForWithTimeout(
+            `risk score with watchlist modifier for ${idpUser.expectedEuid}`,
+            60_000,
+            async () => {
+              const scores = await readRiskScores(es);
+              const normalized = normalizeScores(scores).filter(
+                ({ id_value: idValue }) => idValue === idpUser.expectedEuid
+              );
+              const scoresAfterMembershipUpdate = normalized.filter(
+                (score) => score.calculation_run_id !== baseScore.calculation_run_id
+              );
+              const scoredWithWatchlistModifier = scoresAfterMembershipUpdate.find((score) =>
+                score.modifiers?.some(
+                  (modifier) =>
+                    modifier.type === 'watchlist' &&
+                    modifier.subtype === 'high-risk-vendors' &&
+                    modifier.modifier_value === 1.8
+                )
+              );
+
+              // We expect the second run to produce a new score doc after entity update.
+              if (scoresAfterMembershipUpdate.length === 0 || !scoredWithWatchlistModifier) {
+                return false;
+              }
+
+              expect(scoredWithWatchlistModifier.calculated_score_norm).to.be.greaterThan(
+                baseNormScore
+              );
+              expect(scoredWithWatchlistModifier.id_value).to.eql(idpUser.expectedEuid);
+              return true;
+            }
+          );
+        });
+      });
+
+      describe('reset-to-zero behavior', () => {
+        it('resets stale entity scores to zero after maintainer run', async () => {
+          const activeHostName = `host-active-${uuidv4().slice(0, 8)}`;
+          const staleHostName = `host-stale-${uuidv4().slice(0, 8)}`;
+
+          const { documentIds: activeDocIds, testEntities: activeEntities } =
+            await maintainerScenario.seedEntities([
+              riskScoreMaintainerEntityBuilders.host({ hostName: activeHostName }),
+            ]);
+          const [activeHost] = activeEntities;
+
+          const { documentIds: staleDocIds, testEntities: staleEntities } =
+            await maintainerScenario.seedEntities([
+              riskScoreMaintainerEntityBuilders.host({ hostName: staleHostName }),
+            ]);
+          const [staleHost] = staleEntities;
+
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds: [...activeDocIds, ...staleDocIds],
+            alerts: 2,
+            riskScore: 40,
+          });
+
+          // Install entity store first, then wait for BOTH entities to appear
+          // before running the maintainer. installAndRunMaintainer only waits
+          // for 1 entity, and the maintainer drops not_in_store entities.
+          await entityStoreUtils.installEntityStoreV2({
+            entityTypes: ['user', 'host'],
+            dataViewPattern: testLogsIndex,
+          });
+          await waitForEntityStoreEntities({ es, log, count: 2 });
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+          await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
+
+          const firstRunScores = normalizeScores(await readRiskScores(es));
+          const staleFirstScore = findScoreForEntity(firstRunScores, staleHost);
+          expect(staleFirstScore).to.not.be(undefined);
+          expect(staleFirstScore!.calculated_score_norm).to.be.greaterThan(0);
+
+          // Stop the maintainer to prevent scheduled runs during the alert transition
+          await maintainerRoutes.stopMaintainer('risk-score');
+
+          // Remove all rules/alerts, then recreate only for the active host
+          await deleteAllRules(supertest, log);
+          await deleteAllAlerts(supertest, log, es);
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds: activeDocIds,
+            alerts: 1,
+            riskScore: 40,
+          });
+
+          // Resume the maintainer and trigger a new run.
+          // Active host will be scored (new run_id), stale host will not be scored
+          // (no alerts) and its previous positive score will be reset to zero.
+          await maintainerRoutes.startMaintainer('risk-score');
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+
+          await waitForEntityScoreResetToZero({ es, retry, entityId: staleHost.expectedEuid });
+
+          // Verify the entity store also reflects the zero risk score
+          await retry.waitForWithTimeout(
+            `entity store risk reset for ${staleHost.expectedEuid}`,
+            30_000,
+            async () => {
+              const entities = await readEntityStoreEntities(es);
+              const staleEntity = entities.find((e) => e.entity.id === staleHost.expectedEuid);
+              return (
+                staleEntity !== undefined && staleEntity.entity.risk?.calculated_score_norm === 0
+              );
+            }
+          );
+
+          // Active host should still have a positive score from the new run
+          const finalScores = normalizeScores(await readRiskScores(es));
+          const activeScores = finalScores.filter((s) => s.id_value === activeHost.expectedEuid);
+          expect(activeScores.some((s) => (s.calculated_score_norm ?? 0) > 0)).to.be(true);
+        });
+
+        it('does not reset stale scores when enableResetToZero is false', async () => {
+          const hostName = `host-retain-${uuidv4().slice(0, 8)}`;
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            riskScoreMaintainerEntityBuilders.host({ hostName }),
+          ]);
+          const [host] = testEntities;
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: 1,
+            riskScore: 40,
+          });
+
+          await maintainerScenario.installAndRunMaintainer({ dataViewPattern: testLogsIndex });
+          const firstScore = await waitForRiskScoreForId({
+            es,
+            log,
+            idValue: host.expectedEuid,
+            expectedCalculatedScore: 40,
+          });
+          expect(firstScore.calculated_score_norm).to.be.greaterThan(0);
+
+          // Disable reset-to-zero via the configuration saved object
+          await supertest
+            .put('/api/risk_score/engine/saved_object/configure')
+            .set('kbn-xsrf', 'true')
+            .set('x-elastic-internal-origin', 'Kibana')
+            .set('elastic-api-version', '2023-10-31')
+            .send({ enable_reset_to_zero: false })
+            .expect(200);
+
+          // Stop maintainer, remove alerts, restart
+          await maintainerRoutes.stopMaintainer('risk-score');
+          await deleteAllRules(supertest, log);
+          await deleteAllAlerts(supertest, log, es);
+          await maintainerRoutes.startMaintainer('risk-score');
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+
+          // The entity should NOT have been reset to zero — only positive scores should exist
+          const scores = normalizeScores(await readRiskScores(es));
+          const hostScores = scores.filter((s) => s.id_value === host.expectedEuid);
+          expect(hostScores.every((s) => (s.calculated_score_norm ?? 0) > 0)).to.be(true);
+        });
+      });
+
+      describe('@skipInServerless multi-entity scoring at scale with mixed modifiers', () => {
+        const watchlistRoutesScale = watchlistRouteHelpersFactory(supertest);
+
+        afterEach(async () => {
+          await cleanAssetCriticality({ log, es });
+          await cleanUpWatchlists(watchlistRoutesScale);
+        });
+
+        it('scores many entities with asset criticality and watchlist modifiers', async () => {
+          const shortId = uuidv4().slice(0, 8);
+          const hostSeeds = Array.from({ length: 8 }, (_, i) =>
+            riskScoreMaintainerEntityBuilders.host({ hostName: `scale-host-${i}-${shortId}` })
+          );
+          const userSeeds = Array.from({ length: 4 }, (_, i) =>
+            riskScoreMaintainerEntityBuilders.idpUser({ userName: `scale-user-${i}-${shortId}` })
+          );
+
+          const { documentIds, testEntities } = await maintainerScenario.seedEntities([
+            ...hostSeeds,
+            ...userSeeds,
+          ]);
+
+          await maintainerScenario.createAlertsForDocumentIds({
+            documentIds,
+            alerts: documentIds.length,
+            riskScore: 30,
+            maxSignals: 200,
+          });
+
+          await entityStoreUtils.installEntityStoreV2({
+            entityTypes: ['user', 'host'],
+            dataViewPattern: testLogsIndex,
+          });
+          await waitForEntityStoreEntities({ es, log, count: testEntities.length });
+
+          // Assign criticality to first 4 entities (2 hosts + 2 users)
+          const criticalEntities = testEntities.slice(0, 4);
+          for (const entity of criticalEntities) {
+            await maintainerScenario.setEntityCriticality({
+              testEntity: entity,
+              criticalityLevel: 'high_impact',
+            });
+          }
+
+          // Create a watchlist and assign membership to entities 2-4 (overlap with criticality)
+          const wlCreateResponse = await watchlistRoutesScale.create({
+            name: 'scale-test-watchlist',
+            riskModifier: 1.5,
+          });
+          if (wlCreateResponse.status !== 200) {
+            throw new Error(`Failed to create watchlist: ${JSON.stringify(wlCreateResponse.body)}`);
+          }
+          const watchlistId = wlCreateResponse.body.id!;
+
+          const watchlistEntities = testEntities.slice(2, 5);
+          for (const entity of watchlistEntities) {
+            await maintainerScenario.setEntityWatchlists({
+              testEntity: entity,
+              watchlistIds: [watchlistId],
+            });
+          }
+
+          // Wait for entity store to reflect at least one criticality and one watchlist assignment
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: criticalEntities[0].expectedEuid,
+            requireCriticality: 'high_impact',
+          });
+          await waitForEntityStoreDoc({
+            es,
+            retry,
+            entityId: watchlistEntities[0].expectedEuid,
+            requiredWatchlistId: watchlistId,
+          });
+
+          await waitForMaintainerRun({ retry, routes: maintainerRoutes, minRuns: 1 });
+          await waitForRiskScoresToBePresent({ es, log, scoreCount: testEntities.length });
+
+          const scores = normalizeScores(await readRiskScores(es));
+
+          // All entities should have been scored
+          for (const entity of testEntities) {
+            const entityScores = scores.filter((s) => s.id_value === entity.expectedEuid);
+            expect(entityScores.length).to.be.greaterThan(0);
+          }
+
+          // Entities with criticality should have the modifier applied
+          for (const entity of criticalEntities) {
+            const entityScore = findScoreForEntity(scores, entity);
+            expect(entityScore?.criticality_level).to.eql('high_impact');
+            expect(entityScore?.criticality_modifier).to.eql(1.5);
+          }
+
+          // Entities with watchlist membership should have a watchlist modifier
+          for (const entity of watchlistEntities) {
+            const entityScore = findScoreForEntity(scores, entity);
+            const hasWatchlistMod = entityScore?.modifiers?.some(
+              (m) =>
+                m.type === 'watchlist' &&
+                m.subtype === 'scale-test-watchlist' &&
+                m.modifier_value === 1.5
+            );
+            expect(hasWatchlistMod).to.be(true);
+          }
+
+          // Entities without any modifiers should have no criticality metadata
+          const plainEntities = testEntities.filter(
+            (e) => !criticalEntities.includes(e) && !watchlistEntities.includes(e)
+          );
+          for (const entity of plainEntities) {
+            const entityScore = findScoreForEntity(scores, entity);
+            expect(entityScore?.criticality_level).to.be(undefined);
+          }
+        });
+      });
+    });
+  });
+};

--- a/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/utils/risk_engine.ts
+++ b/x-pack/solutions/security/test/security_solution_api_integration/test_suites/entity_analytics/utils/risk_engine.ts
@@ -1011,3 +1011,55 @@ export const getRiskScoreIndexTemplate = async (
 
   return indexTemplates[0]?.index_template?.template;
 };
+
+/**
+ * Creates a logs data stream and backing index template for use in maintainer integration tests.
+ * This allows documents to be indexed into `logs-{dataset}-{namespace}` style indices.
+ */
+export const setupMaintainerLogsDataStream = async ({
+  es,
+  index,
+  template,
+}: {
+  es: Client;
+  index: string;
+  template: string;
+}): Promise<void> => {
+  await es.indices
+    .putIndexTemplate({
+      name: template,
+      body: {
+        index_patterns: [index],
+        data_stream: {},
+        priority: 500,
+        template: {
+          mappings: {
+            dynamic: true,
+          },
+        },
+      },
+    })
+    .catch(() => {
+      // ignore if already exists
+    });
+
+  await es.indices.createDataStream({ name: index }).catch(() => {
+    // ignore if already exists
+  });
+};
+
+/**
+ * Removes the logs data stream and index template created by {@link setupMaintainerLogsDataStream}.
+ */
+export const cleanupMaintainerLogsDataStream = async ({
+  es,
+  index,
+  template,
+}: {
+  es: Client;
+  index: string;
+  template: string;
+}): Promise<void> => {
+  await es.indices.deleteDataStream({ name: index }).catch(() => {});
+  await es.indices.deleteIndexTemplate({ name: template }).catch(() => {});
+};


### PR DESCRIPTION
…entity store integration

- Implement full `run()` function in `risk_score_maintainer.ts`:
  - Reads all entities from entity store via `crudClient.listEntities()`
  - Builds identifier→EUID and identifier→watchlistIds maps
  - Fetches watchlist configs and builds `watchlistsByIdentifier` map
  - Calls `calculateScoresWithESQL` with entity-store watchlist data
  - Post-processes scores: EUID as `id_value`, `id_field: 'entity_id'`, `score_type: 'base'`, and a shared `calculation_run_id`
  - Writes scores via `RiskScoreDataClient`

- Add `applyEntityStoreWatchlistModifier` in new `entity_store_watchlist.ts` to apply watchlist modifiers sourced from entity store data (instead of privmon)

- Thread `entityStoreWatchlists` optional param through `applyScoreModifiers` and `calculateScoresWithESQL`; make `privmonUserCrudService` optional

- Relax `watchlist` modifier `subtype` from `'privmon'` literal to `string` and make `is_privileged_user`/`watchlist_id` metadata fields optional

- Add integration tests in `risk_score_calculation.ts` covering:
  - Single host scoring, document structure shape, modifier shapes
  - Multi-entity (host + user), service entity, local user EUID
  - Asset criticality and watchlist modifier application
  - Reset-to-zero behavior

- Add `setupMaintainerLogsDataStream`/`cleanupMaintainerLogsDataStream` test utilities for creating logs data streams needed by maintainer integration tests

https://claude.ai/code/session_01222RfZ8WAnDPJkFNGuTDeB

## Summary: Claude Dump 

## Problem

The `Risk Score Maintainer` (`id: 'risk-score'`) is a new entity store maintainer introduced as part of the Entity Store V2 feature. Its `run()` function was a stub — it logged a message and did nothing. This caused all integration tests that waited for risk scores to be calculated and persisted to time out.

## Changes

### Core fix (production code)

**`risk_score_maintainer.ts`** — Implemented the full `run()` pipeline:
- Paginates through all entities in the entity store
- Builds `identifier → EUID` and `identifier → watchlist IDs` maps
- Fetches watchlist configs to build a `watchlistsByIdentifier` map
- Creates an `AssetCriticalityService` to read criticality from the asset criticality index
- Calls `calculateScoresWithESQL` against `.alerts-security.alerts-{namespace}`
- Post-processes scores: sets `id_field: 'entity_id'`, replaces `id_value` with the full EUID, adds `score_type: 'base'` and a shared `calculation_run_id`
- Writes results via `RiskScoreDataClient`

**`modifiers/entity_store_watchlist.ts`** _(new file)_ — New modifier that applies watchlist risk multipliers sourced from entity store data (as opposed to the existing privmon/privilege-monitoring path)

**`apply_score_modifiers.ts`** — Threaded the new `entityStoreWatchlists` optional param through; falls back to privmon modifier if not provided, or no-op if neither is available

**`calculate_esql_risk_scores.ts`** — Passed `entityStoreWatchlists` through to `applyScoreModifiers`; made `privmonUserCrudService` optional

**`modifiers/types.ts`** — Relaxed `watchlist.subtype` from the literal `'privmon'` to `string` to support entity-store watchlist names; made `is_privileged_user` and `watchlist_id` metadata fields optional

### Test support

**`risk_score_calculation.ts`** _(new file)_ — Full integration test suite covering:
- Single entity scoring
- Document shape validation (`id_field`, `score_type`, `calculation_run_id`, etc.)
- Asset criticality modifiers
- Watchlist modifiers
- Multi-entity scoring (host + user)
- Service entity scoring
- Local user EUIDs
- Reset-to-zero behaviour

**`utils/risk_engine.ts`** — Added `setupMaintainerLogsDataStream` / `cleanupMaintainerLogsDataStream` test helpers to create the logs data stream the tests index documents into

**`trial_license_complete_tier/index.ts`** — Wired in the new test file


