### PR TITLE
[Obs AI Assistant] Add maxSize constraint to unbounded arrayOf schemas in rule connector

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.ts
@@ -73,9 +73,10 @@ const ParamsSchema = schema.object({
   prompts: schema.maybe(
     schema.arrayOf(
       schema.object({
-        statuses: schema.arrayOf(schema.string()),
+        statuses: schema.arrayOf(schema.string(), { maxSize: 3 }),
         message: schema.string({ minLength: 1 }),
-      })
+      }),
+      { maxSize: 3 }
     )
   ),
   status: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Adds `maxSize: 3` to the `prompts` and `statuses` `schema.arrayOf()` calls in the Observability AI  assistant rule connector.
                                                                                                       
 The UI already constrains this — the "Add Prompt" button is [disabled when `prompts.length ===     ALERT_STATUSES.length` (3)](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/rule_connector/ai_assistant_params.tsx#L196), and there are only 3 valid alert statuses (`active`, `recovered`, `untracked`). This change enforces the same bounds at the schema validation level for API consumers bypassing the UI.


<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->