### PR TITLE
[Streams] Add bi-directional color coding for DISSECT processor

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
@@ -1,0 +1,510 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useContext, useMemo } from 'react';
+import { css } from '@emotion/react';
+import { useEuiTheme, EuiToolTip } from '@elastic/eui';
+import type { EuiThemeComputed } from '@elastic/eui';
+
+// Same color palette as GROK for consistency
+const EUI_COLOR_PALETTE_VALUES = [
+  'Primary',
+  'Accent',
+  'AccentSecondary',
+  'Success',
+  'Warning',
+  'Risk',
+  'Danger',
+];
+
+// --- Types ---
+
+interface DissectFieldToken {
+  type: 'field';
+  name: string;
+  color: string;
+  isSkip: boolean;
+  hasRightPadding: boolean;
+}
+
+interface DissectLiteralToken {
+  type: 'literal';
+  value: string;
+}
+
+type DissectToken = DissectFieldToken | DissectLiteralToken;
+
+interface DissectHighlightSpan {
+  startIndex: number;
+  endIndex: number;
+  fieldName: string;
+  color: string;
+  isSkip: boolean;
+}
+
+interface DissectHighlightContextValue {
+  tokens: DissectToken[];
+}
+
+// --- Tokenizer ---
+
+/**
+ * Parses a dissect pattern into an ordered array of tokens (literals and fields),
+ * assigning colors from the EUI palette to each field token.
+ */
+export function parseDissectTokens(pattern: string): DissectToken[] {
+  const tokens: DissectToken[] = [];
+  const fieldColorMap = new Map<string, string>();
+  let colorIndex = 0;
+
+  const regex = /%\{([^}]*)}/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(pattern)) !== null) {
+    // Add literal before this field
+    if (match.index > lastIndex) {
+      tokens.push({ type: 'literal', value: pattern.slice(lastIndex, match.index) });
+    }
+
+    let keyDefinition = match[1];
+    if (!keyDefinition) {
+      // Empty field %{} — anonymous skip
+      tokens.push({
+        type: 'field',
+        name: '',
+        color: 'Subdued',
+        isSkip: true,
+        hasRightPadding: false,
+      });
+      lastIndex = regex.lastIndex;
+      continue;
+    }
+
+    // Check left modifier
+    const firstChar = keyDefinition[0];
+    const isSkip = firstChar === '?' || firstChar === '*' || firstChar === '&';
+    const isAppend = firstChar === '+';
+
+    if (firstChar === '?' || firstChar === '+' || firstChar === '*' || firstChar === '&') {
+      keyDefinition = keyDefinition.slice(1);
+    }
+
+    // Check right padding modifier
+    const hasRightPadding = keyDefinition.endsWith('->');
+    if (hasRightPadding) {
+      keyDefinition = keyDefinition.slice(0, -2);
+    }
+
+    // Check order specifier /n
+    const orderMatch = keyDefinition.match(/^(.+)\/(\d+)$/);
+    if (orderMatch) {
+      keyDefinition = orderMatch[1];
+    }
+
+    keyDefinition = keyDefinition.trim();
+    if (!keyDefinition) {
+      tokens.push({
+        type: 'field',
+        name: '',
+        color: 'Subdued',
+        isSkip: true,
+        hasRightPadding,
+      });
+      lastIndex = regex.lastIndex;
+      continue;
+    }
+
+    // Assign color
+    let color: string;
+    if (isSkip) {
+      color = 'Subdued';
+    } else if (isAppend && fieldColorMap.has(keyDefinition)) {
+      color = fieldColorMap.get(keyDefinition)!;
+    } else if (fieldColorMap.has(keyDefinition)) {
+      color = fieldColorMap.get(keyDefinition)!;
+    } else {
+      color = EUI_COLOR_PALETTE_VALUES[colorIndex % EUI_COLOR_PALETTE_VALUES.length];
+      colorIndex++;
+      fieldColorMap.set(keyDefinition, color);
+    }
+
+    tokens.push({
+      type: 'field',
+      name: keyDefinition,
+      color,
+      isSkip,
+      hasRightPadding,
+    });
+
+    lastIndex = regex.lastIndex;
+  }
+
+  // Trailing literal
+  if (lastIndex < pattern.length) {
+    tokens.push({ type: 'literal', value: pattern.slice(lastIndex) });
+  }
+
+  return tokens;
+}
+
+// --- Matcher ---
+
+/**
+ * Matches a sample string against parsed dissect tokens and returns highlight spans
+ * for each field extraction.
+ */
+export function matchDissectSample(
+  sample: string,
+  tokens: DissectToken[]
+): DissectHighlightSpan[] | null {
+  if (tokens.length === 0) return null;
+
+  const spans: DissectHighlightSpan[] = [];
+  let pos = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token.type === 'literal') {
+      const idx = sample.indexOf(token.value, pos);
+      if (idx === -1) return null; // Pattern doesn't match
+      pos = idx + token.value.length;
+    } else {
+      // Field token — find the end boundary
+      const fieldStart = pos;
+      let fieldEnd: number;
+
+      // Find the next literal token to determine field boundary
+      const nextLiteralIndex = findNextLiteral(tokens, i + 1);
+
+      if (nextLiteralIndex === -1) {
+        // No more literals — field consumes rest of string
+        fieldEnd = sample.length;
+      } else {
+        const nextLiteral = tokens[nextLiteralIndex] as DissectLiteralToken;
+        const literalPos = sample.indexOf(nextLiteral.value, pos);
+        if (literalPos === -1) return null; // Pattern doesn't match
+        fieldEnd = literalPos;
+      }
+
+      // Handle right padding: the highlight span should exclude trailing whitespace,
+      // but we still advance pos past the padding.
+      let highlightEnd = fieldEnd;
+      if (token.hasRightPadding && fieldEnd > fieldStart) {
+        while (highlightEnd > fieldStart && /\s/.test(sample[highlightEnd - 1])) {
+          highlightEnd--;
+        }
+      }
+
+      if (highlightEnd > fieldStart) {
+        spans.push({
+          startIndex: fieldStart,
+          endIndex: highlightEnd,
+          fieldName: token.name,
+          color: token.color,
+          isSkip: token.isSkip,
+        });
+      }
+
+      pos = fieldEnd;
+    }
+  }
+
+  return spans.length > 0 ? spans : null;
+}
+
+function findNextLiteral(tokens: DissectToken[], startIndex: number): number {
+  for (let i = startIndex; i < tokens.length; i++) {
+    if (tokens[i].type === 'literal') return i;
+  }
+  return -1;
+}
+
+// --- Color palette styles ---
+
+export function getDissectColourPaletteStyles(
+  euiTheme: EuiThemeComputed
+): Record<string, { backgroundColor: string; color: string; cursor: string }> {
+  const styles: Record<string, { backgroundColor: string; color: string; cursor: string }> = {};
+
+  for (const colour of EUI_COLOR_PALETTE_VALUES) {
+    styles[`.dissect-field-match-${colour}`] = {
+      backgroundColor: euiTheme.colors[
+        `backgroundLight${colour}` as keyof EuiThemeComputed['colors']
+      ] as string,
+      color: euiTheme.colors[`text${colour}` as keyof EuiThemeComputed['colors']] as string,
+      cursor: 'pointer',
+    };
+  }
+
+  // Subdued style for skip/reference fields
+  styles['.dissect-field-match-Subdued'] = {
+    backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    color: euiTheme.colors.textSubdued,
+    cursor: 'default',
+  };
+
+  return styles;
+}
+
+function colourToClassName(colour: string) {
+  return `dissect-field-match-${colour}`;
+}
+
+// --- Context ---
+
+const DissectHighlightContext = createContext<DissectHighlightContextValue | undefined>(undefined);
+
+interface DissectHighlightProviderProps {
+  pattern: string;
+  children: React.ReactNode;
+}
+
+export const DissectHighlightProvider = ({ pattern, children }: DissectHighlightProviderProps) => {
+  const tokens = useMemo(() => parseDissectTokens(pattern), [pattern]);
+
+  return (
+    <DissectHighlightContext.Provider value={{ tokens }}>
+      {children}
+    </DissectHighlightContext.Provider>
+  );
+};
+
+export const useDissectHighlight = () => {
+  const context = useContext(DissectHighlightContext);
+  if (context === undefined) {
+    throw new Error('useDissectHighlight must be used within a DissectHighlightProvider');
+  }
+  return context;
+};
+
+// --- Sample component ---
+
+interface DissectSampleProps {
+  sample: string;
+}
+
+export const DissectSample = ({ sample }: DissectSampleProps) => {
+  const eui = useEuiTheme();
+  const { tokens } = useDissectHighlight();
+
+  const colourPaletteStyles = useMemo(
+    () => getDissectColourPaletteStyles(eui.euiTheme),
+    [eui.euiTheme]
+  );
+
+  const highlights = useMemo(() => matchDissectSample(sample, tokens), [sample, tokens]);
+
+  if (!sample) {
+    return <>&nbsp;</>;
+  }
+
+  if (!highlights || highlights.length === 0) {
+    return <>{sample}</>;
+  }
+
+  return (
+    <div
+      css={css`
+        .dissect-pattern-match {
+          background-color: ${eui.euiTheme.colors.highlight};
+        }
+        ${colourPaletteStyles}
+        white-space: pre-wrap;
+      `}
+    >
+      <div>{renderHighlightedSample(sample, highlights)}</div>
+    </div>
+  );
+};
+
+function renderHighlightedSample(
+  sample: string,
+  highlights: DissectHighlightSpan[]
+): React.ReactNode {
+  // Find the overall match bounds (from first highlight start to last highlight end)
+  const overallStart = highlights[0].startIndex;
+  const overallEnd = highlights[highlights.length - 1].endIndex;
+
+  const parts: React.ReactNode[] = [];
+
+  // Text before any match
+  if (overallStart > 0) {
+    parts.push(<span key="pre">{sample.slice(0, overallStart)}</span>);
+  }
+
+  // The matched region with field highlights
+  let pos = overallStart;
+  for (let i = 0; i < highlights.length; i++) {
+    const hl = highlights[i];
+
+    // Literal text between fields (delimiters)
+    if (pos < hl.startIndex) {
+      parts.push(
+        <span key={`lit-${pos}`} className="dissect-pattern-match">
+          {sample.slice(pos, hl.startIndex)}
+        </span>
+      );
+    }
+
+    // Field highlight
+    const fieldSpan = (
+      <span key={`field-${hl.startIndex}`} className={colourToClassName(hl.color)}>
+        {sample.slice(hl.startIndex, hl.endIndex)}
+      </span>
+    );
+
+    if (hl.fieldName) {
+      parts.push(
+        <EuiToolTip
+          key={`tt-${hl.startIndex}`}
+          position="top"
+          content={
+            <p>
+              {hl.isSkip ? 'Skip field: ' : 'Field: '}
+              {hl.fieldName}
+            </p>
+          }
+        >
+          {fieldSpan}
+        </EuiToolTip>
+      );
+    } else {
+      parts.push(fieldSpan);
+    }
+
+    pos = hl.endIndex;
+  }
+
+  // Literal text after the last field but within the match
+  if (pos < overallEnd) {
+    parts.push(
+      <span key={`lit-${pos}`} className="dissect-pattern-match">
+        {sample.slice(pos, overallEnd)}
+      </span>
+    );
+  }
+
+  // Text after the match
+  if (overallEnd < sample.length) {
+    parts.push(<span key="post">{sample.slice(overallEnd)}</span>);
+  }
+
+  return parts;
+}
+
+// --- Pattern preview (for source-side color sync) ---
+
+interface DissectPatternPreviewProps {
+  pattern: string;
+}
+
+/**
+ * Renders a read-only colored preview of the dissect pattern,
+ * showing %{field} tokens with their assigned highlight colors.
+ */
+export const DissectPatternPreview = ({ pattern }: DissectPatternPreviewProps) => {
+  const eui = useEuiTheme();
+  const tokens = useMemo(() => parseDissectTokens(pattern), [pattern]);
+
+  const colourPaletteStyles = useMemo(
+    () => getDissectColourPaletteStyles(eui.euiTheme),
+    [eui.euiTheme]
+  );
+
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      css={css`
+        ${colourPaletteStyles}
+        white-space: pre-wrap;
+        font-family: ${eui.euiTheme.font.familyCode};
+        font-size: ${eui.euiTheme.size.m};
+        padding: ${eui.euiTheme.size.xs} ${eui.euiTheme.size.s};
+        border-radius: ${eui.euiTheme.border.radius.small};
+        background-color: ${eui.euiTheme.colors.backgroundBaseSubdued};
+        line-height: 1.5;
+      `}
+    >
+      {tokens.map((token, i) => {
+        if (token.type === 'literal') {
+          return <span key={`lit-${i}`}>{token.value}</span>;
+        }
+
+        // Reconstruct the original %{...} syntax for display
+        let prefix = '';
+        if (token.isSkip && token.name) {
+          prefix = '?';
+        }
+        const suffix = token.hasRightPadding ? '->' : '';
+        const display = `%{${prefix}${token.name}${suffix}}`;
+
+        return (
+          <EuiToolTip
+            key={`field-${i}`}
+            position="top"
+            content={
+              <p>
+                {token.isSkip ? 'Skip field: ' : 'Field: '}
+                {token.name || '(anonymous)'}
+              </p>
+            }
+          >
+            <span className={colourToClassName(token.color)}>{display}</span>
+          </EuiToolTip>
+        );
+      })}
+    </div>
+  );
+};
+
+// --- Helpers for integration ---
+
+/**
+ * Checks if a dissect pattern extracts into a field with the same name as the source field.
+ */
+export function dissectPatternOverwritesSourceField(
+  pattern: string,
+  sourceField: string
+): boolean {
+  const regex = /%\{([^}]*)}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(pattern)) !== null) {
+    let keyDefinition = match[1];
+    if (!keyDefinition) continue;
+
+    // Strip left modifiers
+    const firstChar = keyDefinition[0];
+    if (firstChar === '?' || firstChar === '+' || firstChar === '*' || firstChar === '&') {
+      keyDefinition = keyDefinition.slice(1);
+    }
+
+    // Skip fields don't output
+    if (firstChar === '?') continue;
+
+    // Strip right padding
+    if (keyDefinition.endsWith('->')) {
+      keyDefinition = keyDefinition.slice(0, -2);
+    }
+
+    // Strip order specifier
+    const orderMatch = keyDefinition.match(/^(.+)\/(\d+)$/);
+    if (orderMatch) {
+      keyDefinition = orderMatch[1];
+    }
+
+    keyDefinition = keyDefinition.trim();
+    if (keyDefinition === sourceField) return true;
+  }
+
+  return false;
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
@@ -252,7 +252,7 @@ export function getDissectColourPaletteStyles(
   return styles;
 }
 
-function colourToClassName(colour: string) {
+export function colourToClassName(colour: string) {
   return `dissect-field-match-${colour}`;
 }
 
@@ -397,74 +397,6 @@ function renderHighlightedSample(
 
   return parts;
 }
-
-// --- Pattern preview (for source-side color sync) ---
-
-interface DissectPatternPreviewProps {
-  pattern: string;
-}
-
-/**
- * Renders a read-only colored preview of the dissect pattern,
- * showing %{field} tokens with their assigned highlight colors.
- */
-export const DissectPatternPreview = ({ pattern }: DissectPatternPreviewProps) => {
-  const eui = useEuiTheme();
-  const tokens = useMemo(() => parseDissectTokens(pattern), [pattern]);
-
-  const colourPaletteStyles = useMemo(
-    () => getDissectColourPaletteStyles(eui.euiTheme),
-    [eui.euiTheme]
-  );
-
-  if (tokens.length === 0) {
-    return null;
-  }
-
-  return (
-    <div
-      css={css`
-        ${colourPaletteStyles}
-        white-space: pre-wrap;
-        font-family: ${eui.euiTheme.font.familyCode};
-        font-size: ${eui.euiTheme.size.m};
-        padding: ${eui.euiTheme.size.xs} ${eui.euiTheme.size.s};
-        border-radius: ${eui.euiTheme.border.radius.small};
-        background-color: ${eui.euiTheme.colors.backgroundBaseSubdued};
-        line-height: 1.5;
-      `}
-    >
-      {tokens.map((token, i) => {
-        if (token.type === 'literal') {
-          return <span key={`lit-${i}`}>{token.value}</span>;
-        }
-
-        // Reconstruct the original %{...} syntax for display
-        let prefix = '';
-        if (token.isSkip && token.name) {
-          prefix = '?';
-        }
-        const suffix = token.hasRightPadding ? '->' : '';
-        const display = `%{${prefix}${token.name}${suffix}}`;
-
-        return (
-          <EuiToolTip
-            key={`field-${i}`}
-            position="top"
-            content={
-              <p>
-                {token.isSkip ? 'Skip field: ' : 'Field: '}
-                {token.name || '(anonymous)'}
-              </p>
-            }
-          >
-            <span className={colourToClassName(token.color)}>{display}</span>
-          </EuiToolTip>
-        );
-      })}
-    </div>
-  );
-};
 
 // --- Helpers for integration ---
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/dissect_highlighting.tsx
@@ -327,19 +327,10 @@ function renderHighlightedSample(
   sample: string,
   highlights: DissectHighlightSpan[]
 ): React.ReactNode {
-  // Find the overall match bounds (from first highlight start to last highlight end)
-  const overallStart = highlights[0].startIndex;
-  const overallEnd = highlights[highlights.length - 1].endIndex;
-
   const parts: React.ReactNode[] = [];
 
-  // Text before any match
-  if (overallStart > 0) {
-    parts.push(<span key="pre">{sample.slice(0, overallStart)}</span>);
-  }
-
-  // The matched region with field highlights
-  let pos = overallStart;
+  // Start from the beginning — leading literals are part of the dissect pattern too
+  let pos = 0;
   for (let i = 0; i < highlights.length; i++) {
     const hl = highlights[i];
 
@@ -381,18 +372,13 @@ function renderHighlightedSample(
     pos = hl.endIndex;
   }
 
-  // Literal text after the last field but within the match
-  if (pos < overallEnd) {
+  // Trailing literal after the last field — still part of the dissect pattern
+  if (pos < sample.length) {
     parts.push(
       <span key={`lit-${pos}`} className="dissect-pattern-match">
-        {sample.slice(pos, overallEnd)}
+        {sample.slice(pos)}
       </span>
     );
-  }
-
-  // Text after the match
-  if (overallEnd < sample.length) {
-    parts.push(<span key="post">{sample.slice(overallEnd)}</span>);
   }
 
   return parts;

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview.tsx
@@ -19,7 +19,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import type { GrokProcessor } from '@kbn/streamlang';
+import type { DissectProcessor, GrokProcessor } from '@kbn/streamlang';
 import { isActionBlock } from '@kbn/streamlang';
 import type { FlattenRecord, SampleDocument } from '@kbn/streams-schema';
 import { isEmpty } from 'lodash';
@@ -36,10 +36,16 @@ import { toDataTableRecordWithIndex } from '../stream_detail_routing/utils';
 import { DOC_VIEW_DIFF_ID, DocViewerContext } from './doc_viewer_diff';
 import {
   createOriginalGrokFieldValuesMap,
+  getDissectFieldDisplayValue,
   getGrokFieldDisplayValue,
   grokExpressionOverwritesSourceField,
   hasPrecedingProcessorTouchedField,
 } from './processor_outcome_preview_helpers';
+import {
+  DissectHighlightProvider,
+  DissectSample,
+  dissectPatternOverwritesSourceField,
+} from './dissect_highlighting';
 import {
   NoPreviewDocumentsEmptyPrompt,
   NoProcessingDataAvailableEmptyPrompt,
@@ -376,6 +382,29 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
       ? draftProcessor.processor.patterns
       : [];
 
+  // Get dissect pattern from the draft processor
+  const dissectPattern =
+    draftProcessor?.processor &&
+    'action' in draftProcessor.processor &&
+    draftProcessor.processor.action === 'dissect'
+      ? draftProcessor.processor.pattern
+      : '';
+
+  // Determine if the dissect processor is active (has a from field and a pattern)
+  const isDissectProcessorActive =
+    draftProcessor?.processor &&
+    'action' in draftProcessor.processor &&
+    draftProcessor.processor.action === 'dissect' &&
+    !isEmpty(draftProcessor.processor.from) &&
+    !isEmpty(draftProcessor.processor.pattern);
+
+  // Get the source field for the dissect processor
+  const dissectSourceField = isDissectProcessorActive
+    ? (draftProcessor.processor as DissectProcessor).from
+    : undefined;
+  const validDissectSourceField =
+    dissectSourceField && allColumns.includes(dissectSourceField) ? dissectSourceField : undefined;
+
   // Convert patterns to DraftGrokExpression instances for field analysis
   const grokExpressions = useGrokExpressions(grokPatterns);
 
@@ -432,13 +461,43 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
 
   const validGrokField = grokMode ? validGrokSourceField : undefined;
 
+  // Check if the dissect pattern overwrites the source field
+  const dissectOverwritesSourceField = useMemo(() => {
+    if (!validDissectSourceField || !dissectPattern) return false;
+    return dissectPatternOverwritesSourceField(dissectPattern, validDissectSourceField);
+  }, [dissectPattern, validDissectSourceField]);
+
+  // Check if any preceding processor has touched the dissect source field
+  const precedingProcessorTouchedDissectField = useMemo(() => {
+    if (!validDissectSourceField) return false;
+    return hasPrecedingProcessorTouchedField(
+      stepIds,
+      currentStepId,
+      processorsMetrics,
+      validDissectSourceField
+    );
+  }, [stepIds, currentStepId, processorsMetrics, validDissectSourceField]);
+
+  /**
+   * Dissect mode enables the special highlighting preview for dissect patterns.
+   * Same logic as grok mode.
+   */
+  const dissectMode =
+    isDissectProcessorActive &&
+    validDissectSourceField !== undefined &&
+    !(dissectOverwritesSourceField && precedingProcessorTouchedDissectField);
+
+  const validDissectField = dissectMode ? validDissectSourceField : undefined;
+
   const validCurrentProcessorSourceField =
     currentProcessorSourceField && allColumns.includes(currentProcessorSourceField)
       ? currentProcessorSourceField
       : undefined;
 
   // Calculate if view mode should be forced to 'columns'
-  const isViewModeForced = Boolean(validGrokField || validCurrentProcessorSourceField);
+  const isViewModeForced = Boolean(
+    validGrokField || validDissectField || validCurrentProcessorSourceField
+  );
 
   // Determine the effective view mode (forced to 'columns' if needed, otherwise user's choice)
   const effectiveViewMode = isViewModeForced ? 'columns' : userSelectedViewMode ?? 'summary';
@@ -483,6 +542,14 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
   );
 
   /**
+   * Same as grokColumns but for dissect mode.
+   */
+  const dissectColumns = useMemo(
+    () => (validDissectField ? [validDissectField] : undefined),
+    [validDissectField]
+  );
+
+  /**
    * Map from preview document to the original (pre-transformation) value of the grok field.
    * This is needed when the grok pattern extracts into the same field it reads from (e.g., message → message).
    * We use a WeakMap keyed by the document object reference for O(1) lookup in renderCellValue.
@@ -498,7 +565,23 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     return createOriginalGrokFieldValuesMap(previewDocuments, originalSamples, validGrokField);
   }, [grokMode, validGrokField, originalSamples, previewDocuments, grokOverwritesSourceField]);
 
-  const previewColumns = grokColumns ?? availableColumns;
+  /**
+   * Same as originalGrokFieldValues but for dissect mode.
+   */
+  const originalDissectFieldValues = useMemo(() => {
+    if (!dissectMode || !validDissectField || !originalSamples) return undefined;
+    if (!dissectOverwritesSourceField) return undefined;
+
+    return createOriginalGrokFieldValuesMap(previewDocuments, originalSamples, validDissectField);
+  }, [
+    dissectMode,
+    validDissectField,
+    originalSamples,
+    previewDocuments,
+    dissectOverwritesSourceField,
+  ]);
+
+  const previewColumns = dissectColumns ?? grokColumns ?? availableColumns;
 
   // Calculate columns specifically for summary mode
   const displayColumnsForSummaryMode = useMemo(() => {
@@ -568,27 +651,48 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     ]
   );
 
-  const renderCellValue = useMemo(
-    () =>
-      grokMode && validGrokField
-        ? (document: SampleDocument, columnId: string) => {
-            // Use the original (pre-transformation) value for the grok field.
-            // This ensures highlighting works even when grok extracts into the same field it reads from.
-            const value = getGrokFieldDisplayValue(
-              document,
-              columnId,
-              validGrokField,
-              originalGrokFieldValues
-            );
+  const renderCellValue = useMemo(() => {
+    if (grokMode && validGrokField) {
+      return (document: SampleDocument, columnId: string) => {
+        const value = getGrokFieldDisplayValue(
+          document,
+          columnId,
+          validGrokField,
+          originalGrokFieldValues
+        );
 
-            if (typeof value === 'string') {
-              return <GrokSampleWithContext sample={value} />;
-            }
-            return <>&nbsp;</>;
-          }
-        : undefined,
-    [grokMode, originalGrokFieldValues, validGrokField]
-  );
+        if (typeof value === 'string') {
+          return <GrokSampleWithContext sample={value} />;
+        }
+        return <>&nbsp;</>;
+      };
+    }
+
+    if (dissectMode && validDissectField) {
+      return (document: SampleDocument, columnId: string) => {
+        const value = getDissectFieldDisplayValue(
+          document,
+          columnId,
+          validDissectField,
+          originalDissectFieldValues
+        );
+
+        if (typeof value === 'string') {
+          return <DissectSample sample={value} />;
+        }
+        return <>&nbsp;</>;
+      };
+    }
+
+    return undefined;
+  }, [
+    grokMode,
+    originalGrokFieldValues,
+    validGrokField,
+    dissectMode,
+    originalDissectFieldValues,
+    validDissectField,
+  ]);
 
   const hits = useMemo(() => {
     return toDataTableRecordWithIndex(previewDocuments);
@@ -633,7 +737,7 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
         <MemoPreviewTable
           documents={previewDocuments}
           displayColumns={displayColumnsForTable}
-          rowHeightsOptions={validGrokField ? staticRowHeightsOptions : undefined}
+          rowHeightsOptions={validGrokField || validDissectField ? staticRowHeightsOptions : undefined}
           toolbarVisibility
           setVisibleColumns={setVisibleColumns}
           sorting={previewColumnsSorting}
@@ -659,12 +763,16 @@ const OutcomePreviewTable = ({ previewDocuments }: { previewDocuments: FlattenRe
     </>
   );
 
-  // Wrap with GrokExpressionsProvider when in grok mode to provide patterns to Sample components
-  return grokMode ? (
-    <GrokExpressionsProvider patterns={grokPatterns}>{content}</GrokExpressionsProvider>
-  ) : (
-    content
-  );
+  // Wrap with appropriate provider when in highlighting mode
+  if (grokMode) {
+    return <GrokExpressionsProvider patterns={grokPatterns}>{content}</GrokExpressionsProvider>;
+  }
+
+  if (dissectMode && dissectPattern) {
+    return <DissectHighlightProvider pattern={dissectPattern}>{content}</DissectHighlightProvider>;
+  }
+
+  return content;
 };
 
 const staticRowHeightsOptions: EuiDataGridRowHeightsOptions = { defaultHeight: 'auto' };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview_helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/processor_outcome_preview_helpers.ts
@@ -138,3 +138,27 @@ export function grokExpressionOverwritesSourceField(
     return Array.from(fields.values()).some((field) => field.name === sourceField);
   });
 }
+
+/**
+ * Gets the value to display for a dissect field, preferring the original (pre-transformation) value
+ * over the transformed value. This ensures highlighting works correctly even when the dissect pattern
+ * extracts into the same field it reads from.
+ */
+export function getDissectFieldDisplayValue(
+  document: SampleDocument | FlattenRecord,
+  columnId: string,
+  dissectField: string,
+  originalDissectFieldValues?: WeakMap<FlattenRecord, string | undefined>
+): string | undefined {
+  if (columnId !== dissectField) {
+    return undefined;
+  }
+
+  const originalValue = originalDissectFieldValues?.get(document as FlattenRecord);
+  if (typeof originalValue === 'string') {
+    return originalValue;
+  }
+
+  const value = document[columnId];
+  return typeof value === 'string' ? value : undefined;
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_definition.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_definition.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef, useMemo, useCallback, useEffect } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
-import { EuiFormRow, EuiLink, EuiSpacer } from '@elastic/eui';
+import { EuiFormRow, EuiLink, EuiSpacer, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import type { CodeEditorProps, monaco } from '@kbn/code-editor';
 import { CodeEditor } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -15,7 +17,11 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import { useKibana } from '../../../../../../../../hooks/use_kibana';
 import { useAIFeatures } from '../../../../../../../../hooks/use_ai_features';
 import type { ProcessorFormState } from '../../../../types';
-import { DissectPatternPreview } from '../../../../dissect_highlighting';
+import {
+  parseDissectTokens,
+  getDissectColourPaletteStyles,
+  colourToClassName,
+} from '../../../../dissect_highlighting';
 
 const DissectPatternAISuggestions = dynamic(() =>
   import('./dissect_pattern_suggestion').then((mod) => ({
@@ -23,11 +29,23 @@ const DissectPatternAISuggestions = dynamic(() =>
   }))
 );
 
+// Regex to match %{...} tokens in a dissect pattern with their positions
+const DISSECT_FIELD_PATTERN_REGEX = /%\{([^}]*)}/g;
+
 export const DissectPatternDefinition = () => {
   const { core } = useKibana();
   const esDocUrl = core.docLinks.links.ingest.dissectKeyModifiers;
   const aiFeatures = useAIFeatures();
   const { setValue } = useFormContext();
+  const eui = useEuiTheme();
+
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const decorationsRef = useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
+
+  const colourPaletteStyles = useMemo(
+    () => getDissectColourPaletteStyles(eui.euiTheme),
+    [eui.euiTheme]
+  );
 
   const { field, fieldState } = useController<ProcessorFormState, 'pattern'>({
     name: 'pattern',
@@ -40,6 +58,99 @@ export const DissectPatternDefinition = () => {
   });
 
   const { invalid, error } = fieldState;
+
+  const updateDecorations = useCallback(
+    (text: string) => {
+      if (!editorRef.current || !decorationsRef.current) return;
+
+      const model = editorRef.current.getModel();
+      if (!model) return;
+
+      // Parse tokens to get field -> colour mapping
+      const tokens = parseDissectTokens(text);
+      const fieldColourMap = new Map<string, string>();
+      for (const token of tokens) {
+        if (token.type === 'field' && token.name && !fieldColourMap.has(token.name)) {
+          fieldColourMap.set(token.name, token.color);
+        }
+      }
+
+      const decorations: Array<{
+        range: {
+          startLineNumber: number;
+          startColumn: number;
+          endLineNumber: number;
+          endColumn: number;
+        };
+        options: { inlineClassName: string };
+      }> = [];
+
+      // Find all %{...} patterns and apply colour decorations
+      let match;
+      DISSECT_FIELD_PATTERN_REGEX.lastIndex = 0;
+      while ((match = DISSECT_FIELD_PATTERN_REGEX.exec(text)) !== null) {
+        let keyDefinition = match[1];
+        if (!keyDefinition) continue;
+
+        // Strip modifiers to get the field name (same logic as parseDissectTokens)
+        const firstChar = keyDefinition[0];
+        const isSkip = firstChar === '?' || firstChar === '*' || firstChar === '&';
+        if (
+          firstChar === '?' ||
+          firstChar === '+' ||
+          firstChar === '*' ||
+          firstChar === '&'
+        ) {
+          keyDefinition = keyDefinition.slice(1);
+        }
+        if (keyDefinition.endsWith('->')) {
+          keyDefinition = keyDefinition.slice(0, -2);
+        }
+        const orderMatch = keyDefinition.match(/^(.+)\/(\d+)$/);
+        if (orderMatch) {
+          keyDefinition = orderMatch[1];
+        }
+        keyDefinition = keyDefinition.trim();
+        if (!keyDefinition) continue;
+
+        // Determine colour: skip fields get Subdued, others get their assigned colour
+        const colour = isSkip ? 'Subdued' : fieldColourMap.get(keyDefinition);
+        if (!colour) continue;
+
+        const startPos = model.getPositionAt(match.index);
+        const endPos = model.getPositionAt(match.index + match[0].length);
+        decorations.push({
+          range: {
+            startLineNumber: startPos.lineNumber,
+            startColumn: startPos.column,
+            endLineNumber: endPos.lineNumber,
+            endColumn: endPos.column,
+          },
+          options: {
+            inlineClassName: colourToClassName(colour),
+          },
+        });
+      }
+
+      decorationsRef.current.clear();
+      decorationsRef.current.set(decorations);
+    },
+    []
+  );
+
+  const onEditorMount: CodeEditorProps['editorDidMount'] = useCallback(
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
+      editorRef.current = editor;
+      decorationsRef.current = editor.createDecorationsCollection();
+      updateDecorations(serialize(field.value));
+    },
+    [field.value, updateDecorations]
+  );
+
+  // Re-apply decorations when pattern changes externally (e.g. from form state)
+  useEffect(() => {
+    updateDecorations(serialize(field.value));
+  }, [field.value, updateDecorations]);
 
   return (
     <>
@@ -73,27 +184,31 @@ export const DissectPatternDefinition = () => {
         error={error?.message}
         fullWidth
       >
-        <CodeEditor
-          value={serialize(field.value)}
-          onChange={(value) => field.onChange(deserialize(value))}
-          languageId="text"
-          height={75}
-          options={{
-            automaticLayout: true,
-            minimap: { enabled: false },
-          }}
-          aria-label={i18n.translate(
-            'xpack.streams.streamDetailView.managementTab.enrichment.processor.dissectPatternDefinitionsAriaLabel',
-            { defaultMessage: 'Pattern editor' }
-          )}
-        />
+        <div
+          css={css`
+            ${colourPaletteStyles}
+          `}
+        >
+          <CodeEditor
+            value={serialize(field.value)}
+            onChange={(value) => {
+              field.onChange(deserialize(value));
+              updateDecorations(value);
+            }}
+            languageId="text"
+            height={75}
+            editorDidMount={onEditorMount}
+            options={{
+              automaticLayout: true,
+              minimap: { enabled: false },
+            }}
+            aria-label={i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processor.dissectPatternDefinitionsAriaLabel',
+              { defaultMessage: 'Pattern editor' }
+            )}
+          />
+        </div>
       </EuiFormRow>
-      {field.value && (
-        <>
-          <EuiSpacer size="s" />
-          <DissectPatternPreview pattern={field.value} />
-        </>
-      )}
       {aiFeatures && (
         <>
           <EuiSpacer size="s" />

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_definition.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/dissect/dissect_pattern_definition.tsx
@@ -15,6 +15,7 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import { useKibana } from '../../../../../../../../hooks/use_kibana';
 import { useAIFeatures } from '../../../../../../../../hooks/use_ai_features';
 import type { ProcessorFormState } from '../../../../types';
+import { DissectPatternPreview } from '../../../../dissect_highlighting';
 
 const DissectPatternAISuggestions = dynamic(() =>
   import('./dissect_pattern_suggestion').then((mod) => ({
@@ -87,6 +88,12 @@ export const DissectPatternDefinition = () => {
           )}
         />
       </EuiFormRow>
+      {field.value && (
+        <>
+          <EuiSpacer size="s" />
+          <DissectPatternPreview pattern={field.value} />
+        </>
+      )}
       {aiFeatures && (
         <>
           <EuiSpacer size="s" />


### PR DESCRIPTION
## Summary

Extends the GROK color coding feature (from #261153) to DISSECT processors in the streams processing UI.

- When editing a dissect processor, the preview table highlights extracted field regions in the source text with matching colors
- The pattern editor applies **inline color coding** directly in the Monaco editor via decorations (same approach as GROK in #261153) — each `%{field}` token is highlighted with its assigned color as the user types
- All literal separators in the pattern (leading, in-between, and trailing) are highlighted consistently in the preview table
- Handles dissect modifiers: skip (`?`), append (`+`), reference (`*`/`&`), right padding (`->`)
- Skip and reference fields get a muted subdued color, distinct from the regular match field palette
- Uses the same 7 EUI theme colors as GROK (Primary, Accent, AccentSecondary, Success, Warning, Risk, Danger)

### Current experience

https://github.com/user-attachments/assets/63d38825-805e-4441-b035-c83f464c0e1e

### Suggested experience

https://github.com/user-attachments/assets/cf69d391-88ba-401c-ad3d-f78e91e09458

### Changes
- **New**: `dissect_highlighting.tsx` — tokenizer, matcher, `DissectSample` component, `DissectHighlightProvider` context, color palette utilities
- **Modified**: `processor_outcome_preview.tsx` — added `dissectMode` parallel to `grokMode`
- **Modified**: `processor_outcome_preview_helpers.ts` — added `getDissectFieldDisplayValue`
- **Modified**: `dissect_pattern_definition.tsx` — inline Monaco decorations for pattern field coloring

## Test plan

- [ ] Open streams processing UI (`/app/streams/{stream}/management/processing`)
- [ ] Add a DISSECT processor, select a source field (e.g. `message`)
- [ ] Enter a pattern like `no %{attributes.foo} found %{attributes.bar}`
- [ ] Verify `%{field}` tokens in the editor are color-coded inline as you type
- [ ] Verify preview table shows source field with colored highlights for each extracted region
- [ ] Verify all literal separators (including leading text like "no") are highlighted consistently
- [ ] Verify colors are consistent between pattern editor and table preview
- [ ] Test skip fields (`%{?skip_me}`) show a muted/subdued color in both editor and table
- [ ] Test right padding (`%{field->}`) trims trailing whitespace in table highlight
- [ ] Verify switching between GROK and DISSECT processors toggles highlighting correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)