### PR TITLE
[Rules v2] Add description to details page header

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.test.tsx
@@ -28,14 +28,39 @@ describe('RuleHeaderDescription', () => {
     expect(screen.getByText('infra')).toBeInTheDocument();
   });
 
-  it('returns null when labels are empty', () => {
+  it('renders description text', () => {
+    const rule = {
+      ...baseRule,
+      metadata: { name: 'My Rule', description: 'Alert when errors exceed threshold.' },
+    } as RuleApiResponse;
+    wrap(<RuleHeaderDescription rule={rule} />);
+    expect(screen.getByTestId('ruleDescription')).toHaveTextContent(
+      'Alert when errors exceed threshold.'
+    );
+  });
+
+  it('renders both description and tags when both are present', () => {
+    const rule = {
+      ...baseRule,
+      metadata: {
+        name: 'My Rule',
+        description: 'Some description',
+        labels: ['prod', 'infra'],
+      },
+    } as RuleApiResponse;
+    wrap(<RuleHeaderDescription rule={rule} />);
+    expect(screen.getByTestId('ruleDescription')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleTags')).toBeInTheDocument();
+  });
+
+  it('returns null when labels are empty and no description', () => {
     const { container } = wrap(
       <RuleHeaderDescription rule={{ ...baseRule, metadata: { name: 'No Tags' } }} />
     );
     expect(container.innerHTML).toBe('');
   });
 
-  it('returns null when labels are undefined', () => {
+  it('returns null when labels are undefined and no description', () => {
     const rule = { ...baseRule, metadata: { name: 'No Labels' } } as RuleApiResponse;
     const { container } = wrap(<RuleHeaderDescription rule={rule} />);
     expect(container.innerHTML).toBe('');

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import type { RuleApiResponse } from '../../services/rules_api';
@@ -29,21 +29,34 @@ const KIND_ICONS: Record<string, string> = {
 };
 
 /**
- * Renders the tags row below the page title.
+ * Renders the description and tags row below the page title.
  */
 export const RuleHeaderDescription: React.FC<RuleHeaderDescriptionProps> = ({ rule }) => {
-  if (!rule.metadata.labels || rule.metadata.labels.length === 0) {
+  const { description, labels } = rule.metadata;
+  const hasLabels = labels && labels.length > 0;
+
+  if (!description && !hasLabels) {
     return null;
   }
 
   return (
-    <EuiFlexGroup gutterSize="xs" wrap responsive={false} data-test-subj="ruleTags">
-      {rule.metadata.labels.map((label) => (
-        <EuiFlexItem key={label} grow={false}>
-          <EuiBadge color="hollow">{label}</EuiBadge>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGroup>
+    <>
+      {description && (
+        <EuiText size="s" color="subdued" data-test-subj="ruleDescription">
+          {description}
+        </EuiText>
+      )}
+      <EuiSpacer size="m" />
+      {hasLabels && (
+        <EuiFlexGroup gutterSize="xs" wrap responsive={false} data-test-subj="ruleTags">
+          {labels!.map((label) => (
+            <EuiFlexItem key={label} grow={false}>
+              <EuiBadge color="hollow">{label}</EuiBadge>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- Displays the rule description (gray subdued text) below the title and above the tags on the rule v2 details page
- Adds tests for description rendering (alone, combined with tags, and null cases)

Closes https://github.com/elastic/rna-program/issues/259

## Test plan
- [ ] Create a rule with a description and verify it appears on the details page as subdued text below the title
- [ ] Create a rule without a description and verify no empty space is rendered
- [ ] Verify tags still render correctly below the description
- [ ] Run unit tests: `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/components/rule_details/rule_header_description.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)