### PR TITLE
[9.3] [EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests (#260334)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_exceptions/view/components/endpoint_exceptions_flyout.test.tsx
@@ -31,6 +31,8 @@ jest.mock('../../../../../detection_engine/rule_exceptions/logic/use_close_alert
 jest.mock('../../../../../detections/containers/detection_engine/alerts/use_signal_index');
 
 describe('Endpoint exceptions flyout', () => {
+  jest.setTimeout(10000);
+
   let mockedContext: AppContextTestRender;
   let render: (
     props?: Partial<EndpointExceptionsFlyoutProps>
@@ -183,15 +185,12 @@ describe('Endpoint exceptions flyout', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253883
-  describe.skip('When valid form state', () => {
+  describe('When valid form state', () => {
     it('should enable "Add endpoint exception" button when form is valid', async () => {
       render({ alertData, isAlertDataLoading: false });
 
-      await userEvent.type(
-        renderResult.getByTestId('endpointExceptions-form-name-input'),
-        'Test exception'
-      );
+      await userEvent.clear(renderResult.getByTestId('endpointExceptions-form-name-input'));
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       expect(confirmButton.hasAttribute('disabled')).toBeFalsy();
@@ -212,10 +211,8 @@ describe('Endpoint exceptions flyout', () => {
       (useCloseAlertsFromExceptions as jest.Mock).mockImplementation(() => [true, jest.fn()]);
 
       render({ alertData, isAlertDataLoading: false });
-      await userEvent.type(
-        renderResult.getByTestId('endpointExceptions-form-name-input'),
-        'Test exception'
-      );
+      await userEvent.clear(renderResult.getByTestId('endpointExceptions-form-name-input'));
+      await userEvent.paste('Test exception');
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
 
       await waitFor(() => {
@@ -227,7 +224,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -245,7 +243,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -261,7 +260,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -278,7 +278,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
 
       const confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       await userEvent.click(confirmButton);
@@ -299,7 +300,8 @@ describe('Endpoint exceptions flyout', () => {
         render({ alertData, isAlertDataLoading: false, alertStatus: 'open', rules });
 
         const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-        await userEvent.type(nameInput, 'Test exception');
+        await userEvent.clear(nameInput);
+        await userEvent.paste('Test exception');
 
         confirmButton = renderResult.getByTestId('add-endpoint-exception-confirm-button');
       });
@@ -373,7 +375,8 @@ describe('Endpoint exceptions flyout', () => {
       render({ alertData, isAlertDataLoading: false });
 
       const nameInput = renderResult.getByTestId('endpointExceptions-form-name-input');
-      await userEvent.type(nameInput, 'Test exception');
+      await userEvent.clear(nameInput);
+      await userEvent.paste('Test exception');
     });
 
     it('pressing confirm should show confirm modal instead of saving exception', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_devices/view/components/form.test.tsx
@@ -46,6 +46,8 @@ jest.mock('../../../../../common/containers/source', () => ({
 import { useFetchIndex } from '../../../../../common/containers/source';
 
 describe('Trusted devices form', () => {
+  jest.setTimeout(10000);
+
   const formPrefix = 'trustedDevices-form';
   let resetHTMLElementOffsetWidth: ReturnType<typeof forceHTMLElementOffsetWidth>;
 
@@ -119,11 +121,9 @@ describe('Trusted devices form', () => {
     textField: HTMLInputElement | HTMLTextAreaElement,
     value: string
   ) => {
-    // For EuiComboBox (has role="combobox"), use userEvent.type
     if (textField.getAttribute('role') === 'combobox') {
       await userEvent.clear(textField);
-      await userEvent.type(textField, value);
-      // Press Enter to create the custom option
+      await userEvent.paste(value);
       await userEvent.keyboard('{Enter}');
     } else {
       // For regular text fields
@@ -298,9 +298,7 @@ describe('Trusted devices form', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/253353
-  // FLAKY: https://github.com/elastic/kibana/issues/253563
-  describe.skip('Conditions', () => {
+  describe('Conditions', () => {
     beforeEach(async () => {
       await render();
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests (#260334)](https://github.com/elastic/kibana/pull/260334)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2026-04-01T16:09:20Z","message":"[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests (#260334)\n\nFixes flaky Jest test timeouts in two test files by replacing slow\n`userEvent.type` (per-character keystroke simulation) with\n`userEvent.clear` + `userEvent.paste` (single event), and adding\n`jest.setTimeout(10000)` as CI safety margin.\n\n### `endpoint_exceptions_flyout.test.tsx`\nUnskips two `describe` blocks (\"When valid form state\" and \"When\nwildcard warning is active\"). All 8 instances of `userEvent.type`\nreplaced. 20 tests now pass.\n\n### `form.test.tsx` (trusted devices)\nUnskips the \"Conditions\" `describe` block. Fixed `setTextFieldValue`\nhelper to use `paste` instead of `type` for EuiComboBox inputs. 28 tests\nnow pass.\n\nCloses https://github.com/elastic/kibana/issues/253883\nCloses https://github.com/elastic/kibana/issues/253640\nCloses https://github.com/elastic/kibana/issues/253648\nCloses https://github.com/elastic/kibana/issues/253353\nCloses https://github.com/elastic/kibana/issues/253368\nCloses https://github.com/elastic/kibana/issues/253563","sha":"af1e412240cbb0d7149a74dea8ee8a001891e5be","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Defend Workflows","backport:version","v9.3.0","v9.4.0","backport:prev-minor"],"title":"[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests","number":260334,"url":"https://github.com/elastic/kibana/pull/260334","mergeCommit":{"message":"[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests (#260334)\n\nFixes flaky Jest test timeouts in two test files by replacing slow\n`userEvent.type` (per-character keystroke simulation) with\n`userEvent.clear` + `userEvent.paste` (single event), and adding\n`jest.setTimeout(10000)` as CI safety margin.\n\n### `endpoint_exceptions_flyout.test.tsx`\nUnskips two `describe` blocks (\"When valid form state\" and \"When\nwildcard warning is active\"). All 8 instances of `userEvent.type`\nreplaced. 20 tests now pass.\n\n### `form.test.tsx` (trusted devices)\nUnskips the \"Conditions\" `describe` block. Fixed `setTextFieldValue`\nhelper to use `paste` instead of `type` for EuiComboBox inputs. 28 tests\nnow pass.\n\nCloses https://github.com/elastic/kibana/issues/253883\nCloses https://github.com/elastic/kibana/issues/253640\nCloses https://github.com/elastic/kibana/issues/253648\nCloses https://github.com/elastic/kibana/issues/253353\nCloses https://github.com/elastic/kibana/issues/253368\nCloses https://github.com/elastic/kibana/issues/253563","sha":"af1e412240cbb0d7149a74dea8ee8a001891e5be"}},"sourceBranch":"main","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260334","number":260334,"mergeCommit":{"message":"[EDR Workflows] Unskip flaky endpoint exceptions and trusted devices tests (#260334)\n\nFixes flaky Jest test timeouts in two test files by replacing slow\n`userEvent.type` (per-character keystroke simulation) with\n`userEvent.clear` + `userEvent.paste` (single event), and adding\n`jest.setTimeout(10000)` as CI safety margin.\n\n### `endpoint_exceptions_flyout.test.tsx`\nUnskips two `describe` blocks (\"When valid form state\" and \"When\nwildcard warning is active\"). All 8 instances of `userEvent.type`\nreplaced. 20 tests now pass.\n\n### `form.test.tsx` (trusted devices)\nUnskips the \"Conditions\" `describe` block. Fixed `setTextFieldValue`\nhelper to use `paste` instead of `type` for EuiComboBox inputs. 28 tests\nnow pass.\n\nCloses https://github.com/elastic/kibana/issues/253883\nCloses https://github.com/elastic/kibana/issues/253640\nCloses https://github.com/elastic/kibana/issues/253648\nCloses https://github.com/elastic/kibana/issues/253353\nCloses https://github.com/elastic/kibana/issues/253368\nCloses https://github.com/elastic/kibana/issues/253563","sha":"af1e412240cbb0d7149a74dea8ee8a001891e5be"}}]}] BACKPORT-->