### PR TITLE
[GA][Metrics][Discover] Remove technical preview badge

### DIFF
--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.test.tsx
@@ -197,15 +197,6 @@ describe('MetricsExperienceGridContent', () => {
     expect(getByTestId('unifiedMetricsExperienceGrid')).toBeInTheDocument();
   });
 
-  it('renders the technical preview badge', () => {
-    const { getByText, getByTestId } = render(<MetricsExperienceGridContent {...defaultProps} />, {
-      wrapper: IntlProvider,
-    });
-
-    expect(getByTestId('metricsExperienceTechnicalPreviewBadge')).toBeInTheDocument();
-    expect(getByText('Technical preview')).toBeInTheDocument();
-  });
-
   it('renders the loading state when Discover is reloading', () => {
     const { getByTestId } = render(
       <MetricsExperienceGridContent {...defaultProps} isDiscoverLoading />,

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.tsx
@@ -11,7 +11,6 @@ import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import {
-  EuiBetaBadge,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -108,45 +107,18 @@ export const MetricsExperienceGridContent = ({
         <EuiFlexGroup
           justifyContent="spaceBetween"
           alignItems="center"
-          gutterSize="s"
           responsive={false}
-          direction="row"
+          gutterSize="s"
         >
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              justifyContent="spaceBetween"
-              alignItems="center"
-              responsive={false}
-              gutterSize="s"
-            >
-              <EuiFlexItem grow={false}>
-                <EuiText size="s">
-                  <strong>
-                    {i18n.translate('metricsExperience.grid.metricsCount.label', {
-                      defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
-                      values: { count: filteredFieldsCount },
-                    })}
-                  </strong>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiBetaBadge
-              label={i18n.translate('metricsExperience.grid.technicalPreview.label', {
-                defaultMessage: 'Technical preview',
-              })}
-              tooltipContent={i18n.translate('metricsExperience.grid.technicalPreview.tooltip', {
-                defaultMessage:
-                  'This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
-              })}
-              tooltipPosition="left"
-              title={i18n.translate('metricsExperience.grid.technicalPreview.title', {
-                defaultMessage: 'Technical preview',
-              })}
-              size="s"
-              data-test-subj="metricsExperienceTechnicalPreviewBadge"
-            />
+            <EuiText size="s">
+              <strong>
+                {i18n.translate('metricsExperience.grid.metricsCount.label', {
+                  defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
+                  values: { count: filteredFieldsCount },
+                })}
+              </strong>
+            </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.tsx
+++ b/src/platform/packages/shared/kbn-unified-chart-section-viewer/src/components/observability/metrics/metrics_experience_grid_content.tsx
@@ -104,23 +104,14 @@ export const MetricsExperienceGridContent = ({
       `}
     >
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
-          alignItems="center"
-          responsive={false}
-          gutterSize="s"
-        >
-          <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <strong>
-                {i18n.translate('metricsExperience.grid.metricsCount.label', {
-                  defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
-                  values: { count: filteredFieldsCount },
-                })}
-              </strong>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiText size="s">
+          <strong>
+            {i18n.translate('metricsExperience.grid.metricsCount.label', {
+              defaultMessage: '{count} {count, plural, one {metric} other {metrics}}',
+              values: { count: filteredFieldsCount },
+            })}
+          </strong>
+        </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow>
         {isDiscoverLoading && <MetricsGridLoadingProgress />}


### PR DESCRIPTION
Closes #236079 

## Summary

Transition the feature from technical preview to GA by removing the Technical Badge shown in the Metrics Charts section.

### Changes
- Removed `EuiBetaBadge` component with "Technical Preview" text
- Removed corresponding rendering test

### Expected Results

**After: No Badge is shown**
<img width="1041" height="549" alt="image" src="https://github.com/user-attachments/assets/fc411197-6dc5-4d51-802a-f744d2ba4e29" />

**Before: Badge is present on the top right**
<img width="1036" height="557" alt="image" src="https://github.com/user-attachments/assets/3aa89b59-d122-4ccd-b178-46ca1b4f72b4" />

