### PR TITLE
[Lens as Code] Clean filters

### DIFF
--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
@@ -125,7 +125,7 @@ describe('Bucket Operation Schemas', () => {
           {
             label: 'My Filter',
             filter: {
-              language: 'kuery',
+              language: 'kql',
               expression: 'category: "electronics"',
             },
           },
@@ -219,7 +219,7 @@ describe('Bucket Operation Schemas', () => {
           filters: [
             {
               label: 'Filter',
-              filter: { language: 'kuery', expression: 'status:active' },
+              filter: { language: 'kql', expression: 'status:active' },
             },
           ],
         },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/bucket_ops.test.ts
@@ -126,7 +126,7 @@ describe('Bucket Operation Schemas', () => {
             label: 'My Filter',
             filter: {
               language: 'kuery',
-              query: 'category: "electronics"',
+              expression: 'category: "electronics"',
             },
           },
         ],
@@ -219,7 +219,7 @@ describe('Bucket Operation Schemas', () => {
           filters: [
             {
               label: 'Filter',
-              filter: { language: 'kuery', query: 'status:active' },
+              filter: { language: 'kuery', expression: 'status:active' },
             },
           ],
         },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.test.ts
@@ -70,7 +70,7 @@ describe('Region Map Schema', () => {
             {
               filter: {
                 language: 'kuery',
-                query: 'location: "US"',
+                expression: 'location: "US"',
               },
               label: 'US',
             },
@@ -122,7 +122,7 @@ describe('Region Map Schema', () => {
             {
               filter: {
                 language: 'kuery',
-                query: 'location: "US"',
+                expression: 'location: "US"',
               },
               label: 'US',
             },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/region_map.test.ts
@@ -69,7 +69,7 @@ describe('Region Map Schema', () => {
           filters: [
             {
               filter: {
-                language: 'kuery',
+                language: 'kql',
                 expression: 'location: "US"',
               },
               label: 'US',
@@ -121,7 +121,7 @@ describe('Region Map Schema', () => {
           filters: [
             {
               filter: {
-                language: 'kuery',
+                language: 'kql',
                 expression: 'location: "US"',
               },
               label: 'US',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.test.ts
@@ -388,7 +388,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', query: 'order_amount > 1000' },
+                    query: { language: 'kuery', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: { visible: true },
                     color: {
@@ -520,7 +520,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', query: 'order_amount > 1000' },
+                    query: { language: 'kuery', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: {
                       visible: true,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/charts/xy.test.ts
@@ -388,7 +388,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', expression: 'order_amount > 1000' },
+                    query: { language: 'kql', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: { visible: true },
                     color: {
@@ -520,7 +520,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', expression: 'order_amount > 1000' },
+                    query: { language: 'kql', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: {
                       visible: true,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.test.ts
@@ -13,7 +13,7 @@ describe('Filter Schemas', () => {
   describe('filterSchema', () => {
     it('validates a valid KQL filter', () => {
       const input = {
-        language: 'kuery' as const,
+        language: 'kql',
         expression: 'status:active AND category:electronics',
       };
 
@@ -23,7 +23,7 @@ describe('Filter Schemas', () => {
 
     it('validates a valid Lucene filter', () => {
       const input = {
-        language: 'lucene' as const,
+        language: 'lucene',
         expression: 'status:active AND category:electronics',
       };
 
@@ -33,7 +33,7 @@ describe('Filter Schemas', () => {
 
     it('throws on invalid language', () => {
       const input = {
-        language: 'invalid' as const,
+        language: 'invalid',
         expression: 'status:active',
       };
 
@@ -42,7 +42,7 @@ describe('Filter Schemas', () => {
 
     it('throws on missing expression', () => {
       const input = {
-        language: 'kuery' as const,
+        language: 'kql',
       };
 
       expect(() => filterSchema.validate(input)).toThrow(/\[expression\]: expected value of type/);
@@ -53,7 +53,7 @@ describe('Filter Schemas', () => {
     it('validates a filter with label', () => {
       const input = {
         filter: {
-          language: 'kuery' as const,
+          language: 'kql',
           expression: 'status:active',
         },
         label: 'Active Status',
@@ -66,7 +66,7 @@ describe('Filter Schemas', () => {
     it('validates a filter without label', () => {
       const input = {
         filter: {
-          language: 'lucene' as const,
+          language: 'lucene',
           expression: 'status:active',
         },
       };
@@ -86,7 +86,7 @@ describe('Filter Schemas', () => {
     it('throws on invalid filter', () => {
       const input = {
         filter: {
-          language: 'invalid' as const,
+          language: 'invalid',
           expression: 'status:active',
         },
         label: 'Active Status',
@@ -98,7 +98,7 @@ describe('Filter Schemas', () => {
     it('validates complex KQL queries', () => {
       const input = {
         filter: {
-          language: 'kuery' as const,
+          language: 'kql',
           expression: 'status:active OR (category:electronics AND price >= 100)',
         },
         label: 'Complex Filter',
@@ -111,7 +111,7 @@ describe('Filter Schemas', () => {
     it('validates complex Lucene queries', () => {
       const input = {
         filter: {
-          language: 'lucene' as const,
+          language: 'lucene',
           expression: 'status:active OR (category:electronics AND price:[100 TO *])',
         },
         label: 'Complex Filter',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.test.ts
@@ -14,7 +14,7 @@ describe('Filter Schemas', () => {
     it('validates a valid KQL filter', () => {
       const input = {
         language: 'kuery' as const,
-        query: 'status:active AND category:electronics',
+        expression: 'status:active AND category:electronics',
       };
 
       const validated = filterSchema.validate(input);
@@ -24,7 +24,7 @@ describe('Filter Schemas', () => {
     it('validates a valid Lucene filter', () => {
       const input = {
         language: 'lucene' as const,
-        query: 'status:active AND category:electronics',
+        expression: 'status:active AND category:electronics',
       };
 
       const validated = filterSchema.validate(input);
@@ -34,18 +34,18 @@ describe('Filter Schemas', () => {
     it('throws on invalid language', () => {
       const input = {
         language: 'invalid' as const,
-        query: 'status:active',
+        expression: 'status:active',
       };
 
       expect(() => filterSchema.validate(input)).toThrow();
     });
 
-    it('throws on missing query', () => {
+    it('throws on missing expression', () => {
       const input = {
         language: 'kuery' as const,
       };
 
-      expect(() => filterSchema.validate(input)).toThrow(/\[query\]: expected value of type/);
+      expect(() => filterSchema.validate(input)).toThrow(/\[expression\]: expected value of type/);
     });
   });
 
@@ -54,7 +54,7 @@ describe('Filter Schemas', () => {
       const input = {
         filter: {
           language: 'kuery' as const,
-          query: 'status:active',
+          expression: 'status:active',
         },
         label: 'Active Status',
       };
@@ -67,7 +67,7 @@ describe('Filter Schemas', () => {
       const input = {
         filter: {
           language: 'lucene' as const,
-          query: 'status:active',
+          expression: 'status:active',
         },
       };
 
@@ -87,7 +87,7 @@ describe('Filter Schemas', () => {
       const input = {
         filter: {
           language: 'invalid' as const,
-          query: 'status:active',
+          expression: 'status:active',
         },
         label: 'Active Status',
       };
@@ -99,7 +99,7 @@ describe('Filter Schemas', () => {
       const input = {
         filter: {
           language: 'kuery' as const,
-          query: 'status:active OR (category:electronics AND price >= 100)',
+          expression: 'status:active OR (category:electronics AND price >= 100)',
         },
         label: 'Complex Filter',
       };
@@ -112,7 +112,7 @@ describe('Filter Schemas', () => {
       const input = {
         filter: {
           language: 'lucene' as const,
-          query: 'status:active OR (category:electronics AND price:[100 TO *])',
+          expression: 'status:active OR (category:electronics AND price:[100 TO *])',
         },
         label: 'Complex Filter',
       };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
@@ -14,16 +14,13 @@ export const filterSchema = schema.object(
     language: schema.oneOf([schema.literal('kuery'), schema.literal('lucene')], {
       defaultValue: 'kuery',
     }),
-    /**
-     * Filter query
-     */
     query: schema.string({
       meta: {
-        description: 'Filter query',
+        description: 'A query expression in KQL or Lucene syntax',
       },
     }),
   },
-  { meta: { id: 'filterSimple', title: 'Simple Filter' } }
+  { meta: { id: 'filterSimple', title: 'Filter' } }
 );
 
 export const filterWithLabelSchema = schema.object(

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
@@ -11,8 +11,8 @@ import { schema } from '@kbn/config-schema';
 
 export const filterSchema = schema.object(
   {
-    language: schema.oneOf([schema.literal('kuery'), schema.literal('lucene')], {
-      defaultValue: 'kuery',
+    language: schema.oneOf([schema.literal('kql'), schema.literal('lucene')], {
+      defaultValue: 'kql',
     }),
     expression: schema.string({
       meta: {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/filter.ts
@@ -14,7 +14,7 @@ export const filterSchema = schema.object(
     language: schema.oneOf([schema.literal('kuery'), schema.literal('lucene')], {
       defaultValue: 'kuery',
     }),
-    query: schema.string({
+    expression: schema.string({
       meta: {
         description: 'A query expression in KQL or Lucene syntax',
       },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { expression } from 'joi';
 import { LENS_EMPTY_AS_NULL_DEFAULT_VALUE } from '../transforms/columns/utils';
 import {
   LENS_LAST_VALUE_DEFAULT_SHOW_ARRAY_VALUES,
@@ -87,7 +88,7 @@ describe('Metric Operations Schemas', () => {
         time_scale: 's' as const,
         filter: {
           language: 'kuery' as const,
-          query: 'status:active',
+          expression: 'status:active',
         },
       };
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/schema/metric_ops.test.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { expression } from 'joi';
 import { LENS_EMPTY_AS_NULL_DEFAULT_VALUE } from '../transforms/columns/utils';
 import {
   LENS_LAST_VALUE_DEFAULT_SHOW_ARRAY_VALUES,
@@ -87,7 +86,7 @@ describe('Metric Operations Schemas', () => {
         empty_as_null: true,
         time_scale: 's' as const,
         filter: {
-          language: 'kuery' as const,
+          language: 'kql' as const,
           expression: 'status:active',
         },
       };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
@@ -64,7 +64,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -117,7 +117,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -165,7 +165,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -211,7 +211,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -258,7 +258,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -323,7 +323,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -389,7 +389,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -450,7 +450,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -510,7 +510,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -587,7 +587,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -664,7 +664,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -723,7 +723,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -783,7 +783,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -860,7 +860,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -970,7 +970,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1042,7 +1042,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1153,7 +1153,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1247,7 +1247,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1341,7 +1341,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1421,7 +1421,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {
@@ -1585,7 +1585,7 @@ export const esqlCharts: Array<PartitionConfig> = [
     },
     query: {
       expression: 'test: true',
-      language: 'kuery',
+      language: 'kql',
     },
   },
   {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/lens_api_config.mock.ts
@@ -63,7 +63,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -116,7 +116,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -164,7 +164,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -210,7 +210,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -257,7 +257,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -322,7 +322,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -388,7 +388,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -449,7 +449,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -509,7 +509,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -586,7 +586,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -663,7 +663,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -722,7 +722,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -782,7 +782,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -859,7 +859,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -969,7 +969,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1041,7 +1041,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1152,7 +1152,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       position: 'outside',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1246,7 +1246,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1340,7 +1340,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1420,7 +1420,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },
@@ -1584,7 +1584,7 @@ export const esqlCharts: Array<PartitionConfig> = [
       mode: 'percentage',
     },
     query: {
-      query: '',
+      expression: 'test: true',
       language: 'kuery',
     },
   },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/partition.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/partition.test.ts
@@ -32,6 +32,7 @@ import {
   waffleLegacyESQLState,
 } from './lens_state_config.mock';
 import type { LensPartitionVisualizationState } from '@kbn/lens-common';
+import { query } from 'express';
 
 describe('Partition', () => {
   describe('validateConverter', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/partition.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/partition/partition.test.ts
@@ -32,7 +32,6 @@ import {
   waffleLegacyESQLState,
 } from './lens_state_config.mock';
 import type { LensPartitionVisualizationState } from '@kbn/lens-common';
-import { query } from 'express';
 
 describe('Partition', () => {
   describe('validateConverter', () => {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/region_map/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/region_map/lens_api_config.mock.ts
@@ -123,7 +123,7 @@ export const comprehensiveRegionMapWithAdHocDataView = {
     filters: [
       {
         filter: {
-          query: 'geo.dest : "US"',
+          expression: 'geo.dest : "US"',
           language: 'kuery',
         },
         label: 'US',
@@ -157,7 +157,7 @@ export const comprehensiveRegionMapWithDataView = {
     filters: [
       {
         filter: {
-          query: 'geo.dest : "US"',
+          expression: 'geo.dest : "US"',
           language: 'kuery',
         },
         label: 'US',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/region_map/lens_api_config.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/region_map/lens_api_config.mock.ts
@@ -124,7 +124,7 @@ export const comprehensiveRegionMapWithAdHocDataView = {
       {
         filter: {
           expression: 'geo.dest : "US"',
-          language: 'kuery',
+          language: 'kql',
         },
         label: 'US',
       },
@@ -158,7 +158,7 @@ export const comprehensiveRegionMapWithDataView = {
       {
         filter: {
           expression: 'geo.dest : "US"',
-          language: 'kuery',
+          language: 'kql',
         },
         label: 'US',
       },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/basicXY.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/basicXY.mock.ts
@@ -1158,7 +1158,7 @@ export const apiXYWithNoYTitleAndInsideLegend: LensApiState = {
   ],
   query: {
     expression: 'test: true',
-    language: 'kuery',
+    language: 'kql',
   },
 };
 
@@ -1254,7 +1254,7 @@ export const apiXYWithTopListWithTruncationLegend: LensApiState = {
   ],
   query: {
     expression: 'test: true',
-    language: 'kuery',
+    language: 'kql',
   },
 };
 
@@ -1345,6 +1345,6 @@ export const apiXYWithNoTitleAndCustomOutsideLegend: LensApiState = {
   ],
   query: {
     expression: 'test: true',
-    language: 'kuery',
+    language: 'kql',
   },
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/basicXY.mock.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/basicXY.mock.ts
@@ -1157,7 +1157,7 @@ export const apiXYWithNoYTitleAndInsideLegend: LensApiState = {
     },
   ],
   query: {
-    query: '',
+    expression: 'test: true',
     language: 'kuery',
   },
 };
@@ -1253,7 +1253,7 @@ export const apiXYWithTopListWithTruncationLegend: LensApiState = {
     },
   ],
   query: {
-    query: '',
+    expression: 'test: true',
     language: 'kuery',
   },
 };
@@ -1344,7 +1344,7 @@ export const apiXYWithNoTitleAndCustomOutsideLegend: LensApiState = {
     },
   ],
   query: {
-    query: '',
+    expression: 'test: true',
     language: 'kuery',
   },
 };

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
@@ -499,7 +499,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', query: 'order_amount > 1000' },
+                    query: { language: 'kuery', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: {
                       visible: true,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/tests/xy/xy.test.ts
@@ -499,7 +499,7 @@ describe('XY', () => {
                   {
                     type: 'query',
                     label: 'Bingo!',
-                    query: { language: 'kuery', expression: 'order_amount > 1000' },
+                    query: { language: 'kql', expression: 'order_amount > 1000' },
                     time_field: 'order_date',
                     text: {
                       visible: true,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
@@ -449,9 +449,10 @@ export function buildAPIAnnotationsLayer(
             ? {
                 language: annotation.filter.language as 'kuery' | 'lucene',
                 // it should never be a non-string here as schema ensures that
-                query: typeof annotation.filter.query === 'string' ? annotation.filter.query : '',
+                expression:
+                  typeof annotation.filter.query === 'string' ? annotation.filter.query : '',
               }
-            : { language: 'kuery', query: '' },
+            : { language: 'kuery', expression: '' },
 
           time_field: annotation.timeField!,
           ...(annotation.extraFields ? { extra_fields: annotation.extraFields } : {}),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/api_layers.ts
@@ -42,6 +42,7 @@ import type { LensApiStaticValueOperation } from '../../../schema/metric_ops';
 import { isEsqlTableTypeDataset } from '../../../utils';
 import { fromColorMappingLensStateToAPI, fromStaticColorLensStateToAPI } from '../../coloring';
 import { getValueApiColumn } from '../../columns/esql_column';
+import { toApiFilterLanguage } from '../../columns/filter';
 import {
   isAPIColumnOfBucketType,
   isAPIColumnOfReferenceType,
@@ -447,12 +448,12 @@ export function buildAPIAnnotationsLayer(
           label: annotation.label,
           query: annotation.filter
             ? {
-                language: annotation.filter.language as 'kuery' | 'lucene',
+                language: toApiFilterLanguage(annotation.filter.language),
                 // it should never be a non-string here as schema ensures that
                 expression:
                   typeof annotation.filter.query === 'string' ? annotation.filter.query : '',
               }
-            : { language: 'kuery', expression: '' },
+            : { language: 'kql', expression: '' },
 
           time_field: annotation.timeField!,
           ...(annotation.extraFields ? { extra_fields: annotation.extraFields } : {}),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -152,7 +152,11 @@ function buildByValueAnnotationLayer(
       return {
         type: 'query',
         id: `${layer.type}_event_${index}`,
-        filter: { type: 'kibana_query', ...annotation.query },
+        filter: {
+          type: 'kibana_query',
+          query: annotation.query.expression,
+          language: annotation.query.language,
+        },
         label: annotation.label ?? 'Event',
         color: annotation.color?.color,
         ...(annotation.visible != null ? { isHidden: !annotation.visible } : {}),

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/charts/xy/state_layers.ts
@@ -19,6 +19,7 @@ import type {
 import type { SavedObjectReference } from '@kbn/core/server';
 import { EVENT_ANNOTATION_GROUP_TYPE } from '@kbn/event-annotation-common';
 import { getValueColumn } from '../../columns/esql_column';
+import { toLensStateFilterLanguage } from '../../columns/filter';
 import type {
   DataLayerType,
   ReferenceLineLayerType,
@@ -155,7 +156,7 @@ function buildByValueAnnotationLayer(
         filter: {
           type: 'kibana_query',
           query: annotation.query.expression,
-          language: annotation.query.language,
+          language: toLensStateFilterLanguage(annotation.query.language),
         },
         label: annotation.label ?? 'Event',
         color: annotation.color?.color,

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
@@ -54,7 +54,7 @@ describe('Buckets Transforms', () => {
     it('should transform filters API to lens state', () => {
       const input: LensApiFiltersOperation = {
         operation: 'filters',
-        filters: [{ filter: { language: 'kuery', query: 'status:active' }, label: 'Active' }],
+        filters: [{ filter: { language: 'kuery', expression: 'status:active' }, label: 'Active' }],
       };
       const result = fromBucketLensApiToLensState(input, metricColumns);
       if (!isLensStateColumnOfType<FiltersIndexPatternColumn>('filters', result)) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/buckets.test.ts
@@ -54,7 +54,7 @@ describe('Buckets Transforms', () => {
     it('should transform filters API to lens state', () => {
       const input: LensApiFiltersOperation = {
         operation: 'filters',
-        filters: [{ filter: { language: 'kuery', expression: 'status:active' }, label: 'Active' }],
+        filters: [{ filter: { language: 'kql', expression: 'status:active' }, label: 'Active' }],
       };
       const result = fromBucketLensApiToLensState(input, metricColumns);
       if (!isLensStateColumnOfType<FiltersIndexPatternColumn>('filters', result)) {

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
@@ -10,13 +10,24 @@
 import type { Query } from '@kbn/es-query';
 import type { LensApiFilterType } from '../../schema/filter';
 
+type LensStateFilterLanguage = 'kuery' | 'lucene';
+type ApiFilterLanguage = LensApiFilterType['language'];
+
+export const toLensStateFilterLanguage = (
+  language: ApiFilterLanguage | string
+): LensStateFilterLanguage => (language === 'lucene' ? 'lucene' : 'kuery');
+
+export const toApiFilterLanguage = (
+  language: LensStateFilterLanguage | string
+): ApiFilterLanguage => (language === 'lucene' ? 'lucene' : 'kql');
+
 export function fromFilterAPIToLensState(filter: LensApiFilterType | undefined): Query | undefined {
   if (!filter) {
     return;
   }
 
   return {
-    language: filter.language,
+    language: toLensStateFilterLanguage(filter.language),
     query: filter.expression,
   };
 }
@@ -31,10 +42,11 @@ export function fromFilterLensStateToAPI({
   if (language !== 'kuery' && language !== 'lucene') {
     return;
   }
-  return { expression: query, language };
+
+  return { expression: query, language: toApiFilterLanguage(language) };
 }
 
 export const DEFAULT_FILTER = {
   expression: '*',
-  language: 'kuery',
+  language: toApiFilterLanguage('kuery'),
 } satisfies LensApiFilterType;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
@@ -14,20 +14,27 @@ export function fromFilterAPIToLensState(filter: LensApiFilterType | undefined):
   if (!filter) {
     return;
   }
-  return filter;
+
+  return {
+    language: filter.language,
+    query: filter.query,
+  };
 }
 
-export function fromFilterLensStateToAPI(filter: Query): LensApiFilterType | undefined {
-  if (typeof filter.query !== 'string') {
+export function fromFilterLensStateToAPI({
+  query,
+  language,
+}: Query): LensApiFilterType | undefined {
+  if (typeof query !== 'string') {
     return;
   }
-  return {
-    query: filter.query,
-    language: filter.language as 'kuery' | 'lucene',
-  };
+  if (language !== 'kuery' && language !== 'lucene') {
+    return;
+  }
+  return { query, language };
 }
 
 export const DEFAULT_FILTER = {
   query: '*',
-  language: 'kuery' as 'kuery' | 'lucene',
-};
+  language: 'kuery',
+} satisfies LensApiFilterType;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filter.ts
@@ -17,7 +17,7 @@ export function fromFilterAPIToLensState(filter: LensApiFilterType | undefined):
 
   return {
     language: filter.language,
-    query: filter.query,
+    query: filter.expression,
   };
 }
 
@@ -31,10 +31,10 @@ export function fromFilterLensStateToAPI({
   if (language !== 'kuery' && language !== 'lucene') {
     return;
   }
-  return { query, language };
+  return { expression: query, language };
 }
 
 export const DEFAULT_FILTER = {
-  query: '*',
+  expression: '*',
   language: 'kuery',
 } satisfies LensApiFilterType;

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.test.ts
@@ -17,8 +17,8 @@ describe('Filters Transforms', () => {
       const input: LensApiFiltersOperation = {
         operation: 'filters',
         filters: [
-          { filter: { language: 'kuery', query: 'status:active' }, label: 'Active' },
-          { filter: { language: 'lucene', query: 'status:inactive' } },
+          { filter: { language: 'kuery', expression: 'status:active' }, label: 'Active' },
+          { filter: { language: 'lucene', expression: 'status:inactive' } },
         ],
       };
 
@@ -78,9 +78,12 @@ describe('Filters Transforms', () => {
       expect(result.operation).toBe('filters');
       expect(result.label).toBe('Filters');
       expect(result.filters).toHaveLength(2);
-      expect(result.filters[0].filter).toEqual({ language: 'kuery', query: 'status:active' });
+      expect(result.filters[0].filter).toEqual({ language: 'kuery', expression: 'status:active' });
       expect(result.filters[0].label).toBe('Active');
-      expect(result.filters[1].filter).toEqual({ language: 'lucene', query: 'status:inactive' });
+      expect(result.filters[1].filter).toEqual({
+        language: 'lucene',
+        expression: 'status:inactive',
+      });
       expect(result.filters[1].label).toBe('Inactive');
     });
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.test.ts
@@ -17,7 +17,7 @@ describe('Filters Transforms', () => {
       const input: LensApiFiltersOperation = {
         operation: 'filters',
         filters: [
-          { filter: { language: 'kuery', expression: 'status:active' }, label: 'Active' },
+          { filter: { language: 'kql', expression: 'status:active' }, label: 'Active' },
           { filter: { language: 'lucene', expression: 'status:inactive' } },
         ],
       };
@@ -78,7 +78,7 @@ describe('Filters Transforms', () => {
       expect(result.operation).toBe('filters');
       expect(result.label).toBe('Filters');
       expect(result.filters).toHaveLength(2);
-      expect(result.filters[0].filter).toEqual({ language: 'kuery', expression: 'status:active' });
+      expect(result.filters[0].filter).toEqual({ language: 'kql', expression: 'status:active' });
       expect(result.filters[0].label).toBe('Active');
       expect(result.filters[1].filter).toEqual({
         language: 'lucene',

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.ts
@@ -28,7 +28,10 @@ export function fromFiltersLensApiToLensState(
         // do not propagate advanced filters within dimensions
         .filter((filter) => filter.filter.language != null)
         .map((filter) => ({
-          input: filter.filter,
+          input: {
+            query: filter.filter.expression,
+            language: filter.filter.language,
+          },
           label: filter.label ?? 'Filter',
         })),
     },

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/filters.ts
@@ -9,7 +9,7 @@
 
 import type { FiltersIndexPatternColumn } from '@kbn/lens-common';
 import type { LensApiFiltersOperation } from '../../schema/bucket_ops';
-import { DEFAULT_FILTER, fromFilterLensStateToAPI } from './filter';
+import { DEFAULT_FILTER, fromFilterAPIToLensState, fromFilterLensStateToAPI } from './filter';
 import { getLensAPIBucketSharedProps, getLensStateBucketSharedProps } from './utils';
 
 export function fromFiltersLensApiToLensState(
@@ -27,13 +27,17 @@ export function fromFiltersLensApiToLensState(
       filters: (filters ?? [])
         // do not propagate advanced filters within dimensions
         .filter((filter) => filter.filter.language != null)
-        .map((filter) => ({
-          input: {
-            query: filter.filter.expression,
-            language: filter.filter.language,
-          },
-          label: filter.label ?? 'Filter',
-        })),
+        .map((filter) => {
+          const lensStateFilter = fromFilterAPIToLensState(filter.filter);
+
+          return {
+            input: {
+              query: lensStateFilter?.query ?? '',
+              language: lensStateFilter?.language ?? 'kuery',
+            },
+            label: filter.label ?? 'Filter',
+          };
+        }),
     },
   };
 }

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/columns/utils.ts
@@ -22,6 +22,7 @@ import type {
   ReferableMetricLensStateColumn,
 } from './types';
 import type { LensApiAllOperations, LensApiBucketOperations } from '../../schema';
+import type { LensApiFilterType } from '../../schema/filter';
 
 export const LENS_EMPTY_AS_NULL_DEFAULT_VALUE = false;
 
@@ -31,7 +32,7 @@ export function getLensStateMetricSharedProps(
     time_scale?: TimeScaleUnit;
     reduced_time_range?: string;
     time_shift?: string;
-    filter?: { query: string; language: 'kuery' | 'lucene' };
+    filter?: LensApiFilterType;
     label?: string;
   },
   dataType: DataType = 'number'

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -692,7 +692,7 @@ describe('filtersAndQueryToApiFormat', () => {
         ],
         "query": Object {
           "expression": "brand: \\"apple\\"",
-          "language": "kuery",
+          "language": "kql",
         },
       }
     `);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.test.ts
@@ -691,8 +691,8 @@ describe('filtersAndQueryToApiFormat', () => {
           },
         ],
         "query": Object {
+          "expression": "brand: \\"apple\\"",
           "language": "kuery",
-          "query": "brand: \\"apple\\"",
         },
       }
     `);

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -43,6 +43,7 @@ import type { LensApiFilterType } from '../schema/filter';
 import type { DatasetType, DatasetTypeESQL, DatasetTypeNoESQL } from '../schema/dataset';
 import type { LayerTypeESQL } from '../schema/charts/xy';
 import type { XScaleSchemaType } from '../schema/charts/shared';
+import { fromFilterLensStateToAPI } from './columns/filter';
 
 export type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)
@@ -540,16 +541,6 @@ export const generateApiLayer = (options: PersistedIndexPatternLayer | TextBased
   };
 };
 
-export const queryToApiFormat = (query: Query): LensApiFilterType | undefined => {
-  if (typeof query.query !== 'string') {
-    return;
-  }
-  return {
-    query: query.query,
-    language: query.language as 'kuery' | 'lucene',
-  };
-};
-
 function injectFilterReferences(filters: Filter[], references: SavedObjectReference[]): Filter[] {
   const dataViewReferences = references.filter((r) => r.type === INDEX_PATTERN_ID);
 
@@ -632,13 +623,16 @@ export const filtersAndQueryToApiFormat = (
     state.state.filters ?? [],
     state.references ?? []
   );
-  const asCodeFilters = fromStoredFilters(injectedStoredFilters) ?? [];
+  const filters = fromStoredFilters(injectedStoredFilters) ?? [];
+
+  const query =
+    state.state.query && !isOfAggregateQueryType(state.state.query)
+      ? fromFilterLensStateToAPI(state.state.query)
+      : undefined;
 
   return {
-    ...(asCodeFilters.length ? { filters: asCodeFilters } : {}),
-    ...(state.state.query && !isOfAggregateQueryType(state.state.query)
-      ? { query: queryToApiFormat(state.state.query) }
-      : {}),
+    ...(filters.length ? { filters } : {}),
+    ...(query?.query.length ? { query } : {}),
   };
 };
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -610,7 +610,7 @@ function extractFilterReferences(filters: Filter[], references: SavedObjectRefer
 }
 
 export const queryToLensState = (query: LensApiFilterType): Query => {
-  return { query: query.query, language: query.language as 'kuery' | 'lucene' };
+  return { query: query.expression, language: query.language as 'kuery' | 'lucene' };
 };
 
 export const filtersAndQueryToApiFormat = (
@@ -632,7 +632,7 @@ export const filtersAndQueryToApiFormat = (
 
   return {
     ...(filters.length ? { filters } : {}),
-    ...(query?.query.length ? { query } : {}),
+    ...(query?.expression.length ? { query } : {}),
   };
 };
 

--- a/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
+++ b/src/platform/packages/shared/kbn-lens-embeddable-utils/config_builder/transforms/utils.ts
@@ -43,7 +43,7 @@ import type { LensApiFilterType } from '../schema/filter';
 import type { DatasetType, DatasetTypeESQL, DatasetTypeNoESQL } from '../schema/dataset';
 import type { LayerTypeESQL } from '../schema/charts/xy';
 import type { XScaleSchemaType } from '../schema/charts/shared';
-import { fromFilterLensStateToAPI } from './columns/filter';
+import { fromFilterLensStateToAPI, toLensStateFilterLanguage } from './columns/filter';
 
 export type DataSourceStateLayer =
   | FormBasedPersistedState['layers'] // metric chart can return 2 layers (one for the metric and one for the trendline)
@@ -610,7 +610,10 @@ function extractFilterReferences(filters: Filter[], references: SavedObjectRefer
 }
 
 export const queryToLensState = (query: LensApiFilterType): Query => {
-  return { query: query.expression, language: query.language as 'kuery' | 'lucene' };
+  return {
+    query: query.expression,
+    language: toLensStateFilterLanguage(query.language),
+  };
 };
 
 export const filtersAndQueryToApiFormat = (


### PR DESCRIPTION
## Summary

In this PR I've:
- renamed the filter `query` to `expression`
- renamed the `kuery` to `kql` only for the API output/input (not in the LensState
- removed the  root visualization query object if the query is empty.

fix https://github.com/elastic/kibana/issues/258617
Address lens part of https://github.com/elastic/kibana/issues/261040
