### PR TITLE
[Search] Add console tutorial for Vector DB

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/index.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/index.ts
@@ -15,6 +15,7 @@ import { agentBuilderTutorialCommands } from './agent_builder';
 
 import type { ConsoleTutorial } from './types';
 import { timeSeriesDataStreamTutorialCommands } from './time_series_data_stream_tutorial';
+import { vectorDatabaseTutorialCommands } from './vector_database_tutorial';
 
 export const consoleTutorials: ConsoleTutorial = {
   basics: basicsTutorialCommands,
@@ -24,6 +25,6 @@ export const consoleTutorials: ConsoleTutorial = {
   semanticSearch: semanticTutorialCommands,
   timeSeriesDataStreams: timeSeriesDataStreamTutorialCommands,
   hybridSearch: `# Hybrid Search Tutorial`,
-  vectorSearch: `# Vector Search Tutorial`,
+  vectorDatabase: vectorDatabaseTutorialCommands,
   agentBuilder: agentBuilderTutorialCommands,
 };

--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/types.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/types.ts
@@ -13,6 +13,6 @@ export interface ConsoleTutorial {
   semanticSearch: string;
   timeSeriesDataStreams: string;
   hybridSearch: string;
-  vectorSearch: string;
+  vectorDatabase: string;
   agentBuilder: string;
 }

--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
@@ -1,0 +1,889 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const vectorDatabaseTutorialCommands: string = `
+# ===============================================
+# Elasticsearch Vector DB Tutorial
+# ===============================================
+
+# Vector databases are the storage and retrieval layer behind most modern AI
+# applications: custom chatbots, LLMs that need context from your data, and
+# recommendation engines ("you might also like"). They're also the foundation
+# of semantic and vector search — search that understands the meaning behind a query,
+# not just the exact words. All of these rely on the same core idea: convert text
+# into numbers that capture meaning, then find the closest matches.
+
+# Elasticsearch is a vector database — and it has a superpower dedicated
+# vector databases don't: you can bring your own embeddings (vectors you generate
+# with OpenAI, Cohere, or any model), OR you can let Elasticsearch generate them
+# for you using its built-in models via Elastic Inference Service (EIS).
+
+# ─────────────────────────────────────────────
+# To build any of these experiences, you'll need to index documents
+# into Elasticsearch.
+# This tutorial uses sample national parks data so you can explore the APIs without
+# needing your own data yet. However, the patterns, field types, and query structures
+# shown are the same ones you'd use in production — not simplified for demo purposes.
+
+# This tutorial covers both approaches below — choose the one
+# that fits your situation:
+
+# PATH A — Let Elastic generate embeddings for you
+# ✓ You index plain text. Elastic converts it to vectors and stores them.
+# ✓ No external AI service, no API key, no extra code to write or maintain.
+
+# PATH B — You generate embeddings outside Elasticsearch
+# (for existing external pipelines)
+# ✓ You already use OpenAI, Cohere, or a custom model
+# running outside of Elasticsearch.
+# → Jump to: PATH B below (Steps B1–B9)
+
+# Not sure? Start with Path A.
+# ─────────────────────────────────────────────
+
+# ╔═══════════════════════════════════════════╗
+# ║ PATH A — Elastic Handles Embeddings ║
+# ╚═══════════════════════════════════════════╝
+
+# Run each step by clicking ▶️ or pressing Ctrl+Enter / Cmd+Enter
+
+# ===============================================
+# PATH A — PART 1: CREATE YOUR INDEX
+# ===============================================
+
+# -----------------------------------------------
+# Step A1: Create the index
+# -----------------------------------------------
+# An index stores your documents in Elasticsearch. Before you insert anything,
+# you define a mapping — a list of fields where each field has a type. The type
+# isn't just a label: it's an instruction — see the inline examples below.
+
+PUT /kibana_sample_data_vectordb
+{
+  "mappings": {
+    "properties": {
+      // "text" — word-searchable; "canyon" matches "Grand Canyon National Park". Use for fields users will search through.
+      "title": { "type": "text" },
+      // "semantic_text" — stores text AND auto-generates vector embeddings. Powers semantic and hybrid search; not BM25-searchable directly.
+      "content": { "type": "semantic_text" },
+      // "keyword" — exact-match only. Use for filters (e.g. source="national-parks"), not for searching words.
+      "source": { "type": "keyword" }
+    }
+  }
+}
+
+# ✅ You should see {"acknowledged": true} — index created successfully.
+
+# Seeing "resource_already_exists_exception"? The index already exists.
+# Run the DELETE below and repeat Step A1.
+DELETE /kibana_sample_data_vectordb
+
+
+# Want to see the index you just created? Go to:
+# Data Management → Index Management → Indices
+# You should see "kibana_sample_data_vectordb" listed. Come back here when done.
+
+# ⚠️ NOTE — the embedding model matters in production
+# This tutorial uses Elasticsearch's default.
+# Before going live, verify it fits your use case:
+# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference/eis
+# To use a specific model, see Step A2 below.
+
+# ╔═══════════════════════════════════════════════════════════╗
+# ║ OPTIONAL: Use a specific Elastic model ║
+# ╚═══════════════════════════════════════════════════════════╝
+
+# -----------------------------------------------
+# Step A2: Choose your embedding model
+# -----------------------------------------------
+# Using the default? Skip this step entirely and go to Step A3.
+# Only run this if you want to use a specific model instead of the default.
+# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference/eis
+
+# To use a specific model: create an inference endpoint and bind it via inference_id.
+
+PUT _inference/text_embedding/my-eis-endpoint
+{
+  "service": "elastic",
+  "service_settings": {
+    "model_id": "jina-embeddings-v3" // check the docs link above for the current model list
+  }
+}
+
+# Then create your index with the model bound to the semantic_text field:
+
+PUT /my-custom-model-index
+{
+  "mappings": {
+    "properties": {
+      "title": { "type": "text" },
+      "content": {
+        "type": "semantic_text",
+        "inference_id": "my-eis-endpoint" // ← binds this field to your chosen model
+      },
+      "source": { "type": "keyword" }
+    }
+  }
+}
+
+# ✅ Inference endpoint created. Continue to Step A3.
+
+# -----------------------------------------------
+# Step A3: Understand mapping constraints
+# -----------------------------------------------
+# You can add new fields to this mapping at any time — just run a PUT mapping
+# request with the new field — Elasticsearch adds it without touching existing docs.
+
+# However, changing an existing field's type is not possible in place.
+# It requires reindexing: create a new index with the updated mapping, re-import
+# your documents, then swap the index. This is why getting the field types right
+# upfront matters. For this tutorial the mapping is already correct — this note
+# is for when you adapt this pattern to your own data.
+
+
+# ===============================================
+# PATH A — PART 2: INDEX YOUR DOCUMENTS
+# ===============================================
+
+# -----------------------------------------------
+# Step A2: Index your documents
+# -----------------------------------------------
+# This step stores 5 sample documents into the index you just created.
+# You might expect to write embedding code here — something like calling OpenAI
+# to convert each document to a vector before sending it to Elasticsearch.
+# You don't need to. That's the point of Path A.
+
+# Elasticsearch generates the vectors for you server-side, invisibly,
+# as each document is stored. When you defined 'content' as type semantic_text
+# in Step A1, you gave Elasticsearch standing instructions: "whenever a document
+# arrives with a field of type semantic_text, call the built-in embedding model,
+# convert the text to a vector, and store both the text and the vector."
+# The vectors are there — you just didn't have to write any code to create them.
+
+# So you send plain text. Elasticsearch stores the text AND the vector.
+# No embedding API call in your code. No model to manage. No extra dependencies.
+
+# We use the bulk API to store multiple documents in one request.
+# The bulk format alternates two lines per document — it looks odd at first:
+# Line 1: metadata — tells Elasticsearch what to do and where to store it
+# {"index": {"_index": "kibana_sample_data_vectordb"}}
+# Line 2: the actual document content you want to store and search
+# {"title": "Yellowstone", "content": "...", "source": "national-parks"}
+# Every pair of lines = one document. 5 pairs below = 5 documents indexed.
+
+# ⏳ If you get a 503 or model error on first run, wait 10–15 seconds and retry.
+# This is normal — the embedding model hasn't been used yet and needs a moment
+# to load into memory. This only happens on the very first request after a period
+# of inactivity (called a cold start). In production with regular traffic,
+# the model stays loaded and this delay disappears entirely.
+
+# ?refresh=wait_for tells Elasticsearch to wait until the indexed documents are
+# visible to search before returning a response. Without it, you might run a
+# search query immediately after indexing and get zero results — because
+# Elasticsearch indexes asynchronously and the documents might not be searchable yet.
+# In production you'd typically remove this parameter (or use refresh=false)
+# since waiting slows down bulk indexing. It's here so your search in Step A3
+# works immediately after you run this step.
+POST /_bulk?refresh=wait_for
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. Its most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Rocky Mountain National Park", "content": "Rocky Mountain National Park receives over 4.5 million visitors annually and is known for its mountainous terrain, including Longs Peak. The park is home to elk, mule deer, moose, and bighorn sheep. It contains montane, subalpine, and alpine tundra ecosystems and is a popular destination for hiking, camping, and wildlife viewing.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Grand Canyon National Park", "content": "The Grand Canyon is a steep-sided canyon carved by the Colorado River in Arizona. It is 277 miles long, up to 18 miles wide and attains a depth of over a mile. The park receives nearly six million visitors per year and offers hiking, rafting, and helicopter tours. It is one of the Seven Natural Wonders of the World.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Zion National Park", "content": "Zion National Park is located in southwestern Utah and is known for its steep red cliffs and narrow canyons. The Virgin River runs through the main canyon. The park is famous for the Angels Landing and Narrows hikes, and receives over four million visitors annually. Wildlife includes mule deer, mountain lions, and California condors.", "source": "national-parks"}
+
+# ✅ You should see: {"errors": false, "took": ..., "items": [...]}
+# "errors": false means all 5 documents indexed successfully.
+# If errors is true, check the "items" array for which document failed and why.
+# If something looks wrong and you want to start fresh, run Step A7 (DELETE) first,
+# then re-run Steps A1 and A2. Deleting the index removes everything and lets you
+# start clean with a new mapping.
+
+
+# ===============================================
+# PATH A — PART 3: SEARCH YOUR DATA
+# ===============================================
+
+# -----------------------------------------------
+# Step A3: Semantic-only search — demonstration step
+# -----------------------------------------------
+# This step shows what semantic search does well — and where it falls short.
+# Both examples use the same search mechanism. The contrast sets up why
+# hybrid search (Step A4) is the right default.
+
+# QUERY 1 — where semantic shines:
+# "volcanic activity" doesn't appear anywhere in our data. But Yellowstone's
+# content mentions "Yellowstone Caldera", "super volcano", and "geyser" — all
+# descriptions of the same concept. Semantic finds it. Keyword search wouldn't.
+
+GET /kibana_sample_data_vectordb/_search
+{
+  "retriever": {
+    "standard": {
+      "query": {
+        "semantic": {
+          "field": "content",
+          "query": "volcanic activity"
+        }
+      }
+    }
+  }
+}
+
+# ✅ Yellowstone should rank first — zero shared words, pure meaning match.
+
+# QUERY 2 — where semantic falls short:
+# "El Capitan" is the famous cliff in Yosemite — mentioned by name in the content.
+# Semantic search may not rank Yosemite first — it looks for meaning-similarity,
+# not exact word matches. A proper noun with no surrounding context is hard for a
+# semantic model to anchor. Keyword search (BM25) would find it immediately.
+
+GET /kibana_sample_data_vectordb/_search
+{
+  "retriever": {
+    "standard": {
+      "query": {
+        "semantic": {
+          "field": "content",
+          "query": "El Capitan"
+        }
+      }
+    }
+  }
+}
+
+# ✅ Check whether Yosemite ranked first. If it didn't — that's the point.
+# Semantic search trades exact-match precision for meaning-based recall.
+# Step A4 fixes this by combining both.
+
+# -----------------------------------------------
+# Step A4: Hybrid search — keyword + semantic combined USE THIS IN PRODUCTION
+# -----------------------------------------------
+# This is the query pattern you should use as your default.
+# It runs both a keyword retriever (BM25) and a semantic retriever simultaneously,
+# then merges the results using RRF (Reciprocal Rank Fusion).
+
+# Run the same "El Capitan" query from Step A3 — but this time as hybrid.
+# BM25 finds the exact words in Yosemite's content. Semantic adds context.
+# RRF fuses both rankings. Yosemite should now rank first — the exact-match weakness
+# from Step A3 is fixed.
+
+# Hybrid also handles the "volcanic activity" case from Step A3: semantic finds
+# Yellowstone via meaning, BM25 contributes where there are exact title matches.
+# You get both — that's why it's the default.
+
+GET /kibana_sample_data_vectordb/_search
+{
+  "retriever": {
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "match": {
+                "title": "El Capitan"
+                // BM25: finds documents where the title contains these exact words
+              }
+            }
+          }
+        },
+        {
+          "standard": {
+            "query": {
+              "semantic": {
+                "field": "content",
+                "query": "El Capitan"
+                // Semantic: finds documents whose meaning is closest to this phrase
+              }
+            }
+          }
+        }
+      ],
+      "rank_window_size": 50, // How many candidates from each retriever to consider before fusion
+      "rank_constant": 20 // Controls how aggressively top-ranked results are favored
+    }
+  }
+}
+
+# ✅ Yosemite should now rank first — the exact-match weakness from Step A3 is fixed.
+# BM25 caught "El Capitan" directly. Semantic reinforced with meaning-based context.
+# RRF fused both rankings into one.
+# 📖 https://www.elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
+
+# -----------------------------------------------
+# Step A5: Add a filter to the hybrid search
+# -----------------------------------------------
+# This step shows how to restrict which documents are searched
+# without affecting the relevance score of the results that do match.
+# This is how you implement access control, tenant isolation, or category filtering.
+# Apply the same filter to both retrievers so they search the same subset.
+
+# Example real-world uses:
+# filter by user_id → each user only searches their own documents
+# filter by org_id → multi-tenant SaaS, each company sees only their data
+# filter by category → search only within a specific section of your content
+
+GET /kibana_sample_data_vectordb/_search
+{
+  "retriever": {
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "bool": {
+                "must": { "match": { "title": "wildlife" } },
+                "filter": { "term": { "source": "national-parks" } }
+                // filter: only search documents where source equals "national-parks"
+                // This doesn't affect the score of matched documents — it just excludes others
+              }
+            }
+          }
+        },
+        {
+          "standard": {
+            "query": {
+              "bool": {
+                "must": {
+                  "semantic": {
+                    "field": "content",
+                    "query": "rock climbing destinations"
+                  }
+                },
+                "filter": { "term": { "source": "national-parks" } }
+                // Apply the same filter to the semantic retriever too
+              }
+            }
+          }
+        }
+      ],
+      "rank_window_size": 50
+    }
+  }
+}
+
+# ✅ Only documents with source="national-parks" appear in results.
+
+
+# ===============================================
+# PATH A — PART 4: USE THIS IN YOUR APPLICATION
+# ===============================================
+
+# -----------------------------------------------
+# Step A6: Retrieve chunks for a RAG pipeline
+# -----------------------------------------------
+# RAG (Retrieval-Augmented Generation) is a pattern where you:
+# 1. Search your data for relevant documents (this step)
+# 2. Pass those documents as context to an LLM (e.g. ChatGPT, Claude)
+# 3. The LLM answers the user's question based on that context
+
+# This query is designed for step 1: return only the top 3 most relevant
+# documents and only the fields your LLM needs (title and content).
+# Fewer fields = fewer tokens = cheaper LLM calls.
+
+GET /kibana_sample_data_vectordb/_search
+{
+  "size": 3, // Return only the top 3 results
+  "_source": ["title", "content"], // Only return these fields — omit vectors and metadata
+  "retriever": {
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "match": { "title": "best park for families" }
+            }
+          }
+        },
+        {
+          "standard": {
+            "query": {
+              "semantic": {
+                "field": "content",
+                "query": "best park for families with children"
+              }
+            }
+          }
+        }
+      ],
+      "rank_window_size": 50
+    }
+  }
+}
+
+# ✅ The 3 results you get back feed directly into your LLM prompt as context.
+# Your application code would look like:
+# chunks = [hit["_source"]["content"] for hit in response["hits"]["hits"]]
+# prompt = f"Answer based on this context:\n{chunks}\n\nQuestion: {user_question}"
+
+# To connect with popular AI frameworks:
+# 📖 LangChain (Python): https://www.elastic.co/search-labs/integrations/langchain
+# 📖 LlamaIndex (Python): https://www.elastic.co/search-labs/integrations/llama-index
+
+
+# ===============================================
+# PATH A — CLEANUP (optional)
+# ===============================================
+
+# Step A7: Delete the index
+# This step removes the sample index and everything in it.
+# Run this the same way you ran the steps above — paste it in the console and hit ▶️.
+# Warning: this permanently deletes all 5 documents. Cannot be undone.
+
+DELETE /kibana_sample_data_vectordb
+
+# ✅ You should see: {"acknowledged": true}
+
+# -----------------------------------------------
+# Path A complete.
+
+# What you built: a semantic retrieval layer using 0 lines of embedding code.
+# What Elastic handled: model selection, vector generation, vector storage,
+# query-time embedding generation, and automatic chunking of long documents.
+
+# When you're ready to go deeper:
+# - Add reranking: a second AI pass that re-orders top results for higher precision
+# 📖 https://www.elastic.co/docs/solutions/search/ranking/semantic-reranking
+# - Connect to LangChain for full RAG pipelines
+# 📖 https://www.elastic.co/search-labs/integrations/langchain
+# -----------------------------------------------
+
+
+# ╔═══════════════════════════════════════════╗
+# ║ PATH B — Bring Your Own Embeddings ║
+# ╚═══════════════════════════════════════════╝
+# Run each step by clicking ▶️ or pressing Ctrl+Enter / Cmd+Enter
+
+# Use this path if you already generate vectors outside of Elasticsearch —
+# for example, you're calling OpenAI's embeddings API, Cohere, or a custom model
+# running on your own infrastructure.
+
+# The key difference from Path A: instead of semantic_text (which hides everything),
+# you use a dense_vector field and are responsible for generating vectors yourself,
+# both at ingest time and at query time.
+
+# ⚠️ The most important rule in this path (read before starting):
+# You must use the EXACT SAME model at ingest time and at query time.
+# If you index documents with OpenAI's text-embedding-3-small,
+# you must also embed queries with text-embedding-3-small.
+# Mixing models produces meaningless results — documents and queries
+# would be encoded in different vector spaces with no shared meaning.
+# Changing models later requires re-embedding and re-indexing every document.
+# Choose carefully before you index real data at scale.
+
+# Note: if you want to use a specific Elastic model but still have Elastic
+# generate embeddings, see the "Optional: Choose a specific Elastic model"
+# section at the end of Path A above. Path B is specifically for cases where
+# the embedding model lives outside of Elasticsearch.
+
+
+# ===============================================
+# PATH B — PART 1: CONNECT TO YOUR EXTERNAL EMBEDDING MODEL
+# ===============================================
+
+# -----------------------------------------------
+# Step B1: Register your external embedding model with Elasticsearch
+# -----------------------------------------------
+# This step creates a named connection to the model that generates your vectors.
+# Elasticsearch calls this an "inference endpoint" — you give it a name
+# ("my-embedding-endpoint") and reference that name in later steps whenever
+# Elasticsearch needs to call the model to embed a query at search time.
+
+# ⚠️ Production note: whatever model you choose here, you must use the exact same
+# model at query time too. If you index with OpenAI text-embedding-3-small,
+# your search
+# queries must also be embedded with text-embedding-3-small. Mixing models produces
+# meaningless results. Changing models later means re-embedding all your documents.
+# For this tutorial the model is already set up correctly — this note is for when
+# you adapt the pattern to your own data.
+
+# Use OpenAI or another external provider (Cohere, Azure OpenAI, etc.):
+
+PUT _inference/text_embedding/my-embedding-endpoint
+{
+  "service": "openai",
+  "service_settings": {
+    "api_key": "YOUR_OPENAI_API_KEY", // Replace with your actual key
+    "model_id": "text-embedding-3-small"
+    // text-embedding-3-small outputs 1536-dimensional vectors
+    // You'll need to set dims: 1536 in Step B2
+  }
+}
+
+# ✅ You should see an object with "inference_id": "my-embedding-endpoint"
+# The "inference_id" is what you'll reference in later steps.
+
+# Other supported providers: Cohere, Azure OpenAI, Amazon Bedrock, Google Vertex
+# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference
+
+
+# ===============================================
+# PATH B — PART 2: CREATE YOUR INDEX
+# ===============================================
+
+# -----------------------------------------------
+# Step B2: Create the index
+# -----------------------------------------------
+# This step creates an empty index — same concept as Step A1, but the mapping
+# is different. Instead of semantic_text (which hides vectors inside a single field),
+# here you declare a separate dense_vector field that stores the raw numbers.
+# You control the dimensions, similarity function, and compression level.
+
+# The 'dims' value must exactly match your model's output size — this is the
+# most common mistake in Path B and requires a full reindex to fix if wrong.
+
+# Model dimension reference:
+# Jina v3 (default above): 1024 (can also use 256 or 512 via Matryoshka)
+# OpenAI text-embedding-3-small: 1536
+# OpenAI text-embedding-3-large: 3072
+# Cohere embed-v3: 1024
+# E5-small: 384
+
+# 'int8_hnsw' is the index type — it stores vectors in a compressed format
+# that uses roughly 4x less memory with minimal impact on search quality.
+# Use 'hnsw' instead if you need maximum accuracy and don't care about memory.
+
+PUT /kibana_sample_data_vectordb_byoe
+{
+  "mappings": {
+    "properties": {
+      "title": { "type": "text" }, // Standard keyword search field (BM25)
+      "content": { "type": "text" }, // The original text — stored for display
+      "content_embedding": {
+        "type": "dense_vector",
+        "dims": 1024, // ← Must match your model's output size exactly
+        "index": true, // Must be true to enable vector search
+        "similarity": "cosine", // How to measure similarity between vectors
+        "index_options": {
+          "type": "int8_hnsw" // Compressed index — ~4x memory savings
+        }
+      },
+      "source": { "type": "keyword" } // Label field for filtering — e.g. tenant ID, category, document source
+    }
+  }
+}
+
+# ✅ You should see: {"acknowledged": true, "shards_acknowledged": true}
+# Unlike Path A, this index stores text and vectors as separate fields.
+# You are responsible for making sure they stay in sync.
+# 📖 https://elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector
+
+
+# ===============================================
+# PATH B — PART 3: SET UP EMBEDDING AT INGEST TIME
+# ===============================================
+
+# -----------------------------------------------
+# Step B3: Create an ingest pipeline that auto-generates vectors
+# -----------------------------------------------
+# This step creates a reusable pipeline that runs on every document before
+# it's stored. When a document arrives, the pipeline calls the inference
+# endpoint from Step B1, generates the vector from the 'content' field,
+# and writes it to 'content_embedding' — all before the document is saved.
+
+# Your application sends plain text. The pipeline generates and stores the embedding.
+# This keeps embedding logic out of your application code and in one place.
+
+# If you'd rather generate vectors in your application code before indexing,
+# skip this step and see Step B4b instead.
+
+PUT _ingest/pipeline/embedding-pipeline
+{
+  "description": "Generate embeddings for the content field before indexing",
+  "processors": [
+    {
+      "inference": {
+        "model_id": "my-embedding-endpoint", // The inference endpoint from Step B1
+        "input_output": [
+          {
+            "input_field": "content", // Read text from this field
+            "output_field": "content_embedding" // Write the vector to this field
+          }
+        ]
+      }
+    }
+  ]
+}
+
+# ✅ You should see: {"acknowledged": true}
+# The pipeline is now available to use during indexing.
+
+
+# ===============================================
+# PATH B — PART 4: INDEX YOUR DOCUMENTS
+# ===============================================
+
+# -----------------------------------------------
+# Step B4a: Index your documents (pipeline generates embeddings automatically)
+# -----------------------------------------------
+# This step stores documents into the index. By passing ?pipeline=embedding-pipeline,
+# each document is automatically routed through the pipeline before storage.
+# The pipeline calls the inference endpoint, generates the vector from 'content',
+# and adds it to 'content_embedding'. You send text; Elasticsearch stores both.
+
+# ⏳ If you get a model error on first run, wait 10–15 seconds and retry.
+
+# ?pipeline=embedding-pipeline — route each document through the pipeline
+# ?refresh=wait_for — wait until searchable before returning (same as Step A2)
+POST /_bulk?pipeline=embedding-pipeline&refresh=wait_for
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. Its most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Rocky Mountain National Park", "content": "Rocky Mountain National Park receives over 4.5 million visitors annually and is known for its mountainous terrain, including Longs Peak. The park is home to elk, mule deer, moose, and bighorn sheep. It contains montane, subalpine, and alpine tundra ecosystems and is a popular destination for hiking, camping, and wildlife viewing.", "source": "national-parks"}
+
+# ✅ You should see: {"errors": false, "took": ..., "items": [...]}
+# "errors": false confirms all documents were embedded and indexed successfully.
+
+# -----------------------------------------------
+# Step B4b: Application-side embedding (alternative)
+# -----------------------------------------------
+# Use this instead of Steps B3/B4a if you prefer to generate vectors in your
+# application before sending them to Elasticsearch. Some teams prefer this
+# when they want full control over batching, retries, or preprocessing.
+
+# ⚠️ Reminder: use the same model here as in Step B1.
+
+# Python example (run in your app, not in this console):
+
+# from elasticsearch import Elasticsearch, helpers
+# import openai
+
+# es = Elasticsearch("https://your-cluster:443", api_key="YOUR_API_KEY")
+# client = openai.OpenAI()
+
+# def embed(text):
+# # Calls OpenAI to convert text to a list of 1536 numbers
+# return client.embeddings.create(
+# model="text-embedding-3-small", input=text
+# ).data[0].embedding
+
+# helpers.bulk(es, [
+# {
+# "_index": "kibana_sample_data_vectordb_byoe",
+# "_source": {
+# "title": "Yellowstone National Park",
+# "content": "Yellowstone is famous for Old Faithful...",
+# "content_embedding": embed("Yellowstone..."),
+# # Pass the pre-computed vector directly — Elasticsearch stores it as-is
+# "source": "national-parks"
+# }
+# }
+# ])
+
+# ⚠️ At query time (Step B5), you must also call embed() on the user's query
+# before passing it to Elasticsearch. The query vector must use the same model.
+
+
+# ===============================================
+# PATH B — PART 5: SEARCH YOUR DATA
+# ===============================================
+
+# -----------------------------------------------
+# Step B5: Run your first vector search
+# -----------------------------------------------
+# This step searches the index using kNN — k-nearest neighbors.
+# It finds the k documents whose vectors are closest in meaning to your query.
+# "query_vector_builder" tells Elasticsearch to call the inference endpoint
+# to embed the search string at query time — using the same model as ingest.
+# Same model = vectors are in the same "space" = meaningful comparison.
+
+# num_candidates: how many candidate documents to evaluate per shard before
+# returning top k. Higher = better recall but slower. Start at 50–100.
+
+GET /kibana_sample_data_vectordb_byoe/_search
+{
+  "retriever": {
+    "knn": {
+      "field": "content_embedding", // The dense_vector field to search
+      "query_vector_builder": {
+        "text_embedding": {
+          "model_id": "my-embedding-endpoint", // Calls this endpoint to embed the query
+          "model_text": "volcanic activity"
+        }
+      },
+      "k": 3, // Return the top 3 most similar documents
+      "num_candidates": 50 // Evaluate 50 candidates per shard — increase for better recall
+    }
+  }
+}
+
+# ✅ Results ranked by vector similarity. Higher "_score" = closer meaning match.
+
+# -----------------------------------------------
+# Step B6: Run a hybrid search — the recommended default
+# -----------------------------------------------
+# This step upgrades from pure vector search to hybrid: combining kNN (meaning-based)
+# with BM25 (keyword-based) via RRF — same idea as Step A6, different retrievers.
+# This should be your default query pattern — it outperforms either method alone.
+
+GET /kibana_sample_data_vectordb_byoe/_search
+{
+  "retriever": {
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "match": {
+                "title": "mountain wildlife"
+                // BM25: keyword matching on the title field
+              }
+            }
+          }
+        },
+        {
+          "knn": {
+            "field": "content_embedding",
+            "query_vector_builder": {
+              "text_embedding": {
+                "model_id": "my-embedding-endpoint",
+                "model_text": "mountain wildlife hiking"
+                // Vector search: meaning-based matching on the content embedding
+              }
+            },
+            "k": 10,
+            "num_candidates": 50
+          }
+        }
+      ],
+      "rank_window_size": 50, // Candidates from each retriever before RRF fusion
+      "rank_constant": 20
+    }
+  }
+}
+
+# ✅ Combined keyword + vector results, fused by RRF.
+# 📖 https://www.elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
+
+# -----------------------------------------------
+# Step B7: Add a filter to the hybrid search
+# -----------------------------------------------
+# This step restricts which documents are searched — same concept as Path A Step A5.
+# Apply the filter to both the BM25 retriever and the kNN retriever.
+# If you only apply it to one, the other will search the full index.
+
+GET /kibana_sample_data_vectordb_byoe/_search
+{
+  "retriever": {
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "bool": {
+                "must": { "match": { "content": "rock climbing" } },
+                "filter": { "term": { "source": "national-parks" } }
+              }
+            }
+          }
+        },
+        {
+          "knn": {
+            "field": "content_embedding",
+            "query_vector_builder": {
+              "text_embedding": {
+                "model_id": "my-embedding-endpoint",
+                "model_text": "rock climbing destinations"
+              }
+            },
+            "k": 10,
+            "num_candidates": 50,
+            "filter": { "term": { "source": "national-parks" } }
+            // Apply the filter to the kNN retriever too — otherwise it searches all documents
+          }
+        }
+      ],
+      "rank_window_size": 50
+    }
+  }
+}
+
+# ✅ Only documents with source="national-parks" appear in results.
+
+
+# ===============================================
+# PATH B — PART 6: PREPARE FOR PRODUCTION ⚠️
+# ===============================================
+
+# -----------------------------------------------
+# Step B8: Create an alias and verify your mapping
+# -----------------------------------------------
+# This step does two things before you go to production:
+
+# First: create an alias — a pointer to your index. Your application queries
+# the alias name ("vectordb-current"), never the raw index name. This matters
+# because changing your embedding model later means re-embedding all documents
+# into a new index, then swapping the alias. With an alias, your application
+# code never changes. Without one, every model upgrade requires a code deployment.
+
+# Second: verify the mapping looks correct — specifically that 'dims' matches
+# your model's output. If it's wrong, the time to find out is before you index
+# real production data, not after.
+
+# The reindex-on-model-change flow:
+# 1. Create index_v2 with the new model's dims
+# 2. Re-embed and re-index all documents into index_v2
+# 3. POST /_aliases: swap alias from v1 to v2 — atomic, zero downtime
+# 4. Delete index_v1
+
+PUT /kibana_sample_data_vectordb_byoe/_alias/vectordb-current
+
+# ✅ You should see: {"acknowledged": true}
+# Your app should now reference "vectordb-current" instead of the full index name.
+# 📖 https://www.elastic.co/docs/manage-data/data-store/aliases
+
+# Verify your index looks correct before going to production:
+
+GET /kibana_sample_data_vectordb_byoe/_mapping
+
+# ✅ Confirm 'content_embedding' shows:
+# "type": "dense_vector"
+# "dims": 1024 (or whatever your model outputs)
+# "index": true
+# If dims is wrong, delete the index and start from Step B2 with the correct value.
+
+
+# ===============================================
+# PATH B — CLEANUP (optional)
+# ===============================================
+
+# Step B9: Delete all resources created in this tutorial
+# Run each DELETE request below the same way as earlier — paste and hit ▶️.
+# Warning: deleting the index permanently removes all stored documents and vectors.
+
+DELETE /kibana_sample_data_vectordb_byoe
+
+DELETE _ingest/pipeline/embedding-pipeline
+
+DELETE _inference/text_embedding/my-embedding-endpoint
+
+# ✅ You should see: {"acknowledged": true} for each deletion.
+
+# -----------------------------------------------
+# Path B complete.
+
+# What you built: a vector database with full control over the embedding model.
+
+# Key things to remember:
+# - Same model at ingest time AND query time — always
+# - dims must match your model's output size — check before indexing real data
+# - Create the alias before indexing production data — model changes require reindex
+# - Hybrid search (kNN + BM25 via RRF) is the default — don't use vector-only
+
+# When you're ready to improve search quality:
+# - Reranking: a second AI pass on the top results for higher precision
+# 📖 https://www.elastic.co/docs/solutions/search/ranking/semantic-reranking
+# - _rank_eval: measure your search quality objectively with labeled test queries
+# 📖 https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval
+# -----------------------------------------------
+`;

--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
@@ -10,139 +10,117 @@ export const vectorDatabaseTutorialCommands: string = `
 # Elasticsearch Vector DB Tutorial
 # ===============================================
 
-# Vector databases are the storage and retrieval layer behind most modern AI
-# applications: custom chatbots, LLMs that need context from your data, and
-# recommendation engines ("you might also like"). They're also the foundation
-# of semantic and vector search — search that understands the meaning behind a query,
-# not just the exact words. All of these rely on the same core idea: convert text
-# into numbers that capture meaning, then find the closest matches.
+# Vector databases are the storage and retrieval layer behind AI applications like chatbots, RAG pipelines, and recommendation engines. They also enable semantic search, which matches on meaning rather than exact words. The core idea: convert text into numerical vectors (embeddings) that capture semantic meaning, then find the closest matches.
 
-# Elasticsearch is a vector database — and it has a superpower dedicated
-# vector databases don't: you can bring your own embeddings (vectors you generate
-# with OpenAI, Cohere, or any model), OR you can let Elasticsearch generate them
-# for you using its built-in models via Elastic Inference Service (EIS).
+# Elasticsearch is a vector database that lets you bring your own embeddings (from OpenAI, Cohere, etc.) or generate them automatically via Elastic Inference Service (EIS).
 
-# ─────────────────────────────────────────────
-# To build any of these experiences, you'll need to index documents
-# into Elasticsearch.
-# This tutorial uses sample national parks data so you can explore the APIs without
-# needing your own data yet. However, the patterns, field types, and query structures
-# shown are the same ones you'd use in production — not simplified for demo purposes.
+# ───────────────────────────────────────────────
 
-# This tutorial covers both approaches below — choose the one
-# that fits your situation:
+# This tutorial uses sample national parks data so you can explore the APIs without needing your own data. The patterns, field types, and query structures shown are the same ones you'd use in production.
 
-# PATH A — Let Elastic generate embeddings for you
-# ✓ You index plain text. Elastic converts it to vectors and stores them.
-# ✓ No external AI service, no API key, no extra code to write or maintain.
+# Choose the path that fits your situation:
 
-# PATH B — You generate embeddings outside Elasticsearch
-# (for existing external pipelines)
-# ✓ You already use OpenAI, Cohere, or a custom model
-# running outside of Elasticsearch.
-# → Jump to: PATH B below (Steps B1–B9)
+# 🎯 PATH A — Let Elastic generate embeddings for you
+#   ✓ You index plain text sample data. Elastic converts it to vectors and stores them.
+#   ✓ No external AI service, no API key, no extra code.
+
+# 🎯 PATH B — You generate embeddings outside Elasticsearch (for existing external pipelines)
+#   ✓ You already use OpenAI, Cohere, or a custom model running outside Elasticsearch.
+#   ➡️ Jump to: PATH B below (Steps B1-B9)
 
 # Not sure? Start with Path A.
-# ─────────────────────────────────────────────
+
 
 # ╔═══════════════════════════════════════════╗
-# ║ PATH A — Elastic Handles Embeddings ║
+#   PATH A — Elastic generated embeddings       
 # ╚═══════════════════════════════════════════╝
 
-# Run each step by clicking ▶️ or pressing Ctrl+Enter / Cmd+Enter
+# After selecting a command, execute it by clicking the ▶️ button or pressing Ctrl+Enter or Cmd+Enter.
 
 # ===============================================
-# PATH A — PART 1: CREATE YOUR INDEX
+# PATH A — PART 1: CREATING AN INDEX
 # ===============================================
 
 # -----------------------------------------------
-# Step A1: Create the index
+# 📦 Step A1: Create your index
 # -----------------------------------------------
-# An index stores your documents in Elasticsearch. Before you insert anything,
-# you define a mapping — a list of fields where each field has a type. The type
-# isn't just a label: it's an instruction — see the inline examples below.
+# An index is where your documents live in Elasticsearch. Before indexing documents, you define a mapping (a schema that declares each field and its type). The field type controls how Elasticsearch stores and searches the data, so choosing the right type is the most important decision you make per field.
+
+# Annotated version of the mapping you'll create:
+
+# {
+#  "mappings": {
+#   "properties": {
+#     "title": {
+#       "type": "text" // Full-text search via BM25. Matches individual words: "Canyon" finds "Grand Canyon National Park".
+#     },
+#     "semantic_text": {
+#       "type": "semantic_text" // Stores text and auto-generates vector embeddings. Enables search by meaning, not just keywords.
+#     },
+#     "content": {
+#       "type": "text", // Full-text search via BM25, like "title".
+#       "copy_to": "semantic_text" // Copies content into the semantic_text field so embeddings are generated automatically.
+#     },
+#     "source": {
+#       "type": "keyword" // Exact-match only. Designed for filtering and aggregations (e.g. source="national-parks"), not full-text search.
+#     }
+#   }
+#  }
+# }
+
+# Create your index with mappings for each field:
+
+# ⚠️ NOTE — the embedding model matters in production
+# This tutorial uses Elasticsearch's default inference model. Before going live, verify it fits your use case:
+#   📖 https://elastic.co/docs/explore-analyze/elastic-inference/eis
+
+# To use a specific model, add the inference ID associated with the model to the "inference_id" field below.
 
 PUT /kibana_sample_data_vectordb
 {
   "mappings": {
     "properties": {
-      // "text" — word-searchable; "canyon" matches "Grand Canyon National Park". Use for fields users will search through.
-      "title": { "type": "text" },
-      // "semantic_text" — stores text AND auto-generates vector embeddings. Powers semantic and hybrid search; not BM25-searchable directly.
-      "content": { "type": "semantic_text" },
-      // "keyword" — exact-match only. Use for filters (e.g. source="national-parks"), not for searching words.
-      "source": { "type": "keyword" }
+      "title": { 
+        "type": "text" 
+      },
+      "semantic_text": {
+        "type": "semantic_text",
+        "inference_id": ".jina-embeddings-v3" // ← Specify an inference endpoint ID, or remove if using the default.
+      },
+      "content": {
+        "type": "text",
+        "copy_to": "semantic_text"
+      },
+      "source": { 
+        "type": "keyword" 
+      }
     }
   }
 }
 
-# ✅ You should see {"acknowledged": true} — index created successfully.
+# ✅ You should see {"acknowledged": true}.
 
 # Seeing "resource_already_exists_exception"? The index already exists.
 # Run the DELETE below and repeat Step A1.
+
 DELETE /kibana_sample_data_vectordb
 
 
-# Want to see the index you just created? Go to:
-# Data Management → Index Management → Indices
-# You should see "kibana_sample_data_vectordb" listed. Come back here when done.
-
-# ⚠️ NOTE — the embedding model matters in production
-# This tutorial uses Elasticsearch's default.
-# Before going live, verify it fits your use case:
-# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference/eis
-# To use a specific model, see Step A2 below.
-
-# ╔═══════════════════════════════════════════════════════════╗
-# ║ OPTIONAL: Use a specific Elastic model ║
-# ╚═══════════════════════════════════════════════════════════╝
-
 # -----------------------------------------------
-# Step A2: Choose your embedding model
+# 🔧 Step A2: Understand mapping constraints (optional)
 # -----------------------------------------------
-# Using the default? Skip this step entirely and go to Step A3.
-# Only run this if you want to use a specific model instead of the default.
-# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference/eis
+# You can add new fields at any time with a PUT mapping request. Elasticsearch adds them without touching existing docs.
 
-# To use a specific model: create an inference endpoint and bind it via inference_id.
-
-PUT _inference/text_embedding/my-eis-endpoint
+PUT /kibana_sample_data_vectordb/_mapping
 {
-  "service": "elastic",
-  "service_settings": {
-    "model_id": "jina-embeddings-v3" // check the docs link above for the current model list
-  }
-}
-
-# Then create your index with the model bound to the semantic_text field:
-
-PUT /my-custom-model-index
-{
-  "mappings": {
-    "properties": {
-      "title": { "type": "text" },
-      "content": {
-        "type": "semantic_text",
-        "inference_id": "my-eis-endpoint" // ← binds this field to your chosen model
-      },
-      "source": { "type": "keyword" }
+  "properties": {
+    "subtitle": { 
+      "type": "text" 
     }
   }
 }
 
-# ✅ Inference endpoint created. Continue to Step A3.
-
-# -----------------------------------------------
-# Step A3: Understand mapping constraints
-# -----------------------------------------------
-# You can add new fields to this mapping at any time — just run a PUT mapping
-# request with the new field — Elasticsearch adds it without touching existing docs.
-
-# However, changing an existing field's type is not possible in place.
-# It requires reindexing: create a new index with the updated mapping, re-import
-# your documents, then swap the index. This is why getting the field types right
-# upfront matters. For this tutorial the mapping is already correct — this note
-# is for when you adapt this pattern to your own data.
+# ⚠️ NOTE — Changing an existing field's type requires reindexing. You'd need to create a new index with the updated mapping, reimport your documents, then swap. Getting field types right upfront matters. The mapping in this tutorial is already correct, but keep this in mind for your own data.
 
 
 # ===============================================
@@ -150,49 +128,24 @@ PUT /my-custom-model-index
 # ===============================================
 
 # -----------------------------------------------
-# Step A2: Index your documents
+# 📄 Step A3: Index your documents
 # -----------------------------------------------
-# This step stores 5 sample documents into the index you just created.
-# You might expect to write embedding code here — something like calling OpenAI
-# to convert each document to a vector before sending it to Elasticsearch.
-# You don't need to. That's the point of Path A.
+# Index 5 sample documents. No embedding code needed: 'content' copies into 'semantic_text', so Elasticsearch generates and stores vectors automatically.
 
-# Elasticsearch generates the vectors for you server-side, invisibly,
-# as each document is stored. When you defined 'content' as type semantic_text
-# in Step A1, you gave Elasticsearch standing instructions: "whenever a document
-# arrives with a field of type semantic_text, call the built-in embedding model,
-# convert the text to a vector, and store both the text and the vector."
-# The vectors are there — you just didn't have to write any code to create them.
+# The bulk API indexes multiple documents in one request, with two lines per document:
+#   Line 1 (metadata):  {"index": {"_index": "kibana_sample_data_vectordb"}}
+#   Line 2 (document):  {"title": "Yellowstone", "content": "...", "source": "national-parks"}
 
-# So you send plain text. Elasticsearch stores the text AND the vector.
-# No embedding API call in your code. No model to manage. No extra dependencies.
+# ⏳ 503 or model error on first run? Wait 10-15 seconds and retry.
+# If the model hasn't loaded yet, it needs a moment to start (cold start). In production with regular traffic, the model stays loaded.
 
-# We use the bulk API to store multiple documents in one request.
-# The bulk format alternates two lines per document — it looks odd at first:
-# Line 1: metadata — tells Elasticsearch what to do and where to store it
-# {"index": {"_index": "kibana_sample_data_vectordb"}}
-# Line 2: the actual document content you want to store and search
-# {"title": "Yellowstone", "content": "...", "source": "national-parks"}
-# Every pair of lines = one document. 5 pairs below = 5 documents indexed.
+# "?refresh=wait_for" blocks until the documents are searchable. Remove it in production to avoid slowing down bulk indexing.
 
-# ⏳ If you get a 503 or model error on first run, wait 10–15 seconds and retry.
-# This is normal — the embedding model hasn't been used yet and needs a moment
-# to load into memory. This only happens on the very first request after a period
-# of inactivity (called a cold start). In production with regular traffic,
-# the model stays loaded and this delay disappears entirely.
-
-# ?refresh=wait_for tells Elasticsearch to wait until the indexed documents are
-# visible to search before returning a response. Without it, you might run a
-# search query immediately after indexing and get zero results — because
-# Elasticsearch indexes asynchronously and the documents might not be searchable yet.
-# In production you'd typically remove this parameter (or use refresh=false)
-# since waiting slows down bulk indexing. It's here so your search in Step A3
-# works immediately after you run this step.
 POST /_bulk?refresh=wait_for
 { "index": { "_index": "kibana_sample_data_vectordb" } }
-{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. Its most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
+{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. It's most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb" } }
-{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
+{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. Its most famous cliff, El Capitan, rises about 3,000 feet from Yosemite Valley. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb" } }
 {"title": "Rocky Mountain National Park", "content": "Rocky Mountain National Park receives over 4.5 million visitors annually and is known for its mountainous terrain, including Longs Peak. The park is home to elk, mule deer, moose, and bighorn sheep. It contains montane, subalpine, and alpine tundra ecosystems and is a popular destination for hiking, camping, and wildlife viewing.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb" } }
@@ -202,10 +155,10 @@ POST /_bulk?refresh=wait_for
 
 # ✅ You should see: {"errors": false, "took": ..., "items": [...]}
 # "errors": false means all 5 documents indexed successfully.
-# If errors is true, check the "items" array for which document failed and why.
-# If something looks wrong and you want to start fresh, run Step A7 (DELETE) first,
-# then re-run Steps A1 and A2. Deleting the index removes everything and lets you
-# start clean with a new mapping.
+
+# If "errors": true, inspect the "items" array for details. To start fresh, run the DELETE request, then re-run Steps A1 and A3.
+
+DELETE /kibana_sample_data_vectordb
 
 
 # ===============================================
@@ -213,16 +166,12 @@ POST /_bulk?refresh=wait_for
 # ===============================================
 
 # -----------------------------------------------
-# Step A3: Semantic-only search — demonstration step
+# 🔍 Step A4: Semantic-only search — demonstration step
 # -----------------------------------------------
-# This step shows what semantic search does well — and where it falls short.
-# Both examples use the same search mechanism. The contrast sets up why
-# hybrid search (Step A4) is the right default.
+# This step has two examples that show what semantic search does well and where it falls short. The contrast sets up why hybrid search (Step A5) is the better default.
 
-# QUERY 1 — where semantic shines:
-# "volcanic activity" doesn't appear anywhere in our data. But Yellowstone's
-# content mentions "Yellowstone Caldera", "super volcano", and "geyser" — all
-# descriptions of the same concept. Semantic finds it. Keyword search wouldn't.
+# QUERY 1 - where semantic shines:
+# "volcanic activity" doesn't appear anywhere in our data, but Yellowstone's content mentions "Yellowstone Caldera", "super volcano", and "geyser". Semantic search finds it by meaning when keyword search wouldn't.
 
 GET /kibana_sample_data_vectordb/_search
 {
@@ -230,7 +179,7 @@ GET /kibana_sample_data_vectordb/_search
     "standard": {
       "query": {
         "semantic": {
-          "field": "content",
+          "field": "semantic_text",
           "query": "volcanic activity"
         }
       }
@@ -238,13 +187,10 @@ GET /kibana_sample_data_vectordb/_search
   }
 }
 
-# ✅ Yellowstone should rank first — zero shared words, pure meaning match.
+# ✅ Yellowstone should rank first. Zero shared words, pure meaning match.
 
-# QUERY 2 — where semantic falls short:
-# "El Capitan" is the famous cliff in Yosemite — mentioned by name in the content.
-# Semantic search may not rank Yosemite first — it looks for meaning-similarity,
-# not exact word matches. A proper noun with no surrounding context is hard for a
-# semantic model to anchor. Keyword search (BM25) would find it immediately.
+# QUERY 2 - where semantic falls short:
+# "Arizona" is mentioned by name in Grand Canyon's content. Semantic search may not rank Grand Canyon first because it looks for meaning-similarity, not exact word matches. A proper noun with no surrounding context is hard for a semantic model to anchor. Keyword search (BM25) would find it immediately.
 
 GET /kibana_sample_data_vectordb/_search
 {
@@ -252,33 +198,27 @@ GET /kibana_sample_data_vectordb/_search
     "standard": {
       "query": {
         "semantic": {
-          "field": "content",
-          "query": "El Capitan"
+          "field": "semantic_text",
+          "query": "Arizona"
         }
       }
     }
   }
 }
 
-# ✅ Check whether Yosemite ranked first. If it didn't — that's the point.
+# ✅ Check whether Grand Canyon ranked first. If it didn't, that's the point.
+
 # Semantic search trades exact-match precision for meaning-based recall.
-# Step A4 fixes this by combining both.
+# Step A5 fixes this by combining both.
 
 # -----------------------------------------------
-# Step A4: Hybrid search — keyword + semantic combined USE THIS IN PRODUCTION
+# ⚡ Step A5: Hybrid search — keyword + semantic combined
 # -----------------------------------------------
-# This is the query pattern you should use as your default.
-# It runs both a keyword retriever (BM25) and a semantic retriever simultaneously,
-# then merges the results using RRF (Reciprocal Rank Fusion).
+# This is the query pattern you should use as your default in production. It runs both a keyword retriever (BM25) and a semantic retriever, then merges results using RRF (Reciprocal Rank Fusion).
 
-# Run the same "El Capitan" query from Step A3 — but this time as hybrid.
-# BM25 finds the exact words in Yosemite's content. Semantic adds context.
-# RRF fuses both rankings. Yosemite should now rank first — the exact-match weakness
-# from Step A3 is fixed.
+# Run the same "Arizona" query from Step A4, but as hybrid. BM25 finds the exact words in Grand Canyon's content. Semantic adds context. RRF fuses both rankings. Grand Canyon should now rank first.
 
-# Hybrid also handles the "volcanic activity" case from Step A3: semantic finds
-# Yellowstone via meaning, BM25 contributes where there are exact title matches.
-# You get both — that's why it's the default.
+# Hybrid also handles the "volcanic activity" case from Step A4: semantic finds Yellowstone via meaning, BM25 contributes where there are exact title matches.
 
 GET /kibana_sample_data_vectordb/_search
 {
@@ -289,8 +229,8 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "match": {
-                "title": "El Capitan"
-                // BM25: finds documents where the title contains these exact words
+                "content": "Arizona"
+                // BM25: finds documents where the content contains these exact words
               }
             }
           }
@@ -299,37 +239,44 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "semantic": {
-                "field": "content",
-                "query": "El Capitan"
-                // Semantic: finds documents whose meaning is closest to this phrase
+                "field": "semantic_text",
+                "query": "Arizona"
+                // Semantic: finds documents whose meaning is closest to this word
               }
             }
           }
         }
       ],
       "rank_window_size": 50, // How many candidates from each retriever to consider before fusion
-      "rank_constant": 20 // Controls how aggressively top-ranked results are favored
+      "rank_constant": 20 // Lower values favor top-ranked results more aggressively. Higher values weight ranks more equally.
     }
   }
 }
 
-# ✅ Yosemite should now rank first — the exact-match weakness from Step A3 is fixed.
-# BM25 caught "El Capitan" directly. Semantic reinforced with meaning-based context.
+# ✅ Grand Canyon should now rank first.
+
+# BM25 caught "Arizona" directly. Semantic reinforced it with meaning-based context.
 # RRF fused both rankings into one.
-# 📖 https://www.elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
+# 📖 https://elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
+
 
 # -----------------------------------------------
-# Step A5: Add a filter to the hybrid search
+# 🔒 Step A6: Add a filter to the hybrid search
 # -----------------------------------------------
-# This step shows how to restrict which documents are searched
-# without affecting the relevance score of the results that do match.
-# This is how you implement access control, tenant isolation, or category filtering.
-# Apply the same filter to both retrievers so they search the same subset.
+# Filters restrict which documents are searched without affecting relevance scores. Use this for access control, tenant isolation, or category filtering.
 
 # Example real-world uses:
-# filter by user_id → each user only searches their own documents
-# filter by org_id → multi-tenant SaaS, each company sees only their data
-# filter by category → search only within a specific section of your content
+#   👤 filter by user_id → each user only searches their own documents
+#   🏢 filter by org_id → multi-tenant SaaS, each company sees only their data
+#   🏷️ filter by category → search only within a specific section of your content
+
+# First, index a document with source "state-park" so we can verify the filter (source: "national-parks") excludes it from results.
+
+POST /_bulk?refresh=wait_for
+{ "index": { "_index": "kibana_sample_data_vectordb" } }
+{"title": "Harriman State Park", "content": "Harriman State Park is one of the largest state parks in New York, covering approximately 47,000 acres in the Hudson Valley region. The park features over 200 miles of hiking trails, 31 lakes and reservoirs, and stunning views of the surrounding landscape. It is home to white-tailed deer, black bears, wild turkeys, and a variety of bird species. Popular activities include hiking, fishing, swimming, and cross-country skiing in winter. The park also contains several historic sites, including old iron mines and the remains of early 20th century villages.", "source": "state-park"}
+
+# Apply the same filter to both retrievers so they search the same subset.
 
 GET /kibana_sample_data_vectordb/_search
 {
@@ -340,10 +287,10 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "bool": {
-                "must": { "match": { "title": "wildlife" } },
+                "must": { "match": { "content": "hiking" } },
+                // must: full-text match that scores documents by relevance to the query term
                 "filter": { "term": { "source": "national-parks" } }
                 // filter: only search documents where source equals "national-parks"
-                // This doesn't affect the score of matched documents — it just excludes others
               }
             }
           }
@@ -354,8 +301,8 @@ GET /kibana_sample_data_vectordb/_search
               "bool": {
                 "must": {
                   "semantic": {
-                    "field": "content",
-                    "query": "rock climbing destinations"
+                    "field": "semantic_text",
+                    "query": "hiking"
                   }
                 },
                 "filter": { "term": { "source": "national-parks" } }
@@ -374,19 +321,21 @@ GET /kibana_sample_data_vectordb/_search
 
 
 # ===============================================
-# PATH A — PART 4: USE THIS IN YOUR APPLICATION
+# PATH A — PART 4: RETRIEVE CONTEXT FOR RAG
 # ===============================================
 
+# For use in your application.
+
 # -----------------------------------------------
-# Step A6: Retrieve chunks for a RAG pipeline
+# 🤖 Step A7: Retrieve chunks for a RAG pipeline
 # -----------------------------------------------
 # RAG (Retrieval-Augmented Generation) is a pattern where you:
-# 1. Search your data for relevant documents (this step)
-# 2. Pass those documents as context to an LLM (e.g. ChatGPT, Claude)
-# 3. The LLM answers the user's question based on that context
+#   1. Search your data for relevant documents (this step)
+#   2. Pass those documents as context to an LLM (e.g. ChatGPT, Claude)
+#   3. The LLM answers the user's question based on that context
 
-# This query is designed for step 1: return only the top 3 most relevant
-# documents and only the fields your LLM needs (title and content).
+# This query is designed for step 1 in the RAG pattern. It returns only the top 3 most relevant documents and only the fields your LLM needs (title and content).
+
 # Fewer fields = fewer tokens = cheaper LLM calls.
 
 GET /kibana_sample_data_vectordb/_search
@@ -399,7 +348,7 @@ GET /kibana_sample_data_vectordb/_search
         {
           "standard": {
             "query": {
-              "match": { "title": "best park for families" }
+              "match": { "content": "best park for wildlife" }
             }
           }
         },
@@ -407,8 +356,8 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "semantic": {
-                "field": "content",
-                "query": "best park for families with children"
+                "field": "semantic_text",
+                "query": "best park for wildlife"
               }
             }
           }
@@ -419,70 +368,60 @@ GET /kibana_sample_data_vectordb/_search
   }
 }
 
-# ✅ The 3 results you get back feed directly into your LLM prompt as context.
-# Your application code would look like:
+# ✅ The 3 results feed directly into your LLM prompt as context.
+
+# Your application code might look like:
+
 # chunks = [hit["_source"]["content"] for hit in response["hits"]["hits"]]
-# prompt = f"Answer based on this context:\n{chunks}\n\nQuestion: {user_question}"
+# prompt = f"Answer based on this context: {chunks} Question: {user_question}"
 
 # To connect with popular AI frameworks:
-# 📖 LangChain (Python): https://www.elastic.co/search-labs/integrations/langchain
-# 📖 LlamaIndex (Python): https://www.elastic.co/search-labs/integrations/llama-index
+#   📖 LangChain (Python): https://elastic.co/search-labs/integrations/langchain
+#   📖 LlamaIndex (Python): https://elastic.co/search-labs/integrations/llama-index
 
 
 # ===============================================
 # PATH A — CLEANUP (optional)
 # ===============================================
 
-# Step A7: Delete the index
+# -----------------------------------------------
+# 🧹 Step A8: Delete the index
+# -----------------------------------------------
 # This step removes the sample index and everything in it.
-# Run this the same way you ran the steps above — paste it in the console and hit ▶️.
-# Warning: this permanently deletes all 5 documents. Cannot be undone.
+# Warning: this permanently deletes all 6 documents. Cannot be undone.
 
 DELETE /kibana_sample_data_vectordb
 
 # ✅ You should see: {"acknowledged": true}
 
 # -----------------------------------------------
+
 # Path A complete.
 
-# What you built: a semantic retrieval layer using 0 lines of embedding code.
-# What Elastic handled: model selection, vector generation, vector storage,
-# query-time embedding generation, and automatic chunking of long documents.
+# What you built: a semantic retrieval layer using zero lines of embedding code.
+# What Elastic handled: model selection, vector generation, storage, query-time embedding, and automatic chunking of long documents.
 
 # When you're ready to go deeper:
-# - Add reranking: a second AI pass that re-orders top results for higher precision
-# 📖 https://www.elastic.co/docs/solutions/search/ranking/semantic-reranking
-# - Connect to LangChain for full RAG pipelines
-# 📖 https://www.elastic.co/search-labs/integrations/langchain
+#   - Add reranking: a second AI pass that re-orders top results for higher precision
+#     📖 https://elastic.co/docs/solutions/search/ranking/semantic-reranking
+#   - Connect to LangChain for full RAG pipelines
+#     📖 https://elastic.co/search-labs/integrations/langchain
+
 # -----------------------------------------------
 
 
 # ╔═══════════════════════════════════════════╗
-# ║ PATH B — Bring Your Own Embeddings ║
+#   PATH B — Bring Your Own Embeddings
 # ╚═══════════════════════════════════════════╝
+
 # Run each step by clicking ▶️ or pressing Ctrl+Enter / Cmd+Enter
 
-# Use this path if you already generate vectors outside of Elasticsearch —
-# for example, you're calling OpenAI's embeddings API, Cohere, or a custom model
-# running on your own infrastructure.
+# Use this path if you already generate vectors outside of Elasticsearch, for example by calling OpenAI's embeddings API, Cohere, or a custom model on your own infrastructure.
 
-# The key difference from Path A: instead of semantic_text (which hides everything),
-# you use a dense_vector field and are responsible for generating vectors yourself,
-# both at ingest time and at query time.
+# The key difference from Path A: instead of semantic_text (which handles everything), you use a dense_vector field and are responsible for generating vectors yourself, both at ingest time and at query time.
 
 # ⚠️ The most important rule in this path (read before starting):
-# You must use the EXACT SAME model at ingest time and at query time.
-# If you index documents with OpenAI's text-embedding-3-small,
-# you must also embed queries with text-embedding-3-small.
-# Mixing models produces meaningless results — documents and queries
-# would be encoded in different vector spaces with no shared meaning.
-# Changing models later requires re-embedding and re-indexing every document.
-# Choose carefully before you index real data at scale.
-
-# Note: if you want to use a specific Elastic model but still have Elastic
-# generate embeddings, see the "Optional: Choose a specific Elastic model"
-# section at the end of Path A above. Path B is specifically for cases where
-# the embedding model lives outside of Elasticsearch.
+# You must use the SAME model at ingest time and at query time. If you index documents with OpenAI's text-embedding-3-small, you must also embed queries with text-embedding-3-small. Mixing models produces meaningless results because documents and queries would be in different vector spaces. Changing models later requires re-embedding and reindexing every document. Choose carefully before indexing real data at scale.
 
 
 # ===============================================
@@ -490,29 +429,18 @@ DELETE /kibana_sample_data_vectordb
 # ===============================================
 
 # -----------------------------------------------
-# Step B1: Register your external embedding model with Elasticsearch
+# 🔌 Step B1: Register your external embedding model with Elasticsearch
 # -----------------------------------------------
-# This step creates a named connection to the model that generates your vectors.
-# Elasticsearch calls this an "inference endpoint" — you give it a name
-# ("my-embedding-endpoint") and reference that name in later steps whenever
-# Elasticsearch needs to call the model to embed a query at search time.
-
-# ⚠️ Production note: whatever model you choose here, you must use the exact same
-# model at query time too. If you index with OpenAI text-embedding-3-small,
-# your search
-# queries must also be embedded with text-embedding-3-small. Mixing models produces
-# meaningless results. Changing models later means re-embedding all your documents.
-# For this tutorial the model is already set up correctly — this note is for when
-# you adapt the pattern to your own data.
+# This step creates a named connection (an "inference endpoint") to the model that generates your vectors. You reference this name ("my-embedding-endpoint") in later steps whenever Elasticsearch needs to embed a query at search time.
 
 # Use OpenAI or another external provider (Cohere, Azure OpenAI, etc.):
 
-PUT _inference/text_embedding/my-embedding-endpoint
+PUT /_inference/text_embedding/my-embedding-endpoint
 {
   "service": "openai",
   "service_settings": {
-    "api_key": "YOUR_OPENAI_API_KEY", // Replace with your actual key
-    "model_id": "text-embedding-3-small"
+    "api_key": "YOUR_OPENAI_API_KEY", // ⚠️ Replace with your actual key
+    "model_id": "text-embedding-3-small" // Model ID from OpenAI or your chosen provider
     // text-embedding-3-small outputs 1536-dimensional vectors
     // You'll need to set dims: 1536 in Step B2
   }
@@ -522,7 +450,7 @@ PUT _inference/text_embedding/my-embedding-endpoint
 # The "inference_id" is what you'll reference in later steps.
 
 # Other supported providers: Cohere, Azure OpenAI, Amazon Bedrock, Google Vertex
-# 📖 https://www.elastic.co/docs/explore-analyze/elastic-inference
+# 📖 https://elastic.co/docs/explore-analyze/elastic-inference
 
 
 # ===============================================
@@ -530,50 +458,79 @@ PUT _inference/text_embedding/my-embedding-endpoint
 # ===============================================
 
 # -----------------------------------------------
-# Step B2: Create the index
+# 📦 Step B2: Create the index
 # -----------------------------------------------
-# This step creates an empty index — same concept as Step A1, but the mapping
-# is different. Instead of semantic_text (which hides vectors inside a single field),
-# here you declare a separate dense_vector field that stores the raw numbers.
+# Same concept as Step A1, but the mapping is different. Instead of semantic_text (which hides vectors inside a single field), you declare a separate dense_vector field that stores the raw numbers.
+
 # You control the dimensions, similarity function, and compression level.
 
-# The 'dims' value must exactly match your model's output size — this is the
-# most common mistake in Path B and requires a full reindex to fix if wrong.
+# The 'dims' value must exactly match your model's output size. This is the most common mistake in Path B and requires a full reindex to fix.
 
 # Model dimension reference:
-# Jina v3 (default above): 1024 (can also use 256 or 512 via Matryoshka)
-# OpenAI text-embedding-3-small: 1536
-# OpenAI text-embedding-3-large: 3072
-# Cohere embed-v3: 1024
-# E5-small: 384
+#   - Jina v3 (default in PATH A): 1024 (also supports 256 or 512 via Matryoshka)
+#   - OpenAI text-embedding-3-small: 1536
+#   - OpenAI text-embedding-3-large: 3072
+#   - Cohere embed-v3: 1024
+#   - E5-small: 384
 
-# 'int8_hnsw' is the index type — it stores vectors in a compressed format
-# that uses roughly 4x less memory with minimal impact on search quality.
-# Use 'hnsw' instead if you need maximum accuracy and don't care about memory.
+# Annotated version of the mapping you'll create:
+
+# {
+#  "mappings": {
+#   "properties": {
+#     "title": {
+#       "type": "text" // Full-text search via BM25.
+#     },
+#     "content": {
+#       "type": "text" // The original text. Stored for display and BM25 search. Embeddings are stored separately.
+#     },
+#     "content_embedding": {
+#       "type": "dense_vector", // Stores the raw vector (list of numbers) from your embedding model.
+#       "dims": 1536, // Must exactly match your model's output size. Wrong dims = full reindex to fix.
+#       "index": true, // Required for kNN search. Without this, vectors are stored but not searchable.
+#       "similarity": "cosine", // How Elasticsearch measures closeness between vectors. Cosine is the most common choice.
+#       "index_options": {
+#         "type": "int8_hnsw" // Compressed index type for ~4x memory savings.
+#         // Use 'hnsw' instead if you need maximum accuracy without concern for memory.
+#       }
+#     },
+#     "source": {
+#       "type": "keyword" // Exact-match only. Used for filtering, e.g. tenant ID, category, document source
+#     }
+#   }
+#  }
+# }
 
 PUT /kibana_sample_data_vectordb_byoe
 {
   "mappings": {
     "properties": {
-      "title": { "type": "text" }, // Standard keyword search field (BM25)
-      "content": { "type": "text" }, // The original text — stored for display
+      "title": { 
+        "type": "text" 
+      },
+      "content": { 
+        "type": "text"
+      }, 
       "content_embedding": {
         "type": "dense_vector",
-        "dims": 1024, // ← Must match your model's output size exactly
-        "index": true, // Must be true to enable vector search
-        "similarity": "cosine", // How to measure similarity between vectors
+        "dims": 1536, // ⚠️ Must match your model's output size exactly
+        "index": true,
+        "similarity": "cosine",
         "index_options": {
-          "type": "int8_hnsw" // Compressed index — ~4x memory savings
+          "type": "int8_hnsw"
         }
       },
-      "source": { "type": "keyword" } // Label field for filtering — e.g. tenant ID, category, document source
+      "source": { 
+        "type": "keyword"
+      }
     }
   }
 }
 
 # ✅ You should see: {"acknowledged": true, "shards_acknowledged": true}
+
 # Unlike Path A, this index stores text and vectors as separate fields.
-# You are responsible for making sure they stay in sync.
+# You are responsible for keeping them in sync.
 # 📖 https://elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector
 
 
@@ -581,21 +538,19 @@ PUT /kibana_sample_data_vectordb_byoe
 # PATH B — PART 3: SET UP EMBEDDING AT INGEST TIME
 # ===============================================
 
+# ⚡ Prefer to generate embeddings in your own code? Skip Parts 3 and 4, go to Step B5.
+
 # -----------------------------------------------
-# Step B3: Create an ingest pipeline that auto-generates vectors
+# ⚙️ Step B3: Create an ingest pipeline that auto-generates vectors
 # -----------------------------------------------
-# This step creates a reusable pipeline that runs on every document before
-# it's stored. When a document arrives, the pipeline calls the inference
-# endpoint from Step B1, generates the vector from the 'content' field,
-# and writes it to 'content_embedding' — all before the document is saved.
+# This step creates a reusable pipeline that runs on every document before it's stored. The pipeline calls the inference endpoint from Step B1, generates the vector from 'content', and writes it to 'content_embedding' before saving.
 
 # Your application sends plain text. The pipeline generates and stores the embedding.
-# This keeps embedding logic out of your application code and in one place.
+# This keeps embedding logic out of your application code.
 
-# If you'd rather generate vectors in your application code before indexing,
-# skip this step and see Step B4b instead.
+# If you'd rather generate vectors in your application, skip Steps B3 and B4 and go to Step B5.
 
-PUT _ingest/pipeline/embedding-pipeline
+PUT /_ingest/pipeline/embedding-pipeline
 {
   "description": "Generate embeddings for the content field before indexing",
   "processors": [
@@ -614,91 +569,89 @@ PUT _ingest/pipeline/embedding-pipeline
 }
 
 # ✅ You should see: {"acknowledged": true}
-# The pipeline is now available to use during indexing.
+# The pipeline is now available for indexing.
 
 
 # ===============================================
-# PATH B — PART 4: INDEX YOUR DOCUMENTS
+# PATH B — PART 4: INDEX YOUR DOCUMENTS (VIA PIPELINE)
 # ===============================================
 
 # -----------------------------------------------
-# Step B4a: Index your documents (pipeline generates embeddings automatically)
+# 📄 Step B4: Index your documents (pipeline generates embeddings automatically)
 # -----------------------------------------------
-# This step stores documents into the index. By passing ?pipeline=embedding-pipeline,
-# each document is automatically routed through the pipeline before storage.
-# The pipeline calls the inference endpoint, generates the vector from 'content',
-# and adds it to 'content_embedding'. You send text; Elasticsearch stores both.
+# By passing ?pipeline=embedding-pipeline, each document is routed through the pipeline before storage. The pipeline calls the inference endpoint, generates the vector from 'content', and writes it to 'content_embedding'. You send text; Elasticsearch stores both.
 
-# ⏳ If you get a model error on first run, wait 10–15 seconds and retry.
+# ⏳ Model error on first run? Wait 10-15 seconds and retry.
 
 # ?pipeline=embedding-pipeline — route each document through the pipeline
-# ?refresh=wait_for — wait until searchable before returning (same as Step A2)
+# ?refresh=wait_for — wait until searchable before returning (same as Step A3)
+
 POST /_bulk?pipeline=embedding-pipeline&refresh=wait_for
 { "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
-{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. Its most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
+{"title": "Yellowstone National Park", "content": "Yellowstone National Park is one of the largest national parks in the United States. It ranges from Wyoming to Montana and Idaho, and contains an area of 2,219,791 acres. It's most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
-{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
+{"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. Its most famous cliff, El Capitan, rises about 3,000 feet from Yosemite Valley. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
 {"title": "Rocky Mountain National Park", "content": "Rocky Mountain National Park receives over 4.5 million visitors annually and is known for its mountainous terrain, including Longs Peak. The park is home to elk, mule deer, moose, and bighorn sheep. It contains montane, subalpine, and alpine tundra ecosystems and is a popular destination for hiking, camping, and wildlife viewing.", "source": "national-parks"}
 
 # ✅ You should see: {"errors": false, "took": ..., "items": [...]}
-# "errors": false confirms all documents were embedded and indexed successfully.
+# "errors": false confirms all documents were embedded and indexed.
+
+
+# ===============================================
+# PATH B — PART 5: APP-SIDE EMBEDDING (ALTERNATIVE TO PARTS 3-4)
+# ===============================================
 
 # -----------------------------------------------
-# Step B4b: Application-side embedding (alternative)
+# 💻 Step B5: Index your documents (your app generates embeddings)
 # -----------------------------------------------
-# Use this instead of Steps B3/B4a if you prefer to generate vectors in your
-# application before sending them to Elasticsearch. Some teams prefer this
-# when they want full control over batching, retries, or preprocessing.
+# Use this if you generate vectors in your application before sending them to Elasticsearch. Some teams prefer this for full control over batching, retries, or preprocessing.
 
 # ⚠️ Reminder: use the same model here as in Step B1.
 
-# Python example (run in your app, not in this console):
+#╭─────────────────── Python example ────────────────────╮
+#           (run in your app, not in this console)
+#
+#  from elasticsearch import Elasticsearch, helpers
+#  import openai
+#
+#  es = Elasticsearch("https://your-cluster:443", api_key="YOUR_API_KEY")
+#  client = openai.OpenAI()
+#
+#  def embed(text):
+#      # Calls OpenAI to convert text to a list of 1536 numbers
+#      return client.embeddings.create(
+#          model="text-embedding-3-small", input=text
+#      ).data[0].embedding
+#
+#  helpers.bulk(es, [
+#      {
+#          "_index": "kibana_sample_data_vectordb_byoe",
+#          "_source": {
+#              "title": "Yellowstone National Park",
+#              "content": "Yellowstone is famous for Old Faithful...",
+#              "content_embedding": embed("Yellowstone..."),
+#              # Pass the pre-computed vector directly — Elasticsearch stores it as-is
+#              "source": "national-parks"
+#          }
+#      }
+#  ])
+#
+# ╰───────────────────────────────────────────────────────╯
 
-# from elasticsearch import Elasticsearch, helpers
-# import openai
-
-# es = Elasticsearch("https://your-cluster:443", api_key="YOUR_API_KEY")
-# client = openai.OpenAI()
-
-# def embed(text):
-# # Calls OpenAI to convert text to a list of 1536 numbers
-# return client.embeddings.create(
-# model="text-embedding-3-small", input=text
-# ).data[0].embedding
-
-# helpers.bulk(es, [
-# {
-# "_index": "kibana_sample_data_vectordb_byoe",
-# "_source": {
-# "title": "Yellowstone National Park",
-# "content": "Yellowstone is famous for Old Faithful...",
-# "content_embedding": embed("Yellowstone..."),
-# # Pass the pre-computed vector directly — Elasticsearch stores it as-is
-# "source": "national-parks"
-# }
-# }
-# ])
-
-# ⚠️ At query time (Step B5), you must also call embed() on the user's query
-# before passing it to Elasticsearch. The query vector must use the same model.
+# ⚠️ At query time (Step B6), you must also call embed() on the user's query before passing it to Elasticsearch. The query vector must use the same model.
 
 
 # ===============================================
-# PATH B — PART 5: SEARCH YOUR DATA
+# PATH B — PART 6: SEARCH YOUR DATA
 # ===============================================
 
 # -----------------------------------------------
-# Step B5: Run your first vector search
+# 🔍 Step B6: Run your first vector search
 # -----------------------------------------------
-# This step searches the index using kNN — k-nearest neighbors.
-# It finds the k documents whose vectors are closest in meaning to your query.
-# "query_vector_builder" tells Elasticsearch to call the inference endpoint
-# to embed the search string at query time — using the same model as ingest.
-# Same model = vectors are in the same "space" = meaningful comparison.
+# This step searches using kNN (k-nearest neighbors), finding the k documents whose vectors are closest in meaning to your query. "query_vector_builder" tells Elasticsearch to call the inference endpoint to embed the search string at query time.
 
-# num_candidates: how many candidate documents to evaluate per shard before
-# returning top k. Higher = better recall but slower. Start at 50–100.
+# num_candidates: how many candidates to evaluate per shard before returning top k. Higher = better recall but slower. Start at 50 to 100.
 
 GET /kibana_sample_data_vectordb_byoe/_search
 {
@@ -720,10 +673,10 @@ GET /kibana_sample_data_vectordb_byoe/_search
 # ✅ Results ranked by vector similarity. Higher "_score" = closer meaning match.
 
 # -----------------------------------------------
-# Step B6: Run a hybrid search — the recommended default
+# ⚡ Step B7: Run a hybrid search — the recommended default
 # -----------------------------------------------
-# This step upgrades from pure vector search to hybrid: combining kNN (meaning-based)
-# with BM25 (keyword-based) via RRF — same idea as Step A6, different retrievers.
+# This step combines kNN (meaning-based) with BM25 (keyword-based) via RRF. Same idea as Step A5, different retrievers.
+
 # This should be your default query pattern — it outperforms either method alone.
 
 GET /kibana_sample_data_vectordb_byoe/_search
@@ -735,8 +688,8 @@ GET /kibana_sample_data_vectordb_byoe/_search
           "standard": {
             "query": {
               "match": {
-                "title": "mountain wildlife"
-                // BM25: keyword matching on the title field
+                "content": "mountain wildlife"
+                // BM25: keyword matching on the content field
               }
             }
           }
@@ -747,7 +700,7 @@ GET /kibana_sample_data_vectordb_byoe/_search
             "query_vector_builder": {
               "text_embedding": {
                 "model_id": "my-embedding-endpoint",
-                "model_text": "mountain wildlife hiking"
+                "model_text": "mountain wildlife"
                 // Vector search: meaning-based matching on the content embedding
               }
             },
@@ -763,14 +716,20 @@ GET /kibana_sample_data_vectordb_byoe/_search
 }
 
 # ✅ Combined keyword + vector results, fused by RRF.
-# 📖 https://www.elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
+# 📖 https://elastic.co/docs/solutions/search/ranking/reciprocal-rank-fusion
 
 # -----------------------------------------------
-# Step B7: Add a filter to the hybrid search
+# 🔒 Step B8: Add a filter to the hybrid search
 # -----------------------------------------------
-# This step restricts which documents are searched — same concept as Path A Step A5.
-# Apply the filter to both the BM25 retriever and the kNN retriever.
-# If you only apply it to one, the other will search the full index.
+# This step restricts which documents are searched, same concept as Step A6.
+
+# First, index a document with source "state-park" to verify the filter (source: "national-parks") excludes it from results.
+
+POST /_bulk?pipeline=embedding-pipeline&refresh=wait_for
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Harriman State Park", "content": "Harriman State Park is one of the largest state parks in New York, covering approximately 47,000 acres in the Hudson Valley region. The park features over 200 miles of hiking trails, 31 lakes and reservoirs, and stunning views of the surrounding landscape. It is home to white-tailed deer, black bears, wild turkeys, and a variety of bird species. Popular activities include hiking, fishing, swimming, and cross-country skiing in winter. The park also contains several historic sites, including old iron mines and the remains of early 20th century villages.", "source": "state-park"}
+
+# Apply the filter to both the BM25 and kNN retrievers. If you only apply it to one, the other searches the full index.
 
 GET /kibana_sample_data_vectordb_byoe/_search
 {
@@ -799,7 +758,6 @@ GET /kibana_sample_data_vectordb_byoe/_search
             "k": 10,
             "num_candidates": 50,
             "filter": { "term": { "source": "national-parks" } }
-            // Apply the filter to the kNN retriever too — otherwise it searches all documents
           }
         }
       ],
@@ -812,44 +770,42 @@ GET /kibana_sample_data_vectordb_byoe/_search
 
 
 # ===============================================
-# PATH B — PART 6: PREPARE FOR PRODUCTION ⚠️
+# PATH B — PART 7: PREPARE FOR PRODUCTION ⚠️
 # ===============================================
 
 # -----------------------------------------------
-# Step B8: Create an alias and verify your mapping
+# 🏷️ Step B9: Create an alias and verify your mapping
 # -----------------------------------------------
 # This step does two things before you go to production:
 
-# First: create an alias — a pointer to your index. Your application queries
-# the alias name ("vectordb-current"), never the raw index name. This matters
-# because changing your embedding model later means re-embedding all documents
-# into a new index, then swapping the alias. With an alias, your application
-# code never changes. Without one, every model upgrade requires a code deployment.
+# First: create an alias — a pointer to your index. 
+# Your application queries the alias name ("vectordb-current"), never the raw index name. This matters because changing your embedding model later means re-embedding all documents into a new index, then swapping the alias. With an alias, your application code never changes. Without one, every model upgrade requires a code deployment.
 
-# Second: verify the mapping looks correct — specifically that 'dims' matches
-# your model's output. If it's wrong, the time to find out is before you index
-# real production data, not after.
+# Second: verify the mapping looks correct.
+# Specifically check that 'dims' matches your model's output. Find out now, not after you've indexed production data.
 
 # The reindex-on-model-change flow:
-# 1. Create index_v2 with the new model's dims
-# 2. Re-embed and re-index all documents into index_v2
-# 3. POST /_aliases: swap alias from v1 to v2 — atomic, zero downtime
-# 4. Delete index_v1
+#   1. Create index_v2 with the new model's dims
+#   2. Re-embed and reindex all documents into index_v2
+#   3. POST /_aliases: swap alias from v1 to v2 (atomic, zero downtime)
+#   4. Delete index_v1
 
 PUT /kibana_sample_data_vectordb_byoe/_alias/vectordb-current
 
 # ✅ You should see: {"acknowledged": true}
+
 # Your app should now reference "vectordb-current" instead of the full index name.
-# 📖 https://www.elastic.co/docs/manage-data/data-store/aliases
+# 📖 https://elastic.co/docs/manage-data/data-store/aliases
 
 # Verify your index looks correct before going to production:
 
 GET /kibana_sample_data_vectordb_byoe/_mapping
 
 # ✅ Confirm 'content_embedding' shows:
-# "type": "dense_vector"
-# "dims": 1024 (or whatever your model outputs)
-# "index": true
+#   "type": "dense_vector"
+#   "dims": 1536 (or whatever your model outputs)
+#   "index": true
+
 # If dims is wrong, delete the index and start from Step B2 with the correct value.
 
 
@@ -857,33 +813,34 @@ GET /kibana_sample_data_vectordb_byoe/_mapping
 # PATH B — CLEANUP (optional)
 # ===============================================
 
-# Step B9: Delete all resources created in this tutorial
-# Run each DELETE request below the same way as earlier — paste and hit ▶️.
+# 🧹 Step B10: Delete all resources created in this tutorial
 # Warning: deleting the index permanently removes all stored documents and vectors.
 
 DELETE /kibana_sample_data_vectordb_byoe
 
-DELETE _ingest/pipeline/embedding-pipeline
+DELETE /_ingest/pipeline/embedding-pipeline
 
-DELETE _inference/text_embedding/my-embedding-endpoint
+DELETE /_inference/text_embedding/my-embedding-endpoint
 
 # ✅ You should see: {"acknowledged": true} for each deletion.
 
 # -----------------------------------------------
+
 # Path B complete.
 
 # What you built: a vector database with full control over the embedding model.
 
 # Key things to remember:
-# - Same model at ingest time AND query time — always
-# - dims must match your model's output size — check before indexing real data
-# - Create the alias before indexing production data — model changes require reindex
-# - Hybrid search (kNN + BM25 via RRF) is the default — don't use vector-only
+#   - Same model at ingest time AND query time — always
+#   - dims must match your model's output size — check before indexing real data
+#   - Create the alias before indexing production data — model changes require reindex
+#   - Hybrid search (kNN + BM25 via RRF) is the default — don't use vector-only
 
 # When you're ready to improve search quality:
-# - Reranking: a second AI pass on the top results for higher precision
-# 📖 https://www.elastic.co/docs/solutions/search/ranking/semantic-reranking
-# - _rank_eval: measure your search quality objectively with labeled test queries
-# 📖 https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval
+#   - Reranking: a second AI pass on the top results for higher precision
+#     📖 https://elastic.co/docs/solutions/search/ranking/semantic-reranking
+#   - _rank_eval: measure your search quality objectively with labeled test queries
+#     📖 https://elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval
+
 # -----------------------------------------------
 `;

--- a/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
+++ b/x-pack/solutions/search/packages/kbn-search-code-examples/src/api-tutorials/vector_database_tutorial.ts
@@ -7,10 +7,12 @@
 
 export const vectorDatabaseTutorialCommands: string = `
 # ===============================================
-# Elasticsearch Vector DB Tutorial
+# 🚀 Elasticsearch Vector Database Tutorial
 # ===============================================
 
-# Vector databases are the storage and retrieval layer behind AI applications like chatbots, RAG pipelines, and recommendation engines. They also enable semantic search, which matches on meaning rather than exact words. The core idea: convert text into numerical vectors (embeddings) that capture semantic meaning, then find the closest matches.
+# Vector databases are the storage and retrieval layer behind AI applications like chatbots, RAG pipelines, and recommendation engines. They also enable semantic search, which matches on meaning rather than exact words. 
+
+# The core idea: convert text into numerical vectors (embeddings) that capture semantic meaning, then find the closest matches.
 
 # Elasticsearch is a vector database that lets you bring your own embeddings (from OpenAI, Cohere, etc.) or generate them automatically via Elastic Inference Service (EIS).
 
@@ -26,7 +28,7 @@ export const vectorDatabaseTutorialCommands: string = `
 
 # 🎯 PATH B — You generate embeddings outside Elasticsearch (for existing external pipelines)
 #   ✓ You already use OpenAI, Cohere, or a custom model running outside Elasticsearch.
-#   ➡️ Jump to: PATH B below (Steps B1-B9)
+#   ➡️ Scroll to: PATH B below (Steps B1-B9)
 
 # Not sure? Start with Path A.
 
@@ -44,29 +46,7 @@ export const vectorDatabaseTutorialCommands: string = `
 # -----------------------------------------------
 # 📦 Step A1: Create your index
 # -----------------------------------------------
-# An index is where your documents live in Elasticsearch. Before indexing documents, you define a mapping (a schema that declares each field and its type). The field type controls how Elasticsearch stores and searches the data, so choosing the right type is the most important decision you make per field.
-
-# Annotated version of the mapping you'll create:
-
-# {
-#  "mappings": {
-#   "properties": {
-#     "title": {
-#       "type": "text" // Full-text search via BM25. Matches individual words: "Canyon" finds "Grand Canyon National Park".
-#     },
-#     "semantic_text": {
-#       "type": "semantic_text" // Stores text and auto-generates vector embeddings. Enables search by meaning, not just keywords.
-#     },
-#     "content": {
-#       "type": "text", // Full-text search via BM25, like "title".
-#       "copy_to": "semantic_text" // Copies content into the semantic_text field so embeddings are generated automatically.
-#     },
-#     "source": {
-#       "type": "keyword" // Exact-match only. Designed for filtering and aggregations (e.g. source="national-parks"), not full-text search.
-#     }
-#   }
-#  }
-# }
+# An index is where your documents live in Elasticsearch. Before indexing documents, you define a mapping (a schema that declares each field and its type). The field type controls how Elasticsearch stores and searches the data, so choosing the right type is very important.
 
 # Create your index with mappings for each field:
 
@@ -74,25 +54,24 @@ export const vectorDatabaseTutorialCommands: string = `
 # This tutorial uses Elasticsearch's default inference model. Before going live, verify it fits your use case:
 #   📖 https://elastic.co/docs/explore-analyze/elastic-inference/eis
 
-# To use a specific model, add the inference ID associated with the model to the "inference_id" field below.
-
 PUT /kibana_sample_data_vectordb
 {
   "mappings": {
     "properties": {
       "title": { 
-        "type": "text" 
+        "type": "text" // Full-text search via BM25. Matches individual words: "Canyon" finds "Grand Canyon National Park".
       },
-      "semantic_text": {
-        "type": "semantic_text",
-        "inference_id": ".jina-embeddings-v3" // ← Specify an inference endpoint ID, or remove if using the default.
+      "semantic_content": {
+        "type": "semantic_text" // Stores text and auto-generates vector embeddings. Enables search by meaning, not just keywords.
+        // To use a specific model instead of Elastic's default add:
+        // "inference_id": ".your-model-endpoint-id"
       },
       "content": {
-        "type": "text",
-        "copy_to": "semantic_text"
+        "type": "text", // Full-text search via BM25, like "title".
+        "copy_to": "semantic_content" // Copies content into the semantic_content field so embeddings are generated automatically.
       },
       "source": { 
-        "type": "keyword" 
+        "type": "keyword" // Exact-match only. Designed for filtering and aggregations (e.g. source="national-parks"), not full-text search.
       }
     }
   }
@@ -105,9 +84,8 @@ PUT /kibana_sample_data_vectordb
 
 DELETE /kibana_sample_data_vectordb
 
-
 # -----------------------------------------------
-# 🔧 Step A2: Understand mapping constraints (optional)
+# 💡 Good to know - Adding new fields to a mapping
 # -----------------------------------------------
 # You can add new fields at any time with a PUT mapping request. Elasticsearch adds them without touching existing docs.
 
@@ -128,9 +106,9 @@ PUT /kibana_sample_data_vectordb/_mapping
 # ===============================================
 
 # -----------------------------------------------
-# 📄 Step A3: Index your documents
+# 📄 Step A2: Index your documents
 # -----------------------------------------------
-# Index 5 sample documents. No embedding code needed: 'content' copies into 'semantic_text', so Elasticsearch generates and stores vectors automatically.
+# Index 5 sample documents. No embedding code needed: 'content' copies into 'semantic_content', so Elasticsearch generates and stores vectors automatically.
 
 # The bulk API indexes multiple documents in one request, with two lines per document:
 #   Line 1 (metadata):  {"index": {"_index": "kibana_sample_data_vectordb"}}
@@ -156,7 +134,7 @@ POST /_bulk?refresh=wait_for
 # ✅ You should see: {"errors": false, "took": ..., "items": [...]}
 # "errors": false means all 5 documents indexed successfully.
 
-# If "errors": true, inspect the "items" array for details. To start fresh, run the DELETE request, then re-run Steps A1 and A3.
+# If "errors": true, inspect the "items" array for details. To start fresh, run the DELETE request, then re-run Steps A1 and A2.
 
 DELETE /kibana_sample_data_vectordb
 
@@ -166,9 +144,9 @@ DELETE /kibana_sample_data_vectordb
 # ===============================================
 
 # -----------------------------------------------
-# 🔍 Step A4: Semantic-only search — demonstration step
+# 🔍 Step A3: Semantic-only search — demonstration step
 # -----------------------------------------------
-# This step has two examples that show what semantic search does well and where it falls short. The contrast sets up why hybrid search (Step A5) is the better default.
+# This step has two examples that show what semantic search does well and where it falls short. The contrast sets up why hybrid search (Step A4) is the better default.
 
 # QUERY 1 - where semantic shines:
 # "volcanic activity" doesn't appear anywhere in our data, but Yellowstone's content mentions "Yellowstone Caldera", "super volcano", and "geyser". Semantic search finds it by meaning when keyword search wouldn't.
@@ -179,7 +157,7 @@ GET /kibana_sample_data_vectordb/_search
     "standard": {
       "query": {
         "semantic": {
-          "field": "semantic_text",
+          "field": "semantic_content",
           "query": "volcanic activity"
         }
       }
@@ -188,6 +166,8 @@ GET /kibana_sample_data_vectordb/_search
 }
 
 # ✅ Yellowstone should rank first. Zero shared words, pure meaning match.
+
+# 📋 Reading the response: your results are in hits.hits[]. The top result is first. Each hit has a _score (higher = better match) and _source (the original document you indexed).
 
 # QUERY 2 - where semantic falls short:
 # "Arizona" is mentioned by name in Grand Canyon's content. Semantic search may not rank Grand Canyon first because it looks for meaning-similarity, not exact word matches. A proper noun with no surrounding context is hard for a semantic model to anchor. Keyword search (BM25) would find it immediately.
@@ -198,7 +178,7 @@ GET /kibana_sample_data_vectordb/_search
     "standard": {
       "query": {
         "semantic": {
-          "field": "semantic_text",
+          "field": "semantic_content",
           "query": "Arizona"
         }
       }
@@ -208,17 +188,16 @@ GET /kibana_sample_data_vectordb/_search
 
 # ✅ Check whether Grand Canyon ranked first. If it didn't, that's the point.
 
-# Semantic search trades exact-match precision for meaning-based recall.
-# Step A5 fixes this by combining both.
+# Semantic search trades exact-match precision for meaning-based recall. Step A4 fixes this by combining both.
 
 # -----------------------------------------------
-# ⚡ Step A5: Hybrid search — keyword + semantic combined
+# ⚡ Step A4: Hybrid search — keyword + semantic combined
 # -----------------------------------------------
 # This is the query pattern you should use as your default in production. It runs both a keyword retriever (BM25) and a semantic retriever, then merges results using RRF (Reciprocal Rank Fusion).
 
-# Run the same "Arizona" query from Step A4, but as hybrid. BM25 finds the exact words in Grand Canyon's content. Semantic adds context. RRF fuses both rankings. Grand Canyon should now rank first.
+# Run the same "Arizona" query from Step A3, but as hybrid. BM25 finds the exact words in Grand Canyon's content. Semantic adds context. RRF fuses both rankings. Grand Canyon should now rank first.
 
-# Hybrid also handles the "volcanic activity" case from Step A4: semantic finds Yellowstone via meaning, BM25 contributes where there are exact title matches.
+# Hybrid also handles the "volcanic activity" case from Step A3: semantic finds Yellowstone via meaning, BM25 contributes where there are exact title matches.
 
 GET /kibana_sample_data_vectordb/_search
 {
@@ -239,7 +218,7 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "semantic": {
-                "field": "semantic_text",
+                "field": "semantic_content",
                 "query": "Arizona"
                 // Semantic: finds documents whose meaning is closest to this word
               }
@@ -261,7 +240,7 @@ GET /kibana_sample_data_vectordb/_search
 
 
 # -----------------------------------------------
-# 🔒 Step A6: Add a filter to the hybrid search
+# 🔒 Step A5: Add a filter to the hybrid search
 # -----------------------------------------------
 # Filters restrict which documents are searched without affecting relevance scores. Use this for access control, tenant isolation, or category filtering.
 
@@ -301,7 +280,7 @@ GET /kibana_sample_data_vectordb/_search
               "bool": {
                 "must": {
                   "semantic": {
-                    "field": "semantic_text",
+                    "field": "semantic_content",
                     "query": "hiking"
                   }
                 },
@@ -327,7 +306,7 @@ GET /kibana_sample_data_vectordb/_search
 # For use in your application.
 
 # -----------------------------------------------
-# 🤖 Step A7: Retrieve chunks for a RAG pipeline
+# 🤖 Step A6: Retrieve chunks for a RAG pipeline
 # -----------------------------------------------
 # RAG (Retrieval-Augmented Generation) is a pattern where you:
 #   1. Search your data for relevant documents (this step)
@@ -356,7 +335,7 @@ GET /kibana_sample_data_vectordb/_search
           "standard": {
             "query": {
               "semantic": {
-                "field": "semantic_text",
+                "field": "semantic_content",
                 "query": "best park for wildlife"
               }
             }
@@ -385,7 +364,7 @@ GET /kibana_sample_data_vectordb/_search
 # ===============================================
 
 # -----------------------------------------------
-# 🧹 Step A8: Delete the index
+# 🧹 Step A7: Delete the index
 # -----------------------------------------------
 # This step removes the sample index and everything in it.
 # Warning: this permanently deletes all 6 documents. Cannot be undone.
@@ -420,8 +399,9 @@ DELETE /kibana_sample_data_vectordb
 
 # The key difference from Path A: instead of semantic_text (which handles everything), you use a dense_vector field and are responsible for generating vectors yourself, both at ingest time and at query time.
 
-# ⚠️ The most important rule in this path (read before starting):
-# You must use the SAME model at ingest time and at query time. If you index documents with OpenAI's text-embedding-3-small, you must also embed queries with text-embedding-3-small. Mixing models produces meaningless results because documents and queries would be in different vector spaces. Changing models later requires re-embedding and reindexing every document. Choose carefully before indexing real data at scale.
+# ⚠️ The most important rule in this path (read before starting) ⚠️
+
+#   You must use the SAME model at ingest time and at query time. If you index documents with OpenAI's text-embedding-3-small, you must also embed queries with text-embedding-3-small. Mixing models produces meaningless results because documents and queries would be in different vector spaces. Changing models later requires re-embedding and reindexing every document. Choose carefully before indexing real data at scale.
 
 
 # ===============================================
@@ -473,55 +453,27 @@ PUT /_inference/text_embedding/my-embedding-endpoint
 #   - Cohere embed-v3: 1024
 #   - E5-small: 384
 
-# Annotated version of the mapping you'll create:
-
-# {
-#  "mappings": {
-#   "properties": {
-#     "title": {
-#       "type": "text" // Full-text search via BM25.
-#     },
-#     "content": {
-#       "type": "text" // The original text. Stored for display and BM25 search. Embeddings are stored separately.
-#     },
-#     "content_embedding": {
-#       "type": "dense_vector", // Stores the raw vector (list of numbers) from your embedding model.
-#       "dims": 1536, // Must exactly match your model's output size. Wrong dims = full reindex to fix.
-#       "index": true, // Required for kNN search. Without this, vectors are stored but not searchable.
-#       "similarity": "cosine", // How Elasticsearch measures closeness between vectors. Cosine is the most common choice.
-#       "index_options": {
-#         "type": "int8_hnsw" // Compressed index type for ~4x memory savings.
-#         // Use 'hnsw' instead if you need maximum accuracy without concern for memory.
-#       }
-#     },
-#     "source": {
-#       "type": "keyword" // Exact-match only. Used for filtering, e.g. tenant ID, category, document source
-#     }
-#   }
-#  }
-# }
-
 PUT /kibana_sample_data_vectordb_byoe
 {
   "mappings": {
     "properties": {
-      "title": { 
-        "type": "text" 
+      "title": {
+        "type": "text" // Full-text search via BM25.
       },
-      "content": { 
-        "type": "text"
-      }, 
+      "content": {
+        "type": "text" // Stored for display and BM25 search. Embeddings are stored separately.
+      },
       "content_embedding": {
-        "type": "dense_vector",
-        "dims": 1536, // ⚠️ Must match your model's output size exactly
-        "index": true,
-        "similarity": "cosine",
+        "type": "dense_vector", // Stores the raw vector (list of numbers) from your embedding model.
+        "dims": 1536, // ⚠️ Must exactly match your model's output size. Wrong dims = full reindex to fix.
+        "index": true, // Required for kNN search. Without this, vectors are stored but not searchable.
+        "similarity": "cosine", // How Elasticsearch measures closeness between vectors. Cosine is the most common choice.
         "index_options": {
-          "type": "int8_hnsw"
+          "type": "int8_hnsw" // Compressed index type for ~4x memory savings. Use 'hnsw' for maximum accuracy.
         }
       },
-      "source": { 
-        "type": "keyword"
+      "source": {
+        "type": "keyword" // Exact-match only. Used for filtering, e.g. tenant ID, category, document source.
       }
     }
   }
@@ -579,12 +531,12 @@ PUT /_ingest/pipeline/embedding-pipeline
 # -----------------------------------------------
 # 📄 Step B4: Index your documents (pipeline generates embeddings automatically)
 # -----------------------------------------------
-# By passing ?pipeline=embedding-pipeline, each document is routed through the pipeline before storage. The pipeline calls the inference endpoint, generates the vector from 'content', and writes it to 'content_embedding'. You send text; Elasticsearch stores both.
+# By passing "?pipeline=embedding-pipeline", each document is routed through the pipeline before storage. The pipeline calls the inference endpoint, generates the vector from 'content', and writes it to 'content_embedding'. You send text; Elasticsearch stores both.
 
 # ⏳ Model error on first run? Wait 10-15 seconds and retry.
 
-# ?pipeline=embedding-pipeline — route each document through the pipeline
-# ?refresh=wait_for — wait until searchable before returning (same as Step A3)
+# ?pipeline=embedding-pipeline → route each document through the pipeline
+# ?refresh=wait_for → wait until searchable before returning (same as Step A2)
 
 POST /_bulk?pipeline=embedding-pipeline&refresh=wait_for
 { "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
@@ -593,6 +545,11 @@ POST /_bulk?pipeline=embedding-pipeline&refresh=wait_for
 {"title": "Yosemite National Park", "content": "Yosemite National Park covers over 750,000 acres of land in California. The park is best known for its granite cliffs, waterfalls and giant sequoia trees. Its most famous cliff, El Capitan, rises about 3,000 feet from Yosemite Valley. It is home to a diverse range of wildlife, including mule deer, black bears, and the endangered Sierra Nevada bighorn sheep. The park has 1,200 square miles of wilderness and is a popular destination for rock climbers.", "source": "national-parks"}
 { "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
 {"title": "Rocky Mountain National Park", "content": "Rocky Mountain National Park receives over 4.5 million visitors annually and is known for its mountainous terrain, including Longs Peak. The park is home to elk, mule deer, moose, and bighorn sheep. It contains montane, subalpine, and alpine tundra ecosystems and is a popular destination for hiking, camping, and wildlife viewing.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Grand Canyon National Park", "content": "The Grand Canyon is a steep-sided canyon carved by the Colorado River in Arizona. It is 277 miles long, up to 18 miles wide and attains a depth of over a mile. The park receives nearly six million visitors per year and offers hiking, rafting, and helicopter tours. It is one of the Seven Natural Wonders of the World.", "source": "national-parks"}
+{ "index": { "_index": "kibana_sample_data_vectordb_byoe" } }
+{"title": "Zion National Park", "content": "Zion National Park is located in southwestern Utah and is known for its steep red cliffs and narrow canyons. The Virgin River runs through the main canyon. The park is famous for the Angels Landing and Narrows hikes, and receives over four million visitors annually. Wildlife includes mule deer, mountain lions, and California condors.", "source": "national-parks"}
+
 
 # ✅ You should see: {"errors": false, "took": ..., "items": [...]}
 # "errors": false confirms all documents were embedded and indexed.
@@ -675,7 +632,7 @@ GET /kibana_sample_data_vectordb_byoe/_search
 # -----------------------------------------------
 # ⚡ Step B7: Run a hybrid search — the recommended default
 # -----------------------------------------------
-# This step combines kNN (meaning-based) with BM25 (keyword-based) via RRF. Same idea as Step A5, different retrievers.
+# This step combines kNN (meaning-based) with BM25 (keyword-based) via RRF. Same idea as Step A4, different retrievers.
 
 # This should be your default query pattern — it outperforms either method alone.
 
@@ -721,7 +678,7 @@ GET /kibana_sample_data_vectordb_byoe/_search
 # -----------------------------------------------
 # 🔒 Step B8: Add a filter to the hybrid search
 # -----------------------------------------------
-# This step restricts which documents are searched, same concept as Step A6.
+# This step restricts which documents are searched, same concept as Step A5.
 
 # First, index a document with source "state-park" to verify the filter (source: "national-parks") excludes it from results.
 

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -127,6 +127,22 @@ export const ConsoleTutorialsGroup = () => {
         buttonRef: React.createRef<HTMLButtonElement>(),
         publishedAt: new Date('2026-02-04'),
       },
+      {
+        title: i18n.translate('xpack.searchGettingStarted.consoleTutorials.vectorSearchTitle', {
+          defaultMessage: 'Vector DB',
+        }),
+        dataTestSubj: 'console_tutorials_vector_search',
+        description: i18n.translate(
+          'xpack.searchGettingStarted.consoleTutorials.vectorSearchDescription',
+          {
+            defaultMessage: 'Learn how to use vector DB',
+          }
+        ),
+        request: consoleTutorials.vectorDatabase,
+        image: `${assetBasePath}/search_hourglass.svg`,
+        buttonRef: React.createRef<HTMLButtonElement>(),
+        publishedAt: new Date('2026-04-01'),
+      },
     ];
     return orderBy(items, ({ publishedAt }) => publishedAt.getTime(), ['desc']).slice(
       0,

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -129,14 +129,14 @@ export const ConsoleTutorialsGroup = () => {
       },
       {
         title: i18n.translate('xpack.searchGettingStarted.consoleTutorials.vectorSearchTitle', {
-          defaultMessage: 'Vector DB',
+          defaultMessage: 'Vector Database',
         }),
         dataTestSubj: 'console_tutorials_vector_search',
         description: i18n.translate(
           'xpack.searchGettingStarted.consoleTutorials.vectorSearchDescription',
           {
             defaultMessage:
-              'Learn to use Elastic as a vector datastore for chatbots, RAG, and recommenders. Generate embeddings or bring your own.',
+              'Store and search vectors for semantic search, chatbots, recommenders, and RAG. Generate embeddings or bring your own vectors.',
           }
         ),
         request: consoleTutorials.vectorDatabase,

--- a/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
+++ b/x-pack/solutions/search/plugins/search_getting_started/public/components/tutorials/console_tutorials_group.tsx
@@ -135,7 +135,8 @@ export const ConsoleTutorialsGroup = () => {
         description: i18n.translate(
           'xpack.searchGettingStarted.consoleTutorials.vectorSearchDescription',
           {
-            defaultMessage: 'Learn how to use vector DB',
+            defaultMessage:
+              'Learn to use Elastic as a vector datastore for chatbots, RAG, and recommenders. Generate embeddings or bring your own.',
           }
         ),
         request: consoleTutorials.vectorDatabase,


### PR DESCRIPTION
## Summary

Adds a new Vector DB console tutorial to the Search Getting Started page.

The tutorial covers two learning paths: 
- Path A (Elastic-generated embeddings via semantic_text)
- Path B (bring-your-own embeddings via dense_vector + inference endpoints)

<img width="600" alt="Screenshot 2026-04-02 at 13 10 23" src="https://github.com/user-attachments/assets/ec583cae-1a17-44cd-a0f4-d46cb3078059" />
<img width="600" alt="Screenshot 2026-04-02 at 13 10 32" src="https://github.com/user-attachments/assets/32e20b4f-292c-4664-b6ac-cb6457f20aaa" />


### Testing

To test this tutorial you'll either need to be Cloud Connected with EIS enabled, or running the EIS script locally.

- [ ] Navigate to the Search Getting Started page and verify the "Vector DB" tutorial card appears first in the list with the `New` badge
- [ ] Click the card and confirm the tutorial content loads in the console
- [ ] Walk through Path A steps (A1–A8) against a running Elasticsearch cluster with EIS access
- [ ] Walk through Path B steps (B1–B9) with either a valid OpenAI API or Cohere key

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
- [ ] ~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [ ] ~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~
- [ ] ~Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.~

