### PR TITLE
[Dashboard Markdown] Add support for [link](url){target=value} syntax

### DIFF
--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.test.tsx
@@ -313,5 +313,29 @@ describe('MarkdownEmbeddable', () => {
       // Links should now open in the same tab
       expect(screen.getByRole('link', { name: /click here/i })).toHaveAttribute('target', '_self');
     });
+
+    it('per-link {target=...} overrides the global setting', async () => {
+      await renderEmbeddable({
+        initialState: {
+          content: '[opens in new tab](https://example.com){target="_blank"}',
+          settings: { open_links_in_new_tab: false },
+        },
+      });
+      const link = screen.getByRole('link', { name: /opens in new tab/i });
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('links without {target=...} use the global setting', async () => {
+      await renderEmbeddable({
+        initialState: {
+          content: '[overridden](https://a.com){target="_self"} and [default](https://b.com)',
+          settings: { open_links_in_new_tab: true },
+        },
+      });
+      const overridden = screen.getByRole('link', { name: /overridden/i });
+      const defaultLink = screen.getByRole('link', { name: /default/i });
+      expect(overridden).toHaveAttribute('target', '_self');
+      expect(defaultLink).toHaveAttribute('target', '_blank');
+    });
   });
 });

--- a/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/markdown_embeddable.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { EuiMarkdownEditorUiPlugin } from '@elastic/eui';
 import { euiMarkdownLinkValidator, getDefaultEuiMarkdownPlugins } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
@@ -30,7 +31,12 @@ import type {
 } from '../server';
 import { APP_NAME, MARKDOWN_EMBEDDABLE_TYPE } from '../common/constants';
 import type { MarkdownEditorApi } from './types';
-import { resolveRelativeLinksPlugin } from './plugins/resolve_relative_links';
+import {
+  defaultLinkTargetPlugin,
+  linkAttributesParsingPlugin,
+  linkAttributesUiPlugin,
+  resolveRelativeLinksPlugin,
+} from './plugins';
 import { MarkdownEditor } from './components/markdown_editor';
 import { MarkdownEditorPreviewSwitch } from './components/markdown_editor_preview_switch';
 import { MarkdownRenderer } from './components/markdown_renderer';
@@ -213,17 +219,20 @@ export const markdownEmbeddableFactory: EmbeddableFactory<
             titleManager.api.hideTitle$
           );
 
+        const defaultTarget = settings?.open_links_in_new_tab ? '_blank' : '_self';
+
         const {
           parsingPlugins: parsingPluginList,
           processingPlugins: processingPluginList,
           uiPlugins,
-        } = getDefaultEuiMarkdownPlugins({
-          processingConfig: {
-            linkProps: {
-              target: settings?.open_links_in_new_tab ? '_blank' : '_self',
-            },
-          },
-        });
+        } = getDefaultEuiMarkdownPlugins();
+        // Don't apply the defaultTarget here in processingConfig.linkProps. Because of
+        // the way the default EUI processing plugin applies linkProps, it would override
+        // the props manually set using [link](url){target=value} syntax. Instead, process
+        // the default target with our own processing plugin
+
+        // TODO typecast is a workaround for https://github.com/elastic/eui/issues/9557
+        uiPlugins.push(linkAttributesUiPlugin as EuiMarkdownEditorUiPlugin);
 
         // Insert before the link validator so document relative links like
         // [discover](discover) get resolved before validation rejects them.
@@ -234,7 +243,21 @@ export const markdownEmbeddableFactory: EmbeddableFactory<
         parsingPluginList.splice(
           linkValidatorIndex !== -1 ? linkValidatorIndex : parsingPluginList.length,
           0,
-          [resolveRelativeLinksPlugin(), {}]
+          [resolveRelativeLinksPlugin(), {}],
+          [linkAttributesParsingPlugin(), {}]
+        );
+
+        // Insert a rehype plugin before rehype-react that sets the default
+        // target on <a> elements. Links with a per-link {target=...} already
+        // have target set via hProperties; this fills in the global default
+        // for the rest.
+        const rehypeReactIndex = processingPluginList.findIndex(
+          (entry) => Array.isArray(entry) && (entry[1] as Record<string, unknown>)?.components
+        );
+        processingPluginList.splice(
+          rehypeReactIndex !== -1 ? rehypeReactIndex : processingPluginList.length,
+          0,
+          [defaultLinkTargetPlugin, { defaultTarget }] as any
         );
 
         const editorContent =

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/default_link_target.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/default_link_target.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * A rehype plugin that sets a default `target` attribute on all `<a>` elements
+ * that don't already have one (e.g. from a per-link {target=...} directive).
+ */
+export function defaultLinkTargetPlugin({ defaultTarget }: { defaultTarget: string }) {
+  return (tree: any) => {
+    const visit = (node: any) => {
+      if (node.tagName === 'a' && node.properties && !node.properties.target) {
+        node.properties.target = defaultTarget;
+      }
+      if (node.children) {
+        node.children.forEach(visit);
+      }
+    };
+    visit(tree);
+  };
+}

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/index.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { defaultLinkTargetPlugin } from './default_link_target';
+export { linkAttributesParsingPlugin, linkAttributesUiPlugin } from './link_attributes';
+export { resolveRelativeLinksPlugin } from './resolve_relative_links';

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/index.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { linkAttributesParsingPlugin } from './parsing_plugin';
+export { linkAttributesUiPlugin } from './ui_plugin';

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/parsing_plugin.test.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/parsing_plugin.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Root, Link, Text } from 'mdast';
+import { linkAttributesParsingPlugin } from './parsing_plugin';
+
+interface NodeDataWithHProperties {
+  hProperties?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+const createLinkNode = (url: string): Link => ({
+  type: 'link',
+  url,
+  children: [{ type: 'text', value: 'link text' }],
+});
+
+const createTextNode = (value: string): Text => ({
+  type: 'text',
+  value,
+});
+
+const createAndParseTree = (...children: Array<Link | Text>): Root => {
+  const tree: Root = {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children,
+      },
+    ],
+  };
+  linkAttributesParsingPlugin()()(tree);
+  return tree;
+};
+
+const getParagraphChildren = (tree: Root) => (tree.children[0] as any).children;
+const getLink = (tree: Root): Link => getParagraphChildren(tree)[0];
+
+describe('linkAttributesPlugin', () => {
+  it('parses {target="_blank"} after a link with double quotes', () => {
+    // [link text](https://example.com){target="_blank"}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{target="_blank"}')
+    );
+
+    // <a href="https://example.com" target="_blank">link text</a>
+    const link = getLink(tree);
+    expect((link.data as NodeDataWithHProperties).hProperties).toEqual({ target: '_blank' });
+    expect(getParagraphChildren(tree)).toHaveLength(1);
+  });
+
+  it("parses {target='_self'} with single quotes", () => {
+    // [link text](https://example.com){target='_self'}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode("{target='_self'}")
+    );
+
+    // <a href="https://example.com" target="_self">link text</a>
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      target: '_self',
+    });
+  });
+
+  it('parses {target=_blank} without quotes', () => {
+    // [link text](https://example.com){target=_blank}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{target=_blank}')
+    );
+
+    // <a href="https://example.com" target="_blank">link text</a>
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      target: '_blank',
+    });
+  });
+
+  it('preserves trailing text after the attribute block', () => {
+    // [link text](https://example.com){target="_blank"} and some trailing text
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{target="_blank"} and some trailing text')
+    );
+
+    // <a href="https://example.com" target="_blank">link text</a> and some trailing text
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      target: '_blank',
+    });
+    const children = getParagraphChildren(tree);
+    expect(children).toHaveLength(2);
+    expect(children[1].value).toBe(' and some trailing text');
+  });
+
+  it('ignores attributes not in the whitelist', () => {
+    // [link text](https://example.com){class="evil" onclick="alert(1)" target="_blank"}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{class="evil" onclick="alert(1)" target="_blank"}')
+    );
+
+    // <a href="https://example.com" target="_blank">link text</a>
+    // class and onclick are silently dropped
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      target: '_blank',
+    });
+  });
+
+  it('leaves the attribute block as text if no whitelisted attributes are found', () => {
+    // [link text](https://example.com){class="evil"}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{class="evil"}')
+    );
+
+    // <a href="https://example.com">link text</a>{class="evil"}
+    expect(getLink(tree).data).toBeUndefined();
+    expect(getParagraphChildren(tree)).toHaveLength(2);
+    expect(getParagraphChildren(tree)[1].value).toBe('{class="evil"}');
+  });
+
+  it('does not modify links without a following attribute block', () => {
+    // [link text](https://example.com)
+    const tree = createAndParseTree(createLinkNode('https://example.com'));
+
+    // <a href="https://example.com">link text</a>
+    expect(getLink(tree).data).toBeUndefined();
+  });
+
+  it('does not modify links followed by non-attribute text', () => {
+    // [link text](https://example.com) some normal text
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode(' some normal text')
+    );
+
+    // <a href="https://example.com">link text</a> some normal text
+    expect(getLink(tree).data).toBeUndefined();
+    expect(getParagraphChildren(tree)).toHaveLength(2);
+  });
+
+  it('does not match unclosed curly braces', () => {
+    // [link text](https://example.com){ here's some stuff without a closing brace
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode("{ here's some stuff without a closing brace")
+    );
+
+    // <a href="https://example.com">link text</a>{ here's some stuff without a closing brace
+    expect(getLink(tree).data).toBeUndefined();
+    expect(getParagraphChildren(tree)).toHaveLength(2);
+    expect(getParagraphChildren(tree)[1].value).toBe("{ here's some stuff without a closing brace");
+  });
+
+  it('tolerates whitespace inside the curly braces', () => {
+    // [link text](https://example.com){ target=_self }
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode('{ target=_self }')
+    );
+
+    // <a href="https://example.com" target="_self">link text</a>
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      target: '_self',
+    });
+  });
+
+  it('does not match attribute block separated from link by a space', () => {
+    // [link text](https://example.com) {target="_self"}
+    const tree = createAndParseTree(
+      createLinkNode('https://example.com'),
+      createTextNode(' {target="_self"}')
+    );
+
+    // <a href="https://example.com">link text</a> {target="_self"}
+    expect(getLink(tree).data).toBeUndefined();
+    expect(getParagraphChildren(tree)).toHaveLength(2);
+    expect(getParagraphChildren(tree)[1].value).toBe(' {target="_self"}');
+  });
+
+  it('handles multiple links with different attributes', () => {
+    // [link text](https://a.com){target="_blank"} then [link text](https://b.com){target="_self"}
+    const tree = createAndParseTree(
+      createLinkNode('https://a.com'),
+      createTextNode('{target="_blank"} then '),
+      createLinkNode('https://b.com'),
+      createTextNode('{target="_self"}')
+    );
+
+    // <a href="https://a.com" target="_blank">link text</a> then
+    // <a href="https://b.com" target="_self">link text</a>
+    const children = getParagraphChildren(tree);
+    const linkA = children[0] as Link;
+    const linkB = children.find((c: any, i: number) => i > 0 && c.type === 'link') as Link;
+    expect((linkA.data as NodeDataWithHProperties).hProperties).toEqual({ target: '_blank' });
+    expect((linkB.data as NodeDataWithHProperties).hProperties).toEqual({ target: '_self' });
+  });
+
+  it('preserves existing node data', () => {
+    // [link text](https://example.com){target="_blank"}
+    // (link node pre-seeded with rel="noopener" via hProperties)
+    const link = createLinkNode('https://example.com');
+    link.data = { hProperties: { rel: 'noopener' } } as NodeDataWithHProperties;
+    const tree = createAndParseTree(link, createTextNode('{target="_blank"}'));
+
+    // <a href="https://example.com" rel="noopener" target="_blank">link text</a>
+    expect((getLink(tree).data as NodeDataWithHProperties).hProperties).toEqual({
+      rel: 'noopener',
+      target: '_blank',
+    });
+  });
+});

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/parsing_plugin.ts
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/parsing_plugin.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Node } from 'unist';
+import type { Link, Parent, Text } from 'mdast';
+
+interface NodeDataWithHProperties {
+  hProperties?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+const ALLOWED_ATTRIBUTES = new Set(['target']);
+
+function isParent(node: Node): node is Parent {
+  return 'children' in node;
+}
+
+function isLink(node: Node): node is Link {
+  return node.type === 'link';
+}
+
+function isText(node: Node): node is Text {
+  return node.type === 'text';
+}
+
+/**
+ * Parses an attribute block like `{target="_blank" rel="noopener"}` from the
+ * start of a string. Returns the parsed (and whitelisted) attributes and the
+ * number of characters consumed, or null if no attribute block was found.
+ */
+function parseAttributeBlock(
+  raw: string
+): { attrs: Record<string, string>; length: number } | null {
+  const braceMatch = raw.match(/^\{([^}]+)\}/);
+  if (!braceMatch) return null;
+
+  /**
+   * Matches key=value pairs in three flavors:
+   *   key="double quoted value"
+   *   key='single quoted value'
+   *   key=unquoted_value  (terminated by whitespace or end of string)
+   */
+  const keyValRegex = /([\w-]+)=(?:"([^"]*)"|'([^']*)'|(\S+?)(?=\s|$))/g;
+  const attrs = [...braceMatch[1].matchAll(keyValRegex)].reduce((acc, match) => {
+    if (ALLOWED_ATTRIBUTES.has(match[1])) {
+      acc[match[1]] = match[2] ?? match[3] ?? match[4];
+    }
+    return acc;
+  }, {} as Record<string, string>);
+
+  if (Object.keys(attrs).length === 0) return null;
+  return { attrs, length: braceMatch[0].length };
+}
+
+/**
+ * A remark parsing plugin that extracts inline attribute blocks from text
+ * immediately following a markdown link. For example:
+ *
+ *   [click here](https://example.com){target="_blank"}
+ *
+ * The `{target="_blank"}` is parsed and applied to the link node via
+ * `data.hProperties`, which mdast-util-to-hast merges into the HTML element's
+ * attributes. Only attributes in ALLOWED_ATTRIBUTES are applied.
+ */
+export function linkAttributesParsingPlugin() {
+  return () => {
+    const visitor = (node: Node) => {
+      if (!isParent(node)) return;
+
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        const nextIndex = i + 1;
+
+        // For each link, examine the node immediately next to it
+        if (isLink(child) && nextIndex < node.children.length) {
+          const next = node.children[nextIndex];
+          // If the character immediately after the link node is a curly brace, parse the contents of the curly braces
+          if (isText(next) && next.value.startsWith('{')) {
+            const result = parseAttributeBlock(next.value);
+            if (result) {
+              const data = (child.data ?? {}) as NodeDataWithHProperties;
+              child.data = {
+                ...data,
+                hProperties: { ...data.hProperties, ...result.attrs },
+              };
+              next.value = next.value.slice(result.length);
+              if (!next.value) {
+                node.children.splice(nextIndex, 1);
+              }
+            }
+          }
+        }
+
+        visitor(child);
+      }
+    };
+
+    return (tree: Node) => {
+      visitor(tree);
+    };
+  };
+}

--- a/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/ui_plugin.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/plugins/link_attributes/ui_plugin.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiCodeBlock, EuiText } from '@elastic/eui';
+
+// EUI's type requires `button` and `formatting`/`editor`, but passing an empty
+// `button` and omitting both formatting and editor successfully adds help text
+// to the help popup without rendering a toolbar button.
+export const linkAttributesUiPlugin = {
+  name: 'linkAttributes',
+  button: {},
+  helpText: (
+    <div>
+      <EuiText size="xs">
+        <p>
+          Add attributes to links by appending curly braces after the link. Currently only{' '}
+          <code>target</code> is supported
+        </p>
+      </EuiText>
+      <EuiCodeBlock language="md" paddingSize="s" fontSize="l">
+        {'[link text](url){target="_blank"}'}
+      </EuiCodeBlock>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

Followup enhancement to https://github.com/elastic/kibana/issues/253431

Adds a markdown parsing plugin allowing users to manually override the default link target for certain links. Partial implementation of the [CommonMark inline directives syntax](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444).

The plugin is designed to be easily extensible to more attributes than just `target` if we want to allow more of the inline directives syntax in the future.

<img width="987" height="473" alt="Screenshot 2026-04-02 at 2 10 09 PM" src="https://github.com/user-attachments/assets/487959c5-8859-414b-8da4-b711365a1570" />

<img width="977" height="442" alt="Screenshot 2026-04-02 at 2 10 24 PM" src="https://github.com/user-attachments/assets/dc0488af-c5c4-4462-987f-7bc2a4d7b832" />

<img width="793" height="496" alt="Screenshot 2026-04-02 at 2 10 28 PM" src="https://github.com/user-attachments/assets/9993e808-8b8e-40c2-81af-41a05a0f5969" />

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

