### PR TITLE
[Streams] Fix flaky cross compatibility Streamlang Scout tests

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/lowercase.spec.ts
@@ -40,7 +40,7 @@ apiTest.describe(
         ];
 
         await testBed.ingest('ingest-e2e-test-lowercase-basic', docs, processors);
-        const ingestResult = await testBed.getDocs('ingest-e2e-test-lowercase-basic');
+        const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-lowercase-basic');
 
         await testBed.ingest('esql-e2e-test-lowercase-basic', docs);
         const esqlResult = await esql.queryOnIndex('esql-e2e-test-lowercase-basic', query);
@@ -49,9 +49,9 @@ apiTest.describe(
         expect(ingestResult[0]?.message).toBe('test message 1');
         expect(ingestResult[1]?.message).toBe('test message 2');
 
-        expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0]?.message).toBe('test message 1');
-        expect(esqlResult.documents[1]?.message).toBe('test message 2');
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+        expect(esqlResult.documentsOrdered[0]?.message).toBe('test message 1');
+        expect(esqlResult.documentsOrdered[1]?.message).toBe('test message 2');
       }
     );
 
@@ -71,7 +71,7 @@ apiTest.describe(
 
       const docs = [{ message: 'TEST MESSAGE 1' }, { message: 'TEST MESSAGE 2' }];
       await testBed.ingest('ingest-e2e-test-lowercase-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-lowercase-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-lowercase-basic');
 
       await testBed.ingest('esql-e2e-test-lowercase-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-lowercase-basic', query);
@@ -80,9 +80,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message_lowercase).toBe('test message 1');
       expect(ingestResult[1]?.message_lowercase).toBe('test message 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message_lowercase).toBe('test message 1');
-      expect(esqlResult.documents[1]?.message_lowercase).toBe('test message 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message_lowercase).toBe('test message 1');
+      expect(esqlResult.documentsOrdered[1]?.message_lowercase).toBe('test message 2');
     });
 
     apiTest('should lowercase a field with a where condition', async ({ testBed, esql }) => {
@@ -107,7 +107,7 @@ apiTest.describe(
         { message: 'TEST MESSAGE 2', should_lowercase: 'no' },
       ];
       await testBed.ingest('ingest-e2e-test-lowercase-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-lowercase-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-lowercase-basic');
 
       await testBed.ingest('esql-e2e-test-lowercase-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-lowercase-basic', query);
@@ -116,9 +116,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message).toBe('test message 1');
       expect(ingestResult[1]?.message).toBe('TEST MESSAGE 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message).toBe('test message 1');
-      expect(esqlResult.documents[1]?.message).toBe('TEST MESSAGE 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message).toBe('test message 1');
+      expect(esqlResult.documentsOrdered[1]?.message).toBe('TEST MESSAGE 2');
     });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/trim.spec.ts
@@ -38,7 +38,7 @@ apiTest.describe(
       ];
 
       await testBed.ingest('ingest-e2e-test-trim-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-trim-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-trim-basic');
 
       await testBed.ingest('esql-e2e-test-trim-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-trim-basic', query);
@@ -47,9 +47,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message).toBe('test message 1');
       expect(ingestResult[1]?.message).toBe('test message 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message).toBe('test message 1');
-      expect(esqlResult.documents[1]?.message).toBe('test message 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message).toBe('test message 1');
+      expect(esqlResult.documentsOrdered[1]?.message).toBe('test message 2');
     });
 
     apiTest('should trim a field into a target field', async ({ testBed, esql }) => {
@@ -68,7 +68,7 @@ apiTest.describe(
 
       const docs = [{ message: '   test message 1   ' }, { message: '   test message 2   ' }];
       await testBed.ingest('ingest-e2e-test-trim-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-trim-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-trim-basic');
 
       await testBed.ingest('esql-e2e-test-trim-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-trim-basic', query);
@@ -77,9 +77,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message_trimmed).toBe('test message 1');
       expect(ingestResult[1]?.message_trimmed).toBe('test message 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message_trimmed).toBe('test message 1');
-      expect(esqlResult.documents[1]?.message_trimmed).toBe('test message 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message_trimmed).toBe('test message 1');
+      expect(esqlResult.documentsOrdered[1]?.message_trimmed).toBe('test message 2');
     });
 
     apiTest('should trim a field with a where condition', async ({ testBed, esql }) => {
@@ -104,7 +104,7 @@ apiTest.describe(
         { message: '   test message 2   ', should_trim: 'no' },
       ];
       await testBed.ingest('ingest-e2e-test-trim-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-trim-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-trim-basic');
 
       await testBed.ingest('esql-e2e-test-trim-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-trim-basic', query);
@@ -113,9 +113,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message).toBe('test message 1');
       expect(ingestResult[1]?.message).toBe('   test message 2   ');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message).toBe('test message 1');
-      expect(esqlResult.documents[1]?.message).toBe('   test message 2   ');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message).toBe('test message 1');
+      expect(esqlResult.documentsOrdered[1]?.message).toBe('   test message 2   ');
     });
   }
 );

--- a/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
+++ b/x-pack/platform/packages/shared/kbn-streamlang-tests/test/scout/api/tests/cross_compatibility/uppercase.spec.ts
@@ -40,7 +40,7 @@ apiTest.describe(
         ];
 
         await testBed.ingest('ingest-e2e-test-uppercase-basic', docs, processors);
-        const ingestResult = await testBed.getDocs('ingest-e2e-test-uppercase-basic');
+        const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-uppercase-basic');
 
         await testBed.ingest('esql-e2e-test-uppercase-basic', docs);
         const esqlResult = await esql.queryOnIndex('esql-e2e-test-uppercase-basic', query);
@@ -49,9 +49,9 @@ apiTest.describe(
         expect(ingestResult[0]?.message).toBe('TEST MESSAGE 1');
         expect(ingestResult[1]?.message).toBe('TEST MESSAGE 2');
 
-        expect(esqlResult.documents).toHaveLength(2);
-        expect(esqlResult.documents[0]?.message).toBe('TEST MESSAGE 1');
-        expect(esqlResult.documents[1]?.message).toBe('TEST MESSAGE 2');
+        expect(esqlResult.documentsOrdered).toHaveLength(2);
+        expect(esqlResult.documentsOrdered[0]?.message).toBe('TEST MESSAGE 1');
+        expect(esqlResult.documentsOrdered[1]?.message).toBe('TEST MESSAGE 2');
       }
     );
 
@@ -71,7 +71,7 @@ apiTest.describe(
 
       const docs = [{ message: 'test message 1' }, { message: 'test message 2' }];
       await testBed.ingest('ingest-e2e-test-uppercase-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-uppercase-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-uppercase-basic');
 
       await testBed.ingest('esql-e2e-test-uppercase-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-uppercase-basic', query);
@@ -80,9 +80,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message_upper).toBe('TEST MESSAGE 1');
       expect(ingestResult[1]?.message_upper).toBe('TEST MESSAGE 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message_upper).toBe('TEST MESSAGE 1');
-      expect(esqlResult.documents[1]?.message_upper).toBe('TEST MESSAGE 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message_upper).toBe('TEST MESSAGE 1');
+      expect(esqlResult.documentsOrdered[1]?.message_upper).toBe('TEST MESSAGE 2');
     });
 
     apiTest('should uppercase a field with a where condition', async ({ testBed, esql }) => {
@@ -107,7 +107,7 @@ apiTest.describe(
         { message: 'test message 2', should_uppercase: 'no' },
       ];
       await testBed.ingest('ingest-e2e-test-uppercase-basic', docs, processors);
-      const ingestResult = await testBed.getDocs('ingest-e2e-test-uppercase-basic');
+      const ingestResult = await testBed.getDocsOrdered('ingest-e2e-test-uppercase-basic');
 
       await testBed.ingest('esql-e2e-test-uppercase-basic', docs);
       const esqlResult = await esql.queryOnIndex('esql-e2e-test-uppercase-basic', query);
@@ -116,9 +116,9 @@ apiTest.describe(
       expect(ingestResult[0]?.message).toBe('TEST MESSAGE 1');
       expect(ingestResult[1]?.message).toBe('test message 2');
 
-      expect(esqlResult.documents).toHaveLength(2);
-      expect(esqlResult.documents[0]?.message).toBe('TEST MESSAGE 1');
-      expect(esqlResult.documents[1]?.message).toBe('test message 2');
+      expect(esqlResult.documentsOrdered).toHaveLength(2);
+      expect(esqlResult.documentsOrdered[0]?.message).toBe('TEST MESSAGE 1');
+      expect(esqlResult.documentsOrdered[1]?.message).toBe('test message 2');
     });
   }
 );


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/260167 https://github.com/elastic/kibana/issues/260244 https://github.com/elastic/kibana/issues/261131

## Summary

Fixes three flaky Scout tests in the `cross_compatibility/` suite that were failing intermittently in CI due to non-deterministic ES|QL result ordering.

ES|QL does not guarantee result order without an explicit SORT clause. The affected tests were using `esqlResult.documents` (explicitly non-deterministic per the fixture's own JSDoc) and `testBed.getDocs()` (also non-deterministic) to make positional assertions like `[0]` / `[1]`. Depending on how Elasticsearch ordered documents internally, assertions would fail when a document came back at the wrong index.

The fix switches all order-dependent assertions to `esqlResult.documentsOrdered` and `testBed.getDocsOrdered()`, which sort by the `order_id` automatically injected during `testBed.ingest()`.

This is the same fix applied to the `esql/` subdirectory by #259979 