### PR TITLE
[Security Solution] Add alert tags actions to footer Take action dropdown

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -13,6 +13,7 @@ import type { TimelineNonEcsData } from '../../../../common/search_strategy';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
+import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
 import { TakeActionButton } from './take_action_button';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
@@ -21,10 +22,12 @@ jest.mock('../../../detections/components/alerts_table/timeline_actions/use_aler
 jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions'
 );
+jest.mock('../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions');
 
 const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
 const mockUseAlertsActions = useAlertsActions as jest.Mock;
 const mockUseAlertAssigneesActions = useAlertAssigneesActions as jest.Mock;
+const mockUseAlertTagsActions = useAlertTagsActions as jest.Mock;
 
 const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord =>
   ({
@@ -58,6 +61,7 @@ describe('<TakeActionButton />', () => {
       alertAssigneesItems: [],
       alertAssigneesPanels: [],
     });
+    mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [], alertTagsPanels: [] });
   });
 
   it('should render the take action button', () => {
@@ -161,9 +165,21 @@ describe('<TakeActionButton />', () => {
     expect(mockRefetchFlyoutData).toHaveBeenCalled();
   });
 
+  it('should call useAlertTagsActions with ecsData and onAlertUpdated as refetch', () => {
+    renderTakeActionButton();
+
+    expect(mockUseAlertTagsActions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ecsRowData: mockEcsData,
+        refetch: mockOnAlertUpdated,
+      })
+    );
+  });
+
   describe('alert vs non-alert document', () => {
     const statusItem = { name: 'Mark as acknowledged', onClick: jest.fn() };
     const assigneeItem = { name: 'Assign alert', onClick: jest.fn() };
+    const tagsItem = { name: 'Apply alert tags', onClick: jest.fn() };
 
     beforeEach(() => {
       mockUseAlertsActions.mockReturnValue({ actionItems: [statusItem], panels: [] });
@@ -171,6 +187,7 @@ describe('<TakeActionButton />', () => {
         alertAssigneesItems: [assigneeItem],
         alertAssigneesPanels: [],
       });
+      mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [tagsItem], alertTagsPanels: [] });
     });
 
     it('should include status and assignees items for alert documents (event.kind === signal)', () => {
@@ -181,6 +198,7 @@ describe('<TakeActionButton />', () => {
 
       expect(getByText('Mark as acknowledged')).toBeInTheDocument();
       expect(getByText('Assign alert')).toBeInTheDocument();
+      expect(getByText('Apply alert tags')).toBeInTheDocument();
     });
 
     it('should exclude status and assignees items for non-alert documents', () => {
@@ -194,6 +212,7 @@ describe('<TakeActionButton />', () => {
 
       expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
+      expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
     });
 
     it('should exclude status and assignees items when event.kind is not set', () => {
@@ -206,6 +225,7 @@ describe('<TakeActionButton />', () => {
 
       expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
+      expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -18,6 +18,7 @@ import type { Status } from '../../../../common/api/detection_engine';
 import { useAddToCaseActions } from '../../../detections/components/alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
+import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
@@ -81,6 +82,12 @@ export const TakeActionButton = memo(
       refetch: onAlertUpdated,
     });
 
+    const { alertTagsItems, alertTagsPanels } = useAlertTagsActions({
+      closePopover: closePopoverHandler,
+      ecsRowData: ecsData,
+      refetch: onAlertUpdated,
+    });
+
     const onAssigneesUpdate = useCallback(() => {
       onAlertUpdated();
       refetchFlyoutData();
@@ -97,8 +104,9 @@ export const TakeActionButton = memo(
         ...addToCaseActionItems,
         ...(isAlert ? statusActionItems : []),
         ...(isAlert ? alertAssigneesItems : []),
+        ...(isAlert ? alertTagsItems : []),
       ],
-      [addToCaseActionItems, isAlert, statusActionItems, alertAssigneesItems]
+      [addToCaseActionItems, alertTagsItems, isAlert, statusActionItems, alertAssigneesItems]
     );
 
     const panels = useMemo(
@@ -106,8 +114,9 @@ export const TakeActionButton = memo(
         { id: 0, items },
         ...(isAlert ? statusActionPanels : []),
         ...(isAlert ? alertAssigneesPanels : []),
+        ...(isAlert ? alertTagsPanels : []),
       ],
-      [isAlert, items, statusActionPanels, alertAssigneesPanels]
+      [alertTagsPanels, isAlert, items, statusActionPanels, alertAssigneesPanels]
     );
 
     const takeActionButton = (


### PR DESCRIPTION
> [!NOTE]
> A lot of the changes in this PR are also included in this other two PRS: https://github.com/elastic/kibana/pull/261294 and https://github.com/elastic/kibana/pull/261295

## Summary

This PR adds the alert tag actions to the footer of the new flyout.

The actions are accessible when the flyout is opened in Security Solution

https://github.com/user-attachments/assets/9b31e621-4e03-4bcd-a2da-9e8d5d1c1c48

And also when it's opened in Discover

https://github.com/user-attachments/assets/b0c1f4a1-05e9-418a-8f60-6ff23e6ec2f5

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

## What to look for when testing

- verify that the footer's Take action button has the new tags entries

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
