### PR TITLE
SIEM Readiness Serverless Fixes

### DIFF
--- a/x-pack/solutions/security/packages/siem-readiness/src/types.ts
+++ b/x-pack/solutions/security/packages/siem-readiness/src/types.ts
@@ -96,6 +96,8 @@ export interface PipelineStats {
   indices: string[];
   docsCount: number;
   failedDocsCount: number;
+  /** False when the server cannot provide ingestion stats (e.g. serverless mode). */
+  statsAvailable: boolean;
 }
 export interface CasesSearchResponse {
   total: number;

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/components/category_accordion_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/components/category_accordion_table.tsx
@@ -409,6 +409,7 @@ export const CategoryAccordionTable = <T extends Record<string, unknown>>({
                           border: euiTheme.border.thin,
                           padding: euiTheme.size.xl,
                           borderRadius: euiTheme.border.radius.medium,
+                          // overflow: 'hidden',
                         }}
                         items={category.items}
                         columns={columns}
@@ -433,7 +434,7 @@ export const CategoryAccordionTable = <T extends Record<string, unknown>>({
                             values: { itemName, category: category.category },
                           }
                         )}
-                        tableLayout="auto"
+                        tableLayout="fixed"
                       />
                     </>
                   )}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/components/category_accordion_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/components/category_accordion_table.tsx
@@ -409,7 +409,6 @@ export const CategoryAccordionTable = <T extends Record<string, unknown>>({
                           border: euiTheme.border.thin,
                           padding: euiTheme.size.xl,
                           borderRadius: euiTheme.border.radius.medium,
-                          // overflow: 'hidden',
                         }}
                         items={category.items}
                         columns={columns}

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiText,
   EuiButtonEmpty,
+  EuiCallOut,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -65,6 +66,9 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
 
   const { data: categoriesData, isLoading: categoriesLoading } = getReadinessCategories;
   const { data: pipelinesData, isLoading: pipelinesLoading } = getReadinessPipelines;
+
+  // If any pipeline has statsAvailable: false, stats are not available for this environment
+  const statsAvailable = pipelinesData ? pipelinesData.every((p) => p.statsAvailable) : true;
 
   // Build index → category mapping from getReadinessCategories
   const indexToCategoryMap = useMemo(() => {
@@ -166,62 +170,66 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
         }),
         sortable: true,
         truncateText: true,
-        width: '30%',
+        width: statsAvailable ? '30%' : '70%',
       },
-      {
-        field: 'docsCount',
-        name: i18n.translate(
-          'xpack.securitySolution.siemReadiness.continuity.column.docsIngested',
-          {
-            defaultMessage: 'Docs Ingested',
-          }
-        ),
-        sortable: true,
-        render: (docsCount: number) => docsCount.toLocaleString(),
-        width: '20%',
-      },
-      {
-        field: 'failedDocsCount',
-        name: i18n.translate('xpack.securitySolution.siemReadiness.continuity.column.failedDocs', {
-          defaultMessage: 'Failed Docs',
-        }),
-        sortable: true,
-        render: (failedDocsCount: number) => failedDocsCount.toLocaleString(),
-        width: '15%',
-      },
-      {
-        field: 'failureRate',
-        name: i18n.translate('xpack.securitySolution.siemReadiness.continuity.column.failureRate', {
-          defaultMessage: 'Failure Rate',
-        }),
-        sortable: true,
-        render: (failureRate: string) => `${failureRate}%`,
-        width: '15%',
-      },
-      {
-        field: 'failureRate',
-        name: i18n.translate('xpack.securitySolution.siemReadiness.continuity.column.status', {
-          defaultMessage: 'Status',
-        }),
-        render: (failureRate: string) => {
-          const isCritical = Number(failureRate) > 1;
-          return (
-            <EuiBadge color={isCritical ? 'danger' : 'success'}>
-              {isCritical
-                ? i18n.translate(
-                    'xpack.securitySolution.siemReadiness.continuity.status.criticalFailureRate',
-                    {
-                      defaultMessage: 'Critical failure rate',
-                    }
-                  )
-                : i18n.translate('xpack.securitySolution.siemReadiness.continuity.status.healthy', {
-                    defaultMessage: 'Healthy',
-                  })}
-            </EuiBadge>
-          );
-        },
-        width: '20%',
-      },
+      ...(statsAvailable
+        ? [
+            {
+              field: 'docsCount',
+              name: i18n.translate(
+                'xpack.securitySolution.siemReadiness.continuity.column.docsIngested',
+                { defaultMessage: 'Docs Ingested' }
+              ),
+              sortable: true,
+              render: (docsCount: number) => docsCount.toLocaleString(),
+              width: '20%',
+            } as EuiBasicTableColumn<PipelineInfoWithStatus>,
+            {
+              field: 'failedDocsCount',
+              name: i18n.translate(
+                'xpack.securitySolution.siemReadiness.continuity.column.failedDocs',
+                { defaultMessage: 'Failed Docs' }
+              ),
+              sortable: true,
+              render: (failedDocsCount: number) => failedDocsCount.toLocaleString(),
+              width: '15%',
+            } as EuiBasicTableColumn<PipelineInfoWithStatus>,
+            {
+              field: 'failureRate',
+              name: i18n.translate(
+                'xpack.securitySolution.siemReadiness.continuity.column.failureRate',
+                { defaultMessage: 'Failure Rate' }
+              ),
+              sortable: true,
+              render: (failureRate: string) => `${failureRate}%`,
+              width: '15%',
+            } as EuiBasicTableColumn<PipelineInfoWithStatus>,
+            {
+              field: 'failureRate',
+              name: i18n.translate(
+                'xpack.securitySolution.siemReadiness.continuity.column.status',
+                { defaultMessage: 'Status' }
+              ),
+              render: (failureRate: string) => {
+                const isCritical = Number(failureRate) > 1;
+                return (
+                  <EuiBadge color={isCritical ? 'danger' : 'success'}>
+                    {isCritical
+                      ? i18n.translate(
+                          'xpack.securitySolution.siemReadiness.continuity.status.criticalFailureRate',
+                          { defaultMessage: 'Critical failure rate' }
+                        )
+                      : i18n.translate(
+                          'xpack.securitySolution.siemReadiness.continuity.status.healthy',
+                          { defaultMessage: 'Healthy' }
+                        )}
+                  </EuiBadge>
+                );
+              },
+              width: '20%',
+            } as EuiBasicTableColumn<PipelineInfoWithStatus>,
+          ]
+        : []),
       {
         field: 'name' as const,
         name: i18n.translate('xpack.securitySolution.siemReadiness.continuity.column.actions', {
@@ -254,7 +262,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
         ],
       },
     ],
-    [basePath]
+    [basePath, statsAvailable]
   );
 
   // Render function for accordion extra action (right side badges/stats)
@@ -268,32 +276,35 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
         {/* Status */}
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {i18n.translate('xpack.securitySolution.siemReadiness.continuity.status.label', {
-              defaultMessage: 'Status:',
-            })}
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiBadge color={isCritical ? 'warning' : 'success'}>
-            {isCritical
-              ? i18n.translate(
-                  'xpack.securitySolution.siemReadiness.continuity.status.actionsRequired',
-                  {
-                    defaultMessage: 'Actions required',
-                  }
-                )
-              : i18n.translate('xpack.securitySolution.siemReadiness.continuity.status.healthy', {
-                  defaultMessage: 'Healthy',
+        {statsAvailable && (
+          <>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('xpack.securitySolution.siemReadiness.continuity.status.label', {
+                  defaultMessage: 'Status:',
                 })}
-          </EuiBadge>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {'|'}
-          </EuiText>
-        </EuiFlexItem>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={isCritical ? 'warning' : 'success'}>
+                {isCritical
+                  ? i18n.translate(
+                      'xpack.securitySolution.siemReadiness.continuity.status.actionsRequired',
+                      { defaultMessage: 'Actions required' }
+                    )
+                  : i18n.translate(
+                      'xpack.securitySolution.siemReadiness.continuity.status.healthy',
+                      { defaultMessage: 'Healthy' }
+                    )}
+              </EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {'|'}
+              </EuiText>
+            </EuiFlexItem>
+          </>
+        )}
         {/* Pipelines */}
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued">
@@ -305,38 +316,44 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
         <EuiFlexItem grow={false}>
           <EuiBadge color="hollow">{totalPipelines}</EuiBadge>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {'|'}
-          </EuiText>
-        </EuiFlexItem>
-        {/* Docs Ingested */}
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {i18n.translate('xpack.securitySolution.siemReadiness.continuity.docsIngested.label', {
-              defaultMessage: 'Docs Ingested:',
-            })}
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiBadge color="hollow">{totalDocs.toLocaleString()}</EuiBadge>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {'|'}
-          </EuiText>
-        </EuiFlexItem>
-        {/* Failure Rate */}
-        <EuiFlexItem grow={false}>
-          <EuiText size="xs" color="subdued">
-            {i18n.translate('xpack.securitySolution.siemReadiness.continuity.failureRate.label', {
-              defaultMessage: 'Failure Rate:',
-            })}
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiBadge color="hollow">{`${overallFailureRate}%`}</EuiBadge>
-        </EuiFlexItem>
+        {statsAvailable && (
+          <>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {'|'}
+              </EuiText>
+            </EuiFlexItem>
+            {/* Docs Ingested */}
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate(
+                  'xpack.securitySolution.siemReadiness.continuity.docsIngested.label',
+                  { defaultMessage: 'Docs Ingested:' }
+                )}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{totalDocs.toLocaleString()}</EuiBadge>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {'|'}
+              </EuiText>
+            </EuiFlexItem>
+            {/* Failure Rate */}
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs" color="subdued">
+                {i18n.translate(
+                  'xpack.securitySolution.siemReadiness.continuity.failureRate.label',
+                  { defaultMessage: 'Failure Rate:' }
+                )}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="hollow">{`${overallFailureRate}%`}</EuiBadge>
+            </EuiFlexItem>
+          </>
+        )}
       </EuiFlexGroup>
     );
   };
@@ -359,7 +376,31 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
   return (
     <>
       <EuiSpacer size="m" />
-      {hasDocCriticalFailures && (
+      {!statsAvailable && (
+        <>
+          <EuiCallOut
+            announceOnMount
+            title={i18n.translate(
+              'xpack.securitySolution.siemReadiness.continuity.statsUnavailable.title',
+              { defaultMessage: 'Ingestion stats not available' }
+            )}
+            color="warning"
+            iconType="warning"
+          >
+            <p>
+              {i18n.translate(
+                'xpack.securitySolution.siemReadiness.continuity.statsUnavailable.body',
+                {
+                  defaultMessage:
+                    'Pipeline ingestion stats (docs ingested, failed docs, failure rate) are not available in serverless mode. Pipelines are listed below for reference.',
+                }
+              )}
+            </p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+      {statsAvailable && hasDocCriticalFailures && (
         <>
           <ContinuityWarningPrompt />
           <EuiSpacer size="m" />
@@ -374,7 +415,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
             })}
           </EuiText>
         </EuiFlexItem>
-        {hasDocCriticalFailures && (
+        {statsAvailable && hasDocCriticalFailures && (
           <>
             <EuiFlexItem grow={false}>
               <ViewCasesButton caseTagsArray={DATA_CONTINUITY_CASE_TAGS} />

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/continuity/continuity_tab.tsx
@@ -211,7 +211,7 @@ export const ContinuityTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
                 { defaultMessage: 'Status' }
               ),
               render: (failureRate: string) => {
-                const isCritical = Number(failureRate) > 1;
+                const isCritical = isCriticalFailureRateFromString(failureRate);
                 return (
                   <EuiBadge color={isCritical ? 'danger' : 'success'}>
                     {isCritical

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/quality/use_auto_check_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/quality/use_auto_check_indices.ts
@@ -45,16 +45,28 @@ interface CheckResult {
 const fetchIndexStats = async (
   http: ReturnType<typeof useKibana>['services']['http'],
   indexName: string,
-  abortController: AbortController
+  abortController: AbortController,
+  isServerless: boolean
 ): Promise<{ sizeInBytes: number; docsCount: number }> => {
   try {
     const encodedIndexName = encodeURIComponent(indexName);
+
+    // ILM and index /_stats are not available in serverless mode.
+    // Use the metering stats path instead (isILMAvailable: false) with a date range.
+    const query = isServerless
+      ? {
+          isILMAvailable: false,
+          startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days ago
+          endDate: new Date().toISOString(),
+        }
+      : { isILMAvailable: true };
+
     const stats = await http.fetch<StatsResponse>(
       `${GET_INDEX_STATS_ENDPOINT}/${encodedIndexName}`,
       {
         method: 'GET',
         version: INTERNAL_API_VERSION,
-        query: { isILMAvailable: true },
+        query,
         signal: abortController.signal,
       }
     );
@@ -156,7 +168,8 @@ interface UseAutoCheckIndicesProps {
 }
 
 export const useAutoCheckIndices = ({ indexNames, enabled }: UseAutoCheckIndicesProps) => {
-  const { http } = useKibana().services;
+  const { http, serverless } = useKibana().services;
+  const isServerless = !!serverless;
   const formatBytes = useFormatBytes();
   const queryClient = useQueryClient();
 
@@ -251,7 +264,8 @@ export const useAutoCheckIndices = ({ indexNames, enabled }: UseAutoCheckIndices
           const { sizeInBytes, docsCount } = await fetchIndexStats(
             http,
             indexName,
-            abortController.current
+            abortController.current,
+            isServerless
           );
 
           const storageResult = formatStorageResult({
@@ -316,7 +330,7 @@ export const useAutoCheckIndices = ({ indexNames, enabled }: UseAutoCheckIndices
       setIsComplete(true);
       // Keep progress and currentIndexName visible for complete state
     }
-  }, [indexNames, formatBytes, http, refreshIndexResults]);
+  }, [indexNames, formatBytes, http, isServerless, refreshIndexResults]);
 
   // Auto-start checks when enabled (only once)
   useEffect(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/retention/retention_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/tabs/retention/retention_tab.tsx
@@ -270,7 +270,7 @@ export const RetentionTab: React.FC<SiemReadinessTabActiveCategoriesProps> = ({
           }
         ),
         sortable: (item: RetentionInfoWithStatus) => item?.retentionDays ?? 0,
-        width: '20%',
+        width: '15%',
         render: (retentionPeriod: string | null, item: RetentionInfoWithStatus) => {
           if (!retentionPeriod) {
             return (

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/visibility_section_boxes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_readiness/pages/visibility_section_boxes.tsx
@@ -172,15 +172,15 @@ export const VisibilitySectionBoxes: React.FC<VisibilitySectionBoxesProps> = ({
         statusDescriptions: {
           healthy: i18n.translate(
             'xpack.securitySolution.siemReadiness.visibility.retention.healthy.description',
-            { defaultMessage: 'All ILM policies meet requirements.' }
+            { defaultMessage: 'All Lifecycle Policies meet requirements.' }
           ),
           actionsRequired: i18n.translate(
             'xpack.securitySolution.siemReadiness.visibility.retention.actionsRequired.description',
-            { defaultMessage: 'Some ILM policies needs increasing.' }
+            { defaultMessage: 'Some Lifecycle Policies need increasing.' }
           ),
           noData: i18n.translate(
             'xpack.securitySolution.siemReadiness.visibility.retention.noData.description',
-            { defaultMessage: 'No data in ILM management.' }
+            { defaultMessage: 'No data in Lifecycle management.' }
           ),
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/register_siem_readiness_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/register_siem_readiness_routes.ts
@@ -18,6 +18,6 @@ export const registerSiemReadinessRoutes = ({
 }: SiemReadinessRoutesDeps) => {
   getReadinessCategoriesRoute(router, logger);
   getMitreDataIndicesDocsCountRoute(router, logger);
-  getReadinessRetentionRoute(router, logger);
+  getReadinessRetentionRoute(router, logger, isServerless);
   getReadinessPipelinesRoute(router, logger, isServerless);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/register_siem_readiness_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/register_siem_readiness_routes.ts
@@ -11,9 +11,13 @@ import { getMitreDataIndicesDocsCountRoute } from './routes/get_mitre_data_indic
 import { getReadinessRetentionRoute } from './routes/get_readiness_retention';
 import { getReadinessPipelinesRoute } from './routes/get_readiness_pipelines';
 
-export const registerSiemReadinessRoutes = ({ router, logger }: SiemReadinessRoutesDeps) => {
+export const registerSiemReadinessRoutes = ({
+  router,
+  logger,
+  isServerless,
+}: SiemReadinessRoutesDeps) => {
   getReadinessCategoriesRoute(router, logger);
   getMitreDataIndicesDocsCountRoute(router, logger);
   getReadinessRetentionRoute(router, logger);
-  getReadinessPipelinesRoute(router, logger);
+  getReadinessPipelinesRoute(router, logger, isServerless);
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
@@ -17,6 +17,8 @@ export interface PipelineStats {
   indices: string[];
   docsCount: number;
   failedDocsCount: number;
+  /** False when the server cannot provide ingestion stats (e.g. serverless mode). */
+  statsAvailable: boolean;
 }
 
 export type PipelinesResponse = PipelineStats[];
@@ -85,6 +87,7 @@ export const getReadinessPipelinesRoute = (
               indices: Array.from(pipelineToIndices[name] || []),
               docsCount: 0,
               failedDocsCount: 0,
+              statsAvailable: false,
             }));
 
             logger.info(`Retrieved ${pipelines.length} ingest pipelines (serverless mode)`);
@@ -124,6 +127,7 @@ export const getReadinessPipelinesRoute = (
               indices: Array.from(pipelineToIndices[name] || []),
               docsCount: pipelineStatsMap[name].count,
               failedDocsCount: pipelineStatsMap[name].failed,
+              statsAvailable: true,
             }));
 
           logger.info(`Retrieved ${pipelines.length} active ingest pipelines`);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
@@ -78,13 +78,12 @@ export const getReadinessPipelinesRoute = (
           });
 
           // nodes.stats ingest API is not available in serverless mode.
-          // Fall back to ingest.getPipeline() and return pipelines with their indices
-          // but without stats (docsCount/failedDocsCount) since those are unavailable.
+          // Use pipelineToIndices (built from logs-*/metrics-* index settings) to return
+          // only pipelines that are referenced by SIEM-related indices, without stats.
           if (isServerless) {
-            const pipelinesResponse = await esClient.ingest.getPipeline();
-            const pipelines: PipelinesResponse = Object.keys(pipelinesResponse).map((name) => ({
+            const pipelines: PipelinesResponse = Object.keys(pipelineToIndices).map((name) => ({
               name,
-              indices: Array.from(pipelineToIndices[name] || []),
+              indices: Array.from(pipelineToIndices[name]),
               docsCount: 0,
               failedDocsCount: 0,
               statsAvailable: false,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_pipelines.ts
@@ -23,7 +23,8 @@ export type PipelinesResponse = PipelineStats[];
 
 export const getReadinessPipelinesRoute = (
   router: SiemReadinessRoutesDeps['router'],
-  logger: SiemReadinessRoutesDeps['logger']
+  logger: SiemReadinessRoutesDeps['logger'],
+  isServerless: boolean
 ) => {
   router.versioned
     .get({
@@ -48,33 +49,8 @@ export const getReadinessPipelinesRoute = (
           const core = await context.core;
           const esClient = core.elasticsearch.client.asCurrentUser;
 
-          // Step 1: Get pipeline stats from all nodes
-          const nodesStatsRequest: NodesStatsRequest = {
-            metric: 'ingest',
-            filter_path: ['nodes.*.ingest.pipelines.*.count', 'nodes.*.ingest.pipelines.*.failed'],
-            timeout: '30s',
-          };
-
-          const nodesStatsResponse = await esClient.nodes.stats(nodesStatsRequest);
-
-          // Aggregate pipeline stats across all nodes
-          const pipelineStatsMap: Record<string, { count: number; failed: number }> = {};
-
-          const nodes = Object.values(nodesStatsResponse.nodes || {});
-          nodes.forEach((node) => {
-            const pipelines = node.ingest?.pipelines || {};
-            const pipelineNames = Object.keys(pipelines);
-            pipelineNames.forEach((pipelineName) => {
-              const pipelineData = pipelines[pipelineName];
-              if (!pipelineStatsMap[pipelineName]) {
-                pipelineStatsMap[pipelineName] = { count: 0, failed: 0 };
-              }
-              pipelineStatsMap[pipelineName].count += pipelineData.count || 0;
-              pipelineStatsMap[pipelineName].failed += pipelineData.failed || 0;
-            });
-          });
-
-          // Step 2: Get index settings to find which indices use which pipelines
+          // Step 1: Get index settings to find which indices use which pipelines.
+          // This works in both serverless and non-serverless modes.
           const settingsResponse = await esClient.indices.getSettings({
             index: ['logs-*', 'metrics-*', '.ds-logs-*', '.ds-metrics-*'],
             filter_path: ['*.settings.index.default_pipeline', '*.settings.index.final_pipeline'],
@@ -93,31 +69,62 @@ export const getReadinessPipelinesRoute = (
             pipelineToIndices[pipeline].add(indexName);
           };
 
-          const indexNames = Object.keys(settingsResponse);
-          indexNames.forEach((indexName) => {
+          Object.keys(settingsResponse).forEach((indexName) => {
             const indexData = settingsResponse[indexName];
-            const defaultPipeline = indexData.settings?.index?.default_pipeline;
-            const finalPipeline = indexData.settings?.index?.final_pipeline;
-            addPipelineIndex(defaultPipeline, indexName);
-            addPipelineIndex(finalPipeline, indexName);
+            addPipelineIndex(indexData.settings?.index?.default_pipeline, indexName);
+            addPipelineIndex(indexData.settings?.index?.final_pipeline, indexName);
           });
 
-          // Step 3: Combine stats with indices mapping
-          const pipelines: PipelinesResponse = [];
-          // Filter out pipelines with 0 docs processed
-          const activePipelineNames = Object.keys(pipelineStatsMap).filter(
-            (name) => pipelineStatsMap[name].count > 0
-          );
-
-          activePipelineNames.forEach((name) => {
-            const activePipelineStats = pipelineStatsMap[name];
-            pipelines.push({
+          // nodes.stats ingest API is not available in serverless mode.
+          // Fall back to ingest.getPipeline() and return pipelines with their indices
+          // but without stats (docsCount/failedDocsCount) since those are unavailable.
+          if (isServerless) {
+            const pipelinesResponse = await esClient.ingest.getPipeline();
+            const pipelines: PipelinesResponse = Object.keys(pipelinesResponse).map((name) => ({
               name,
               indices: Array.from(pipelineToIndices[name] || []),
-              docsCount: activePipelineStats.count,
-              failedDocsCount: activePipelineStats.failed,
+              docsCount: 0,
+              failedDocsCount: 0,
+            }));
+
+            logger.info(`Retrieved ${pipelines.length} ingest pipelines (serverless mode)`);
+            return response.ok({ body: pipelines });
+          }
+
+          // Step 2: Get pipeline stats from all nodes (non-serverless only)
+          const nodesStatsRequest: NodesStatsRequest = {
+            metric: 'ingest',
+            filter_path: ['nodes.*.ingest.pipelines.*.count', 'nodes.*.ingest.pipelines.*.failed'],
+            timeout: '30s',
+          };
+
+          const nodesStatsResponse = await esClient.nodes.stats(nodesStatsRequest);
+
+          // Aggregate pipeline stats across all nodes
+          const pipelineStatsMap: Record<string, { count: number; failed: number }> = {};
+
+          const nodes = Object.values(nodesStatsResponse.nodes || {});
+          nodes.forEach((node) => {
+            const nodePipelines = node.ingest?.pipelines || {};
+            Object.keys(nodePipelines).forEach((pipelineName) => {
+              const pipelineData = nodePipelines[pipelineName];
+              if (!pipelineStatsMap[pipelineName]) {
+                pipelineStatsMap[pipelineName] = { count: 0, failed: 0 };
+              }
+              pipelineStatsMap[pipelineName].count += pipelineData.count || 0;
+              pipelineStatsMap[pipelineName].failed += pipelineData.failed || 0;
             });
           });
+
+          // Step 3: Combine stats with indices mapping, filtering out pipelines with 0 docs processed
+          const pipelines: PipelinesResponse = Object.keys(pipelineStatsMap)
+            .filter((name) => pipelineStatsMap[name].count > 0)
+            .map((name) => ({
+              name,
+              indices: Array.from(pipelineToIndices[name] || []),
+              docsCount: pipelineStatsMap[name].count,
+              failedDocsCount: pipelineStatsMap[name].failed,
+            }));
 
           logger.info(`Retrieved ${pipelines.length} active ingest pipelines`);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_retention.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/routes/get_readiness_retention.ts
@@ -150,7 +150,8 @@ const extractStandaloneIndices = (
 
 export const getReadinessRetentionRoute = (
   router: SiemReadinessRoutesDeps['router'],
-  logger: SiemReadinessRoutesDeps['logger']
+  logger: SiemReadinessRoutesDeps['logger'],
+  isServerless: boolean
 ) => {
   router.versioned
     .get({
@@ -175,11 +176,43 @@ export const getReadinessRetentionRoute = (
           const core = await context.core;
           const esClient = core.elasticsearch.client.asCurrentUser;
 
-          // 1. Get all data streams
+          // 1. Get all data streams (works in both serverless and non-serverless)
           const dataStreamsResponse: IndicesGetDataStreamResponse =
             await esClient.indices.getDataStream({ name: '*' });
 
-          // 2. Get all ILM policies
+          // In serverless, ILM is not available. Data streams use DSL (data stream lifecycle)
+          // only, and there are no standalone indices — so skip ILM and resolveIndex calls.
+          if (isServerless) {
+            const dataStreamItems: RetentionInfo[] = dataStreamsResponse.data_streams.map(
+              (dataStream) => {
+                const { retentionType, retentionPeriod, policyName } = extractRetentionInfo(
+                  dataStream,
+                  {} // no ILM policies in serverless
+                );
+                const retentionDays = parseRetentionToDays(retentionPeriod);
+
+                return {
+                  indexName: dataStream.name,
+                  isDataStream: true,
+                  retentionType,
+                  retentionPeriod,
+                  retentionDays,
+                  policyName,
+                  status: getRetentionStatus(retentionDays),
+                };
+              }
+            );
+
+            const responseBody: RetentionResponse = { items: dataStreamItems };
+
+            logger.info(
+              `Retrieved retention data for ${dataStreamItems.length} data streams (serverless mode)`
+            );
+
+            return response.ok({ body: responseBody });
+          }
+
+          // 2. Get all ILM policies (non-serverless only)
           const ilmPoliciesResponse: IlmGetLifecycleResponse = await esClient.ilm.getLifecycle();
 
           // 3. Resolve index to get standalone indices (excludes backing indices)

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_readiness/types.ts
@@ -11,4 +11,5 @@ import type { SecuritySolutionPluginRouter } from '../../types';
 export interface SiemReadinessRoutesDeps {
   router: SecuritySolutionPluginRouter;
   logger: Logger;
+  isServerless: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -162,7 +162,7 @@ export const initRoutes = (
 
   registerAssetInventoryRoutes({ router, logger });
 
-  registerSiemReadinessRoutes({ router, logger });
+  registerSiemReadinessRoutes({ router, logger, isServerless });
 
   registerTrialCompanionRoutes(trialCompanionDeps);
 


### PR DESCRIPTION
## Summary

various fixes for specific issues with serverless envs that effects SIEM Readiness

- retention page now showing DSL only, previously broke due to failing API calls for ILMs.
- continuity page is showing a prompt explaining the serverless limitation, still showing the table but without the stats
- quality page API calls now include ILM not available flag to prevent errors in serverless

Resolves #260542