### PR TITLE
[9.3] [Fleet] agent rollback telemetry

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/collectors/agent_upgrade_rollbacks.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/collectors/agent_upgrade_rollbacks.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
+import { getAgentUpgradeRollbacks } from './agent_upgrade_rollbacks';
+
+describe('getAgentUpgradeRollbacks', () => {
+  it('returns 0 when esClient is undefined', async () => {
+    const result = await getAgentUpgradeRollbacks(undefined);
+    expect(result).toEqual({ agent_upgrade_rollbacks: 0 });
+  });
+
+  it('counts only hits where data.rollback is true', async () => {
+    const esClientMock = {
+      search: jest.fn().mockResolvedValue({
+        hits: {
+          hits: [
+            { _source: { data: { rollback: true } } },
+            { _source: { data: { rollback: true } } },
+            { _source: { data: { rollback: false } } },
+            { _source: { data: {} } },
+            { _source: {} },
+          ],
+        },
+      }),
+    } as unknown as ElasticsearchClient;
+
+    const result = await getAgentUpgradeRollbacks(esClientMock);
+    expect(result).toEqual({ agent_upgrade_rollbacks: 2 });
+  });
+
+  it('returns 0 when there are no UPGRADE actions', async () => {
+    const esClientMock = {
+      search: jest.fn().mockResolvedValue({
+        hits: { hits: [] },
+      }),
+    } as unknown as ElasticsearchClient;
+
+    const result = await getAgentUpgradeRollbacks(esClientMock);
+    expect(result).toEqual({ agent_upgrade_rollbacks: 0 });
+  });
+
+  it('queries .fleet-actions with type:UPGRADE and 1h time range', async () => {
+    const searchMock = jest.fn().mockResolvedValue({ hits: { hits: [] } });
+    const esClientMock = { search: searchMock } as unknown as ElasticsearchClient;
+
+    await getAgentUpgradeRollbacks(esClientMock);
+
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    const [params] = searchMock.mock.calls[0];
+    expect(params.index).toBe('.fleet-actions');
+    expect(params.query.bool.filter).toEqual(
+      expect.arrayContaining([
+        { term: { type: 'UPGRADE' } },
+        { range: { '@timestamp': { gte: 'now-1h' } } },
+      ])
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/server/collectors/agent_upgrade_rollbacks.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/collectors/agent_upgrade_rollbacks.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
+import { AGENT_ACTIONS_INDEX, SO_SEARCH_LIMIT } from '../../common';
+
+export interface AgentUpgradeRollbacksData {
+  agent_upgrade_rollbacks: number;
+}
+
+const DEFAULT_DATA: AgentUpgradeRollbacksData = {
+  agent_upgrade_rollbacks: 0,
+};
+
+interface ActionDoc {
+  data?: {
+    rollback?: boolean;
+  };
+}
+
+export async function getAgentUpgradeRollbacks(
+  esClient?: ElasticsearchClient
+): Promise<AgentUpgradeRollbacksData> {
+  if (!esClient) {
+    return DEFAULT_DATA;
+  }
+
+  const res = await esClient.search<ActionDoc>(
+    {
+      index: AGENT_ACTIONS_INDEX,
+      size: SO_SEARCH_LIMIT,
+      _source: ['data.rollback'],
+      query: {
+        bool: {
+          filter: [
+            { term: { type: 'UPGRADE' } },
+            {
+              range: {
+                '@timestamp': {
+                  gte: 'now-1h',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    { ignore: [404] }
+  );
+
+  const count = res.hits.hits.filter((hit) => hit._source?.data?.rollback === true).length;
+
+  return {
+    agent_upgrade_rollbacks: count,
+  };
+}

--- a/x-pack/platform/plugins/shared/fleet/server/collectors/register.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/collectors/register.ts
@@ -29,6 +29,7 @@ import { getAgentsPerOutput } from './agents_per_output';
 import type { IntegrationsDetails } from './integrations_collector';
 import { getIntegrationsDetails } from './integrations_collector';
 import { getModifiedILMs } from './modified_ilms';
+import { getAgentUpgradeRollbacks } from './agent_upgrade_rollbacks';
 
 export interface Usage {
   agents_enabled: boolean;
@@ -52,6 +53,7 @@ export interface FleetUsage extends Usage, AgentData {
   agents_per_output_type: AgentsPerOutputType[];
   integrations_details: IntegrationsDetails[];
   modified_ilms: string[];
+  agent_upgrade_rollbacks: number;
 }
 
 export const fetchFleetUsage = async (
@@ -80,6 +82,7 @@ export const fetchFleetUsage = async (
     integrations_details: await getIntegrationsDetails(soClient),
     agentless_agents: await getAgentUsage(soClient, esClient, true),
     modified_ilms: await getModifiedILMs(),
+    ...(await getAgentUpgradeRollbacks(esClient)),
   };
   return usage;
 };

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -282,6 +282,41 @@ describe('fleet usage telemetry', () => {
       refresh: 'wait_for',
     });
 
+    await esClient.bulk({
+      index: '.fleet-actions',
+      body: [
+        // Rollback action within 1h — should be counted
+        { create: { _id: 'rollback1' } },
+        {
+          type: 'UPGRADE',
+          '@timestamp': new Date().toISOString(),
+          data: { rollback: true, version: '8.11.0' },
+        },
+        // Another rollback within 1h — should be counted
+        { create: { _id: 'rollback2' } },
+        {
+          type: 'UPGRADE',
+          '@timestamp': new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30m ago
+          data: { rollback: true, version: '8.10.0' },
+        },
+        // Non-rollback UPGRADE within 1h — should NOT be counted
+        { create: { _id: 'upgrade-no-rollback' } },
+        {
+          type: 'UPGRADE',
+          '@timestamp': new Date().toISOString(),
+          data: { rollback: false, version: '8.12.0' },
+        },
+        // Rollback outside 1h window — should NOT be counted
+        { create: { _id: 'rollback-old' } },
+        {
+          type: 'UPGRADE',
+          '@timestamp': new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2h ago
+          data: { rollback: true, version: '8.9.0' },
+        },
+      ],
+      refresh: 'wait_for',
+    });
+
     await esClient.create({
       index: 'logs-elastic_agent-default',
       id: 'panic1',
@@ -616,6 +651,7 @@ describe('fleet usage telemetry', () => {
           'stderr panic close of closed channel',
         ]),
         fleet_server_logs_top_errors: ['failed to unenroll offline agents'],
+        agent_upgrade_rollbacks: 2,
         integrations_details: [
           {
             total_integration_policies: 2,

--- a/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -524,6 +524,13 @@ export const fleetUsagesSchema: RootSchema<any> = {
       _meta: { description: 'list of managed ILMs modified by users' },
     },
   },
+  agent_upgrade_rollbacks: {
+    type: 'long',
+    _meta: {
+      description:
+        'Number of agent upgrade rollback actions (type:UPGRADE, data.rollback:true) in the last 1 hour',
+    },
+  },
 };
 
 export const fleetIntegrationsSchema: RootSchema<any> = {


### PR DESCRIPTION
# Backport

This is a backport of PR #260477 to the `9.3` branch.

## Original summary

Added telemetry to fleet-usages to count how many agent upgrade rollback actions were created in the last 1h window.

Closes https://github.com/elastic/ingest-dev/issues/7076

## Conflict resolution

The 9.3 branch does not have `version_specific_policies_collector` (main-only), so the incoming `getVersionSpecificPoliciesUsage` import and related fields were excluded. Only `getAgentUpgradeRollbacks` was cherry-picked.