### PR TITLE
[9.3] [Cases] Fix incremental_id drift issues (#258789)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/actions/severity/use_severity_action.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/severity/use_severity_action.tsx
@@ -66,6 +66,7 @@ export const useSeverityAction = ({
         {
           cases: casesToUpdate,
           successToasterTitle: getSeverityToasterMessage(severity, selectedCases),
+          originalCases: selectedCases,
         },
         { onSuccess: onActionSuccess }
       );

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/status/use_status_action.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/status/use_status_action.tsx
@@ -57,6 +57,7 @@ export const useStatusAction = ({
         {
           cases: casesToUpdate,
           successToasterTitle: getStatusToasterMessage(status, selectedCases),
+          originalCases: selectedCases,
         },
         { onSuccess: onActionSuccess }
       );

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/use_items_action.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/use_items_action.tsx
@@ -87,6 +87,7 @@ export const useItemsAction = <T,>({
         {
           cases: casesToUpdate,
           successToasterTitle: successToasterTitle(selectedCasesToEdit.length),
+          originalCases: selectedCasesToEdit,
         },
         { onSuccess: onActionSuccess }
       );

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.test.tsx
@@ -371,14 +371,13 @@ describe('Case View Page activity tab', () => {
       },
     });
 
+    const caseDataWithCustomFields: CaseUI = {
+      ...caseProps.caseData,
+      customFields: [customFieldsMock[1]],
+    };
+
     renderWithTestingProviders(
-      <CaseViewActivity
-        {...caseProps}
-        caseData={{
-          ...caseProps.caseData,
-          customFields: [customFieldsMock[1]],
-        }}
-      />
+      <CaseViewActivity {...caseProps} caseData={caseDataWithCustomFields} />
     );
 
     await userEvent.click(await screen.findByRole('switch'));
@@ -387,6 +386,7 @@ describe('Case View Page activity tab', () => {
       expect(replaceCustomField).toHaveBeenCalledWith({
         caseId: caseData.id,
         caseVersion: caseData.version,
+        caseData: caseDataWithCustomFields,
         customFieldId: customFieldsMock[1].key,
         customFieldValue: false,
       });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_activity.tsx
@@ -174,6 +174,7 @@ export const CaseViewActivity = ({
         customFieldId: customField.key,
         customFieldValue: customField.value,
         caseVersion: caseData.version,
+        caseData,
       });
     },
     [replaceCustomField, caseData]

--- a/x-pack/platform/plugins/shared/cases/public/containers/__mocks__/api.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/__mocks__/api.ts
@@ -55,6 +55,14 @@ import { DEFAULT_FROM_DATE, DEFAULT_TO_DATE } from '../constants';
 export const resolveCase = async (caseId: string, signal: AbortSignal): Promise<ResolvedCase> =>
   Promise.resolve(basicResolvedCase);
 
+export const getCase = async ({
+  caseId,
+  signal,
+}: {
+  caseId: string;
+  signal?: AbortSignal;
+}): Promise<CaseUI> => Promise.resolve(basicCase);
+
 export const getSingleCaseMetrics = async (
   caseId: string,
   signal: AbortSignal

--- a/x-pack/platform/plugins/shared/cases/public/containers/api.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/api.ts
@@ -131,6 +131,21 @@ export const resolveCase = async ({
   return convertCaseResolveToCamelCase(decodeCaseResolveResponse(response));
 };
 
+export const getCase = async ({
+  caseId,
+  signal,
+}: {
+  caseId: string;
+  signal?: AbortSignal;
+}): Promise<CaseUI> => {
+  const response = await KibanaServices.get().http.fetch<Case>(getCaseDetailsUrl(caseId), {
+    method: 'GET',
+    signal,
+  });
+
+  return convertCaseToCamelCase(decodeCaseResponse(response));
+};
+
 export const getTags = async ({
   owner,
   signal,

--- a/x-pack/platform/plugins/shared/cases/public/containers/conflict_rebase.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/conflict_rebase.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getCaseConflictRebaseDecision,
+  isRetryableCaseConflictError,
+  rebaseCaseMutationOnConflict,
+} from './conflict_rebase';
+import { basicCaseFixture } from './test_fixtures';
+
+describe('conflict_rebase', () => {
+  const conflictError = Object.assign(new Error('Conflict'), {
+    body: { statusCode: 409 },
+  });
+
+  it('treats incremental id drift as rebasable system drift', () => {
+    const latestCase = {
+      ...basicCaseFixture,
+      incrementalId: 42,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      version: 'WzQ4LDFd',
+    };
+
+    expect(
+      getCaseConflictRebaseDecision({
+        staleCases: [basicCaseFixture],
+        latestCases: [latestCase],
+      })
+    ).toBe('only_system_drift');
+  });
+
+  it('treats user-visible case changes as conflicting drift', () => {
+    expect(
+      getCaseConflictRebaseDecision({
+        staleCases: [basicCaseFixture],
+        latestCases: [{ ...basicCaseFixture, title: 'A different title', version: 'WzQ4LDFd' }],
+      })
+    ).toBe('conflicting_case_change');
+  });
+
+  it('retries once with rebuilt request after a retryable conflict', async () => {
+    const latestCase = {
+      ...basicCaseFixture,
+      incrementalId: 42,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      version: 'WzQ4LDFd',
+    };
+    const executeRequest = jest
+      .fn()
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce('ok');
+    const fetchLatestCase = jest.fn().mockResolvedValue(latestCase);
+
+    const response = await rebaseCaseMutationOnConflict({
+      request: { caseId: basicCaseFixture.id, version: basicCaseFixture.version },
+      staleCases: [basicCaseFixture],
+      executeRequest,
+      fetchLatestCase,
+      buildRetryRequest: ({ request, latestCases }) => ({
+        ...request,
+        version: latestCases.get(basicCaseFixture.id)?.version ?? request.version,
+      }),
+    });
+
+    expect(response).toBe('ok');
+    expect(fetchLatestCase).toHaveBeenCalledWith(basicCaseFixture.id);
+    expect(executeRequest).toHaveBeenNthCalledWith(2, {
+      caseId: basicCaseFixture.id,
+      version: latestCase.version,
+    });
+  });
+
+  it('re-throws the original error when user-visible fields changed on the latest case', async () => {
+    const executeRequest = jest
+      .fn()
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce('ok');
+    const fetchLatestCase = jest.fn().mockResolvedValue({
+      ...basicCaseFixture,
+      title: 'A different title',
+      version: 'WzQ4LDFd',
+    });
+
+    await expect(
+      rebaseCaseMutationOnConflict({
+        request: { caseId: basicCaseFixture.id, version: basicCaseFixture.version },
+        staleCases: [basicCaseFixture],
+        executeRequest,
+        fetchLatestCase,
+        buildRetryRequest: ({ request }) => request,
+      })
+    ).rejects.toThrow('Conflict');
+
+    expect(fetchLatestCase).toHaveBeenCalledWith(basicCaseFixture.id);
+    expect(executeRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt a rebase for non-conflict errors', async () => {
+    const executeRequest = jest.fn().mockRejectedValue(new Error('boom'));
+    const fetchLatestCase = jest.fn();
+
+    await expect(
+      rebaseCaseMutationOnConflict({
+        request: { caseId: basicCaseFixture.id, version: basicCaseFixture.version },
+        staleCases: [basicCaseFixture],
+        executeRequest,
+        fetchLatestCase,
+        buildRetryRequest: ({ request }) => request,
+      })
+    ).rejects.toThrow('boom');
+
+    expect(fetchLatestCase).not.toHaveBeenCalled();
+    expect(isRetryableCaseConflictError(new Error('boom'))).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/cases/public/containers/conflict_rebase.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/conflict_rebase.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEqual, omit } from 'lodash';
+import type { CaseUI } from './types';
+import type { ServerError } from '../types';
+
+/**
+ * Fields that the server can mutate without any user action:
+ * - `incrementalId`: assigned by a background task that runs periodically and writes a
+ *   sequential ID to cases that don't have one yet. This bumps the ES document version,
+ *   which can cause a 409 on a concurrent PATCH even though no human changed the case.
+ * - `version`: the ES-level optimistic-concurrency token — always differs between stale and latest.
+ * - `updatedAt`: updated by the server on every write, including the background task.
+ * These fields are excluded from conflict detection so only genuine user-driven changes
+ * cause a retry to be rejected.
+ */
+const SYSTEM_MANAGED_CASE_FIELDS = ['incrementalId', 'updatedAt', 'version'] as const;
+
+export type CaseWithOptionalComments = Omit<CaseUI, 'comments'> & {
+  comments?: CaseUI['comments'];
+};
+
+export type CaseConflictRebaseDecision = 'only_system_drift' | 'conflicting_case_change';
+
+interface RebaseCaseMutationOnConflictParams<TRequest, TResponse> {
+  request: TRequest;
+  staleCases: CaseWithOptionalComments[];
+  executeRequest: (request: TRequest) => Promise<TResponse>;
+  fetchLatestCase: (caseId: string) => Promise<CaseWithOptionalComments>;
+  buildRetryRequest: (args: {
+    request: TRequest;
+    latestCases: Map<string, CaseWithOptionalComments>;
+  }) => TRequest;
+}
+
+const getErrorStatusCode = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error == null) {
+    return;
+  }
+
+  const typedError = error as Partial<ServerError> & {
+    response?: { status?: number };
+    body?: { statusCode?: number };
+  };
+
+  return typedError.body?.statusCode ?? typedError.response?.status;
+};
+
+/**
+ * Only "409 - Conflict" is safe to retry: it means an optimistic-concurrency mismatch that
+ * __may__ have been caused by a benign server-side write. Any other status code represents a
+ * genuine failure (validation error, auth problem, etc.) that retrying won't fix.
+ */
+export const isRetryableCaseConflictError = (error: unknown): boolean => {
+  const statusCode = getErrorStatusCode(error);
+
+  return statusCode != null && statusCode === 409;
+};
+
+/**
+ * Strip system-managed fields before comparing stale vs. latest so that only
+ * user-owned content is considered. If the stripped objects are equal, the case
+ * was not changed by a human and it is safe to retry.
+ */
+const normalizeCaseForRebase = (theCase: CaseWithOptionalComments) =>
+  omit(theCase, SYSTEM_MANAGED_CASE_FIELDS);
+/**
+ * Decides whether a 409 can be safely retried.
+ * Returns 'only_system_drift'        → the stale and latest cases differ only in
+ *                                       system-managed fields; retry is safe.
+ * Returns 'conflicting_case_change'  → a user-owned field changed between the
+ *                                       original request and now; the caller must
+ *                                       surface the conflict to the user.
+ */
+export const getCaseConflictRebaseDecision = ({
+  staleCases,
+  latestCases,
+}: {
+  staleCases: CaseWithOptionalComments[];
+  latestCases: CaseWithOptionalComments[];
+}): CaseConflictRebaseDecision => {
+  if (staleCases.length !== latestCases.length) {
+    return 'conflicting_case_change';
+  }
+
+  const latestCasesById = new Map(latestCases.map((theCase) => [theCase.id, theCase]));
+
+  for (const staleCase of staleCases) {
+    const latestCase = latestCasesById.get(staleCase.id);
+
+    if (latestCase == null) {
+      return 'conflicting_case_change';
+    }
+
+    if (!isEqual(normalizeCaseForRebase(staleCase), normalizeCaseForRebase(latestCase))) {
+      return 'conflicting_case_change';
+    }
+  }
+
+  return 'only_system_drift';
+};
+
+/**
+ * Executes a case mutation and transparently retries once if the server returns a
+ * 409 Conflict that was caused solely by a server-side system write (e.g. the
+ * `incrementalId` background task bumping the ES document version).
+ *
+ * Flow:
+ *  1. Attempt the mutation with the original request.
+ *  2. On 409: fetch the latest version of every affected case.
+ *  3. Compare stale vs. latest (ignoring system-managed fields).
+ *     - If only system fields changed → rebuild the request with fresh version
+ *       tokens and retry. The user's intended change is preserved.
+ *     - If any user-owned field changed → a real concurrent edit occurred;
+ *       re-throw the original error so the caller can inform the user.
+ *  4. Any non-409 error is re-thrown immediately without a retry attempt.
+ */
+export const rebaseCaseMutationOnConflict = async <TRequest, TResponse>({
+  request,
+  staleCases,
+  executeRequest,
+  fetchLatestCase,
+  buildRetryRequest,
+}: RebaseCaseMutationOnConflictParams<TRequest, TResponse>): Promise<TResponse> => {
+  try {
+    return await executeRequest(request);
+  } catch (error) {
+    if (!isRetryableCaseConflictError(error) || staleCases.length === 0) {
+      throw error;
+    }
+
+    const latestCases = await Promise.all(staleCases.map(({ id }) => fetchLatestCase(id)));
+    const rebaseDecision = getCaseConflictRebaseDecision({ staleCases, latestCases });
+
+    if (rebaseDecision !== 'only_system_drift') {
+      throw error;
+    }
+
+    return executeRequest(
+      buildRetryRequest({
+        request,
+        latestCases: new Map(latestCases.map((theCase) => [theCase.id, theCase])),
+      })
+    );
+  }
+};

--- a/x-pack/platform/plugins/shared/cases/public/containers/test_fixtures.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/test_fixtures.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CaseSeverity, CaseStatuses, ConnectorTypes } from '../../common/types/domain';
+import type { CaseUI } from './types';
+
+const elasticUser = {
+  fullName: 'Leslie Knope',
+  username: 'lknope',
+  email: 'leslie.knope@elastic.co',
+};
+
+export const basicCaseFixture: CaseUI = {
+  owner: 'securitySolution',
+  closedAt: null,
+  closedBy: null,
+  id: 'basic-case-id',
+  comments: [],
+  createdAt: '2020-02-19T23:06:33.798Z',
+  createdBy: elasticUser,
+  connector: {
+    id: 'none',
+    name: 'My Connector',
+    type: ConnectorTypes.none,
+    fields: null,
+  },
+  duration: null,
+  severity: CaseSeverity.LOW,
+  description: 'Security banana Issue',
+  externalService: null,
+  status: CaseStatuses.open,
+  tags: ['coke', 'pepsi'],
+  title: 'Another horrible breach!!',
+  totalComment: 0,
+  totalAlerts: 0,
+  totalEvents: 0,
+  updatedAt: '2020-02-20T15:02:57.995Z',
+  updatedBy: elasticUser,
+  version: 'WzQ3LDFd',
+  settings: {
+    syncAlerts: true,
+    extractObservables: true,
+  },
+  assignees: [],
+  category: null,
+  customFields: [],
+  observables: [],
+  totalObservables: 0,
+  incrementalId: undefined,
+};

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_bulk_update_case.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_bulk_update_case.test.tsx
@@ -7,48 +7,79 @@
 
 import React from 'react';
 import { act, waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useUpdateCases } from './use_bulk_update_case';
-import { allCases } from './mock';
-import { useToasts } from '../common/lib/kibana';
+import { useCasesToast } from '../common/use_cases_toast';
 import * as api from './api';
 import { casesQueriesKeys } from './constants';
-import { TestProviders, createTestQueryClient } from '../common/mock';
+import { basicCaseFixture } from './test_fixtures';
 
-jest.mock('./api');
-jest.mock('../common/lib/kibana');
+jest.mock('./api', () => ({
+  getCase: jest.fn(),
+  updateCases: jest.fn(),
+}));
+jest.mock('../common/use_cases_toast', () => ({
+  useCasesToast: jest.fn(),
+}));
 
 describe('useUpdateCases', () => {
-  const addSuccess = jest.fn();
-  const addError = jest.fn();
+  const showSuccessToast = jest.fn();
+  const showErrorToast = jest.fn();
 
-  (useToasts as jest.Mock).mockReturnValue({ addSuccess, addError });
+  (useCasesToast as jest.Mock).mockReturnValue({ showSuccessToast, showErrorToast });
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+  const getWrapper = (queryClient: QueryClient) =>
+    function Wrapper({ children }: React.PropsWithChildren<{}>) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'updateCases');
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useUpdateCases(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
-      result.current.mutate({ cases: allCases.cases, successToasterTitle: 'Success title' });
+      result.current.mutate({
+        cases: [{ id: basicCaseFixture.id, version: basicCaseFixture.version }],
+        successToasterTitle: 'Success title',
+        originalCases: [basicCaseFixture],
+      });
     });
 
-    await waitFor(() => expect(spy).toHaveBeenCalledWith({ cases: allCases.cases }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith({
+        cases: [{ id: basicCaseFixture.id, version: basicCaseFixture.version }],
+      })
+    );
   });
 
   it('invalidates the queries correctly', async () => {
-    const queryClient = createTestQueryClient();
+    const queryClient = createQueryClient();
     const queryClientSpy = jest.spyOn(queryClient, 'invalidateQueries');
     const { result } = renderHook(() => useUpdateCases(), {
-      wrapper: (props) => <TestProviders {...props} queryClient={queryClient} />,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
-      result.current.mutate({ cases: allCases.cases, successToasterTitle: 'Success title' });
+      result.current.mutate({
+        cases: [{ id: basicCaseFixture.id, version: basicCaseFixture.version }],
+        successToasterTitle: 'Success title',
+        originalCases: [basicCaseFixture],
+      });
     });
 
     await waitFor(() => {
@@ -60,33 +91,79 @@ describe('useUpdateCases', () => {
   });
 
   it('shows a success toaster', async () => {
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useUpdateCases(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
-      result.current.mutate({ cases: allCases.cases, successToasterTitle: 'Success title' });
+      result.current.mutate({
+        cases: [{ id: basicCaseFixture.id, version: basicCaseFixture.version }],
+        successToasterTitle: 'Success title',
+        originalCases: [basicCaseFixture],
+      });
     });
 
-    await waitFor(() =>
-      expect(addSuccess).toHaveBeenCalledWith({
-        title: 'Success title',
-        className: 'eui-textBreakWord',
-      })
-    );
+    await waitFor(() => expect(showSuccessToast).toHaveBeenCalledWith('Success title'));
+  });
+
+  it('retries once with refreshed versions when only system-managed fields changed', async () => {
+    const latestCase = {
+      ...basicCaseFixture,
+      incrementalId: 42,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      version: 'WzQ4LDFd',
+    };
+    const conflictError = Object.assign(new Error('Conflict'), {
+      body: { statusCode: 409 },
+    });
+    const casesToUpdate = [
+      { id: basicCaseFixture.id, version: basicCaseFixture.version, description: 'updated' },
+    ];
+
+    const updateCasesSpy = jest
+      .spyOn(api, 'updateCases')
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce([{ ...latestCase, description: 'updated' }]);
+    const getCaseSpy = jest.spyOn(api, 'getCase').mockResolvedValue(latestCase);
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useUpdateCases(), {
+      wrapper: getWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({
+        cases: casesToUpdate,
+        successToasterTitle: 'Success title',
+        originalCases: [basicCaseFixture],
+      });
+    });
+
+    await waitFor(() => expect(updateCasesSpy).toHaveBeenCalledTimes(2));
+
+    expect(getCaseSpy).toHaveBeenCalledWith({ caseId: basicCaseFixture.id });
+    expect(updateCasesSpy).toHaveBeenNthCalledWith(2, {
+      cases: [{ ...casesToUpdate[0], version: latestCase.version }],
+    });
   });
 
   it('shows a toast error when the api return an error', async () => {
     jest.spyOn(api, 'updateCases').mockRejectedValue(new Error('useUpdateCases: Test error'));
+    const queryClient = createQueryClient();
 
     const { result } = renderHook(() => useUpdateCases(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
-      result.current.mutate({ cases: allCases.cases, successToasterTitle: 'Success title' });
+      result.current.mutate({
+        cases: [{ id: basicCaseFixture.id, version: basicCaseFixture.version }],
+        successToasterTitle: 'Success title',
+        originalCases: [basicCaseFixture],
+      });
     });
 
-    await waitFor(() => expect(addError).toHaveBeenCalled());
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalled());
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_bulk_update_case.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_bulk_update_case.tsx
@@ -7,34 +7,64 @@
 
 import { useQueryClient, useMutation } from '@kbn/react-query';
 import * as i18n from './translations';
-import { updateCases } from './api';
-import type { CaseUpdateRequest } from './types';
+import { getCase, updateCases } from './api';
+import type { CaseUpdateRequest, CasesUI } from './types';
 import { useCasesToast } from '../common/use_cases_toast';
 import type { ServerError } from '../types';
 import { casesQueriesKeys, casesMutationsKeys } from './constants';
+import { rebaseCaseMutationOnConflict } from './conflict_rebase';
 
 interface MutationArgs {
   cases: CaseUpdateRequest[];
   successToasterTitle: string;
+  originalCases: CasesUI;
 }
 
+/**
+ * Executes bulk case updates and retries once on version conflicts caused only by
+ * system-managed field drift.
+ *
+ * `cases` is the minimal patch payload sent to the API. `originalCases` is the
+ * pre-update snapshot used to decide whether a 409 can be safely rebased with
+ * fresh versions. `originalCases` may be a superset of `cases` when unchanged
+ * selected cases are filtered out before the request; only matching ids are used
+ * for the rebase check.
+ */
 export const useUpdateCases = () => {
   const queryClient = useQueryClient();
   const { showErrorToast, showSuccessToast } = useCasesToast();
 
-  return useMutation(({ cases }: MutationArgs) => updateCases({ cases }), {
-    mutationKey: casesMutationsKeys.updateCases,
-    onSuccess: (_, { successToasterTitle }) => {
-      queryClient.invalidateQueries(casesQueriesKeys.casesList());
-      queryClient.invalidateQueries(casesQueriesKeys.tags());
-      queryClient.invalidateQueries(casesQueriesKeys.userProfiles());
+  return useMutation(
+    (request: MutationArgs) =>
+      rebaseCaseMutationOnConflict({
+        request,
+        staleCases: request.originalCases.filter(({ id }) =>
+          request.cases.some((caseToUpdate) => caseToUpdate.id === id)
+        ),
+        executeRequest: ({ cases }) => updateCases({ cases }),
+        fetchLatestCase: (caseId) => getCase({ caseId }),
+        buildRetryRequest: ({ request: retryRequest, latestCases }) => ({
+          ...retryRequest,
+          cases: retryRequest.cases.map((theCase) => ({
+            ...theCase,
+            version: latestCases.get(theCase.id)?.version ?? theCase.version,
+          })),
+        }),
+      }),
+    {
+      mutationKey: casesMutationsKeys.updateCases,
+      onSuccess: (_, { successToasterTitle }) => {
+        queryClient.invalidateQueries(casesQueriesKeys.casesList());
+        queryClient.invalidateQueries(casesQueriesKeys.tags());
+        queryClient.invalidateQueries(casesQueriesKeys.userProfiles());
 
-      showSuccessToast(successToasterTitle);
-    },
-    onError: (error: ServerError) => {
-      showErrorToast(error, { title: i18n.ERROR_UPDATING });
-    },
-  });
+        showSuccessToast(successToasterTitle);
+      },
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_UPDATING });
+      },
+    }
+  );
 };
 
 export type UseUpdateCases = ReturnType<typeof useUpdateCases>;

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_replace_custom_field.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_replace_custom_field.test.tsx
@@ -7,38 +7,57 @@
 
 import React from 'react';
 import { act, waitFor, renderHook } from '@testing-library/react';
-import { basicCase } from './mock';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import * as api from './api';
-import { useToasts } from '../common/lib/kibana';
+import { useCasesToast } from '../common/use_cases_toast';
 import { casesQueriesKeys } from './constants';
 import { useReplaceCustomField } from './use_replace_custom_field';
-import { TestProviders, createTestQueryClient } from '../common/mock';
+import { basicCaseFixture } from './test_fixtures';
+import { CustomFieldTypes } from '../../common/types/domain';
 
-jest.mock('./api');
-jest.mock('../common/lib/kibana');
+jest.mock('./api', () => ({
+  getCase: jest.fn(),
+  replaceCustomField: jest.fn(),
+}));
+jest.mock('../common/use_cases_toast', () => ({
+  useCasesToast: jest.fn(),
+}));
 
 describe('useReplaceCustomField', () => {
   const sampleData = {
-    caseId: basicCase.id,
+    caseId: basicCaseFixture.id,
     customFieldId: 'test_key_1',
     customFieldValue: 'this is an updated custom field',
-    caseVersion: basicCase.version,
+    caseVersion: basicCaseFixture.version,
+    caseData: basicCaseFixture,
   };
 
-  const addSuccess = jest.fn();
-  const addError = jest.fn();
-  (useToasts as jest.Mock).mockReturnValue({ addSuccess, addError });
+  const showErrorToast = jest.fn();
+  (useCasesToast as jest.Mock).mockReturnValue({ showErrorToast });
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+  const getWrapper = (queryClient: QueryClient) =>
+    function Wrapper({ children }: React.PropsWithChildren<{}>) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+
   it('replace a customField and refresh the case page', async () => {
-    const queryClient = createTestQueryClient();
+    const queryClient = createQueryClient();
     const queryClientSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useReplaceCustomField(), {
-      wrapper: (props) => <TestProviders {...props} queryClient={queryClient} />,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -54,8 +73,9 @@ describe('useReplaceCustomField', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const patchCustomFieldSpy = jest.spyOn(api, 'replaceCustomField');
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useReplaceCustomField(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -76,14 +96,16 @@ describe('useReplaceCustomField', () => {
 
   it('calls the api when invoked with the correct parameters of toggle field', async () => {
     const newData = {
-      caseId: basicCase.id,
+      caseId: basicCaseFixture.id,
       customFieldId: 'test_key_2',
       customFieldValue: false,
-      caseVersion: basicCase.version,
+      caseVersion: basicCaseFixture.version,
+      caseData: basicCaseFixture,
     };
     const patchCustomFieldSpy = jest.spyOn(api, 'replaceCustomField');
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useReplaceCustomField(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -104,14 +126,16 @@ describe('useReplaceCustomField', () => {
 
   it('calls the api when invoked with the correct parameters with null value', async () => {
     const newData = {
-      caseId: basicCase.id,
+      caseId: basicCaseFixture.id,
       customFieldId: 'test_key_3',
       customFieldValue: null,
-      caseVersion: basicCase.version,
+      caseVersion: basicCaseFixture.version,
+      caseData: basicCaseFixture,
     };
     const patchCustomFieldSpy = jest.spyOn(api, 'replaceCustomField');
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useReplaceCustomField(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -130,19 +154,63 @@ describe('useReplaceCustomField', () => {
     );
   });
 
-  it('shows a toast error when the api return an error', async () => {
-    jest
+  it('retries once with the latest version when only system-managed fields changed', async () => {
+    const latestCase = {
+      ...basicCaseFixture,
+      incrementalId: 42,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      version: 'WzQ4LDFd',
+    };
+    const conflictError = Object.assign(new Error('Conflict'), {
+      body: { statusCode: 409 },
+    });
+
+    const replaceCustomFieldSpy = jest
       .spyOn(api, 'replaceCustomField')
-      .mockRejectedValue(new Error('useUpdateComment: Test error'));
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce({
+        key: sampleData.customFieldId,
+        type: CustomFieldTypes.TEXT,
+        value: sampleData.customFieldValue,
+      });
+    const getCaseSpy = jest.spyOn(api, 'getCase').mockResolvedValue(latestCase);
+    const queryClient = createQueryClient();
 
     const { result } = renderHook(() => useReplaceCustomField(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
       result.current.mutate(sampleData);
     });
 
-    await waitFor(() => expect(addError).toHaveBeenCalled());
+    await waitFor(() => expect(replaceCustomFieldSpy).toHaveBeenCalledTimes(2));
+
+    expect(getCaseSpy).toHaveBeenCalledWith({ caseId: basicCaseFixture.id });
+    expect(replaceCustomFieldSpy).toHaveBeenNthCalledWith(2, {
+      caseId: sampleData.caseId,
+      customFieldId: sampleData.customFieldId,
+      request: {
+        value: sampleData.customFieldValue,
+        caseVersion: latestCase.version,
+      },
+    });
+  });
+
+  it('shows a toast error when the api return an error', async () => {
+    jest
+      .spyOn(api, 'replaceCustomField')
+      .mockRejectedValue(new Error('useUpdateComment: Test error'));
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useReplaceCustomField(), {
+      wrapper: getWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(sampleData);
+    });
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalled());
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_replace_custom_field.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_replace_custom_field.tsx
@@ -9,15 +9,18 @@ import { useMutation } from '@kbn/react-query';
 import { useCasesToast } from '../common/use_cases_toast';
 import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import type { ServerError } from '../types';
-import { replaceCustomField } from './api';
+import type { CaseUI } from './types';
+import { getCase, replaceCustomField } from './api';
 import { casesMutationsKeys } from './constants';
 import * as i18n from './translations';
+import { rebaseCaseMutationOnConflict } from './conflict_rebase';
 
 interface ReplaceCustomField {
   caseId: string;
   customFieldId: string;
   customFieldValue: string | number | boolean | null;
   caseVersion: string;
+  caseData: CaseUI;
 }
 
 export const useReplaceCustomField = () => {
@@ -25,11 +28,34 @@ export const useReplaceCustomField = () => {
   const refreshCaseViewPage = useRefreshCaseViewPage();
 
   return useMutation(
-    ({ caseId, customFieldId, customFieldValue, caseVersion }: ReplaceCustomField) =>
-      replaceCustomField({
-        caseId,
-        customFieldId,
-        request: { value: customFieldValue, caseVersion },
+    (request: ReplaceCustomField) =>
+      rebaseCaseMutationOnConflict({
+        request,
+        staleCases: [request.caseData],
+        executeRequest: ({ caseId, customFieldId, customFieldValue, caseVersion }) =>
+          replaceCustomField({
+            caseId,
+            customFieldId,
+            request: { value: customFieldValue, caseVersion },
+          }),
+        fetchLatestCase: (caseId) => getCase({ caseId }),
+        buildRetryRequest: ({ request: retryRequest, latestCases }) => {
+          const latestCase = latestCases.get(retryRequest.caseId);
+
+          if (latestCase == null) {
+            return retryRequest;
+          }
+
+          return {
+            ...retryRequest,
+            caseVersion: latestCase.version,
+            caseData: {
+              ...retryRequest.caseData,
+              ...latestCase,
+              comments: retryRequest.caseData.comments,
+            },
+          };
+        },
       }),
     {
       mutationKey: casesMutationsKeys.replaceCustomField,

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_update_case.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_update_case.test.tsx
@@ -7,16 +7,31 @@
 
 import React from 'react';
 import { act, waitFor, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { useUpdateCase } from './use_update_case';
-import { basicCase } from './mock';
 import * as api from './api';
 import type { UpdateKey } from './types';
 import { useToasts } from '../common/lib/kibana';
+import { useCasesToast } from '../common/use_cases_toast';
 import { casesQueriesKeys } from './constants';
-import { TestProviders, createTestQueryClient } from '../common/mock';
+import { basicCaseFixture } from './test_fixtures';
 
-jest.mock('./api');
-jest.mock('../common/lib/kibana');
+jest.mock('./api', () => ({
+  getCase: jest.fn(),
+  patchCase: jest.fn(),
+}));
+jest.mock('../common/lib/kibana', () => ({
+  useToasts: jest.fn(),
+}));
+jest.mock('../common/use_cases_toast', () => ({
+  useCasesToast: jest.fn(),
+}));
+jest.mock('./utils', () => ({
+  createUpdateSuccessToaster: jest.fn().mockReturnValue({
+    title: 'Updated "Another horrible breach!!"',
+    className: 'eui-textBreakWord',
+  }),
+}));
 
 describe('useUpdateCase', () => {
   const updateKey: UpdateKey = 'description';
@@ -24,23 +39,40 @@ describe('useUpdateCase', () => {
   const addSuccess = jest.fn();
   const addError = jest.fn();
   (useToasts as jest.Mock).mockReturnValue({ addSuccess, addError });
+  const showErrorToast = jest.fn();
+  (useCasesToast as jest.Mock).mockReturnValue({ showErrorToast });
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (api.patchCase as jest.Mock).mockResolvedValue([basicCaseFixture]);
+    (api.getCase as jest.Mock).mockResolvedValue(basicCaseFixture);
   });
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+  const getWrapper = (queryClient: QueryClient) =>
+    function Wrapper({ children }: React.PropsWithChildren<{}>) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
 
   const sampleUpdate = {
     updateKey,
     updateValue: 'updated description',
-    caseData: basicCase,
+    caseData: basicCaseFixture,
   };
 
   it('patch case and refresh the case page', async () => {
-    const queryClient = createTestQueryClient();
+    const queryClient = createQueryClient();
     const queryClientSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useUpdateCase(), {
-      wrapper: (props) => <TestProviders {...props} queryClient={queryClient} />,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -56,8 +88,9 @@ describe('useUpdateCase', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const patchCaseSpy = jest.spyOn(api, 'patchCase');
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useUpdateCase(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -66,16 +99,17 @@ describe('useUpdateCase', () => {
 
     await waitFor(() =>
       expect(patchCaseSpy).toHaveBeenCalledWith({
-        caseId: basicCase.id,
+        caseId: basicCaseFixture.id,
         updatedCase: { description: 'updated description' },
-        version: basicCase.version,
+        version: basicCaseFixture.version,
       })
     );
   });
 
   it('shows a success toaster', async () => {
+    const queryClient = createQueryClient();
     const { result } = renderHook(() => useUpdateCase(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
@@ -90,17 +124,54 @@ describe('useUpdateCase', () => {
     );
   });
 
-  it('shows a toast error when the api return an error', async () => {
-    jest.spyOn(api, 'patchCase').mockRejectedValue(new Error('useUpdateCase: Test error'));
+  it('retries once with the latest version when only system-managed fields changed', async () => {
+    const latestCase = {
+      ...basicCaseFixture,
+      incrementalId: 42,
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      version: 'WzQ4LDFd',
+    };
+    const conflictError = Object.assign(new Error('Conflict'), {
+      body: { statusCode: 409 },
+    });
+
+    const patchCaseSpy = jest
+      .spyOn(api, 'patchCase')
+      .mockRejectedValueOnce(conflictError)
+      .mockResolvedValueOnce([{ ...latestCase, description: sampleUpdate.updateValue }]);
+    const getCaseSpy = jest.spyOn(api, 'getCase').mockResolvedValue(latestCase);
+    const queryClient = createQueryClient();
 
     const { result } = renderHook(() => useUpdateCase(), {
-      wrapper: TestProviders,
+      wrapper: getWrapper(queryClient),
     });
 
     act(() => {
       result.current.mutate(sampleUpdate);
     });
 
-    await waitFor(() => expect(addError).toHaveBeenCalled());
+    await waitFor(() => expect(patchCaseSpy).toHaveBeenCalledTimes(2));
+
+    expect(getCaseSpy).toHaveBeenCalledWith({ caseId: basicCaseFixture.id });
+    expect(patchCaseSpy).toHaveBeenNthCalledWith(2, {
+      caseId: basicCaseFixture.id,
+      updatedCase: { description: 'updated description' },
+      version: latestCase.version,
+    });
+  });
+
+  it('shows a toast error when the api return an error', async () => {
+    jest.spyOn(api, 'patchCase').mockRejectedValue(new Error('useUpdateCase: Test error'));
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useUpdateCase(), {
+      wrapper: getWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate(sampleUpdate);
+    });
+
+    await waitFor(() => expect(showErrorToast).toHaveBeenCalled());
   });
 });

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_update_case.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_update_case.tsx
@@ -7,7 +7,7 @@
 
 import { useMutation } from '@kbn/react-query';
 
-import { patchCase } from './api';
+import { getCase, patchCase } from './api';
 import * as i18n from './translations';
 import { useCasesToast } from '../common/use_cases_toast';
 import { casesMutationsKeys } from './constants';
@@ -16,6 +16,7 @@ import type { UpdateByKey } from './types';
 import { useRefreshCaseViewPage } from '../components/case_view/use_on_refresh_case_view_page';
 import { createUpdateSuccessToaster } from './utils';
 import { useToasts } from '../common/lib/kibana';
+import { rebaseCaseMutationOnConflict } from './conflict_rebase';
 
 export const useUpdateCase = () => {
   const toasts = useToasts();
@@ -24,10 +25,32 @@ export const useUpdateCase = () => {
 
   return useMutation(
     (request: UpdateByKey) =>
-      patchCase({
-        caseId: request.caseData.id,
-        updatedCase: { [request.updateKey]: request.updateValue },
-        version: request.caseData.version,
+      rebaseCaseMutationOnConflict({
+        request,
+        staleCases: [request.caseData],
+        executeRequest: (retryRequest) =>
+          patchCase({
+            caseId: retryRequest.caseData.id,
+            updatedCase: { [retryRequest.updateKey]: retryRequest.updateValue },
+            version: retryRequest.caseData.version,
+          }),
+        fetchLatestCase: (caseId) => getCase({ caseId }),
+        buildRetryRequest: ({ request: retryRequest, latestCases }) => {
+          const latestCase = latestCases.get(retryRequest.caseData.id);
+
+          if (latestCase == null) {
+            return retryRequest;
+          }
+
+          return {
+            ...retryRequest,
+            caseData: {
+              ...retryRequest.caseData,
+              ...latestCase,
+              comments: retryRequest.caseData.comments,
+            },
+          };
+        },
       }),
     {
       mutationKey: casesMutationsKeys.updateCase,

--- a/x-pack/platform/test/functional/services/cases/files.ts
+++ b/x-pack/platform/test/functional/services/cases/files.ts
@@ -28,6 +28,9 @@ export function CasesFilesTableServiceProvider({ getService, getPageObject }: Ft
       // upload a file
       await common.setFileInputPath(fileInputPath);
       await testSubjects.click('uploadButton');
+
+      // hide the upload notification
+      await (await find.byCssSelector('[data-test-subj="toastCloseButton"]')).click();
     },
 
     async searchByFileName(fileName: string) {

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -29,10 +29,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const cases = getService('cases');
   const retry = getService('retry');
   const comboBox = getService('comboBox');
-  const security = getPageObject('security');
-  const kibanaServer = getService('kibanaServer');
   const browser = getService('browser');
-  const esArchiver = getService('esArchiver');
 
   const hasFocus = async (testSubject: string) => {
     const targetElement = await testSubjects.find(testSubject);
@@ -40,11 +37,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     return (await targetElement._webElement.getId()) === (await activeElement._webElement.getId());
   };
 
-  // https://github.com/elastic/kibana/pull/190690
-  // fails after missing `awaits` were added
-  // Failing: See https://github.com/elastic/kibana/issues/239759
-  // Failing: See https://github.com/elastic/kibana/issues/239774
-  describe.skip('View case', () => {
+  describe('View case', () => {
     describe('page', () => {
       createOneCaseBeforeDeleteAllAfter(getPageObject, getService);
 
@@ -53,10 +46,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.existOrFail('header-page-supplements');
         await testSubjects.existOrFail('case-action-bar-wrapper');
 
-        await testSubjects.existOrFail('case-view-tabs');
-        await testSubjects.existOrFail('case-view-tab-title-alerts');
         await testSubjects.existOrFail('case-view-tab-title-activity');
-        await testSubjects.existOrFail('case-view-tab-title-files');
+        await testSubjects.existOrFail('case-view-tab-title-attachments');
         await testSubjects.existOrFail('description');
 
         await testSubjects.existOrFail('case-view-activity');
@@ -152,7 +143,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
@@ -248,20 +239,6 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         await find.byCssSelector('[data-test-subj*="tags-delete-action"]');
-      });
-
-      it('shows error when more than 200 tags are added to the case', async () => {
-        const tags = Array(200).fill('foo');
-
-        await cases.common.addMultipleTags(tags);
-        await testSubjects.click('edit-tags-submit');
-
-        const error = await find.byCssSelector('.euiFormErrorText');
-        expect(await error.getVisibleText()).equal(
-          'Too many tags. The maximum number of allowed tags is 200'
-        );
-
-        await testSubjects.click('edit-tags-cancel');
       });
 
       describe('status', () => {
@@ -386,7 +363,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -423,7 +400,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -462,7 +439,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal(comment);
@@ -630,7 +607,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
     });
 
-    describe('Lens visualization', () => {
+    describe.skip('Lens visualization', () => {
       before(async () => {
         await cases.testResources.installKibanaSampleData('logs');
       });
@@ -711,7 +688,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await header.waitUntilLoadingHasFinished();
 
         const createdComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
 
         await createdComment.findByCssSelector('[data-test-subj="xyVisChart"]');
@@ -884,167 +861,17 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
     });
 
-    describe('Assignees field', () => {
-      before(async () => {
-        await createUsersAndRoles(getService, users, roles);
-        await cases.api.activateUserProfiles([casesAllUser, casesAllUser2]);
-      });
-
-      after(async () => {
-        await deleteUsersAndRoles(getService, users, roles);
-      });
-
-      describe('unknown users', () => {
-        beforeEach(async () => {
-          await kibanaServer.importExport.load(
-            'x-pack/platform/test/functional/fixtures/kbn_archives/cases/8.5.0/cases_assignees.json'
-          );
-
-          await cases.navigation.navigateToApp();
-          await cases.casesTable.waitForCasesToBeListed();
-          await cases.casesTable.goToFirstListedCase();
-          await header.waitUntilLoadingHasFinished();
-        });
-
-        afterEach(async () => {
-          await kibanaServer.importExport.unload(
-            'x-pack/platform/test/functional/fixtures/kbn_archives/cases/8.5.0/cases_assignees.json'
-          );
-
-          await cases.api.deleteAllCases();
-        });
-
-        it('shows the unknown assignee', async () => {
-          await testSubjects.existOrFail('user-profile-assigned-user-abc-remove-group');
-        });
-
-        it('removes the unknown assignee when selecting the remove all users in the popover', async () => {
-          await testSubjects.existOrFail('user-profile-assigned-user-abc-remove-group');
-
-          await cases.singleCase.openAssigneesPopover();
-          await cases.common.setSearchTextInAssigneesPopover('case');
-          await cases.common.selectFirstRowInAssigneesPopover();
-
-          await (await find.byButtonText('Remove all assignees')).click();
-          await cases.singleCase.closeAssigneesPopover();
-          await testSubjects.missingOrFail('user-profile-assigned-user-abc-remove-group');
-        });
-      });
-
-      describe('login with cases all user', () => {
-        before(async () => {
-          await security.forceLogout();
-          await security.login(casesAllUser.username, casesAllUser.password);
-          await createAndNavigateToCase(getPageObject, getService);
-        });
-
-        after(async () => {
-          await cases.api.deleteAllCases();
-          await security.forceLogout();
-        });
-
-        it('assigns the case to the current user when clicking the assign to self link', async () => {
-          await testSubjects.click('case-view-assign-yourself-link');
-          await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
-        });
-      });
-
-      describe('logs in with default user', () => {
-        beforeEach(async () => {
-          await createAndNavigateToCase(getPageObject, getService);
-        });
-
-        afterEach(async () => {
-          await cases.api.deleteAllCases();
-        });
-
-        it('shows the assign users popover when clicked', async () => {
-          await testSubjects.missingOrFail('euiSelectableList');
-          await cases.singleCase.openAssigneesPopover();
-          await cases.singleCase.closeAssigneesPopover();
-        });
-
-        it('assigns a user from the popover', async () => {
-          await cases.singleCase.openAssigneesPopover();
-          await cases.common.setSearchTextInAssigneesPopover('case');
-          await cases.common.selectFirstRowInAssigneesPopover();
-          await cases.singleCase.closeAssigneesPopover();
-          await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
-        });
-
-        it('assigns multiple users', async () => {
-          await cases.singleCase.openAssigneesPopover();
-          await cases.common.setSearchTextInAssigneesPopover('case');
-          await cases.common.selectAllRowsInAssigneesPopover();
-
-          await cases.singleCase.closeAssigneesPopover();
-          await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
-          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user2-remove-group');
-        });
-      });
-
-      describe('logs in with default user and creates case before each', () => {
-        createOneCaseBeforeDeleteAllAfter(getPageObject, getService);
-
-        it('removes an assigned user', async () => {
-          await cases.singleCase.openAssigneesPopover();
-          await cases.common.setSearchTextInAssigneesPopover('case');
-          await cases.common.selectFirstRowInAssigneesPopover();
-
-          // navigate out of the modal
-          await cases.singleCase.closeAssigneesPopover();
-          await header.waitUntilLoadingHasFinished();
-          await testSubjects.existOrFail('user-profile-assigned-user-cases_all_user-remove-group');
-
-          // hover over the assigned user
-          await (
-            await find.byCssSelector(
-              '[data-test-subj="user-profile-assigned-user-cases_all_user-remove-group"]'
-            )
-          ).moveMouseTo();
-
-          // delete the user
-          await testSubjects.click('user-profile-assigned-user-cases_all_user-remove-button');
-
-          await testSubjects.existOrFail('case-view-assign-yourself-link');
-        });
-      });
-    });
-
     describe('Tabs', () => {
       createOneCaseBeforeDeleteAllAfter(getPageObject, getService);
-
-      it('renders tabs correctly', async () => {
-        await testSubjects.existOrFail('case-view-tab-title-activity');
-        await testSubjects.existOrFail('case-view-tab-title-files');
-        await testSubjects.existOrFail('case-view-tab-title-alerts');
-      });
 
       it('shows the "activity" tab by default', async () => {
         await testSubjects.existOrFail('case-view-tab-title-activity');
         await testSubjects.existOrFail('case-view-tab-content-activity');
       });
 
-      it("shows the 'activity' tab when clicked", async () => {
-        // Go to the files tab first
-        await testSubjects.click('case-view-tab-title-files');
-        await testSubjects.existOrFail('case-view-tab-content-files');
-
-        await testSubjects.click('case-view-tab-title-activity');
-        await testSubjects.existOrFail('case-view-tab-content-activity');
-      });
-
-      it("shows the 'alerts' tab when clicked", async () => {
-        await testSubjects.click('case-view-tab-title-alerts');
-        await testSubjects.existOrFail('case-view-tab-content-alerts');
-      });
-
-      it("shows the 'files' tab when clicked", async () => {
-        await testSubjects.click('case-view-tab-title-files');
-        await testSubjects.existOrFail('case-view-tab-content-files');
+      it("shows the 'attachments' tab when clicked", async () => {
+        await testSubjects.click('case-view-tab-title-attachments');
+        await testSubjects.existOrFail('case-view-attachments');
       });
 
       describe('Query params', () => {
@@ -1078,52 +905,12 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
     });
 
-    describe('Tabs - alerts linked to case', () => {
-      before(async () => {
-        await esArchiver.loadIfNeeded(
-          'x-pack/platform/test/fixtures/es_archives/rule_registry/alerts'
-        );
-        await cases.navigation.navigateToApp();
-        const theCase = await cases.api.createCase();
-        await cases.casesTable.waitForCasesToBeListed();
-        await retry.try(async () => {
-          await cases.api.createAttachment({
-            caseId: theCase.id,
-            params: {
-              type: AttachmentType.alert,
-              alertId: ['NoxgpHkBqbdrfX07MqXV'],
-              index: '.alerts-observability.apm.alerts',
-              rule: { id: 'id', name: 'name' },
-              owner: theCase.owner,
-            },
-          });
-        });
-      });
-
-      after(async () => {
-        await cases.api.deleteAllCases();
-        await esArchiver.unload('x-pack/platform/test/fixtures/es_archives/rule_registry/alerts/');
-      });
-
-      beforeEach(async () => {
-        await cases.navigation.navigateToApp();
-        await cases.casesTable.goToFirstListedCase();
-        await header.waitUntilLoadingHasFinished();
-      });
-
-      it('should show the right amount of alerts linked to a case', async () => {
-        const visibleText = await testSubjects.getVisibleText('case-view-alerts-stats-badge');
-        expect(visibleText).to.be('1');
-      });
-
-      it('should render the alerts table when opening the alerts tab', async () => {
-        await testSubjects.click('case-view-tab-title-alerts');
-        await testSubjects.existOrFail('alertsTableEmptyState');
-      });
-    });
-
     describe('Files', () => {
       createOneCaseBeforeDeleteAllAfter(getPageObject, getService);
+      before(async () => {
+        // open attachments to have access to the files tab
+        await testSubjects.click('case-view-tab-title-attachments');
+      });
 
       it('adds a file to the case', async () => {
         // navigate to files tab

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -143,7 +143,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
@@ -363,7 +363,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -400,7 +400,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -439,7 +439,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal(comment);
@@ -688,7 +688,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await header.waitUntilLoadingHasFinished();
 
         const createdComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         await createdComment.findByCssSelector('[data-test-subj="xyVisChart"]');

--- a/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/platform/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -143,7 +143,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
@@ -363,7 +363,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -400,7 +400,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -439,7 +439,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         expect(await newComment.getVisibleText()).equal(comment);
@@ -688,7 +688,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await header.waitUntilLoadingHasFinished();
 
         const createdComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
 
         await createdComment.findByCssSelector('[data-test-subj="xyVisChart"]');

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
@@ -34,10 +34,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const svlCommonPage = getPageObject('svlCommonPage');
 
-  // https://github.com/elastic/kibana/pull/190690
-  // fails after missing `awaits` were added
-  // Failing: See https://github.com/elastic/kibana/issues/240911
-  describe.skip('Case View', function () {
+  describe('Case View', function () {
     before(async () => {
       await svlCommonPage.loginWithPrivilegedRole();
     });
@@ -54,7 +51,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.existOrFail('header-page-supplements');
 
         await testSubjects.existOrFail('case-view-tab-title-activity');
-        await testSubjects.existOrFail('case-view-tab-title-files');
+        await testSubjects.existOrFail('case-view-tab-title-attachments');
         await testSubjects.existOrFail('description');
 
         await testSubjects.existOrFail('case-view-activity');
@@ -101,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });
@@ -276,7 +273,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
 
     // FLAKY
-    describe('Lens visualization', () => {
+    describe.skip('Lens visualization', () => {
       before(async () => {
         await cases.testResources.installKibanaSampleData('logs');
         await createAndNavigateToCase(getPageObject, getService, owner);
@@ -385,14 +382,18 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.existOrFail('case-view-tab-content-activity');
       });
 
-      it("shows the 'files' tab when clicked", async () => {
-        await testSubjects.click('case-view-tab-title-files');
-        await testSubjects.existOrFail('case-view-tab-content-files');
+      it("shows the 'attachments' tab when clicked", async () => {
+        await testSubjects.click('case-view-tab-title-attachments');
+        await testSubjects.existOrFail('case-view-attachments');
       });
     });
 
     describe('Files', () => {
       createOneCaseBeforeDeleteAllAfter(getPageObject, getService, owner);
+      before(async () => {
+        // open attachments to have access to the files tab
+        await testSubjects.click('case-view-tab-title-attachments');
+      });
 
       it('adds a file to the case', async () => {
         await testSubjects.click('case-view-tab-title-files');

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
@@ -98,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });

--- a/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
+++ b/x-pack/solutions/observability/test/serverless/functional/test_suites/cases/view_case.ts
@@ -98,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -98,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -98,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });

--- a/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
+++ b/x-pack/solutions/security/test/serverless/functional/test_suites/ftr/cases/view_case.ts
@@ -35,10 +35,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const svlCommonPage = getPageObject('svlCommonPage');
 
-  // https://github.com/elastic/kibana/pull/190690
-  // fails after missing `awaits` were added
-  // Flaky: See https://github.com/elastic/kibana/issues/241493
-  describe.skip('Case View', function () {
+  describe('Case View', function () {
     before(async () => {
       await svlCommonPage.loginWithPrivilegedRole();
     });
@@ -101,7 +98,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         // validate user action
         const newComment = await find.byCssSelector(
-          '[data-test-subj*="comment-create-action"] [data-test-subj="scrollable-markdown"]'
+          '[data-test-subj="comment-comment-comment"] [data-test-subj="scrollable-markdown"]'
         );
         expect(await newComment.getVisibleText()).equal('Test comment from automation');
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Cases] Fix incremental_id drift issues (#258789)](https://github.com/elastic/kibana/pull/258789)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2026-04-02T14:12:12Z","message":"[Cases] Fix incremental_id drift issues (#258789)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/241493\nFixes https://github.com/elastic/kibana/issues/260552\n\nWith the introduction of the incremental ID feature, the case ftr tests\nbecame flaky and the feature added the potential for more theoretial 409\nconflicts due to the async nature of the assignment of ids.\n\nThis PR addresses those issues on the Kibana frontend side by adding a\nrebase/retry logic for very specific case updates:\n\n```mermaid\nflowchart TD\n      A([Update case]) --> B{409 Conflict?}\n      B -- No --> C([Done])\n      B -- Yes --> D[Fetch latest case from server]\n      D --> E{\"Only system fields changed?\\n(e.g. incrementalId auto-incremented)\"}\n      E -- No --> F([Fail — real conflict])\n      E -- Yes --> G[Retry with updated version token]\n      G --> C\n```\n\n### Conflict-rebase algorithm:\n\n1. First attempt is executeing the mutation normally.\n2. When a 409 is returned, instead of failing immediately, it fetches\nthe latest server state for all involved cases.\n3. For each case a rebase decision is made: compares stale (what the\nclient had) vs latest (what the server has now), but strips\nsystem-managed fields (`incrementalId`, `updatedAt`, `version`) before\ncomparing. If the stripped copies are identical, the drift was purely\n`system-driven`.\n4. When it's only a system drift, it rebuilds the request using the\nlatest version tokens and retries. The user's intended change _should_\ngo through now (unless another change was made in the meantime)\n5. When it's a conflicting case change (made by another user), the\noriginal error is re-thrown so the caller can surface a real conflict to\nthe user.\n\n## Flaky test runner\n\n✅\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11308\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"674997f5c43283c1afa5c4999899bf40fd2df1fd","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:version","Team:Cases","v9.3.0","v9.4.0","reviewer:coderabbit","reviewer:macroscope"],"title":"[Cases] Fix incremental_id drift issues","number":258789,"url":"https://github.com/elastic/kibana/pull/258789","mergeCommit":{"message":"[Cases] Fix incremental_id drift issues (#258789)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/241493\nFixes https://github.com/elastic/kibana/issues/260552\n\nWith the introduction of the incremental ID feature, the case ftr tests\nbecame flaky and the feature added the potential for more theoretial 409\nconflicts due to the async nature of the assignment of ids.\n\nThis PR addresses those issues on the Kibana frontend side by adding a\nrebase/retry logic for very specific case updates:\n\n```mermaid\nflowchart TD\n      A([Update case]) --> B{409 Conflict?}\n      B -- No --> C([Done])\n      B -- Yes --> D[Fetch latest case from server]\n      D --> E{\"Only system fields changed?\\n(e.g. incrementalId auto-incremented)\"}\n      E -- No --> F([Fail — real conflict])\n      E -- Yes --> G[Retry with updated version token]\n      G --> C\n```\n\n### Conflict-rebase algorithm:\n\n1. First attempt is executeing the mutation normally.\n2. When a 409 is returned, instead of failing immediately, it fetches\nthe latest server state for all involved cases.\n3. For each case a rebase decision is made: compares stale (what the\nclient had) vs latest (what the server has now), but strips\nsystem-managed fields (`incrementalId`, `updatedAt`, `version`) before\ncomparing. If the stripped copies are identical, the drift was purely\n`system-driven`.\n4. When it's only a system drift, it rebuilds the request using the\nlatest version tokens and retries. The user's intended change _should_\ngo through now (unless another change was made in the meantime)\n5. When it's a conflicting case change (made by another user), the\noriginal error is re-thrown so the caller can surface a real conflict to\nthe user.\n\n## Flaky test runner\n\n✅\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11308\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"674997f5c43283c1afa5c4999899bf40fd2df1fd"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/258789","number":258789,"mergeCommit":{"message":"[Cases] Fix incremental_id drift issues (#258789)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/241493\nFixes https://github.com/elastic/kibana/issues/260552\n\nWith the introduction of the incremental ID feature, the case ftr tests\nbecame flaky and the feature added the potential for more theoretial 409\nconflicts due to the async nature of the assignment of ids.\n\nThis PR addresses those issues on the Kibana frontend side by adding a\nrebase/retry logic for very specific case updates:\n\n```mermaid\nflowchart TD\n      A([Update case]) --> B{409 Conflict?}\n      B -- No --> C([Done])\n      B -- Yes --> D[Fetch latest case from server]\n      D --> E{\"Only system fields changed?\\n(e.g. incrementalId auto-incremented)\"}\n      E -- No --> F([Fail — real conflict])\n      E -- Yes --> G[Retry with updated version token]\n      G --> C\n```\n\n### Conflict-rebase algorithm:\n\n1. First attempt is executeing the mutation normally.\n2. When a 409 is returned, instead of failing immediately, it fetches\nthe latest server state for all involved cases.\n3. For each case a rebase decision is made: compares stale (what the\nclient had) vs latest (what the server has now), but strips\nsystem-managed fields (`incrementalId`, `updatedAt`, `version`) before\ncomparing. If the stripped copies are identical, the drift was purely\n`system-driven`.\n4. When it's only a system drift, it rebuilds the request using the\nlatest version tokens and retries. The user's intended change _should_\ngo through now (unless another change was made in the meantime)\n5. When it's a conflicting case change (made by another user), the\noriginal error is re-thrown so the caller can surface a real conflict to\nthe user.\n\n## Flaky test runner\n\n✅\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/11308\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"674997f5c43283c1afa5c4999899bf40fd2df1fd"}}]}] BACKPORT-->