### PR TITLE
Add git remote guard hook for AI coding agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/scripts/git_remote_guard_hook.js --claude"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/scripts/git_remote_guard_hook.js --claude"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "node scripts/git_remote_guard_hook.js"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ target
 .claude/*.local.json
 .claude/worktrees/
 .cursor
+!.cursor/hooks.json
 !x-pack/solutions/security/.cursor
 !x-pack/solutions/security/test/security_solution_cypress/.cursor/
 .windsurf

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ target
 .idea
 .claude/*.local.json
 .claude/worktrees/
-.cursor
+.cursor/*
 !.cursor/hooks.json
 !x-pack/solutions/security/.cursor
 !x-pack/solutions/security/test/security_solution_cypress/.cursor/

--- a/scripts/git_remote_guard_hook.js
+++ b/scripts/git_remote_guard_hook.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+require('@kbn/setup-node-env');
+require('../src/dev/github/git_remote_guard_hook').runGitRemoteGuardHook();

--- a/src/dev/github/git_remote_guard_hook.test.ts
+++ b/src/dev/github/git_remote_guard_hook.test.ts
@@ -108,6 +108,7 @@ describe('git remote guard hook', () => {
 
     const cases = [
       'git pull bamieh main',
+      'git pull bamieh refs/heads/main',
       'git pull --rebase bamieh main',
       'git pull --ff-only bamieh main',
       'git fetch bamieh main',
@@ -157,6 +158,24 @@ describe('git remote guard hook', () => {
       { claude: true }
     );
     expect(allow).toBeNull();
+  });
+
+  it('ignores unrelated remotes when checking for fork', () => {
+    const remotesWithUnrelated = [
+      'origin\tgit@github.com:elastic/kibana.git (fetch)',
+      'origin\tgit@github.com:elastic/kibana.git (push)',
+      'other\tgit@github.com:someuser/other-repo.git (fetch)',
+      'other\tgit@github.com:someuser/other-repo.git (push)',
+    ].join('\n');
+
+    setupGit({
+      'remote -v': remotesWithUnrelated,
+      'remote get-url other': 'git@github.com:someuser/other-repo.git',
+    });
+
+    expect(runHook({ command: 'git push origin my-branch', cwd: '/repo' })).toEqual({
+      permission: 'allow',
+    });
   });
 
   it('allows everything when KIBANA_GIT_REMOTE_GUARD_BYPASS=1', () => {

--- a/src/dev/github/git_remote_guard_hook.test.ts
+++ b/src/dev/github/git_remote_guard_hook.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { runGitRemoteGuardHook } from './git_remote_guard_hook';
+
+jest.mock('node:child_process');
+jest.mock('node:fs');
+
+const spawnSyncMock = spawnSync as jest.MockedFunction<typeof spawnSync>;
+const readFileSyncMock = readFileSync as jest.MockedFunction<typeof readFileSync>;
+
+const REMOTES = [
+  'origin\tgit@github.com:elastic/kibana.git (fetch)',
+  'origin\tgit@github.com:elastic/kibana.git (push)',
+  'bamieh\tgit@github.com:Bamieh/kibana.git (fetch)',
+  'bamieh\tgit@github.com:Bamieh/kibana.git (push)',
+].join('\n');
+
+const ok = (stdout: string) =>
+  ({ stdout, status: 0, stderr: '', pid: 0, output: [], signal: null } as any);
+const fail = () =>
+  ({
+    stdout: '',
+    status: 1,
+    stderr: '',
+    pid: 0,
+    output: [],
+    signal: null,
+    error: new Error(),
+  } as any);
+
+const setupGit = (overrides: Record<string, string> = {}) => {
+  const responses: Record<string, string> = {
+    'rev-parse --show-toplevel': '/repo',
+    'remote -v': REMOTES,
+    'branch --show-current': 'my-feature',
+    'remote get-url origin': 'git@github.com:elastic/kibana.git',
+    'remote get-url bamieh': 'git@github.com:Bamieh/kibana.git',
+    ...overrides,
+  };
+  spawnSyncMock.mockImplementation((_cmd, args) => {
+    const key = (args as string[]).join(' ');
+    const match = Object.entries(responses).find(([k]) => key.includes(k));
+    return match ? ok(match[1]) : fail();
+  });
+};
+
+const runHook = (payload: object, { claude = false }: { claude?: boolean } = {}) => {
+  let output = '';
+
+  readFileSyncMock.mockReturnValue(JSON.stringify(payload));
+
+  const originalArgv = process.argv;
+  process.argv = claude ? ['node', 'hook', '--claude'] : ['node', 'hook'];
+
+  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    output += chunk;
+    return true;
+  });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+    throw new Error(`EXIT:${code ?? 0}`);
+  });
+
+  try {
+    runGitRemoteGuardHook();
+  } catch (e: any) {
+    if (!e.message.startsWith('EXIT:')) throw e;
+  }
+
+  writeSpy.mockRestore();
+  exitSpy.mockRestore();
+  process.argv = originalArgv;
+
+  return output.trim() ? JSON.parse(output.trim()) : null;
+};
+
+describe('git remote guard hook', () => {
+  it('allows safe commands', () => {
+    setupGit();
+
+    expect(runHook({ command: 'npm install', cwd: '/repo' })).toEqual({ permission: 'allow' });
+    expect(runHook({ command: 'git status', cwd: '/repo' })).toEqual({ permission: 'allow' });
+    expect(runHook({ command: 'git pull origin main', cwd: '/repo' })).toEqual({
+      permission: 'allow',
+    });
+    expect(runHook({ command: 'git push bamieh my-branch', cwd: '/repo' })).toEqual({
+      permission: 'allow',
+    });
+    expect(runHook({ command: 'git pull bamieh feature', cwd: '/repo' })).toEqual({
+      permission: 'allow',
+    });
+    expect(runHook({ command: 'gh pr create --title test', cwd: '/repo' })).toEqual({
+      permission: 'allow',
+    });
+  });
+
+  it('blocks pulling main from fork remote', () => {
+    setupGit();
+
+    const cases = [
+      'git pull bamieh main',
+      'git pull --rebase bamieh main',
+      'git pull --ff-only bamieh main',
+      'git fetch bamieh main',
+      'git fetch bamieh refs/heads/main',
+      'git merge bamieh/main',
+      'git rebase bamieh/main',
+      'git checkout main && git pull bamieh main',
+    ];
+
+    for (const cmd of cases) {
+      const json = runHook({ command: cmd, cwd: '/repo' });
+      expect(json).toMatchObject({ continue: false, permission: 'deny' });
+      expect(json.agentMessage).toContain('Bamieh/kibana');
+    }
+  });
+
+  it('blocks git pull <fork> when on main branch', () => {
+    setupGit({ 'branch --show-current': 'main' });
+
+    const json = runHook({ command: 'git pull bamieh', cwd: '/repo' });
+    expect(json).toMatchObject({ continue: false, permission: 'deny' });
+  });
+
+  it('blocks pushing to canonical when fork exists', () => {
+    setupGit();
+
+    const cases = ['git push origin my-branch', 'git push -u origin my-branch'];
+
+    for (const cmd of cases) {
+      const json = runHook({ command: cmd, cwd: '/repo' });
+      expect(json).toMatchObject({ continue: false, permission: 'deny' });
+      expect(json.agentMessage).toContain('Push to your fork');
+    }
+  });
+
+  it('responds with Claude format when --claude is set', () => {
+    setupGit();
+
+    const deny = runHook(
+      { tool_input: { command: 'git pull bamieh main' }, cwd: '/repo' },
+      { claude: true }
+    );
+    expect(deny.hookSpecificOutput.permissionDecision).toBe('deny');
+
+    const allow = runHook(
+      { tool_input: { command: 'git status' }, cwd: '/repo' },
+      { claude: true }
+    );
+    expect(allow).toBeNull();
+  });
+
+  it('allows everything when KIBANA_GIT_REMOTE_GUARD_BYPASS=1', () => {
+    setupGit();
+    const orig = process.env.KIBANA_GIT_REMOTE_GUARD_BYPASS;
+    process.env.KIBANA_GIT_REMOTE_GUARD_BYPASS = '1';
+    try {
+      expect(runHook({ command: 'git pull bamieh main', cwd: '/repo' })).toEqual({
+        permission: 'allow',
+      });
+    } finally {
+      process.env.KIBANA_GIT_REMOTE_GUARD_BYPASS = orig;
+    }
+  });
+});

--- a/src/dev/github/git_remote_guard_hook.test.ts
+++ b/src/dev/github/git_remote_guard_hook.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { SpawnSyncReturns } from 'node:child_process';
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { runGitRemoteGuardHook } from './git_remote_guard_hook';
@@ -24,18 +25,18 @@ const REMOTES = [
   'bamieh\tgit@github.com:Bamieh/kibana.git (push)',
 ].join('\n');
 
-const ok = (stdout: string) =>
-  ({ stdout, status: 0, stderr: '', pid: 0, output: [], signal: null } as any);
-const fail = () =>
-  ({
-    stdout: '',
-    status: 1,
-    stderr: '',
-    pid: 0,
-    output: [],
-    signal: null,
-    error: new Error(),
-  } as any);
+const spawnResult = (overrides: Partial<SpawnSyncReturns<string>>): SpawnSyncReturns<string> => ({
+  stdout: '',
+  stderr: '',
+  status: 0,
+  pid: 0,
+  output: [],
+  signal: null,
+  ...overrides,
+});
+
+const ok = (stdout: string) => spawnResult({ stdout });
+const fail = () => spawnResult({ status: 1, error: new Error() });
 
 const setupGit = (overrides: Record<string, string> = {}) => {
   const responses: Record<string, string> = {
@@ -73,11 +74,11 @@ const runHook = (payload: object, { claude = false }: { claude?: boolean } = {})
     runGitRemoteGuardHook();
   } catch (e: any) {
     if (!e.message.startsWith('EXIT:')) throw e;
+  } finally {
+    writeSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.argv = originalArgv;
   }
-
-  writeSpy.mockRestore();
-  exitSpy.mockRestore();
-  process.argv = originalArgv;
 
   return output.trim() ? JSON.parse(output.trim()) : null;
 };

--- a/src/dev/github/git_remote_guard_hook.ts
+++ b/src/dev/github/git_remote_guard_hook.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+export interface HookPayload {
+  command?: string;
+  cwd?: string;
+  workspace_roots?: string[];
+  tool_name?: string;
+  tool_input?: { command?: string };
+}
+
+export interface GuardedRemote {
+  remote: string;
+  kind: 'pull' | 'push';
+}
+
+export function parseEnv() {
+  return {
+    canonical: (process.env.KIBANA_GIT_CANONICAL_REPO ?? 'elastic/kibana').toLowerCase(),
+    bypass: process.env.KIBANA_GIT_REMOTE_GUARD_BYPASS === '1',
+    isClaude: process.argv.includes('--claude'),
+  };
+}
+
+export function runGitRemoteGuardHook() {
+  const { canonical, bypass, isClaude } = parseEnv();
+  const allow = () => respond(isClaude, 'allow');
+  const deny = (msg: string) => respond(isClaude, 'deny', msg);
+
+  if (bypass) return allow();
+
+  let payload: HookPayload = {};
+  try {
+    // fd 0 = stdin, both Cursor and Claude hooks pipe JSON here
+    payload = JSON.parse(readFileSync(0, 'utf8'));
+  } catch {
+    /* stdin empty or not JSON */
+  }
+
+  const extracted = extractGitCommand(payload, isClaude);
+  if (!extracted) return allow();
+
+  const { git, getRemotes, findCanonicalRemote, isNonCanonical, findGuardedRemotes } =
+    createGitUtils({ cwd: extracted.cwd, canonical });
+
+  const remotes = getRemotes();
+  const canonRemote = findCanonicalRemote(remotes);
+  if (!canonRemote) return allow();
+
+  const onMain = git(['branch', '--show-current']) === 'main';
+  const guarded = findGuardedRemotes(extracted.cmd, onMain);
+  if (guarded.length === 0) return allow();
+
+  const hasForkRemote = [...remotes.values()].some(isNonCanonical);
+
+  for (const { remote, kind } of guarded) {
+    const url = remotes.get(remote) ?? git(['remote', 'get-url', remote]);
+    if (!url) continue;
+
+    if (kind === 'pull' && isNonCanonical(url)) {
+      return deny(
+        `Blocked: pulling main from "${remote}" (${url}) which is not elastic/kibana. ` +
+          `Use: git pull ${canonRemote} main. ` +
+          `Set KIBANA_GIT_REMOTE_GUARD_BYPASS=1 to override.`
+      );
+    }
+
+    if (kind === 'push' && !isNonCanonical(url) && hasForkRemote) {
+      return deny(
+        `Blocked: pushing to "${remote}" (${url}) which is elastic/kibana. ` +
+          `Push to your fork remote instead. ` +
+          `Set KIBANA_GIT_REMOTE_GUARD_BYPASS=1 to override.`
+      );
+    }
+  }
+
+  return allow();
+}
+
+// --- response formatting ---
+
+function respond(isClaude: boolean, decision: 'allow' | 'deny', message?: string): never {
+  if (decision === 'allow') {
+    if (!isClaude) process.stdout.write(JSON.stringify({ permission: 'allow' }) + '\n');
+    return process.exit(0);
+  }
+  const json = isClaude
+    ? {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: message,
+        },
+      }
+    : { continue: false, permission: 'deny', agentMessage: message, userMessage: message };
+  process.stdout.write(JSON.stringify(json) + '\n');
+  return process.exit(0);
+}
+
+// --- payload extraction ---
+
+function extractGitCommand(
+  payload: HookPayload,
+  isClaude: boolean
+): { cmd: string; cwd: string } | null {
+  const cmd = isClaude ? payload.tool_input?.command : payload.command;
+  if (typeof cmd !== 'string' || !/\bgit\s/.test(cmd)) return null;
+  return { cmd, cwd: payload.cwd ?? process.cwd() };
+}
+
+// --- git utilities ---
+
+export function createGitUtils(options: { cwd: string; canonical: string }) {
+  const { canonical } = options;
+
+  const parseGithubRepo = (url: string): string | null => {
+    try {
+      const normalized = url.trim().replace(/^git@github\.com:/, 'https://github.com/');
+      const { hostname, pathname } = new URL(normalized);
+      if (hostname !== 'github.com') return null;
+      const [owner, repo] = pathname
+        .replace(/^\//, '')
+        .replace(/\.git$/, '')
+        .split('/');
+      return owner && repo ? `${owner}/${repo}`.toLowerCase() : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const gitRoot = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    maxBuffer: 2 ** 20,
+  });
+  const root = gitRoot.error || gitRoot.status !== 0 ? options.cwd : gitRoot.stdout.trim();
+
+  const git = (args: string[]): string | null => {
+    const r = spawnSync('git', args, { cwd: root, encoding: 'utf8', maxBuffer: 2 ** 20 });
+    return r.error || r.status !== 0 ? null : r.stdout.trim();
+  };
+
+  const getRemotes = (): Map<string, string> => {
+    const out = git(['remote', '-v']);
+    if (!out) return new Map();
+    const result = new Map<string, string>();
+    for (const line of out.split('\n')) {
+      if (!line.endsWith('(fetch)')) continue;
+      const [name, url] = line.split(/\s+/);
+      if (name && url) result.set(name, url);
+    }
+    return result;
+  };
+
+  const findCanonicalRemote = (remotes: Map<string, string>): string | null => {
+    for (const [name, url] of remotes) {
+      if (parseGithubRepo(url) === canonical) return name;
+    }
+    return null;
+  };
+
+  // non-GitHub URLs (local paths, self-hosted) are not considered non-canonical
+  const isNonCanonical = (url: string): boolean => {
+    const parsed = parseGithubRepo(url);
+    return parsed !== null && parsed !== canonical;
+  };
+
+  const findGuardedRemotes = (command: string, onMain: boolean): GuardedRemote[] => {
+    const tracking = git(['rev-parse', '--abbrev-ref', '@{u}']);
+    const upstream = tracking?.includes('/') ? tracking.split('/')[0] : null;
+    const result: GuardedRemote[] = [];
+
+    // split compound shell commands: "git checkout main && git pull origin main" → segments
+    for (const seg of command.split(/\s*(?:&&|\|\||\||;)\s*/)) {
+      const [bin, sub, ...rest] = seg.trim().split(/\s+/);
+      if (bin !== 'git') continue;
+
+      // e.g. ['--rebase', 'origin', 'main'] → ['origin', 'main']
+      const args = rest.filter((t) => !t.startsWith('-'));
+
+      switch (sub) {
+        // git pull origin main | git pull origin (on main) | git pull (on main, uses upstream)
+        case 'pull':
+          if (args.length >= 2 && args[1] === 'main')
+            result.push({ remote: args[0], kind: 'pull' });
+          else if (args.length === 1 && onMain) result.push({ remote: args[0], kind: 'pull' });
+          else if (args.length === 0 && onMain && upstream)
+            result.push({ remote: upstream, kind: 'pull' });
+          break;
+        // git fetch origin main | git fetch origin refs/heads/main
+        case 'fetch':
+          if (
+            args.length >= 2 &&
+            args.slice(1).some((r) => r === 'main' || r === 'refs/heads/main')
+          )
+            result.push({ remote: args[0], kind: 'pull' });
+          break;
+        // git merge origin/main | git rebase origin/main
+        case 'merge':
+        case 'rebase': {
+          const [remote, branch] = (args[0] ?? '').split('/');
+          if (branch === 'main') result.push({ remote, kind: 'pull' });
+          break;
+        }
+        // git push origin my-branch | git push (uses upstream)
+        case 'push': {
+          const remote = args[0] ?? upstream;
+          if (remote) result.push({ remote, kind: 'push' });
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
+  return { git, getRemotes, findCanonicalRemote, isNonCanonical, findGuardedRemotes };
+}

--- a/src/dev/github/git_remote_guard_hook.ts
+++ b/src/dev/github/git_remote_guard_hook.ts
@@ -168,11 +168,15 @@ export function createGitUtils(options: { cwd: string; canonical: string }) {
     return null;
   };
 
-  // non-GitHub URLs (local paths, self-hosted) are not considered non-canonical
+  // only flag GitHub repos whose repo name matches canonical but owner differs
+  // (e.g. Bamieh/kibana is a fork, elastic/elasticsearch is unrelated)
   const isNonCanonical = (url: string): boolean => {
     const parsed = parseGithubRepo(url);
-    return parsed !== null && parsed !== canonical;
+    if (!parsed || parsed === canonical) return false;
+    return parsed.split('/')[1] === canonical.split('/')[1];
   };
+
+  const isMainRef = (ref: string) => ref === 'main' || ref === 'refs/heads/main';
 
   const findGuardedRemotes = (command: string, onMain: boolean): GuardedRemote[] => {
     const tracking = git(['rev-parse', '--abbrev-ref', '@{u}']);
@@ -188,20 +192,16 @@ export function createGitUtils(options: { cwd: string; canonical: string }) {
       const args = rest.filter((t) => !t.startsWith('-'));
 
       switch (sub) {
-        // git pull origin main | git pull origin (on main) | git pull (on main, uses upstream)
+        // git pull origin main | git pull origin refs/heads/main | git pull origin (on main)
         case 'pull':
-          if (args.length >= 2 && args[1] === 'main')
+          if (args.length >= 2 && isMainRef(args[1]))
             result.push({ remote: args[0], kind: 'pull' });
           else if (args.length === 1 && onMain) result.push({ remote: args[0], kind: 'pull' });
           else if (args.length === 0 && onMain && upstream)
             result.push({ remote: upstream, kind: 'pull' });
           break;
-        // git fetch origin main | git fetch origin refs/heads/main
         case 'fetch':
-          if (
-            args.length >= 2 &&
-            args.slice(1).some((r) => r === 'main' || r === 'refs/heads/main')
-          )
+          if (args.length >= 2 && args.slice(1).some(isMainRef))
             result.push({ remote: args[0], kind: 'pull' });
           break;
         // git merge origin/main | git rebase origin/main


### PR DESCRIPTION
## Summary

AI coding agents (Cursor, Claude Code) frequently cause broken PRs by operating on the wrong git remote. The typical failure modes:

1. **Stale main**: the agent pulls `main` from the developer's fork instead of `elastic/kibana`. The fork's `main` is behind, so the PR branch diverges and shows hundreds of unrelated file changes.
2. **Wrong push target**: the agent pushes the feature branch to `elastic/kibana` instead of the fork. This creates duplicate branches (one on the fork, one on upstream), and subsequent pulls mix the two, corrupting the PR diff.
3. **Reviewer spam**: both cases trigger CODEOWNERS-based reviewer assignments on files the developer never touched, pinging unrelated teams across the org.

This has been hitting multiple teams recently and the cleanup (force-push, re-request reviewers, explain to pinged teams) is a time sink.

### What this PR adds

A pre-execution hook that intercepts git commands before the agent runs them and blocks the dangerous patterns:

- **Pull main from fork**: `git pull <fork> main`, `git fetch <fork> main`, `git merge <fork>/main`, `git rebase <fork>/main` are denied when the remote is a GitHub repo that is not `elastic/kibana`.
- **Push to canonical**: `git push origin <branch>` is denied when `origin` is `elastic/kibana` and a fork remote exists (meaning you should push there instead).

The hook resolves remotes by URL (not by alias name) so it works regardless of how developers name their remotes. Both Cursor and Claude Code pipe JSON to stdin before executing shell commands; the hook parses the command, classifies remotes via `git remote -v`, and returns allow/deny in the format each tool expects.

- **Bypass**: `KIBANA_GIT_REMOTE_GUARD_BYPASS=1` to override for a single command.
- **Configurable canonical repo**: `KIBANA_GIT_CANONICAL_REPO` env var (defaults to `elastic/kibana`).

### Files

- `src/dev/github/git_remote_guard_hook.ts` — core guard logic
- `src/dev/github/git_remote_guard_hook.test.ts` — Jest tests
- `scripts/git_remote_guard_hook.js` — Node entry point
- `.claude/settings.json` — Claude Code `PreToolUse` hook wiring
- `.cursor/hooks.json` — Cursor `beforeShellExecution` hook wiring
- `.gitignore` — allowlist `.cursor/hooks.json` for tracking

### How it looks

<img width="458" height="234" alt="image" src="https://github.com/user-attachments/assets/68c90dfa-b7ca-4ba3-8c39-3a2361a0cd5c" />