### PR TITLE
[Security Solution] Set 382px as min width and 50% as max width for new alert flyout in Security Solution

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/moon.yml
+++ b/x-pack/solutions/security/plugins/security_solution/moon.yml
@@ -291,6 +291,7 @@ dependsOn:
   - '@kbn/controls-schemas'
   - '@kbn/search-inference-endpoints'
   - '@kbn/shared-ux-column-presets'
+  - '@kbn/core-overlays-browser'
 tags:
   - plugin
   - prod

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -133,6 +133,8 @@ const RowActionComponent = ({
           ),
         }),
         {
+          maxWidth: '50%',
+          minWidth: 382,
           ownFocus: false,
           resizable: true,
           size: 's',

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -32,6 +32,7 @@ import { DocumentEventTypes, NotesEventTypes } from '../../../lib/telemetry';
 import { getMappedNonEcsValue } from '../../../utils/get_mapped_non_ecs_value';
 import { useUserPrivileges } from '../../user_privileges';
 import { flyoutProviders } from '../../../../flyout_v2/shared/components/flyout_provider';
+import { useDefaultDocumentFlyoutProperties } from '../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export type RowActionProps = EuiDataGridCellValueElementProps & {
   columnHeaders: ColumnHeaderOptions[];
@@ -90,6 +91,7 @@ const RowActionComponent = ({
 
   const { openFlyout } = useExpandableFlyoutApi();
   const newFlyoutSystemEnabled = useIsExperimentalFeatureEnabled('newFlyoutSystemEnabled');
+  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
   const columnValues = useMemo(
     () =>
@@ -132,14 +134,7 @@ const RowActionComponent = ({
             />
           ),
         }),
-        {
-          maxWidth: '50%',
-          minWidth: 382,
-          ownFocus: false,
-          resizable: true,
-          size: 's',
-          type: 'overlay',
-        }
+        { ...defaultFlyoutProperties }
       );
     } else {
       openFlyout({
@@ -158,6 +153,7 @@ const RowActionComponent = ({
       });
     }
   }, [
+    defaultFlyoutProperties,
     newFlyoutSystemEnabled,
     hit,
     overlays,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
@@ -118,7 +118,14 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
             />
           ),
         }),
-        { ownFocus: false, resizable: true, session: 'inherit', size: 's' }
+        {
+          maxWidth: '50%',
+          minWidth: 382,
+          ownFocus: false,
+          resizable: true,
+          session: 'inherit',
+          size: 's',
+        }
       ),
     [history, onAlertUpdated, services, store]
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
@@ -29,6 +29,10 @@ import { flyoutProviders } from '../../shared/components/flyout_provider';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { CorrelationsDetails } from '../../correlations';
 import { ThreatIntelligenceDetails } from '../../threat_intelligence';
+import {
+  defaultToolsFlyoutProperties,
+  useDefaultDocumentFlyoutProperties,
+} from '../../shared/hooks/use_default_flyout_properties';
 
 export const INSIGHTS_SECTION_TEST_ID = `${PREFIX}InsightsSection` as const;
 
@@ -61,6 +65,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
   const { overlays } = services;
   const store = useStore();
   const history = useHistory();
+  const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
 
   const expanded = useExpandSection({
@@ -94,12 +99,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
         history,
         children: <ThreatIntelligenceDetails hit={hit} />,
       }),
-      {
-        ownFocus: false,
-        resizable: true,
-        size: 'm',
-        type: 'overlay',
-      }
+      { ...defaultToolsFlyoutProperties }
     );
   }, [history, hit, overlays, services, store]);
   const onShowAlert = useCallback(
@@ -118,16 +118,9 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
             />
           ),
         }),
-        {
-          maxWidth: '50%',
-          minWidth: 382,
-          ownFocus: false,
-          resizable: true,
-          session: 'inherit',
-          size: 's',
-        }
+        { ...defaultFlyoutProperties, session: 'inherit' }
       ),
-    [history, onAlertUpdated, services, store]
+    [defaultFlyoutProperties, history, onAlertUpdated, services, store]
   );
   const onShowCorrelationsDetails = useCallback(() => {
     overlays.openSystemFlyout(
@@ -144,12 +137,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
           />
         ),
       }),
-      {
-        ownFocus: false,
-        resizable: true,
-        size: 'm',
-        type: 'overlay',
-      }
+      { ...defaultToolsFlyoutProperties }
     );
   }, [history, hit, onShowAlert, overlays, services, store]);
   const onShowPrevalenceDetails = useCallback(() => {
@@ -167,12 +155,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
           />
         ),
       }),
-      {
-        ownFocus: false,
-        resizable: true,
-        size: 'm',
-        type: 'overlay',
-      }
+      { ...defaultToolsFlyoutProperties }
     );
   }, [history, hit, investigationFields, isInSecurityApp, overlays, services, store]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
@@ -12,6 +12,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 import { EventKind } from '../constants/event_kinds';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { useKibana } from '../../../common/lib/kibana';
@@ -94,12 +95,7 @@ export const InvestigationSection = memo(
           history,
           children: <InvestigationGuideToolsFlyout hit={hit} />,
         }),
-        {
-          ownFocus: false,
-          resizable: true,
-          size: 'm',
-          type: 'overlay',
-        }
+        { ...defaultToolsFlyoutProperties }
       );
     }, [history, hit, overlays, services, store]);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
@@ -22,6 +22,7 @@ import { flyoutProviders } from '../../shared/components/flyout_provider';
 import { AnalyzerGraph } from '../../analyzer';
 import { useSessionViewConfig } from '../../session_view/hooks/use_session_view_config';
 import { SessionView } from '../../session_view';
+import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 
 export const VISUALIZATION_SECTION_TEST_ID = `${PREFIX}Visualizations` as const;
 
@@ -82,12 +83,7 @@ export const VisualizationsSection = memo(
               />
             ),
           }),
-          {
-            ownFocus: false,
-            resizable: true,
-            size: 'm',
-            type: 'overlay',
-          }
+          { ...defaultToolsFlyoutProperties }
         ),
       [history, hit, onAlertUpdated, overlays, renderCellActions, services, store]
     );
@@ -108,12 +104,7 @@ export const VisualizationsSection = memo(
               />
             ),
           }),
-          {
-            ownFocus: false,
-            resizable: true,
-            size: 'm',
-            type: 'overlay',
-          }
+          { ...defaultToolsFlyoutProperties }
         ),
       [
         history,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
@@ -20,6 +20,7 @@ import { AlertsTab } from './alerts_tab';
 import { MetadataTab } from './metadata_tab';
 import { ProcessTab } from './process_tab';
 import { useKibana } from '../../../common/lib/kibana';
+import { useDefaultDocumentFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 
 export const SESSION_VIEW_DETAILS_TEST_ID = `${PREFIX}SessionViewDetails` as const;
 
@@ -76,6 +77,7 @@ export const SessionViewDetails = memo(
     const { overlays } = services;
     const store = useStore();
     const history = useHistory();
+    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
     const onShowAlertDetails = useCallback(
       (alertId: string, alertIndex: string) => {
@@ -93,17 +95,18 @@ export const SessionViewDetails = memo(
               />
             ),
           }),
-          {
-            maxWidth: '50%',
-            minWidth: 382,
-            ownFocus: false,
-            resizable: true,
-            session: 'inherit',
-            size: 's',
-          }
+          { ...defaultFlyoutProperties, session: 'inherit' }
         );
       },
-      [history, onAlertUpdated, overlays, renderCellActions, services, store]
+      [
+        defaultFlyoutProperties,
+        history,
+        onAlertUpdated,
+        overlays,
+        renderCellActions,
+        services,
+        store,
+      ]
     );
 
     const handleJumpToEvent = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
@@ -94,6 +94,8 @@ export const SessionViewDetails = memo(
             ),
           }),
           {
+            maxWidth: '50%',
+            minWidth: 382,
             ownFocus: false,
             resizable: true,
             session: 'inherit',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
@@ -92,6 +92,8 @@ export const SessionView: FC<SessionViewProps> = memo(
             ),
           }),
           {
+            maxWidth: '50%',
+            minWidth: 382,
             ownFocus: false,
             resizable: true,
             session: 'inherit',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
@@ -19,6 +19,7 @@ import { useUserPrivileges } from '../../common/components/user_privileges';
 import { useKibana } from '../../common/lib/kibana';
 import { useSessionViewConfig } from './hooks/use_session_view_config';
 import { flyoutProviders } from '../shared/components/flyout_provider';
+import { useDefaultDocumentFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import { SessionViewDetails } from './components/session_view_details';
 
 export const SESSION_VIEW_TEST_ID = `${PREFIX}SessionView` as const;
@@ -62,6 +63,7 @@ export const SessionView: FC<SessionViewProps> = memo(
     const { overlays, sessionView } = services;
     const store = useStore();
     const history = useHistory();
+    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
     const { canReadPolicyManagement } = useUserPrivileges().endpointPrivileges;
 
@@ -91,17 +93,17 @@ export const SessionView: FC<SessionViewProps> = memo(
               />
             ),
           }),
-          {
-            maxWidth: '50%',
-            minWidth: 382,
-            ownFocus: false,
-            resizable: true,
-            session: 'inherit',
-            size: 's',
-            type: 'overlay',
-          }
+          { ...defaultFlyoutProperties, session: 'inherit' }
         ),
-      [history, onAlertUpdated, overlays, renderCellActions, services, store]
+      [
+        defaultFlyoutProperties,
+        history,
+        onAlertUpdated,
+        overlays,
+        renderCellActions,
+        services,
+        store,
+      ]
     );
 
     const handleJumpToEvent = useCallback(
@@ -156,16 +158,11 @@ export const SessionView: FC<SessionViewProps> = memo(
               />
             ),
           }),
-          {
-            ownFocus: false,
-            resizable: true,
-            session: 'inherit',
-            size: 's',
-            type: 'overlay',
-          }
+          { ...defaultFlyoutProperties, session: 'inherit' }
         );
       },
       [
+        defaultFlyoutProperties,
         handleJumpToEvent,
         history,
         onAlertUpdated,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/shared/hooks/use_default_flyout_properties.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEuiTheme } from '@elastic/eui';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+
+/**
+ * Hook that returns the main properties used when opening a document flyout, to ensure consistency.
+ * The minWidth and maxWidth values are mimicking what Discover is doing here `src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx`.
+ */
+export const useDefaultDocumentFlyoutProperties = (): OverlaySystemFlyoutOpenOptions => {
+  const { euiTheme } = useEuiTheme();
+
+  return {
+    maxWidth: euiTheme.breakpoint.xl,
+    minWidth: euiTheme.base * 24,
+    ownFocus: false,
+    resizable: true,
+    size: 's',
+  };
+};
+
+/**
+ * Hook that returns the main properties used when opening a tools flyout, to ensure consistency.
+ */
+export const defaultToolsFlyoutProperties: OverlaySystemFlyoutOpenOptions = {
+  ownFocus: false,
+  resizable: true,
+  size: 'm',
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -158,6 +158,8 @@ export const ResolverWithoutProviders = React.memo(
               ),
             }),
             {
+              maxWidth: '50%',
+              minWidth: 382,
               ownFocus: false,
               resizable: true,
               session: 'inherit',

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -36,6 +36,7 @@ import { DocumentDetailsAnalyzerPanelKey } from '../../flyout/document_details/s
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 import { DocumentFlyoutWrapper } from '../../flyout_v2/document/document_flyout_wrapper';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { useDefaultDocumentFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 export const ANALYZER_PREVIEW_BANNER = {
   title: i18n.translate(
@@ -74,6 +75,7 @@ export const ResolverWithoutProviders = React.memo(
     const { overlays } = services;
     const store = useStore();
     const history = useHistory();
+    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
     const { openPreviewPanel } = useExpandableFlyoutApi();
 
     useResolverQueryParamCleaner(resolverComponentInstanceID);
@@ -157,16 +159,17 @@ export const ResolverWithoutProviders = React.memo(
                 />
               ),
             }),
-            {
-              maxWidth: '50%',
-              minWidth: 382,
-              ownFocus: false,
-              resizable: true,
-              session: 'inherit',
-              size: 's',
-            }
+            { ...defaultFlyoutProperties, session: 'inherit' }
           ),
-      [handleAlertUpdated, history, overlays, renderCellActions, services, store]
+      [
+        defaultFlyoutProperties,
+        handleAlertUpdated,
+        history,
+        overlays,
+        renderCellActions,
+        services,
+        store,
+      ]
     );
 
     const onShowPanel = useCallback(() => {
@@ -186,12 +189,7 @@ export const ResolverWithoutProviders = React.memo(
               </EuiPanel>
             ),
           }),
-          {
-            ownFocus: false,
-            resizable: true,
-            session: 'inherit',
-            size: 's',
-          }
+          { ...defaultFlyoutProperties, session: 'inherit' }
         );
       } else {
         openPreviewPanel({
@@ -203,6 +201,7 @@ export const ResolverWithoutProviders = React.memo(
         });
       }
     }, [
+      defaultFlyoutProperties,
       history,
       newFlyoutSystemEnabled,
       onShowEvent,

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -200,6 +200,8 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
               ),
             }),
             {
+              maxWidth: '50%',
+              minWidth: 382,
               ownFocus: false,
               resizable: true,
               size: 's',

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -58,6 +58,7 @@ import { getTimelineRowTypeIndicator } from './get_row_indicator';
 import { isAttackDiscoveryRow } from './is_attack_discovery_row';
 import { DocumentFlyoutWrapper } from '../../../../../flyout_v2/document/document_flyout_wrapper';
 import { flyoutProviders } from '../../../../../flyout_v2/shared/components/flyout_provider';
+import { useDefaultDocumentFlyoutProperties } from '../../../../../flyout_v2/shared/hooks/use_default_flyout_properties';
 
 const DataGridMemoized = React.memo(UnifiedDataTable);
 
@@ -124,6 +125,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     const dispatch = useDispatch();
     const store = useStore();
     const history = useHistory();
+    const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
 
     // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
     const [activeStatefulEventContext] = useState({
@@ -199,14 +201,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
                 />
               ),
             }),
-            {
-              maxWidth: '50%',
-              minWidth: 382,
-              ownFocus: false,
-              resizable: true,
-              size: 's',
-              type: 'overlay',
-            }
+            { ...defaultFlyoutProperties }
           );
         } else {
           const isAttackRow = isAttackDiscoveryRow(eventData);
@@ -237,6 +232,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
         }
       },
       [
+        defaultFlyoutProperties,
         newFlyoutSystemEnabled,
         overlays,
         services,

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -293,5 +293,6 @@
     "@kbn/controls-schemas",
     "@kbn/search-inference-endpoints",
     "@kbn/shared-ux-column-presets",
+    "@kbn/core-overlays-browser",
   ]
 }


### PR DESCRIPTION
## Summary

This PR makes a very small UI improvement to the new flyout in Security Solution:
- it sets the minimum width to 382px to mimic what Discover does when opening their document flyout
- it sets the maximum width to 50% of the screen, to mimic what we do currently in the expandable flyout

### Min width

| Before  | After |
| ------------- | ------------- |
| <img width="1353" height="779" alt="Screenshot 2026-04-05 at 10 53 49 PM" src="https://github.com/user-attachments/assets/80a855be-d50a-48e3-8d72-b18ce1495860" /> | <img width="1355" height="777" alt="Screenshot 2026-04-05 at 10 54 10 PM" src="https://github.com/user-attachments/assets/c22fff0f-7846-428f-a6d6-4686fa8f54d5" /> |

### Max width

| Before  | After |
| ------------- | ------------- |
| <img width="1353" height="779" alt="Screenshot 2026-04-05 at 10 57 41 PM" src="https://github.com/user-attachments/assets/cd41085c-0bfe-413a-b12b-7f3bb44c111c" /> | <img width="1355" height="779" alt="Screenshot 2026-04-05 at 10 57 13 PM" src="https://github.com/user-attachments/assets/cdc09066-f26d-44b7-adf8-ef93b51a8a82" /> |

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
