### PR TITLE
[9.2] [Cases] add status column to add to existing case modal and disable select button for closed cases (#260990)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -399,6 +399,32 @@ describe('AllCasesListGeneric', () => {
     });
   });
 
+  it('should disable select and not call onRowClick for closed cases with modal=true', async () => {
+    const theCase = {
+      ...defaultGetCases.data.cases[0],
+      status: CaseStatuses.closed,
+    };
+    useGetCasesMock.mockReturnValue({
+      ...defaultGetCases,
+      data: {
+        ...defaultGetCases.data,
+        cases: [theCase, ...defaultGetCases.data.cases.slice(1)],
+      },
+    });
+
+    renderWithTestingProviders(<AllCasesList isSelectorView={true} onRowClick={onRowClick} />);
+
+    const selectButton = await screen.findByTestId(`cases-table-row-select-${theCase.id}`);
+    expect(selectButton).toBeDisabled();
+    expect(selectButton).toHaveTextContent('Select');
+    expect(selectButton).not.toHaveTextContent('Added');
+
+    await userEvent.click(selectButton);
+    await waitFor(() => {
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
   it('should NOT call onRowClick when clicking a case with modal=true', async () => {
     renderWithTestingProviders(<AllCasesList isSelectorView={false} />);
 

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -303,6 +303,13 @@ describe('useCasesColumns ', () => {
             "width": "15%",
           },
           Object {
+            "field": "status",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "100px",
+          },
+          Object {
             "field": "severity",
             "name": "Severity",
             "render": [Function],
@@ -352,6 +359,13 @@ describe('useCasesColumns ', () => {
             "render": [Function],
             "sortable": true,
             "width": "15%",
+          },
+          Object {
+            "field": "status",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "100px",
           },
           Object {
             "field": "severity",
@@ -405,6 +419,13 @@ describe('useCasesColumns ', () => {
             "width": "15%",
           },
           Object {
+            "field": "status",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+            "width": "100px",
+          },
+          Object {
             "field": "severity",
             "name": "Severity",
             "render": [Function],
@@ -419,6 +440,29 @@ describe('useCasesColumns ', () => {
         ],
         "isLoadingColumns": false,
         "rowHeader": "title",
+      }
+    `);
+  });
+
+  it('keeps the selector action column for closed status filtering', async () => {
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          isSelectorView: true,
+          filterStatus: [CaseStatuses.closed],
+        }),
+      {
+        wrapper: TestProviders,
+      }
+    );
+
+    const assignActionColumn = result.current.columns[result.current.columns.length - 1];
+    expect(assignActionColumn).toMatchInlineSnapshot(`
+      Object {
+        "align": "right",
+        "render": [Function],
+        "width": "120px",
       }
     `);
   });

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { Status } from '@kbn/cases-components/src/status/status';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { CaseStatuses } from '../../../common/types/domain';
 
 import type { ActionConnector } from '../../../common/types/domain';
 import type { CaseUI } from '../../../common/ui/types';
@@ -329,16 +330,18 @@ export const useCasesColumns = ({
         align: RIGHT_ALIGNMENT,
         render: (theCase: CaseUI) => {
           if (theCase.id != null) {
-            const disabled = disabledCases?.has(theCase.id) ?? false;
+            const isAlreadyAttached = disabledCases?.has(theCase.id) ?? false;
+            const isClosed = theCase.status === CaseStatuses.closed;
+            const disabled = isAlreadyAttached || isClosed;
             return (
               <EuiButton
                 data-test-subj={`cases-table-row-select-${theCase.id}`}
                 onClick={() => assignCaseAction(theCase)}
                 size="s"
-                iconType={disabled ? 'check' : undefined}
+                iconType={isAlreadyAttached ? 'check' : undefined}
                 disabled={disabled}
               >
-                {disabled ? i18n.ALREADY_ATTACHED : i18n.SELECT}
+                {isAlreadyAttached ? i18n.ALREADY_ATTACHED : i18n.SELECT}
               </EuiButton>
             );
           }

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -100,7 +100,7 @@ export const useCasesColumnsConfiguration = (
     status: {
       field: 'status',
       name: i18n.STATUS,
-      canDisplay: canDisplayDefault && !isSelectorView,
+      canDisplay: canDisplayDefault,
       isCheckedDefault: true,
     },
     severity: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Cases] add status column to add to existing case modal and disable select button for closed cases (#260990)](https://github.com/elastic/kibana/pull/260990)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2026-04-02T21:28:32Z","message":"[Cases] add status column to add to existing case modal and disable select button for closed cases (#260990)\n\n## Summary\n\nThis PR makes a small UI changes to the `Add to existing case` modal:\n- we're now showing the status column, to show the status of the case\n- we're now disabling the `Select` button when the case is closed\n\n### Reason for the change\n\nWhile testing the `Add to existing case` functionality in the new\ndocument flyout, I realized that when you select a case that is already\nclosed, the UI lets you do that like for an opened case. We close the\nmodal, but then a couple of seconds later we show a pop up that says\n`Can't add an alert to a closed case`.\n\n\nhttps://github.com/user-attachments/assets/182544df-6ebe-48d1-99bb-1480c1cd3f20\n\nThis UX isn't ideal, instead we should let the user know that the case\nis closed and prevent them from selecting it.\n\n### Small UI changes\n\nHere's the new UI, with the added status column and the disabled button:\n\n\nhttps://github.com/user-attachments/assets/aa505bef-1cc3-4b32-8670-6f93b841ee38\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1c627488d779c640ed877f16a25571fb6c4939f1","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting:Investigations","backport:all-open","v9.4.0"],"title":"[Cases] add status column to add to existing case modal and disable select button for closed cases","number":260990,"url":"https://github.com/elastic/kibana/pull/260990","mergeCommit":{"message":"[Cases] add status column to add to existing case modal and disable select button for closed cases (#260990)\n\n## Summary\n\nThis PR makes a small UI changes to the `Add to existing case` modal:\n- we're now showing the status column, to show the status of the case\n- we're now disabling the `Select` button when the case is closed\n\n### Reason for the change\n\nWhile testing the `Add to existing case` functionality in the new\ndocument flyout, I realized that when you select a case that is already\nclosed, the UI lets you do that like for an opened case. We close the\nmodal, but then a couple of seconds later we show a pop up that says\n`Can't add an alert to a closed case`.\n\n\nhttps://github.com/user-attachments/assets/182544df-6ebe-48d1-99bb-1480c1cd3f20\n\nThis UX isn't ideal, instead we should let the user know that the case\nis closed and prevent them from selecting it.\n\n### Small UI changes\n\nHere's the new UI, with the added status column and the disabled button:\n\n\nhttps://github.com/user-attachments/assets/aa505bef-1cc3-4b32-8670-6f93b841ee38\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1c627488d779c640ed877f16a25571fb6c4939f1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/260990","number":260990,"mergeCommit":{"message":"[Cases] add status column to add to existing case modal and disable select button for closed cases (#260990)\n\n## Summary\n\nThis PR makes a small UI changes to the `Add to existing case` modal:\n- we're now showing the status column, to show the status of the case\n- we're now disabling the `Select` button when the case is closed\n\n### Reason for the change\n\nWhile testing the `Add to existing case` functionality in the new\ndocument flyout, I realized that when you select a case that is already\nclosed, the UI lets you do that like for an opened case. We close the\nmodal, but then a couple of seconds later we show a pop up that says\n`Can't add an alert to a closed case`.\n\n\nhttps://github.com/user-attachments/assets/182544df-6ebe-48d1-99bb-1480c1cd3f20\n\nThis UX isn't ideal, instead we should let the user know that the case\nis closed and prevent them from selecting it.\n\n### Small UI changes\n\nHere's the new UI, with the added status column and the disabled button:\n\n\nhttps://github.com/user-attachments/assets/aa505bef-1cc3-4b32-8670-6f93b841ee38\n\n### Checklist\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- [x] Review the [backport\nguidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing)\nand apply applicable `backport:*` labels.","sha":"1c627488d779c640ed877f16a25571fb6c4939f1"}},{"url":"https://github.com/elastic/kibana/pull/261142","number":261142,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->