### PR TITLE
[Streams] Activate source and destination fields in processing table preview

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
@@ -49,6 +49,7 @@ import { selectDraftProcessor } from './state_management/interactive_mode_machin
 import type { PreviewDocsFilterOption } from './state_management/simulation_state_machine';
 import {
   getAllFieldsInOrder,
+  getDestinationField,
   getOriginalSampleDocument,
   getSourceField,
   getTableColumns,
@@ -310,11 +311,16 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     selectHasSimulatedRecords(snapshot.context)
   );
 
-  const { currentProcessorSourceField, currentStepId, stepIds } = useStreamEnrichmentSelector(
-    (state) => {
+  const { currentProcessorSourceField, currentProcessorDestinationField, currentStepId, stepIds } =
+    useStreamEnrichmentSelector((state) => {
       const isInteractiveMode = selectIsInteractiveMode(state);
       if (!isInteractiveMode || !state.context.interactiveModeRef) {
-        return { currentProcessorSourceField: undefined, currentStepId: undefined, stepIds: [] };
+        return {
+          currentProcessorSourceField: undefined,
+          currentProcessorDestinationField: undefined,
+          currentStepId: undefined,
+          stepIds: [],
+        };
       }
 
       const stepRefs = state.context.interactiveModeRef.getSnapshot().context.stepRefs;
@@ -327,6 +333,7 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
         if (isActionBlock(step) && isStepUnderEdit(snapshot)) {
           return {
             currentProcessorSourceField: getSourceField(step),
+            currentProcessorDestinationField: getDestinationField(step),
             currentStepId: stepRef.id,
             stepIds: allStepIds,
           };
@@ -335,11 +342,11 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
 
       return {
         currentProcessorSourceField: undefined,
+        currentProcessorDestinationField: undefined,
         currentStepId: undefined,
         stepIds: allStepIds,
       };
-    }
-  );
+    });
 
   const processorsMetrics = useSimulatorSelector(
     (snapshot) => snapshot.context.simulation?.processors_metrics
@@ -437,8 +444,15 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
       ? currentProcessorSourceField
       : undefined;
 
+  const validCurrentProcessorDestinationField =
+    currentProcessorDestinationField && allColumns.includes(currentProcessorDestinationField)
+      ? currentProcessorDestinationField
+      : undefined;
+
   // Calculate if view mode should be forced to 'columns'
-  const isViewModeForced = Boolean(validGrokField || validCurrentProcessorSourceField);
+  const isViewModeForced = Boolean(
+    validGrokField || validCurrentProcessorSourceField || validCurrentProcessorDestinationField
+  );
 
   // Determine the effective view mode (forced to 'columns' if needed, otherwise user's choice)
   const effectiveViewMode = isViewModeForced ? 'columns' : userSelectedViewMode ?? 'summary';
@@ -446,6 +460,7 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
   const availableColumns = useMemo(() => {
     let cols = getTableColumns({
       currentProcessorSourceField: validCurrentProcessorSourceField,
+      currentProcessorDestinationField: validCurrentProcessorDestinationField,
       detectedFields,
       previewDocsFilter,
     });
@@ -471,6 +486,7 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     explicitlyEnabledPreviewColumns,
     previewDocsFilter,
     validCurrentProcessorSourceField,
+    validCurrentProcessorDestinationField,
   ]);
 
   /**

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/simulation_state_machine/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/state_management/simulation_state_machine/utils.ts
@@ -36,16 +36,34 @@ export function getSourceField(
 ): string | undefined {
   const processorSourceField = (() => {
     switch (processor.action) {
-      case 'append':
-      case 'set':
-        return processor.to;
       case 'convert':
       case 'rename':
       case 'grok':
       case 'dissect':
       case 'date':
+      case 'replace':
+      case 'split':
+      case 'sort':
+      case 'redact':
+      case 'uppercase':
+      case 'lowercase':
+      case 'trim':
+      case 'remove':
+      case 'remove_by_prefix':
         return processor.from;
+      case 'json_extract':
+        return processor.field;
+      case 'network_direction':
+        return processor.source_ip;
+      case 'append':
+      case 'set':
+      case 'concat':
+      case 'join':
+      case 'math':
+      case 'enrich':
+        return processor.to;
       case 'manual_ingest_pipeline':
+      case 'drop_document':
         return undefined;
       default:
         return undefined;
@@ -54,6 +72,40 @@ export function getSourceField(
 
   const trimmedSourceField = processorSourceField?.trim();
   return trimmedSourceField && trimmedSourceField.length > 0 ? trimmedSourceField : undefined;
+}
+
+export function getDestinationField(
+  processor: StreamlangProcessorDefinitionWithUIAttributes
+): string | undefined {
+  const processorDestinationField = (() => {
+    switch (processor.action) {
+      case 'convert':
+      case 'rename':
+      case 'date':
+      case 'replace':
+      case 'split':
+      case 'sort':
+      case 'uppercase':
+      case 'lowercase':
+      case 'trim':
+      case 'set':
+      case 'append':
+      case 'concat':
+      case 'join':
+      case 'math':
+      case 'enrich':
+        return processor.to;
+      case 'network_direction':
+        return processor.target_field;
+      default:
+        return undefined;
+    }
+  })();
+
+  const trimmedDestinationField = processorDestinationField?.trim();
+  return trimmedDestinationField && trimmedDestinationField.length > 0
+    ? trimmedDestinationField
+    : undefined;
 }
 
 export function getUniqueDetectedFields(detectedFields: DetectedField[] = []) {
@@ -140,24 +192,30 @@ export function getAllFieldsInOrder(
 
 export function getTableColumns({
   currentProcessorSourceField,
+  currentProcessorDestinationField,
   detectedFields = [],
   previewDocsFilter,
 }: {
   currentProcessorSourceField?: string;
+  currentProcessorDestinationField?: string;
   detectedFields?: DetectedField[];
   previewDocsFilter: PreviewDocsFilterOption;
 }) {
-  if (!currentProcessorSourceField) {
+  const baseFields = [currentProcessorSourceField, currentProcessorDestinationField].filter(
+    (f): f is string => Boolean(f)
+  );
+
+  if (baseFields.length === 0) {
     return [];
   }
 
   if (['outcome_filter_failed', 'outcome_filter_skipped'].includes(previewDocsFilter)) {
-    return [currentProcessorSourceField];
+    return baseFields;
   }
 
   const uniqueDetectedFields = getUniqueDetectedFields(detectedFields);
 
-  return uniq([currentProcessorSourceField, ...uniqueDetectedFields]);
+  return uniq([...baseFields, ...uniqueDetectedFields]);
 }
 
 type SimulationDocReport = Simulation['documents'][number];


### PR DESCRIPTION
## Summary

When editing a processor in the Streams processing UI, the table preview should activate (show) the source field and destination field columns the processor operates on. Previously, only a handful of processor types (`convert`, `rename`, `date`, `set`, `append`, `grok`, `dissect`) were handled — all others fell through to a `default: return undefined` case, causing the table preview to show no focused columns.

This PR:

1. **Adds `getSourceFields()`** — returns all source fields as an array, with multi-field support for `concat` (extracts field-type entries from the array) and `join` (all fields from the array)
2. **Adds `getDestinationField()`** — returns the destination field (`to` or `target_field`)
3. **Wires both through `getTableColumns()` and `ProcessorOutcomePreview`** so all relevant columns are activated

### Current experience

https://github.com/user-attachments/assets/881a2e5a-cd28-48ed-87ce-3f75f78995a7

### Suggested experience

https://github.com/user-attachments/assets/262732c1-11ad-4cb4-8f23-1c8f5e4fd9e5

### Processors fixed

| Processor | Source field(s) | Destination field | Fix |
|-----------|----------------|-------------------|-----|
| `replace` | `from` | `to` | Added to `getSourceFields` |
| `split` | `from` | `to` | Added to `getSourceFields` |
| `sort` | `from` | `to` | Added to `getSourceFields` |
| `redact` | `from` | — | Added to `getSourceFields` |
| `uppercase` | `from` | `to` | Added to `getSourceFields` |
| `lowercase` | `from` | `to` | Added to `getSourceFields` |
| `trim` | `from` | `to` | Added to `getSourceFields` |
| `network_direction` | `source_ip` | `target_field` | Added with correct field keys |
| `concat` | All field-type entries from `from[]` | `to` | Multi-field: extracts field values from array |
| `join` | All entries from `from[]` | `to` | Multi-field: all source fields displayed |
| `math` | — | `to` | Destination-only (source is expression) |
| `enrich` | — | `to` | Destination-only (source is policy) |

### Intentionally excluded

| Processor | Reason |
|-----------|--------|
| `grok`, `dissect` | Specialized highlighting — handled separately |
| `json_extract` | Handled separately |
| `remove`, `remove_by_prefix` | Fields are being removed — no value in displaying them |
| `drop_document`, `manual_ingest_pipeline` | No individual field operations |

### Changes

- **`utils.ts`**: Added `getSourceFields()` (returns `string[]` with multi-field support), `getDestinationField()`, helper `trimFields()`; updated `getTableColumns()` to accept source fields array + destination field
- **`processor_outcome_preview.tsx`**: Uses `getSourceFields` and `getDestinationField` in the selector; validates all source fields against available columns; passes arrays through to `getTableColumns`

## Test plan

- [ ] Open Streams processing UI for any stream
- [ ] Edit each processor type and verify the table preview activates the correct source/destination columns
- [ ] For `concat` and `join`, verify all source fields from the array are shown as columns
- [ ] Verify grok and dissect behavior is unchanged
- [ ] Verify that excluded processors (`remove`, `drop_document`, etc.) don't activate any columns
- [ ] Verify column visibility toggling still works correctly