### PR TITLE
[Alerting v2] [Rule Management] Align rule details page action buttons with design spec

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_detail_page.tsx
@@ -63,6 +63,7 @@ export const RuleDetailPage: React.FunctionComponent<RuleDetailPageProps> = ({ r
               { defaultMessage: 'Edit Rule' }
             )}
             data-test-subj="openEditRuleFlyoutButton"
+            color="text"
             iconType="pencil"
             name="edit"
             href={basePath.prepend(paths.ruleEdit(rule.id))}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_details_actions_menu.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React, { useState } from 'react';
-import { EuiButtonEmpty, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import { CoreStart, useService } from '@kbn/core-di-browser';
 import type { RuleApiResponse } from '../../services/rules_api';
 import { paths } from '../../constants';
@@ -89,10 +89,15 @@ export const RuleDetailsActionsMenu: React.FunctionComponent<RuleDetailsActionsM
 
   return (
     <EuiPopover
+      aria-label={i18n.translate('xpack.alertingV2.ruleDetails.actionsMenuPopoverAriaLabel', {
+        defaultMessage: 'Rule actions',
+      })}
       button={
-        <EuiButtonEmpty
+        <EuiButtonIcon
           data-test-subj="ruleDetailsActionsButton"
           iconType="boxesHorizontal"
+          color="text"
+          size="m"
           onClick={() => setIsPopoverOpen(!isPopoverOpen)}
           aria-label={i18n.translate('xpack.alertingV2.ruleDetails.actionsMenuAriaLabel', {
             defaultMessage: 'Actions',


### PR DESCRIPTION
## Summary

Closes elastic/rna-program#260

Fixes the appearance of the right-side header buttons on the rule detail page to match the design spec.

- Replace `EuiButtonEmpty` with `EuiButtonIcon` for the "more actions" (⋯) button — this corrects the hover state
- Add `color="text"` to both the "more actions" button and the "Edit rule" button — this corrects the button color from `primary` to neutral
- Add `aria-label` to the `EuiPopover` wrapping the actions menu for accessibility

## Testing

Navigate to `/app/management/insightsAndAlerting/alerting_v2` → open a rule detail page and verify:
- [ ] The pencil ("Edit rule") button renders in neutral/text color, not blue
- [ ] The ⋯ ("more actions") button renders in neutral/text color with correct hover state
- [ ] Clicking ⋯ still opens the actions menu (disable/enable, clone, delete)
- [ ] Clicking the pencil navigates to the rule edit page
