### PR TITLE
Fix alert recovery targeting wrong document when multiple lifecycles exist for same instance ID

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.test.ts
@@ -122,10 +122,62 @@ describe('get_tracked_alerts', () => {
       const mockAlert = {
         [ALERT_UUID]: 'uuid-1',
         [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
       } as unknown as TestAlertDoc;
       tracked.all['uuid-1'] = mockAlert;
+      tracked.active['uuid-1'] = mockAlert;
       expect(tracked.getById('id-1')).toBe(mockAlert);
       expect(tracked.getById('nonexistent')).toBeUndefined();
+    });
+
+    it('getById prefers active over recovered when same instance id exists in both', () => {
+      const tracked = createEmptyTrackedAlerts<{}>();
+      const recoveredAlert = {
+        [ALERT_UUID]: 'uuid-old',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
+      } as unknown as TestAlertDoc;
+      const activeAlert = {
+        [ALERT_UUID]: 'uuid-new',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
+      } as unknown as TestAlertDoc;
+      tracked.all['uuid-old'] = recoveredAlert;
+      tracked.recovered['uuid-old'] = recoveredAlert;
+      tracked.all['uuid-new'] = activeAlert;
+      tracked.active['uuid-new'] = activeAlert;
+      expect(tracked.getById('id-1')).toBe(activeAlert);
+    });
+
+    it('getById prefers recovered over delayed when same instance id exists in both', () => {
+      const tracked = createEmptyTrackedAlerts<{}>();
+      const delayedAlert = {
+        [ALERT_UUID]: 'uuid-delayed',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_DELAYED,
+      } as unknown as TestAlertDoc;
+      const recoveredAlert = {
+        [ALERT_UUID]: 'uuid-recovered',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
+      } as unknown as TestAlertDoc;
+      tracked.all['uuid-delayed'] = delayedAlert;
+      tracked.delayed['uuid-delayed'] = delayedAlert;
+      tracked.all['uuid-recovered'] = recoveredAlert;
+      tracked.recovered['uuid-recovered'] = recoveredAlert;
+      expect(tracked.getById('id-1')).toBe(recoveredAlert);
+    });
+
+    it('getById falls back to delayed when no active or recovered match', () => {
+      const tracked = createEmptyTrackedAlerts<{}>();
+      const delayedAlert = {
+        [ALERT_UUID]: 'uuid-delayed',
+        [ALERT_INSTANCE_ID]: 'id-1',
+        [ALERT_STATUS]: ALERT_STATUS_DELAYED,
+      } as unknown as TestAlertDoc;
+      tracked.all['uuid-delayed'] = delayedAlert;
+      tracked.delayed['uuid-delayed'] = delayedAlert;
+      expect(tracked.getById('id-1')).toBe(delayedAlert);
     });
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_tracked_alerts.ts
@@ -103,7 +103,11 @@ export function createEmptyTrackedAlerts<
       return this.all[uuid];
     },
     getById(id: string) {
-      return Object.values(this.all).find((alert) => get(alert, ALERT_INSTANCE_ID) === id);
+      return (
+        Object.values(this.active).find((alert) => get(alert, ALERT_INSTANCE_ID) === id) ??
+        Object.values(this.recovered).find((alert) => get(alert, ALERT_INSTANCE_ID) === id) ??
+        Object.values(this.delayed).find((alert) => get(alert, ALERT_INSTANCE_ID) === id)
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

- Fix a bug in `getById` where `buildRecoveredAlerts()` could target a stale document from a previous alert lifecycle instead of the current active one, leaving the active alert stuck in "active" status permanently
- The root cause was `Object.values(this.all).find()` returning whichever document appeared first in ES query results — non-deterministic when multiple documents share the same `kibana.alert.instance.id`
- The fix changes `getById` to search status-specific dictionaries in priority order: active, then recovered, then delayed

### Problem

When an alert instance goes through multiple fire/recover cycles, the `.alerts-*` data stream accumulates multiple documents for the same `kibana.alert.instance.id` (each with a unique `kibana.alert.uuid`). During `initializeExecution`, `getTrackedAlerts` fetches documents from recent executions and populates `trackedAlerts.all` with both the old recovered document and the current active document.

When recovery runs, `AlertBuilder.buildRecoveredAlerts()` calls `trackedAlerts.getById(instanceId)` to find the document to update. The previous implementation used `Object.values(this.all).find()`, which returned the first match by insertion order. If the old recovered document was returned first (e.g., because it resided in an earlier backing index), the recovery update targeted the wrong document — updating the already-recovered document again while leaving the current active document untouched.

This caused:
- The active alert document remaining permanently stuck with `kibana.alert.status: active`
- The event log recording the recovery for the correct UUID (from task state), creating a divergence between the alert index and event log
- UI showing conflicting statuses depending on which data source was queried

### Fix

Changed `getById` to search `active`, `recovered`, and `delayed` dictionaries in priority order instead of scanning the unordered `all` dictionary. Since `populateTrackedAlerts` already categorizes documents by status, this ensures recovery always targets the active document first.

## Manual verification with pattern firing rule:

1. To reproduce the bug, temporarily change `getById` priority to `recovered → active → delayed`:
   ```typescript
   Object.values(this.recovered).find(...) ??
   Object.values(this.active).find(...) ??
   Object.values(this.delayed).find(...)
   ```
2. Create a Pattern Firing AAD rule with pattern `(a - a -)`
3. Run the rule 4 times
4. Observe: 1 active alert + 1 recovered alert — the active alert is stuck and never recovers (bug confirmed)
5. Revert to the fix (active → recovered → delayed priority)
6. Create the rule again with the same pattern `(a - a -)` and run 4 times
7. Observe: 2 recovered alerts — both lifecycles recover correctly


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->