### PR TITLE
[Cases] add status column to add to existing case modal and disable select button for closed cases

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -409,6 +409,32 @@ describe('AllCasesListGeneric', () => {
     });
   });
 
+  it('should disable select and not call onRowClick for closed cases with modal=true', async () => {
+    const theCase = {
+      ...defaultGetCases.data.cases[0],
+      status: CaseStatuses.closed,
+    };
+    useGetCasesMock.mockReturnValue({
+      ...defaultGetCases,
+      data: {
+        ...defaultGetCases.data,
+        cases: [theCase, ...defaultGetCases.data.cases.slice(1)],
+      },
+    });
+
+    renderWithTestingProviders(<AllCasesList isSelectorView={true} onRowClick={onRowClick} />);
+
+    const selectButton = await screen.findByTestId(`cases-table-row-select-${theCase.id}`);
+    expect(selectButton).toBeDisabled();
+    expect(selectButton).toHaveTextContent('Select');
+    expect(selectButton).not.toHaveTextContent('Added');
+
+    await userEvent.click(selectButton);
+    await waitFor(() => {
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
   it('should NOT call onRowClick when clicking a case with modal=true', async () => {
     renderWithTestingProviders(<AllCasesList isSelectorView={false} />);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -338,6 +338,15 @@ describe('useCasesColumns ', () => {
           },
           Object {
             "className": "eui-textNoWrap",
+            "field": "status",
+            "minWidth": "6.5em",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "6.5em",
+          },
+          Object {
+            "className": "eui-textNoWrap",
             "field": "severity",
             "minWidth": "6em",
             "name": "Severity",
@@ -391,6 +400,15 @@ describe('useCasesColumns ', () => {
             "render": [Function],
             "sortable": true,
             "width": "9em",
+          },
+          Object {
+            "className": "eui-textNoWrap",
+            "field": "status",
+            "minWidth": "6.5em",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "6.5em",
           },
           Object {
             "className": "eui-textNoWrap",
@@ -450,6 +468,15 @@ describe('useCasesColumns ', () => {
           },
           Object {
             "className": "eui-textNoWrap",
+            "field": "status",
+            "minWidth": "6.5em",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "6.5em",
+          },
+          Object {
+            "className": "eui-textNoWrap",
             "field": "severity",
             "minWidth": "6em",
             "name": "Severity",
@@ -465,6 +492,29 @@ describe('useCasesColumns ', () => {
         ],
         "isLoadingColumns": false,
         "rowHeader": "title",
+      }
+    `);
+  });
+
+  it('keeps the selector action column for closed status filtering', async () => {
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          isSelectorView: true,
+          filterStatus: [CaseStatuses.closed],
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    const assignActionColumn = result.current.columns[result.current.columns.length - 1];
+    expect(assignActionColumn).toMatchInlineSnapshot(`
+      Object {
+        "align": "right",
+        "render": [Function],
+        "width": "8em",
       }
     `);
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -19,6 +19,7 @@ import {
 } from '@elastic/eui';
 import { Status } from '@kbn/cases-components/src/status/status';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { CaseStatuses } from '../../../common/types/domain';
 
 import {
   tableColumnPresetDateRelative,
@@ -295,16 +296,18 @@ export const useCasesColumns = ({
         align: RIGHT_ALIGNMENT,
         render: (theCase: CaseUI) => {
           if (theCase.id != null) {
-            const disabled = disabledCases?.has(theCase.id) ?? false;
+            const isAlreadyAttached = disabledCases?.has(theCase.id) ?? false;
+            const isClosed = theCase.status === CaseStatuses.closed;
+            const disabled = isAlreadyAttached || isClosed;
             return (
               <EuiButton
                 data-test-subj={`cases-table-row-select-${theCase.id}`}
                 onClick={() => assignCaseAction(theCase)}
                 size="s"
-                iconType={disabled ? 'check' : undefined}
+                iconType={isAlreadyAttached ? 'check' : undefined}
                 disabled={disabled}
               >
-                {disabled ? i18n.ALREADY_ATTACHED : i18n.SELECT}
+                {isAlreadyAttached ? i18n.ALREADY_ATTACHED : i18n.SELECT}
               </EuiButton>
             );
           }

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -100,7 +100,7 @@ export const useCasesColumnsConfiguration = (
     status: {
       field: 'status',
       name: i18n.STATUS,
-      canDisplay: canDisplayDefault && !isSelectorView,
+      canDisplay: canDisplayDefault,
       isCheckedDefault: true,
     },
     severity: {


### PR DESCRIPTION
## Summary

This PR makes a small UI changes to the `Add to existing case` modal:
- we're now showing the status column, to show the status of the case
- we're now disabling the `Select` button when the case is closed

### Reason for the change

While testing the `Add to existing case` functionality in the new document flyout, I realized that when you select a case that is already closed, the UI lets you do that like for an opened case. We close the modal, but then a couple of seconds later we show a pop up that says `Can't add an alert to a closed case`.

https://github.com/user-attachments/assets/182544df-6ebe-48d1-99bb-1480c1cd3f20

This UX isn't ideal, instead we should let the user know that the case is closed and prevent them from selecting it.

### Small UI changes

Here's the new UI, with the added status column and the disabled button:

https://github.com/user-attachments/assets/aa505bef-1cc3-4b32-8670-6f93b841ee38

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->