### PR TITLE
docs(saved-objects): Remove docs-builder syntax from saved_objects.mdx

### DIFF
--- a/dev_docs/key_concepts/saved_objects.mdx
+++ b/dev_docs/key_concepts/saved_objects.mdx
@@ -7,6 +7,4 @@ date: 2021-02-02
 tags: ['kibana', 'dev', 'contributor', 'api docs']
 ---
 
-::::{note}
 This page has moved. For up-to-date documentation on Saved Objects — including how to define and evolve types, perform CRUD operations, manage security and spaces, and choose between a scoped and a system client — see the **[Saved Objects](https://www.elastic.co/docs/extend/kibana/saved-objects)** section of the Kibana developer documentation.
-::::


### PR DESCRIPTION
## Summary

PR #260743 introduced docs-builder syntax on docsmobile pages, breaking the pipeline: 

```
Error occurred prerendering page "/kibana-dev-docs/key-concepts/saved-objects-intro". [...]
ReferenceError: note is not defined
```

Removing the `note` declaration should unblock deployments, and puts the current statement in line with others already present.