### PR TITLE
[8.19] Improve DHQ error handling (#256956)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/__mocks__/index.ts
@@ -69,6 +69,12 @@ export const createMockEsClient = () => {
     ilm: {
       explainLifecycle: jest.fn(),
     },
+    indices: {
+      exists: jest.fn(),
+    },
+    security: {
+      hasPrivileges: jest.fn(),
+    },
     helpers: mockHelpers,
     cluster: { health: jest.fn() },
     nodes: { stats: jest.fn() },
@@ -161,6 +167,8 @@ export const setupPointInTime = (
 ) => {
   mockEsClient.openPointInTime.mockResolvedValue({ id: pitId });
   mockEsClient.closePointInTime.mockResolvedValue({});
+  mockEsClient.indices.exists.mockResolvedValue(true);
+  mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true });
 };
 
 export const createTestObserver = () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { CircuitBreakingQueryExecutorImpl } from './health_diagnostic_receiver';
-import { QueryType } from './health_diagnostic_service.types';
+import { QueryType, PermissionError } from './health_diagnostic_service.types';
 import { ValidationError } from './health_diagnostic_circuit_breakers.types';
 import {
   createMockLogger,
@@ -157,6 +157,11 @@ describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryEx
       { _source: { '@timestamp': '2023-01-01T00:01:00Z', event: { action: 'logout' } } },
     ];
 
+    beforeEach(() => {
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true });
+    });
+
     test('should run EQL query with events successfully', (done) => {
       const query = createMockQuery(QueryType.EQL, {
         query: 'process where process.name == "cmd.exe"',
@@ -232,6 +237,11 @@ describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryEx
   });
 
   describe('ES|QL queries', () => {
+    beforeEach(() => {
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: true });
+    });
+
     test('should run ES|QL query successfully', (done) => {
       const query = createMockQuery(QueryType.ESQL, { query: 'stats count() by user.name' });
       const circuitBreaker = createMockCircuitBreaker(true);
@@ -448,6 +458,200 @@ describe('Security Solution - Health Diagnostic Queries - CircuitBreakingQueryEx
         },
         done
       );
+    });
+  });
+
+  describe('Permission checking', () => {
+    test('should proceed when index exists and has read privileges', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      setupPointInTime(mockEsClient);
+      mockEsClient.search.mockResolvedValue(createMockSearchResponse([]));
+
+      executeObservableTest(
+        queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }),
+        () => {
+          expect(mockEsClient.indices.exists).toHaveBeenCalledWith({
+            index: ['test-index'],
+            allow_no_indices: false,
+          });
+          expect(mockEsClient.security.hasPrivileges).toHaveBeenCalledWith({
+            index: [{ names: ['test-index'], privileges: ['read'] }],
+          });
+          expect(mockEsClient.openPointInTime).toHaveBeenCalled();
+          done();
+        },
+        done
+      );
+    });
+
+    test('should throw PermissionError when indices.exists returns false', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(false);
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Index does not exist');
+          expect(mockEsClient.openPointInTime).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError when indices.exists throws', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockRejectedValue(new Error('index_not_found_exception'));
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Error accessing index');
+          expect(error.message).toContain('index_not_found_exception');
+          expect(mockEsClient.openPointInTime).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError when missing read privileges', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: false });
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Error checking privileges');
+          expect(mockEsClient.openPointInTime).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError when security.hasPrivileges throws', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockRejectedValue(new Error('security_exception'));
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Error checking privileges');
+          expect(error.message).toContain('security_exception');
+          expect(mockEsClient.openPointInTime).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should not call closePointInTime when permission check fails', (done) => {
+      const query = createMockQuery(QueryType.DSL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockRejectedValue(new Error('no access'));
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: () => {
+          setTimeout(() => {
+            expect(mockEsClient.closePointInTime).not.toHaveBeenCalled();
+            done();
+          }, 10);
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError for EQL when index does not exist', (done) => {
+      const query = createMockQuery(QueryType.EQL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(false);
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Index does not exist');
+          expect(mockEsClient.eql.search).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError for EQL when missing read privileges', (done) => {
+      const query = createMockQuery(QueryType.EQL);
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: false });
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Error checking privileges');
+          expect(mockEsClient.eql.search).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError for ESQL when index does not exist', (done) => {
+      const query = createMockQuery(QueryType.ESQL, { query: 'stats count() by user.name' });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(false);
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Index does not exist');
+          expect(mockEsClient.helpers.esql).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
+    });
+
+    test('should throw PermissionError for ESQL when missing read privileges', (done) => {
+      const query = createMockQuery(QueryType.ESQL, { query: 'stats count() by user.name' });
+      const circuitBreaker = createMockCircuitBreaker(true);
+
+      mockEsClient.indices.exists.mockResolvedValue(true);
+      mockEsClient.security.hasPrivileges.mockResolvedValue({ has_all_requested: false });
+
+      queryExecutor.search({ query, circuitBreakers: [circuitBreaker] }).subscribe({
+        next: () => {},
+        error: (error) => {
+          expect(error).toBeInstanceOf(PermissionError);
+          expect(error.message).toContain('Error checking privileges');
+          expect(mockEsClient.helpers.esql).not.toHaveBeenCalled();
+          done();
+        },
+        complete: () => done(new Error('Should not complete successfully')),
+      });
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_receiver.ts
@@ -22,6 +22,7 @@ import * as rx from 'rxjs';
 import type { ElasticsearchClient, LogMeta, Logger } from '@kbn/core/server';
 import type {
   EqlSearchRequest,
+  Indices,
   SearchRequest,
   SortResults,
 } from '@elastic/elasticsearch/lib/api/types';
@@ -31,7 +32,11 @@ import {
   type CircuitBreaker,
   type CircuitBreakerResult,
 } from './health_diagnostic_circuit_breakers.types';
-import { type HealthDiagnosticQuery, QueryType } from './health_diagnostic_service.types';
+import {
+  type HealthDiagnosticQuery,
+  QueryType,
+  PermissionError,
+} from './health_diagnostic_service.types';
 import type { TelemetryLogger } from '../telemetry_logger';
 import { newTelemetryLogger, withErrorMessage } from '../helpers';
 
@@ -65,46 +70,85 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
     const regex = /^[\s\r\n]*FROM/;
 
     return from(this.indicesFor(diagnosticQuery)).pipe(
-      mergeMap((index) => {
-        const query = regex.test(diagnosticQuery.query)
-          ? diagnosticQuery.query
-          : `FROM ${index} | ${diagnosticQuery.query}`;
+      mergeMap((index) =>
+        from(this.checkPermissions(index)).pipe(
+          mergeMap(() => {
+            const query = regex.test(diagnosticQuery.query)
+              ? diagnosticQuery.query
+              : `FROM ${index} | ${diagnosticQuery.query}`;
 
-        return from(this.client.helpers.esql({ query }, { signal: abortSignal }).toRecords()).pipe(
-          mergeMap((resp) => {
-            return resp.records.map((r) => r as T);
+            return from(
+              this.client.helpers.esql({ query }, { signal: abortSignal }).toRecords()
+            ).pipe(
+              mergeMap((resp) => {
+                return resp.records.map((r) => r as T);
+              })
+            );
           })
-        );
-      })
+        )
+      )
     );
   }
 
   streamEql<T>(diagnosticQuery: HealthDiagnosticQuery, abortSignal: AbortSignal): Observable<T> {
     return from(this.indicesFor(diagnosticQuery)).pipe(
-      mergeMap((index) => {
-        const request: EqlSearchRequest = {
-          index,
-          query: diagnosticQuery.query,
-          size: diagnosticQuery.size,
-        };
+      mergeMap((index) =>
+        from(this.checkPermissions(index)).pipe(
+          mergeMap(() => {
+            const request: EqlSearchRequest = {
+              index,
+              query: diagnosticQuery.query,
+              size: diagnosticQuery.size,
+            };
 
-        return from(this.client.eql.search(request, { signal: abortSignal })).pipe(
-          mergeMap((resp) => {
-            if (resp.hits.events) {
-              return resp.hits.events.map((h) => h._source as T);
-            } else if (resp.hits.sequences) {
-              return resp.hits.sequences.map((seq) => seq.events.map((h) => h._source) as T);
-            } else {
-              this.logger.warn(
-                '>> Neither hits.events nor hits.sequences found in the response for query',
-                { queryName: diagnosticQuery.name } as LogMeta
-              );
-              return [];
-            }
+            return from(this.client.eql.search(request, { signal: abortSignal })).pipe(
+              mergeMap((resp) => {
+                if (resp.hits.events) {
+                  return resp.hits.events.map((h) => h._source as T);
+                } else if (resp.hits.sequences) {
+                  return resp.hits.sequences.map((seq) => seq.events.map((h) => h._source) as T);
+                } else {
+                  this.logger.warn(
+                    '>> Neither hits.events nor hits.sequences found in the response for query',
+                    { queryName: diagnosticQuery.name } as LogMeta
+                  );
+                  return [];
+                }
+              })
+            );
           })
-        );
-      })
+        )
+      )
     );
+  }
+
+  private async checkPermissions(index: Indices) {
+    let exists = false;
+    try {
+      exists = await this.client.indices.exists({ index, allow_no_indices: false });
+    } catch (e) {
+      throw new PermissionError(`Error accessing index: ${e}`);
+    }
+
+    if (!exists) {
+      throw new PermissionError('Index does not exist');
+    }
+
+    try {
+      const res = await this.client.security.hasPrivileges({
+        index: [
+          {
+            names: index,
+            privileges: ['read'],
+          },
+        ],
+      });
+      if (!res.has_all_requested) {
+        throw new PermissionError('Missing read privileges');
+      }
+    } catch (e) {
+      throw new PermissionError(`Error checking privileges: ${e}`);
+    }
   }
 
   streamDSL<T>(
@@ -130,8 +174,13 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
     };
 
     return from(this.indicesFor(diagnosticQuery)).pipe(
-      mergeMap((index) => from(this.client.openPointInTime({ index, keep_alive: pitKeepAlive }))),
-
+      mergeMap((index) =>
+        from(this.checkPermissions(index)).pipe(
+          mergeMap(() => {
+            return from(this.client.openPointInTime({ index, keep_alive: pitKeepAlive }));
+          })
+        )
+      ),
       map((res) => res.id),
 
       mergeMap((id) => {
@@ -164,9 +213,11 @@ export class CircuitBreakingQueryExecutorImpl implements CircuitBreakingQueryExe
       }),
 
       finalize(() => {
-        this.client.closePointInTime({ id: pitId }).catch((error) => {
-          this.logger.warn('>> closePointInTime error', withErrorMessage(error));
-        });
+        if (pitId !== undefined) {
+          this.client.closePointInTime({ id: pitId }).catch((error) => {
+            this.logger.warn('>> closePointInTime error', withErrorMessage(error));
+          });
+        }
       })
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.test.ts
@@ -10,6 +10,7 @@ import type { ElasticsearchClient, AnalyticsServiceStart, Logger } from '@kbn/co
 import { HealthDiagnosticServiceImpl } from './health_diagnostic_service';
 import { CircuitBreakingQueryExecutorImpl } from './health_diagnostic_receiver';
 import { ValidationError } from './health_diagnostic_circuit_breakers.types';
+import { PermissionError } from './health_diagnostic_service.types';
 import { artifactService } from '../artifact';
 import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import type { TelemetryConfigProvider } from '../../../../common/telemetry_config/telemetry_config_provider';
@@ -204,6 +205,31 @@ describe('Security Solution - Health Diagnostic Queries - HealthDiagnosticServic
             },
           },
         });
+      });
+
+      test('should log info (not error) for PermissionError', async () => {
+        await startService();
+
+        const lastExecutionByQuery = { 'test-query': 1640995200000 };
+        const permissionError = new PermissionError('Missing read privileges');
+        mockQueryExecutor.search.mockReturnValue(throwError(() => permissionError));
+
+        const result = await service.runHealthDiagnosticQueries(lastExecutionByQuery);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          name: 'test-query',
+          passed: false,
+          failure: {
+            message: 'Missing read privileges',
+            reason: undefined,
+          },
+        });
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          'Permission error running query.',
+          expect.objectContaining({ error: permissionError })
+        );
+        expect(mockLogger.error).not.toHaveBeenCalled();
       });
 
       test('should handle artifact service errors gracefully', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.ts
@@ -20,6 +20,7 @@ import type {
   AnalyticsServiceStart,
 } from '@kbn/core/server';
 import {
+  PermissionError,
   type HealthDiagnosticQuery,
   type HealthDiagnosticQueryStats,
   type HealthDiagnosticService,
@@ -172,7 +173,11 @@ export class HealthDiagnosticServiceImpl implements HealthDiagnosticService {
                 message: error.message,
                 reason: error instanceof ValidationError ? error.result : undefined,
               };
-              this.logger.error('Error running query', withErrorMessage(error));
+              if (error instanceof PermissionError) {
+                this.logger.info('Permission error running query.', withErrorMessage(error));
+              } else {
+                this.logger.error('Error running query', withErrorMessage(error));
+              }
               resolve({
                 ...queryStats,
                 failure,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/diagnostic/health_diagnostic_service.types.ts
@@ -160,3 +160,11 @@ export interface HealthDiagnosticQueryFailure {
   message: string;
   reason?: CircuitBreakerResult;
 }
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermissionError';
+    Object.setPrototypeOf(this, PermissionError.prototype);
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -1144,6 +1144,10 @@ export const TELEMETRY_HEALTH_DIAGNOSTIC_QUERY_STATS_EVENT: EventTypeOpts<Health
                 },
               },
             },
+            _meta: {
+              optional: true,
+              description: 'Reason for the failure if the query execution was unsuccessful.',
+            },
           },
         },
         _meta: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Improve DHQ error handling (#256956)](https://github.com/elastic/kibana/pull/256956)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2026-03-13T09:19:01Z","message":"Improve DHQ error handling (#256956)\n\n## Summary\n\nThis PR adds a new specific error type to manage permission-related\nerrors when executing DHQ queries, so we can handle them less verbosely\nwhile still making queries fail and hence sending the proper EBT stats.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>","sha":"ad64335fac51d9ff33eacd05315b04c19a9090e1","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:version","v9.4.0","v9.1.11","v9.2.7","v9.3.2"],"title":"Improve DHQ error handling","number":256956,"url":"https://github.com/elastic/kibana/pull/256956","mergeCommit":{"message":"Improve DHQ error handling (#256956)\n\n## Summary\n\nThis PR adds a new specific error type to manage permission-related\nerrors when executing DHQ queries, so we can handle them less verbosely\nwhile still making queries fail and hence sending the proper EBT stats.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>","sha":"ad64335fac51d9ff33eacd05315b04c19a9090e1"}},"sourceBranch":"main","suggestedTargetBranches":["9.1"],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/256956","number":256956,"mergeCommit":{"message":"Improve DHQ error handling (#256956)\n\n## Summary\n\nThis PR adds a new specific error type to manage permission-related\nerrors when executing DHQ queries, so we can handle them less verbosely\nwhile still making queries fail and hence sending the proper EBT stats.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [ ] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.\n\n---------\n\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>","sha":"ad64335fac51d9ff33eacd05315b04c19a9090e1"}},{"branch":"9.1","label":"v9.1.11","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.2","label":"v9.2.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/257607","number":257607,"state":"MERGED","mergeCommit":{"sha":"b23f6e3c842d6a4fd130358c87439c7944f2607f","message":"[9.2] Improve DHQ error handling (#256956) (#257607)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [Improve DHQ error handling\n(#256956)](https://github.com/elastic/kibana/pull/256956)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/257608","number":257608,"state":"MERGED","mergeCommit":{"sha":"810cd7d210c64fb6378df225b109010440ce4ac0","message":"[9.3] Improve DHQ error handling (#256956) (#257608)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [Improve DHQ error handling\n(#256956)](https://github.com/elastic/kibana/pull/256956)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>\nCo-authored-by: Boris Ilyushonak <57406418+biscout42@users.noreply.github.com>"}}]}] BACKPORT-->