### PR TITLE
[Alerting v2] [Rule authoring] Add compressed prop to flyout rule form fields

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.test.tsx
@@ -12,7 +12,7 @@ import { AlertDelayField } from './alert_delay_field';
 import { RecoveryDelayField } from './recovery_delay_field';
 import type { FormValues } from '../types';
 import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 let getFormValues: (() => FormValues) | undefined;
 
@@ -112,6 +112,14 @@ describe('AlertDelayField', () => {
   it('renders the mode toggle button group', () => {
     render(<AlertDelayField />, {
       wrapper: createFormWrapper({ kind: 'alert' }),
+    });
+
+    expect(screen.getByTestId('stateTransitionDelayMode')).toBeInTheDocument();
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<AlertDelayField />, {
+      wrapper: createFormWrapper({ kind: 'alert' }, createMockServices(), { layout: 'flyout' }),
     });
 
     expect(screen.getByTestId('stateTransitionDelayMode')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/alert_delay_field.tsx
@@ -13,6 +13,7 @@ import type { FormValues } from '../types';
 import { deriveAlertDelayModeFromStateTransition } from '../utils/rule_request_mappers';
 import { StateTransitionCountField } from './state_transition_count_field';
 import { StateTransitionTimeframeField } from './state_transition_timeframe_field';
+import { useRuleFormMeta } from '../contexts';
 
 type DelayMode = 'immediate' | 'breaches' | 'duration';
 
@@ -60,6 +61,7 @@ const DEFAULT_PENDING_TIMEFRAME = '2m';
 
 export const AlertDelayField = () => {
   const { control, getValues, setValue } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const stateTransition = useWatch({ control, name: 'stateTransition' });
   const selectedMode = useWatch({ control, name: 'stateTransitionAlertDelayMode' });
   const displayMode: DelayMode =
@@ -121,7 +123,7 @@ export const AlertDelayField = () => {
     >
       <>
         <EuiButtonGroup
-          buttonSize="s"
+          buttonSize={layout === 'flyout' ? 'compressed' : 's'}
           legend={i18n.translate('xpack.alertingV2.ruleForm.alertDelay.delayModeLegend', {
             defaultMessage: 'Alert delay mode',
           })}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DescriptionField } from './description_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('DescriptionField', () => {
   it('renders "Add description" button when no description value exists', () => {
@@ -71,6 +71,17 @@ describe('DescriptionField', () => {
     await user.type(textarea, 'My new description');
 
     expect(textarea).toHaveValue('My new description');
+  });
+
+  it('renders correctly in flyout layout', async () => {
+    const user = userEvent.setup();
+    render(<DescriptionField />, {
+      wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
+    });
+
+    await user.click(screen.getByTestId('addDescriptionButton'));
+
+    expect(screen.getByTestId('ruleDescriptionInput')).toBeInTheDocument();
   });
 
   it('keeps textarea visible after clearing the value', async () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/description_field.tsx
@@ -10,11 +10,13 @@ import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiTextArea, EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
 
 const DESCRIPTION_ROW_ID = 'ruleV2FormDescriptionField';
 
 export const DescriptionField = () => {
   const { control, watch } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const descriptionValue = watch('metadata.description');
 
   // Show the input if there's already a description value
@@ -71,6 +73,7 @@ export const DescriptionField = () => {
             rows={2}
             fullWidth
             isInvalid={!!error}
+            compressed={layout === 'flyout'}
             placeholder={i18n.translate('xpack.alertingV2.ruleForm.descriptionPlaceholder', {
               defaultMessage: 'Add an optional description for this rule...',
             })}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/duration_input.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/duration_input.tsx
@@ -20,6 +20,7 @@ export interface DurationInputProps {
   unitAriaLabel: string;
   dataTestSubj: string;
   idPrefix: string;
+  compressed?: boolean;
 }
 
 /**
@@ -32,7 +33,17 @@ export interface DurationInputProps {
  */
 export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputProps>(
   (
-    { value, onChange, fallback, errors, numberLabel, unitAriaLabel, dataTestSubj, idPrefix },
+    {
+      value,
+      onChange,
+      fallback,
+      errors,
+      numberLabel,
+      unitAriaLabel,
+      dataTestSubj,
+      idPrefix,
+      compressed,
+    },
     ref
   ) => {
     const effectiveValue = value || fallback || '1m';
@@ -77,6 +88,7 @@ export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputPro
               prepend={numberLabel ? [numberLabel] : undefined}
               isInvalid={!!errors}
               name="interval"
+              compressed={compressed}
               data-test-subj={`${idPrefix}NumberInput`}
               id={`${idPrefix}NumberInput`}
               aria-label={numberLabel || undefined}
@@ -88,6 +100,7 @@ export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputPro
               value={intervalUnit}
               options={getTimeOptions(intervalNumber ?? 1)}
               onChange={onIntervalUnitChange}
+              compressed={compressed}
               data-test-subj={`${idPrefix}UnitInput`}
               aria-label={unitAriaLabel}
             />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.test.tsx
@@ -161,6 +161,16 @@ describe('GroupFieldSelect', () => {
     });
   });
 
+  it('renders correctly in flyout layout', () => {
+    render(<GroupFieldSelect />, {
+      wrapper: createFormWrapper({ evaluation: { query: { base: defaultQuery } } }, mockServices, {
+        layout: 'flyout',
+      }),
+    });
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
   it('renders empty when no columns available', () => {
     mockUseQueryColumns.mockReturnValue({
       data: [],

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/group_field_select.tsx
@@ -11,10 +11,11 @@ import { EuiComboBox, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { FormValues } from '../types';
 import { useQueryColumns, type QueryColumn } from '../hooks/use_query_columns';
-import { useRuleFormServices } from '../contexts';
+import { useRuleFormServices, useRuleFormMeta } from '../contexts';
 
 export const GroupFieldSelect = () => {
   const { data } = useRuleFormServices();
+  const { layout } = useRuleFormMeta();
   const { control, setValue, getValues } = useFormContext<FormValues>();
   const query = useWatch({ name: 'evaluation.query.base', control });
   const groupByRowId = 'ruleV2FormGroupByField';
@@ -77,6 +78,7 @@ export const GroupFieldSelect = () => {
               isInvalid={!!error}
               isLoading={isLoading}
               fullWidth
+              compressed={layout === 'flyout'}
             />
           </EuiFormRow>
         );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window.tsx
@@ -27,6 +27,7 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   errors?: string;
+  compressed?: boolean;
 }
 
 export const LookbackWindow = React.forwardRef<HTMLInputElement, Props>((props, ref) => (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window_field.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { LookbackWindowField } from './lookback_window_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('LookbackWindowField', () => {
   it('renders the lookback window label', () => {
@@ -39,6 +39,15 @@ describe('LookbackWindowField', () => {
     expect(screen.getByTestId('lookbackWindow')).toBeInTheDocument();
     expect(screen.getByTestId('lookbackWindowNumberInput')).toBeInTheDocument();
     expect(screen.getByTestId('lookbackWindowUnitInput')).toBeInTheDocument();
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<LookbackWindowField />, {
+      wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByText('Lookback Window')).toBeInTheDocument();
+    expect(screen.getByTestId('lookbackWindowNumberInput')).toBeInTheDocument();
   });
 
   it('allows clearing the number input and typing a new value', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/lookback_window_field.tsx
@@ -12,6 +12,7 @@ import { EuiFormRow } from '@elastic/eui';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { LookbackWindow } from './lookback_window';
+import { useRuleFormMeta } from '../contexts';
 
 const LOOKBACK_WINDOW_ROW_ID = 'ruleV2FormLookbackWindowField';
 
@@ -25,6 +26,7 @@ const LOOKBACK_LESS_THAN_INTERVAL_WARNING = i18n.translate(
 
 export const LookbackWindowField = () => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const scheduleEvery = useWatch({ control, name: 'schedule.every' });
 
   return (
@@ -62,7 +64,7 @@ export const LookbackWindowField = () => {
             isInvalid={!!error}
             fullWidth
           >
-            <LookbackWindow {...field} errors={error?.message} />
+            <LookbackWindow {...field} errors={error?.message} compressed={layout === 'flyout'} />
           </EuiFormRow>
         );
       }}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/number_input.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/number_input.tsx
@@ -20,6 +20,7 @@ export interface NumberInputProps {
   max?: number;
   step?: number;
   prepend?: string | React.ReactElement | Array<string | React.ReactElement>;
+  compressed?: boolean;
   'data-test-subj'?: string;
   id?: string;
   name?: string;

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.test.tsx
@@ -12,7 +12,7 @@ import { RecoveryDelayField } from './recovery_delay_field';
 import { AlertDelayField } from './alert_delay_field';
 import type { FormValues } from '../types';
 import { mapFormValuesToUpdateRequest } from '../utils/rule_request_mappers';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 let getFormValues: (() => FormValues) | undefined;
 
@@ -112,6 +112,14 @@ describe('RecoveryDelayField', () => {
   it('renders the mode toggle button group', () => {
     render(<RecoveryDelayField />, {
       wrapper: createFormWrapper({ kind: 'alert' }),
+    });
+
+    expect(screen.getByTestId('recoveryDelayMode')).toBeInTheDocument();
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<RecoveryDelayField />, {
+      wrapper: createFormWrapper({ kind: 'alert' }, createMockServices(), { layout: 'flyout' }),
     });
 
     expect(screen.getByTestId('recoveryDelayMode')).toBeInTheDocument();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_delay_field.tsx
@@ -13,6 +13,7 @@ import type { FormValues } from '../types';
 import { deriveRecoveryDelayModeFromStateTransition } from '../utils/rule_request_mappers';
 import { StateTransitionCountField } from './state_transition_count_field';
 import { StateTransitionTimeframeField } from './state_transition_timeframe_field';
+import { useRuleFormMeta } from '../contexts';
 
 type DelayMode = 'immediate' | 'breaches' | 'duration';
 
@@ -60,6 +61,7 @@ const DEFAULT_RECOVERING_TIMEFRAME = '2m';
 
 export const RecoveryDelayField = () => {
   const { control, getValues, setValue } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const stateTransition = useWatch({ control, name: 'stateTransition' });
   const selectedMode = useWatch({ control, name: 'stateTransitionRecoveryDelayMode' });
   const displayMode: DelayMode =
@@ -121,7 +123,7 @@ export const RecoveryDelayField = () => {
     >
       <>
         <EuiButtonGroup
-          buttonSize="s"
+          buttonSize={layout === 'flyout' ? 'compressed' : 's'}
           legend={i18n.translate('xpack.alertingV2.ruleForm.recoveryDelay.delayModeLegend', {
             defaultMessage: 'Recovery delay mode',
           })}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_type_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_type_field.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { RecoveryTypeField } from './recovery_type_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('RecoveryTypeField', () => {
   it('renders the recovery label', () => {
@@ -61,6 +61,14 @@ describe('RecoveryTypeField', () => {
     fireEvent.change(select, { target: { value: 'query' } });
 
     expect(select.value).toBe('query');
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<RecoveryTypeField />, {
+      wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByTestId('recoveryTypeSelect')).toBeInTheDocument();
   });
 
   it('updates value back to no_breach', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_type_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/recovery_type_field.tsx
@@ -11,6 +11,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import type { RecoveryPolicyType } from '@kbn/alerting-v2-schemas';
 import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
 
 const RECOVERY_TYPE_OPTIONS: Array<{ value: RecoveryPolicyType; text: string }> = [
   {
@@ -36,6 +37,7 @@ const RECOVERY_TYPE_OPTIONS: Array<{ value: RecoveryPolicyType; text: string }> 
  */
 export const RecoveryTypeField = () => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
 
   return (
     <Controller
@@ -56,6 +58,7 @@ export const RecoveryTypeField = () => {
             value={field.value}
             onChange={(e) => field.onChange(e.target.value)}
             fullWidth
+            compressed={layout === 'flyout'}
             data-test-subj="recoveryTypeSelect"
           />
         </EuiFormRow>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_schedule.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/rule_schedule.tsx
@@ -24,6 +24,7 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   errors?: string;
+  compressed?: boolean;
 }
 
 export const RuleSchedule = React.forwardRef<HTMLInputElement, Props>((props, ref) => (

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/schedule_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/schedule_field.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ScheduleField } from './schedule_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('ScheduleField', () => {
   it('renders the schedule label', () => {
@@ -28,6 +28,14 @@ describe('ScheduleField', () => {
 
     // The EuiIconTip renders a span with "Info" text
     expect(screen.getByText('Info')).toBeInTheDocument();
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<ScheduleField />, {
+      wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByText('Schedule')).toBeInTheDocument();
   });
 
   it('displays initial schedule value', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/schedule_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/schedule_field.tsx
@@ -17,11 +17,13 @@ import { EuiFormRow, EuiIconTip } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { RuleSchedule } from './rule_schedule';
+import { useRuleFormMeta } from '../contexts';
 
 const SCHEDULE_ROW_ID = 'ruleV2FormScheduleField';
 
 export const ScheduleField = () => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
 
   return (
     <Controller
@@ -72,7 +74,7 @@ export const ScheduleField = () => {
           }
           isInvalid={!!error}
         >
-          <RuleSchedule {...field} errors={error?.message} />
+          <RuleSchedule {...field} errors={error?.message} compressed={layout === 'flyout'} />
         </EuiFormRow>
       )}
     />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StateTransitionCountField } from './state_transition_count_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('StateTransitionCountField', () => {
   it('renders the consecutive breaches count input', () => {
@@ -30,6 +30,14 @@ describe('StateTransitionCountField', () => {
     });
 
     expect(screen.getByTestId('stateTransitionCountInput')).toHaveValue(5);
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<StateTransitionCountField />, {
+      wrapper: createFormWrapper({ kind: 'alert' }, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByTestId('stateTransitionCountInput')).toBeInTheDocument();
   });
 
   describe('variant="recovering"', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_count_field.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { NumberInput } from './number_input';
+import { useRuleFormMeta } from '../contexts';
 
 const DEFAULT_COUNT = 2;
 
@@ -42,6 +43,7 @@ export const StateTransitionCountField = ({
   variant = 'pending',
 }: StateTransitionCountFieldProps) => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const fieldName = FIELD_NAMES[variant];
   const testSubj = TEST_SUBJS[variant];
 
@@ -77,6 +79,7 @@ export const StateTransitionCountField = ({
           isInvalid={!!error}
           data-test-subj={testSubj}
           fullWidth
+          compressed={layout === 'flyout'}
           prepend={prependLabel ? [prependLabel] : undefined}
         />
       )}

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_timeframe_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_timeframe_field.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StateTransitionTimeframeField } from './state_transition_timeframe_field';
-import { createFormWrapper } from '../../test_utils';
+import { createFormWrapper, createMockServices } from '../../test_utils';
 
 describe('StateTransitionTimeframeField', () => {
   it('renders the breached-for-duration timeframe input', () => {
@@ -90,6 +90,15 @@ describe('StateTransitionTimeframeField', () => {
 
     expect(screen.getByTestId('stateTransitionTimeframeNumberInput')).toHaveValue(15);
     expect(screen.getByTestId('stateTransitionTimeframeUnitInput')).toHaveValue('m');
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<StateTransitionTimeframeField numberPrependLabel="Active for" />, {
+      wrapper: createFormWrapper({ kind: 'alert' }, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByTestId('stateTransitionTimeframeNumberInput')).toBeInTheDocument();
+    expect(screen.getByTestId('stateTransitionTimeframeUnitInput')).toBeInTheDocument();
   });
 
   describe('variant="recovering"', () => {

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_timeframe_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/state_transition_timeframe_field.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
 import { DurationInput } from './duration_input';
+import { useRuleFormMeta } from '../contexts';
 
 const TIMEFRAME_UNIT_ARIA_LABEL = i18n.translate(
   'xpack.alertingV2.ruleForm.stateTransition.timeframeUnitAriaLabel',
@@ -43,6 +44,7 @@ export const StateTransitionTimeframeField = ({
   variant = 'pending',
 }: StateTransitionTimeframeFieldProps) => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
   const fieldName = FIELD_NAMES[variant];
 
   return (
@@ -80,6 +82,7 @@ export const StateTransitionTimeframeField = ({
           unitAriaLabel={TIMEFRAME_UNIT_ARIA_LABEL}
           dataTestSubj={TEST_SUBJ_PREFIXES[variant]}
           idPrefix={TEST_SUBJ_PREFIXES[variant]}
+          compressed={layout === 'flyout'}
         />
       )}
     />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TagsField } from './tags_field';
+import { createFormWrapper, createMockServices } from '../../test_utils';
+
+describe('TagsField', () => {
+  it('renders the tags label', () => {
+    render(<TagsField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+  });
+
+  it('renders the optional label', () => {
+    render(<TagsField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByText('optional')).toBeInTheDocument();
+  });
+
+  it('renders the combo box', () => {
+    render(<TagsField />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders correctly in flyout layout', () => {
+    render(<TagsField />, {
+      wrapper: createFormWrapper({}, createMockServices(), { layout: 'flyout' }),
+    });
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/tags_field.tsx
@@ -10,9 +10,11 @@ import { i18n } from '@kbn/i18n';
 import { EuiFormRow, EuiComboBox } from '@elastic/eui';
 import { Controller, useFormContext } from 'react-hook-form';
 import type { FormValues } from '../types';
+import { useRuleFormMeta } from '../contexts';
 
 export const TagsField = () => {
   const { control } = useFormContext<FormValues>();
+  const { layout } = useRuleFormMeta();
 
   return (
     <Controller
@@ -44,6 +46,7 @@ export const TagsField = () => {
               isClearable={true}
               isInvalid={!!error}
               fullWidth
+              compressed={layout === 'flyout'}
             />
           </EuiFormRow>
         );

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.test.tsx
@@ -107,6 +107,14 @@ describe('TimeFieldSelect', () => {
     expect(select).toHaveValue('event_time');
   });
 
+  it('renders correctly in flyout layout', () => {
+    render(<TimeFieldSelect />, {
+      wrapper: createFormWrapper({}, mockServices, { layout: 'flyout' }),
+    });
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
   it('passes query to useDataFields hook', () => {
     render(<TimeFieldSelect />, {
       wrapper: createFormWrapper(

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/fields/time_field_select.tsx
@@ -13,12 +13,13 @@ import { i18n } from '@kbn/i18n';
 import type { FormValues } from '../types';
 import { firstFieldOption, getTimeFieldOptions } from '../utils';
 import { useDataFields } from '../hooks/use_data_fields';
-import { useRuleFormServices } from '../contexts';
+import { useRuleFormServices, useRuleFormMeta } from '../contexts';
 
 const PREFERRED_TIME_FIELD = '@timestamp';
 
 export const TimeFieldSelect = () => {
   const { http, dataViews } = useRuleFormServices();
+  const { layout } = useRuleFormMeta();
   const { control, setValue, getValues } = useFormContext<FormValues>();
   const query = useWatch({ name: 'evaluation.query.base', control });
 
@@ -84,6 +85,7 @@ export const TimeFieldSelect = () => {
               isInvalid={!!error}
               isLoading={isLoading}
               fullWidth
+              compressed={layout === 'flyout'}
             />
           </EuiFormRow>
         );


### PR DESCRIPTION
Closes elastic/rna-program#244

## Summary

Applies EUI `compressed` density to all form input components when the rule form is rendered in flyout layout (`layout === 'flyout'`). The full-page layout is unaffected.

The change follows the pattern established in #260750: read `layout` from `useRuleFormMeta()` and conditionally apply flyout-specific props.

## What changed

**Shared utility components** — added a `compressed` prop to the interface so callers can pass it down without these components reaching into context:
- `NumberInput` — forwarded to `EuiFieldNumber` via `...rest`
- `DurationInput` — passed explicitly to `NumberInput` and `EuiSelect`
- `LookbackWindow`, `RuleSchedule` — forwarded via `{...props}` spread to `DurationInput`

**Field components** — each reads `const { layout } = useRuleFormMeta()` and passes `compressed={layout === 'flyout'}` to its EUI input:
- `TagsField` → `EuiComboBox`
- `DescriptionField` → `EuiTextArea`
- `RecoveryTypeField` → `EuiSelect`
- `GroupFieldSelect` → `EuiComboBox`
- `TimeFieldSelect` → `EuiSelect`
- `ScheduleField` / `LookbackWindowField` → threaded down to `DurationInput`
- `AlertDelayField` / `RecoveryDelayField` → `EuiButtonGroup buttonSize` (`'compressed'` in flyout, `'s'` in page)
- `StateTransitionCountField` → `NumberInput`
- `StateTransitionTimeframeField` → `DurationInput`

**Excluded** (no `compressed` prop in EUI): `NameField` (`EuiInlineEditTitle`), `KindField` (`EuiCheckableCard`), `RunbookField` (markdown modal).

## Testing

- Added flyout layout smoke tests to all modified test files
- Created `tags_field.test.tsx` (was missing)

