### PR TITLE
[Streams] Reset preview columns when processor type changes

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/interactive_mode_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/interactive_mode_machine.ts
@@ -569,6 +569,11 @@ export const interactiveModeMachine = setup({
                 { type: 'sendStepsToSimulator', params: ({ event }) => event },
               ],
             },
+            'step.processorTypeChanged': {
+              actions: ({ context }) => {
+                context.parentRef.send({ type: 'simulation.reset' });
+              },
+            },
             'step.parentChanged': {
               actions: [
                 { type: 'reassignSteps' },
@@ -659,6 +664,11 @@ export const interactiveModeMachine = setup({
                 { type: 'sendStepsToSimulator' },
               ],
             },
+            'step.processorTypeChanged': {
+              actions: ({ context }) => {
+                context.parentRef.send({ type: 'simulation.reset' });
+              },
+            },
             'step.delete': {
               target: 'idle',
               guard: 'hasManagePrivileges',
@@ -697,6 +707,11 @@ export const interactiveModeMachine = setup({
           on: {
             'step.change': {
               actions: [{ type: 'syncToDSL' }, { type: 'sendStepsToSimulator' }],
+            },
+            'step.processorTypeChanged': {
+              actions: ({ context }) => {
+                context.parentRef.send({ type: 'simulation.reset' });
+              },
             },
             'step.cancel': {
               target: 'idle',

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/interactive_mode_machine/types.ts
@@ -102,6 +102,7 @@ export type InteractiveModeEvent =
       step: StreamlangConditionBlock;
     }
   | { type: 'step.change'; id: string }
+  | { type: 'step.processorTypeChanged'; id: string }
   | { type: 'step.parentChanged'; id: string }
   | { type: 'step.delete'; id: string }
   | { type: 'step.reorder'; stepId: string; direction: 'up' | 'down' }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/steps_state_machine/steps_state_machine.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/steps_state_machine/steps_state_machine.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import type { ActorRefFrom, SnapshotFrom } from 'xstate';
-import { and, assign, forwardTo, sendTo, setup } from 'xstate';
+import { and, assign, enqueueActions, forwardTo, sendTo, setup } from 'xstate';
 import type {
   StreamlangProcessorDefinition,
   StreamlangStepWithUIAttributes,
@@ -122,6 +122,15 @@ export const stepMachine = setup({
         id: context.step.customIdentifier,
       })
     ),
+    forwardProcessorTypeChangeIfNeeded: enqueueActions(({ context, event, enqueue }) => {
+      const newStep = (event as { step: StreamlangProcessorDefinition }).step;
+      if (isActionBlock(context.step) && context.step.action !== newStep.action) {
+        enqueue.sendTo(context.parentRef, {
+          type: 'step.processorTypeChanged',
+          id: context.step.customIdentifier,
+        });
+      }
+    }),
     forwardParentChangeEventToParent: sendTo(
       ({ context }) => context.parentRef,
       ({ context }) => ({
@@ -196,6 +205,7 @@ export const stepMachine = setup({
         },
         'step.changeProcessor': {
           actions: [
+            { type: 'forwardProcessorTypeChangeIfNeeded' },
             { type: 'changeProcessor', params: ({ event }) => event },
             { type: 'updateGrokPatternDefinitions' },
             { type: 'forwardChangeEventToParent' },
@@ -254,6 +264,7 @@ export const stepMachine = setup({
             },
             'step.changeProcessor': {
               actions: [
+                { type: 'forwardProcessorTypeChangeIfNeeded' },
                 { type: 'changeProcessor', params: ({ event }) => event },
                 { type: 'updateGrokPatternDefinitions' },
                 { type: 'forwardChangeEventToParent' },

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/steps_state_machine/types.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/steps_state_machine/types.ts
@@ -16,6 +16,7 @@ import type {
 export type StepToParentEvent =
   | { type: 'step.cancel'; id: string }
   | { type: 'step.change'; id: string }
+  | { type: 'step.processorTypeChanged'; id: string }
   | { type: 'step.parentChanged'; id: string }
   | { type: 'step.delete'; id: string }
   | { type: 'step.edit'; id: string }


### PR DESCRIPTION
## Summary

When editing a processor in the Streams enrichment UI and changing its type (e.g. from Grok to Dissect), the data preview table on the right side retained column customizations (explicitly enabled/disabled columns, column order) from the previous processor type. This was confusing because the activated columns were specific to the old processor's output fields and had no relevance to the new processor type.

### Root cause

No mechanism existed to notify the simulation layer that a processor's type had changed. The `step.changeProcessor` event was used for all processor edits (type changes and parameter edits alike), and the downstream `simulation.updateSteps` handler simply stored the new steps without resetting any preview state.

### Fix

Detects processor type changes at the source — the **step machine** — which already has both the current and incoming processor definitions. When the `action` field differs, a new `step.processorTypeChanged` event is sent to the interactive mode machine, which triggers `simulation.reset` through the existing event chain. This clears stale preview columns, detected fields, and simulation results. The `simulation.updateSteps` event that immediately follows (from the regular `step.change` flow) re-populates the steps and triggers a fresh simulation.

Regular parameter edits within the same processor type (e.g. editing a grok pattern) do **not** trigger a reset, preserving the user's column preferences during normal editing.

### Changed files (4 files, +28/-1)

| File | Change |
|------|--------|
| `steps_state_machine.ts` | Added `forwardProcessorTypeChangeIfNeeded` action — compares old vs new `action`, sends `step.processorTypeChanged` if changed |
| `steps_state_machine/types.ts` | Added `step.processorTypeChanged` to `StepToParentEvent` |
| `interactive_mode_machine.ts` | Handle `step.processorTypeChanged` in all 3 step states (idle, creating, editing) by sending `simulation.reset` |
| `interactive_mode_machine/types.ts` | Added `step.processorTypeChanged` to `InteractiveModeEvent` |

## Test plan

1. Open a wired stream's processing management page
2. Add or edit a processor (e.g. Grok) and configure it so the preview table shows results
3. Manually enable/disable some columns in the preview table
4. Change the processor type (e.g. switch from Grok to Dissect)
5. **Expected:** Preview table columns reset — previously enabled/disabled columns from the old processor type are no longer carried over
6. Verify that changing parameters within the same processor type (e.g. editing the grok pattern) does **not** reset column preferences