### PR TITLE
[ChromeNext] Add a switch to toggle `chrome-next` in devbar

### DIFF
--- a/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
+++ b/src/core/packages/chrome/browser-components/src/shared/chrome_hooks.ts
@@ -23,7 +23,7 @@ import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import { useObservable } from '@kbn/use-observable';
 import { useChromeService } from '@kbn/core-chrome-browser-context';
-import { NEXT_CHROME_FEATURE_FLAG_KEY } from '@kbn/core-chrome-feature-flags';
+import { isNextChrome } from '@kbn/core-chrome-feature-flags';
 import { useChromeComponentsDeps } from '../context';
 
 /**
@@ -253,5 +253,5 @@ export function useNextHeader(): ChromeNextHeaderConfig | undefined {
 /** Returns whether the next-chrome experience is enabled via feature flag. */
 export function useIsNextChrome(): boolean {
   const { featureFlags } = useChromeComponentsDeps();
-  return featureFlags.getBooleanValue(NEXT_CHROME_FEATURE_FLAG_KEY, false);
+  return isNextChrome(featureFlags);
 }

--- a/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
+++ b/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback } from 'react';
+import { EuiBadge, EuiToolTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
+import { isNextChrome, toggleNextChrome } from './index';
+
+const badgeStyles = css`
+  cursor: pointer;
+`;
+
+interface ChromeNextToggleProps {
+  featureFlags: FeatureFlagsStart;
+}
+
+export const ChromeNextToggle: React.FC<ChromeNextToggleProps> = ({ featureFlags }) => {
+  const isEnabled = isNextChrome(featureFlags);
+
+  const onClick = useCallback(() => {
+    toggleNextChrome(featureFlags);
+  }, [featureFlags]);
+
+  return (
+    <EuiToolTip content={`Click to ${isEnabled ? 'disable' : 'enable'} Vibranium chrome. Page will reload.`}>
+      <EuiBadge
+        color={isEnabled ? 'success' : 'danger'}
+        css={badgeStyles}
+        iconType="beaker"
+        iconSide="left"
+        onClick={onClick}
+        onClickAriaLabel="Toggle Vibranium chrome"
+      >
+        Vibranium: {isEnabled ? 'ON' : 'OFF'}
+      </EuiBadge>
+    </EuiToolTip>
+  );
+};

--- a/src/core/packages/chrome/feature-flags/index.ts
+++ b/src/core/packages/chrome/feature-flags/index.ts
@@ -9,8 +9,25 @@
 
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
 
+export { ChromeNextToggle } from './chrome_next_toggle';
+
 export const NEXT_CHROME_FEATURE_FLAG_KEY = 'core.chrome.next';
+export const NEXT_CHROME_SESSION_STORAGE_KEY = 'dev.core.chrome.next';
 
 export const isNextChrome = (featureFlags: FeatureFlagsStart): boolean => {
+  try {
+    const override = sessionStorage.getItem(NEXT_CHROME_SESSION_STORAGE_KEY);
+    if (override !== null) {
+      return override === 'true';
+    }
+  } catch {
+    // sessionStorage may be unavailable
+  }
   return featureFlags.getBooleanValue(NEXT_CHROME_FEATURE_FLAG_KEY, false);
+};
+
+export const toggleNextChrome = (featureFlags: FeatureFlagsStart): void => {
+  const next = !isNextChrome(featureFlags);
+  sessionStorage.setItem(NEXT_CHROME_SESSION_STORAGE_KEY, String(next));
+  window.location.reload();
 };

--- a/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
+++ b/src/platform/plugins/shared/developer_toolbar/public/plugin.tsx
@@ -14,6 +14,8 @@ import type { InternalChromeStart } from '@kbn/core-chrome-browser-internal-type
 
 import { BehaviorSubject } from 'rxjs';
 import type { DeveloperToolbarItemProps } from '@kbn/developer-toolbar';
+import { DeveloperToolbarItem } from '@kbn/developer-toolbar';
+import { ChromeNextToggle } from '@kbn/core-chrome-feature-flags';
 
 export type UnregisterItemFn = () => void;
 export interface DeveloperToolbarItemRegistry {
@@ -41,6 +43,9 @@ export class DeveloperToolbarPlugin
     (core.chrome as InternalChromeStart).setGlobalFooter(
       <Suspense>
         <LazyToolbar items$={this.items$} envInfo={this.context.env} />
+        <DeveloperToolbarItem id="chromeNext">
+          <ChromeNextToggle featureFlags={core.featureFlags} />
+        </DeveloperToolbarItem>
       </Suspense>
     );
 

--- a/src/platform/plugins/shared/developer_toolbar/tsconfig.json
+++ b/src/platform/plugins/shared/developer_toolbar/tsconfig.json
@@ -12,5 +12,6 @@
     "@kbn/core-chrome-layout-components",
     "@kbn/config-schema",
     "@kbn/core-chrome-browser-internal-types",
+    "@kbn/core-chrome-feature-flags",
   ]
 }


### PR DESCRIPTION
## Summary

<img width="1624" height="1056" alt="Screenshot 2026-04-02 at 16 58 32" src="https://github.com/user-attachments/assets/14716fe5-5550-428c-9b92-86bcd1597827" />

Note: it is possible to make it work without a page reload, but I thought it was not worth the complexity.