### PR TITLE
[Streams] Optimize grok processor preview rendering performance

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
@@ -19,11 +19,10 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { GrokProcessor } from '@kbn/streamlang';
 import { isActionBlock } from '@kbn/streamlang';
 import type { FlattenRecord, SampleDocument } from '@kbn/streams-schema';
 import { isEmpty } from 'lodash';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { useGrokExpressions, GrokExpressionsProvider, GrokSampleWithContext } from '@kbn/grok-ui';
 import { useDocViewerSetup } from '../../../../hooks/use_doc_viewer_setup';
@@ -45,7 +44,7 @@ import {
   NoProcessingDataAvailableEmptyPrompt,
 } from './empty_prompts';
 import { useDataSourceSelector } from './state_management/data_source_state_machine';
-import { selectDraftProcessor } from './state_management/interactive_mode_machine/selectors';
+import { selectDraftProcessorDefinition } from './state_management/interactive_mode_machine/selectors';
 import type { PreviewDocsFilterOption } from './state_management/simulation_state_machine';
 import {
   getAllFieldsInOrder,
@@ -310,35 +309,44 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     selectHasSimulatedRecords(snapshot.context)
   );
 
-  const { currentProcessorSourceField, currentStepId, stepIds } = useStreamEnrichmentSelector(
-    (state) => {
-      const isInteractiveMode = selectIsInteractiveMode(state);
-      if (!isInteractiveMode || !state.context.interactiveModeRef) {
-        return { currentProcessorSourceField: undefined, currentStepId: undefined, stepIds: [] };
+  const currentProcessorSourceField = useStreamEnrichmentSelector((state) => {
+    const isInteractiveMode = selectIsInteractiveMode(state);
+    if (!isInteractiveMode || !state.context.interactiveModeRef) return undefined;
+    const stepRefs = state.context.interactiveModeRef.getSnapshot().context.stepRefs;
+    for (const stepRef of stepRefs) {
+      const snapshot = stepRef.getSnapshot();
+      const step = snapshot.context.step;
+      if (isActionBlock(step) && isStepUnderEdit(snapshot)) {
+        return getSourceField(step);
       }
-
-      const stepRefs = state.context.interactiveModeRef.getSnapshot().context.stepRefs;
-      const allStepIds = stepRefs.map((ref) => ref.id);
-
-      for (const stepRef of stepRefs) {
-        const snapshot = stepRef.getSnapshot();
-        const step = snapshot.context.step;
-
-        if (isActionBlock(step) && isStepUnderEdit(snapshot)) {
-          return {
-            currentProcessorSourceField: getSourceField(step),
-            currentStepId: stepRef.id,
-            stepIds: allStepIds,
-          };
-        }
-      }
-
-      return {
-        currentProcessorSourceField: undefined,
-        currentStepId: undefined,
-        stepIds: allStepIds,
-      };
     }
+    return undefined;
+  });
+
+  const currentStepId = useStreamEnrichmentSelector((state) => {
+    const isInteractiveMode = selectIsInteractiveMode(state);
+    if (!isInteractiveMode || !state.context.interactiveModeRef) return undefined;
+    const stepRefs = state.context.interactiveModeRef.getSnapshot().context.stepRefs;
+    for (const stepRef of stepRefs) {
+      const snapshot = stepRef.getSnapshot();
+      if (isActionBlock(snapshot.context.step) && isStepUnderEdit(snapshot)) {
+        return stepRef.id;
+      }
+    }
+    return undefined;
+  });
+
+  // Stabilize stepIds: join into a string for selector comparison, then split back.
+  // This avoids returning a new array reference on every XState state change.
+  const stepIdsString = useStreamEnrichmentSelector((state) => {
+    const isInteractiveMode = selectIsInteractiveMode(state);
+    if (!isInteractiveMode || !state.context.interactiveModeRef) return '';
+    const stepRefs = state.context.interactiveModeRef.getSnapshot().context.stepRefs;
+    return stepRefs.map((ref) => ref.id).join('\0');
+  });
+  const stepIds = useMemo(
+    () => (stepIdsString ? stepIdsString.split('\0') : []),
+    [stepIdsString]
   );
 
   const processorsMetrics = useSimulatorSelector(
@@ -358,38 +366,66 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     return getAllFieldsInOrder(previewDocuments, detectedFields);
   }, [detectedFields, previewDocuments]);
 
-  const draftProcessor = useStreamEnrichmentSelector((snapshot) => {
+  // Extract only primitive/stable values from the draft processor to avoid re-renders.
+  // We select the grok source field (a string or undefined) and the patterns (joined as a string)
+  // so that the selector returns stable values when the user is typing but hasn't changed
+  // which field is being processed or the set of patterns.
+  const grokSourceField = useStreamEnrichmentSelector((snapshot) => {
     const isInteractiveMode = selectIsInteractiveMode(snapshot);
-    return isInteractiveMode && snapshot.context.interactiveModeRef
-      ? selectDraftProcessor(snapshot.context.interactiveModeRef.getSnapshot().context)
-      : {
-          processor: undefined,
-          resources: undefined,
-        };
+    if (!isInteractiveMode || !snapshot.context.interactiveModeRef) return undefined;
+    const proc = selectDraftProcessorDefinition(
+      snapshot.context.interactiveModeRef.getSnapshot().context
+    );
+    if (proc && 'action' in proc && proc.action === 'grok' && !isEmpty(proc.from)) {
+      return proc.from;
+    }
+    return undefined;
   });
 
-  // Get grok patterns from the draft processor
-  const grokPatterns =
-    draftProcessor?.processor &&
-    'action' in draftProcessor.processor &&
-    draftProcessor.processor.action === 'grok'
-      ? draftProcessor.processor.patterns
-      : [];
+  // Select grok patterns as a joined string for stable comparison.
+  // Only re-renders when the actual pattern text changes, not on unrelated state changes.
+  const grokPatternsString = useStreamEnrichmentSelector((snapshot) => {
+    const isInteractiveMode = selectIsInteractiveMode(snapshot);
+    if (!isInteractiveMode || !snapshot.context.interactiveModeRef) return '';
+    const proc = selectDraftProcessorDefinition(
+      snapshot.context.interactiveModeRef.getSnapshot().context
+    );
+    if (proc && 'action' in proc && proc.action === 'grok') {
+      return proc.patterns.join('\0');
+    }
+    return '';
+  });
 
-  // Convert patterns to DraftGrokExpression instances for field analysis
-  const grokExpressions = useGrokExpressions(grokPatterns);
+  const grokPatterns = useMemo(
+    () => (grokPatternsString ? grokPatternsString.split('\0') : []),
+    [grokPatternsString]
+  );
 
-  // Determine if the grok processor is active (has a from field)
-  const isGrokProcessorActive =
-    draftProcessor?.processor &&
-    'action' in draftProcessor.processor &&
-    draftProcessor.processor.action === 'grok' &&
-    !isEmpty(draftProcessor.processor.from);
+  const isGrokProcessorActive = grokSourceField !== undefined;
 
-  // Get the source field for the grok processor
-  const grokSourceField = isGrokProcessorActive
-    ? (draftProcessor.processor as GrokProcessor).from
-    : undefined;
+  // Debounce grok patterns before passing to useGrokExpressions.
+  // The @kbn/grok-ui updateExpression() calls resolvePattern(true) synchronously,
+  // triggering expensive Oniguruma regex resolution on every keystroke.
+  // Debouncing prevents this per-keystroke cost for highlighting.
+  const [debouncedGrokPatterns, setDebouncedGrokPatterns] = useState(grokPatterns);
+  const grokPatternsDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(() => {
+    // Clear debounced patterns immediately when leaving grok mode to prevent
+    // stale patterns from briefly rendering after switching processor type.
+    if (!isGrokProcessorActive) {
+      clearTimeout(grokPatternsDebounceRef.current);
+      setDebouncedGrokPatterns([]);
+      return;
+    }
+    clearTimeout(grokPatternsDebounceRef.current);
+    grokPatternsDebounceRef.current = setTimeout(() => {
+      setDebouncedGrokPatterns(grokPatterns);
+    }, 1000);
+    return () => clearTimeout(grokPatternsDebounceRef.current);
+  }, [grokPatterns, isGrokProcessorActive]);
+
+  // Convert debounced patterns to DraftGrokExpression instances for highlighting
+  const grokExpressions = useGrokExpressions(debouncedGrokPatterns);
   const validGrokSourceField =
     grokSourceField && allColumns.includes(grokSourceField) ? grokSourceField : undefined;
 
@@ -659,9 +695,11 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     </>
   );
 
-  // Wrap with GrokExpressionsProvider when in grok mode to provide patterns to Sample components
+  // Wrap with GrokExpressionsProvider when in grok mode to provide patterns to Sample components.
+  // Use debouncedGrokPatterns to prevent the provider from re-rendering the entire tree
+  // (including all table cells and GrokSampleWithContext components) on every keystroke.
   return grokMode ? (
-    <GrokExpressionsProvider patterns={grokPatterns}>{content}</GrokExpressionsProvider>
+    <GrokExpressionsProvider patterns={debouncedGrokPatterns}>{content}</GrokExpressionsProvider>
   ) : (
     content
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/selectors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/selectors.ts
@@ -11,9 +11,15 @@ import { isStepUnderEdit } from '../steps_state_machine';
 import type { InteractiveModeContext } from './types';
 
 /**
- * Selects the processor marked as the draft processor.
+ * Selects the processor definition from the draft step (the new step currently being edited).
+ * Returns undefined if no draft step exists.
+ *
+ * NOTE: This returns the processor *definition* directly (or undefined), NOT a wrapper object.
+ * Returning a bare value instead of `{ processor }` avoids creating a new object reference
+ * on every XState state change, which would bust React's selector memoization and cause
+ * expensive re-renders of the entire preview table on every keystroke.
  */
-export const selectDraftProcessor = (context: InteractiveModeContext) => {
+export const selectDraftProcessorDefinition = (context: InteractiveModeContext) => {
   const draft = context.stepRefs.find((stepRef) => {
     const snapshot = stepRef.getSnapshot();
     return (
@@ -23,13 +29,9 @@ export const selectDraftProcessor = (context: InteractiveModeContext) => {
 
   const snapshot = draft?.getSnapshot();
 
-  return draft && isActionBlock(snapshot?.context.step)
-    ? {
-        processor: snapshot?.context.step,
-      }
-    : {
-        processor: undefined,
-      };
+  return draft && snapshot && isActionBlock(snapshot.context.step)
+    ? snapshot.context.step
+    : undefined;
 };
 
 /**


### PR DESCRIPTION
## Summary
Performance optimization for the processing preview table when editing grok processors:
- Split object-returning selectors into primitive-returning selectors (strings) to prevent unstable references from busting React.memo
- Debounce grok patterns (1s) before `useGrokExpressions` to avoid synchronous Oniguruma regex resolution on every keystroke
- Pass debounced patterns to `GrokExpressionsProvider` to prevent context tree re-renders

## Test plan
- [ ] Edit a grok processor — rapidly type in pattern field, verify no UI lag
- [ ] Verify grok highlighting still works (appears after ~1s pause)
- [ ] Verify no regressions on other processor types