### PR TITLE
Security Solution] Fix string spread bug when syncing watchlists to Entity Store 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entities/service.ts
@@ -101,9 +101,15 @@ export const createWatchlistEntitiesService = ({
 
           acc.entityIdsByType[entityType].push(euid);
 
-          const watchlists = get(record, 'entity.attributes.watchlists') as string[] | undefined;
+          const rawWatchlists = get(record, 'entity.attributes.watchlists');
+          const watchlists = Array.isArray(rawWatchlists)
+            ? rawWatchlists
+            : typeof rawWatchlists === 'string'
+            ? [rawWatchlists]
+            : undefined;
+
           if (watchlists) {
-            acc.watchlistsByEuid.set(euid, watchlists);
+            acc.watchlistsByEuid.set(euid, watchlists as string[]);
           }
 
           if (!isIndexSync) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/entity_store_sync.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/entity_store_sync.ts
@@ -34,7 +34,11 @@ export const addWatchlistAttributeToStore = async ({
   if (entityRefs.length === 0) return;
 
   const objects = entityRefs.map(({ euid, type, currentWatchlists }) => {
-    const watchlists = currentWatchlists ?? [];
+    const watchlists = Array.isArray(currentWatchlists)
+      ? currentWatchlists
+      : typeof currentWatchlists === 'string'
+      ? [currentWatchlists]
+      : [];
     const updated = watchlists.includes(watchlistId) ? watchlists : [...watchlists, watchlistId];
 
     return {
@@ -73,7 +77,7 @@ export const removeWatchlistAttributeFromStore = async ({
 }): Promise<void> => {
   // Only update entities whose current watchlists are known — if we don't have the current value we'd blindly write an empty array to the store.
   const knownRefs = entityRefs.filter((ref): ref is EntityRef & { currentWatchlists: string[] } =>
-    Boolean(ref.currentWatchlists)
+    Boolean(ref.currentWatchlists) && Array.isArray(ref.currentWatchlists)
   );
   if (knownRefs.length === 0) return;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/entity_store_sync.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/watchlists/entity_sources/sync/entity_store_sync.ts
@@ -76,8 +76,9 @@ export const removeWatchlistAttributeFromStore = async ({
   watchlistId: string;
 }): Promise<void> => {
   // Only update entities whose current watchlists are known — if we don't have the current value we'd blindly write an empty array to the store.
-  const knownRefs = entityRefs.filter((ref): ref is EntityRef & { currentWatchlists: string[] } =>
-    Boolean(ref.currentWatchlists) && Array.isArray(ref.currentWatchlists)
+  const knownRefs = entityRefs.filter(
+    (ref): ref is EntityRef & { currentWatchlists: string[] } =>
+      Boolean(ref.currentWatchlists) && Array.isArray(ref.currentWatchlists)
   );
   if (knownRefs.length === 0) return;
 


### PR DESCRIPTION
### Summary: 

Fix string spread bug when syncing watchlists to entity store

Fixes a bug where single-string `entity.attributes.watchlists` values
in the Entity Store were being incorrectly parsed and spread into an
array of individual characters during sync.

If the Entity Store contained a single string value instead of an array
(e.g., `"privileged-user-monitoring-watchlist-id"`), the sync logic
would destructure it via `[...watchlists, watchlistId]`, resulting in
an array of characters `["p", "r", "i", "v", ...]`.

This commit adds defensive checks in both `WatchlistEntitiesService`
(when reading from Elasticsearch) and `entity_store_sync` (before mutating)
to ensure `currentWatchlists` is always safely coerced into an array of
strings before any spread operations occur.