### PR TITLE
feat(agent builder): query params for entity selection in agent centric UX

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/plugins/agent_plugins.tsx
@@ -25,6 +25,8 @@ import {
 } from '@elastic/eui';
 import type { PluginDefinition } from '@kbn/agent-builder-common';
 import { useMutation, useQueryClient } from '@kbn/react-query';
+import { useQueryState } from '../../../hooks/use_query_state';
+import { searchParamNames } from '../../../search_param_names';
 import { labels } from '../../../utils/i18n';
 import { appPaths } from '../../../utils/app_paths';
 import { useNavigation } from '../../../hooks/use_navigation';
@@ -54,7 +56,7 @@ export const AgentPlugins: React.FC = () => {
   const { plugins: allPlugins, isLoading: pluginsLoading } = usePluginsService();
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedPluginId, setSelectedPluginId] = useState<string | null>(null);
+  const [selectedPluginId, setSelectedPluginId] = useQueryState<string>(searchParamNames.pluginId);
   const pendingSelectPluginIdRef = useRef<string | null>(null);
   const [isAddMenuOpen, setIsAddMenuOpen] = useState(false);
   const [mutatingPluginId, setMutatingPluginId] = useState<string | null>(null);
@@ -109,6 +111,8 @@ export const AgentPlugins: React.FC = () => {
   }, [allPlugins, agentPluginIdSet, enableElasticCapabilities, builtinPlugins]);
 
   useEffect(() => {
+    if (agentLoading || pluginsLoading) return;
+
     if (pendingSelectPluginIdRef.current) {
       const pendingInActive = activePlugins.some((p) => p.id === pendingSelectPluginIdRef.current);
       if (pendingInActive) {
@@ -128,7 +132,7 @@ export const AgentPlugins: React.FC = () => {
         setSelectedPluginId(activePlugins[0]?.id ?? null);
       }
     }
-  }, [activePlugins, selectedPluginId]);
+  }, [activePlugins, selectedPluginId, setSelectedPluginId, agentLoading, pluginsLoading]);
 
   const filteredActivePlugins = useMemo(() => {
     if (!searchQuery.trim()) return activePlugins;
@@ -185,7 +189,7 @@ export const AgentPlugins: React.FC = () => {
         onSettled: () => setMutatingPluginId(null),
       });
     },
-    [agentPluginIds, updatePluginsMutation, addSuccessToast]
+    [agentPluginIds, updatePluginsMutation, addSuccessToast, setSelectedPluginId]
   );
 
   const handleTogglePlugin = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
@@ -6,8 +6,6 @@
  */
 
 import React, { useMemo, useState, useEffect, useRef } from 'react';
-import { useQueryState } from '../../../hooks/use_query_state';
-import { searchParamNames } from '../../../search_param_names';
 import { useParams } from 'react-router-dom';
 import {
   EuiButton,
@@ -26,6 +24,8 @@ import {
 } from '@elastic/eui';
 import type { PublicSkillDefinition, PublicSkillSummary } from '@kbn/agent-builder-common';
 import { useMutation, useQueryClient } from '@kbn/react-query';
+import { searchParamNames } from '../../../search_param_names';
+import { useQueryState } from '../../../hooks/use_query_state';
 import { labels } from '../../../utils/i18n';
 import { appPaths } from '../../../utils/app_paths';
 import { useNavigation } from '../../../hooks/use_navigation';

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/skills/agent_skills.tsx
@@ -6,6 +6,8 @@
  */
 
 import React, { useMemo, useState, useEffect, useRef } from 'react';
+import { useQueryState } from '../../../hooks/use_query_state';
+import { searchParamNames } from '../../../search_param_names';
 import { useParams } from 'react-router-dom';
 import {
   EuiButton,
@@ -54,7 +56,7 @@ export const AgentSkills: React.FC = () => {
   const { skills: allSkills, isLoading: skillsLoading } = useSkillsService();
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [selectedSkillId, setSelectedSkillId] = useQueryState<string>(searchParamNames.skillId);
   const pendingSelectSkillIdRef = useRef<string | null>(null);
   const [editingSkillId, setEditingSkillId] = useState<string | null>(null);
   const [isCreateFlyoutOpen, setIsCreateFlyoutOpen] = useState(false);
@@ -103,6 +105,8 @@ export const AgentSkills: React.FC = () => {
   }, [allSkills, agentSkillIdSet, enableElasticCapabilities, builtinSkills]);
 
   useEffect(() => {
+    if (agentLoading || skillsLoading) return;
+
     if (pendingSelectSkillIdRef.current) {
       const pendingInActive = activeSkills.some((s) => s.id === pendingSelectSkillIdRef.current);
       if (pendingInActive) {
@@ -122,7 +126,7 @@ export const AgentSkills: React.FC = () => {
         setSelectedSkillId(activeSkills[0]?.id ?? null);
       }
     }
-  }, [activeSkills, selectedSkillId]);
+  }, [activeSkills, selectedSkillId, setSelectedSkillId, agentLoading, skillsLoading]);
 
   const filteredActiveSkills = useMemo(() => {
     if (!searchQuery.trim()) return activeSkills;

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/agents/tools/agent_tools.tsx
@@ -23,6 +23,8 @@ import {
 import type { ToolDefinition, ToolSelection } from '@kbn/agent-builder-common';
 import { defaultAgentToolIds } from '@kbn/agent-builder-common';
 import { useMutation, useQueryClient } from '@kbn/react-query';
+import { useQueryState } from '../../../hooks/use_query_state';
+import { searchParamNames } from '../../../search_param_names';
 import { labels } from '../../../utils/i18n';
 import { appPaths } from '../../../utils/app_paths';
 import { useNavigation } from '../../../hooks/use_navigation';
@@ -118,7 +120,7 @@ export const AgentTools: React.FC = () => {
   const { tools: allTools, isLoading: toolsLoading } = useToolsService();
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
+  const [selectedToolId, setSelectedToolId] = useQueryState<string>(searchParamNames.toolId);
   const [mutatingToolId, setMutatingToolId] = useState<string | null>(null);
   const {
     isOpen: isLibraryOpen,
@@ -151,6 +153,8 @@ export const AgentTools: React.FC = () => {
   }, [activeToolIdSet, enableElasticCapabilities, defaultToolIdSet]);
 
   useEffect(() => {
+    if (agentLoading || toolsLoading) return;
+
     if (!selectedToolId) {
       if (activeTools.length > 0) {
         setSelectedToolId(activeTools[0].id);
@@ -161,7 +165,7 @@ export const AgentTools: React.FC = () => {
         setSelectedToolId(activeTools[0]?.id ?? null);
       }
     }
-  }, [activeTools, selectedToolId]);
+  }, [activeTools, selectedToolId, setSelectedToolId, agentLoading, toolsLoading]);
 
   const filteredActiveTools = useMemo(() => {
     if (!searchQuery.trim()) return activeTools;
@@ -210,7 +214,7 @@ export const AgentTools: React.FC = () => {
         onSettled: () => setMutatingToolId(null),
       });
     },
-    [agentToolSelections, allTools, updateToolsMutation, addSuccessToast]
+    [agentToolSelections, allTools, updateToolsMutation, addSuccessToast, setSelectedToolId]
   );
 
   const handleToggleTool = useCallback(

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/search_param_names.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/search_param_names.ts
@@ -8,4 +8,7 @@
 export const searchParamNames = {
   agentId: 'agent_id',
   sourceId: 'source_id',
+  skillId: 'skillId',
+  toolId: 'toolId',
+  pluginId: 'pluginId',
 } as const;


### PR DESCRIPTION
Closes https://github.com/elastic/search-team/issues/13633

## Summary

Selecting skills/plugins/tools now changes the query parameter. Sharing this URL will now open that view with the selected entity.



https://github.com/user-attachments/assets/df266783-217d-4ac6-9b45-9f3aabbfc295






