### PR TITLE
Add rule request preview modal to alerting v2 rule form

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RequestCodeBlock } from './request_code_block';
+import { createFormWrapper, defaultTestFormValues } from '../../test_utils';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
+
+describe('RequestCodeBlock', () => {
+  const formValues = {
+    ...defaultTestFormValues,
+    metadata: { name: 'Test rule', enabled: true },
+    evaluation: { query: { base: 'FROM logs-* | STATS count = COUNT(*)' } },
+  };
+
+  it('renders create request with POST method and correct path', () => {
+    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+      wrapper: createFormWrapper(formValues),
+    });
+
+    const codeBlock = screen.getByTestId('codeBlock');
+    expect(codeBlock.textContent).toContain(`POST kbn:${ALERTING_V2_RULE_API_PATH}`);
+  });
+
+  it('renders update request with PATCH method and rule ID in path', () => {
+    render(
+      <RequestCodeBlock activeTab="update" ruleId="rule-abc-123" data-test-subj="codeBlock" />,
+      { wrapper: createFormWrapper(formValues) }
+    );
+
+    const codeBlock = screen.getByTestId('codeBlock');
+    expect(codeBlock.textContent).toContain(`PATCH kbn:${ALERTING_V2_RULE_API_PATH}/rule-abc-123`);
+  });
+
+  it('renders pretty-printed JSON body for create', () => {
+    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+      wrapper: createFormWrapper(formValues),
+    });
+
+    const content = screen.getByTestId('codeBlock').textContent!;
+    expect(content).toContain('"kind"');
+    expect(content).toContain('"metadata"');
+    expect(content).toContain('"schedule"');
+    expect(content).toContain('"evaluation"');
+  });
+
+  it('renders update body without kind field', () => {
+    render(
+      <RequestCodeBlock activeTab="update" ruleId="rule-abc-123" data-test-subj="codeBlock" />,
+      { wrapper: createFormWrapper(formValues) }
+    );
+
+    const content = screen.getByTestId('codeBlock').textContent!;
+    expect(content).not.toContain('"kind"');
+    expect(content).toContain('"metadata"');
+  });
+
+  it('renders copyable code block', () => {
+    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+      wrapper: createFormWrapper(formValues),
+    });
+
+    const codeBlock = screen.getByTestId('codeBlock');
+    expect(codeBlock).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.test.tsx
@@ -10,6 +10,7 @@ import { render, screen } from '@testing-library/react';
 import { RequestCodeBlock } from './request_code_block';
 import { createFormWrapper, defaultTestFormValues } from '../../test_utils';
 import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
+import * as ruleRequestMappers from '../utils/rule_request_mappers';
 
 describe('RequestCodeBlock', () => {
   const formValues = {
@@ -67,5 +68,22 @@ describe('RequestCodeBlock', () => {
 
     const codeBlock = screen.getByTestId('codeBlock');
     expect(codeBlock).toBeInTheDocument();
+  });
+
+  it('renders error message when request serialization fails', () => {
+    const createMapperSpy = jest
+      .spyOn(ruleRequestMappers, 'mapFormValuesToCreateRequest')
+      .mockImplementation(() => {
+        throw new Error('serialization error');
+      });
+
+    render(<RequestCodeBlock activeTab="create" data-test-subj="codeBlock" />, {
+      wrapper: createFormWrapper(formValues),
+    });
+
+    const content = screen.getByTestId('codeBlock').textContent!;
+    expect(content).toContain('Error serializing rule request');
+
+    createMapperSpy.mockRestore();
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
+import { useFormContext } from 'react-hook-form';
+import { i18n } from '@kbn/i18n';
+import { ALERTING_V2_RULE_API_PATH } from '@kbn/alerting-v2-constants';
+import type { FormValues } from '../types';
+import {
+  mapFormValuesToCreateRequest,
+  mapFormValuesToUpdateRequest,
+} from '../utils/rule_request_mappers';
+
+export type ShowRequestActivePage = 'create' | 'update';
+
+const SHOW_REQUEST_ERROR = i18n.translate(
+  'xpack.alertingV2.ruleForm.showRequest.errorSerializing',
+  { defaultMessage: 'Error serializing rule request' }
+);
+
+const stringifyRequest = (formValues: FormValues, activeTab: ShowRequestActivePage): string => {
+  try {
+    const body =
+      activeTab === 'update'
+        ? mapFormValuesToUpdateRequest(formValues)
+        : mapFormValuesToCreateRequest(formValues);
+    return JSON.stringify(body, null, 2);
+  } catch {
+    return SHOW_REQUEST_ERROR;
+  }
+};
+
+interface RequestCodeBlockProps {
+  activeTab: ShowRequestActivePage;
+  ruleId?: string;
+  'data-test-subj'?: string;
+}
+
+export const RequestCodeBlock = ({
+  activeTab,
+  ruleId,
+  'data-test-subj': dataTestSubj,
+}: RequestCodeBlockProps) => {
+  const { getValues } = useFormContext<FormValues>();
+  const formValues = getValues();
+
+  const formattedRequest = useMemo(
+    () => stringifyRequest(formValues, activeTab),
+    [formValues, activeTab]
+  );
+
+  const method = activeTab === 'update' ? 'PATCH' : 'POST';
+  const path =
+    activeTab === 'update' ? `${ALERTING_V2_RULE_API_PATH}/${ruleId}` : ALERTING_V2_RULE_API_PATH;
+
+  return (
+    <EuiCodeBlock language="json" isCopyable data-test-subj={dataTestSubj}>
+      {`${method} kbn:${path}\n${formattedRequest}`}
+    </EuiCodeBlock>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/request_code_block.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
 import { useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
@@ -49,10 +49,7 @@ export const RequestCodeBlock = ({
   const { getValues } = useFormContext<FormValues>();
   const formValues = getValues();
 
-  const formattedRequest = useMemo(
-    () => stringifyRequest(formValues, activeTab),
-    [formValues, activeTab]
-  );
+  const formattedRequest = stringifyRequest(formValues, activeTab);
 
   const method = activeTab === 'update' ? 'PATCH' : 'POST';
   const path =

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
@@ -51,14 +51,10 @@ describe('ShowRequestModal', () => {
     expect(screen.getByTestId('showRequestUpdateTab')).toBeInTheDocument();
   });
 
-  it('switches to update tab and changes title/subtitle', async () => {
-    const user = userEvent.setup();
-
+  it('defaults to update tab when ruleId is provided', () => {
     render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
       wrapper: createFormWrapper(),
     });
-
-    await user.click(screen.getByTestId('showRequestUpdateTab'));
 
     expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
       'Update alerting rule request'
@@ -68,18 +64,32 @@ describe('ShowRequestModal', () => {
     );
   });
 
-  it('switches back to create tab', async () => {
+  it('switches to create tab from update default', async () => {
     const user = userEvent.setup();
 
     render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
       wrapper: createFormWrapper(),
     });
 
-    await user.click(screen.getByTestId('showRequestUpdateTab'));
     await user.click(screen.getByTestId('showRequestCreateTab'));
 
     expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
       'Create alerting rule request'
+    );
+  });
+
+  it('switches back to update tab', async () => {
+    const user = userEvent.setup();
+
+    render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
+      wrapper: createFormWrapper(),
+    });
+
+    await user.click(screen.getByTestId('showRequestCreateTab'));
+    await user.click(screen.getByTestId('showRequestUpdateTab'));
+
+    expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
+      'Update alerting rule request'
     );
   });
 

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShowRequestModal } from './show_request_modal';
+import { createFormWrapper } from '../../test_utils';
+
+describe('ShowRequestModal', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the modal with create title by default', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('ruleV2ShowRequestModal')).toBeInTheDocument();
+    expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
+      'Create alerting rule request'
+    );
+  });
+
+  it('renders create subtitle by default', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('showRequestModalSubtitle')).toHaveTextContent(
+      'This Kibana request will create this rule.'
+    );
+  });
+
+  it('does not render tabs when ruleId is not provided', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    expect(screen.queryByTestId('showRequestCreateTab')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('showRequestUpdateTab')).not.toBeInTheDocument();
+  });
+
+  it('renders tabs when ruleId is provided', () => {
+    render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
+      wrapper: createFormWrapper(),
+    });
+
+    expect(screen.getByTestId('showRequestCreateTab')).toBeInTheDocument();
+    expect(screen.getByTestId('showRequestUpdateTab')).toBeInTheDocument();
+  });
+
+  it('switches to update tab and changes title/subtitle', async () => {
+    const user = userEvent.setup();
+
+    render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
+      wrapper: createFormWrapper(),
+    });
+
+    await user.click(screen.getByTestId('showRequestUpdateTab'));
+
+    expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
+      'Update alerting rule request'
+    );
+    expect(screen.getByTestId('showRequestModalSubtitle')).toHaveTextContent(
+      'This Kibana request will update this rule.'
+    );
+  });
+
+  it('switches back to create tab', async () => {
+    const user = userEvent.setup();
+
+    render(<ShowRequestModal ruleId="rule-123" onClose={onClose} />, {
+      wrapper: createFormWrapper(),
+    });
+
+    await user.click(screen.getByTestId('showRequestUpdateTab'));
+    await user.click(screen.getByTestId('showRequestCreateTab'));
+
+    expect(screen.getByTestId('showRequestModalTitle')).toHaveTextContent(
+      'Create alerting rule request'
+    );
+  });
+
+  it('renders the code block', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('showRequestModalCodeBlock')).toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ShowRequestModal } from './show_request_modal';
 import { createFormWrapper } from '../../test_utils';
@@ -97,5 +97,13 @@ describe('ShowRequestModal', () => {
     render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
 
     expect(screen.getByTestId('showRequestModalCodeBlock')).toBeInTheDocument();
+  });
+
+  it('calls onClose when modal close button is clicked', () => {
+    render(<ShowRequestModal onClose={onClose} />, { wrapper: createFormWrapper() });
+
+    fireEvent.click(screen.getByLabelText('Closes this modal window'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
@@ -51,7 +51,7 @@ interface ShowRequestModalProps {
 }
 
 export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => {
-  const [activeTab, setActiveTab] = useState<ShowRequestActivePage>('create');
+  const [activeTab, setActiveTab] = useState<ShowRequestActivePage>(ruleId ? 'update' : 'create');
 
   const onCloseModal = useCallback(() => {
     onClose();

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiTab,
+  EuiTabs,
+  EuiText,
+  EuiTextColor,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { RequestCodeBlock, type ShowRequestActivePage } from './request_code_block';
+
+const TITLE_CREATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.titleCreate', {
+  defaultMessage: 'Create alerting rule request',
+});
+
+const TITLE_UPDATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.titleUpdate', {
+  defaultMessage: 'Update alerting rule request',
+});
+
+const SUBTITLE_CREATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.subtitleCreate', {
+  defaultMessage: 'This Kibana request will create this rule.',
+});
+
+const SUBTITLE_UPDATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.subtitleUpdate', {
+  defaultMessage: 'This Kibana request will update this rule.',
+});
+
+const TAB_CREATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.tabCreate', {
+  defaultMessage: 'Create',
+});
+
+const TAB_UPDATE = i18n.translate('xpack.alertingV2.ruleForm.showRequest.tabUpdate', {
+  defaultMessage: 'Update',
+});
+
+interface ShowRequestModalProps {
+  ruleId?: string;
+  onClose: () => void;
+}
+
+export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => {
+  const [activeTab, setActiveTab] = useState<ShowRequestActivePage>('create');
+
+  const onCloseModal = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const title = activeTab === 'update' ? TITLE_UPDATE : TITLE_CREATE;
+  const subtitle = activeTab === 'update' ? SUBTITLE_UPDATE : SUBTITLE_CREATE;
+
+  return (
+    <EuiModal
+      data-test-subj="ruleV2ShowRequestModal"
+      aria-labelledby="showRequestModal"
+      onClose={onCloseModal}
+    >
+      <EuiModalHeader>
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiModalHeaderTitle id="showRequestModal" data-test-subj="showRequestModalTitle">
+              {title}
+            </EuiModalHeaderTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText data-test-subj="showRequestModalSubtitle">
+              <p>
+                <EuiTextColor color="subdued">{subtitle}</EuiTextColor>
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+          {ruleId && (
+            <EuiTabs>
+              <EuiTab
+                isSelected={activeTab === 'create'}
+                onClick={() => setActiveTab('create')}
+                data-test-subj="showRequestCreateTab"
+              >
+                {TAB_CREATE}
+              </EuiTab>
+              <EuiTab
+                isSelected={activeTab === 'update'}
+                onClick={() => setActiveTab('update')}
+                data-test-subj="showRequestUpdateTab"
+              >
+                {TAB_UPDATE}
+              </EuiTab>
+            </EuiTabs>
+          )}
+        </EuiFlexGroup>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <RequestCodeBlock
+          activeTab={activeTab}
+          ruleId={ruleId}
+          data-test-subj="showRequestModalCodeBlock"
+        />
+      </EuiModalBody>
+    </EuiModal>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/show_request_modal.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -53,10 +53,6 @@ interface ShowRequestModalProps {
 export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => {
   const [activeTab, setActiveTab] = useState<ShowRequestActivePage>(ruleId ? 'update' : 'create');
 
-  const onCloseModal = useCallback(() => {
-    onClose();
-  }, [onClose]);
-
   const title = activeTab === 'update' ? TITLE_UPDATE : TITLE_CREATE;
   const subtitle = activeTab === 'update' ? SUBTITLE_UPDATE : SUBTITLE_CREATE;
 
@@ -64,7 +60,7 @@ export const ShowRequestModal = ({ ruleId, onClose }: ShowRequestModalProps) => 
     <EuiModal
       data-test-subj="ruleV2ShowRequestModal"
       aria-labelledby="showRequestModal"
-      onClose={onCloseModal}
+      onClose={onClose}
     >
       <EuiModalHeader>
         <EuiFlexGroup direction="column" gutterSize="s">

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.test.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SubmissionButtons } from './submission_buttons';
+import { createFormWrapper } from '../../test_utils';
+
+describe('SubmissionButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the show request button', () => {
+    render(<SubmissionButtons isSubmitting={false} />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('ruleV2FormShowRequestButton')).toBeInTheDocument();
+    expect(screen.getByTestId('ruleV2FormShowRequestButton')).toHaveTextContent('Show request');
+  });
+
+  it('opens the modal when show request button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<SubmissionButtons isSubmitting={false} />, { wrapper: createFormWrapper() });
+
+    expect(screen.queryByTestId('ruleV2ShowRequestModal')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('ruleV2FormShowRequestButton'));
+
+    expect(screen.getByTestId('ruleV2ShowRequestModal')).toBeInTheDocument();
+  });
+
+  it('disables show request button when submitting', () => {
+    render(<SubmissionButtons isSubmitting />, { wrapper: createFormWrapper() });
+
+    expect(screen.getByTestId('ruleV2FormShowRequestButton')).toBeDisabled();
+  });
+
+  it('passes ruleId to the modal', async () => {
+    const user = userEvent.setup();
+
+    render(<SubmissionButtons isSubmitting={false} ruleId="rule-456" />, {
+      wrapper: createFormWrapper(),
+    });
+
+    await user.click(screen.getByTestId('ruleV2FormShowRequestButton'));
+
+    expect(screen.getByTestId('showRequestCreateTab')).toBeInTheDocument();
+    expect(screen.getByTestId('showRequestUpdateTab')).toBeInTheDocument();
+  });
+
+  it('does not show tabs in modal when ruleId is not provided', async () => {
+    const user = userEvent.setup();
+
+    render(<SubmissionButtons isSubmitting={false} />, { wrapper: createFormWrapper() });
+
+    await user.click(screen.getByTestId('ruleV2FormShowRequestButton'));
+
+    expect(screen.queryByTestId('showRequestCreateTab')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('showRequestUpdateTab')).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -14,13 +14,20 @@ import {
   EuiHorizontalRule,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import { RULE_FORM_ID } from '../constants';
+import { ShowRequestModal } from './show_request_modal';
+
+const SHOW_REQUEST_LABEL = i18n.translate('xpack.alertingV2.ruleForm.showRequestLabel', {
+  defaultMessage: 'Show request',
+});
 
 export interface SubmissionButtonsProps {
   isSubmitting: boolean;
   onCancel?: () => void;
   submitLabel?: React.ReactNode;
   cancelLabel?: React.ReactNode;
+  ruleId?: string;
 }
 
 export const SubmissionButtons = ({
@@ -28,7 +35,13 @@ export const SubmissionButtons = ({
   onCancel,
   submitLabel,
   cancelLabel,
+  ruleId,
 }: SubmissionButtonsProps) => {
+  const [isShowRequestVisible, setIsShowRequestVisible] = useState(false);
+
+  const onShowRequest = useCallback(() => setIsShowRequestVisible(true), []);
+  const onCloseShowRequest = useCallback(() => setIsShowRequestVisible(false), []);
+
   const defaultSubmitLabel = (
     <FormattedMessage id="xpack.alertingV2.ruleForm.submitLabel" defaultMessage="Save" />
   );
@@ -53,18 +66,32 @@ export const SubmissionButtons = ({
           </EuiFlexItem>
         )}
         <EuiFlexItem grow={false}>
-          <EuiButton
-            type="submit"
-            form={RULE_FORM_ID}
-            isLoading={isSubmitting}
-            fill
-            iconType="plusInCircle"
-            data-test-subj="ruleV2FormSubmitButton"
-          >
-            {submitLabel ?? defaultSubmitLabel}
-          </EuiButton>
+          <EuiFlexGroup gutterSize="m">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                onClick={onShowRequest}
+                isDisabled={isSubmitting}
+                data-test-subj="ruleV2FormShowRequestButton"
+              >
+                {SHOW_REQUEST_LABEL}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                type="submit"
+                form={RULE_FORM_ID}
+                isLoading={isSubmitting}
+                fill
+                iconType="plusInCircle"
+                data-test-subj="ruleV2FormSubmitButton"
+              >
+                {submitLabel ?? defaultSubmitLabel}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
+      {isShowRequestVisible && <ShowRequestModal ruleId={ruleId} onClose={onCloseShowRequest} />}
     </>
   );
 };

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/components/submission_buttons.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { RULE_FORM_ID } from '../constants';
+
+export interface SubmissionButtonsProps {
+  isSubmitting: boolean;
+  onCancel?: () => void;
+  submitLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+}
+
+export const SubmissionButtons = ({
+  isSubmitting,
+  onCancel,
+  submitLabel,
+  cancelLabel,
+}: SubmissionButtonsProps) => {
+  const defaultSubmitLabel = (
+    <FormattedMessage id="xpack.alertingV2.ruleForm.submitLabel" defaultMessage="Save" />
+  );
+
+  const defaultCancelLabel = (
+    <FormattedMessage id="xpack.alertingV2.ruleForm.cancelLabel" defaultMessage="Cancel" />
+  );
+
+  return (
+    <>
+      <EuiHorizontalRule />
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        {onCancel && (
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              onClick={onCancel}
+              isDisabled={isSubmitting}
+              data-test-subj="ruleV2FormCancelButton"
+            >
+              {cancelLabel ?? defaultCancelLabel}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            type="submit"
+            form={RULE_FORM_ID}
+            isLoading={isSubmitting}
+            fill
+            iconType="plusInCircle"
+            data-test-subj="ruleV2FormSubmitButton"
+          >
+            {submitLabel ?? defaultSubmitLabel}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -177,6 +177,7 @@ const RuleFormContent = ({
           onCancel={onCancel}
           submitLabel={submitLabel}
           cancelLabel={cancelLabel}
+          ruleId={ruleId}
         />
       )}
     </>

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/rule_form.tsx
@@ -6,19 +6,12 @@
  */
 
 import React, { useCallback, useRef, useMemo, useState } from 'react';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { useFormContext } from 'react-hook-form';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
-import { FormattedMessage } from '@kbn/i18n-react';
 import type { FormValues } from './types';
 import { EditModeToggle, type EditMode } from './components/edit_mode_toggle';
+import { SubmissionButtons } from './components/submission_buttons';
 import {
   RuleFormProvider,
   useRuleFormServices,
@@ -33,7 +26,6 @@ import { NameField } from './fields/name_field';
 import { ErrorCallOut } from './error_callout';
 import { useCreateRule } from './hooks/use_create_rule';
 import { useUpdateRule } from './hooks/use_update_rule';
-import { RULE_FORM_ID } from './constants';
 
 export type { RuleFormServices } from './contexts';
 
@@ -63,59 +55,6 @@ export interface RuleFormProps {
   /** When provided, the form operates in edit mode and uses PATCH instead of POST on submission. */
   ruleId?: string;
 }
-
-interface SubmissionButtonsProps {
-  isSubmitting: boolean;
-  onCancel?: () => void;
-  submitLabel?: React.ReactNode;
-  cancelLabel?: React.ReactNode;
-}
-
-const SubmissionButtons = ({
-  isSubmitting,
-  onCancel,
-  submitLabel,
-  cancelLabel,
-}: SubmissionButtonsProps) => {
-  const defaultSubmitLabel = (
-    <FormattedMessage id="xpack.alertingV2.ruleForm.submitLabel" defaultMessage="Save" />
-  );
-
-  const defaultCancelLabel = (
-    <FormattedMessage id="xpack.alertingV2.ruleForm.cancelLabel" defaultMessage="Cancel" />
-  );
-
-  return (
-    <>
-      <EuiHorizontalRule />
-      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-        {onCancel && (
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              onClick={onCancel}
-              isDisabled={isSubmitting}
-              data-test-subj="ruleV2FormCancelButton"
-            >
-              {cancelLabel ?? defaultCancelLabel}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-        )}
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            type="submit"
-            form={RULE_FORM_ID}
-            isLoading={isSubmitting}
-            fill
-            iconType="plusInCircle"
-            data-test-subj="ruleV2FormSubmitButton"
-          >
-            {submitLabel ?? defaultSubmitLabel}
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
-  );
-};
 
 /**
  * Inner content component that renders the appropriate form based on edit mode.


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/cd6d3c21-210e-43e5-a67e-902703af2826

Adds a "Show request" button to the v2 rule form that opens a modal previewing the API request in Kibana Dev Tools console format. Users can copy the request and paste it directly into Dev Tools to execute.

The implementation draws inspiration from the v1 rule form's request preview (`RulePageShowRequestModal` / `RuleFlyoutShowRequest`) but uses the v2 form architecture: react-hook-form for state, `mapFormValuesToCreateRequest` / `mapFormValuesToUpdateRequest` for body serialization, and the v2 API path (`/api/alerting/v2/rules`).

Key decisions:
- Always renders as a modal regardless of layout (page or flyout), avoiding the v1 complexity of flyout content replacement
- No new context provider needed -- modal state is owned locally by `SubmissionButtons`
- Create/Update tabs appear when editing an existing rule (`ruleId` provided); create-only otherwise
- Update preview uses `PATCH` (v2) instead of `PUT` (v1)

Closes https://github.com/elastic/rna-program/issues/234

## Test plan

- [x] Unit tests added for `RequestCodeBlock`, `ShowRequestModal`, and `SubmissionButtons` (17 new tests, all passing)
- [x] Existing `rule_form.test.tsx` tests verified passing (27 tests, no regressions)
- [x] Manual: Open rule creation form with `includeSubmission` enabled, click "Show request", verify modal shows `POST kbn:/api/alerting/v2/rules` with correct JSON body
- [x] Manual: Open rule edit form (with `ruleId`), verify Create/Update tabs appear and switching tabs changes method/path/body
- [x] Manual: Copy request from modal, paste into Dev Tools console, verify it executes successfully

Made with [Cursor](https://cursor.com)