### PR TITLE
[Yaml Rule Editor] Adjust YAML editor height

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/yaml-rule-editor/src/types.ts
+++ b/x-pack/platform/packages/shared/response-ops/yaml-rule-editor/src/types.ts
@@ -80,6 +80,6 @@ export interface YamlRuleEditorProps {
    */
   esqlPropertyNames?: string[];
   isReadOnly?: boolean;
-  height?: number;
+  height?: number | string;
   dataTestSubj?: string;
 }

--- a/x-pack/platform/packages/shared/response-ops/yaml-rule-editor/src/yaml_rule_editor.tsx
+++ b/x-pack/platform/packages/shared/response-ops/yaml-rule-editor/src/yaml_rule_editor.tsx
@@ -76,7 +76,7 @@ export const YamlRuleEditor: React.FC<YamlRuleEditorProps> = ({
   esqlCallbacks,
   esqlPropertyNames = DEFAULT_ESQL_PROPERTY_NAMES,
   isReadOnly = false,
-  height = 320,
+  height = 'clamp(320px, calc(100vh - 500px), 750px)',
   dataTestSubj = 'alertingV2YamlRuleEditor',
 }) => {
   const editorSuggestDisposable = useRef<monaco.IDisposable | null>(null);
@@ -262,6 +262,7 @@ export const YamlRuleEditor: React.FC<YamlRuleEditorProps> = ({
       suggestionProvider={suggestionProvider}
       hoverProvider={hoverProvider}
       options={{
+        automaticLayout: true,
         minimap: { enabled: false },
         wordWrap: 'on',
         lineNumbers: 'on',


### PR DESCRIPTION
## Summary

Closes elastic/rna-program#243

The YAML rule editor previously used a fixed `320px` height, wasting most of the available viewport space and making it difficult to edit longer rule definitions.

This PR replaces the fixed height with a viewport-relative `clamp(320px, calc(100vh - 500px), 750px)` so the editor scales with the browser window:
- **Floor (320px):** prevents the editor from becoming unusable on short viewports
- **Preferred (100vh - 500px):** scales with viewport height, accounting for Kibana chrome
- **Cap (750px):** matches the Figma design, prevents excessive height on tall monitors

Also enables Monaco's `automaticLayout` option so the editor canvas re-layouts when the viewport is resized (the CSS `clamp` changes the container size, but Monaco needs a `ResizeObserver` to detect that).

## Changes

- Widened `YamlRuleEditorProps.height` type from `number` to `number | string` to support CSS expressions
- Changed the default height from `320` to `clamp(320px, calc(100vh - 500px), 750px)`
- Added `automaticLayout: true` to Monaco editor options