### PR TITLE
[8.19] [APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildKqlFilter } from './build_kql_filter';
+
+describe('buildKqlFilter', () => {
+  it('should build correct KQL for a single value', () => {
+    const field = 'host.name';
+    const values = ['host1'];
+    const expectedKql = 'host.name: ("host1")';
+
+    const kqlFilter = buildKqlFilter(field, values);
+
+    expect(kqlFilter).toBe(expectedKql);
+  });
+
+  it('should build correct KQL for multiple values', () => {
+    const field = 'host.name';
+    const values = ['host1', 'host2', 'host3'];
+    const expectedKql = 'host.name: ("host1" OR "host2" OR "host3")';
+
+    const kqlFilter = buildKqlFilter(field, values);
+
+    expect(kqlFilter).toBe(expectedKql);
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/build_kql_filter.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const buildKqlFilter = (field: string, value: string[]) =>
+  `${field}: (${value.map((v) => `"${v}"`).join(' OR ')})`;

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/infra_overview/infra_tabs/use_tabs.tsx
@@ -7,13 +7,13 @@
 import type { EuiTabbedContentProps } from '@elastic/eui';
 import { useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { hasOpenTelemetryPrefix } from '@kbn/elastic-agent-utils';
 import type { ApmPluginStartDeps } from '../../../../plugin';
 import { KUBERNETES_POD_NAME, HOST_NAME, CONTAINER_ID } from '../../../../../common/es_fields/apm';
+import { buildKqlFilter } from './build_kql_filter';
 
 type Tab = NonNullable<EuiTabbedContentProps['tabs']>[0] & {
   id: 'containers' | 'pods' | 'hosts';
@@ -62,35 +62,13 @@ export function useTabs({
 
   const k8sFilterFields = useMemo(() => (isOtel ? 'k8s.pod.name' : KUBERNETES_POD_NAME), [isOtel]);
 
-  const hostsFilter = useMemo(
-    (): QueryDslQueryContainer => ({
-      bool: {
-        should: [
-          {
-            terms: {
-              [HOST_NAME]: hostNames,
-            },
-          },
-        ],
-        minimum_should_match: 1,
-      },
-    }),
-    [hostNames]
-  );
+  const hostsFilter = useMemo(() => buildKqlFilter(HOST_NAME, hostNames), [hostNames]);
   const podsFilter = useMemo(
-    () => ({
-      bool: {
-        filter: [{ terms: { [k8sFilterFields]: podNames } }],
-      },
-    }),
+    () => buildKqlFilter(k8sFilterFields, podNames),
     [podNames, k8sFilterFields]
   );
   const containersFilter = useMemo(
-    () => ({
-      bool: {
-        filter: [{ terms: { [CONTAINER_ID]: containerIds } }],
-      },
-    }),
+    () => buildKqlFilter(CONTAINER_ID, containerIds),
     [containerIds]
   );
 
@@ -100,7 +78,7 @@ export function useTabs({
       {ContainerMetricsTable &&
         ContainerMetricsTable({
           timerange,
-          filterClauseDsl: containersFilter,
+          kuery: containersFilter,
           isOtel,
           isK8sContainer: podNames.length > 0,
         })}
@@ -113,7 +91,7 @@ export function useTabs({
       {PodMetricsTable &&
         PodMetricsTable({
           timerange,
-          filterClauseDsl: podsFilter,
+          kuery: podsFilter,
           isOtel,
         })}
     </>
@@ -125,7 +103,7 @@ export function useTabs({
       {HostMetricsTable &&
         HostMetricsTable({
           timerange,
-          filterClauseDsl: hostsFilter,
+          kuery: hostsFilter,
           isOtel,
         })}
     </>

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/metrics_explorer_views/types.ts
@@ -69,7 +69,7 @@ export const metricExplorerOptionsRequiredRT = rt.type({
 export const metricExplorerOptionsOptionalRT = rt.partial({
   limit: rt.number,
   groupBy: rt.union([rt.string, rt.array(rt.string)]),
-  filterQuery: rt.string,
+  kuery: rt.string,
   source: rt.string,
   forceInterval: rt.boolean,
   dropLastBucket: rt.boolean,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/README.md
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/README.md
@@ -3,7 +3,7 @@
 This folder contains components that are used to display metrics about infrastructure components.
 Currently there are tables for containers, pods and hosts.
 
-For use within the Infra plugin, make use of the `useXMetricsTable` hooks and their matching 
+For use within the Infra plugin, make use of the `useXMetricsTable` hooks and their matching
 `XMetricsTable` components.
 
 For use outside of the Infra plugin, consume these components via the lazy components exposed on the
@@ -11,16 +11,16 @@ start contract of the plugin.
 
 ## The shared data hook
 
-All tables get their data from the Metrics Explorer API by making use of the 
+All tables get their data from the Metrics Explorer API by making use of the
 `useInfrastructureNodeMetrics` hook. The key input to the hook is the `MetricsMap` which defines
-which metrics should be requested (by field and type of aggregation). By passing a `MetricsMap` to 
-the helper `metricsToApiOptions` we get back the options we need to pass to 
-`useInfrastructureNodeMetrics`. `metricsToApiOptions` also returns a mapping object that is used to 
+which metrics should be requested (by field and type of aggregation). By passing a `MetricsMap` to
+the helper `metricsToApiOptions` we get back the options we need to pass to
+`useInfrastructureNodeMetrics`. `metricsToApiOptions` also returns a mapping object that is used to
 translate the field name to the format the API returns (e.g. `metric_0`).
 The `MetricsMap` type is mostly to ensure that the object key and the `field` value match to avoid
 mistakes when re-ordering the metrics being used.
 
-`useInfrastructureNodeMetrics` also expects a timerange and a filter (in ES DSL) and a function
+`useInfrastructureNodeMetrics` also expects a timerange, a filter (in KQL) and a function
 to transform the Metrics Explorer response to something more suitable for the table component to
 work with.
 
@@ -28,7 +28,7 @@ Internally, the hook manages loading the source, making the API request, sorting
 response. It also manages the loading state.
 
 Currently, it does a large request and then does sorting and pagination on the client. In the future
-we should replace this with a terms aggregation in the API instead, to do more work in 
+we should replace this with a terms aggregation in the API instead, to do more work in
 Elasticsearch.
 
 ## Hooks and tables per node type
@@ -41,18 +41,18 @@ function. The transformation function makes use of the `metricByField` to unpack
 in a type safe way.
 The body of the hook sets up the page and sort state, then invokes the shared data hook.
 
-The table itself is a fairly simple component that uses EUI components to render a table with 
+The table itself is a fairly simple component that uses EUI components to render a table with
 pagination. It makes use of components found in the shared folder for the things that are common
 across each node type such as the pagination and Node Details page link.
 
-When using the hook it is important to wrap the timerange and filter clause DSL parameters in 
+When using the hook it is important to wrap the timerange and filter kuery parameters in
 something like `useMemo` to avoid a re-rendering loop.
 
 ## The embeddable component factories
 
 To make it as easy as possible to consume these tables we expose them fully integrated on our start
 contract. The component that is exposed lazily loads our component, adds in all of our providers
-and calls the node type specific hook and passes the result to the node type specific table 
+and calls the node type specific hook and passes the result to the node type specific table
 component. Integration should be as simple as dropping in the component in a React hierarchy.
 
 The `createLazyXMetricsTable` factory function accepts our Kibana dependencies and return a new

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
@@ -20,14 +20,8 @@ describe('container_metrics_configs', () => {
     it('returns ECS options when isOtel is false', () => {
       const { options } = getOptionsForSchema(false);
 
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'event.dataset': 'kubernetes.container' } }],
-        },
-      };
-
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.kuery).toBe('event.dataset: "kubernetes.container"');
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: ECS_CONTAINER_CPU_USAGE_LIMIT_PCT, aggregation: 'avg' },
@@ -39,14 +33,9 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv Docker options when isOtel is true and isK8sContainer is false', () => {
       const { options } = getOptionsForSchema(true, false);
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
-        },
-      };
 
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.kuery).toBe('event.dataset: "dockerstatsreceiver.otel"');
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
@@ -58,13 +47,9 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv Docker options when isOtel is true and isK8sContainer is undefined', () => {
       const { options } = getOptionsForSchema(true);
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
-        },
-      };
+
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.kuery).toBe('event.dataset: "dockerstatsreceiver.otel"');
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
@@ -76,13 +61,9 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv K8s options when isOtel is true and isK8sContainer is true', () => {
       const { options } = getOptionsForSchema(true, true);
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }],
-        },
-      };
+
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.kuery).toBe('event.dataset: "kubeletstatsreceiver.otel"');
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION, aggregation: 'avg' },
@@ -93,62 +74,24 @@ describe('container_metrics_configs', () => {
     });
 
     it('combines kuery with ECS source filter when isOtel is false and kuery is provided', () => {
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'container.id': 'abc-123' } }],
-        },
-      };
+      const kuery = 'container.id: "abc-123"';
+      const { options } = getOptionsForSchema(false, undefined, kuery);
 
-      const filterClauseWithEventModuleFilter = {
-        bool: {
-          filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
-        },
-      };
-
-      const { options } = getOptionsForSchema(false, undefined, filterClauseDsl);
-
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+      expect(options.kuery).toBe(`event.dataset: "kubernetes.container" AND (${kuery})`);
     });
 
     it('combines kuery with SemConv Docker when isOtel is true, isK8sContainer false, and kuery is provided', () => {
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'container.id': 'abc-123' } }],
-        },
-      };
+      const kuery = 'container.id: "abc-123"';
+      const { options } = getOptionsForSchema(true, false, kuery);
 
-      const filterClauseWithEventModuleFilter = {
-        bool: {
-          filter: [
-            { term: { 'event.dataset': 'dockerstatsreceiver.otel' } },
-            { ...filterClauseDsl },
-          ],
-        },
-      };
-
-      const { options } = getOptionsForSchema(true, false, filterClauseDsl);
-
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+      expect(options.kuery).toBe(`event.dataset: "dockerstatsreceiver.otel" AND (${kuery})`);
     });
 
     it('combines kuery with SemConv K8s when isOtel is true, isK8sContainer true, and kuery is provided', () => {
-      const filterClauseDsl = {
-        bool: {
-          filter: [{ term: { 'container.id': 'abc-123' } }],
-        },
-      };
-      const filterClauseWithEventModuleFilter = {
-        bool: {
-          filter: [
-            { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
-            { ...filterClauseDsl },
-          ],
-        },
-      };
+      const kuery = 'container.id: "abc-123"';
+      const { options } = getOptionsForSchema(true, true, kuery);
 
-      const { options } = getOptionsForSchema(true, true, filterClauseDsl);
-
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseWithEventModuleFilter));
+      expect(options.kuery).toBe(`event.dataset: "kubeletstatsreceiver.otel" AND (${kuery})`);
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
@@ -96,11 +96,7 @@ export const unpackMetricSemconvK8s = makeUnpackMetric(metricByFieldSemconvK8s);
 /** @deprecated Use metricByFieldEcs for ECS; use unpack from getUnpackMetricsForSchema for transform */
 export const metricByField = metricByFieldEcs;
 
-export function getOptionsForSchema(
-  isOtel: boolean,
-  isK8sContainer?: boolean,
-  kuery?: string
-) {
+export function getOptionsForSchema(isOtel: boolean, isK8sContainer?: boolean, kuery?: string) {
   if (isOtel) {
     return isK8sContainer
       ? metricsToApiOptions(containerMetricsQueryConfigSemconvK8s, kuery)

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { MetricsQueryOptions } from '../shared';
 import { createMetricByFieldLookup, makeUnpackMetric, metricsToApiOptions } from '../shared';
 import {
@@ -23,11 +22,7 @@ type ContainerMetricsFieldEcs =
   | typeof ECS_CONTAINER_MEMORY_USAGE_BYTES;
 
 const containerMetricsQueryConfigEcs: MetricsQueryOptions<ContainerMetricsFieldEcs> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubernetes.container',
-    },
-  },
+  sourceFilter: `event.dataset: "kubernetes.container"`,
   groupByField: 'container.id',
   metricsMap: {
     [ECS_CONTAINER_CPU_USAGE_LIMIT_PCT]: {
@@ -48,11 +43,7 @@ type ContainerMetricsFieldSemconvDocker =
 
 const containerMetricsQueryConfigSemconvDocker: MetricsQueryOptions<ContainerMetricsFieldSemconvDocker> =
   {
-    sourceFilter: {
-      term: {
-        'event.dataset': 'dockerstatsreceiver.otel',
-      },
-    },
+    sourceFilter: `event.dataset: "dockerstatsreceiver.otel"`,
     groupByField: 'container.id',
     metricsMap: {
       [SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION]: {
@@ -73,11 +64,7 @@ type ContainerMetricsFieldSemconvK8s =
 
 const containerMetricsQueryConfigSemconvK8s: MetricsQueryOptions<ContainerMetricsFieldSemconvK8s> =
   {
-    sourceFilter: {
-      term: {
-        'event.dataset': 'kubeletstatsreceiver.otel',
-      },
-    },
+    sourceFilter: `event.dataset: "kubeletstatsreceiver.otel"`,
     groupByField: 'container.id',
     metricsMap: {
       [SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION]: {
@@ -112,12 +99,12 @@ export const metricByField = metricByFieldEcs;
 export function getOptionsForSchema(
   isOtel: boolean,
   isK8sContainer?: boolean,
-  filterClauseDsl?: QueryDslQueryContainer
+  kuery?: string
 ) {
   if (isOtel) {
     return isK8sContainer
-      ? metricsToApiOptions(containerMetricsQueryConfigSemconvK8s, filterClauseDsl)
-      : metricsToApiOptions(containerMetricsQueryConfigSemconvDocker, filterClauseDsl);
+      ? metricsToApiOptions(containerMetricsQueryConfigSemconvK8s, kuery)
+      : metricsToApiOptions(containerMetricsQueryConfigSemconvDocker, kuery);
   }
-  return metricsToApiOptions(containerMetricsQueryConfigEcs, filterClauseDsl);
+  return metricsToApiOptions(containerMetricsQueryConfigEcs, kuery);
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.test.tsx
@@ -35,18 +35,7 @@ describe('ContainerMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
   const mockData = {
     series: [
@@ -67,7 +56,7 @@ describe('ContainerMetricsTable', () => {
         metricsClient
       );
 
-      render(<LazyContainerMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyContainerMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('containerMetricsTable')).not.toBeInTheDocument();
@@ -97,7 +86,7 @@ describe('ContainerMetricsTable', () => {
       const { findByText } = render(
         <IntegratedContainerMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/create_lazy_container_metrics_table.tsx
@@ -16,7 +16,7 @@ const LazyIntegratedContainerMetricsTable = lazy(
 export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
   return ({
     timerange,
-    filterClauseDsl,
+    kuery,
     sourceId,
     isOtel,
     isK8sContainer,
@@ -30,7 +30,7 @@ export function createLazyContainerMetricsTable(core: CoreStart, metricsClient: 
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           isOtel={isOtel}
           isK8sContainer={isK8sContainer}
         />

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/integrated_container_metrics_table.tsx
@@ -16,19 +16,19 @@ type ContainerIntegratedProps = IntegratedNodeMetricsTableProps & {
 
 type HookedContainerMetricsTableProps = Pick<
   ContainerIntegratedProps,
-  'timerange' | 'filterClauseDsl' | 'isOtel' | 'isK8sContainer' | 'metricsClient'
+  'timerange' | 'kuery' | 'isOtel' | 'isK8sContainer' | 'metricsClient'
 >;
 
 function HookedContainerMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   isOtel,
   isK8sContainer,
   metricsClient,
 }: HookedContainerMetricsTableProps) {
   const containerMetricsTableProps = useContainerMetricsTable({
     timerange,
-    filterClauseDsl,
+    kuery,
     isOtel,
     isK8sContainer,
     metricsClient,
@@ -45,7 +45,7 @@ function HookedContainerMetricsTable({
 
 function ContainerMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   isOtel,
   isK8sContainer,
@@ -56,7 +56,7 @@ function ContainerMetricsTableWithProviders({
     <CoreProviders {...coreProvidersProps}>
       <HookedContainerMetricsTable
         timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
+        kuery={kuery}
         isOtel={isOtel}
         metricsClient={metricsClient}
         isK8sContainer={isK8sContainer}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -28,18 +28,8 @@ describe('useContainerMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
-      },
-    };
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -51,32 +41,25 @@ describe('useContainerMetricsTable hook', () => {
     renderHook(() =>
       useContainerMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `event.dataset: "kubernetes.container" AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );
   });
 
   it('should call useInfrastructureNodeMetrics with SemConv Docker metrics when isOtel is true (default)', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }, { ...filterClauseDsl }],
-      },
-    };
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
@@ -86,7 +69,7 @@ describe('useContainerMetricsTable hook', () => {
     renderHook(() =>
       useContainerMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: true,
       })
@@ -95,7 +78,7 @@ describe('useContainerMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "dockerstatsreceiver.otel" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION }),
             expect.objectContaining({ field: SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT }),
@@ -106,31 +89,18 @@ describe('useContainerMetricsTable hook', () => {
   });
 
   it('should call useInfrastructureNodeMetrics with SemConv K8s metrics when isOtel is true and isK8s is true', () => {
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
+
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
       metricIndices: 'test-index',
     });
 
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [
-          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
-          { ...filterClauseDsl },
-        ],
-      },
-    };
-
     renderHook(() =>
       useContainerMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: true,
         isK8sContainer: true,
@@ -140,7 +110,7 @@ describe('useContainerMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "kubeletstatsreceiver.otel" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({
               field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
@@ -155,28 +125,18 @@ describe('useContainerMetricsTable hook', () => {
   });
 
   it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
+
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,
       data: { state: 'empty-indices' },
       metricIndices: 'test-index',
     });
 
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.container' } }, { ...filterClauseDsl }],
-      },
-    };
-
     renderHook(() =>
       useContainerMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: false,
       })
@@ -185,7 +145,7 @@ describe('useContainerMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "kubernetes.container" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({
               field: ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
@@ -85,7 +85,7 @@ function getUnpackMetricsForSchema(isOtel: boolean, isK8sContainer?: boolean): U
 
 export function useContainerMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
   isOtel,
   isK8sContainer,
@@ -97,8 +97,8 @@ export function useContainerMetricsTable({
   });
 
   const metricsExplorerOptions = useMemo(
-    () => getOptionsForSchema(isOtel ?? false, isK8sContainer, filterClauseDsl).options,
-    [isOtel, isK8sContainer, filterClauseDsl]
+    () => getOptionsForSchema(isOtel ?? false, isK8sContainer, kuery).options,
+    [isOtel, isK8sContainer, kuery]
   );
 
   const transform = useMemo(() => {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/create_lazy_host_metrics_table.tsx
@@ -13,7 +13,7 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedHostMetricsTable = lazy(() => import('./integrated_host_metrics_table'));
 
 export function createLazyHostMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId, isOtel }: NodeMetricsTableProps) => {
+  return ({ timerange, kuery, sourceId, isOtel }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedHostMetricsTable
@@ -22,7 +22,7 @@ export function createLazyHostMetricsTable(core: CoreStart, metricsClient: Metri
           sourceId={sourceId || 'default'}
           isOtel={isOtel}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
         />
       </Suspense>
     );

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/host_metrics_table.test.tsx
@@ -37,18 +37,7 @@ describe('HostMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
   const mockData = {
     series: [
@@ -66,7 +55,7 @@ describe('HostMetricsTable', () => {
       const metricsClient = getMetricsClient();
       const LazyHostMetricsTable = createLazyHostMetricsTable(getStartServices()[0], metricsClient);
 
-      render(<LazyHostMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyHostMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('hostMetricsTable')).not.toBeInTheDocument();
@@ -96,7 +85,7 @@ describe('HostMetricsTable', () => {
       const { findByText } = render(
         <IntegratedHostMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/integrated_host_metrics_table.tsx
@@ -13,18 +13,18 @@ import type { IntegratedNodeMetricsTableProps } from '../shared';
 
 type HookedHostMetricsTableProps = Pick<
   IntegratedNodeMetricsTableProps,
-  'timerange' | 'filterClauseDsl' | 'isOtel' | 'metricsClient'
+  'timerange' | 'kuery' | 'isOtel' | 'metricsClient'
 >;
 
 function HookedHostMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
   isOtel,
 }: HookedHostMetricsTableProps) {
   const hostMetricsTableProps = useHostMetricsTable({
     timerange,
-    filterClauseDsl,
+    kuery,
     metricsClient,
     isOtel,
   });
@@ -39,7 +39,7 @@ function HookedHostMetricsTable({
 
 function HostMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   metricsClient,
   isOtel,
@@ -49,7 +49,7 @@ function HostMetricsTableWithProviders({
     <CoreProviders {...coreProvidersProps}>
       <HookedHostMetricsTable
         timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
+        kuery={kuery}
         metricsClient={metricsClient}
         isOtel={isOtel}
       />

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -30,25 +30,8 @@ describe('useHostMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        should: [
-          {
-            terms: {
-              'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-            },
-          },
-        ],
-        minimum_should_match: 1,
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.module': 'system' } }, { ...filterClauseDsl }],
-      },
-    };
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
+    const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -60,32 +43,24 @@ describe('useHostMetricsTable hook', () => {
     renderHook(() =>
       useHostMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `event.module: "system" AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );
   });
 
   it('should call useInfrastructureNodeMetrics with OTEL/semconv metrics when isOtel is true', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'hostmetricsreceiver.otel' } }, { ...filterClauseDsl }],
-      },
-    };
+    const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -97,7 +72,7 @@ describe('useHostMetricsTable hook', () => {
     renderHook(() =>
       useHostMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: true,
       })
@@ -106,7 +81,7 @@ describe('useHostMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "hostmetricsreceiver.otel" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_LOGICAL_COUNT }),
             expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_UTILIZATION }),
@@ -119,17 +94,7 @@ describe('useHostMetricsTable hook', () => {
   });
 
   it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'host.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.module': 'system' } }, { ...filterClauseDsl }],
-      },
-    };
+    const kuery = `host.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -141,7 +106,7 @@ describe('useHostMetricsTable hook', () => {
     renderHook(() =>
       useHostMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: false,
       })
@@ -150,7 +115,7 @@ describe('useHostMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.module: "system" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: SYSTEM_CPU_CORES }),
             expect.objectContaining({ field: SYSTEM_CPU_TOTAL_NORM_PCT }),

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
@@ -37,11 +37,7 @@ type HostMetricsField =
   | typeof SYSTEM_MEMORY_USED_PCT;
 
 const hostsMetricsQueryConfig: MetricsQueryOptions<HostMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.module': 'system',
-    },
-  },
+  sourceFilter: `event.module: "system"`,
   groupByField: 'host.name',
   metricsMap: {
     [SYSTEM_CPU_CORES]: { aggregation: 'max', field: SYSTEM_CPU_CORES },
@@ -64,11 +60,7 @@ type HostMetricsFieldsOtel =
   | typeof SEMCONV_SYSTEM_MEMORY_UTILIZATION;
 
 const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'hostmetricsreceiver.otel',
-    },
-  },
+  sourceFilter: `event.dataset: "hostmetricsreceiver.otel"`,
   groupByField: 'host.name',
   metricsMap: {
     [SEMCONV_SYSTEM_CPU_LOGICAL_COUNT]: {
@@ -102,7 +94,7 @@ export interface HostNodeMetricsRow {
 
 export function useHostMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
   isOtel,
 }: UseNodeMetricsTableOptions) {
@@ -113,13 +105,13 @@ export function useHostMetricsTable({
   });
 
   const { options: hostMetricsOptions } = useMemo(
-    () => metricsToApiOptions(hostsMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(hostsMetricsQueryConfig, kuery),
+    [kuery]
   );
 
   const { options: hostMetricsOptionsOtel } = useMemo(
-    () => metricsToApiOptions(hostsMetricsQueryConfigOtel, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(hostsMetricsQueryConfigOtel, kuery),
+    [kuery]
   );
   const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<HostNodeMetricsRow>({
     metricsExplorerOptions: isOtel ? hostMetricsOptionsOtel : hostMetricsOptions,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/create_lazy_pod_metrics_table.tsx
@@ -13,7 +13,7 @@ import type { NodeMetricsTableProps } from '../shared';
 const LazyIntegratedPodMetricsTable = lazy(() => import('./integrated_pod_metrics_table'));
 
 export function createLazyPodMetricsTable(core: CoreStart, metricsClient: MetricsDataClient) {
-  return ({ timerange, filterClauseDsl, sourceId, isOtel }: NodeMetricsTableProps) => {
+  return ({ timerange, kuery, sourceId, isOtel }: NodeMetricsTableProps) => {
     return (
       <Suspense fallback={null}>
         <LazyIntegratedPodMetricsTable
@@ -21,7 +21,7 @@ export function createLazyPodMetricsTable(core: CoreStart, metricsClient: Metric
           metricsClient={metricsClient}
           sourceId={sourceId || 'default'}
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           isOtel={isOtel}
         />
       </Suspense>

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/integrated_pod_metrics_table.tsx
@@ -13,13 +13,13 @@ import { usePodMetricsTable } from './use_pod_metrics_table';
 
 function HookedPodMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
   isOtel,
 }: UseNodeMetricsTableOptions) {
   const podMetricsTableProps = usePodMetricsTable({
     timerange,
-    filterClauseDsl,
+    kuery,
     metricsClient,
     isOtel,
   });
@@ -34,7 +34,7 @@ function HookedPodMetricsTable({
 
 function PodMetricsTableWithProviders({
   timerange,
-  filterClauseDsl,
+  kuery,
   sourceId,
   metricsClient,
   isOtel,
@@ -44,7 +44,7 @@ function PodMetricsTableWithProviders({
     <CoreProviders {...coreProvidersProps}>
       <HookedPodMetricsTable
         timerange={timerange}
-        filterClauseDsl={filterClauseDsl}
+        kuery={kuery}
         metricsClient={metricsClient}
         isOtel={isOtel}
       />

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.test.tsx
@@ -32,18 +32,7 @@ describe('PodMetricsTable', () => {
     to: 'now',
   };
 
-  const filterClauseDsl = {
-    bool: {
-      should: [
-        {
-          match: {
-            'pod.name': 'gke-edge-oblt-pool-1-9a60016d-lgg9',
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
+  const kuery = `pod.name: "gke-edge-oblt-pool-1-9a60016d-lgg9"`;
 
   const mockData = {
     series: [
@@ -61,7 +50,7 @@ describe('PodMetricsTable', () => {
       const metricsClient = getMetricsClient();
       const LazyPodMetricsTable = createLazyPodMetricsTable(getStartServices()[0], metricsClient);
 
-      render(<LazyPodMetricsTable timerange={timerange} filterClauseDsl={filterClauseDsl} />);
+      render(<LazyPodMetricsTable timerange={timerange} kuery={kuery} />);
 
       expect(screen.queryByTestId(loadingIndicatorTestId)).not.toBeInTheDocument();
       expect(screen.queryByTestId('podMetricsTable')).not.toBeInTheDocument();
@@ -91,7 +80,7 @@ describe('PodMetricsTable', () => {
       const { findByText } = render(
         <IntegratedPodMetricsTable
           timerange={timerange}
-          filterClauseDsl={filterClauseDsl}
+          kuery={kuery}
           sourceId="default"
           metricsClient={metricsClient}
           {...coreProvidersPropsMock}

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -25,18 +25,8 @@ describe('usePodMetricsTable hook', () => {
     typeof useInfrastructureNodeMetrics
   >;
 
-  it('should call useInfrastructureNodeMetrics hook with event.module filter in filterClauseDsl query', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.pod' } }, { ...filterClauseDsl }],
-      },
-    };
+  it('should call useInfrastructureNodeMetrics hook with event.module filter in kuery', () => {
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -48,35 +38,24 @@ describe('usePodMetricsTable hook', () => {
     renderHook(() =>
       usePodMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
       })
     );
 
+    const kueryWithEventModuleFilter = `event.dataset: "kubernetes.pod" AND (${kuery})`;
+
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: kueryWithEventModuleFilter,
         }),
       })
     );
   });
 
   it('should call useInfrastructureNodeMetrics with OTEL/semconv metrics when isOtel is true', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [
-          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
-          { ...filterClauseDsl },
-        ],
-      },
-    };
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -88,7 +67,7 @@ describe('usePodMetricsTable hook', () => {
     renderHook(() =>
       usePodMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: true,
       })
@@ -97,7 +76,7 @@ describe('usePodMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "kubeletstatsreceiver.otel" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION }),
             expect.objectContaining({ field: MEMORY_LIMIT_UTILIZATION }),
@@ -108,17 +87,7 @@ describe('usePodMetricsTable hook', () => {
   });
 
   it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
-    const filterClauseDsl = {
-      bool: {
-        filter: [{ term: { 'container.id': 'gke-edge-oblt-pool-1-9a60016d-lgg9' } }],
-      },
-    };
-
-    const filterClauseWithEventModuleFilter = {
-      bool: {
-        filter: [{ term: { 'event.dataset': 'kubernetes.pod' } }, { ...filterClauseDsl }],
-      },
-    };
+    const kuery = 'container.id: "gke-edge-oblt-pool-1-9a60016d-lgg9"';
 
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -130,7 +99,7 @@ describe('usePodMetricsTable hook', () => {
     renderHook(() =>
       usePodMetricsTable({
         timerange: { from: 'now-30d', to: 'now' },
-        filterClauseDsl,
+        kuery,
         metricsClient: createMetricsClientMock({}),
         isOtel: false,
       })
@@ -139,7 +108,7 @@ describe('usePodMetricsTable hook', () => {
     expect(useInfrastructureNodeMetricsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         metricsExplorerOptions: expect.objectContaining({
-          filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
+          kuery: `event.dataset: "kubernetes.pod" AND (${kuery})`,
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: ECS_POD_CPU_USAGE_LIMIT_PCT }),
             expect.objectContaining({ field: MEMORY_LIMIT_UTILIZATION }),

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
@@ -31,11 +31,7 @@ import {
 type PodMetricsField = typeof ECS_POD_CPU_USAGE_LIMIT_PCT | typeof MEMORY_LIMIT_UTILIZATION;
 
 const podMetricsQueryConfig: MetricsQueryOptions<PodMetricsField> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubernetes.pod',
-    },
-  },
+  sourceFilter: `event.dataset: "kubernetes.pod"`,
   groupByField: ['kubernetes.pod.uid', 'kubernetes.pod.name'],
   metricsMap: {
     [ECS_POD_CPU_USAGE_LIMIT_PCT]: {
@@ -67,11 +63,7 @@ type PodMetricsFieldsOtel =
   | typeof MEMORY_LIMIT_UTILIZATION;
 
 const podMetricsQueryConfigOtel: MetricsQueryOptions<PodMetricsFieldsOtel> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubeletstatsreceiver.otel',
-    },
-  },
+  sourceFilter: `event.dataset: "kubeletstatsreceiver.otel"`,
   groupByField: ['k8s.pod.uid', 'k8s.pod.name'],
   metricsMap: {
     // this is an optional field and wont populate unless specifically enabled in kubeletstatreceiver.
@@ -107,7 +99,7 @@ export interface PodNodeMetricsRow {
 
 export function usePodMetricsTable({
   timerange,
-  filterClauseDsl,
+  kuery,
   metricsClient,
   isOtel,
 }: UseNodeMetricsTableOptions) {
@@ -118,13 +110,13 @@ export function usePodMetricsTable({
   });
 
   const { options: podMetricsOptions } = useMemo(
-    () => metricsToApiOptions(podMetricsQueryConfig, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(podMetricsQueryConfig, kuery),
+    [kuery]
   );
 
   const { options: podMetricsOptionsOtel } = useMemo(
-    () => metricsToApiOptions(podMetricsQueryConfigOtel, filterClauseDsl),
-    [filterClauseDsl]
+    () => metricsToApiOptions(podMetricsQueryConfigOtel, kuery),
+    [kuery]
   );
 
   const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<PodNodeMetricsRow>({

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.test.ts
@@ -13,11 +13,7 @@ describe('metricsToApiOptions', () => {
   type TestNodeTypeMetricsField = 'test.node.type.field1' | 'test.node.type.field2';
 
   const testMetricsMapField1First: MetricsQueryOptions<TestNodeTypeMetricsField> = {
-    sourceFilter: {
-      term: {
-        'event.module': 'test',
-      },
-    },
+    sourceFilter: `event.module: "test"`,
     groupByField: 'test.node.type.groupingField',
     metricsMap: {
       'test.node.type.field1': {
@@ -32,11 +28,7 @@ describe('metricsToApiOptions', () => {
   };
 
   const testMetricsMapField1Second: MetricsQueryOptions<TestNodeTypeMetricsField> = {
-    sourceFilter: {
-      term: {
-        'event.module': 'test',
-      },
-    },
+    sourceFilter: `event.module: "test"`,
     groupByField: 'test.node.type.groupingField',
     metricsMap: {
       'test.node.type.field2': {
@@ -57,7 +49,7 @@ describe('metricsToApiOptions', () => {
     expect(options).toEqual({
       aggregation: 'avg',
       groupBy: 'test.node.type.groupingField',
-      filterQuery: JSON.stringify({ bool: { filter: [{ term: { 'event.module': 'test' } }] } }),
+      kuery: `event.module: "test"`,
       metrics: [
         {
           field: 'test.node.type.field1',
@@ -95,4 +87,10 @@ describe('metricsToApiOptions', () => {
     expect(firstListAsSet).toEqual(secondListAsSet);
     expect(firstList.length).toBe(secondList.length);
   }
+
+  it("should join the source filter and the kuery when it's provided in the expected format", () => {
+    const kuery = 'host.name: "my-host"';
+    const { options } = metricsToApiOptions(testMetricsMapField1First, kuery);
+    expect(options.kuery).toBe(`event.module: "test" AND (host.name: "my-host")`);
+  });
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/metrics_to_api_options.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { ObjectValues } from '../../../../../common/utility_types';
 import type {
   MetricsExplorerOptions,
@@ -46,7 +45,7 @@ Then this code would no longer be needed.
 // sourceFilter is used to define filter to get only relevant docs that contain metrics info
 // e.g: { 'source.module': 'system' }
 export interface MetricsQueryOptions<T extends string> {
-  sourceFilter: QueryDslQueryContainer;
+  sourceFilter: string;
   groupByField: string | string[];
   metricsMap: MetricsMap<T>;
 }
@@ -70,7 +69,7 @@ export interface NodeMetricsExplorerOptionsMetric<Field extends string>
 
 export function metricsToApiOptions<T extends string>(
   metricsQueryOptions: MetricsQueryOptions<T>,
-  filterClauseDsl?: QueryDslQueryContainer
+  kuery?: string
 ) {
   const metrics = Object.values(metricsQueryOptions.metricsMap) as Array<
     NodeMetricsExplorerOptionsMetric<T>
@@ -80,9 +79,7 @@ export function metricsToApiOptions<T extends string>(
     aggregation: 'avg',
     groupBy: metricsQueryOptions.groupByField,
     metrics,
-    filterQuery: JSON.stringify(
-      buildFilterClause(metricsQueryOptions.sourceFilter, filterClauseDsl)
-    ),
+    kuery: buildFilterKuery(metricsQueryOptions.sourceFilter, kuery),
   };
 
   return {
@@ -90,15 +87,8 @@ export function metricsToApiOptions<T extends string>(
   };
 }
 
-function buildFilterClause(
-  sourceFilter: QueryDslQueryContainer,
-  filterClauseDsl?: QueryDslQueryContainer
-): QueryDslQueryContainer {
-  return {
-    bool: {
-      filter: !!filterClauseDsl ? [sourceFilter, filterClauseDsl] : [sourceFilter],
-    },
-  };
+function buildFilterKuery(sourceFilter: string, kuery?: string): string {
+  return !!kuery ? `${sourceFilter} AND (${kuery})` : sourceFilter;
 }
 
 export function createMetricByFieldLookup<T extends string>(metricMap: MetricsMap<T>) {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/use_infrastructure_node_metrics.ts
@@ -114,7 +114,7 @@ export const useInfrastructureNodeMetrics = <T>(
           groupBy: metricsExplorerOptions.groupBy,
           limit: NODE_COUNT_LIMIT,
           indexPattern: metricIndices,
-          filterQuery: metricsExplorerOptions.filterQuery,
+          kuery: metricsExplorerOptions.kuery,
           timerange: timerangeWithInterval,
         };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/types.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { CoreProvidersProps } from '../../../apps/common_providers';
 import type { MetricsDataClient } from '../../../lib/metrics_client';
 
 export interface UseNodeMetricsTableOptions {
   timerange: { from: string; to: string };
-  filterClauseDsl?: QueryDslQueryContainer;
+  kuery?: string;
   metricsClient: MetricsDataClient;
   isOtel?: boolean;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585)](https://github.com/elastic/kibana/pull/250585)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Fernandez","email":"47327793+AlejandroFrndz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-01-28T09:12:34Z","message":"[APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585)\n\n## Summary\n\nCloses #249605\n\nAs part of #226336 this\n[PR](https://github.com/elastic/kibana/pull/229980) introduced a\nrefactor on the metrics explorer API which updated it to use KQL instead\nof Query DSL.\n\nBut, as part of the refactoring we missed the infrastructure tab on the\nservice page which was using that same API. As a result, this piece of\nUI is still sending filter queries in Query DSL format for which the API\nis now not prepared for. This is causing the tab to not work at all.\n\nWe've seen some instances where the network call gets rejected (400\nerror) and the UI crashes while in others the network call is not\nrejected but it doesn't return any results and the UI shows the empty\nresults component. But, both cases originate from the same root cause\nthat it's the query format miss match.\n\nThis PR addresses the issue described above by reworking the\ninfrastructure tab code so that it generates KQL queries that can be\nproperly parsed and applied by the metrics explorer endpoint\n\n## UI Comparison\n\n## Before\n\n<img width=\"2559\" height=\"1327\" alt=\"before\"\nsrc=\"https://github.com/user-attachments/assets/005b6329-5d23-42ee-9adb-4f41796f76c5\"\n/>\n\n## After\n\n<img width=\"2559\" height=\"1326\" alt=\"after\"\nsrc=\"https://github.com/user-attachments/assets/97781bc7-ed63-4d7a-8552-8980b415290c\"\n/>","sha":"3d0090ab0c1bcac676ac43e71fedb7b34acd7029","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.2.0","v9.3.0","v9.4.0","Team:obs-presentation","v9.2.5"],"title":"[APM][Infra] Fix broken API in the Infrastructure tab on the Service page","number":250585,"url":"https://github.com/elastic/kibana/pull/250585","mergeCommit":{"message":"[APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585)\n\n## Summary\n\nCloses #249605\n\nAs part of #226336 this\n[PR](https://github.com/elastic/kibana/pull/229980) introduced a\nrefactor on the metrics explorer API which updated it to use KQL instead\nof Query DSL.\n\nBut, as part of the refactoring we missed the infrastructure tab on the\nservice page which was using that same API. As a result, this piece of\nUI is still sending filter queries in Query DSL format for which the API\nis now not prepared for. This is causing the tab to not work at all.\n\nWe've seen some instances where the network call gets rejected (400\nerror) and the UI crashes while in others the network call is not\nrejected but it doesn't return any results and the UI shows the empty\nresults component. But, both cases originate from the same root cause\nthat it's the query format miss match.\n\nThis PR addresses the issue described above by reworking the\ninfrastructure tab code so that it generates KQL queries that can be\nproperly parsed and applied by the metrics explorer endpoint\n\n## UI Comparison\n\n## Before\n\n<img width=\"2559\" height=\"1327\" alt=\"before\"\nsrc=\"https://github.com/user-attachments/assets/005b6329-5d23-42ee-9adb-4f41796f76c5\"\n/>\n\n## After\n\n<img width=\"2559\" height=\"1326\" alt=\"after\"\nsrc=\"https://github.com/user-attachments/assets/97781bc7-ed63-4d7a-8552-8980b415290c\"\n/>","sha":"3d0090ab0c1bcac676ac43e71fedb7b34acd7029"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/250673","number":250673,"state":"MERGED","mergeCommit":{"sha":"7be584158284726d3c10fbfd65305b6a65a3278b","message":"[9.2] [APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585) (#250673)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[APM][Infra] Fix broken API in the Infrastructure tab on the Service\npage (#250585)](https://github.com/elastic/kibana/pull/250585)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Fernandez <47327793+AlejandroFrndz@users.noreply.github.com>"}},{"branch":"9.3","label":"v9.3.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/250674","number":250674,"state":"MERGED","mergeCommit":{"sha":"764711e8a9833f4009d77be3135e3a0ad0dbcba7","message":"[9.3] [APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585) (#250674)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[APM][Infra] Fix broken API in the Infrastructure tab on the Service\npage (#250585)](https://github.com/elastic/kibana/pull/250585)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Fernandez <47327793+AlejandroFrndz@users.noreply.github.com>"}},{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/250585","number":250585,"mergeCommit":{"message":"[APM][Infra] Fix broken API in the Infrastructure tab on the Service page (#250585)\n\n## Summary\n\nCloses #249605\n\nAs part of #226336 this\n[PR](https://github.com/elastic/kibana/pull/229980) introduced a\nrefactor on the metrics explorer API which updated it to use KQL instead\nof Query DSL.\n\nBut, as part of the refactoring we missed the infrastructure tab on the\nservice page which was using that same API. As a result, this piece of\nUI is still sending filter queries in Query DSL format for which the API\nis now not prepared for. This is causing the tab to not work at all.\n\nWe've seen some instances where the network call gets rejected (400\nerror) and the UI crashes while in others the network call is not\nrejected but it doesn't return any results and the UI shows the empty\nresults component. But, both cases originate from the same root cause\nthat it's the query format miss match.\n\nThis PR addresses the issue described above by reworking the\ninfrastructure tab code so that it generates KQL queries that can be\nproperly parsed and applied by the metrics explorer endpoint\n\n## UI Comparison\n\n## Before\n\n<img width=\"2559\" height=\"1327\" alt=\"before\"\nsrc=\"https://github.com/user-attachments/assets/005b6329-5d23-42ee-9adb-4f41796f76c5\"\n/>\n\n## After\n\n<img width=\"2559\" height=\"1326\" alt=\"after\"\nsrc=\"https://github.com/user-attachments/assets/97781bc7-ed63-4d7a-8552-8980b415290c\"\n/>","sha":"3d0090ab0c1bcac676ac43e71fedb7b34acd7029"}}]}] BACKPORT-->