### PR TITLE
[Discover][Logs] Fix Similar Errors Lens chart failure

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
@@ -72,6 +72,11 @@ export interface TracesFlyout {
       readonly spanLinks: {
         readonly openInDiscoverButton: Locator;
       };
+      readonly similarErrors: {
+        readonly section: Locator;
+        readonly occurrencesChart: Locator;
+        readonly errorCallout: Locator;
+      };
       close(): Promise<void>;
     };
   };
@@ -175,6 +180,15 @@ export function createTracesFlyout(page: ScoutPage): TracesFlyout {
           spanLinks: {
             openInDiscoverButton: childDocContainer.locator(
               '[data-test-subj="docViewerSpanLinksOpenInDiscoverButton"]'
+            ),
+          },
+          similarErrors: {
+            section: childDocContainer.locator('[data-test-subj="docViewerSimilarErrorsSection"]'),
+            occurrencesChart: childDocContainer.locator(
+              '[data-test-subj="docViewerSimilarErrorsOccurrencesChart"]'
+            ),
+            errorCallout: childDocContainer.locator(
+              '[data-test-subj="docViewerSimilarErrorsOccurrencesChart"] [data-test-subj="embeddable-lens-failure"]'
             ),
           },
           async close() {

--- a/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/logs_overview_tab.spec.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/parallel_tests/traces_experience/logs_overview_tab.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { tags } from '@kbn/scout';
+import { expect } from '@kbn/scout/ui';
+import type { PageObjects } from '@kbn/scout';
+import {
+  spaceTest,
+  TRACES,
+  RICH_TRACE,
+  setupTracesExperience,
+  teardownTracesExperience,
+} from '../../fixtures/traces_experience';
+import type { TracesFlyout } from '../../fixtures/traces_experience/page_objects/flyout';
+
+type DiscoverPage = PageObjects['discover'];
+
+const openTraceTimeline = async (pageObjects: {
+  discover: DiscoverPage;
+  tracesExperience: {
+    openOverviewTab: (d: DiscoverPage) => Promise<void>;
+    flyout: TracesFlyout;
+  };
+}) => {
+  await pageObjects.discover.goto();
+  await pageObjects.discover.writeAndSubmitEsqlQuery(
+    `${TRACES.ESQL_QUERY} | WHERE transaction.name == "${RICH_TRACE.TRANSACTION_NAME}"`
+  );
+  await pageObjects.tracesExperience.openOverviewTab(pageObjects.discover);
+  const { flyout } = pageObjects.tracesExperience;
+  await flyout.traceSummary.fullScreenButton.click();
+  await expect(flyout.waterfallFlyout.container).toBeVisible();
+};
+
+spaceTest.describe(
+  'Traces in Discover - Logs overview tab',
+  {
+    tag: [...tags.stateful.all, ...tags.serverless.observability.complete],
+  },
+  () => {
+    spaceTest.beforeAll(async ({ scoutSpace, config }) => {
+      await setupTracesExperience(scoutSpace, config);
+    });
+
+    spaceTest.beforeEach(async ({ browserAuth }) => {
+      await browserAuth.loginAsViewer();
+    });
+
+    spaceTest.afterAll(async ({ scoutSpace }) => {
+      await teardownTracesExperience(scoutSpace);
+    });
+
+    spaceTest(
+      'Similar errors - occurrences chart renders without error in the log child flyout',
+      async ({ pageObjects }) => {
+        const { flyout } = pageObjects.tracesExperience;
+
+        await spaceTest.step('open the trace timeline', async () => {
+          await openTraceTimeline(pageObjects);
+        });
+
+        await spaceTest.step(
+          'click the error badge on the DB span to open the log flyout',
+          async () => {
+            const { errorBadge } = flyout.waterfallFlyout.getWaterfallItem(RICH_TRACE.DB_SPAN_NAME);
+            await errorBadge.click();
+          }
+        );
+
+        await spaceTest.step('occurrences chart renders without an error callout', async () => {
+          await expect(
+            flyout.waterfallFlyout.childDocFlyout.similarErrors.occurrencesChart
+          ).toBeVisible();
+          await expect(
+            flyout.waterfallFlyout.childDocFlyout.similarErrors.errorCallout
+          ).toBeHidden();
+        });
+      }
+    );
+  }
+);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/similar_errors/similar_errors_occurrences_chart/index.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/similar_errors/similar_errors_occurrences_chart/index.tsx
@@ -132,8 +132,7 @@ export function SimilarErrorsOccurrencesChart({
       getSerializedStateForChild: () => ({
         attributes: lensAttributes,
         viewMode: 'view',
-        timeRange,
-        esqlVariables: [],
+        time_range: timeRange,
       }),
       noPadding: true,
     };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/similar_errors/similar_errors_occurrences_chart/similar_errors_occurrences_chart.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/sub_components/similar_errors/similar_errors_occurrences_chart/similar_errors_occurrences_chart.test.tsx
@@ -33,11 +33,14 @@ jest.mock('../../../../content_framework/chart', () => ({
   ),
 }));
 
+let capturedGetParentApi: (() => any) | undefined;
+
 jest.mock('@kbn/embeddable-plugin/public', () => {
   const original = jest.requireActual('@kbn/embeddable-plugin/public');
   return {
     ...original,
-    EmbeddableRenderer: ({ type, getParentApi, hidePanelChrome }: any) => {
+    EmbeddableRenderer: ({ type, getParentApi }: any) => {
+      capturedGetParentApi = getParentApi;
       return <div data-test-subj="lensEmbeddableSimilarErrorsChart">Lens Chart (type: {type})</div>;
     },
   };
@@ -75,6 +78,7 @@ const LensConfigBuilderMock = LensConfigBuilder as jest.MockedClass<typeof LensC
 describe('SimilarErrorsOccurrencesChart', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedGetParentApi = undefined;
     mockUseDataSourcesContext.mockReturnValue({
       indexes: { logs: 'logs-*', apm: {} },
     });
@@ -180,6 +184,19 @@ describe('SimilarErrorsOccurrencesChart', () => {
     const annotationLayer = layers.find((layer: any) => layer.type === 'annotation');
     expect(annotationLayer.events[0].datetime).toBe(timestamp);
     expect(annotationLayer.events[0].name).toBe('Current document');
+  });
+
+  it('passes time_range in serialized state so Lens can resolve ?_tstart/?_tend', async () => {
+    const baseQuery = where('service.name == ?serviceName', { serviceName: 'test-service' });
+    render(<SimilarErrorsOccurrencesChart baseEsqlQuery={baseQuery} />);
+
+    await waitFor(() => {
+      expect(capturedGetParentApi).toBeDefined();
+    });
+
+    const serializedState = capturedGetParentApi!().getSerializedStateForChild();
+    expect(serializedState.time_range).toEqual({ from: 'now-15m', to: 'now' });
+    expect(serializedState).not.toHaveProperty('esqlVariables');
   });
 
   it('does not add annotation layer when currentDocumentTimestamp is not provided', async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/261097

The occurrences chart in the Similar Errors section was failing with an ES error about unknown query parameters `[_tstart]` and `[_tend]`.

These are standard Kibana ES|QL named params that Lens resolves from the panel's time range. The chart renders in standalone mode using `EmbeddableRenderer`, so no dashboard container, no global time range. The parent API was passing the time range under the key `timeRange` (camelCase), which Lens silently ignored. Without a time range to work from, `?_tstart` and `?_tend` were sent to ES unresolved.


|Before|After|
|-|-|
|<img width="1920" height="969" alt="Screenshot 2026-04-03 at 09 34 42" src="https://github.com/user-attachments/assets/50d0021d-eb83-429d-9a66-803271a7c9d2" />|<img width="1920" height="969" alt="Screenshot 2026-04-03 at 09 29 52" src="https://github.com/user-attachments/assets/ded98f11-c811-40ad-8cb7-743761cb0e14" />|

This was a regression likely introduced by https://github.com/elastic/kibana/pull/247997, which flattened the `rawState` wrapper in the Lens embeddable initialization and changed the expected field name in the process.

A Scout test is added to the traces experience suite to cover this: it navigates to a trace with errors, opens the expanded waterfall, clicks an error badge to open the log flyout, and asserts the occurrences chart renders without an error callout.

There is also an [issue planned to improve how we monitor failures in Lens charts](https://github.com/elastic/observability-dev/issues/5348), which should help ensure we are properly notified when something like this happens.
