### PR TITLE
Fix Jira Cloud Oauth flow

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.test.ts
@@ -117,6 +117,41 @@ describe('JiraConnector', () => {
         }
       );
     });
+
+    it('should use api.atlassian.com base URL when using OAuth with cloud ID', async () => {
+      const oauthContext = {
+        ...mockContext,
+        config: {
+          subdomain: 'mycompany',
+          cloudId: '11223344-a1b2-3c33-d444-ef1234567890',
+        },
+        secrets: { authType: 'oauth_authorization_code' },
+      } as unknown as ActionContext;
+
+      const mockResponse = { data: { issues: [], total: 0 } };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      await JiraConnector.actions.searchIssuesWithJql.handler(oauthContext, { jql: 'project = X' });
+
+      expect(mockClient.get).not.toHaveBeenCalled();
+      expect(mockClient.post).toHaveBeenCalledWith(
+        'https://api.atlassian.com/ex/jira/11223344-a1b2-3c33-d444-ef1234567890/rest/api/3/search/jql',
+        { jql: 'project = X' }
+      );
+    });
+
+    it('should throw when OAuth is used without cloud ID', async () => {
+      const oauthContext = {
+        ...mockContext,
+        secrets: { authType: 'oauth_authorization_code' },
+      } as unknown as ActionContext;
+
+      await expect(
+        JiraConnector.actions.searchIssuesWithJql.handler(oauthContext, { jql: 'project = X' })
+      ).rejects.toThrow(
+        'Jira Cloud ID is required in connector configuration when using OAuth authentication.'
+      );
+    });
   });
 
   describe('getIssue action', () => {

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -15,8 +15,18 @@ import getResourceWorkflow from './workflows/get_resource.yaml';
 import searchIssuesWithJqlWorkflow from './workflows/search_issues_with_jql.yaml';
 import searchUsersWorkflow from './workflows/search_users.yaml';
 
-const buildBaseUrl = (ctx: ActionContext) =>
-  `https://${(ctx.config?.subdomain as string).trim()}.atlassian.net`;
+const buildBaseUrl = (ctx: ActionContext): string => {
+  if (ctx.secrets?.authType === 'oauth_authorization_code') {
+    const cloudId = String(ctx.config?.cloudId ?? '').trim();
+    if (cloudId === '') {
+      throw new Error(
+        'Jira Cloud ID is required in connector configuration when using OAuth authentication.'
+      );
+    }
+    return `https://api.atlassian.com/ex/jira/${cloudId}`;
+  }
+  return `https://${(ctx.config?.subdomain as string).trim()}.atlassian.net`;
+};
 
 export const JiraConnector: ConnectorSpec = {
   metadata: {
@@ -74,7 +84,24 @@ export const JiraConnector: ConnectorSpec = {
         placeholder: 'your-domain',
         helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.subdomain.helpText', {
           defaultMessage:
-            'The subdomain for your Jira Cloud site (e.g. your-domain for https://your-domain.atlassian.com)',
+            'The subdomain for your Jira Cloud site (e.g. your-domain for https://your-domain.atlassian.net)',
+        }),
+      }),
+    cloudId: z
+      .string()
+      .optional()
+      .describe(
+        i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.description', {
+          defaultMessage: 'Atlassian cloud ID (OAuth)',
+        })
+      )
+      .meta({
+        widget: 'text',
+        label: i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.label', {
+          defaultMessage: 'Cloud ID',
+        }),
+        helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.helpText', {
+          defaultMessage: 'Required for OAuth. Ignored when using an API token.',
         }),
       }),
   }),

--- a/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/specs/atlassian/jira-cloud/jira.ts
@@ -101,7 +101,8 @@ export const JiraConnector: ConnectorSpec = {
           defaultMessage: 'Cloud ID',
         }),
         helpText: i18n.translate('core.kibanaConnectorSpecs.jira.config.cloudId.helpText', {
-          defaultMessage: 'Required for OAuth. Ignored when using an API token.',
+          defaultMessage:
+            'Required for OAuth. To find your Cloud ID, visit https://your-subdomain.atlassian.net/_edge/tenant_info (replace your-subdomain with your Atlassian subdomain) and use the cloudId value from the response.',
         }),
       }),
   }),


### PR DESCRIPTION
## Summary

Patches the Jira Cloud connector spec to complete OAuth support on top of the existing OAuth infrastructure from the base branch.

Specifically:
- Adds a `cloudId` config field (optional; required when using OAuth) with help text directing users to retrieve it from `https://{subdomain}.atlassian.net/_edge/tenant_info`
- Updates `buildBaseUrl` to route OAuth requests to `https://api.atlassian.com/ex/jira/{cloudId}` instead of the subdomain-based URL used for basic auth

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

- **Additive only** — existing basic-auth Jira connectors are unaffected; `cloudId` is optional and only consulted when OAuth is active.
- **CloudId validation is runtime** — if a user configures OAuth without a Cloud ID, the connector throws at execution time rather than save time, consistent with how other connectors handle auth-type-conditional fields.