### PR TITLE
[Build] Bump publish artifacts disk to 180gb to match build disk

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -157,4 +157,5 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+      diskSizeGb: 180
     timeout_in_minutes: 30


### PR DESCRIPTION
## Summary

Publish has been running out of disk space for three days and failing to produce snapshots for DRA:
https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/8176#019d5305-097d-46ca-b710-3a8e935cac15/L356


