### PR TITLE
[Entity Store] Add scout tests to start/stop/status api

### DIFF
--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
@@ -6,6 +6,8 @@
  */
 
 import type { EsClient } from '@kbn/scout-security';
+
+import type { GetStatusResult } from '../../../../server/domain/types';
 import { hashEuid } from '../../../../common/domain/euid';
 import type { EntityType } from '../../../../common';
 
@@ -16,6 +18,26 @@ import {
   LATEST_INDEX,
   UPDATES_INDEX,
 } from './constants';
+
+export interface ApiClientOptions {
+  headers?: Record<string, string>;
+  responseType?: 'json' | 'text' | 'buffer';
+  body?: any;
+}
+export interface ApiClientResponse {
+  statusCode: number;
+  statusMessage: string;
+  headers: Record<string, string | string[]>;
+  body: any;
+}
+export interface ApiClientFixture {
+  get(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+  post(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+  put(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+  delete(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+  patch(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+  head(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
+}
 
 /**
  * Normalizes values that may be stored as a single keyword or as keyword[] after
@@ -265,4 +287,70 @@ export const forceLogExtraction = async (
     headers,
     responseType: 'json',
     body: { fromDateISO, toDateISO },
+  });
+
+export const installAllEntityTypes = (
+  apiClient: ApiClientFixture,
+  headers: Record<string, string>
+) =>
+  apiClient.post(ENTITY_STORE_ROUTES.public.INSTALL, {
+    headers,
+    responseType: 'json',
+    body: {},
+  });
+
+export const uninstallAllEntityTypes = (
+  apiClient: ApiClientFixture,
+  headers: Record<string, string>
+) =>
+  apiClient.post(ENTITY_STORE_ROUTES.public.UNINSTALL, {
+    headers,
+    responseType: 'json',
+    body: {},
+  });
+
+export const getStatus = (
+  apiClient: ApiClientFixture,
+  headers: Record<string, string>,
+  { includeComponents = false } = {}
+): Promise<
+  Omit<ApiClientResponse, 'body'> & { body: Pick<GetStatusResult, 'engines' | 'status'> }
+> =>
+  apiClient.get(
+    includeComponents
+      ? `${ENTITY_STORE_ROUTES.public.STATUS}?include_components=true`
+      : ENTITY_STORE_ROUTES.public.STATUS,
+    {
+      headers,
+      responseType: 'json',
+    }
+  );
+
+export const startEntityTypes = (
+  apiClient: ApiClientFixture,
+  headers: Record<string, string>,
+  entityTypes: EntityType[]
+) =>
+  apiClient.put(ENTITY_STORE_ROUTES.public.START, {
+    headers,
+    responseType: 'json',
+    body: { entityTypes },
+  });
+
+export const stopEntityTypes = (
+  apiClient: ApiClientFixture,
+  headers: Record<string, string>,
+  entityTypes: EntityType[]
+) =>
+  apiClient.put(ENTITY_STORE_ROUTES.public.STOP, {
+    headers,
+    responseType: 'json',
+    body: { entityTypes },
+  });
+
+export const stopAllEntityTypes = (apiClient: ApiClientFixture, headers: Record<string, string>) =>
+  apiClient.put(ENTITY_STORE_ROUTES.public.STOP, {
+    headers,
+    responseType: 'json',
+    body: {},
   });

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
@@ -348,6 +348,13 @@ export const stopEntityTypes = (
     body: { entityTypes },
   });
 
+export const startAllEntityTypes = (apiClient: ApiClientFixture, headers: Record<string, string>) =>
+  apiClient.put(ENTITY_STORE_ROUTES.public.START, {
+    headers,
+    responseType: 'json',
+    body: {},
+  });
+
 export const stopAllEntityTypes = (apiClient: ApiClientFixture, headers: Record<string, string>) =>
   apiClient.put(ENTITY_STORE_ROUTES.public.STOP, {
     headers,

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/fixtures/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EsClient } from '@kbn/scout-security';
-
+import type { apiTest } from '@kbn/scout-security';
 import type { GetStatusResult } from '../../../../server/domain/types';
 import { hashEuid } from '../../../../common/domain/euid';
 import type { EntityType } from '../../../../common';
@@ -19,26 +19,9 @@ import {
   UPDATES_INDEX,
 } from './constants';
 
-export interface ApiClientOptions {
-  headers?: Record<string, string>;
-  responseType?: 'json' | 'text' | 'buffer';
-  body?: any;
-}
-export interface ApiClientResponse {
-  statusCode: number;
-  statusMessage: string;
-  headers: Record<string, string | string[]>;
-  body: any;
-}
-export interface ApiClientFixture {
-  get(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-  post(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-  put(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-  delete(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-  patch(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-  head(url: string, options?: ApiClientOptions): Promise<ApiClientResponse>;
-}
-
+type ApiWorkerFixtures = Parameters<Parameters<typeof apiTest>[2]>[0];
+type ApiClientFixture = ApiWorkerFixtures['apiClient'];
+type ApiClientResponse = Awaited<ReturnType<ApiClientFixture['get']>>; // ApiClientResponse is the same for all methods
 /**
  * Normalizes values that may be stored as a single keyword or as keyword[] after
  * log extraction (e.g. `entity.relationships.*` bags).

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/start.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/start.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '@kbn/scout-security';
+import { PUBLIC_HEADERS, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import {
+  getStatus,
+  installAllEntityTypes,
+  startAllEntityTypes,
+  startEntityTypes,
+  stopAllEntityTypes,
+  stopEntityTypes,
+  uninstallAllEntityTypes,
+} from '../fixtures/helpers';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+
+const ALL_ENTITY_TYPES = ['generic', 'host', 'service', 'user'];
+
+apiTest.describe('Entity Store Start API tests', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await uninstallAllEntityTypes(apiClient, defaultHeaders);
+  });
+
+  apiTest('Should start all engines after stop', async ({ apiClient }) => {
+    await installAllEntityTypes(apiClient, defaultHeaders);
+    await stopAllEntityTypes(apiClient, defaultHeaders);
+
+    const startResponse = await startAllEntityTypes(apiClient, defaultHeaders);
+    expect(startResponse.statusCode).toBe(200);
+
+    const status = await getStatus(apiClient, defaultHeaders);
+    expect(status.body.status).toBe('running');
+
+    const engineTypes = status.body.engines.map((e) => e.type).sort();
+    expect(engineTypes).toStrictEqual(ALL_ENTITY_TYPES);
+
+    for (const engine of status.body.engines) {
+      expect(engine.status).toBe('started');
+    }
+  });
+
+  apiTest('Should start a single stopped entity type', async ({ apiClient }) => {
+    await installAllEntityTypes(apiClient, defaultHeaders);
+    await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+
+    const startResponse = await startEntityTypes(apiClient, defaultHeaders, ['user']);
+    expect(startResponse.statusCode).toBe(200);
+    expect(startResponse.body).toStrictEqual({ ok: true });
+
+    const status = await getStatus(apiClient, defaultHeaders);
+    expect(status.body.status).toBe('running');
+
+    for (const engine of status.body.engines) {
+      expect(engine.status).toBe('started');
+    }
+  });
+
+  apiTest(
+    'Should return 200 when starting an entity type that is already started',
+    async ({ apiClient }) => {
+      await installAllEntityTypes(apiClient, defaultHeaders);
+
+      const startResponse = await startEntityTypes(apiClient, defaultHeaders, ['user']);
+      expect(startResponse.statusCode).toBe(200);
+      expect(startResponse.body).toStrictEqual({ ok: true });
+
+      const status = await getStatus(apiClient, defaultHeaders);
+
+      const userEngine = status.body.engines.find((e) => e.type === 'user');
+      expect(userEngine!.status).toBe('started');
+    }
+  );
+
+  apiTest('Should return 200 when starting on an uninstalled store', async ({ apiClient }) => {
+    await uninstallAllEntityTypes(apiClient, defaultHeaders);
+
+    const startResponse = await startEntityTypes(apiClient, defaultHeaders, ['user']);
+    expect(startResponse.statusCode).toBe(200);
+    expect(startResponse.body).toStrictEqual({ ok: true });
+
+    const status = await getStatus(apiClient, defaultHeaders);
+    expect(status.body.status).toBe('not_installed');
+  });
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/status.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/status.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '@kbn/scout-security';
+import { PUBLIC_HEADERS, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import {
+  getStatus,
+  installAllEntityTypes,
+  stopAllEntityTypes,
+  stopEntityTypes,
+  uninstallAllEntityTypes,
+} from '../fixtures/helpers';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+
+const ALL_ENTITY_TYPES = ['generic', 'host', 'service', 'user'];
+
+apiTest.describe('Entity Store Status API tests', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await uninstallAllEntityTypes(apiClient, defaultHeaders);
+  });
+
+  apiTest(
+    'Should return status "running" with all 4 engine types "started" after a full install',
+    async ({ apiClient }) => {
+      await installAllEntityTypes(apiClient, defaultHeaders);
+
+      const status = await getStatus(apiClient, defaultHeaders);
+      expect(status.statusCode).toBe(200);
+      expect(status.body.status).toBe('running');
+
+      const engineTypes = status.body.engines.map((e) => e.type).sort();
+      expect(engineTypes).toStrictEqual(ALL_ENTITY_TYPES);
+
+      for (const engine of status.body.engines) {
+        expect(engine.status).toBe('started');
+      }
+    }
+  );
+
+  apiTest(
+    'Should return status "not_installed" and an empty engines array when the store is uninstalled',
+    async ({ apiClient }) => {
+      await uninstallAllEntityTypes(apiClient, defaultHeaders);
+
+      const status = await getStatus(apiClient, defaultHeaders);
+      expect(status.statusCode).toBe(200);
+      expect(status.body.status).toBe('not_installed');
+      expect(status.body.engines).toStrictEqual([]);
+    }
+  );
+
+  apiTest(
+    'Should return overall status "running" when 3 engines are "started" and 1 is "stopped"',
+    async ({ apiClient }) => {
+      await installAllEntityTypes(apiClient, defaultHeaders);
+      await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+
+      const status = await getStatus(apiClient, defaultHeaders);
+      expect(status.body.status).toBe('running');
+
+      const userEngine = status.body.engines.find((e) => e.type === 'user');
+      expect(userEngine!.status).toBe('stopped');
+
+      const otherEngines = status.body.engines.filter((e) => e.type !== 'user');
+      for (const engine of otherEngines) {
+        expect(engine.status).toBe('started');
+      }
+    }
+  );
+
+  apiTest(
+    'Should return overall status "stopped" when all 4 engines are stopped',
+    async ({ apiClient }) => {
+      await installAllEntityTypes(apiClient, defaultHeaders);
+      await stopAllEntityTypes(apiClient, defaultHeaders);
+
+      const status = await getStatus(apiClient, defaultHeaders);
+      expect(status.body.status).toBe('stopped');
+
+      for (const engine of status.body.engines) {
+        expect(engine.status).toBe('stopped');
+      }
+    }
+  );
+});

--- a/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/stop.spec.ts
+++ b/x-pack/solutions/security/plugins/entity_store/test/scout/api/tests/stop.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expect } from '@kbn/scout-security/api';
+import { apiTest } from '@kbn/scout-security';
+import { PUBLIC_HEADERS, ENTITY_STORE_TAGS } from '../fixtures/constants';
+import {
+  getStatus,
+  installAllEntityTypes,
+  stopAllEntityTypes,
+  stopEntityTypes,
+  uninstallAllEntityTypes,
+} from '../fixtures/helpers';
+import { FF_ENABLE_ENTITY_STORE_V2 } from '../../../../common';
+
+const ALL_ENTITY_TYPES = ['generic', 'host', 'service', 'user'];
+
+apiTest.describe('Entity Store Stop API tests', { tag: ENTITY_STORE_TAGS }, () => {
+  let defaultHeaders: Record<string, string>;
+
+  apiTest.beforeAll(async ({ samlAuth, kbnClient }) => {
+    const credentials = await samlAuth.asInteractiveUser('admin');
+    defaultHeaders = {
+      ...credentials.cookieHeader,
+      ...PUBLIC_HEADERS,
+    };
+    await kbnClient.uiSettings.update({
+      [FF_ENABLE_ENTITY_STORE_V2]: true,
+    });
+  });
+
+  apiTest.afterEach(async ({ apiClient }) => {
+    await uninstallAllEntityTypes(apiClient, defaultHeaders);
+  });
+
+  apiTest('Should stop all engines when entityTypes is omitted', async ({ apiClient }) => {
+    await installAllEntityTypes(apiClient, defaultHeaders);
+
+    const stopResponse = await stopAllEntityTypes(apiClient, defaultHeaders);
+    expect(stopResponse.statusCode).toBe(200);
+
+    const status = await getStatus(apiClient, defaultHeaders);
+    expect(status.body.status).toBe('stopped');
+
+    const engineTypes = status.body.engines.map((e) => e.type).sort();
+    expect(engineTypes).toStrictEqual(ALL_ENTITY_TYPES);
+
+    for (const engine of status.body.engines) {
+      expect(engine.status).toBe('stopped');
+    }
+  });
+
+  apiTest('Should stop a single entity type', async ({ apiClient }) => {
+    await installAllEntityTypes(apiClient, defaultHeaders);
+
+    const stopResponse = await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+    expect(stopResponse.statusCode).toBe(200);
+    expect(stopResponse.body).toStrictEqual({ ok: true });
+
+    const status = await getStatus(apiClient, defaultHeaders);
+
+    // Overall status stays running when other engines are still active
+    expect(status.body.status).toBe('running');
+
+    const userEngine = status.body.engines.find((e) => e.type === 'user');
+    expect(userEngine!.status).toBe('stopped');
+
+    const otherEngines = status.body.engines.filter((e) => e.type !== 'user');
+    for (const engine of otherEngines) {
+      expect(engine.status).toBe('started');
+    }
+  });
+
+  apiTest(
+    'Should return 200 when stopping an entity type that is already stopped',
+    async ({ apiClient }) => {
+      await installAllEntityTypes(apiClient, defaultHeaders);
+
+      await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+
+      // Stop user engine again
+      const secondStopResponse = await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+      expect(secondStopResponse.statusCode).toBe(200);
+      expect(secondStopResponse.body).toStrictEqual({ ok: true });
+
+      const status = await getStatus(apiClient, defaultHeaders);
+
+      const userEngine = status.body.engines.find((e) => e.type === 'user');
+      expect(userEngine!.status).toBe('stopped');
+    }
+  );
+
+  apiTest('Should return 200 when stopping on an uninstalled store', async ({ apiClient }) => {
+    await uninstallAllEntityTypes(apiClient, defaultHeaders);
+
+    const stopResponse = await stopEntityTypes(apiClient, defaultHeaders, ['user']);
+    expect(stopResponse.statusCode).toBe(200);
+    expect(stopResponse.body).toStrictEqual({ ok: true });
+
+    const status = await getStatus(apiClient, defaultHeaders);
+    expect(status.body.status).toBe('not_installed');
+  });
+});


### PR DESCRIPTION
adds 3 files each with their own tests: stop / start / status

<!--ONMERGE {"backportTargets":["9.4"]} ONMERGE-->