### PR TITLE
Make processor description clickable to edit

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/edit_step_description_modal.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/edit_step_description_modal.tsx
@@ -60,7 +60,7 @@ export const EditStepDescriptionModal: React.FC<EditStepDescriptionModalProps> =
   const [value, setValue] = useState(initialValue);
 
   const handleSave = () => {
-    onSave(value);
+    onSave(value.trim());
   };
 
   const isEditMode = Boolean(step.description?.trim());

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -306,6 +306,7 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                   data-test-subj="streamsAppProcessorDescription"
                   css={css`
                     font-family: ${euiTheme.font.familyCode};
+                    font-style: italic;
                     ${euiTextTruncate()}
                     ${!readOnly && canEdit
                       ? `cursor: pointer;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -8,6 +8,7 @@
 import {
   EuiBadge,
   EuiButtonEmpty,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -21,8 +22,7 @@ import { i18n } from '@kbn/i18n';
 import type { Condition } from '@kbn/streamlang';
 import { isActionBlock } from '@kbn/streamlang';
 import { useSelector } from '@xstate/react';
-import React from 'react';
-import useToggle from 'react-use/lib/useToggle';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { ActionBlockProps } from '.';
 import {
   useInteractiveModeSelector,
@@ -33,7 +33,6 @@ import { ConditionDisplay } from '../../../../shared';
 import { getStepPanelColour } from '../../../utils';
 import { BlockDisableOverlay } from '../block_disable_overlay';
 import { StepContextMenu } from '../context_menu';
-import { EditStepDescriptionModal } from './edit_step_description_modal';
 import { ProcessorMetricBadges } from './processor_metrics';
 import { ProcessorStatusIndicator } from './processor_status_indicator';
 import { getStepDescription } from './utils';
@@ -57,10 +56,26 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
   const hasValidationErrors = validationErrors.length > 0;
 
   const canEdit = useInteractiveModeSelector((snapshot) => snapshot.can({ type: 'step.edit' }));
-  const [isEditDescriptionModalOpen, toggleEditDescriptionModal] = useToggle(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // For the inner description we once again invert the colours
   const descriptionPanelColour = getStepPanelColour(level + 1);
+
+  useEffect(() => {
+    if (isEditingDescription && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditingDescription]);
+
+  const saveDescription = useCallback(() => {
+    if (!isActionBlock(step)) return;
+    const trimmed = editValue.trim();
+    stepRef.send({ type: 'step.changeDescription', description: trimmed });
+    setIsEditingDescription(false);
+  }, [editValue, step, stepRef]);
 
   if (!isActionBlock(step)) return null;
 
@@ -73,7 +88,19 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
 
   const handleDescriptionClick = () => {
     if (!readOnly && canEdit) {
-      toggleEditDescriptionModal(true);
+      const initialValue =
+        step.description && step.description.trim().length > 0
+          ? step.description
+          : getStepDescription({ ...step, description: undefined });
+      setEditValue(initialValue);
+      setIsEditingDescription(true);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === 'Escape') {
+      e.preventDefault();
+      saveDescription();
     }
   };
 
@@ -246,6 +273,25 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                   }
                 )}
               />
+            ) : isEditingDescription ? (
+              <EuiFieldText
+                inputRef={inputRef}
+                fullWidth
+                compressed
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={saveDescription}
+                onKeyDown={handleKeyDown}
+                data-test-subj="streamsAppProcessorDescriptionInlineEdit"
+                aria-label={i18n.translate(
+                  'xpack.streams.actionBlockListItem.descriptionInlineEdit.ariaLabel',
+                  { defaultMessage: 'Edit processor description' }
+                )}
+                css={css`
+                  font-family: ${euiTheme.font.familyCode};
+                  font-size: ${euiTheme.size.m};
+                `}
+              />
             ) : (
               <EuiToolTip content={stepDescription} display="block">
                 <EuiText
@@ -273,16 +319,6 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
-      {isEditDescriptionModalOpen && (
-        <EditStepDescriptionModal
-          step={step}
-          onCancel={() => toggleEditDescriptionModal(false)}
-          onSave={(description) => {
-            toggleEditDescriptionModal(false);
-            stepRef.send({ type: 'step.changeDescription', description });
-          }}
-        />
-      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -22,13 +22,18 @@ import type { Condition } from '@kbn/streamlang';
 import { isActionBlock } from '@kbn/streamlang';
 import { useSelector } from '@xstate/react';
 import React from 'react';
+import useToggle from 'react-use/lib/useToggle';
 import type { ActionBlockProps } from '.';
-import { useStreamEnrichmentSelector } from '../../../state_management/stream_enrichment_state_machine';
+import {
+  useInteractiveModeSelector,
+  useStreamEnrichmentSelector,
+} from '../../../state_management/stream_enrichment_state_machine';
 import { selectValidationErrors } from '../../../state_management/stream_enrichment_state_machine/selectors';
 import { ConditionDisplay } from '../../../../shared';
 import { getStepPanelColour } from '../../../utils';
 import { BlockDisableOverlay } from '../block_disable_overlay';
 import { StepContextMenu } from '../context_menu';
+import { EditStepDescriptionModal } from './edit_step_description_modal';
 import { ProcessorMetricBadges } from './processor_metrics';
 import { ProcessorStatusIndicator } from './processor_status_indicator';
 import { getStepDescription } from './utils';
@@ -51,6 +56,9 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
 
   const hasValidationErrors = validationErrors.length > 0;
 
+  const canEdit = useInteractiveModeSelector((snapshot) => snapshot.can({ type: 'step.edit' }));
+  const [isEditDescriptionModalOpen, toggleEditDescriptionModal] = useToggle(false);
+
   // For the inner description we once again invert the colours
   const descriptionPanelColour = getStepPanelColour(level + 1);
 
@@ -61,6 +69,12 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
 
   const handleTitleClick = () => {
     stepRef.send({ type: 'step.edit' });
+  };
+
+  const handleDescriptionClick = () => {
+    if (!readOnly && canEdit) {
+      toggleEditDescriptionModal(true);
+    }
   };
 
   return (
@@ -205,6 +219,7 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                         stepUnderEdit={props.stepUnderEdit}
                         isFirstStepInLevel={props.isFirstStepInLevel}
                         isLastStepInLevel={props.isLastStepInLevel}
+                        onEditDescription={() => toggleEditDescriptionModal(true)}
                       />
                     </EuiFlexItem>
                   )}
@@ -238,10 +253,18 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                   size="xs"
                   color="subdued"
                   tabIndex={0}
+                  role={!readOnly && canEdit ? 'button' : undefined}
+                  onClick={handleDescriptionClick}
                   data-test-subj="streamsAppProcessorDescription"
                   css={css`
                     font-family: ${euiTheme.font.familyCode};
                     ${euiTextTruncate()}
+                    ${!readOnly && canEdit
+                      ? `cursor: pointer;
+                      &:hover {
+                        text-decoration: underline;
+                      }`
+                      : ''}
                   `}
                 >
                   {stepDescription}
@@ -251,6 +274,16 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {isEditDescriptionModalOpen && (
+        <EditStepDescriptionModal
+          step={step}
+          onCancel={() => toggleEditDescriptionModal(false)}
+          onSave={(description) => {
+            toggleEditDescriptionModal(false);
+            stepRef.send({ type: 'step.changeDescription', description });
+          }}
+        />
+      )}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -219,7 +219,6 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                         stepUnderEdit={props.stepUnderEdit}
                         isFirstStepInLevel={props.isFirstStepInLevel}
                         isLastStepInLevel={props.isLastStepInLevel}
-                        onEditDescription={() => toggleEditDescriptionModal(true)}
                       />
                     </EuiFlexItem>
                   )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -98,9 +98,12 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === 'Escape') {
+    if (e.key === 'Enter') {
       e.preventDefault();
       saveDescription();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsEditingDescription(false);
     }
   };
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
@@ -27,7 +27,6 @@ import {
 import { selectStreamType } from '../../state_management/stream_enrichment_state_machine/selectors';
 import { collectDescendantStepIds } from '../../state_management/utils';
 import type { StepConfigurationProps } from '../steps_list';
-import { EditStepDescriptionModal } from './action/edit_step_description_modal';
 import { deleteProcessorPromptOptions } from './action/prompt_options';
 import {
   ADD_DESCRIPTION_MENU_LABEL,
@@ -81,13 +80,16 @@ const deleteItemText = i18n.translate(
 type StepContextMenuProps = Pick<
   StepConfigurationProps,
   'stepRef' | 'stepUnderEdit' | 'isFirstStepInLevel' | 'isLastStepInLevel'
->;
+> & {
+  onEditDescription?: () => void;
+};
 
 export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   stepRef,
   stepUnderEdit,
   isFirstStepInLevel,
   isLastStepInLevel,
+  onEditDescription,
 }) => {
   const {
     reorderStep,
@@ -124,7 +126,6 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
     step.description.trim().length > 0;
 
   const [isPopoverOpen, togglePopover] = useToggle(false);
-  const [isEditDescriptionModalOpen, toggleEditDescriptionModal] = useToggle(false);
 
   const menuPopoverId = useGeneratedHtmlId({
     prefix: 'stepContextMenuPopover',
@@ -214,7 +215,7 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
               disabled={!canEdit}
               onClick={() => {
                 togglePopover(false);
-                toggleEditDescriptionModal(true);
+                onEditDescription?.();
               }}
             >
               {EDIT_DESCRIPTION_MENU_LABEL}
@@ -240,7 +241,7 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
               disabled={!canEdit}
               onClick={() => {
                 togglePopover(false);
-                toggleEditDescriptionModal(true);
+                onEditDescription?.();
               }}
             >
               {ADD_DESCRIPTION_MENU_LABEL}
@@ -326,27 +327,15 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   );
 
   return (
-    <>
-      <EuiPopover
-        id={menuPopoverId}
-        data-test-subj="streamsAppStreamDetailEnrichmentStepContextMenuPopover"
-        button={button}
-        isOpen={isPopoverOpen}
-        closePopover={() => togglePopover(false)}
-        panelPaddingSize="none"
-      >
-        <EuiContextMenuPanel size="s" items={items} />
-      </EuiPopover>
-      {isEditDescriptionModalOpen && !isWhere && isActionBlock(step) && (
-        <EditStepDescriptionModal
-          step={step}
-          onCancel={() => toggleEditDescriptionModal(false)}
-          onSave={(description) => {
-            toggleEditDescriptionModal(false);
-            stepRef.send({ type: 'step.changeDescription', description });
-          }}
-        />
-      )}
-    </>
+    <EuiPopover
+      id={menuPopoverId}
+      data-test-subj="streamsAppStreamDetailEnrichmentStepContextMenuPopover"
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={() => togglePopover(false)}
+      panelPaddingSize="none"
+    >
+      <EuiContextMenuPanel size="s" items={items} />
+    </EuiPopover>
   );
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/context_menu.tsx
@@ -13,7 +13,7 @@ import {
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { isActionBlock, isConditionBlock } from '@kbn/streamlang';
+import { isConditionBlock } from '@kbn/streamlang';
 import { useSelector } from '@xstate/react';
 import React from 'react';
 import useToggle from 'react-use/lib/useToggle';
@@ -28,11 +28,6 @@ import { selectStreamType } from '../../state_management/stream_enrichment_state
 import { collectDescendantStepIds } from '../../state_management/utils';
 import type { StepConfigurationProps } from '../steps_list';
 import { deleteProcessorPromptOptions } from './action/prompt_options';
-import {
-  ADD_DESCRIPTION_MENU_LABEL,
-  EDIT_DESCRIPTION_MENU_LABEL,
-  REMOVE_DESCRIPTION_MENU_LABEL,
-} from './action/translations';
 import { deleteConditionPromptOptions } from './where/prompt_options';
 
 const moveUpItemText = i18n.translate(
@@ -80,16 +75,13 @@ const deleteItemText = i18n.translate(
 type StepContextMenuProps = Pick<
   StepConfigurationProps,
   'stepRef' | 'stepUnderEdit' | 'isFirstStepInLevel' | 'isLastStepInLevel'
-> & {
-  onEditDescription?: () => void;
-};
+>;
 
 export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   stepRef,
   stepUnderEdit,
   isFirstStepInLevel,
   isLastStepInLevel,
-  onEditDescription,
 }) => {
   const {
     reorderStep,
@@ -120,10 +112,6 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
   const streamType = useStreamEnrichmentSelector((snapshot) => selectStreamType(snapshot.context));
 
   const isWhere = isConditionBlock(step);
-  const hasCustomDescription =
-    isActionBlock(step) &&
-    typeof step.description === 'string' &&
-    step.description.trim().length > 0;
 
   const [isPopoverOpen, togglePopover] = useToggle(false);
 
@@ -205,49 +193,6 @@ export const StepContextMenu: React.FC<StepContextMenuProps> = ({
     >
       {moveDownItemText}
     </EuiContextMenuItem>,
-    ...(!isWhere
-      ? hasCustomDescription
-        ? [
-            <EuiContextMenuItem
-              data-test-subj="stepContextMenuEditDescriptionItem"
-              key="editDescription"
-              icon="comment"
-              disabled={!canEdit}
-              onClick={() => {
-                togglePopover(false);
-                onEditDescription?.();
-              }}
-            >
-              {EDIT_DESCRIPTION_MENU_LABEL}
-            </EuiContextMenuItem>,
-            <EuiContextMenuItem
-              data-test-subj="stepContextMenuRemoveDescriptionItem"
-              key="removeDescription"
-              icon="minusCircle"
-              disabled={!canEdit}
-              onClick={() => {
-                togglePopover(false);
-                stepRef.send({ type: 'step.changeDescription', description: '' });
-              }}
-            >
-              {REMOVE_DESCRIPTION_MENU_LABEL}
-            </EuiContextMenuItem>,
-          ]
-        : [
-            <EuiContextMenuItem
-              data-test-subj="stepContextMenuEditDescriptionItem"
-              key="editDescription"
-              icon="comment"
-              disabled={!canEdit}
-              onClick={() => {
-                togglePopover(false);
-                onEditDescription?.();
-              }}
-            >
-              {ADD_DESCRIPTION_MENU_LABEL}
-            </EuiContextMenuItem>,
-          ]
-      : []),
     <EuiContextMenuItem
       data-test-subj="stepContextMenuEditItem"
       data-stream-type={streamType}


### PR DESCRIPTION
## Summary

Simplifies the processor description editing UX in the Streams processing management page:

- Clicking on the processor description text now directly opens the edit description modal
- Removed "Add description", "Edit description", and "Remove description" items from the 3-dot context menu
- Clearing the description field in the modal (empty value) removes the custom description, reverting to the auto-generated one

## "But why tho?"

Variety of reasons:
- it's currently unclear that a user can add a description, and that it is even editable.
- the user flow isn't the nicest: submenu + modal input, which breaks the immersion in this (very nice) "processing workbench"
- there's untapped "click estate": clicking the description doesn't do anything currently
- I've changed the text to italic to somewhat highlight that it's a description (rather than the definition of the processor itself)

It also makes the experience consistent with the "old" ingest pipeline edition interface:

<img width="663" height="53" alt="image" src="https://github.com/user-attachments/assets/e0e5b83e-b681-46e5-8101-6933c06fd6d2" />


### Current experience:

https://github.com/user-attachments/assets/e43f5a3d-dab2-466d-834c-df36a72c2a09

### Suggested experience:

https://github.com/user-attachments/assets/d721f2d4-645b-4ffc-800e-0512e2f0add7

## Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


🤖 Generated with [Claude Code](https://claude.com/claude-code)