### PR TITLE
[8.19] Enforce no unsafe hashes (#257209)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1956,7 +1956,9 @@ x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/confi
 #CC# /x-pack/platform/plugins/private/translations/ @elastic/kibana-localization @elastic/kibana-core
 
 # Kibana Platform Security
-# security
+packages/kbn-eslint-plugin-eslint/rules/no_unsafe_hash.js @elastic/kibana-security
+/src/setup_node_env/harden @elastic/kibana-security
+
 /x-pack/platform/test/fixtures/es_archives/security @elastic/kibana-security
 /x-pack/platform/test/functional/fixtures/kbn_archives/spaces @elastic/kibana-security
 /x-pack/platform/test/functional/fixtures/kbn_archives/security @elastic/kibana-security

--- a/packages/kbn-eslint-plugin-disable/src/helpers/protected_rules.ts
+++ b/packages/kbn-eslint-plugin-disable/src/helpers/protected_rules.ts
@@ -14,4 +14,5 @@ export const PROTECTED_RULES = new Set([
   '@kbn/imports/no_unused_imports',
   '@kbn/imports/no_group_crossing_imports',
   '@kbn/imports/no_group_crossing_manifests',
+  '@kbn/eslint/no_unsafe_hash',
 ]);

--- a/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_hash.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_hash.js
@@ -7,6 +7,36 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+const path = require('path');
+const findKibanaRoot = require('../helpers/find_kibana_root');
+
+const KIBANA_ROOT = findKibanaRoot();
+
+// Allowlist (most temporary) of files permitted to use non-FIPS algorithms.
+const ALLOWED_UNSAFE_HASHES = [
+  { path: 'packages/kbn-optimizer/src/common/dll_manifest.ts', algorithms: ['sha1'] },
+  {
+    path: 'src/core/packages/test-helpers/so-type-serializer/src/get_migration_hash.ts',
+    algorithms: ['sha1'],
+  },
+  {
+    path: 'x-pack/platform/test/cases_api_integration/common/plugins/cases/server/routes.ts',
+    algorithms: ['sha1'],
+  },
+  {
+    path: 'src/platform/packages/shared/kbn-babel-register/cache/lmdb_cache.js',
+    algorithms: ['sha1'],
+  },
+  {
+    path: 'packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts',
+    algorithms: ['md5'],
+  },
+  {
+    path: 'packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts',
+    algorithms: ['md5'],
+  },
+];
+
 const allowedAlgorithms = ['sha256', 'sha3-256', 'sha512'];
 
 module.exports = {
@@ -33,8 +63,17 @@ module.exports = {
 
     const disallowedAlgorithmNodes = new Set();
 
+    const filename = context.getFilename();
+    const relativeFilename = path.relative(KIBANA_ROOT, filename);
+    const fileAllowlistEntry = ALLOWED_UNSAFE_HASHES.find(
+      (entry) => entry.path === relativeFilename
+    );
+    const fileScopedAllowedAlgorithms = fileAllowlistEntry
+      ? [...allowedAlgorithms, ...fileAllowlistEntry.algorithms]
+      : allowedAlgorithms;
+
     function isAllowedAlgorithm(algorithm) {
-      return allowedAlgorithms.includes(algorithm);
+      return fileScopedAllowedAlgorithms.includes(algorithm);
     }
 
     function isHashOrCreateHash(value) {

--- a/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_hash.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_unsafe_hash.test.js
@@ -7,10 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+const path = require('path');
 const { RuleTester } = require('eslint');
 const { allowedAlgorithms, ...rule } = require('./no_unsafe_hash');
+const findKibanaRoot = require('../helpers/find_kibana_root');
 
 const dedent = require('dedent');
+
+const KIBANA_ROOT = findKibanaRoot();
 
 const joinedAllowedAlgorithms = `[${allowedAlgorithms.join(', ')}]`;
 
@@ -56,6 +60,25 @@ ruleTester.run('@kbn/eslint/no_unsafe_hash', rule, {
        const myHash = 'sha256';
        hash(myHash);
       `,
+    },
+    // valid: sha1 in a file that has an allowlist entry for sha1
+    {
+      code: dedent`
+       import { createHash } from 'crypto';
+       createHash('sha1');
+      `,
+      filename: path.resolve(KIBANA_ROOT, 'packages/kbn-optimizer/src/common/dll_manifest.ts'),
+    },
+    // valid: md5 in a file that has an allowlist entry for md5
+    {
+      code: dedent`
+       import { createHash } from 'crypto';
+       createHash('md5');
+      `,
+      filename: path.resolve(
+        KIBANA_ROOT,
+        'packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts'
+      ),
     },
   ],
 
@@ -135,6 +158,34 @@ ruleTester.run('@kbn/eslint/no_unsafe_hash', rule, {
         {
           line: 2,
           message: `Usage of hash with "md5" is not allowed. Only the following algorithms are allowed: ${joinedAllowedAlgorithms}. If you need to use a different algorithm, please contact the Kibana security team.`,
+        },
+      ],
+    },
+    // invalid: sha1 in a file with no allowlist entry
+    {
+      code: dedent`
+       import { createHash } from 'crypto';
+       createHash('sha1');
+      `,
+      filename: path.resolve(KIBANA_ROOT, 'src/some/random/file.ts'),
+      errors: [
+        {
+          line: 2,
+          message: `Usage of createHash with "sha1" is not allowed. Only the following algorithms are allowed: ${joinedAllowedAlgorithms}. If you need to use a different algorithm, please contact the Kibana security team.`,
+        },
+      ],
+    },
+    // invalid: md5 in a file whose allowlist only allows sha1
+    {
+      code: dedent`
+       import { createHash } from 'crypto';
+       createHash('md5');
+      `,
+      filename: path.resolve(KIBANA_ROOT, 'packages/kbn-optimizer/src/common/dll_manifest.ts'),
+      errors: [
+        {
+          line: 2,
+          message: `Usage of createHash with "md5" is not allowed. Only the following algorithms are allowed: ${joinedAllowedAlgorithms}. If you need to use a different algorithm, please contact the Kibana security team.`,
         },
       ],
     },

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/generate_scout_test_failure_artifacts.ts
@@ -54,7 +54,7 @@ export async function generateScoutTestFailureArtifacts({
       const htmlFilePath = Path.join(dirPath, htmlReportFilename);
       const failureHTML = fs.readFileSync(htmlFilePath, 'utf-8');
 
-      const hash = createHash('md5').update(name).digest('hex'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+      const hash = createHash('md5').update(name).digest('hex');
       const filenameBase = `${
         process.env.BUILDKITE_JOB_ID ? process.env.BUILDKITE_JOB_ID + '_' : ''
       }${hash}`;

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
@@ -127,7 +127,7 @@ export async function reportFailuresToFile(
   // Jest could, in theory, fail 1000s of tests and write 1000s of failures
   // So let's just write files for the first 20
   for (const failure of failures.slice(0, 20)) {
-    const hash = createHash('md5').update(failure.name).digest('hex'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+    const hash = createHash('md5').update(failure.name).digest('hex');
     const filenameBase = `${
       process.env.BUILDKITE_JOB_ID ? process.env.BUILDKITE_JOB_ID + '_' : ''
     }${hash}`;

--- a/packages/kbn-optimizer/src/common/dll_manifest.ts
+++ b/packages/kbn-optimizer/src/common/dll_manifest.ts
@@ -20,7 +20,7 @@ export interface ParsedDllManifest {
 }
 
 const hash = (s: string) => {
-  return Crypto.createHash('sha1').update(s).digest('base64').replace(/=+$/, ''); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+  return Crypto.createHash('sha1').update(s).digest('base64').replace(/=+$/, '');
 };
 
 export function parseDllManifest(manifest: DllManifest): ParsedDllManifest {

--- a/src/core/packages/test-helpers/so-type-serializer/src/get_migration_hash.ts
+++ b/src/core/packages/test-helpers/so-type-serializer/src/get_migration_hash.ts
@@ -16,7 +16,7 @@ type SavedObjectTypeMigrationHash = string;
 export const getMigrationHash = (soType: SavedObjectsType): SavedObjectTypeMigrationHash => {
   const migInfo = extractMigrationInfo(soType);
 
-  const hash = createHash('sha1'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+  const hash = createHash('sha1');
 
   const hashParts = [
     migInfo.name,

--- a/src/platform/packages/shared/kbn-babel-register/cache/lmdb_cache.js
+++ b/src/platform/packages/shared/kbn-babel-register/cache/lmdb_cache.js
@@ -79,7 +79,7 @@ directory and report this error to the Operations team.\n`);
    * @returns {string}
    */
   getKey(path, source) {
-    return `${this.#prefix}:${Crypto.createHash('sha1').update(path).update(source).digest('hex')}`; // eslint-disable-line @kbn/eslint/no_unsafe_hash
+    return `${this.#prefix}:${Crypto.createHash('sha1').update(path).update(source).digest('hex')}`;
   }
 
   /**

--- a/x-pack/platform/test/cases_api_integration/common/plugins/cases/server/routes.ts
+++ b/x-pack/platform/test/cases_api_integration/common/plugins/cases/server/routes.ts
@@ -22,7 +22,7 @@ import {
 import type { FixtureStartDeps } from './plugin';
 
 const hashParts = (parts: string[]): string => {
-  const hash = createHash('sha1'); // eslint-disable-line @kbn/eslint/no_unsafe_hash
+  const hash = createHash('sha1');
   const hashFeed = parts.join('-');
   return hash.update(hashFeed).digest('hex');
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Enforce no unsafe hashes (#257209)](https://github.com/elastic/kibana/pull/257209)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2026-04-06T13:54:15Z","message":"Enforce no unsafe hashes (#257209)\n\n## Summary\n\nThis updates our `no-unsafe-hashes` ESLint rule so that it cannot be\nignored via comment. There are a handful of existing unsafe usages which\nare still permitted. This is achieved via an allow-list within the rule\nitself, of which @elastic/kibana-security is a code owner.\n\nThe intent of this rule is to prevent, well, the use of unsafe hashing\nalgorithms. Even if you don't require cryptographic safety, you are not\npermitted to use unsafe algorithms because they will not work when\nKibana is configured to run in FIPS Mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"941b675e9e2015e3b29b9c1dddac435395b6084c","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","Feature:Hardening","backport:all-open","Feature:FIPS","v9.4.0"],"title":"Enforce no unsafe hashes","number":257209,"url":"https://github.com/elastic/kibana/pull/257209","mergeCommit":{"message":"Enforce no unsafe hashes (#257209)\n\n## Summary\n\nThis updates our `no-unsafe-hashes` ESLint rule so that it cannot be\nignored via comment. There are a handful of existing unsafe usages which\nare still permitted. This is achieved via an allow-list within the rule\nitself, of which @elastic/kibana-security is a code owner.\n\nThe intent of this rule is to prevent, well, the use of unsafe hashing\nalgorithms. Even if you don't require cryptographic safety, you are not\npermitted to use unsafe algorithms because they will not work when\nKibana is configured to run in FIPS Mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"941b675e9e2015e3b29b9c1dddac435395b6084c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/257209","number":257209,"mergeCommit":{"message":"Enforce no unsafe hashes (#257209)\n\n## Summary\n\nThis updates our `no-unsafe-hashes` ESLint rule so that it cannot be\nignored via comment. There are a handful of existing unsafe usages which\nare still permitted. This is achieved via an allow-list within the rule\nitself, of which @elastic/kibana-security is a code owner.\n\nThe intent of this rule is to prevent, well, the use of unsafe hashing\nalgorithms. Even if you don't require cryptographic safety, you are not\npermitted to use unsafe algorithms because they will not work when\nKibana is configured to run in FIPS Mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"941b675e9e2015e3b29b9c1dddac435395b6084c"}},{"url":"https://github.com/elastic/kibana/pull/261354","number":261354,"branch":"9.3","state":"OPEN"}]}] BACKPORT-->