### PR TITLE
[9.3] [ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout (#260029)

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -154,6 +154,7 @@ enabled:
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group6/config.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group7/config.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group8/config.ts
+  - x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/config.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group3/config_with_schedule_circuit_breaker.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group2/config_non_dedicated_task_runner.ts
   - x-pack/platform/test/alerting_api_integration/security_and_spaces/group4/config_non_dedicated_task_runner.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2269,6 +2269,7 @@ src/platform/packages/shared/kbn-connector-specs/src/specs/virustotal/** @elasti
 /x-pack/platform/plugins/shared/alerting/server/lib/rule_gaps @elastic/response-ops @elastic/security-detection-engine
 /x-pack/platform/plugins/shared/alerting/server/routes/gaps @elastic/response-ops @elastic/security-detection-engine
 /x-pack/platform/test/alerting_api_integration/security_and_spaces/group8/tests/alerting/gap @elastic/response-ops @elastic/security-detection-engine
+/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap @elastic/response-ops @elastic/security-detection-engine
 
 # Enterprise Search
 # search

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/config.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseConfig = await readConfigFile(require.resolve('../group8/config.ts'));
+  return {
+    ...baseConfig.getAll(),
+    testFiles: [require.resolve('./tests')],
+    junit: {
+      reportName: 'X-Pack Alerting API Integration Tests - Security and Spaces - Group 17',
+    },
+  };
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/get_rules_with_gaps.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/get_rules_with_gaps.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { UserAtSpaceScenarios } from '../../../../scenarios';
+import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../../scenarios';
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../../common/lib';
 
@@ -58,7 +58,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               .expect(200);
           });
 
-          it('should return rules with gaps in given time range', async () => {
+          it('should not return the rule id of a deleted rule', async () => {
             // Create 2 rules
             const rresponse1 = await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
@@ -68,13 +68,14 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             const ruleId1 = rresponse1.body.id;
             objectRemover.add(apiOptions.spaceId, ruleId1, 'rule', 'alerting');
 
-            const rresponse2 = await supertest
+            const response2 = await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
               .set('kbn-xsrf', 'foo')
               .send(getRule())
               .expect(200);
-            const ruleId2 = rresponse2.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId2, 'rule', 'alerting');
+            // This rule is intended to be removed during the test.
+            // However it is added to the object remover when not applicable
+            const ruleId2 = response2.body.id;
 
             // Create gaps for both rules
             await supertest
@@ -97,7 +98,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                 spaceId: apiOptions.spaceId,
               });
 
-            const response = await supertestWithoutAuth
+            let response = await supertestWithoutAuth
               .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
               .set('kbn-xsrf', 'foo')
               .auth(apiOptions.username, apiOptions.password)
@@ -109,6 +110,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             switch (scenario.id) {
               case 'no_kibana_privileges at space1':
               case 'space_1_all at space2':
+                objectRemover.add(apiOptions.spaceId, ruleId2, 'rule', 'alerting');
                 expect(response.statusCode).to.eql(403);
                 expect(response.body).to.eql({
                   error: 'Forbidden',
@@ -116,7 +118,7 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                     'Failed to find rules with gaps: Unauthorized to find rules for any rule types',
                   statusCode: 403,
                 });
-                break;
+                return;
 
               case 'global_read at space1':
               case 'space_1_all_alerts_none_actions at space1':
@@ -133,205 +135,29 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               default:
                 throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
             }
-          });
 
-          it('should return rules ordered by oldest gap first by default', async () => {
-            const rresponse1 = await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
+            // Delete rule 2.
+            const deleteResponse = await supertestWithoutAuth
+              .delete(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule/${ruleId2}`)
               .set('kbn-xsrf', 'foo')
-              .send(getRule())
-              .expect(200);
-            const ruleId1 = rresponse1.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId1, 'rule', 'alerting');
+              .auth(SuperuserAtSpace1.user.username, SuperuserAtSpace1.user.password);
 
-            const rresponse2 = await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
-              .set('kbn-xsrf', 'foo')
-              .send(getRule())
-              .expect(200);
-            const ruleId2 = rresponse2.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId2, 'rule', 'alerting');
-
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId1,
-                start: gap1Start,
-                end: gap1End,
-                spaceId: apiOptions.spaceId,
-              });
-            // Additional gap for rule 1 (later than first)
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId1,
-                start: '2024-01-08T00:00:00.000Z',
-                end: '2024-01-09T00:00:00.000Z',
-                spaceId: apiOptions.spaceId,
-              });
-
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId2,
-                start: gap2Start,
-                end: gap2End,
-                spaceId: apiOptions.spaceId,
-              });
-            // Additional gap for rule 2 (later than first)
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId2,
-                start: '2024-01-18T00:00:00.000Z',
-                end: '2024-01-19T00:00:00.000Z',
-                spaceId: apiOptions.spaceId,
-              });
-
-            const response = await supertestWithoutAuth
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
-              .set('kbn-xsrf', 'foo')
-              .auth(apiOptions.username, apiOptions.password)
-              .send({ start: searchStart, end: searchEnd });
-
-            switch (scenario.id) {
-              case 'global_read at space1':
-              case 'space_1_all_alerts_none_actions at space1':
-              case 'superuser at space1':
-              case 'space_1_all at space1':
-              case 'space_1_all_with_restricted_fixture at space1':
-                expect(response.statusCode).to.eql(200);
-                expect(response.body.rule_ids).to.eql([ruleId1, ruleId2]);
-                break;
-              case 'no_kibana_privileges at space1':
-              case 'space_1_all at space2':
-                expect(response.statusCode).to.eql(403);
-                break;
-              default:
-                throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
+            if (deleteResponse.statusCode !== 204) {
+              objectRemover.add(apiOptions.spaceId, ruleId2, 'rule', 'alerting');
             }
-          });
 
-          it('should return rules ordered by newest gap first when sort_order is desc', async () => {
-            const rresponse1 = await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
-              .set('kbn-xsrf', 'foo')
-              .send(getRule())
-              .expect(200);
-            const ruleId1 = rresponse1.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId1, 'rule', 'alerting');
+            expect(deleteResponse.statusCode).to.eql(204);
 
-            const rresponse2 = await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
-              .set('kbn-xsrf', 'foo')
-              .send(getRule())
-              .expect(200);
-            const ruleId2 = rresponse2.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId2, 'rule', 'alerting');
-
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId1,
-                start: gap1Start,
-                end: gap1End,
-                spaceId: apiOptions.spaceId,
-              });
-            // Additional gap for rule 1 (later than first)
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId1,
-                start: '2024-01-08T00:00:00.000Z',
-                end: '2024-01-09T00:00:00.000Z',
-                spaceId: apiOptions.spaceId,
-              });
-
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId2,
-                start: gap2Start,
-                end: gap2End,
-                spaceId: apiOptions.spaceId,
-              });
-            // Additional gap for rule 2 (later than first)
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId: ruleId2,
-                start: '2024-01-18T00:00:00.000Z',
-                end: '2024-01-19T00:00:00.000Z',
-                spaceId: apiOptions.spaceId,
-              });
-
-            const response = await supertestWithoutAuth
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
-              .set('kbn-xsrf', 'foo')
-              .auth(apiOptions.username, apiOptions.password)
-              .send({ start: searchStart, end: searchEnd, sort_order: 'desc' });
-
-            switch (scenario.id) {
-              case 'global_read at space1':
-              case 'space_1_all_alerts_none_actions at space1':
-              case 'superuser at space1':
-              case 'space_1_all at space1':
-              case 'space_1_all_with_restricted_fixture at space1':
-                expect(response.statusCode).to.eql(200);
-                expect(response.body.rule_ids).to.eql([ruleId2, ruleId1]);
-                break;
-              case 'no_kibana_privileges at space1':
-              case 'space_1_all at space2':
-                expect(response.statusCode).to.eql(403);
-                break;
-              default:
-                throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
-            }
-          });
-
-          it('should filter rules by unfilled gap status', async () => {
-            const ruleResponse = await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
-              .set('kbn-xsrf', 'foo')
-              .send(getRule())
-              .expect(200);
-            const ruleId = ruleResponse.body.id;
-            objectRemover.add(apiOptions.spaceId, ruleId, 'rule', 'alerting');
-
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId,
-                start: gap1Start,
-                end: gap1End,
-                spaceId: apiOptions.spaceId,
-              });
-
-            const response = await supertestWithoutAuth
+            response = await supertestWithoutAuth
               .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
               .set('kbn-xsrf', 'foo')
               .auth(apiOptions.username, apiOptions.password)
               .send({
                 start: searchStart,
                 end: searchEnd,
-                statuses: ['unfilled'],
               });
 
             switch (scenario.id) {
-              case 'no_kibana_privileges at space1':
-              case 'space_1_all at space2':
-                expect(response.statusCode).to.eql(403);
-                break;
-
               case 'global_read at space1':
               case 'space_1_all_alerts_none_actions at space1':
               case 'superuser at space1':
@@ -339,7 +165,8 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               case 'space_1_all_with_restricted_fixture at space1':
                 expect(response.statusCode).to.eql(200);
                 expect(response.body.total).to.eql(1);
-                expect(response.body.rule_ids).to.eql([ruleId]);
+                expect(response.body.rule_ids).to.have.length(1);
+                expect(response.body.rule_ids).to.contain(ruleId1);
                 break;
 
               default:
@@ -347,7 +174,8 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             }
           });
 
-          it('should return empty result when filtering by filled gap status', async () => {
+          it('should return empty result when no gaps exist', async () => {
+            // Create a rule without gaps
             const ruleResponse = await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
               .set('kbn-xsrf', 'foo')
@@ -356,16 +184,6 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             const ruleId = ruleResponse.body.id;
             objectRemover.add(apiOptions.spaceId, ruleId, 'rule', 'alerting');
 
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId,
-                start: gap1Start,
-                end: gap1End,
-                spaceId: apiOptions.spaceId,
-              });
-
             const response = await supertestWithoutAuth
               .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
               .set('kbn-xsrf', 'foo')
@@ -373,7 +191,6 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               .send({
                 start: searchStart,
                 end: searchEnd,
-                statuses: ['filled'],
               });
 
             switch (scenario.id) {
@@ -397,7 +214,8 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             }
           });
 
-          it('should filter rules by aggregated unfilled status', async () => {
+          it('should return latest gap timestamp when gaps exist', async () => {
+            // Create a rule
             const ruleResponse = await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
               .set('kbn-xsrf', 'foo')
@@ -406,13 +224,32 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             const ruleId = ruleResponse.body.id;
             objectRemover.add(apiOptions.spaceId, ruleId, 'rule', 'alerting');
 
+            // Create gaps with different timestamps
+            const earlyGapStart = '2024-01-05T00:00:00.000Z';
+            const earlyGapEnd = '2024-01-06T00:00:00.000Z';
+            const lateGapStart = '2024-01-25T00:00:00.000Z';
+            const lateGapEnd = '2024-01-26T00:00:00.000Z';
+
+            // Report early gap first
             await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
               .set('kbn-xsrf', 'foo')
               .send({
                 ruleId,
-                start: gap1Start,
-                end: gap1End,
+                start: earlyGapStart,
+                end: earlyGapEnd,
+                spaceId: apiOptions.spaceId,
+              });
+
+            // Report late gap second (this should have the latest ingestion timestamp)
+            const lateGapReportTime = Date.now();
+            await supertest
+              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
+              .set('kbn-xsrf', 'foo')
+              .send({
+                ruleId,
+                start: lateGapStart,
+                end: lateGapEnd,
                 spaceId: apiOptions.spaceId,
               });
 
@@ -423,7 +260,6 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               .send({
                 start: searchStart,
                 end: searchEnd,
-                highest_priority_gap_fill_statuses: ['unfilled'],
               });
 
             switch (scenario.id) {
@@ -440,6 +276,10 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                 expect(response.statusCode).to.eql(200);
                 expect(response.body.total).to.eql(1);
                 expect(response.body.rule_ids).to.eql([ruleId]);
+                expect(response.body.latest_gap_timestamp).to.be.a('number');
+                // The latest gap timestamp should be the ingestion time of the most recently reported gap
+                // Since we reported the late gap last, it should have the latest ingestion timestamp
+                expect(response.body.latest_gap_timestamp).to.be.greaterThan(lateGapReportTime);
                 break;
 
               default:
@@ -447,7 +287,8 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             }
           });
 
-          it('should return empty result when filtering by aggregated filled status', async () => {
+          it('should not return latest gap timestamp when no gaps exist', async () => {
+            // Create a rule without gaps
             const ruleResponse = await supertest
               .post(`${getUrlPrefix(apiOptions.spaceId)}/api/alerting/rule`)
               .set('kbn-xsrf', 'foo')
@@ -456,16 +297,6 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
             const ruleId = ruleResponse.body.id;
             objectRemover.add(apiOptions.spaceId, ruleId, 'rule', 'alerting');
 
-            await supertest
-              .post(`${getUrlPrefix(apiOptions.spaceId)}/_test/report_gap`)
-              .set('kbn-xsrf', 'foo')
-              .send({
-                ruleId,
-                start: gap1Start,
-                end: gap1End,
-                spaceId: apiOptions.spaceId,
-              });
-
             const response = await supertestWithoutAuth
               .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
               .set('kbn-xsrf', 'foo')
@@ -473,7 +304,6 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
               .send({
                 start: searchStart,
                 end: searchEnd,
-                highest_priority_gap_fill_statuses: ['filled'],
               });
 
             switch (scenario.id) {
@@ -490,10 +320,45 @@ export default function getRuleIdsWithGapsTests({ getService }: FtrProviderConte
                 expect(response.statusCode).to.eql(200);
                 expect(response.body.total).to.eql(0);
                 expect(response.body.rule_ids).to.eql([]);
+                expect(response.body.latest_gap_timestamp).to.eql(undefined);
                 break;
 
               default:
                 throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
+            }
+          });
+
+          it('should handle invalid parameters', async () => {
+            const invalidBodies = [
+              {
+                body: {
+                  start: 'invalid-date',
+                  end: searchEnd,
+                },
+                expectedError: '[request body]: [start]: query start must be valid date',
+              },
+              {
+                body: {
+                  start: searchStart,
+                  end: 'invalid-date',
+                },
+                expectedError: '[request body]: [end]: query end must be valid date',
+              },
+            ];
+
+            for (const { body, expectedError } of invalidBodies) {
+              const response = await supertestWithoutAuth
+                .post(`${getUrlPrefix(apiOptions.spaceId)}/internal/alerting/rules/gaps/_get_rules`)
+                .set('kbn-xsrf', 'foo')
+                .auth(apiOptions.username, apiOptions.password)
+                .send(body);
+
+              expect(response.statusCode).to.eql(400);
+              expect(response.body).to.eql({
+                statusCode: 400,
+                error: 'Bad Request',
+                message: expectedError,
+              });
             }
           });
         });

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/gap/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+
+export default function gapsTests({ loadTestFile }: FtrProviderContext) {
+  describe('rule gaps', () => {
+    loadTestFile(require.resolve('./get_rules_with_gaps'));
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/alerting/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { setupSpacesAndUsers, tearDown } from '../../../setup';
+
+export default function alertingTests({ loadTestFile, getService }: FtrProviderContext) {
+  describe('Alerts - Group 17', () => {
+    describe('alerts', () => {
+      before(async () => {
+        await setupSpacesAndUsers(getService);
+      });
+
+      after(async () => {
+        await tearDown(getService);
+      });
+
+      loadTestFile(require.resolve('./gap'));
+    });
+  });
+}

--- a/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/index.ts
+++ b/x-pack/platform/test/alerting_api_integration/security_and_spaces/group17/tests/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {
+  describe('alerting api integration security and spaces enabled', function () {
+    loadTestFile(require.resolve('./alerting'));
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout (#260029)](https://github.com/elastic/kibana/pull/260029)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stelios Mavro","email":"81311181+steliosmavro@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-31T11:55:34Z","message":"[ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout (#260029)\n\n## Summary\n\n`security_and_spaces/group8` had 262 tests taking ~40 minutes. With ~10\nminutes of step overhead this consistently exceeded the 50-minute\nBuildkite timeout — all tests passed but the step was killed during\npost-test cleanup, triggering 3 automatic retries and wasting ~236\nminutes of CI time per affected PR.\n\nSplit into two groups targeting ~20 minutes each, with minor test\nquality fixes along the way.\n\n## Changes\n\n- **group8** — 5 `it` blocks: return rules with gaps, ordering\n(asc/desc), filter by gap status, filter by aggregated status\n- **group17** (new) — 5 `it` blocks: deleted rule, empty results, latest\ngap timestamp, no timestamp when no gaps, invalid params\n- Registered `group17` in `.buildkite/ftr_platform_stateful_configs.yml`\nand `.github/CODEOWNERS`\n- Replaced inline `if` auth guard with a consistent `switch` pattern\nmatching the rest of the file\n- Split \"filter by gap status\" `it` block into separate `unfilled` and\n`filled` assertions","sha":"37a00eb6f6cc1793c5db0e88796f9c53fd21065a","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout","number":260029,"url":"https://github.com/elastic/kibana/pull/260029","mergeCommit":{"message":"[ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout (#260029)\n\n## Summary\n\n`security_and_spaces/group8` had 262 tests taking ~40 minutes. With ~10\nminutes of step overhead this consistently exceeded the 50-minute\nBuildkite timeout — all tests passed but the step was killed during\npost-test cleanup, triggering 3 automatic retries and wasting ~236\nminutes of CI time per affected PR.\n\nSplit into two groups targeting ~20 minutes each, with minor test\nquality fixes along the way.\n\n## Changes\n\n- **group8** — 5 `it` blocks: return rules with gaps, ordering\n(asc/desc), filter by gap status, filter by aggregated status\n- **group17** (new) — 5 `it` blocks: deleted rule, empty results, latest\ngap timestamp, no timestamp when no gaps, invalid params\n- Registered `group17` in `.buildkite/ftr_platform_stateful_configs.yml`\nand `.github/CODEOWNERS`\n- Replaced inline `if` auth guard with a consistent `switch` pattern\nmatching the rest of the file\n- Split \"filter by gap status\" `it` block into separate `unfilled` and\n`filled` assertions","sha":"37a00eb6f6cc1793c5db0e88796f9c53fd21065a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260029","number":260029,"mergeCommit":{"message":"[ResponseOps] Split alerting security_and_spaces group8 FTR config to fix CI timeout (#260029)\n\n## Summary\n\n`security_and_spaces/group8` had 262 tests taking ~40 minutes. With ~10\nminutes of step overhead this consistently exceeded the 50-minute\nBuildkite timeout — all tests passed but the step was killed during\npost-test cleanup, triggering 3 automatic retries and wasting ~236\nminutes of CI time per affected PR.\n\nSplit into two groups targeting ~20 minutes each, with minor test\nquality fixes along the way.\n\n## Changes\n\n- **group8** — 5 `it` blocks: return rules with gaps, ordering\n(asc/desc), filter by gap status, filter by aggregated status\n- **group17** (new) — 5 `it` blocks: deleted rule, empty results, latest\ngap timestamp, no timestamp when no gaps, invalid params\n- Registered `group17` in `.buildkite/ftr_platform_stateful_configs.yml`\nand `.github/CODEOWNERS`\n- Replaced inline `if` auth guard with a consistent `switch` pattern\nmatching the rest of the file\n- Split \"filter by gap status\" `it` block into separate `unfilled` and\n`filled` assertions","sha":"37a00eb6f6cc1793c5db0e88796f9c53fd21065a"}}]}] BACKPORT-->