### PR TITLE
[Streams] Fix failing data preview test

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/date/date_formats_field.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_management/data_management/stream_detail_enrichment/steps/blocks/action/date/date_formats_field.tsx
@@ -76,7 +76,7 @@ export const DateFormatsField = ({ onGenerate }: { onGenerate?: () => void }) =>
     >
       <EuiComboBox
         {...inputProps}
-        data-test-subj="input"
+        data-test-subj="streamsAppDateProcessorFormatsComboBox"
         fullWidth
         compressed={true}
         inputRef={ref}

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -23,6 +23,7 @@ export class StreamsApp {
   public readonly conditionEditorFieldComboBox;
   public readonly conditionEditorValueComboBox;
   public readonly processorTypeComboBox;
+  public readonly dateProcessorFormatsComboBox;
   public readonly fieldTypeSuperSelect;
   public readonly previewDataGrid;
   public readonly schemaDataGrid;
@@ -59,6 +60,10 @@ export class StreamsApp {
     this.processorTypeComboBox = new EuiComboBoxWrapper(
       this.page,
       'streamsAppProcessorTypeSelector'
+    );
+    this.dateProcessorFormatsComboBox = new EuiComboBoxWrapper(
+      this.page,
+      'streamsAppDateProcessorFormatsComboBox'
     );
     this.fieldTypeSuperSelect = new EuiSuperSelectWrapper(
       this.page,
@@ -742,8 +747,7 @@ export class StreamsApp {
   }
 
   async fillDateProcessorFormatInput(value: string) {
-    await this.page.getByPlaceholder('Type and then hit "Enter"').fill(value);
-    await this.page.keyboard.press('Enter');
+    await this.dateProcessorFormatsComboBox.setCustomMultiOption(value);
   }
 
   async fillDateProcessorTargetFieldInput(value: string) {

--- a/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
+++ b/x-pack/platform/plugins/shared/streams_app/test/scout/ui/fixtures/page_objects/streams_app.ts
@@ -743,6 +743,7 @@ export class StreamsApp {
 
   async fillDateProcessorFormatInput(value: string) {
     await this.page.getByPlaceholder('Type and then hit "Enter"').fill(value);
+    await this.page.keyboard.press('Enter');
   }
 
   async fillDateProcessorTargetFieldInput(value: string) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/260710

## Summary

The `fillDateProcessorFormatInput` page object method was using Playwright's `fill()` to set the date format in an `EuiComboBox`, but `fill()` programmatically sets the DOM input value without updating the component's internal React `searchValue` state. This meant:

- Pressing Enter was never issued, so `onCreateOption` was never called explicitly
- The blur-based fallback (`onContainerBlur` → `setCustomOptions` → `addCustomOption`) also failed because it reads `this.state.searchValue`, which `fill()` left empty
- The `formats` array stayed as `[]`, causing the ES date processor to silently fail (`ignore_failure: true`), leaving the target field unchanged as `"null"`

The fix adds `await this.page.keyboard.press('Enter')` after `fill()`, which explicitly triggers `onCreateOption` and commits the format as a selected pill — matching the pattern used by `EuiComboBoxWrapper.setCustomSingleOption` and `setCustomMultiOption` elsewhere in the Scout test infrastructure.