### PR TITLE
[9.2] [Build] Bump publish artifacts disk to 180gb to match build disk (#261204)

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -157,4 +157,5 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
+      diskSizeGb: 180
     timeout_in_minutes: 30


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Build] Bump publish artifacts disk to 180gb to match build disk (#261204)](https://github.com/elastic/kibana/pull/261204)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-03T22:43:10Z","message":"[Build] Bump publish artifacts disk to 180gb to match build disk (#261204)\n\n## Summary\n\nPublish has been running out of disk space for three days and failing to\nproduce snapshots for DRA:\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/8176#019d5305-097d-46ca-b710-3a8e935cac15/L356","sha":"c7f8f5a78e34d9a26228c2c4b453900dc7beeafd","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:all-open"],"title":"[Build] Bump publish artifacts disk to 180gb to match build disk","number":261204,"url":"https://github.com/elastic/kibana/pull/261204","mergeCommit":{"message":"[Build] Bump publish artifacts disk to 180gb to match build disk (#261204)\n\n## Summary\n\nPublish has been running out of disk space for three days and failing to\nproduce snapshots for DRA:\n\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/8176#019d5305-097d-46ca-b710-3a8e935cac15/L356","sha":"c7f8f5a78e34d9a26228c2c4b453900dc7beeafd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->