### PR TITLE
[8.19] [APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552)

### DIFF
--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
@@ -8,10 +8,11 @@
 import {
   ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
   ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  otelDatasetFilterDsl,
   SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
   SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
-  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
-  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_CONTAINER_CPU_USAGE,
+  SEMCONV_CONTAINER_MEMORY_WORKING_SET,
 } from '../shared/constants';
 import { getOptionsForSchema } from './container_metrics_configs';
 
@@ -39,14 +40,14 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv Docker options when isOtel is true and isK8sContainer is false', () => {
       const { options } = getOptionsForSchema(true, false);
-      const filterClauseDsl = {
+      const expectedFilter = {
         bool: {
-          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
+          filter: [otelDatasetFilterDsl('dockerstatsreceiver.otel')],
         },
       };
 
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.filterQuery).toBe(JSON.stringify(expectedFilter));
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
@@ -58,13 +59,13 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv Docker options when isOtel is true and isK8sContainer is undefined', () => {
       const { options } = getOptionsForSchema(true);
-      const filterClauseDsl = {
+      const expectedFilter = {
         bool: {
-          filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }],
+          filter: [otelDatasetFilterDsl('dockerstatsreceiver.otel')],
         },
       };
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.filterQuery).toBe(JSON.stringify(expectedFilter));
       expect(options.metrics).toEqual(
         expect.arrayContaining([
           { field: SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION, aggregation: 'avg' },
@@ -76,17 +77,17 @@ describe('container_metrics_configs', () => {
 
     it('returns SemConv K8s options when isOtel is true and isK8sContainer is true', () => {
       const { options } = getOptionsForSchema(true, true);
-      const filterClauseDsl = {
+      const expectedFilter = {
         bool: {
-          filter: [{ term: { 'event.dataset': 'kubeletstatsreceiver.otel' } }],
+          filter: [otelDatasetFilterDsl('kubeletstatsreceiver.otel')],
         },
       };
       expect(options.groupBy).toBe('container.id');
-      expect(options.filterQuery).toBe(JSON.stringify(filterClauseDsl));
+      expect(options.filterQuery).toBe(JSON.stringify(expectedFilter));
       expect(options.metrics).toEqual(
         expect.arrayContaining([
-          { field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION, aggregation: 'avg' },
-          { field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION, aggregation: 'avg' },
+          { field: SEMCONV_CONTAINER_CPU_USAGE, aggregation: 'avg' },
+          { field: SEMCONV_CONTAINER_MEMORY_WORKING_SET, aggregation: 'avg' },
         ])
       );
       expect(options.metrics).toHaveLength(2);
@@ -120,7 +121,7 @@ describe('container_metrics_configs', () => {
       const filterClauseWithEventModuleFilter = {
         bool: {
           filter: [
-            { term: { 'event.dataset': 'dockerstatsreceiver.otel' } },
+            otelDatasetFilterDsl('dockerstatsreceiver.otel'),
             { ...filterClauseDsl },
           ],
         },
@@ -140,7 +141,7 @@ describe('container_metrics_configs', () => {
       const filterClauseWithEventModuleFilter = {
         bool: {
           filter: [
-            { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+            otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
             { ...filterClauseDsl },
           ],
         },

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.test.ts
@@ -120,10 +120,7 @@ describe('container_metrics_configs', () => {
 
       const filterClauseWithEventModuleFilter = {
         bool: {
-          filter: [
-            otelDatasetFilterDsl('dockerstatsreceiver.otel'),
-            { ...filterClauseDsl },
-          ],
+          filter: [otelDatasetFilterDsl('dockerstatsreceiver.otel'), { ...filterClauseDsl }],
         },
       };
 
@@ -140,10 +137,7 @@ describe('container_metrics_configs', () => {
       };
       const filterClauseWithEventModuleFilter = {
         bool: {
-          filter: [
-            otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
-            { ...filterClauseDsl },
-          ],
+          filter: [otelDatasetFilterDsl('kubeletstatsreceiver.otel'), { ...filterClauseDsl }],
         },
       };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_configs.ts
@@ -11,10 +11,11 @@ import { createMetricByFieldLookup, makeUnpackMetric, metricsToApiOptions } from
 import {
   ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
   ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  otelDatasetFilterDsl,
   SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
   SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
-  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
-  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_CONTAINER_CPU_USAGE,
+  SEMCONV_CONTAINER_MEMORY_WORKING_SET,
 } from '../shared/constants';
 
 // --- ECS (Elastic Common Schema) ---
@@ -48,11 +49,7 @@ type ContainerMetricsFieldSemconvDocker =
 
 const containerMetricsQueryConfigSemconvDocker: MetricsQueryOptions<ContainerMetricsFieldSemconvDocker> =
   {
-    sourceFilter: {
-      term: {
-        'event.dataset': 'dockerstatsreceiver.otel',
-      },
-    },
+    sourceFilter: otelDatasetFilterDsl('dockerstatsreceiver.otel'),
     groupByField: 'container.id',
     metricsMap: {
       [SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION]: {
@@ -67,26 +64,24 @@ const containerMetricsQueryConfigSemconvDocker: MetricsQueryOptions<ContainerMet
   };
 
 // --- SemConv K8s (Kubernetes container metrics) ---
+// Uses generic container metrics always emitted by kubeletstats,
+// regardless of whether k8s resource limits are configured.
 type ContainerMetricsFieldSemconvK8s =
-  | typeof SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION
-  | typeof SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION;
+  | typeof SEMCONV_CONTAINER_CPU_USAGE
+  | typeof SEMCONV_CONTAINER_MEMORY_WORKING_SET;
 
 const containerMetricsQueryConfigSemconvK8s: MetricsQueryOptions<ContainerMetricsFieldSemconvK8s> =
   {
-    sourceFilter: {
-      term: {
-        'event.dataset': 'kubeletstatsreceiver.otel',
-      },
-    },
+    sourceFilter: otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
     groupByField: 'container.id',
     metricsMap: {
-      [SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION]: {
+      [SEMCONV_CONTAINER_CPU_USAGE]: {
         aggregation: 'avg',
-        field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+        field: SEMCONV_CONTAINER_CPU_USAGE,
       },
-      [SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION]: {
+      [SEMCONV_CONTAINER_MEMORY_WORKING_SET]: {
         aggregation: 'avg',
-        field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+        field: SEMCONV_CONTAINER_MEMORY_WORKING_SET,
       },
     },
   };
@@ -101,7 +96,7 @@ const metricByFieldSemconvDocker = createMetricByFieldLookup(
 );
 export const unpackMetricSemconvDocker = makeUnpackMetric(metricByFieldSemconvDocker);
 
-const metricByFieldSemconvK8s = createMetricByFieldLookup(
+export const metricByFieldSemconvK8s = createMetricByFieldLookup(
   containerMetricsQueryConfigSemconvK8s.metricsMap
 );
 export const unpackMetricSemconvK8s = makeUnpackMetric(metricByFieldSemconvK8s);

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/container_metrics_table.tsx
@@ -138,7 +138,7 @@ function containerNodeColumns({
   ContainerMetricsTableProps,
   'timerange' | 'isOtel' | 'metricsIndices' | 'isK8sContainer'
 >): Array<EuiBasicTableColumn<ContainerNodeMetricsRow>> {
-  const memoryUnit = isOtel ? '%' : ' MB';
+  const memoryUnit = isOtel && !isK8sContainer ? '%' : ' MB';
   return [
     {
       name: i18n.translate('xpack.metricsData.metricsTable.container.idColumnHeader', {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -121,10 +121,7 @@ describe('useContainerMetricsTable hook', () => {
 
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [
-          otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
-          { ...filterClauseDsl },
-        ],
+        filter: [otelDatasetFilterDsl('kubeletstatsreceiver.otel'), { ...filterClauseDsl }],
       },
     };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.test.ts
@@ -8,10 +8,11 @@
 import {
   ECS_CONTAINER_CPU_USAGE_LIMIT_PCT,
   ECS_CONTAINER_MEMORY_USAGE_BYTES,
+  otelDatasetFilterDsl,
   SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
   SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
-  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
-  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_CONTAINER_CPU_USAGE,
+  SEMCONV_CONTAINER_MEMORY_WORKING_SET,
 } from '../shared/constants';
 import { useContainerMetricsTable } from './use_container_metrics_table';
 import { useInfrastructureNodeMetrics } from '../shared';
@@ -74,7 +75,7 @@ describe('useContainerMetricsTable hook', () => {
 
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [{ term: { 'event.dataset': 'dockerstatsreceiver.otel' } }, { ...filterClauseDsl }],
+        filter: [otelDatasetFilterDsl('dockerstatsreceiver.otel'), { ...filterClauseDsl }],
       },
     };
     useInfrastructureNodeMetricsMock.mockReturnValue({
@@ -121,7 +122,7 @@ describe('useContainerMetricsTable hook', () => {
     const filterClauseWithEventModuleFilter = {
       bool: {
         filter: [
-          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+          otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
           { ...filterClauseDsl },
         ],
       },
@@ -143,10 +144,10 @@ describe('useContainerMetricsTable hook', () => {
           filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
           metrics: expect.arrayContaining([
             expect.objectContaining({
-              field: SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
+              field: SEMCONV_CONTAINER_CPU_USAGE,
             }),
             expect.objectContaining({
-              field: SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+              field: SEMCONV_CONTAINER_MEMORY_WORKING_SET,
             }),
           ]),
         }),

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/container/use_container_metrics_table.ts
@@ -23,8 +23,8 @@ import {
   ECS_CONTAINER_MEMORY_USAGE_BYTES,
   SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION,
   SEMCONV_DOCKER_CONTAINER_MEMORY_PERCENT,
-  SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION,
-  SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_CONTAINER_CPU_USAGE,
+  SEMCONV_CONTAINER_MEMORY_WORKING_SET,
 } from '../shared/constants';
 
 export { metricByFieldEcs, metricByField } from './container_metrics_configs';
@@ -52,12 +52,11 @@ const semconvDockerUnpackMetrics = (row: MetricsExplorerRow) => {
 };
 
 const semconvK8sUnpackMetrics = (row: MetricsExplorerRow) => {
-  // semconv k8s unpack metrics
-  const cpuUtilization = unpackMetricSemconvK8s(row, SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION);
-  const memoryUsage = unpackMetricSemconvK8s(row, SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION);
+  const cpuUsage = unpackMetricSemconvK8s(row, SEMCONV_CONTAINER_CPU_USAGE);
+  const memoryBytes = unpackMetricSemconvK8s(row, SEMCONV_CONTAINER_MEMORY_WORKING_SET);
   return {
-    averageCpuUsage: cpuUtilization !== null ? scaleUpPercentage(cpuUtilization) : null,
-    averageMemoryUsage: memoryUsage !== null ? scaleUpPercentage(memoryUsage) : null,
+    averageCpuUsage: cpuUsage !== null ? scaleUpPercentage(cpuUsage) : null,
+    averageMemoryUsage: memoryBytes !== null ? Math.floor(memoryBytes / 1_000_000) : null,
   };
 };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.test.ts
@@ -6,9 +6,10 @@
  */
 
 import {
+  otelDatasetFilterDsl,
   SEMCONV_SYSTEM_CPU_LOGICAL_COUNT,
   SEMCONV_SYSTEM_CPU_UTILIZATION,
-  SEMCONV_SYSTEM_MEMORY_LIMIT,
+  SEMCONV_SYSTEM_MEMORY_TOTAL,
   SEMCONV_SYSTEM_MEMORY_UTILIZATION,
   SYSTEM_CPU_CORES,
   SYSTEM_CPU_TOTAL_NORM_PCT,
@@ -83,7 +84,7 @@ describe('useHostMetricsTable hook', () => {
 
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [{ term: { 'event.dataset': 'hostmetricsreceiver.otel' } }, { ...filterClauseDsl }],
+        filter: [otelDatasetFilterDsl('hostmetricsreceiver.otel'), { ...filterClauseDsl }],
       },
     };
 
@@ -110,12 +111,103 @@ describe('useHostMetricsTable hook', () => {
           metrics: expect.arrayContaining([
             expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_LOGICAL_COUNT }),
             expect.objectContaining({ field: SEMCONV_SYSTEM_CPU_UTILIZATION }),
-            expect.objectContaining({ field: SEMCONV_SYSTEM_MEMORY_LIMIT }),
+            expect.objectContaining({ field: SEMCONV_SYSTEM_MEMORY_TOTAL }),
             expect.objectContaining({ field: SEMCONV_SYSTEM_MEMORY_UTILIZATION }),
           ]),
         }),
       })
     );
+  });
+
+  it('should transform OTel rows into populated host metrics', () => {
+    useInfrastructureNodeMetricsMock.mockClear();
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      useHostMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    const lastCallArgs = useInfrastructureNodeMetricsMock.mock.calls.at(-1);
+    const { transform, metricsExplorerOptions } = lastCallArgs?.[0] ?? {};
+    expect(transform).toBeDefined();
+
+    const metrics = metricsExplorerOptions?.metrics ?? [];
+    const metricIndexByField = new Map(metrics.map((metric, index) => [metric.field, index]));
+
+    const row = transform!({
+      id: 'otel-host-1',
+      columns: [],
+      rows: [
+        {
+          timestamp: Date.now(),
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_CPU_LOGICAL_COUNT)}`]: 8,
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_CPU_UTILIZATION)}`]: 0.42,
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_MEMORY_TOTAL)}`]: 16_000_000_000,
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_MEMORY_UTILIZATION)}`]: 0.25,
+        },
+      ],
+    });
+
+    expect(row).toEqual({
+      name: 'otel-host-1',
+      cpuCount: 8,
+      averageCpuUsagePercent: 42,
+      totalMemoryMegabytes: 16000,
+      averageMemoryUsagePercent: 25,
+    });
+  });
+
+  it('should return null totalMemoryMegabytes when memory total metric is absent (B=0 in equation)', () => {
+    useInfrastructureNodeMetricsMock.mockClear();
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      useHostMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    const lastCallArgs = useInfrastructureNodeMetricsMock.mock.calls.at(-1);
+    const { transform, metricsExplorerOptions } = lastCallArgs?.[0] ?? {};
+    expect(transform).toBeDefined();
+
+    const metrics = metricsExplorerOptions?.metrics ?? [];
+    const metricIndexByField = new Map(metrics.map((metric, index) => [metric.field, index]));
+
+    const row = transform!({
+      id: 'otel-host-2',
+      columns: [],
+      rows: [
+        {
+          timestamp: Date.now(),
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_CPU_LOGICAL_COUNT)}`]: 4,
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_CPU_UTILIZATION)}`]: 0.1,
+          [`metric_${metricIndexByField.get(SEMCONV_SYSTEM_MEMORY_UTILIZATION)}`]: 0.5,
+        },
+      ],
+    });
+
+    expect(row).toEqual({
+      name: 'otel-host-2',
+      cpuCount: 4,
+      averageCpuUsagePercent: 10,
+      totalMemoryMegabytes: null,
+      averageMemoryUsagePercent: 50,
+    });
   });
 
   it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/host/use_host_metrics_table.ts
@@ -20,9 +20,11 @@ import {
   useInfrastructureNodeMetrics,
 } from '../shared';
 import {
+  otelDatasetFilterDsl,
   SEMCONV_SYSTEM_CPU_LOGICAL_COUNT,
   SEMCONV_SYSTEM_CPU_UTILIZATION,
-  SEMCONV_SYSTEM_MEMORY_LIMIT,
+  SEMCONV_SYSTEM_MEMORY_TOTAL,
+  SEMCONV_SYSTEM_MEMORY_USAGE,
   SEMCONV_SYSTEM_MEMORY_UTILIZATION,
   SYSTEM_CPU_CORES,
   SYSTEM_CPU_TOTAL_NORM_PCT,
@@ -60,15 +62,11 @@ const hostsMetricsQueryConfig: MetricsQueryOptions<HostMetricsField> = {
 type HostMetricsFieldsOtel =
   | typeof SEMCONV_SYSTEM_CPU_LOGICAL_COUNT
   | typeof SEMCONV_SYSTEM_CPU_UTILIZATION
-  | typeof SEMCONV_SYSTEM_MEMORY_LIMIT
+  | typeof SEMCONV_SYSTEM_MEMORY_TOTAL
   | typeof SEMCONV_SYSTEM_MEMORY_UTILIZATION;
 
 const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'hostmetricsreceiver.otel',
-    },
-  },
+  sourceFilter: otelDatasetFilterDsl('hostmetricsreceiver.otel'),
   groupByField: 'host.name',
   metricsMap: {
     [SEMCONV_SYSTEM_CPU_LOGICAL_COUNT]: {
@@ -79,9 +77,14 @@ const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = 
       aggregation: 'avg',
       field: SEMCONV_SYSTEM_CPU_UTILIZATION,
     },
-    [SEMCONV_SYSTEM_MEMORY_LIMIT]: {
-      aggregation: 'max',
-      field: SEMCONV_SYSTEM_MEMORY_LIMIT,
+    [SEMCONV_SYSTEM_MEMORY_TOTAL]: {
+      aggregation: 'custom',
+      field: SEMCONV_SYSTEM_MEMORY_TOTAL,
+      custom_metrics: [
+        { name: 'A', aggregation: 'avg', field: SEMCONV_SYSTEM_MEMORY_USAGE },
+        { name: 'B', aggregation: 'avg', field: SEMCONV_SYSTEM_MEMORY_UTILIZATION },
+      ],
+      equation: 'B > 0 ? A / B : null',
     },
     [SEMCONV_SYSTEM_MEMORY_UTILIZATION]: {
       aggregation: 'avg',
@@ -91,6 +94,8 @@ const hostsMetricsQueryConfigOtel: MetricsQueryOptions<HostMetricsFieldsOtel> = 
 };
 export const metricByField = createMetricByFieldLookup(hostsMetricsQueryConfig.metricsMap);
 const unpackMetric = makeUnpackMetric(metricByField);
+const metricByFieldOtel = createMetricByFieldLookup(hostsMetricsQueryConfigOtel.metricsMap);
+const unpackMetricOtel = makeUnpackMetric(metricByFieldOtel);
 
 export interface HostNodeMetricsRow {
   name: string;
@@ -121,10 +126,16 @@ export function useHostMetricsTable({
     () => metricsToApiOptions(hostsMetricsQueryConfigOtel, filterClauseDsl),
     [filterClauseDsl]
   );
+
+  const transform = useMemo(
+    () => (series: MetricsExplorerSeries) => seriesToHostNodeMetricsRow(series, isOtel),
+    [isOtel]
+  );
+
   const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<HostNodeMetricsRow>({
     metricsExplorerOptions: isOtel ? hostMetricsOptionsOtel : hostMetricsOptions,
     timerange,
-    transform: seriesToHostNodeMetricsRow,
+    transform,
     sortState,
     currentPageIndex,
     metricsClient,
@@ -141,14 +152,17 @@ export function useHostMetricsTable({
   };
 }
 
-function seriesToHostNodeMetricsRow(series: MetricsExplorerSeries): HostNodeMetricsRow {
+function seriesToHostNodeMetricsRow(
+  series: MetricsExplorerSeries,
+  isOtel?: boolean
+): HostNodeMetricsRow {
   if (series.rows.length === 0) {
     return rowWithoutMetrics(series.id);
   }
 
   return {
     name: series.id,
-    ...calculateMetricAverages(series.rows),
+    ...calculateMetricAverages(series.rows, isOtel),
   };
 }
 
@@ -162,13 +176,13 @@ function rowWithoutMetrics(name: string) {
   };
 }
 
-function calculateMetricAverages(rows: MetricsExplorerRow[]) {
+function calculateMetricAverages(rows: MetricsExplorerRow[], isOtel?: boolean) {
   const {
     cpuCountValues,
     averageCpuUsagePercentValues,
     totalMemoryMegabytesValues,
     averageMemoryUsagePercentValues,
-  } = collectMetricValues(rows);
+  } = collectMetricValues(rows, isOtel);
 
   let cpuCount = null;
   if (cpuCountValues.length !== 0) {
@@ -200,7 +214,7 @@ function calculateMetricAverages(rows: MetricsExplorerRow[]) {
   };
 }
 
-function collectMetricValues(rows: MetricsExplorerRow[]) {
+function collectMetricValues(rows: MetricsExplorerRow[], isOtel?: boolean) {
   const cpuCountValues: number[] = [];
   const averageCpuUsagePercentValues: number[] = [];
   const totalMemoryMegabytesValues: number[] = [];
@@ -208,7 +222,7 @@ function collectMetricValues(rows: MetricsExplorerRow[]) {
 
   rows.forEach((row) => {
     const { cpuCount, averageCpuUsagePercent, totalMemoryMegabytes, averageMemoryUsagePercent } =
-      unpackMetrics(row);
+      unpackMetrics(row, isOtel);
 
     if (cpuCount !== null) {
       cpuCountValues.push(cpuCount);
@@ -235,7 +249,19 @@ function collectMetricValues(rows: MetricsExplorerRow[]) {
   };
 }
 
-function unpackMetrics(row: MetricsExplorerRow): Omit<HostNodeMetricsRow, 'name'> {
+function unpackMetrics(
+  row: MetricsExplorerRow,
+  isOtel?: boolean
+): Omit<HostNodeMetricsRow, 'name'> {
+  if (isOtel) {
+    return {
+      cpuCount: unpackMetricOtel(row, SEMCONV_SYSTEM_CPU_LOGICAL_COUNT),
+      averageCpuUsagePercent: unpackMetricOtel(row, SEMCONV_SYSTEM_CPU_UTILIZATION),
+      totalMemoryMegabytes: unpackMetricOtel(row, SEMCONV_SYSTEM_MEMORY_TOTAL),
+      averageMemoryUsagePercent: unpackMetricOtel(row, SEMCONV_SYSTEM_MEMORY_UTILIZATION),
+    };
+  }
+
   return {
     cpuCount: unpackMetric(row, SYSTEM_CPU_CORES),
     averageCpuUsagePercent: unpackMetric(row, SYSTEM_CPU_TOTAL_NORM_PCT),

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.stories.tsx
@@ -69,30 +69,35 @@ const loadedPods: PodNodeMetricsRow[] = [
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg1',
     averageCpuUsagePercent: 99,
     averageMemoryUsagePercent: 34,
+    memoryUnit: '%',
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c1',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg2',
     averageCpuUsagePercent: 72,
     averageMemoryUsagePercent: 68,
+    memoryUnit: '%',
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg3',
     averageCpuUsagePercent: 54,
     averageMemoryUsagePercent: 132,
+    memoryUnit: '%',
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg4',
     averageCpuUsagePercent: 34,
     averageMemoryUsagePercent: 264,
+    memoryUnit: '%',
   },
   {
     id: '358d96e3-026f-4440-a487-f6c2301884c0',
     name: 'gke-edge-oblt-pool-1-9a60016d-lgg5',
     averageCpuUsagePercent: 13,
     averageMemoryUsagePercent: 512,
+    memoryUnit: '%',
   },
 ];
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/pod_metrics_table.tsx
@@ -24,8 +24,8 @@ import {
   StepwisePagination,
 } from '../shared';
 import {
-  SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
   SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_MEMORY_WORKING_SET,
 } from '../shared/constants';
 import type { PodNodeMetricsRow } from './use_pod_metrics_table';
 
@@ -152,33 +152,11 @@ function podNodeColumns(
       },
     },
     {
-      name: (
-        <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false} wrap={false}>
-          <EuiFlexItem grow={false}>
-            {i18n.translate(
-              'xpack.metricsData.metricsTable.pod.averageCpuUsagePercentColumnHeader',
-              {
-                defaultMessage: 'CPU usage (avg.)',
-              }
-            )}
-          </EuiFlexItem>
-          {isOtel ? (
-            <EuiFlexItem grow={false}>
-              <EuiIconTip
-                content={i18n.translate(
-                  'xpack.metricsData.metricsTable.pod.metricsOptionalTooltip',
-                  {
-                    defaultMessage:
-                      '{metricName} is optional and may not appear for all pods. Visibility depends on your Kubernetes metrics collection setup.',
-                    values: {
-                      metricName: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
-                    },
-                  }
-                )}
-              />
-            </EuiFlexItem>
-          ) : null}
-        </EuiFlexGroup>
+      name: i18n.translate(
+        'xpack.metricsData.metricsTable.pod.averageCpuUsagePercentColumnHeader',
+        {
+          defaultMessage: 'CPU usage (avg.)',
+        }
       ),
       field: 'averageCpuUsagePercent',
       align: 'right',
@@ -201,12 +179,13 @@ function podNodeColumns(
             <EuiFlexItem grow={false}>
               <EuiIconTip
                 content={i18n.translate(
-                  'xpack.metricsData.metricsTable.pod.metricsOptionalTooltip',
+                  'xpack.metricsData.metricsTable.pod.memoryMetricSourceTooltip',
                   {
                     defaultMessage:
-                      '{metricName} is optional and may not appear for all pods. Visibility depends on your Kubernetes metrics collection setup.',
+                      'Displays {limitMetric} as a percentage when available, otherwise falls back to {workingSetMetric} in MB.',
                     values: {
-                      metricName: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+                      limitMetric: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+                      workingSetMetric: SEMCONV_K8S_POD_MEMORY_WORKING_SET,
                     },
                   }
                 )}
@@ -217,8 +196,8 @@ function podNodeColumns(
       ),
       field: 'averageMemoryUsagePercent',
       align: 'right',
-      render: (averageMemoryUsagePercent: number) => (
-        <NumberCell value={averageMemoryUsagePercent} unit="%" />
+      render: (averageMemoryUsagePercent: number, row: PodNodeMetricsRow) => (
+        <NumberCell value={averageMemoryUsagePercent} unit={row.memoryUnit} />
       ),
     },
   ];

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -74,10 +74,7 @@ describe('usePodMetricsTable hook', () => {
 
     const filterClauseWithEventModuleFilter = {
       bool: {
-        filter: [
-          otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
-          { ...filterClauseDsl },
-        ],
+        filter: [otelDatasetFilterDsl('kubeletstatsreceiver.otel'), { ...filterClauseDsl }],
       },
     };
 

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.test.ts
@@ -8,7 +8,10 @@
 import {
   ECS_POD_CPU_USAGE_LIMIT_PCT,
   MEMORY_LIMIT_UTILIZATION,
-  SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
+  otelDatasetFilterDsl,
+  SEMCONV_K8S_POD_CPU_NODE_UTILIZATION,
+  SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_MEMORY_WORKING_SET,
 } from '../shared/constants';
 import { usePodMetricsTable } from './use_pod_metrics_table';
 import { useInfrastructureNodeMetrics } from '../shared';
@@ -72,7 +75,7 @@ describe('usePodMetricsTable hook', () => {
     const filterClauseWithEventModuleFilter = {
       bool: {
         filter: [
-          { term: { 'event.dataset': 'kubeletstatsreceiver.otel' } },
+          otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
           { ...filterClauseDsl },
         ],
       },
@@ -99,12 +102,104 @@ describe('usePodMetricsTable hook', () => {
         metricsExplorerOptions: expect.objectContaining({
           filterQuery: JSON.stringify(filterClauseWithEventModuleFilter),
           metrics: expect.arrayContaining([
-            expect.objectContaining({ field: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION }),
-            expect.objectContaining({ field: MEMORY_LIMIT_UTILIZATION }),
+            expect.objectContaining({ field: SEMCONV_K8S_POD_CPU_NODE_UTILIZATION }),
+            expect.objectContaining({ field: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION }),
+            expect.objectContaining({ field: SEMCONV_K8S_POD_MEMORY_WORKING_SET }),
           ]),
         }),
       })
     );
+  });
+
+  it('should use memory_limit_utilization as % when available', () => {
+    useInfrastructureNodeMetricsMock.mockClear();
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      usePodMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    const lastCallArgs = useInfrastructureNodeMetricsMock.mock.calls.at(-1);
+    const { transform, metricsExplorerOptions } = lastCallArgs?.[0] ?? {};
+    expect(transform).toBeDefined();
+
+    const metrics = metricsExplorerOptions?.metrics ?? [];
+    const metricIndexByField = new Map(metrics.map((metric, index) => [metric.field, index]));
+
+    const row = transform!({
+      id: 'test-pod-uid',
+      columns: [],
+      keys: ['test-pod-uid', 'test-pod-name'],
+      rows: [
+        {
+          timestamp: Date.now(),
+          [`metric_${metricIndexByField.get(SEMCONV_K8S_POD_CPU_NODE_UTILIZATION)}`]: 0.05,
+          [`metric_${metricIndexByField.get(SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION)}`]: 0.3,
+          [`metric_${metricIndexByField.get(SEMCONV_K8S_POD_MEMORY_WORKING_SET)}`]: 512_000_000,
+        },
+      ],
+    });
+
+    expect(row).toEqual({
+      id: 'test-pod-uid',
+      name: 'test-pod-name',
+      averageCpuUsagePercent: 5,
+      averageMemoryUsagePercent: 30,
+      memoryUnit: '%',
+    });
+  });
+
+  it('should fall back to memory.working_set as MB when limit_utilization is absent', () => {
+    useInfrastructureNodeMetricsMock.mockClear();
+    useInfrastructureNodeMetricsMock.mockReturnValue({
+      isLoading: true,
+      data: { state: 'empty-indices' },
+      metricIndices: 'test-index',
+    });
+
+    renderHook(() =>
+      usePodMetricsTable({
+        timerange: { from: 'now-30d', to: 'now' },
+        metricsClient: createMetricsClientMock({}),
+        isOtel: true,
+      })
+    );
+
+    const lastCallArgs = useInfrastructureNodeMetricsMock.mock.calls.at(-1);
+    const { transform, metricsExplorerOptions } = lastCallArgs?.[0] ?? {};
+    expect(transform).toBeDefined();
+
+    const metrics = metricsExplorerOptions?.metrics ?? [];
+    const metricIndexByField = new Map(metrics.map((metric, index) => [metric.field, index]));
+
+    const row = transform!({
+      id: 'test-pod-uid',
+      columns: [],
+      keys: ['test-pod-uid', 'test-pod-name'],
+      rows: [
+        {
+          timestamp: Date.now(),
+          [`metric_${metricIndexByField.get(SEMCONV_K8S_POD_CPU_NODE_UTILIZATION)}`]: 0.05,
+          [`metric_${metricIndexByField.get(SEMCONV_K8S_POD_MEMORY_WORKING_SET)}`]: 512_000_000,
+        },
+      ],
+    });
+
+    expect(row).toEqual({
+      id: 'test-pod-uid',
+      name: 'test-pod-name',
+      averageCpuUsagePercent: 5,
+      averageMemoryUsagePercent: 512,
+      memoryUnit: ' MB',
+    });
   });
 
   it('should call useInfrastructureNodeMetrics with ECS metrics when isOtel is false', () => {
@@ -120,6 +215,7 @@ describe('usePodMetricsTable hook', () => {
       },
     };
 
+    useInfrastructureNodeMetricsMock.mockClear();
     // include this to prevent rendering error in test
     useInfrastructureNodeMetricsMock.mockReturnValue({
       isLoading: true,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/pod/use_pod_metrics_table.ts
@@ -24,8 +24,10 @@ import {
   KUBERNETES_NODE_MEMORY_ALLOCATABLE_BYTES,
   KUBERNETES_NODE_MEMORY_USAGE_BYTES,
   MEMORY_LIMIT_UTILIZATION,
-  SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION,
+  otelDatasetFilterDsl,
+  SEMCONV_K8S_POD_CPU_NODE_UTILIZATION,
   SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+  SEMCONV_K8S_POD_MEMORY_WORKING_SET,
 } from '../shared/constants';
 
 type PodMetricsField = typeof ECS_POD_CPU_USAGE_LIMIT_PCT | typeof MEMORY_LIMIT_UTILIZATION;
@@ -63,34 +65,25 @@ const podMetricsQueryConfig: MetricsQueryOptions<PodMetricsField> = {
 };
 
 type PodMetricsFieldsOtel =
-  | typeof SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION
-  | typeof MEMORY_LIMIT_UTILIZATION;
+  | typeof SEMCONV_K8S_POD_CPU_NODE_UTILIZATION
+  | typeof SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION
+  | typeof SEMCONV_K8S_POD_MEMORY_WORKING_SET;
 
 const podMetricsQueryConfigOtel: MetricsQueryOptions<PodMetricsFieldsOtel> = {
-  sourceFilter: {
-    term: {
-      'event.dataset': 'kubeletstatsreceiver.otel',
-    },
-  },
+  sourceFilter: otelDatasetFilterDsl('kubeletstatsreceiver.otel'),
   groupByField: ['k8s.pod.uid', 'k8s.pod.name'],
   metricsMap: {
-    // this is an optional field and wont populate unless specifically enabled in kubeletstatreceiver.
-    // There are not pod metrics that can derive this value.
-    [SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION]: {
+    [SEMCONV_K8S_POD_CPU_NODE_UTILIZATION]: {
       aggregation: 'avg',
-      field: SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION, // this is an opt-in field.
+      field: SEMCONV_K8S_POD_CPU_NODE_UTILIZATION,
     },
-    [MEMORY_LIMIT_UTILIZATION]: {
-      field: MEMORY_LIMIT_UTILIZATION,
-      aggregation: 'custom',
-      custom_metrics: [
-        {
-          name: 'A',
-          aggregation: 'avg',
-          field: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
-        },
-      ],
-      equation: 'A',
+    [SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION]: {
+      aggregation: 'avg',
+      field: SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION,
+    },
+    [SEMCONV_K8S_POD_MEMORY_WORKING_SET]: {
+      aggregation: 'avg',
+      field: SEMCONV_K8S_POD_MEMORY_WORKING_SET,
     },
   },
 };
@@ -98,11 +91,15 @@ const podMetricsQueryConfigOtel: MetricsQueryOptions<PodMetricsFieldsOtel> = {
 export const metricByField = createMetricByFieldLookup(podMetricsQueryConfig.metricsMap);
 const unpackMetric = makeUnpackMetric(metricByField);
 
+const metricByFieldOtel = createMetricByFieldLookup(podMetricsQueryConfigOtel.metricsMap);
+const unpackMetricOtel = makeUnpackMetric(metricByFieldOtel);
+
 export interface PodNodeMetricsRow {
   id: string;
   name: string;
   averageCpuUsagePercent: number | null;
   averageMemoryUsagePercent: number | null;
+  memoryUnit: '%' | ' MB';
 }
 
 export function usePodMetricsTable({
@@ -127,10 +124,15 @@ export function usePodMetricsTable({
     [filterClauseDsl]
   );
 
+  const transform = useMemo(
+    () => (series: MetricsExplorerSeries) => seriesToPodNodeMetricsRow(series, isOtel ?? false),
+    [isOtel]
+  );
+
   const { data, isLoading, metricIndices } = useInfrastructureNodeMetrics<PodNodeMetricsRow>({
     metricsExplorerOptions: isOtel ? podMetricsOptionsOtel : podMetricsOptions,
     timerange,
-    transform: seriesToPodNodeMetricsRow,
+    transform,
     sortState,
     currentPageIndex,
     metricsClient,
@@ -148,31 +150,51 @@ export function usePodMetricsTable({
   };
 }
 
-function seriesToPodNodeMetricsRow(series: MetricsExplorerSeries): PodNodeMetricsRow {
+function seriesToPodNodeMetricsRow(
+  series: MetricsExplorerSeries,
+  isOtel: boolean
+): PodNodeMetricsRow {
   const [id, name] = series.keys ?? [];
   if (series.rows.length === 0) {
-    return rowWithoutMetrics(id, name);
+    return rowWithoutMetrics(id, name, isOtel);
   }
 
   return {
     id,
     name,
-    ...calculateMetricAverages(series.rows),
+    ...calculateMetricAverages(series.rows, isOtel),
   };
 }
 
-function rowWithoutMetrics(id: string, name: string) {
+function rowWithoutMetrics(id: string, name: string, isOtel: boolean) {
   return {
     id,
     name,
     averageCpuUsagePercent: null,
     averageMemoryUsagePercent: null,
+    memoryUnit: (isOtel ? ' MB' : '%') as PodNodeMetricsRow['memoryUnit'],
   };
 }
 
-function calculateMetricAverages(rows: MetricsExplorerRow[]) {
-  const { averageCpuUsagePercentValues, averageMemoryUsagePercentValues } =
-    collectMetricValues(rows);
+function calculateMetricAverages(
+  rows: MetricsExplorerRow[],
+  isOtel: boolean
+): Omit<PodNodeMetricsRow, 'id' | 'name'> {
+  const averageCpuUsagePercentValues: number[] = [];
+  const averageMemoryUsagePercentValues: number[] = [];
+  let memoryUnit: PodNodeMetricsRow['memoryUnit'] = '%';
+
+  rows.forEach((row) => {
+    const unpacked = isOtel ? unpackMetricsOtel(row) : unpackMetrics(row);
+
+    if (unpacked.averageCpuUsagePercent !== null) {
+      averageCpuUsagePercentValues.push(unpacked.averageCpuUsagePercent);
+    }
+    if (unpacked.averageMemoryUsagePercent !== null) {
+      averageMemoryUsagePercentValues.push(unpacked.averageMemoryUsagePercent);
+    }
+    memoryUnit = unpacked.memoryUnit;
+  });
 
   let averageCpuUsagePercent = null;
   if (averageCpuUsagePercentValues.length !== 0) {
@@ -181,39 +203,37 @@ function calculateMetricAverages(rows: MetricsExplorerRow[]) {
 
   let averageMemoryUsagePercent = null;
   if (averageMemoryUsagePercentValues.length !== 0) {
-    averageMemoryUsagePercent = scaleUpPercentage(averageOfValues(averageMemoryUsagePercentValues));
+    const avg = averageOfValues(averageMemoryUsagePercentValues);
+    averageMemoryUsagePercent = memoryUnit === '%' ? scaleUpPercentage(avg) : Math.floor(avg);
   }
-  return {
-    averageCpuUsagePercent,
-    averageMemoryUsagePercent,
-  };
-}
 
-function collectMetricValues(rows: MetricsExplorerRow[]) {
-  const averageCpuUsagePercentValues: number[] = [];
-  const averageMemoryUsagePercentValues: number[] = [];
-
-  rows.forEach((row) => {
-    const { averageCpuUsagePercent, averageMemoryUsagePercent } = unpackMetrics(row);
-
-    if (averageCpuUsagePercent !== null) {
-      averageCpuUsagePercentValues.push(averageCpuUsagePercent);
-    }
-
-    if (averageMemoryUsagePercent !== null) {
-      averageMemoryUsagePercentValues.push(averageMemoryUsagePercent);
-    }
-  });
-
-  return {
-    averageCpuUsagePercentValues,
-    averageMemoryUsagePercentValues,
-  };
+  return { averageCpuUsagePercent, averageMemoryUsagePercent, memoryUnit };
 }
 
 function unpackMetrics(row: MetricsExplorerRow): Omit<PodNodeMetricsRow, 'id' | 'name'> {
   return {
     averageCpuUsagePercent: unpackMetric(row, ECS_POD_CPU_USAGE_LIMIT_PCT),
     averageMemoryUsagePercent: unpackMetric(row, MEMORY_LIMIT_UTILIZATION),
+    memoryUnit: '%',
+  };
+}
+
+function unpackMetricsOtel(row: MetricsExplorerRow): Omit<PodNodeMetricsRow, 'id' | 'name'> {
+  const cpuUtilization = unpackMetricOtel(row, SEMCONV_K8S_POD_CPU_NODE_UTILIZATION);
+  const memLimitUtil = unpackMetricOtel(row, SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION);
+
+  if (memLimitUtil != null) {
+    return {
+      averageCpuUsagePercent: cpuUtilization,
+      averageMemoryUsagePercent: memLimitUtil,
+      memoryUnit: '%',
+    };
+  }
+
+  const memoryBytes = unpackMetricOtel(row, SEMCONV_K8S_POD_MEMORY_WORKING_SET);
+  return {
+    averageCpuUsagePercent: cpuUtilization,
+    averageMemoryUsagePercent: memoryBytes != null ? memoryBytes / 1_000_000 : null,
+    memoryUnit: ' MB',
   };
 }

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
@@ -11,11 +11,15 @@
 export const ECS_CONTAINER_CPU_USAGE_LIMIT_PCT = 'kubernetes.container.cpu.usage.limit.pct';
 export const ECS_CONTAINER_MEMORY_USAGE_BYTES = 'kubernetes.container.memory.usage.bytes';
 
-/** SemConv K8s (Kubernetes container) metric field names */
+/** SemConv K8s (Kubernetes container) metric field names — require resource limits to be set */
 export const SEMCONV_K8S_CONTAINER_CPU_LIMIT_UTILIZATION =
   'metrics.k8s.container.cpu_limit_utilization';
 export const SEMCONV_K8S_CONTAINER_MEMORY_LIMIT_UTILIZATION =
   'metrics.k8s.container.memory_limit_utilization';
+
+/** SemConv container metrics always emitted by kubeletstats (no limits required) */
+export const SEMCONV_CONTAINER_CPU_USAGE = 'metrics.container.cpu.usage';
+export const SEMCONV_CONTAINER_MEMORY_WORKING_SET = 'metrics.container.memory.working_set';
 
 /** SemConv container metric names used in UI tooltips (generic / display) */
 export const SEMCONV_DOCKER_CONTAINER_CPU_UTILIZATION = 'metrics.container.cpu.utilization';
@@ -32,7 +36,8 @@ export const SYSTEM_MEMORY_USED_PCT = 'system.memory.used.pct';
 /** SemConv (OpenTelemetry) host metric field names */
 export const SEMCONV_SYSTEM_CPU_LOGICAL_COUNT = 'metrics.system.cpu.logical.count';
 export const SEMCONV_SYSTEM_CPU_UTILIZATION = 'metrics.system.cpu.utilization';
-export const SEMCONV_SYSTEM_MEMORY_LIMIT = 'metrics.system.memory.limit';
+export const SEMCONV_SYSTEM_MEMORY_TOTAL = 'metrics.system.memory.total';
+export const SEMCONV_SYSTEM_MEMORY_USAGE = 'metrics.system.memory.usage';
 export const SEMCONV_SYSTEM_MEMORY_UTILIZATION = 'metrics.system.memory.utilization';
 
 // --- Pod metric field names ---
@@ -47,6 +52,35 @@ export const MEMORY_LIMIT_UTILIZATION = 'memory_limit_utilization';
 export const KUBERNETES_NODE_MEMORY_ALLOCATABLE_BYTES = 'kubernetes.node.memory.allocatable.bytes';
 export const KUBERNETES_NODE_MEMORY_USAGE_BYTES = 'kubernetes.node.memory.usage.bytes';
 
-/** SemConv K8s pod metric field names */
+/** SemConv K8s pod metric field names — require resource limits to be set */
 export const SEMCONV_K8S_POD_CPU_LIMIT_UTILIZATION = 'metrics.k8s.pod.cpu_limit_utilization';
 export const SEMCONV_K8S_POD_MEMORY_LIMIT_UTILIZATION = 'metrics.k8s.pod.memory_limit_utilization';
+
+/** SemConv K8s pod metrics always emitted by kubeletstats (no limits required) */
+export const SEMCONV_K8S_POD_CPU_NODE_UTILIZATION = 'metrics.k8s.pod.cpu.node.utilization';
+export const SEMCONV_K8S_POD_MEMORY_WORKING_SET = 'metrics.k8s.pod.memory.working_set';
+
+// --- OTel dataset filter helpers ---
+
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
+
+/**
+ * Builds a KQL source filter that matches OTel data regardless of whether the
+ * dataset value is stored under `data_stream.dataset` or `event.dataset`.
+ */
+export const otelDatasetFilter = (dataset: string) =>
+  `(data_stream.dataset: "${dataset}" OR event.dataset: "${dataset}")`;
+
+/**
+ * DSL equivalent of otelDatasetFilter — returns a QueryDslQueryContainer
+ * that matches OTel data by both `data_stream.dataset` and `event.dataset`.
+ */
+export const otelDatasetFilterDsl = (dataset: string): QueryDslQueryContainer => ({
+  bool: {
+    should: [
+      { term: { 'data_stream.dataset': dataset } },
+      { term: { 'event.dataset': dataset } },
+    ],
+    minimum_should_match: 1,
+  },
+});

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/constants.ts
@@ -77,10 +77,7 @@ export const otelDatasetFilter = (dataset: string) =>
  */
 export const otelDatasetFilterDsl = (dataset: string): QueryDslQueryContainer => ({
   bool: {
-    should: [
-      { term: { 'data_stream.dataset': dataset } },
-      { term: { 'event.dataset': dataset } },
-    ],
+    should: [{ term: { 'data_stream.dataset': dataset } }, { term: { 'event.dataset': dataset } }],
     minimum_should_match: 1,
   },
 });

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/helpers.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/hooks/helpers.ts
@@ -15,7 +15,8 @@ export function averageOfValues(values: number[]) {
 export function makeUnpackMetric<T extends string>(metricByField: Record<T, string>) {
   // Make sure metrics are accessed as row[metricByField['FIELD_NAME']]
   // Not row['FIELD_NAME'] by accident
-  return (row: MetricsExplorerRow, field: T) => row[metricByField[field]] as number | null;
+  return (row: MetricsExplorerRow, field: T) =>
+    (row[metricByField[field]] as number | null) ?? null;
 }
 
 export function scaleUpPercentage(unscaled: number) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552)](https://github.com/elastic/kibana/pull/259552)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2026-04-02T16:52:34Z","message":"[APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552)\n\n## Summary\n\nCloses #256731\n\nFix OTel metrics in the APM Infrastructure tab so hosts, pods, and\ncontainers display actual values instead of `N/A`. The root causes were:\n(1) hosts queried `metrics.system.memory.limit`, a field that doesn't\nexist in `hostmetricsreceiver` data, (2) pod and container configs\nqueried `_limit_utilization` fields that only exist when Kubernetes\nresource limits are explicitly set — which most deployments don't have,\nand (3) all OTel dataset filters only matched `event.dataset`, missing\ndocuments indexed under `data_stream.dataset`.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/63193175-7893-47fa-8a82-ff76924908fb\n\n\n### After\n\n\nhttps://github.com/user-attachments/assets/440676f7-4168-4c13-9227-1b3b6bc74e57\n\n\n## Problem\n\nFor OTel entities, the Infrastructure tab in APM showed `N/A` for most\nmetrics even when semconv data was present in Elasticsearch:\n\n- **Hosts**: The `metrics.system.memory.limit` field doesn't exist in\n`hostmetricsreceiver` data, causing Memory Total to show `N/A`.\n- **Pods**: CPU used `metrics.k8s.pod.cpu_limit_utilization` (requires\nCPU limits) and memory used `metrics.k8s.pod.memory_limit_utilization`\n(requires memory limits). Both return empty results when limits aren't\nset.\n- **Containers (K8s)**: CPU used\n`metrics.k8s.container.cpu_limit_utilization` and memory used\n`metrics.k8s.container.memory_limit_utilization` — same limits-only\nproblem.\n- **Dataset filters**: All OTel paths only matched `event.dataset`,\nmissing documents indexed under `data_stream.dataset`.\n\n## Field mapping changes\n\n### Hosts\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Memory total | `metrics.system.memory.limit` | Derived:\n`metrics.system.memory.usage / metrics.system.memory.utilization` |\n`memory.limit` doesn't exist in hostmetricsreceiver; total is derived\nfrom usage and utilization ratio |\n| Dataset filter | `event.dataset: \"hostmetricsreceiver.otel\"` |\n`(data_stream.dataset: \"hostmetricsreceiver.otel\" OR event.dataset:\n\"hostmetricsreceiver.otel\")` | Match both field locations |\n\n### Pods\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.pod.cpu_limit_utilization` |\n`metrics.k8s.pod.cpu.node.utilization` | `cpu_limit_utilization`\nrequires resource limits; `cpu.node.utilization` is always emitted by\nkubeletstats |\n| Memory | `metrics.k8s.pod.memory_limit_utilization` |\n`metrics.k8s.pod.memory_limit_utilization` with fallback to\n`metrics.k8s.pod.memory.working_set` | Queries both; prefers\n`memory_limit_utilization` (shown as %) when available, falls back to\n`memory.working_set` (shown as MB) to avoid N/A |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (K8s path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.container.cpu_limit_utilization` |\n`metrics.container.cpu.usage` | `cpu_limit_utilization` requires\nresource limits; `container.cpu.usage` is always emitted by kubeletstats\n(0–1 ratio of one CPU core) |\n| Memory | `metrics.k8s.container.memory_limit_utilization` |\n`metrics.container.memory.working_set` | `memory_limit_utilization`\nrequires resource limits; `memory.working_set` (bytes → MB) is always\navailable |\n| Memory unit | Always `%` for OTel | `MB` for K8s containers, `%` for\nDocker containers | K8s path now uses `working_set` (bytes) not a\npercentage |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (Docker path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Dataset filter | `event.dataset: \"dockerstatsreceiver.otel\"` |\n`(data_stream.dataset: \"dockerstatsreceiver.otel\" OR event.dataset:\n\"dockerstatsreceiver.otel\")` | Match both field locations |\n\n## Other changes\n\n- **Pod memory tooltip**: Added an `EuiIconTip` explaining the fallback\nlogic (prefers `memory_limit_utilization` as %, falls back to\n`memory.working_set` as MB).\n- **Pod CPU tooltip removed**: The old tooltip warned that\n`cpu_limit_utilization` was optional. The new field\n(`cpu.node.utilization`) is always present, making the tooltip\nmisleading.\n- **OTel dataset filter helper**: Extracted `otelDatasetFilter()`\nutility to avoid duplicating the `(data_stream.dataset OR\nevent.dataset)` pattern.\n- **Host OTel unpack path**: Added `metricByFieldOtel` /\n`unpackMetricOtel` so the host table correctly reads OTel metric\npositions instead of falling through to ECS metric keys.\n\n## Test plan\n\n- [x] `yarn test:jest\nx-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/`\n— all 46 tests pass\n- [x] Manual smoke in APM Infrastructure tab with OTel service data\n(e.g. `kbn-otel-demo` with EDOT Collector):\n  - [ ] Hosts tab: CPU count, CPU %, Memory total, Memory % all populate\n- [x] Pods tab: CPU % populates; Memory shows % (with limits) or MB\n(without limits)\n  - [x] Containers tab: CPU % and Memory MB populate for K8s containers","sha":"c6485d753760eac356c74a253cbd440d7ef83227","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:all-open","v9.4.0","Team:obs-presentation","v9.3.3","v9.2.8"],"title":"[APM][Infra] Fix OTel metrics mapping in infrastructure tab","number":259552,"url":"https://github.com/elastic/kibana/pull/259552","mergeCommit":{"message":"[APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552)\n\n## Summary\n\nCloses #256731\n\nFix OTel metrics in the APM Infrastructure tab so hosts, pods, and\ncontainers display actual values instead of `N/A`. The root causes were:\n(1) hosts queried `metrics.system.memory.limit`, a field that doesn't\nexist in `hostmetricsreceiver` data, (2) pod and container configs\nqueried `_limit_utilization` fields that only exist when Kubernetes\nresource limits are explicitly set — which most deployments don't have,\nand (3) all OTel dataset filters only matched `event.dataset`, missing\ndocuments indexed under `data_stream.dataset`.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/63193175-7893-47fa-8a82-ff76924908fb\n\n\n### After\n\n\nhttps://github.com/user-attachments/assets/440676f7-4168-4c13-9227-1b3b6bc74e57\n\n\n## Problem\n\nFor OTel entities, the Infrastructure tab in APM showed `N/A` for most\nmetrics even when semconv data was present in Elasticsearch:\n\n- **Hosts**: The `metrics.system.memory.limit` field doesn't exist in\n`hostmetricsreceiver` data, causing Memory Total to show `N/A`.\n- **Pods**: CPU used `metrics.k8s.pod.cpu_limit_utilization` (requires\nCPU limits) and memory used `metrics.k8s.pod.memory_limit_utilization`\n(requires memory limits). Both return empty results when limits aren't\nset.\n- **Containers (K8s)**: CPU used\n`metrics.k8s.container.cpu_limit_utilization` and memory used\n`metrics.k8s.container.memory_limit_utilization` — same limits-only\nproblem.\n- **Dataset filters**: All OTel paths only matched `event.dataset`,\nmissing documents indexed under `data_stream.dataset`.\n\n## Field mapping changes\n\n### Hosts\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Memory total | `metrics.system.memory.limit` | Derived:\n`metrics.system.memory.usage / metrics.system.memory.utilization` |\n`memory.limit` doesn't exist in hostmetricsreceiver; total is derived\nfrom usage and utilization ratio |\n| Dataset filter | `event.dataset: \"hostmetricsreceiver.otel\"` |\n`(data_stream.dataset: \"hostmetricsreceiver.otel\" OR event.dataset:\n\"hostmetricsreceiver.otel\")` | Match both field locations |\n\n### Pods\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.pod.cpu_limit_utilization` |\n`metrics.k8s.pod.cpu.node.utilization` | `cpu_limit_utilization`\nrequires resource limits; `cpu.node.utilization` is always emitted by\nkubeletstats |\n| Memory | `metrics.k8s.pod.memory_limit_utilization` |\n`metrics.k8s.pod.memory_limit_utilization` with fallback to\n`metrics.k8s.pod.memory.working_set` | Queries both; prefers\n`memory_limit_utilization` (shown as %) when available, falls back to\n`memory.working_set` (shown as MB) to avoid N/A |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (K8s path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.container.cpu_limit_utilization` |\n`metrics.container.cpu.usage` | `cpu_limit_utilization` requires\nresource limits; `container.cpu.usage` is always emitted by kubeletstats\n(0–1 ratio of one CPU core) |\n| Memory | `metrics.k8s.container.memory_limit_utilization` |\n`metrics.container.memory.working_set` | `memory_limit_utilization`\nrequires resource limits; `memory.working_set` (bytes → MB) is always\navailable |\n| Memory unit | Always `%` for OTel | `MB` for K8s containers, `%` for\nDocker containers | K8s path now uses `working_set` (bytes) not a\npercentage |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (Docker path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Dataset filter | `event.dataset: \"dockerstatsreceiver.otel\"` |\n`(data_stream.dataset: \"dockerstatsreceiver.otel\" OR event.dataset:\n\"dockerstatsreceiver.otel\")` | Match both field locations |\n\n## Other changes\n\n- **Pod memory tooltip**: Added an `EuiIconTip` explaining the fallback\nlogic (prefers `memory_limit_utilization` as %, falls back to\n`memory.working_set` as MB).\n- **Pod CPU tooltip removed**: The old tooltip warned that\n`cpu_limit_utilization` was optional. The new field\n(`cpu.node.utilization`) is always present, making the tooltip\nmisleading.\n- **OTel dataset filter helper**: Extracted `otelDatasetFilter()`\nutility to avoid duplicating the `(data_stream.dataset OR\nevent.dataset)` pattern.\n- **Host OTel unpack path**: Added `metricByFieldOtel` /\n`unpackMetricOtel` so the host table correctly reads OTel metric\npositions instead of falling through to ECS metric keys.\n\n## Test plan\n\n- [x] `yarn test:jest\nx-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/`\n— all 46 tests pass\n- [x] Manual smoke in APM Infrastructure tab with OTel service data\n(e.g. `kbn-otel-demo` with EDOT Collector):\n  - [ ] Hosts tab: CPU count, CPU %, Memory total, Memory % all populate\n- [x] Pods tab: CPU % populates; Memory shows % (with limits) or MB\n(without limits)\n  - [x] Containers tab: CPU % and Memory MB populate for K8s containers","sha":"c6485d753760eac356c74a253cbd440d7ef83227"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259552","number":259552,"mergeCommit":{"message":"[APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552)\n\n## Summary\n\nCloses #256731\n\nFix OTel metrics in the APM Infrastructure tab so hosts, pods, and\ncontainers display actual values instead of `N/A`. The root causes were:\n(1) hosts queried `metrics.system.memory.limit`, a field that doesn't\nexist in `hostmetricsreceiver` data, (2) pod and container configs\nqueried `_limit_utilization` fields that only exist when Kubernetes\nresource limits are explicitly set — which most deployments don't have,\nand (3) all OTel dataset filters only matched `event.dataset`, missing\ndocuments indexed under `data_stream.dataset`.\n\n## Demo\n\n### Before\n\n\nhttps://github.com/user-attachments/assets/63193175-7893-47fa-8a82-ff76924908fb\n\n\n### After\n\n\nhttps://github.com/user-attachments/assets/440676f7-4168-4c13-9227-1b3b6bc74e57\n\n\n## Problem\n\nFor OTel entities, the Infrastructure tab in APM showed `N/A` for most\nmetrics even when semconv data was present in Elasticsearch:\n\n- **Hosts**: The `metrics.system.memory.limit` field doesn't exist in\n`hostmetricsreceiver` data, causing Memory Total to show `N/A`.\n- **Pods**: CPU used `metrics.k8s.pod.cpu_limit_utilization` (requires\nCPU limits) and memory used `metrics.k8s.pod.memory_limit_utilization`\n(requires memory limits). Both return empty results when limits aren't\nset.\n- **Containers (K8s)**: CPU used\n`metrics.k8s.container.cpu_limit_utilization` and memory used\n`metrics.k8s.container.memory_limit_utilization` — same limits-only\nproblem.\n- **Dataset filters**: All OTel paths only matched `event.dataset`,\nmissing documents indexed under `data_stream.dataset`.\n\n## Field mapping changes\n\n### Hosts\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Memory total | `metrics.system.memory.limit` | Derived:\n`metrics.system.memory.usage / metrics.system.memory.utilization` |\n`memory.limit` doesn't exist in hostmetricsreceiver; total is derived\nfrom usage and utilization ratio |\n| Dataset filter | `event.dataset: \"hostmetricsreceiver.otel\"` |\n`(data_stream.dataset: \"hostmetricsreceiver.otel\" OR event.dataset:\n\"hostmetricsreceiver.otel\")` | Match both field locations |\n\n### Pods\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.pod.cpu_limit_utilization` |\n`metrics.k8s.pod.cpu.node.utilization` | `cpu_limit_utilization`\nrequires resource limits; `cpu.node.utilization` is always emitted by\nkubeletstats |\n| Memory | `metrics.k8s.pod.memory_limit_utilization` |\n`metrics.k8s.pod.memory_limit_utilization` with fallback to\n`metrics.k8s.pod.memory.working_set` | Queries both; prefers\n`memory_limit_utilization` (shown as %) when available, falls back to\n`memory.working_set` (shown as MB) to avoid N/A |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (K8s path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| CPU | `metrics.k8s.container.cpu_limit_utilization` |\n`metrics.container.cpu.usage` | `cpu_limit_utilization` requires\nresource limits; `container.cpu.usage` is always emitted by kubeletstats\n(0–1 ratio of one CPU core) |\n| Memory | `metrics.k8s.container.memory_limit_utilization` |\n`metrics.container.memory.working_set` | `memory_limit_utilization`\nrequires resource limits; `memory.working_set` (bytes → MB) is always\navailable |\n| Memory unit | Always `%` for OTel | `MB` for K8s containers, `%` for\nDocker containers | K8s path now uses `working_set` (bytes) not a\npercentage |\n| Dataset filter | `event.dataset: \"kubeletstatsreceiver.otel\"` |\n`(data_stream.dataset: \"kubeletstatsreceiver.otel\" OR event.dataset:\n\"kubeletstatsreceiver.otel\")` | Match both field locations |\n\n### Containers (Docker path)\n\n| Metric | Before | After | Why |\n|---|---|---|---|\n| Dataset filter | `event.dataset: \"dockerstatsreceiver.otel\"` |\n`(data_stream.dataset: \"dockerstatsreceiver.otel\" OR event.dataset:\n\"dockerstatsreceiver.otel\")` | Match both field locations |\n\n## Other changes\n\n- **Pod memory tooltip**: Added an `EuiIconTip` explaining the fallback\nlogic (prefers `memory_limit_utilization` as %, falls back to\n`memory.working_set` as MB).\n- **Pod CPU tooltip removed**: The old tooltip warned that\n`cpu_limit_utilization` was optional. The new field\n(`cpu.node.utilization`) is always present, making the tooltip\nmisleading.\n- **OTel dataset filter helper**: Extracted `otelDatasetFilter()`\nutility to avoid duplicating the `(data_stream.dataset OR\nevent.dataset)` pattern.\n- **Host OTel unpack path**: Added `metricByFieldOtel` /\n`unpackMetricOtel` so the host table correctly reads OTel metric\npositions instead of falling through to ECS metric keys.\n\n## Test plan\n\n- [x] `yarn test:jest\nx-pack/solutions/observability/plugins/metrics_data_access/public/components/infrastructure_node_metrics_tables/`\n— all 46 tests pass\n- [x] Manual smoke in APM Infrastructure tab with OTel service data\n(e.g. `kbn-otel-demo` with EDOT Collector):\n  - [ ] Hosts tab: CPU count, CPU %, Memory total, Memory % all populate\n- [x] Pods tab: CPU % populates; Memory shows % (with limits) or MB\n(without limits)\n  - [x] Containers tab: CPU % and Memory MB populate for K8s containers","sha":"c6485d753760eac356c74a253cbd440d7ef83227"}},{"branch":"9.3","label":"v9.3.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260988","number":260988,"state":"MERGED","mergeCommit":{"sha":"527a065dfb9714b23dc7ad5ce4b7083647b3a798","message":"[9.3] [APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552) (#260988)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[APM][Infra] Fix OTel metrics mapping in infrastructure tab\n(#259552)](https://github.com/elastic/kibana/pull/259552)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"9.2","label":"v9.2.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/260987","number":260987,"state":"MERGED","mergeCommit":{"sha":"f4e284b5e9e1d3eeadbcdc9c6bacb72a532d9521","message":"[9.2] [APM][Infra] Fix OTel metrics mapping in infrastructure tab (#259552) (#260987)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.2`:\n- [[APM][Infra] Fix OTel metrics mapping in infrastructure tab\n(#259552)](https://github.com/elastic/kibana/pull/259552)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}}]}] BACKPORT-->