### PR TITLE
[Security Solution] render take action in document flyout in Security Solution and Discover

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/create/flyout/create_case_flyout.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/create/flyout/create_case_flyout.tsx
@@ -50,6 +50,7 @@ export const CreateCaseFlyout = React.memo<CreateCaseFlyoutProps>(
         <ReactQueryDevtools initialIsOpen={false} />
         <EuiFlyout
           onClose={handleCancel}
+          session="never"
           tour-step="create-case-flyout"
           aria-label={i18n.CREATE_CASE_LABEL}
           data-test-subj="create-case-flyout"

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import { useEventDetails } from '../../../flyout/document_details/shared/hooks/use_event_details';
+import { TakeActionButton } from './take_action_button';
+import { TakeAction } from './take_action';
+import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
+
+jest.mock('../../../flyout/document_details/shared/hooks/use_event_details');
+jest.mock('./take_action_button', () => ({
+  TakeActionButton: jest.fn(() => <div data-test-subj="take-action-button-mock" />),
+}));
+
+const mockUseEventDetails = useEventDetails as jest.Mock;
+const mockTakeActionButton = TakeActionButton as unknown as jest.Mock;
+
+const createMockHit = (raw: Partial<DataTableRecord['raw']> = {}): DataTableRecord =>
+  ({
+    id: 'test-id',
+    raw: { _id: 'test-event-id', _index: 'test-index', ...raw },
+    flattened: {},
+    isAnchor: false,
+  } as DataTableRecord);
+
+const mockEcsData: Ecs = { _id: 'test-event-id', _index: 'test-index' };
+const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
+
+const mockDataFormattedForFieldBrowser: TimelineEventsDetailsItem[] = [
+  { field: 'host.name', values: ['test-host'], originalValue: ['test-host'], isObjectArray: false },
+  { field: 'user.name', values: null, originalValue: null, isObjectArray: false },
+];
+
+describe('<TakeAction />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEventDetails.mockReturnValue({
+      loading: false,
+      dataAsNestedObject: mockEcsData,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      refetchFlyoutData: mockRefetchFlyoutData,
+    });
+  });
+
+  it('should render a loading button while data is loading', () => {
+    mockUseEventDetails.mockReturnValue({
+      loading: true,
+      dataAsNestedObject: null,
+      dataFormattedForFieldBrowser: null,
+      refetchFlyoutData: mockRefetchFlyoutData,
+    });
+
+    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+    const button = getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID);
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Loading...');
+    expect(queryByTestId('take-action-button-mock')).not.toBeInTheDocument();
+  });
+
+  it('should render a disabled Take action button when dataAsNestedObject is null', () => {
+    mockUseEventDetails.mockReturnValue({
+      loading: false,
+      dataAsNestedObject: null,
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      refetchFlyoutData: mockRefetchFlyoutData,
+    });
+
+    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
+    expect(queryByTestId('take-action-button-mock')).not.toBeInTheDocument();
+  });
+
+  it('should render a disabled Take action button when dataFormattedForFieldBrowser is null', () => {
+    mockUseEventDetails.mockReturnValue({
+      loading: false,
+      dataAsNestedObject: mockEcsData,
+      dataFormattedForFieldBrowser: null,
+      refetchFlyoutData: mockRefetchFlyoutData,
+    });
+
+    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
+    expect(queryByTestId('take-action-button-mock')).not.toBeInTheDocument();
+  });
+
+  it('should render TakeActionButton when data is available', () => {
+    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+
+    expect(getByTestId('take-action-button-mock')).toBeInTheDocument();
+    expect(queryByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should call useEventDetails with eventId and indexName from hit', () => {
+    render(<TakeAction hit={createMockHit()} />);
+
+    expect(mockUseEventDetails).toHaveBeenCalledWith({
+      eventId: 'test-event-id',
+      indexName: 'test-index',
+    });
+  });
+
+  it('should pass ecsData and refetchFlyoutData from useEventDetails to TakeActionButton', () => {
+    render(<TakeAction hit={createMockHit()} />);
+
+    expect(mockTakeActionButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ecsData: mockEcsData,
+        refetchFlyoutData: mockRefetchFlyoutData,
+      }),
+      expect.anything()
+    );
+  });
+
+  it('should compute nonEcsData from dataFormattedForFieldBrowser and pass it to TakeActionButton', () => {
+    render(<TakeAction hit={createMockHit()} />);
+
+    expect(mockTakeActionButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonEcsData: [
+          { field: 'host.name', value: ['test-host'] },
+          { field: 'user.name', value: null },
+        ],
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
+import { EuiButton } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { useEventDetails } from '../../../flyout/document_details/shared/hooks/use_event_details';
+import { TakeActionButton } from './take_action_button';
+import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
+
+const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
+  defaultMessage: 'Take action',
+});
+
+const TAKE_ACTION_LOADING = i18n.translate(
+  'xpack.securitySolution.flyoutV2.footer.takeActionButtonLoadingLabel',
+  { defaultMessage: 'Loading...' }
+);
+
+export interface TakeActionProps {
+  /**
+   * The document to display
+   */
+  hit: DataTableRecord;
+}
+
+/**
+ * Take action button in the panel footer
+ * We show a loading button while we fetch the document.
+ * If the call succeeds we show the Take action button.
+ * If the call fails, we show a disabled button.
+ * We're doing all of this to avoid having to refactor all the actions that are currently using dataAsNestedObject and dataFormattedForFieldBrowser/
+ * // TODO: refactor all actions to take a DataTableRecord as input.
+ */
+export const TakeAction: FC<TakeActionProps> = ({ hit }) => {
+  const eventId = hit.raw._id;
+  const indexName = hit.raw._index;
+
+  const { dataAsNestedObject, dataFormattedForFieldBrowser, refetchFlyoutData, loading } =
+    useEventDetails({
+      eventId,
+      indexName,
+    });
+
+  const nonEcsData = useMemo(
+    () => dataFormattedForFieldBrowser?.map((d) => ({ field: d.field, value: d.values ?? null })),
+    [dataFormattedForFieldBrowser]
+  );
+
+  if (loading) {
+    return (
+      <EuiButton data-test-subj={FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID} fill isLoading>
+        {TAKE_ACTION_LOADING}
+      </EuiButton>
+    );
+  }
+
+  if (!dataAsNestedObject || !nonEcsData) {
+    return (
+      <EuiButton data-test-subj={FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID} fill isDisabled>
+        {TAKE_ACTION}
+      </EuiButton>
+    );
+  }
+
+  return (
+    <TakeActionButton
+      ecsData={dataAsNestedObject}
+      nonEcsData={nonEcsData}
+      refetchFlyoutData={refetchFlyoutData}
+    />
+  );
+};
+
+TakeAction.displayName = 'TakeAction';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import type { TimelineNonEcsData } from '../../../../common/search_strategy';
+import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
+import { TakeActionButton } from './take_action_button';
+import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
+
+jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions');
+
+const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
+
+const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
+const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['test-host'] }];
+const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
+
+const defaultProps = {
+  ecsData: mockEcsData,
+  nonEcsData: mockNonEcsData,
+  refetchFlyoutData: mockRefetchFlyoutData,
+};
+
+const renderTakeActionButton = (props = defaultProps) => render(<TakeActionButton {...props} />);
+
+describe('<TakeActionButton />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAddToCaseActions.mockReturnValue({ addToCaseActionItems: [] });
+  });
+
+  it('should render the take action button', () => {
+    const { getByTestId } = renderTakeActionButton();
+
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
+  });
+
+  it('should not be disabled', () => {
+    const { getByTestId } = renderTakeActionButton();
+
+    expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).not.toBeDisabled();
+  });
+
+  it('should open the popover when the button is clicked', () => {
+    const { getByTestId } = renderTakeActionButton();
+
+    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+    expect(document.querySelector('[data-test-subj="takeActionPanelMenu"]')).toBeInTheDocument();
+  });
+
+  it('should call useAddToCaseActions with the correct arguments', () => {
+    renderTakeActionButton();
+
+    expect(mockUseAddToCaseActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ecsData: mockEcsData,
+        nonEcsData: mockNonEcsData,
+        onSuccess: mockRefetchFlyoutData,
+      })
+    );
+  });
+
+  it('should render action items in the popover', () => {
+    const mockItems = [
+      { name: 'Add to new case', onClick: jest.fn() },
+      { name: 'Add to existing case', onClick: jest.fn() },
+    ];
+    mockUseAddToCaseActions.mockReturnValue({ addToCaseActionItems: mockItems });
+
+    const { getByTestId } = renderTakeActionButton();
+    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+    expect(getByTestId('takeActionPanelMenu')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import type { TimelineNonEcsData } from '../../../../common/search_strategy';
+import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
+import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
+
+const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
+  defaultMessage: 'Take action',
+});
+
+export interface TakeActionButtonProps {
+  /**
+   * ECS data for the document
+   */
+  ecsData: Ecs;
+  /**
+   * Non-ECS data for the document
+   */
+  nonEcsData: TimelineNonEcsData[];
+  /**
+   * Callback to refetch flyout data
+   */
+  refetchFlyoutData: () => Promise<void>;
+}
+
+/**
+ * Take action button with dropdown used to show all the options available to the user on a document rendered in the expandable flyout
+ * // TODO: refactor all actions to take a DataTableRecord as input.
+ */
+export const TakeActionButton = memo(
+  ({ ecsData, nonEcsData, refetchFlyoutData }: TakeActionButtonProps) => {
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+    const togglePopoverHandler = useCallback(() => {
+      setIsPopoverOpen((open) => !open);
+    }, []);
+    const closePopoverHandler = useCallback(() => {
+      setIsPopoverOpen(false);
+    }, []);
+
+    const { addToCaseActionItems } = useAddToCaseActions({
+      ecsData,
+      nonEcsData,
+      onMenuItemClick: closePopoverHandler,
+      onSuccess: refetchFlyoutData,
+    });
+
+    const items = useMemo(() => [...addToCaseActionItems], [addToCaseActionItems]);
+
+    const takeActionButton = (
+      <EuiButton
+        data-test-subj={FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID}
+        fill
+        iconSide="right"
+        iconType="arrowDown"
+        onClick={togglePopoverHandler}
+      >
+        {TAKE_ACTION}
+      </EuiButton>
+    );
+
+    return (
+      <EuiPopover
+        id="AlertTakeActionPanel"
+        button={takeActionButton}
+        isOpen={isPopoverOpen}
+        closePopover={closePopoverHandler}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+        repositionOnScroll
+      >
+        <EuiContextMenu
+          size="s"
+          initialPanelId={0}
+          panels={[{ id: 0, items }]}
+          data-test-subj="takeActionPanelMenu"
+        />
+      </EuiPopover>
+    );
+  }
+);
+
+TakeActionButton.displayName = 'TakeActionButton';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/test_ids.ts
@@ -113,3 +113,7 @@ export const SUMMARY_ROW_LOADING_TEST_ID = (dataTestSubj: string) => `${dataTest
 export const SUMMARY_ROW_TEXT_TEST_ID = (dataTestSubj: string) => `${dataTestSubj}Text`;
 export const SUMMARY_ROW_VALUE_TEST_ID = (dataTestSubj: string) => `${dataTestSubj}Value`;
 export const SUMMARY_ROW_BUTTON_TEST_ID = (dataTestSubj: string) => `${dataTestSubj}Button`;
+
+/* Footer */
+
+export const FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID = `${PREFIX}FooterDropdownButton` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
@@ -15,6 +15,11 @@ jest.mock('./components/footer_ai_actions', () => ({
     <div data-test-subj="footerAiActions" data-hit-id={hit.id} />
   ),
 }));
+jest.mock('./components/take_action', () => ({
+  TakeAction: ({ hit }: { hit: DataTableRecord }) => (
+    <div data-test-subj="takeAction" data-hit-id={hit.id} />
+  ),
+}));
 
 const createMockHit = (): DataTableRecord =>
   ({
@@ -30,6 +35,16 @@ describe('<Footer />', () => {
     const { getByTestId } = render(<Footer hit={hit} />);
 
     const aiActions = getByTestId('footerAiActions');
+    expect(aiActions).toBeInTheDocument();
+    expect(aiActions).toHaveAttribute('data-hit-id', 'test-id');
+  });
+
+  it('renders TakeAction with the provided hit', () => {
+    const hit = createMockHit();
+
+    const { getByTestId } = render(<Footer hit={hit} />);
+
+    const aiActions = getByTestId('takeAction');
     expect(aiActions).toBeInTheDocument();
     expect(aiActions).toHaveAttribute('data-hit-id', 'test-id');
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
@@ -9,6 +9,7 @@ import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { FooterAiActions } from './components/footer_ai_actions';
+import { TakeAction } from './components/take_action';
 
 export interface FooterProps {
   /**
@@ -25,6 +26,9 @@ export const Footer = memo(({ hit }: FooterProps) => {
     <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
       <EuiFlexItem grow={false}>
         <FooterAiActions hit={hit} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <TakeAction hit={hit} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
## Summary

This PR adds the `Take action` button and dropdown at the bottom of the new flyout. Inside the dropdown, the PR adds the `Add to new case` and `Add to existing casa` actions.

### Code changes

The PR adds and changes the following:
- create a new button and dropdown to host all the actions
- add the cases related actions

> [!TIP]
> I decided to create a new take action button instead of reusing the current one from the expandable alerts flyout. The main reason being that I want to have small easy to review PR, targeting each actions separately. Also some of the actions will not make it in `9.4` so this was to me a better approach instead of a bunch of it/else conditions...

> [!NOTE]
> You'll notice a very small change for the @elastic/kibana-cases team: with the recent changes around Kibana flyouts using the new system flyout, we need to specify `session="never"` for flyouts that don't belong to a parent/child flow. Without that change, the `Add to new case` flyout was opening as a child. I checked with UIUX and we do NOT want that behavior. The `session="never"` takes care of that, as well as ensuring that the case flyout will not be part of the history, which is also desired.

### UI changes

The UI of the current alert/event flyouts (using the expandable flyout framework) in Security Solution should remain unchanged after this PR (when the feature flag is off).

https://github.com/user-attachments/assets/684df96d-cc9c-4594-b306-364a6bc2f7a5

In the new flyout when loaded in Security Solution, we show the new Take action in the footer:

<img width="380" height="839" alt="Screenshot 2026-04-02 at 12 57 24 PM" src="https://github.com/user-attachments/assets/edefdc1b-3d41-457e-9026-6098174248e4" />

The whole flow also works in Discover

https://github.com/user-attachments/assets/55a81b40-8341-48e3-ab01-ec7f40dc486b

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

## What to look for when testing

- verify that the footer has not changed in the expandable flyout (`newFlyoutSystemEnabled` feature flag off)
- verify that the footer shows correctly in the new flyout (`newFlyoutSystemEnabled` feature flag on)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
