### PR TITLE
[Entity Analytics] Fixed api version

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/api.ts
@@ -183,7 +183,7 @@ export const useEntityAnalyticsRoutes = () => {
       });
 
     /**
-     * Fetches entities from the Entity Store v2 unified latest index (internal entity_store plugin route).
+     * Fetches entities from the Entity Store v2 unified latest index (`entity_store` plugin CRUD GET; public API version).
      */
     const fetchEntitiesListV2 = ({
       signal,
@@ -193,7 +193,7 @@ export const useEntityAnalyticsRoutes = () => {
       params: FetchEntitiesListParams;
     }) =>
       http.fetch<ListEntitiesResponse>(ENTITY_STORE_ROUTES.public.CRUD_GET, {
-        version: ENTITY_STORE_API_VERSIONS.internal.v2,
+        version: ENTITY_STORE_API_VERSIONS.public.v1,
         method: 'GET',
         query: {
           entity_types: params.entityTypes,
@@ -390,7 +390,7 @@ export const useEntityAnalyticsRoutes = () => {
      */
     const fetchEntityStoreV2Privileges = () =>
       http.fetch<EntityAnalyticsPrivileges>(ENTITY_STORE_ROUTES.public.CHECK_PRIVILEGES, {
-        version: ENTITY_STORE_API_VERSIONS.internal.v2,
+        version: ENTITY_STORE_API_VERSIONS.public.v1,
         method: 'GET',
       });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -22,8 +22,6 @@ import type {
 import { API_VERSIONS } from '../../../common/entity_analytics/constants';
 import { useKibana } from '../../common/lib/kibana/kibana_react';
 
-const ENTITY_STORE_V2_QUERY = { apiVersion: '2' } as const;
-
 export const useEntityStoreRoutes = () => {
   const { http, uiSettings } = useKibana().services;
   const isV2Enabled = uiSettings.get<boolean>(FF_ENABLE_ENTITY_STORE_V2, false);
@@ -33,7 +31,8 @@ export const useEntityStoreRoutes = () => {
       if (isV2Enabled) {
         return http.fetch<GetEntityStoreStatusResponse>(ENTITY_STORE_ROUTES.public.STATUS, {
           method: 'GET',
-          query: { ...ENTITY_STORE_V2_QUERY, include_components: withComponents },
+          version: API_VERSIONS.public.v1,
+          query: { include_components: withComponents },
         });
       }
       return http.fetch<GetEntityStoreStatusResponse>('/api/entity_store/status', {
@@ -47,7 +46,7 @@ export const useEntityStoreRoutes = () => {
       if (isV2Enabled) {
         return http.fetch<InitEntityStoreResponse>(ENTITY_STORE_ROUTES.public.INSTALL, {
           method: 'POST',
-          query: ENTITY_STORE_V2_QUERY,
+          version: API_VERSIONS.public.v1,
           body: JSON.stringify({}),
         });
       }
@@ -62,7 +61,7 @@ export const useEntityStoreRoutes = () => {
       if (isV2Enabled) {
         return http.fetch<StartEntityEngineResponse>(ENTITY_STORE_ROUTES.public.START, {
           method: 'PUT',
-          query: ENTITY_STORE_V2_QUERY,
+          version: API_VERSIONS.public.v1,
           body: JSON.stringify({}),
         });
       }
@@ -85,7 +84,7 @@ export const useEntityStoreRoutes = () => {
       if (isV2Enabled) {
         return http.fetch<StopEntityEngineResponse>(ENTITY_STORE_ROUTES.public.STOP, {
           method: 'PUT',
-          query: ENTITY_STORE_V2_QUERY,
+          version: API_VERSIONS.public.v1,
           body: JSON.stringify({}),
         });
       }
@@ -108,7 +107,7 @@ export const useEntityStoreRoutes = () => {
       if (isV2Enabled) {
         return http.fetch(ENTITY_STORE_ROUTES.public.UNINSTALL, {
           method: 'POST',
-          query: ENTITY_STORE_V2_QUERY,
+          version: API_VERSIONS.public.v1,
           body: JSON.stringify({}),
         });
       }


### PR DESCRIPTION
## Summary

Aligns Security Solution’s Entity Analytics and Entity Store UI HTTP clients with the **public** versioned APIs exposed by the `entity_store` plugin. Previously, some calls used the **internal** API version or an `apiVersion` query parameter, which does not match how those routes are registered for public use and can cause failed or inconsistent requests.

## What changed

### `api.ts`

- `fetchEntitiesListV2` (public CRUD list) and `fetchEntityStoreV2Privileges` (public privilege check) now send `version: ENTITY_STORE_API_VERSIONS.public.v1` instead of `internal.v2`.
- Comment updated to reflect that these are public, versioned routes.

### `entity_store.ts`

- When the Entity Store v2 feature flag is enabled, status / install / start / stop / uninstall calls no longer pass `apiVersion: '2'` in the query string.
- They now use `version: API_VERSIONS.public.v1` on `http.fetch`, consistent with Kibana’s versioned HTTP API contract.

### `entity_analytics_skill.ts` *(only if this file is in the PR)*

- Agent Builder skill guidance for linking users to Entity Analytics in the UI (dashboards / visualization).

## Release notes

**Skip** — internal bug fix / client–server contract alignment (`release_note:skip`).

## Risk

**Low.** Scoped to how the same endpoints are invoked (correct public `version` vs internal version or query param). Main regression surface: Entity Store v2–gated flows and entity list / privilege checks; smoke-testing those paths is sufficient.

## Testing

- [ ] Entity Store v2 **off**: legacy / unversioned paths unchanged.
- [ ] Entity Store v2 **on**: status, install, start, stop, uninstall succeed without HTTP / version errors.
- [ ] Entity list (v2 unified latest) and Entity Store privilege check load successfully.