### PR TITLE
[Dataset Quality] Fix for failing failed docs open in Discovery test

### DIFF
--- a/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/solutions/observability/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -267,6 +267,13 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
         await PageObjects.datasetQuality.selectQualityIssueChart('failed');
 
+        // Wait for the URL to reflect the chart selection before clicking the link,
+        // otherwise the Discover link may still hold the degraded-docs query.
+        await retry.tryForTime(5000, async () => {
+          const currentUrl = await browser.getCurrentUrl();
+          expect(decodeURIComponent(currentUrl)).to.contain('qualityIssuesChart:failed');
+        });
+
         // This line is required to solve problems where rendered lens visualisation below gets the hover bringing additional action icons
         // which over lap with the button on top of the visualisation causing ElementClickInterceptedError to happen
         await testSubjects.moveMouseTo(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/260182

## Summary

Fixes a flaky FTR test in the Dataset Quality details page

The test `should go to discover in ES|QL mode for failed docs when the button next to breakdown selector is clicked` was clicking the "Open in Discover" link immediately after selecting the failed docs chart, without waiting for the page state to reflect the selection. The Discover link's href is computed from the current chart type (`docsTrendChart`), which defaults to `'degraded'` on page load. If the link is clicked before the URL reflects the new selection, it navigates to Discover with the degraded-docs ES|QL query (`METADATA _ignored`) instead of the failure store query (`::failures`).

The fix adds a `retry.tryForTime` wait for `qualityIssuesChart:failed` to appear in the URL before clicking the link — the same pattern used by the test directly above it, which already validates this mechanism.