### PR TITLE
[Security Solution] Add alert status actions to footer Take action dropdown

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.test.tsx
@@ -15,6 +15,16 @@ import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { EnhancedAlertFlyoutFooter } from './enhanced_alert_flyout_footer';
 import type { ProfileProviderServices } from '../../profile_provider_services';
 
+const mockRefetchNext = jest.fn();
+
+jest.mock('../../../../application/main/state_management/redux', () => ({
+  useCurrentTabDataStateContainer: () => ({
+    refetch$: {
+      next: mockRefetchNext,
+    },
+  }),
+}));
+
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
   ({
     id: '1',
@@ -53,7 +63,13 @@ describe('EnhancedAlertFlyoutFooter', () => {
       </IntlProvider>
     );
 
-    expect(renderFooterFeature).toHaveBeenCalledWith(hit);
+    expect(renderFooterFeature).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hit,
+        dataView: dataViewMock,
+        onAlertUpdated: expect.any(Function),
+      })
+    );
     expect(screen.getByText('Footer')).toBeInTheDocument();
   });
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/security/components/enhanced_alert_flyout_footer.tsx
@@ -8,8 +8,10 @@
  */
 
 import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { useCallback } from 'react';
 import type { ReactElement } from 'react';
 import type { ProfileProviderServices } from '../../profile_provider_services';
+import { useCurrentTabDataStateContainer } from '../../../../application/main/state_management/redux';
 
 export interface EnhancedAlertFlyoutFooterProps extends DocViewRenderProps {
   providerServices: ProfileProviderServices;
@@ -22,12 +24,17 @@ export const EnhancedAlertFlyoutFooter = ({
   fallbackRenderFooter,
   ...docViewProps
 }: EnhancedAlertFlyoutFooterProps) => {
+  const dataStateContainer = useCurrentTabDataStateContainer();
   const alertFlyoutFooterFeature = providerServices.discoverShared.features.registry.getById(
     'security-solution-alert-flyout-footer'
   );
 
   const renderFooter = alertFlyoutFooterFeature?.renderFooter;
+  const onAlertUpdated = useCallback(() => {
+    dataStateContainer.refetch$.next(undefined);
+  }, [dataStateContainer]);
+
   return renderFooter
-    ? renderFooter(hit)
+    ? renderFooter({ hit, ...docViewProps, onAlertUpdated })
     : fallbackRenderFooter?.({ hit, ...docViewProps }) ?? null;
 };

--- a/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
+++ b/src/platform/plugins/shared/discover_shared/public/services/discover_features/types.ts
@@ -132,7 +132,7 @@ export interface SecuritySolutionAlertFlyoutHeaderTitleFeature {
 
 export interface SecuritySolutionAlertFlyoutFooterFeature {
   id: 'security-solution-alert-flyout-footer';
-  renderFooter: (hit: DataTableRecord) => JSX.Element;
+  renderFooter: (props: SecuritySolutionAlertFlyoutRenderProps) => JSX.Element;
 }
 
 export type SecuritySolutionFeature =

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
@@ -33,6 +33,7 @@ const createMockHit = (raw: Partial<DataTableRecord['raw']> = {}): DataTableReco
 
 const mockEcsData: Ecs = { _id: 'test-event-id', _index: 'test-index' };
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
+const mockOnAlertUpdated = jest.fn();
 
 const mockDataFormattedForFieldBrowser: TimelineEventsDetailsItem[] = [
   { field: 'host.name', values: ['test-host'], originalValue: ['test-host'], isObjectArray: false },
@@ -58,7 +59,9 @@ describe('<TakeAction />', () => {
       refetchFlyoutData: mockRefetchFlyoutData,
     });
 
-    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+    const { getByTestId, queryByTestId } = render(
+      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+    );
     const button = getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID);
 
     expect(button).toBeInTheDocument();
@@ -74,7 +77,9 @@ describe('<TakeAction />', () => {
       refetchFlyoutData: mockRefetchFlyoutData,
     });
 
-    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+    const { getByTestId, queryByTestId } = render(
+      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+    );
 
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
@@ -89,7 +94,9 @@ describe('<TakeAction />', () => {
       refetchFlyoutData: mockRefetchFlyoutData,
     });
 
-    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+    const { getByTestId, queryByTestId } = render(
+      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+    );
 
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toHaveTextContent('Take action');
@@ -97,14 +104,16 @@ describe('<TakeAction />', () => {
   });
 
   it('should render TakeActionButton when data is available', () => {
-    const { getByTestId, queryByTestId } = render(<TakeAction hit={createMockHit()} />);
+    const { getByTestId, queryByTestId } = render(
+      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+    );
 
     expect(getByTestId('take-action-button-mock')).toBeInTheDocument();
     expect(queryByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('should call useEventDetails with eventId and indexName from hit', () => {
-    render(<TakeAction hit={createMockHit()} />);
+    render(<TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />);
 
     expect(mockUseEventDetails).toHaveBeenCalledWith({
       eventId: 'test-event-id',
@@ -112,20 +121,24 @@ describe('<TakeAction />', () => {
     });
   });
 
-  it('should pass ecsData and refetchFlyoutData from useEventDetails to TakeActionButton', () => {
-    render(<TakeAction hit={createMockHit()} />);
+  it('should pass hit, ecsData and refetchFlyoutData from useEventDetails to TakeActionButton', () => {
+    const hit = createMockHit();
+    const onAlertUpdated = jest.fn();
+    render(<TakeAction hit={hit} onAlertUpdated={onAlertUpdated} />);
 
     expect(mockTakeActionButton).toHaveBeenCalledWith(
       expect.objectContaining({
+        hit,
         ecsData: mockEcsData,
         refetchFlyoutData: mockRefetchFlyoutData,
+        onAlertUpdated,
       }),
       expect.anything()
     );
   });
 
   it('should compute nonEcsData from dataFormattedForFieldBrowser and pass it to TakeActionButton', () => {
-    render(<TakeAction hit={createMockHit()} />);
+    render(<TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />);
 
     expect(mockTakeActionButton).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
@@ -28,6 +28,10 @@ export interface TakeActionProps {
    * The document to display
    */
   hit: DataTableRecord;
+  /**
+   * Callback invoked after alert mutations to refresh flyout data.
+   */
+  onAlertUpdated: () => void;
 }
 
 /**
@@ -38,7 +42,7 @@ export interface TakeActionProps {
  * We're doing all of this to avoid having to refactor all the actions that are currently using dataAsNestedObject and dataFormattedForFieldBrowser/
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
-export const TakeAction: FC<TakeActionProps> = ({ hit }) => {
+export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated }) => {
   const eventId = hit.raw._id;
   const indexName = hit.raw._index;
 
@@ -71,9 +75,11 @@ export const TakeAction: FC<TakeActionProps> = ({ hit }) => {
 
   return (
     <TakeActionButton
+      hit={hit}
       ecsData={dataAsNestedObject}
       nonEcsData={nonEcsData}
       refetchFlyoutData={refetchFlyoutData}
+      onAlertUpdated={onAlertUpdated}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -7,24 +7,40 @@
 
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import type { DataTableRecord } from '@kbn/discover-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { TimelineNonEcsData } from '../../../../common/search_strategy';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
+import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { TakeActionButton } from './take_action_button';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 jest.mock('../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions');
+jest.mock('../../../detections/components/alerts_table/timeline_actions/use_alerts_actions');
 
 const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
+const mockUseAlertsActions = useAlertsActions as jest.Mock;
+
+const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord =>
+  ({
+    id: 'test-id',
+    raw: { _id: 'test-id', _index: 'test-index' },
+    flattened,
+    isAnchor: false,
+  } as DataTableRecord);
 
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
 const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['test-host'] }];
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 
+const mockOnAlertUpdated = jest.fn();
+
 const defaultProps = {
+  hit: createMockHit(),
   ecsData: mockEcsData,
   nonEcsData: mockNonEcsData,
   refetchFlyoutData: mockRefetchFlyoutData,
+  onAlertUpdated: mockOnAlertUpdated,
 };
 
 const renderTakeActionButton = (props = defaultProps) => render(<TakeActionButton {...props} />);
@@ -33,6 +49,7 @@ describe('<TakeActionButton />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAddToCaseActions.mockReturnValue({ addToCaseActionItems: [] });
+    mockUseAlertsActions.mockReturnValue({ actionItems: [], panels: [] });
   });
 
   it('should render the take action button', () => {
@@ -79,5 +96,42 @@ describe('<TakeActionButton />', () => {
     fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
 
     expect(getByTestId('takeActionPanelMenu')).toBeInTheDocument();
+  });
+
+  it('should pass onAlertUpdated as refetch to useAlertsActions', () => {
+    renderTakeActionButton();
+
+    expect(mockUseAlertsActions).toHaveBeenCalledWith(
+      expect.objectContaining({ refetch: mockOnAlertUpdated })
+    );
+  });
+
+  it('should include status action items when alertStatus is present in hit', () => {
+    const statusItem = { name: 'Mark as acknowledged', onClick: jest.fn() };
+    mockUseAlertsActions.mockReturnValue({ actionItems: [statusItem], panels: [] });
+
+    const alertHit = createMockHit({ 'kibana.alert.workflow_status': 'open' });
+    renderTakeActionButton({ ...defaultProps, hit: alertHit });
+
+    expect(mockUseAlertsActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alertStatus: 'open',
+        eventId: 'test-id',
+        scopeId: '',
+      })
+    );
+  });
+
+  it('should not include status action items when alertStatus is not present in hit', () => {
+    const statusItem = { name: 'Mark as acknowledged', onClick: jest.fn() };
+    mockUseAlertsActions.mockReturnValue({ actionItems: [statusItem], panels: [] });
+
+    renderTakeActionButton({ ...defaultProps, hit: createMockHit() });
+
+    expect(mockUseAlertsActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alertStatus: undefined,
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -8,9 +8,14 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type { DataTableRecord } from '@kbn/discover-utils';
+import { getFieldValue } from '@kbn/discover-utils';
+import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { TimelineNonEcsData } from '../../../../common/search_strategy';
+import type { Status } from '../../../../common/api/detection_engine';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
+import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
@@ -18,6 +23,10 @@ const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeA
 });
 
 export interface TakeActionButtonProps {
+  /**
+   * The raw document record, used to extract alert metadata
+   */
+  hit: DataTableRecord;
   /**
    * ECS data for the document
    */
@@ -30,6 +39,10 @@ export interface TakeActionButtonProps {
    * Callback to refetch flyout data
    */
   refetchFlyoutData: () => Promise<void>;
+  /**
+   * Callback invoked after alert mutations to refresh flyout data.
+   */
+  onAlertUpdated: () => void;
 }
 
 /**
@@ -37,7 +50,7 @@ export interface TakeActionButtonProps {
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
 export const TakeActionButton = memo(
-  ({ ecsData, nonEcsData, refetchFlyoutData }: TakeActionButtonProps) => {
+  ({ hit, ecsData, nonEcsData, refetchFlyoutData, onAlertUpdated }: TakeActionButtonProps) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const togglePopoverHandler = useCallback(() => {
       setIsPopoverOpen((open) => !open);
@@ -46,6 +59,10 @@ export const TakeActionButton = memo(
       setIsPopoverOpen(false);
     }, []);
 
+    const eventId = hit.raw._id as string;
+    const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
+    const alertStatus = (Array.isArray(rawStatus) ? rawStatus[0] : rawStatus) as Status | undefined;
+
     const { addToCaseActionItems } = useAddToCaseActions({
       ecsData,
       nonEcsData,
@@ -53,7 +70,18 @@ export const TakeActionButton = memo(
       onSuccess: refetchFlyoutData,
     });
 
-    const items = useMemo(() => [...addToCaseActionItems], [addToCaseActionItems]);
+    const { actionItems: statusActionItems, panels: statusActionPanels } = useAlertsActions({
+      alertStatus,
+      closePopover: closePopoverHandler,
+      eventId,
+      scopeId: '',
+      refetch: onAlertUpdated,
+    });
+
+    const items = useMemo(
+      () => [...addToCaseActionItems, ...(alertStatus !== undefined ? statusActionItems : [])],
+      [addToCaseActionItems, alertStatus, statusActionItems]
+    );
 
     const takeActionButton = (
       <EuiButton
@@ -80,7 +108,7 @@ export const TakeActionButton = memo(
         <EuiContextMenu
           size="s"
           initialPanelId={0}
-          panels={[{ id: 0, items }]}
+          panels={[{ id: 0, items }, ...statusActionPanels]}
           data-test-subj="takeActionPanelMenu"
         />
       </EuiPopover>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
@@ -15,10 +15,12 @@ jest.mock('./components/footer_ai_actions', () => ({
     <div data-test-subj="footerAiActions" data-hit-id={hit.id} />
   ),
 }));
+const mockTakeAction = jest.fn();
 jest.mock('./components/take_action', () => ({
-  TakeAction: ({ hit }: { hit: DataTableRecord }) => (
-    <div data-test-subj="takeAction" data-hit-id={hit.id} />
-  ),
+  TakeAction: ({ hit, onAlertUpdated }: { hit: DataTableRecord; onAlertUpdated: () => void }) => {
+    mockTakeAction({ hit, onAlertUpdated });
+    return <div data-test-subj="takeAction" data-hit-id={hit.id} />;
+  },
 }));
 
 const createMockHit = (): DataTableRecord =>
@@ -28,11 +30,17 @@ const createMockHit = (): DataTableRecord =>
     flattened: {},
   } as DataTableRecord);
 
+const mockOnAlertUpdated = jest.fn();
+
 describe('<Footer />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders FooterAiActions with the provided hit', () => {
     const hit = createMockHit();
 
-    const { getByTestId } = render(<Footer hit={hit} />);
+    const { getByTestId } = render(<Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} />);
 
     const aiActions = getByTestId('footerAiActions');
     expect(aiActions).toBeInTheDocument();
@@ -42,10 +50,19 @@ describe('<Footer />', () => {
   it('renders TakeAction with the provided hit', () => {
     const hit = createMockHit();
 
-    const { getByTestId } = render(<Footer hit={hit} />);
+    const { getByTestId } = render(<Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} />);
 
     const aiActions = getByTestId('takeAction');
     expect(aiActions).toBeInTheDocument();
     expect(aiActions).toHaveAttribute('data-hit-id', 'test-id');
+  });
+
+  it('passes onAlertUpdated to TakeAction', () => {
+    const hit = createMockHit();
+    const onAlertUpdated = jest.fn();
+
+    render(<Footer hit={hit} onAlertUpdated={onAlertUpdated} />);
+
+    expect(mockTakeAction).toHaveBeenCalledWith(expect.objectContaining({ onAlertUpdated }));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
@@ -16,19 +16,23 @@ export interface FooterProps {
    * The document to display
    */
   hit: DataTableRecord;
+  /**
+   * Callback invoked after alert mutations to refresh flyout data.
+   */
+  onAlertUpdated: () => void;
 }
 
 /**
  * Footer component rendered at the top of the new document flyout in Security Solution and in Discover
  */
-export const Footer = memo(({ hit }: FooterProps) => {
+export const Footer = memo(({ hit, onAlertUpdated }: FooterProps) => {
   return (
     <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
       <EuiFlexItem grow={false}>
         <FooterAiActions hit={hit} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <TakeAction hit={hit} />
+        <TakeAction hit={hit} onAlertUpdated={onAlertUpdated} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
@@ -101,7 +101,7 @@ export const DocumentFlyout = memo(
           />
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
-          <Footer hit={hit} />
+          <Footer hit={hit} onAlertUpdated={onAlertUpdated} />
         </EuiFlyoutFooter>
       </>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
@@ -50,6 +50,8 @@ describe('AlertFlyoutFooter', () => {
     upselling: {},
   } as unknown as StartServices;
 
+  const mockOnAlertUpdated = jest.fn();
+
   it('does not render before promises resolve', () => {
     const hit = { id: '1', raw: {}, flattened: {} } as unknown as DataTableRecord;
     const unresolvedServicesPromise = new Promise<StartServices>(() => undefined);
@@ -60,6 +62,7 @@ describe('AlertFlyoutFooter', () => {
         hit={hit}
         servicesPromise={unresolvedServicesPromise}
         storePromise={unresolvedStorePromise as never}
+        onAlertUpdated={mockOnAlertUpdated}
       />
     );
 
@@ -76,6 +79,7 @@ describe('AlertFlyoutFooter', () => {
         hit={hit}
         servicesPromise={Promise.resolve(servicesMock)}
         storePromise={storePromise}
+        onAlertUpdated={mockOnAlertUpdated}
       />
     );
 
@@ -83,7 +87,9 @@ describe('AlertFlyoutFooter', () => {
       expect(screen.getByText('MockDocumentFooter')).toBeInTheDocument();
     });
 
-    expect(mockDocumentFooter).toHaveBeenCalledWith(expect.objectContaining({ hit }));
+    expect(mockDocumentFooter).toHaveBeenCalledWith(
+      expect.objectContaining({ hit, onAlertUpdated: mockOnAlertUpdated })
+    );
     expect(mockFlyoutProviders).toHaveBeenCalledWith(
       expect.objectContaining({
         services: servicesMock,
@@ -101,6 +107,7 @@ describe('AlertFlyoutFooter', () => {
         hit={hit}
         servicesPromise={Promise.reject(new Error('services failed'))}
         storePromise={Promise.resolve(store as never)}
+        onAlertUpdated={mockOnAlertUpdated}
       />
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
@@ -25,12 +25,17 @@ export interface AlertFlyoutFooterProps {
    * A promise that resolves to a Security Solution redux store for flyout rendering.
    */
   storePromise: Promise<SecurityAppStore>;
+  /**
+   * Callback invoked after alert mutations to refresh the Discover table.
+   */
+  onAlertUpdated: () => void;
 }
 
 export const AlertFlyoutFooter = ({
   hit,
   servicesPromise,
   storePromise,
+  onAlertUpdated,
 }: AlertFlyoutFooterProps) => {
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
@@ -66,6 +71,6 @@ export const AlertFlyoutFooter = ({
   return flyoutProviders({
     services,
     store,
-    children: <Footer hit={hit} />,
+    children: <Footer hit={hit} onAlertUpdated={onAlertUpdated} />,
   });
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/plugin.tsx
@@ -431,7 +431,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     });
     const headerFooterFeature: SecuritySolutionAlertFlyoutFooterFeature = {
       id: 'security-solution-alert-flyout-footer',
-      renderFooter: (hit) => {
+      renderFooter: ({ hit, onAlertUpdated }) => {
         const servicesPromise = this.getDiscoverFlyoutServices(core);
         const storePromise = this.getDiscoverFlyoutStore(core);
 
@@ -441,6 +441,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
               hit={hit}
               servicesPromise={servicesPromise}
               storePromise={storePromise}
+              onAlertUpdated={onAlertUpdated}
             />
           </React.Suspense>
         );


### PR DESCRIPTION
> [!NOTE]
> A lot of the changes in this PR are also included in this other two PRS: https://github.com/elastic/kibana/pull/261295 and https://github.com/elastic/kibana/pull/261296

## Summary

This PR adds the alert status actions to the footer of the new flyout.

The actions are accessible when the flyout is opened in Security Solution

https://github.com/user-attachments/assets/31092c3a-7eaa-4259-b537-fa83c3ba0c85

And also when it's opened in Discover

https://github.com/user-attachments/assets/e892d56c-8780-48d5-ad58-6f4715533934

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

## What to look for when testing

- verify that the footer's Take action button has the new alert status entries

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.