### PR TITLE
[Cases] make AllCasesList ignore history and location when opened in the add to existing case modal

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.test.tsx
@@ -25,27 +25,52 @@ import { CustomFieldTypes } from '../../../common/types/domain';
 import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 
-const mockLocation = { search: '' };
-const mockPush = jest.fn();
-const mockReplace = jest.fn();
-
 jest.mock('../../containers/configure/use_get_case_configuration');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn().mockImplementation(() => {
-    return mockLocation;
-  }),
-  useHistory: jest.fn().mockImplementation(() => ({
-    replace: mockReplace,
-    push: mockPush,
-    location: {
-      search: '',
-    },
-  })),
+}));
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...(() => {
+    const ReactActual = jest.requireActual('react');
+    const mockLocation = { search: '' };
+    const mockPush = jest.fn();
+    const mockReplace = jest.fn();
+    const mockNavigationContextValue: { navigator?: unknown } = {
+      navigator: {
+        replace: mockReplace,
+        push: mockPush,
+        location: mockLocation,
+      },
+    };
+    const mockedRouterModule = {
+      ...jest.requireActual('react-router-dom-v5-compat'),
+      __mockLocation: mockLocation,
+      __mockPush: mockPush,
+      __mockReplace: mockReplace,
+      __mockNavigationContextValue: mockNavigationContextValue,
+    };
+    const unsafeNavigationContextKey = 'UNSAFE_NavigationContext';
+    (mockedRouterModule as Record<string, unknown>)[unsafeNavigationContextKey] =
+      ReactActual.createContext(mockNavigationContextValue);
+
+    return mockedRouterModule;
+  })(),
 }));
 
 const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
+const {
+  __mockLocation: mockLocation,
+  __mockPush: mockPush,
+  __mockReplace: mockReplace,
+  __mockNavigationContextValue: mockNavigationContextValue,
+} = jest.requireMock('react-router-dom-v5-compat') as {
+  __mockLocation: { search: string };
+  __mockPush: jest.Mock;
+  __mockReplace: jest.Mock;
+  __mockNavigationContextValue: { navigator?: unknown };
+};
 
 const LS_KEY = 'securitySolution.cases.list.state';
 
@@ -53,6 +78,11 @@ describe('useAllCasesQueryParams', () => {
   beforeEach(() => {
     localStorage.clear();
     mockLocation.search = '';
+    mockNavigationContextValue.navigator = {
+      replace: mockReplace,
+      push: mockPush,
+      location: mockLocation,
+    };
 
     useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
   });
@@ -715,6 +745,30 @@ describe('useAllCasesQueryParams', () => {
   });
 
   describe('Modal', () => {
+    it('does not require router context', () => {
+      mockNavigationContextValue.navigator = undefined;
+
+      const { result } = renderHook(() => useAllCasesState(true), {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <TestProviders>{children}</TestProviders>
+        ),
+      });
+
+      expect(result.current.queryParams).toStrictEqual(DEFAULT_CASES_TABLE_STATE.queryParams);
+      expect(result.current.filterOptions).toStrictEqual(DEFAULT_CASES_TABLE_STATE.filterOptions);
+
+      act(() => {
+        result.current.setFilterOptions({ status: [CaseStatuses.closed] });
+      });
+
+      expect(result.current.filterOptions).toStrictEqual({
+        ...DEFAULT_CASES_TABLE_STATE.filterOptions,
+        status: [CaseStatuses.closed],
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
     it('returns default state with empty URL and local storage', () => {
       const { result } = renderHook(() => useAllCasesState(true), {
         wrapper: ({ children }: React.PropsWithChildren<{}>) => (

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import type { Context } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { History } from 'history';
+import { UNSAFE_NavigationContext } from 'react-router-dom-v5-compat';
 import deepEqual from 'react-fast-compare';
 import { isEmpty } from 'lodash';
 
@@ -37,7 +39,7 @@ export function useAllCasesState(isModalView: boolean = false): UseAllCasesState
   const isStateLoadedFromLocalStorage = useRef(false);
   const isFirstRun = useRef(false);
   const [tableState, setTableState] = useState<AllCasesTableState>(DEFAULT_CASES_TABLE_STATE);
-  const [urlState, setUrlState] = useAllCasesUrlState();
+  const [urlState, setUrlState] = useAllCasesUrlState(isModalView);
   const [localStorageState, setLocalStorageState] = useAllCasesLocalStorage();
   const { isFetching: isLoadingCasesConfiguration } = useGetCaseConfiguration();
 
@@ -112,30 +114,37 @@ export function useAllCasesState(isModalView: boolean = false): UseAllCasesState
   };
 }
 
-const useAllCasesUrlState = (): [
-  AllCasesURLState,
-  (updated: AllCasesTableState, mode?: 'push' | 'replace') => void
-] => {
-  const history = useHistory();
-  const location = useLocation();
+const useAllCasesUrlState = (
+  isModalView: boolean
+): [AllCasesURLState, (updated: AllCasesTableState, mode?: 'push' | 'replace') => void] => {
+  const navigationContext = useContext(
+    UNSAFE_NavigationContext as unknown as Context<{ navigator?: History } | undefined>
+  );
+  const history = navigationContext?.navigator;
+
   const {
     data: { customFields: customFieldsConfiguration },
   } = useGetCaseConfiguration();
 
-  const urlParams = parseUrlParams(new URLSearchParams(decodeURIComponent(location.search)));
+  const search = history?.location?.search ?? '';
+  const urlParams = parseUrlParams(new URLSearchParams(decodeURIComponent(search)));
   const parsedUrlParams = allCasesUrlStateDeserializer(urlParams, customFieldsConfiguration);
 
   const updateQueryParams = useCallback(
     (updated: AllCasesTableState, mode: 'push' | 'replace' = 'push') => {
+      if (history == null || isModalView) {
+        return;
+      }
+
       const updatedQuery = allCasesUrlStateSerializer(updated);
-      const search = stringifyUrlParams(updatedQuery, location.search);
+      const updatedSearch = stringifyUrlParams(updatedQuery, history.location.search);
 
       history[mode]({
-        ...location,
-        search,
+        ...history.location,
+        search: updatedSearch,
       });
     },
-    [history, location]
+    [history, isModalView]
   );
 
   return [parsedUrlParams, updateQueryParams];


### PR DESCRIPTION
## Summary

While implementing the `Take action` button in the new document flyout, I realized that we HAVE TO wrap the `CaseProvider` within a `Router` which is inconvenient.

### Why this happens

The [useAllCasesState hook](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.tsx#L36) calls this other  [useAllCasesUrlState hook](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_all_cases_state.tsx#L115) which internally uses `useLocation` and `useHistory`. This means that everywhere we use the `CasesProvider`, we always need to be sure that a `Router` is done correctly above...

This is inconvinient. Developers shouldn't have to know and have to do that... While adding the `Take action` button to the new flyout, due to the fact that we use the `overlays.openSystemFlyout` function, all our flyout content is oustide of Security Solution. This means we would have to have a `Router` specifically for the `Add to existing case` functionality.

It seems that `history` and `location` are actually only needed for the cases page. The page needs URL/history sync, the modal does not.

### Code changes

The behavior on the cases page remains unchanged, but the modal is now router-independent

- `useAllCasesState(true)` now passes modal intent into URL-state logic.
- reworked URL-state access to read router data from `UNSAFE_NavigationContext` from `react-router-dom-v5-compat` instead of unguarded `useLocation`/`useHistory` calls.
- in modal mode (or when router context is unavailable), URL writes are now no-ops.
- non-modal page behavior remains URL/localStorage-synced.

Preserve full URL/localStorage sync when isModalView === false

### The cases pages should see no changes!

https://github.com/user-attachments/assets/08176485-d086-484e-8db3-a5509ae15b17

### The add to existing case also sees no UI changes

#### Issue with flyout

https://github.com/user-attachments/assets/1ac7d527-6c6b-40e7-b4db-703a7aecb7a2

#### No solved

https://github.com/user-attachments/assets/b0ab04ed-d99a-447e-88fa-7eef2c9bd259

### Expected gains / tradeoffs - from Cursor

- **Gains**: fixes crash in selector modal across all integrations; better separation of page URL concerns vs modal ephemeral state; fewer router-coupling regressions.
- No intended behavior loss: Cases page URL/history functionality remains intact.

- **Risk**: accidental non-modal URL regression if refactor is broad; mitigated by preserving and re-running existing hook tests.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

PR developed with Cursor + gpt-5.3-Codex