### PR TITLE
[Security Solution] Add run workflow action to footer Take action dropdown

### DIFF
--- a/packages/kbn-babel-preset/styled_components_files.js
+++ b/packages/kbn-babel-preset/styled_components_files.js
@@ -181,7 +181,6 @@ module.exports = {
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]item_details_card[\/\\]index.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]line_clamp[\/\\]index.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]link_icon[\/\\]index.tsx/,
-    /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]loader[\/\\]index.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]ml[\/\\]score[\/\\]anomaly_score.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]ml[\/\\]score[\/\\]create_description_list.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]ml[\/\\]tables[\/\\]basic_table.tsx/,

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/loader/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/loader/__snapshots__/index.test.tsx.snap
@@ -1,16 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering renders correctly 1`] = `
-<Aside
-  overlay={true}
-  overlayBackground="#fff"
+<aside
+  css="unknown styles"
 >
-  <FlexGroup
-    overlay={
-      Object {
-        "overlay": true,
-      }
-    }
+  <EuiFlexGroup
+    alignItems="center"
+    css="unknown styles"
+    direction="column"
+    gutterSize="s"
+    justifyContent="center"
   >
     <EuiFlexItem
       grow={false}
@@ -32,6 +31,6 @@ exports[`rendering renders correctly 1`] = `
         </p>
       </EuiText>
     </EuiFlexItem>
-  </FlexGroup>
-</Aside>
+  </EuiFlexGroup>
+</aside>
 `;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/loader/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/loader/index.tsx
@@ -9,45 +9,10 @@ import type {
   // @ts-expect-error
   EuiLoadingSpinnerSize,
 } from '@elastic/eui';
-import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiText, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { rgba } from 'polished';
 import React from 'react';
-import styled, { css } from 'styled-components';
-
-const Aside = styled.aside<{ overlay?: boolean; overlayBackground?: string }>`
-  padding: ${({ theme }) => theme.eui.euiSizeM};
-
-  ${({ overlay, overlayBackground, theme }) =>
-    overlay &&
-    css`
-      background: ${overlayBackground
-        ? rgba(overlayBackground, 0.9)
-        : rgba(theme.eui.euiColorEmptyShade, 0.9)};
-      bottom: 0;
-      left: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: ${theme.eui.euiZLevel1};
-    `}
-`;
-
-Aside.displayName = 'Aside';
-
-const FlexGroup = styled(EuiFlexGroup).attrs(() => ({
-  alignItems: 'center',
-  direction: 'column',
-  gutterSize: 's',
-  justifyContent: 'center',
-}))<{ overlay: { overlay?: boolean } }>`
-  ${({ overlay }) =>
-    overlay &&
-    css`
-      height: 100%;
-    `}
-`;
-
-FlexGroup.displayName = 'FlexGroup';
 
 export interface LoaderProps {
   overlay?: boolean;
@@ -56,22 +21,54 @@ export interface LoaderProps {
   children?: React.ReactChild;
 }
 
-export const Loader = React.memo<LoaderProps>(({ children, overlay, overlayBackground, size }) => (
-  <Aside overlay={overlay} overlayBackground={overlayBackground}>
-    <FlexGroup overlay={{ overlay }}>
-      <EuiFlexItem grow={false}>
-        <EuiLoadingSpinner data-test-subj="loading-spinner" size={size} />
-      </EuiFlexItem>
+export const Loader = React.memo<LoaderProps>(({ children, overlay, overlayBackground, size }) => {
+  const { euiTheme } = useEuiTheme();
 
-      {children && (
+  const asideStyles = css`
+    padding: ${euiTheme.size.m};
+    ${overlay &&
+    css`
+      background: ${overlayBackground
+        ? rgba(overlayBackground, 0.9)
+        : rgba(euiTheme.colors.emptyShade, 0.9)};
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: ${euiTheme.levels.flyout};
+    `}
+  `;
+
+  const flexGroupStyles = overlay
+    ? css`
+        height: 100%;
+      `
+    : undefined;
+
+  return (
+    <aside css={asideStyles}>
+      <EuiFlexGroup
+        alignItems="center"
+        direction="column"
+        gutterSize="s"
+        justifyContent="center"
+        css={flexGroupStyles}
+      >
         <EuiFlexItem grow={false}>
-          <EuiText color="subdued" size="s">
-            <p>{children}</p>
-          </EuiText>
+          <EuiLoadingSpinner data-test-subj="loading-spinner" size={size} />
         </EuiFlexItem>
-      )}
-    </FlexGroup>
-  </Aside>
-));
+
+        {children && (
+          <EuiFlexItem grow={false}>
+            <EuiText color="subdued" size="s">
+              <p>{children}</p>
+            </EuiText>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </aside>
+  );
+});
 
 Loader.displayName = 'Loader';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -16,6 +16,7 @@ import { useAlertAssigneesActions } from '../../../detections/components/alerts_
 import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
 import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
+import { useRunAlertWorkflowPanel } from '../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel';
 import { TakeActionButton } from './take_action_button';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
@@ -29,11 +30,15 @@ jest.mock(
   '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
 );
 jest.mock('../../../common/hooks/is_in_security_app');
+jest.mock(
+  '../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel'
+);
 
 const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
 const mockUseAlertsActions = useAlertsActions as jest.Mock;
 const mockUseAlertAssigneesActions = useAlertAssigneesActions as jest.Mock;
 const mockUseAlertTagsActions = useAlertTagsActions as jest.Mock;
+
 const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord =>
   ({
     id: 'test-id',
@@ -41,7 +46,6 @@ const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord
     flattened,
     isAnchor: false,
   } as DataTableRecord);
-
 const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
 const mockUseIsInSecurityApp = useIsInSecurityApp as jest.Mock;
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
@@ -49,6 +53,7 @@ const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['tes
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 const mockOnAlertUpdated = jest.fn();
 const mockOnShowNotes = jest.fn();
+const mockUseRunAlertWorkflowPanel = useRunAlertWorkflowPanel as jest.Mock;
 
 const defaultProps = {
   hit: createMockHit(),
@@ -73,6 +78,10 @@ describe('<TakeActionButton />', () => {
     mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [], alertTagsPanels: [] });
     mockUseInvestigateInTimeline.mockReturnValue({ investigateInTimelineActionItems: [] });
     mockUseIsInSecurityApp.mockReturnValue(true);
+    mockUseRunAlertWorkflowPanel.mockReturnValue({
+      runWorkflowMenuItem: [],
+      runAlertWorkflowPanel: [],
+    });
   });
 
   it('should render the take action button', () => {
@@ -210,10 +219,31 @@ describe('<TakeActionButton />', () => {
     );
   });
 
+  it('should call useRunAlertWorkflowPanel with ecsData and closePopover', () => {
+    renderTakeActionButton();
+
+    expect(mockUseRunAlertWorkflowPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ ecsRowData: mockEcsData })
+    );
+  });
+
+  it('should not include run workflow menu item when hook returns empty (no permissions)', () => {
+    mockUseRunAlertWorkflowPanel.mockReturnValue({
+      runWorkflowMenuItem: [],
+      runAlertWorkflowPanel: [],
+    });
+
+    const { getByTestId, queryByText } = renderTakeActionButton();
+    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+
+    expect(queryByText('Run workflow')).not.toBeInTheDocument();
+  });
+
   describe('alert vs non-alert document', () => {
     const statusItem = { name: 'Mark as acknowledged', onClick: jest.fn() };
     const assigneeItem = { name: 'Assign alert', onClick: jest.fn() };
     const tagsItem = { name: 'Apply alert tags', onClick: jest.fn() };
+    const workflowItem = { name: 'Run workflow', onClick: jest.fn() };
 
     beforeEach(() => {
       mockUseAlertsActions.mockReturnValue({ actionItems: [statusItem], panels: [] });
@@ -222,9 +252,13 @@ describe('<TakeActionButton />', () => {
         alertAssigneesPanels: [],
       });
       mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [tagsItem], alertTagsPanels: [] });
+      mockUseRunAlertWorkflowPanel.mockReturnValue({
+        runWorkflowMenuItem: [workflowItem],
+        runAlertWorkflowPanel: [],
+      });
     });
 
-    it('should include status, assignees and tags items for alert documents (event.kind === signal)', () => {
+    it('should include all items for alert documents (event.kind === signal)', () => {
       const alertHit = createMockHit({ 'event.kind': 'signal' });
       const { getByTestId, getByText, queryByText } = renderTakeActionButton({
         ...defaultProps,
@@ -237,9 +271,10 @@ describe('<TakeActionButton />', () => {
       expect(getByText('Assign alert')).toBeInTheDocument();
       expect(getByText('Apply alert tags')).toBeInTheDocument();
       expect(queryByText('Add note')).not.toBeInTheDocument();
+      expect(getByText('Run workflow')).toBeInTheDocument();
     });
 
-    it('should exclude status, assignees and tags items but have note item for non-alert documents', () => {
+    it('should exclude some items for non-alert documents', () => {
       const eventHit = createMockHit({ 'event.kind': 'event' });
       const { getByTestId, getByText, queryByText } = renderTakeActionButton({
         ...defaultProps,
@@ -252,9 +287,10 @@ describe('<TakeActionButton />', () => {
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
       expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
       expect(getByText('Add note')).toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
     });
 
-    it('should exclude status, assignees and tags items but have note item when event.kind is not set', () => {
+    it('should exclude some items when event.kind is not set', () => {
       const { getByTestId, getByText, queryByText } = renderTakeActionButton({
         ...defaultProps,
         hit: createMockHit(),
@@ -266,6 +302,7 @@ describe('<TakeActionButton />', () => {
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
       expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
       expect(getByText('Add note')).toBeInTheDocument();
+      expect(queryByText('Run workflow')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -21,6 +21,7 @@ import { useAlertAssigneesActions } from '../../../detections/components/alerts_
 import { useAlertTagsActions } from '../../../detections/components/alerts_table/timeline_actions/use_alert_tags_actions';
 import { useInvestigateInTimeline } from '../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
+import { useRunAlertWorkflowPanel } from '../../../detections/components/alerts_table/timeline_actions/use_run_alert_workflow_panel';
 import { FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID } from './test_ids';
 
 const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeActionButtonLabel', {
@@ -144,12 +145,18 @@ export const TakeActionButton = memo(
       [closePopoverHandler, onShowNotes]
     );
 
+    const { runWorkflowMenuItem, runAlertWorkflowPanel } = useRunAlertWorkflowPanel({
+      ecsRowData: ecsData,
+      closePopover: closePopoverHandler,
+    });
+
     const items = useMemo(
       () => [
         ...addToCaseActionItems,
         ...(isAlert ? statusActionItems : []),
         ...(isAlert ? alertAssigneesItems : []),
         ...(isAlert ? alertTagsItems : []),
+        ...(isAlert ? runWorkflowMenuItem : []),
         ...(isAlert ? [] : noteItems),
         ...(isInSecurityApp ? investigateInTimelineActionItems : []),
       ],
@@ -160,6 +167,7 @@ export const TakeActionButton = memo(
         isAlert,
         isInSecurityApp,
         noteItems,
+        runWorkflowMenuItem,
         statusActionItems,
         alertAssigneesItems,
       ]
@@ -171,8 +179,16 @@ export const TakeActionButton = memo(
         ...(isAlert ? statusActionPanels : []),
         ...(isAlert ? alertAssigneesPanels : []),
         ...(isAlert ? alertTagsPanels : []),
+        ...(isAlert ? runAlertWorkflowPanel : []),
       ],
-      [alertTagsPanels, isAlert, items, statusActionPanels, alertAssigneesPanels]
+      [
+        alertAssigneesPanels,
+        alertTagsPanels,
+        isAlert,
+        items,
+        statusActionPanels,
+        runAlertWorkflowPanel,
+      ]
     );
 
     const takeActionButton = (


### PR DESCRIPTION
## Summary

This PR adds the run worfklow action to the footer of the new flyout.

The actions are accessible when the flyout is opened in Security Solution

https://github.com/user-attachments/assets/6c6168fd-2b66-45a1-902e-6d97e94cee7f

And also when it's opened in Discover

https://github.com/user-attachments/assets/88686deb-6305-43b3-b6ea-47f9b4527c48

The PR also makes a small change to the `loader` component, to now rely on `styled-components` but instead use `@emotion`. This allows us to not have to put a specific provider for the flyout.

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
