### PR TITLE
[One Workflow] Bugfix - execution editor UI

### DIFF
--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
@@ -231,9 +231,7 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
         direction="column"
         gutterSize="m"
         css={css`
-          flex: 1;
           min-height: 0;
-          align-self: stretch;
         `}
       >
         <EuiFlexItem grow={false}>
@@ -259,17 +257,13 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
         {selectedStepExecution && (
           <EuiFlexItem
             css={css`
-              flex: 1;
-              min-height: 0;
-              display: flex;
-              flex-direction: column;
+              overflow: hidden;
             `}
           >
             <EuiFlexGroup
               direction="column"
               gutterSize="s"
               css={css`
-                flex: 1;
                 min-height: 0;
               `}
             >
@@ -280,10 +274,7 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
               )}
               <EuiFlexItem
                 css={css`
-                  flex: 1;
-                  min-height: 0;
-                  display: flex;
-                  flex-direction: column;
+                  overflow: hidden;
                 `}
               >
                 <EuiFormRow

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
@@ -227,7 +227,15 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
     );
 
     return (
-      <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="m"
+        css={css`
+          flex: 1;
+          min-height: 0;
+          align-self: stretch;
+        `}
+      >
         <EuiFlexItem grow={false}>
           <EuiFormRow label={translations.selectStepExecutionLabel} fullWidth>
             <EuiComboBox
@@ -249,23 +257,56 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
         </EuiFlexItem>
 
         {selectedStepExecution && (
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem
+            css={css`
+              flex: 1;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+            `}
+          >
+            <EuiFlexGroup
+              direction="column"
+              gutterSize="s"
+              css={css`
+                flex: 1;
+                min-height: 0;
+              `}
+            >
               {((errors && errors !== NOT_READY_SENTINEL) || warnings) && (
                 <EuiFlexItem grow={false}>
                   <InputValidationCallout errors={errors} warnings={warnings} />
                 </EuiFlexItem>
               )}
-              <EuiFlexItem>
-                <EuiFormRow label={translations.contextOverrideLabel} fullWidth>
+              <EuiFlexItem
+                css={css`
+                  flex: 1;
+                  min-height: 0;
+                  display: flex;
+                  flex-direction: column;
+                `}
+              >
+                <EuiFormRow
+                  label={translations.contextOverrideLabel}
+                  fullWidth
+                  css={css`
+                    flex: 1;
+                    display: flex;
+                    flex-direction: column;
+                    min-height: 0;
+                    .euiFormRow__fieldWrapper {
+                      flex: 1;
+                      min-height: 0;
+                      display: flex;
+                      flex-direction: column;
+                    }
+                  `}
+                >
                   <CodeEditor
                     languageId="json"
                     value={value}
-                    fitToContent={{
-                      minLines: 5,
-                      maxLines: 15,
-                    }}
                     width="100%"
+                    height="100%"
                     onChange={setValue}
                     editorDidMount={handleMount}
                     dataTestSubj="workflow-test-step-historical-json-editor"

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_historical_form.tsx
@@ -139,7 +139,7 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
           const loopIndex = loopStepRunIdsIndex.get(workflowRunId) ?? 0;
           loopStepRunIdsIndex.set(workflowRunId, loopIndex - 1); // decrement the index for the next loop iteration (time descending order)
           append.push(
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem key={`${id}-loop-indicator`} grow={false}>
               <EuiIconTip
                 type="refresh"
                 aria-hidden={true}
@@ -150,7 +150,7 @@ export const StepExecuteHistoricalForm = React.memo<StepExecuteHistoricalFormPro
         }
         if (isTestRun) {
           append.push(
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem key={`${id}-test-run`} grow={false}>
               <EuiIconTip type="flask" aria-hidden={true} content={translations.testRun} />
             </EuiFlexItem>
           );

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
@@ -62,9 +62,7 @@ export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
         direction="column"
         gutterSize="s"
         css={css`
-          flex: 1;
           min-height: 0;
-          align-self: stretch;
         `}
       >
         {(errors || warnings) && (
@@ -74,10 +72,7 @@ export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
         )}
         <EuiFlexItem
           css={css`
-            flex: 1;
-            min-height: 0;
-            display: flex;
-            flex-direction: column;
+            overflow: hidden;
           `}
         >
           <EuiFormRow
@@ -90,14 +85,14 @@ export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
               display: flex;
               flex-direction: column;
               min-height: 0;
-              .euiFormRow__labelWrapper {
-                padding-left: 0;
-              }
               .euiFormRow__fieldWrapper {
                 flex: 1;
                 min-height: 0;
                 display: flex;
                 flex-direction: column;
+              }
+              .euiFormRow__labelWrapper {
+                padding-left: 0;
               }
             `}
           >

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_manual_form.tsx
@@ -58,33 +58,56 @@ export const StepExecuteManualForm = React.memo<StepExecuteManualFormProps>(
     );
 
     return (
-      <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="s"
+        css={css`
+          flex: 1;
+          min-height: 0;
+          align-self: stretch;
+        `}
+      >
         {(errors || warnings) && (
           <EuiFlexItem grow={false}>
             <InputValidationCallout errors={errors} warnings={warnings} />
           </EuiFlexItem>
         )}
-        <EuiFlexItem>
+        <EuiFlexItem
+          css={css`
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+          `}
+        >
           <EuiFormRow
             label={i18n.translate('workflows.testStepModal.inputDataLabel', {
               defaultMessage: 'Input Data',
             })}
             fullWidth
             css={css`
+              flex: 1;
+              display: flex;
+              flex-direction: column;
+              min-height: 0;
               .euiFormRow__labelWrapper {
                 padding-left: 0;
+              }
+              .euiFormRow__fieldWrapper {
+                flex: 1;
+                min-height: 0;
+                display: flex;
+                flex-direction: column;
               }
             `}
           >
             <CodeEditor
               languageId="json"
               value={value}
+              width="100%"
+              height="100%"
               editorDidMount={handleMount}
               onChange={setValue}
-              fitToContent={{
-                minLines: 5,
-                maxLines: 15,
-              }}
               dataTestSubj="workflow-event-manual-json-editor"
               overflowWidgetsContainerZIndexOverride={6001}
               options={{

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
@@ -182,11 +182,24 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
             border-top: ${euiTheme.colors.borderBasePlain};
             border-bottom: ${euiTheme.colors.borderBasePlain};
             .euiModalBody__overflow {
+              flex: 1;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
               padding-inline: 0;
+              overflow: hidden;
             }
           `}
         >
-          <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
+          <EuiFlexGroup
+            direction="column"
+            gutterSize="m"
+            css={css`
+              flex: 1;
+              min-height: 0;
+              align-self: stretch;
+            `}
+          >
             <EuiFlexItem
               grow={false}
               css={css`
@@ -240,6 +253,11 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
 
             <EuiFlexItem
               css={css`
+                flex: 1;
+                min-height: 0;
+                display: flex;
+                flex-direction: column;
+                overflow: hidden;
                 background-color: ${euiTheme.colors.backgroundBaseSubdued};
                 padding: ${euiTheme.size.m} ${euiTheme.size.l};
               `}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/step_execute_modal.tsx
@@ -195,9 +195,7 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
             direction="column"
             gutterSize="m"
             css={css`
-              flex: 1;
               min-height: 0;
-              align-self: stretch;
             `}
           >
             <EuiFlexItem
@@ -253,10 +251,6 @@ export const StepExecuteModal = React.memo<StepExecuteModalProps>(
 
             <EuiFlexItem
               css={css`
-                flex: 1;
-                min-height: 0;
-                display: flex;
-                flex-direction: column;
                 overflow: hidden;
                 background-color: ${euiTheme.colors.backgroundBaseSubdued};
                 padding: ${euiTheme.size.m} ${euiTheme.size.l};

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
@@ -173,9 +173,7 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
         direction="column"
         gutterSize="m"
         css={css`
-          flex: 1;
           min-height: 0;
-          align-self: stretch;
         `}
       >
         <EuiFlexItem grow={false}>
@@ -201,17 +199,13 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
         {selectedExecution && (
           <EuiFlexItem
             css={css`
-              flex: 1;
-              min-height: 0;
-              display: flex;
-              flex-direction: column;
+              overflow: hidden;
             `}
           >
             <EuiFlexGroup
               direction="column"
               gutterSize="s"
               css={css`
-                flex: 1;
                 min-height: 0;
               `}
             >
@@ -223,10 +217,7 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
 
               <EuiFlexItem
                 css={css`
-                  flex: 1;
-                  min-height: 0;
-                  display: flex;
-                  flex-direction: column;
+                  overflow: hidden;
                 `}
               >
                 <EuiFormRow

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_historical_form.tsx
@@ -169,7 +169,15 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
     );
 
     return (
-      <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="m"
+        css={css`
+          flex: 1;
+          min-height: 0;
+          align-self: stretch;
+        `}
+      >
         <EuiFlexItem grow={false}>
           <EuiFormRow label={translations.selectExecutionLabel} fullWidth>
             <EuiComboBox
@@ -191,29 +199,59 @@ export const WorkflowExecuteHistoricalForm = React.memo<WorkflowExecuteHistorica
         </EuiFlexItem>
 
         {selectedExecution && (
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem
+            css={css`
+              flex: 1;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+            `}
+          >
+            <EuiFlexGroup
+              direction="column"
+              gutterSize="s"
+              css={css`
+                flex: 1;
+                min-height: 0;
+              `}
+            >
               {errors && errors !== NOT_READY_SENTINEL && (
                 <EuiFlexItem grow={false}>
                   <InputValidationCallout errors={errors} />
                 </EuiFlexItem>
               )}
 
-              <EuiFlexItem>
+              <EuiFlexItem
+                css={css`
+                  flex: 1;
+                  min-height: 0;
+                  display: flex;
+                  flex-direction: column;
+                `}
+              >
                 <EuiFormRow
                   label={translations.getInputDataLabel(
                     getTriggerTypeLabel(selectedExecution.context)
                   )}
                   fullWidth
+                  css={css`
+                    flex: 1;
+                    display: flex;
+                    flex-direction: column;
+                    min-height: 0;
+                    .euiFormRow__fieldWrapper {
+                      flex: 1;
+                      min-height: 0;
+                      display: flex;
+                      flex-direction: column;
+                    }
+                  `}
                 >
                   <CodeEditor
                     languageId="json"
                     value={value}
-                    fitToContent={{
-                      minLines: 5,
-                      maxLines: 15,
-                    }}
                     width="100%"
+                    height="100%"
                     onChange={setValue}
                     editorDidMount={handleMount}
                     dataTestSubj={'workflow-historical-json-editor'}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
@@ -8,6 +8,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { css } from '@emotion/react';
 import type { JSONSchema7 } from 'json-schema';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { CodeEditor, monaco } from '@kbn/code-editor';
@@ -115,27 +116,52 @@ export const WorkflowExecuteManualForm = ({
   );
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s">
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      css={css`
+        flex: 1;
+        min-height: 0;
+        align-self: stretch;
+      `}
+    >
       {errors && (
         <EuiFlexItem grow={false}>
           <InputValidationCallout errors={errors} />
         </EuiFlexItem>
       )}
 
-      <EuiFlexItem>
+      <EuiFlexItem
+        css={css`
+          flex: 1;
+          min-height: 0;
+          display: flex;
+          flex-direction: column;
+        `}
+      >
         <EuiFormRow
           label={i18n.translate('workflows.workflowExecuteManualForm.inputDataLabel', {
             defaultMessage: 'Input Data',
           })}
           fullWidth
+          css={css`
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+            .euiFormRow__fieldWrapper {
+              flex: 1;
+              min-height: 0;
+              display: flex;
+              flex-direction: column;
+            }
+          `}
         >
           <CodeEditor
             languageId="json"
             value={value}
-            fitToContent={{
-              minLines: 5,
-              maxLines: 15,
-            }}
+            width="100%"
+            height="100%"
             onChange={setValue}
             editorDidMount={handleMount}
             dataTestSubj={'workflow-manual-json-editor'}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_manual_form.tsx
@@ -120,9 +120,7 @@ export const WorkflowExecuteManualForm = ({
       direction="column"
       gutterSize="s"
       css={css`
-        flex: 1;
         min-height: 0;
-        align-self: stretch;
       `}
     >
       {errors && (
@@ -133,10 +131,7 @@ export const WorkflowExecuteManualForm = ({
 
       <EuiFlexItem
         css={css`
-          flex: 1;
-          min-height: 0;
-          display: flex;
-          flex-direction: column;
+          overflow: hidden;
         `}
       >
         <EuiFormRow

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -211,11 +211,24 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
               border-top: ${euiTheme.colors.borderBasePlain};
               border-bottom: ${euiTheme.colors.borderBasePlain};
               .euiModalBody__overflow {
+                flex: 1;
+                min-height: 0;
+                display: flex;
+                flex-direction: column;
                 padding-inline: 0;
+                overflow: hidden;
               }
             `}
           >
-            <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
+            <EuiFlexGroup
+              direction="column"
+              gutterSize="m"
+              css={css`
+                flex: 1;
+                min-height: 0;
+                align-self: stretch;
+              `}
+            >
               <EuiFlexItem
                 grow={false}
                 css={css`
@@ -269,6 +282,11 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
 
               <EuiFlexItem
                 css={css`
+                  flex: 1;
+                  min-height: 0;
+                  display: flex;
+                  flex-direction: column;
+                  overflow: hidden;
                   background-color: ${euiTheme.colors.backgroundBaseSubdued};
                   padding: ${euiTheme.size.m} ${euiTheme.size.l};
                 `}

--- a/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/features/run_workflow/ui/workflow_execute_modal.tsx
@@ -224,9 +224,7 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
               direction="column"
               gutterSize="m"
               css={css`
-                flex: 1;
                 min-height: 0;
-                align-self: stretch;
               `}
             >
               <EuiFlexItem
@@ -282,10 +280,6 @@ export const WorkflowExecuteModal = React.memo<WorkflowExecuteModalProps>(
 
               <EuiFlexItem
                 css={css`
-                  flex: 1;
-                  min-height: 0;
-                  display: flex;
-                  flex-direction: column;
                   overflow: hidden;
                   background-color: ${euiTheme.colors.backgroundBaseSubdued};
                   padding: ${euiTheme.size.m} ${euiTheme.size.l};


### PR DESCRIPTION
### Before:
In step execution and in manual/historical workflow execution modals the scrollable editor didn't fill the parent container.
<img width="1290" height="909" alt="image" src="https://github.com/user-attachments/assets/969e1601-a23c-49c5-9468-bbc634f75254" />

➕ console error message
<img width="704" height="363" alt="image" src="https://github.com/user-attachments/assets/2f1fe51c-8bf9-48d9-b42b-8ca7cd2a5399" />

### After:
<img width="1236" height="858" alt="image" src="https://github.com/user-attachments/assets/15322ae1-0913-4f6a-ae55-1c7fd9e995a7" />

➕ console err gone // bonus

Fixes: https://github.com/elastic/security-team/issues/16579