### PR TITLE
[Security Solution] Add investigate in timeline action to footer Take action dropdown

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -14,6 +14,8 @@ import { useAddToCaseActions } from '../../../detections/components/alerts_table
 import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
 import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
+import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { TakeActionButton } from './take_action_button';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
@@ -23,6 +25,10 @@ jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions'
 );
 jest.mock('../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions');
+jest.mock(
+  '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
+);
+jest.mock('../../../common/hooks/is_in_security_app');
 
 const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
 const mockUseAlertsActions = useAlertsActions as jest.Mock;
@@ -36,7 +42,8 @@ const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord
     flattened,
     isAnchor: false,
   } as DataTableRecord);
-
+const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
+const mockUseIsInSecurityApp = useIsInSecurityApp as jest.Mock;
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
 const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['test-host'] }];
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
@@ -62,6 +69,8 @@ describe('<TakeActionButton />', () => {
       alertAssigneesPanels: [],
     });
     mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [], alertTagsPanels: [] });
+    mockUseInvestigateInTimeline.mockReturnValue({ investigateInTimelineActionItems: [] });
+    mockUseIsInSecurityApp.mockReturnValue(true);
   });
 
   it('should render the take action button', () => {
@@ -97,17 +106,40 @@ describe('<TakeActionButton />', () => {
     );
   });
 
-  it('should render action items in the popover', () => {
-    const mockItems = [
-      { name: 'Add to new case', onClick: jest.fn() },
-      { name: 'Add to existing case', onClick: jest.fn() },
-    ];
-    mockUseAddToCaseActions.mockReturnValue({ addToCaseActionItems: mockItems });
+  it('should call useInvestigateInTimeline with the correct arguments', () => {
+    renderTakeActionButton();
 
-    const { getByTestId } = renderTakeActionButton();
-    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+    expect(mockUseInvestigateInTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({ ecsRowData: mockEcsData })
+    );
+  });
 
-    expect(getByTestId('takeActionPanelMenu')).toBeInTheDocument();
+  it('should include investigateInTimelineActionItems when in Security app', () => {
+    mockUseIsInSecurityApp.mockReturnValue(true);
+    const timelineItem = { name: 'Investigate in timeline', onClick: jest.fn() };
+    mockUseInvestigateInTimeline.mockReturnValue({
+      investigateInTimelineActionItems: [timelineItem],
+    });
+
+    renderTakeActionButton();
+
+    expect(mockUseInvestigateInTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({ ecsRowData: mockEcsData })
+    );
+  });
+
+  it('should not include investigateInTimelineActionItems when not in Security app (e.g. Discover)', () => {
+    mockUseIsInSecurityApp.mockReturnValue(false);
+    const timelineItem = { name: 'Investigate in timeline', onClick: jest.fn() };
+    mockUseInvestigateInTimeline.mockReturnValue({
+      investigateInTimelineActionItems: [timelineItem],
+    });
+
+    const { queryByText } = renderTakeActionButton();
+
+    fireEvent.click(queryByText('Take action')!.closest('button')!);
+
+    expect(queryByText('Investigate in timeline')).not.toBeInTheDocument();
   });
 
   it('should pass onAlertUpdated as refetch to useAlertsActions', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -19,6 +19,8 @@ import { useAddToCaseActions } from '../../../detections/components/alerts_table
 import { useAlertsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alerts_actions';
 import { useAlertAssigneesActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_assignees_actions';
 import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
+import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
@@ -62,6 +64,8 @@ export const TakeActionButton = memo(
       setIsPopoverOpen(false);
     }, []);
 
+    const isInSecurityApp = useIsInSecurityApp();
+
     const eventId = hit.raw._id as string;
     const isAlert = (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal;
     const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
@@ -99,14 +103,28 @@ export const TakeActionButton = memo(
       refetch: onAssigneesUpdate,
     });
 
+    const { investigateInTimelineActionItems } = useInvestigateInTimeline({
+      ecsRowData: ecsData,
+      onInvestigateInTimelineAlertClick: closePopoverHandler,
+    });
+
     const items = useMemo(
       () => [
         ...addToCaseActionItems,
         ...(isAlert ? statusActionItems : []),
         ...(isAlert ? alertAssigneesItems : []),
         ...(isAlert ? alertTagsItems : []),
+        ...(isInSecurityApp ? investigateInTimelineActionItems : []),
       ],
-      [addToCaseActionItems, alertTagsItems, isAlert, statusActionItems, alertAssigneesItems]
+      [
+        addToCaseActionItems,
+        alertTagsItems,
+        investigateInTimelineActionItems,
+        isAlert,
+        isInSecurityApp,
+        statusActionItems,
+        alertAssigneesItems,
+      ]
     );
 
     const panels = useMemo(


### PR DESCRIPTION
## Summary

This PR adds the investigate in Timeline action to the footer of the new flyout.

The actions are accessible when the flyout is opened in Security Solution

https://github.com/user-attachments/assets/3f70bc77-bd77-4a93-b0f2-ab8155756ff4

But NOT when the flyout is opened in Discover

<img width="1357" height="853" alt="Screenshot 2026-04-05 at 10 45 21 PM" src="https://github.com/user-attachments/assets/3b14092b-8dc6-4dac-ae04-b5629fa19adf" />

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
