### PR TITLE
Fix flaky ResolveAllConflicts jest test pointer-events failure

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.test.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/copy_saved_objects_to_space/components/resolve_all_conflicts.test.tsx
@@ -19,6 +19,8 @@ import type { ImportRetry } from '../types';
 const renderWithIntl = (ui: React.ReactElement) => render(<I18nProvider>{ui}</I18nProvider>);
 
 describe('ResolveAllConflicts', () => {
+  const user = userEvent.setup({ pointerEventsCheck: 0 });
+
   const summarizedCopyResult = {
     objects: [
       { type: 'type-1', id: 'id-1', conflict: undefined },
@@ -69,7 +71,7 @@ describe('ResolveAllConflicts', () => {
   };
 
   const openPopover = async () => {
-    await userEvent.click(screen.getByText('(resolve all)'));
+    await user.click(screen.getByText('(resolve all)'));
     await waitFor(() => {
       expect(screen.getByTestId('cts-resolve-all-conflicts-overwrite')).toBeInTheDocument();
     });
@@ -98,7 +100,7 @@ describe('ResolveAllConflicts', () => {
     await openPopover();
     expect(onRetriesChange).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByTestId('cts-resolve-all-conflicts-overwrite'));
+    await user.click(screen.getByTestId('cts-resolve-all-conflicts-overwrite'));
     expect(onRetriesChange).toHaveBeenCalledWith([
       { type: 'type-1', id: 'id-1', overwrite: false },
       { type: 'type-5', id: 'id-5', overwrite: true, destinationId: 'dest-5b' },
@@ -115,7 +117,7 @@ describe('ResolveAllConflicts', () => {
     expect(onRetriesChange).not.toHaveBeenCalled();
     expect(onDestinationMapChange).not.toHaveBeenCalled();
 
-    await userEvent.click(screen.getByTestId('cts-resolve-all-conflicts-skip'));
+    await user.click(screen.getByTestId('cts-resolve-all-conflicts-skip'));
     expect(onRetriesChange).toHaveBeenCalledWith([
       { type: 'type-1', id: 'id-1', overwrite: false },
     ]);


### PR DESCRIPTION
EUI v114 introduced pointer-events: none on EuiPopover panels during open animations. JSDOM doesn't fire CSS transitionend events, so the property removal is timing-dependent, causing userEvent.click to intermittently fail. Use userEvent.setup({ pointerEventsCheck: 0 }) matching the existing pattern in other Kibana tests.

Not backporting, as following the original EUI PR https://github.com/elastic/kibana/pull/259497

Created due to it failing on main: https://buildkite.com/elastic/kibana-on-merge/builds/92848#019d62ac-39f7-4ade-90c9-baf043ccc5ae

Resolves https://github.com/elastic/kibana/issues/259669