### PR TITLE
[Streams] Fix EIS callout flag

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_ai_features.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_ai_features.tsx
@@ -74,7 +74,7 @@ export function useAIFeatures(): AIFeatures | null {
   const selectedConnector = (genAiConnectors.connectors || []).find(
     (connector) => connector.connectorId === genAiConnectors.selectedConnector
   );
-  const isManagedAIConnector = selectedConnector?.isPreconfigured || false;
+  const isManagedAIConnector = selectedConnector?.isEis || false;
 
   return {
     loading: false,


### PR DESCRIPTION
## Summary

Use `isEis` for the `isManagedAIConnector` to show/not show the EIS Additional Charges callout