### PR TITLE
feat(streams): make entire processor row clickable to edit

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useSelector } from '@xstate/react';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { EuiPanel, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { css } from '@emotion/react';
@@ -26,6 +26,7 @@ import { selectStreamType } from '../../../state_management/stream_enrichment_st
 
 export type ActionBlockProps = StepConfigurationProps & {
   processorMetrics?: ProcessorMetrics;
+  onInteractiveHover?: (enabled: boolean) => void;
 };
 export function ActionBlock(props: StepConfigurationProps) {
   const { stepRef, level, readOnly = false } = props;
@@ -62,6 +63,7 @@ export function ActionBlock(props: StepConfigurationProps) {
   }, [isFirstMount, isUnderEdit]);
 
   const isClickable = !isUnderEdit && !readOnly;
+  const [tooltipEnabled, setTooltipEnabled] = useState(true);
 
   const panel = (
     <EuiPanel
@@ -91,7 +93,11 @@ export function ActionBlock(props: StepConfigurationProps) {
       {isUnderEdit ? (
         <ActionBlockEditor {...props} ref={freshBlockRef} processorMetrics={processorMetrics} />
       ) : (
-        <ActionBlockListItem {...props} processorMetrics={processorMetrics} />
+        <ActionBlockListItem
+          {...props}
+          processorMetrics={processorMetrics}
+          onInteractiveHover={setTooltipEnabled}
+        />
       )}
     </EuiPanel>
   );
@@ -100,10 +106,14 @@ export function ActionBlock(props: StepConfigurationProps) {
     return (
       <EuiToolTip
         position="top"
-        content={i18n.translate('xpack.streams.actionBlock.tooltip.editProcessorLabel', {
-          defaultMessage: 'Edit {stepAction} processor',
-          values: { stepAction: step.action },
-        })}
+        content={
+          tooltipEnabled
+            ? i18n.translate('xpack.streams.actionBlock.tooltip.editProcessorLabel', {
+                defaultMessage: 'Edit {stepAction} processor',
+                values: { stepAction: step.action },
+              })
+            : null
+        }
         display="block"
       >
         {panel}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -65,7 +65,6 @@ export function ActionBlock(props: StepConfigurationProps) {
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
       hasShadow={false}
-      grow={false}
       color={isUnderEdit && isRootStepValue ? undefined : panelColour}
       onClick={isClickable ? handlePanelClick : undefined}
       css={
@@ -79,15 +78,9 @@ export function ActionBlock(props: StepConfigurationProps) {
               border: ${euiTheme.border.thin};
               border-radius: ${euiTheme.size.s};
               padding: ${euiTheme.size.m};
+              overflow: hidden;
               ${isClickable
-                ? `
-                  cursor: pointer;
-                  &:hover {
-                    background-color: ${euiTheme.colors.lightestShade};
-                    box-shadow: none;
-                    transform: none;
-                  }
-                `
+                ? `cursor: pointer;`
                 : ''}
             `
       }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -7,9 +7,11 @@
 
 import { useSelector } from '@xstate/react';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiPanel, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { isActionBlock } from '@kbn/streamlang';
 import {
   useSimulatorSelector,
   useStreamEnrichmentSelector,
@@ -30,6 +32,7 @@ export function ActionBlock(props: StepConfigurationProps) {
   const { euiTheme } = useEuiTheme();
   const isUnderEdit = useSelector(stepRef, (snapshot) => isStepUnderEdit(snapshot));
   const isRootStepValue = useSelector(stepRef, (snapshot) => isRootStep(snapshot));
+  const step = useSelector(stepRef, (snapshot) => snapshot.context.step);
 
   const simulation = useSimulatorSelector((snapshot) => snapshot.context.simulation);
 
@@ -60,7 +63,15 @@ export function ActionBlock(props: StepConfigurationProps) {
 
   const isClickable = !isUnderEdit && !readOnly;
 
-  return (
+  const tooltipContent =
+    isClickable && isActionBlock(step)
+      ? i18n.translate('xpack.streams.actionBlock.tooltip.editProcessorLabel', {
+          defaultMessage: 'Edit {stepAction} processor',
+          values: { stepAction: step.action },
+        })
+      : undefined;
+
+  const panel = (
     <EuiPanel
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
@@ -91,5 +102,16 @@ export function ActionBlock(props: StepConfigurationProps) {
         <ActionBlockListItem {...props} processorMetrics={processorMetrics} />
       )}
     </EuiPanel>
+  );
+
+  if (tooltipContent) {
+    return (
+      <EuiToolTip position="top" content={tooltipContent} display="block">
+        {panel}
+      </EuiToolTip>
+    );
+  }
+
+  return panel;
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useSelector } from '@xstate/react';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { EuiPanel, useEuiTheme } from '@elastic/eui';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { css } from '@emotion/react';
@@ -26,7 +26,7 @@ export type ActionBlockProps = StepConfigurationProps & {
   processorMetrics?: ProcessorMetrics;
 };
 export function ActionBlock(props: StepConfigurationProps) {
-  const { stepRef, level } = props;
+  const { stepRef, level, readOnly = false } = props;
   const { euiTheme } = useEuiTheme();
   const isUnderEdit = useSelector(stepRef, (snapshot) => isStepUnderEdit(snapshot));
   const isRootStepValue = useSelector(stepRef, (snapshot) => isRootStep(snapshot));
@@ -42,6 +42,12 @@ export function ActionBlock(props: StepConfigurationProps) {
   const isFirstMount = useFirstMountState();
   const freshBlockRef = useRef<HTMLDivElement>(null);
 
+  const handlePanelClick = useCallback(() => {
+    if (!isUnderEdit && !readOnly) {
+      stepRef.send({ type: 'step.edit' });
+    }
+  }, [isUnderEdit, readOnly, stepRef]);
+
   useEffect(() => {
     if (isFirstMount && isUnderEdit && freshBlockRef.current) {
       freshBlockRef.current.scrollIntoView({
@@ -52,12 +58,15 @@ export function ActionBlock(props: StepConfigurationProps) {
     }
   }, [isFirstMount, isUnderEdit]);
 
+  const isClickable = !isUnderEdit && !readOnly;
+
   return (
     <EuiPanel
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
       hasShadow={false}
       color={isUnderEdit && isRootStepValue ? undefined : panelColour}
+      onClick={isClickable ? handlePanelClick : undefined}
       css={
         isUnderEdit
           ? css`
@@ -69,6 +78,9 @@ export function ActionBlock(props: StepConfigurationProps) {
               border: ${euiTheme.border.thin};
               border-radius: ${euiTheme.size.s};
               padding: ${euiTheme.size.m};
+              ${isClickable
+                ? `cursor: pointer;`
+                : ''}
             `
       }
     >

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -7,11 +7,9 @@
 
 import { useSelector } from '@xstate/react';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { EuiPanel, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { EuiPanel, useEuiTheme } from '@elastic/eui';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { css } from '@emotion/react';
-import { i18n } from '@kbn/i18n';
-import { isActionBlock } from '@kbn/streamlang';
 import {
   useSimulatorSelector,
   useStreamEnrichmentSelector,
@@ -32,7 +30,6 @@ export function ActionBlock(props: StepConfigurationProps) {
   const { euiTheme } = useEuiTheme();
   const isUnderEdit = useSelector(stepRef, (snapshot) => isStepUnderEdit(snapshot));
   const isRootStepValue = useSelector(stepRef, (snapshot) => isRootStep(snapshot));
-  const step = useSelector(stepRef, (snapshot) => snapshot.context.step);
 
   const simulation = useSimulatorSelector((snapshot) => snapshot.context.simulation);
 
@@ -63,15 +60,7 @@ export function ActionBlock(props: StepConfigurationProps) {
 
   const isClickable = !isUnderEdit && !readOnly;
 
-  const tooltipContent =
-    isClickable && isActionBlock(step)
-      ? i18n.translate('xpack.streams.actionBlock.tooltip.editProcessorLabel', {
-          defaultMessage: 'Edit {stepAction} processor',
-          values: { stepAction: step.action },
-        })
-      : undefined;
-
-  const panel = (
+  return (
     <EuiPanel
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
@@ -102,16 +91,5 @@ export function ActionBlock(props: StepConfigurationProps) {
         <ActionBlockListItem {...props} processorMetrics={processorMetrics} />
       )}
     </EuiPanel>
-  );
-
-  if (tooltipContent) {
-    return (
-      <EuiToolTip position="top" content={tooltipContent} display="block">
-        {panel}
-      </EuiToolTip>
-    );
-  }
-
-  return panel;
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -65,6 +65,7 @@ export function ActionBlock(props: StepConfigurationProps) {
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
       hasShadow={false}
+      grow={false}
       color={isUnderEdit && isRootStepValue ? undefined : panelColour}
       onClick={isClickable ? handlePanelClick : undefined}
       css={
@@ -79,7 +80,14 @@ export function ActionBlock(props: StepConfigurationProps) {
               border-radius: ${euiTheme.size.s};
               padding: ${euiTheme.size.m};
               ${isClickable
-                ? `cursor: pointer;`
+                ? `
+                  cursor: pointer;
+                  &:hover {
+                    background-color: ${euiTheme.colors.lightestShade};
+                    box-shadow: none;
+                    transform: none;
+                  }
+                `
                 : ''}
             `
       }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/index.tsx
@@ -7,9 +7,11 @@
 
 import { useSelector } from '@xstate/react';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiPanel, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { isActionBlock } from '@kbn/streamlang';
 import {
   useSimulatorSelector,
   useStreamEnrichmentSelector,
@@ -30,6 +32,7 @@ export function ActionBlock(props: StepConfigurationProps) {
   const { euiTheme } = useEuiTheme();
   const isUnderEdit = useSelector(stepRef, (snapshot) => isStepUnderEdit(snapshot));
   const isRootStepValue = useSelector(stepRef, (snapshot) => isRootStep(snapshot));
+  const step = useSelector(stepRef, (snapshot) => snapshot.context.step);
 
   const simulation = useSimulatorSelector((snapshot) => snapshot.context.simulation);
 
@@ -60,7 +63,7 @@ export function ActionBlock(props: StepConfigurationProps) {
 
   const isClickable = !isUnderEdit && !readOnly;
 
-  return (
+  const panel = (
     <EuiPanel
       data-test-subj="streamsAppProcessorBlock"
       data-stream-type={streamType}
@@ -92,4 +95,21 @@ export function ActionBlock(props: StepConfigurationProps) {
       )}
     </EuiPanel>
   );
+
+  if (isClickable && isActionBlock(step)) {
+    return (
+      <EuiToolTip
+        position="top"
+        content={i18n.translate('xpack.streams.actionBlock.tooltip.editProcessorLabel', {
+          defaultMessage: 'Edit {stepAction} processor',
+          values: { stepAction: step.action },
+        })}
+        display="block"
+      >
+        {panel}
+      </EuiToolTip>
+    );
+  }
+
+  return panel;
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -7,7 +7,6 @@
 
 import {
   EuiBadge,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -21,7 +20,7 @@ import { i18n } from '@kbn/i18n';
 import type { Condition } from '@kbn/streamlang';
 import { isActionBlock } from '@kbn/streamlang';
 import { useSelector } from '@xstate/react';
-import React from 'react';
+import React, { type MouseEvent } from 'react';
 import type { ActionBlockProps } from '.';
 import { useStreamEnrichmentSelector } from '../../../state_management/stream_enrichment_state_machine';
 import { selectValidationErrors } from '../../../state_management/stream_enrichment_state_machine/selectors';
@@ -59,9 +58,7 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
   const stepDescription = getStepDescription(step);
   const actionDisplayName = step.action.toUpperCase();
 
-  const handleTitleClick = () => {
-    stepRef.send({ type: 'step.edit' });
-  };
+  const stopPropagation = (e: MouseEvent) => e.stopPropagation();
 
   return (
     <>
@@ -76,11 +73,11 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="xs" alignItems="center">
             {!readOnly && (
-              <EuiFlexItem grow={false}>
+              <EuiFlexItem grow={false} onClick={stopPropagation}>
                 <DragHandle />
               </EuiFlexItem>
             )}
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} onClick={stopPropagation}>
               <ProcessorStatusIndicator
                 stepRef={stepRef}
                 stepsProcessingSummaryMap={props.stepsProcessingSummaryMap}
@@ -107,58 +104,23 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                     max-width: 100%;
                   `}
                 >
-                  <EuiToolTip
-                    position="top"
-                    content={
-                      <>
-                        <p>
-                          <strong>{actionDisplayName}</strong>
-                        </p>
-                        <p>
-                          {i18n.translate(
-                            'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
-                            {
-                              defaultMessage: 'Edit {stepAction} processor',
-                              values: {
-                                stepAction: step.action,
-                              },
-                            }
-                          )}
-                        </p>
-                      </>
-                    }
+                  <EuiText
+                    size="s"
+                    component="span"
+                    style={{ fontWeight: euiTheme.font.weight.bold }}
+                    data-test-subj="streamsAppProcessorTitleEditButton"
+                    css={css`
+                      display: block;
+                      ${euiTextTruncate()}
+                    `}
                   >
-                    <EuiButtonEmpty
-                      onClick={handleTitleClick}
-                      color="text"
-                      aria-label={i18n.translate(
-                        'xpack.streams.actionBlockListItem.euiButtonEmpty.editProcessorLabel',
-                        { defaultMessage: 'Edit processor' }
-                      )}
-                      size="xs"
-                      data-test-subj="streamsAppProcessorTitleEditButton"
-                      css={css`
-                        max-width: 100%;
-                      `}
-                    >
-                      <EuiText
-                        size="s"
-                        component="span"
-                        style={{ fontWeight: euiTheme.font.weight.bold }}
-                        css={css`
-                          display: block;
-                          ${euiTextTruncate()}
-                        `}
-                      >
-                        {actionDisplayName}
-                      </EuiText>
-                    </EuiButtonEmpty>
-                  </EuiToolTip>
+                    {actionDisplayName}
+                  </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
             {(processorMetrics || hasValidationErrors || isUnsaved || !readOnly) && (
-              <EuiFlexItem grow={false}>
+              <EuiFlexItem grow={false} onClick={stopPropagation}>
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   {processorMetrics && (
                     <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -104,31 +104,18 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                     max-width: 100%;
                   `}
                 >
-                  <EuiToolTip
-                    position="top"
-                    content={i18n.translate(
-                      'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
-                      {
-                        defaultMessage: 'Edit {stepAction} processor',
-                        values: {
-                          stepAction: step.action,
-                        },
-                      }
-                    )}
+                  <EuiText
+                    size="s"
+                    component="span"
+                    style={{ fontWeight: euiTheme.font.weight.bold }}
+                    data-test-subj="streamsAppProcessorTitleEditButton"
+                    css={css`
+                      display: block;
+                      ${euiTextTruncate()}
+                    `}
                   >
-                    <EuiText
-                      size="s"
-                      component="span"
-                      style={{ fontWeight: euiTheme.font.weight.bold }}
-                      data-test-subj="streamsAppProcessorTitleEditButton"
-                      css={css`
-                        display: block;
-                        ${euiTextTruncate()}
-                      `}
-                    >
-                      {actionDisplayName}
-                    </EuiText>
-                  </EuiToolTip>
+                    {actionDisplayName}
+                  </EuiText>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -90,34 +90,46 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                 margin-right: ${euiTheme.size.s};
               `}
             >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="xs"
-                css={css`
-                  min-width: 0;
-                `}
+              <EuiToolTip
+                position="top"
+                content={i18n.translate(
+                  'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
+                  {
+                    defaultMessage: 'Edit {stepAction} processor',
+                    values: { stepAction: step.action },
+                  }
+                )}
+                display="block"
               >
-                <EuiFlexItem
-                  grow={false}
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="xs"
                   css={css`
                     min-width: 0;
-                    max-width: 100%;
                   `}
                 >
-                  <EuiText
-                    size="s"
-                    component="span"
-                    style={{ fontWeight: euiTheme.font.weight.bold }}
-                    data-test-subj="streamsAppProcessorTitleEditButton"
+                  <EuiFlexItem
+                    grow={false}
                     css={css`
-                      display: block;
-                      ${euiTextTruncate()}
+                      min-width: 0;
+                      max-width: 100%;
                     `}
                   >
-                    {actionDisplayName}
-                  </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+                    <EuiText
+                      size="s"
+                      component="span"
+                      style={{ fontWeight: euiTheme.font.weight.bold }}
+                      data-test-subj="streamsAppProcessorTitleEditButton"
+                      css={css`
+                        display: block;
+                        ${euiTextTruncate()}
+                      `}
+                    >
+                      {actionDisplayName}
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiToolTip>
             </EuiFlexItem>
             {(processorMetrics || hasValidationErrors || isUnsaved || !readOnly) && (
               <EuiFlexItem grow={false} onClick={stopPropagation}>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -90,46 +90,34 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                 margin-right: ${euiTheme.size.s};
               `}
             >
-              <EuiToolTip
-                position="top"
-                content={i18n.translate(
-                  'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
-                  {
-                    defaultMessage: 'Edit {stepAction} processor',
-                    values: { stepAction: step.action },
-                  }
-                )}
-                display="block"
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                css={css`
+                  min-width: 0;
+                `}
               >
-                <EuiFlexGroup
-                  alignItems="center"
-                  gutterSize="xs"
+                <EuiFlexItem
+                  grow={false}
                   css={css`
                     min-width: 0;
+                    max-width: 100%;
                   `}
                 >
-                  <EuiFlexItem
-                    grow={false}
+                  <EuiText
+                    size="s"
+                    component="span"
+                    style={{ fontWeight: euiTheme.font.weight.bold }}
+                    data-test-subj="streamsAppProcessorTitleEditButton"
                     css={css`
-                      min-width: 0;
-                      max-width: 100%;
+                      display: block;
+                      ${euiTextTruncate()}
                     `}
                   >
-                    <EuiText
-                      size="s"
-                      component="span"
-                      style={{ fontWeight: euiTheme.font.weight.bold }}
-                      data-test-subj="streamsAppProcessorTitleEditButton"
-                      css={css`
-                        display: block;
-                        ${euiTextTruncate()}
-                      `}
-                    >
-                      {actionDisplayName}
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiToolTip>
+                    {actionDisplayName}
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
             {(processorMetrics || hasValidationErrors || isUnsaved || !readOnly) && (
               <EuiFlexItem grow={false} onClick={stopPropagation}>
@@ -207,20 +195,19 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                 )}
               />
             ) : (
-              <EuiToolTip content={stepDescription} display="block">
-                <EuiText
-                  size="xs"
-                  color="subdued"
-                  tabIndex={0}
-                  data-test-subj="streamsAppProcessorDescription"
-                  css={css`
-                    font-family: ${euiTheme.font.familyCode};
-                    ${euiTextTruncate()}
-                  `}
-                >
-                  {stepDescription}
-                </EuiText>
-              </EuiToolTip>
+              <EuiText
+                size="xs"
+                color="subdued"
+                tabIndex={0}
+                title={stepDescription}
+                data-test-subj="streamsAppProcessorDescription"
+                css={css`
+                  font-family: ${euiTheme.font.familyCode};
+                  ${euiTextTruncate()}
+                `}
+              >
+                {stepDescription}
+              </EuiText>
             )}
           </EuiPanel>
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -35,7 +35,7 @@ import { DragHandle } from '../../draggable_step_wrapper';
 
 export const ActionBlockListItem = (props: ActionBlockProps) => {
   const { euiTheme } = useEuiTheme();
-  const { stepRef, level, processorMetrics, readOnly = false } = props;
+  const { stepRef, level, processorMetrics, readOnly = false, onInteractiveHover } = props;
 
   const step = useSelector(stepRef, (snapshot) => snapshot.context.step);
   const isUnsaved = useSelector(
@@ -59,6 +59,8 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
   const actionDisplayName = step.action.toUpperCase();
 
   const stopPropagation = (e: MouseEvent) => e.stopPropagation();
+  const suppressTooltip = () => onInteractiveHover?.(false);
+  const restoreTooltip = () => onInteractiveHover?.(true);
 
   return (
     <>
@@ -73,7 +75,12 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="xs" alignItems="center">
             {!readOnly && (
-              <EuiFlexItem grow={false} onClick={stopPropagation}>
+              <EuiFlexItem
+                grow={false}
+                onClick={stopPropagation}
+                onMouseEnter={suppressTooltip}
+                onMouseLeave={restoreTooltip}
+              >
                 <DragHandle />
               </EuiFlexItem>
             )}
@@ -120,7 +127,12 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
               </EuiFlexGroup>
             </EuiFlexItem>
             {(processorMetrics || hasValidationErrors || isUnsaved || !readOnly) && (
-              <EuiFlexItem grow={false} onClick={stopPropagation}>
+              <EuiFlexItem
+                grow={false}
+                onClick={stopPropagation}
+                onMouseEnter={suppressTooltip}
+                onMouseLeave={restoreTooltip}
+              >
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   {processorMetrics && (
                     <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/list_item.tsx
@@ -104,18 +104,31 @@ export const ActionBlockListItem = (props: ActionBlockProps) => {
                     max-width: 100%;
                   `}
                 >
-                  <EuiText
-                    size="s"
-                    component="span"
-                    style={{ fontWeight: euiTheme.font.weight.bold }}
-                    data-test-subj="streamsAppProcessorTitleEditButton"
-                    css={css`
-                      display: block;
-                      ${euiTextTruncate()}
-                    `}
+                  <EuiToolTip
+                    position="top"
+                    content={i18n.translate(
+                      'xpack.streams.actionBlockListItem.tooltip.editProcessorLabel',
+                      {
+                        defaultMessage: 'Edit {stepAction} processor',
+                        values: {
+                          stepAction: step.action,
+                        },
+                      }
+                    )}
                   >
-                    {actionDisplayName}
-                  </EuiText>
+                    <EuiText
+                      size="s"
+                      component="span"
+                      style={{ fontWeight: euiTheme.font.weight.bold }}
+                      data-test-subj="streamsAppProcessorTitleEditButton"
+                      css={css`
+                        display: block;
+                        ${euiTextTruncate()}
+                      `}
+                    >
+                      {actionDisplayName}
+                    </EuiText>
+                  </EuiToolTip>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>


### PR DESCRIPTION
## Summary

Makes the entire processor panel row clickable to open the processor editor, instead of requiring a click specifically on the processor name badge.

## "But why tho?"

I find it annoying to have to click the tiny (comparatively speaking) name of the processor, when we have the entire "card" available as click estate.

### Current experience

https://github.com/user-attachments/assets/7093defb-3744-44dc-b997-55e0051cb640

### Suggested experience

https://github.com/user-attachments/assets/dd2e9c2b-de84-4915-ac8e-627bf48b9683

## Test plan

- [x] Navigate to a stream's Processing tab (e.g. `/app/streams/<stream>/management/processing`)
- [x] Verify clicking anywhere on the grey processor row opens the editor
_NOTE: clicking the description also triggers edition of the processor_
- [x] Verify clicking the drag handle does **not** open the editor
- [x] Verify clicking the context menu (three dots) does **not** open the editor
_NOTE: verified for both, it was not initially the case but is covered by https://github.com/elastic/kibana/pull/261156/commits/e29b49e008a8ba530bd8e14e8fabaea95187ab64_
- [x] Verify clicking the status indicator does **not** open the editor
- [x] Verify clicking badges (Unsaved, error, metrics) does **not** open the editor
- [x] Verify cursor changes to pointer when hovering over the row
_NOTE: and the display of the "hand" pointer when hovering the drag handle isn't affected_
- [ ] Verify read-only mode is unaffected (no pointer cursor, no click behavior)