### PR TITLE
[8.19] [scout] support example plugins (#259170)

### DIFF
--- a/examples/ui_actions_explorer/moon.yml
+++ b/examples/ui_actions_explorer/moon.yml
@@ -25,7 +25,8 @@ dependsOn:
 tags:
   - plugin
   - prod
-  - group-undefined
+  - group-platform
+  - private
 fileGroups:
   src:
     - index.ts

--- a/examples/ui_actions_explorer/moon.yml
+++ b/examples/ui_actions_explorer/moon.yml
@@ -25,8 +25,7 @@ dependsOn:
 tags:
   - plugin
   - prod
-  - group-platform
-  - private
+  - group-undefined
 fileGroups:
   src:
     - index.ts

--- a/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/scout_no_cross_boundary_imports.js
@@ -41,6 +41,14 @@ const getAllowedPackage = (filePath) => {
     return { package: '@kbn/scout' };
   }
 
+  // example plugins (OSS and x-pack)
+  if (/\/examples\/[^/]+\/test\/(?:scout|scout_\w+)\//.test(filePath)) {
+    return { package: '@kbn/scout' };
+  }
+  if (/\/x-pack\/examples\/[^/]+\/test\/(?:scout|scout_\w+)\//.test(filePath)) {
+    return { package: '@kbn/scout' };
+  }
+
   return null;
 };
 

--- a/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.test.ts
@@ -1,0 +1,373 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import mm from 'micromatch';
+import {
+  TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB,
+  SCOUT_CONFIG_PATH_GLOB,
+  SCOUT_CONFIG_PATH_REGEX,
+  SCOUT_CONFIG_MANIFEST_PATH_GLOB,
+  SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX,
+  SCOUT_UNIFIED_CONFIG_PATH_REGEX,
+  TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX,
+} from './paths';
+
+describe('Scout path globs', () => {
+  describe('TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB', () => {
+    const shouldMatch = [
+      'src/platform/plugins/shared/my_plugin/test/scout',
+      'src/platform/plugins/private/my_plugin/test/scout',
+      'src/platform/packages/shared/my_package/test/scout',
+      'src/platform/packages/private/my_package/test/scout',
+      'src/core/packages/my_package/test/scout',
+      'x-pack/platform/plugins/shared/my_plugin/test/scout',
+      'x-pack/solutions/security/plugins/my_plugin/test/scout',
+      'x-pack/solutions/observability/plugins/my_plugin/test/scout',
+      'src/platform/plugins/shared/my_plugin/test/scout_custom',
+      'x-pack/solutions/security/plugins/my_plugin/test/scout_uiam_local',
+      'examples/hello_world/test/scout',
+      'examples/hello_world/test/scout_examples',
+      'x-pack/examples/hello_world/test/scout',
+      'x-pack/examples/hello_world/test/scout_examples',
+    ];
+
+    const shouldNotMatch = [
+      'random/path/test/scout',
+      'src/platform/plugins/shared/my_plugin/src/scout',
+      'not_examples/hello_world/test/scout',
+    ];
+
+    it.each(shouldMatch)('matches: %s', (testPath) => {
+      expect(mm.isMatch(testPath, TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB)).toBe(true);
+    });
+
+    it.each(shouldNotMatch)('does not match: %s', (testPath) => {
+      expect(mm.isMatch(testPath, TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB)).toBe(false);
+    });
+  });
+
+  describe('SCOUT_CONFIG_PATH_GLOB', () => {
+    const shouldMatch = [
+      'src/platform/plugins/shared/my_plugin/test/scout/api/playwright.config.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/ui/playwright.config.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/api/parallel.playwright.config.ts',
+      'x-pack/solutions/security/plugins/my_plugin/test/scout/api/playwright.config.ts',
+      'x-pack/solutions/security/plugins/my_plugin/test/scout_custom/ui/playwright.config.ts',
+      'src/core/packages/my_package/test/scout/api/playwright.config.ts',
+      'examples/hello_world/test/scout_examples/api/playwright.config.ts',
+      'examples/hello_world/test/scout_examples/ui/playwright.config.ts',
+      'x-pack/examples/hello_world/test/scout_examples/api/playwright.config.ts',
+      'x-pack/examples/hello_world/test/scout/ui/parallel.playwright.config.ts',
+    ];
+
+    const shouldNotMatch = [
+      'examples/hello_world/test/scout_examples/api/jest.config.ts',
+      'random/path/test/scout/api/playwright.config.ts',
+      'src/platform/plugins/shared/my_plugin/test/scout/api/not_playwright.config.ts',
+    ];
+
+    it.each(shouldMatch)('matches: %s', (testPath) => {
+      expect(mm.isMatch(testPath, SCOUT_CONFIG_PATH_GLOB)).toBe(true);
+    });
+
+    it.each(shouldNotMatch)('does not match: %s', (testPath) => {
+      expect(mm.isMatch(testPath, SCOUT_CONFIG_PATH_GLOB)).toBe(false);
+    });
+  });
+
+  describe('SCOUT_CONFIG_MANIFEST_PATH_GLOB', () => {
+    const shouldMatch = [
+      'src/platform/plugins/shared/my_plugin/test/scout/.meta/api/standard.json',
+      'src/platform/plugins/shared/my_plugin/test/scout/.meta/ui/parallel.json',
+      'x-pack/solutions/security/plugins/my_plugin/test/scout/.meta/api/standard.json',
+      'examples/hello_world/test/scout_examples/.meta/api/standard.json',
+      'x-pack/examples/hello_world/test/scout_examples/.meta/ui/standard.json',
+    ];
+
+    const shouldNotMatch = [
+      'random/path/.meta/api/standard.json',
+      'examples/hello_world/test/scout_examples/.meta/other/standard.json',
+    ];
+
+    it.each(shouldMatch)('matches: %s', (testPath) => {
+      expect(mm.isMatch(testPath, SCOUT_CONFIG_MANIFEST_PATH_GLOB)).toBe(true);
+    });
+
+    it.each(shouldNotMatch)('does not match: %s', (testPath) => {
+      expect(mm.isMatch(testPath, SCOUT_CONFIG_MANIFEST_PATH_GLOB)).toBe(false);
+    });
+  });
+});
+
+describe('Scout path regexes', () => {
+  describe('TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX', () => {
+    it('matches platform plugin paths with correct groups', () => {
+      const match = 'src/platform/plugins/shared/my_plugin/test/scout'.match(
+        TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('platform');
+      expect(match![2]).toBeUndefined();
+      expect(match![3]).toBe('plugins');
+      expect(match![4]).toBe('shared');
+      expect(match![5]).toBe('my_plugin');
+      expect(match![6]).toBeUndefined();
+    });
+
+    it('matches solution plugin paths with correct groups', () => {
+      const match = 'x-pack/solutions/security/plugins/my_plugin/test/scout'.match(
+        TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBeUndefined();
+      expect(match![2]).toBe('security');
+      expect(match![3]).toBe('plugins');
+    });
+
+    it('captures custom config set names', () => {
+      const match = 'src/platform/plugins/shared/my_plugin/test/scout_uiam_local'.match(
+        TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![6]).toBe('uiam_local');
+    });
+
+    it('does not match examples/ paths', () => {
+      expect(TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX.test('examples/hello_world/test/scout')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('SCOUT_CONFIG_PATH_REGEX', () => {
+    it('matches standard playwright config', () => {
+      const match =
+        'src/platform/plugins/shared/my_plugin/test/scout/api/playwright.config.ts'.match(
+          SCOUT_CONFIG_PATH_REGEX
+        );
+      expect(match).not.toBeNull();
+      expect(match![7]).toBe('api');
+      expect(match![8]).toBe('');
+    });
+
+    it('matches named playwright config', () => {
+      const match =
+        'src/platform/plugins/shared/my_plugin/test/scout/ui/parallel.playwright.config.ts'.match(
+          SCOUT_CONFIG_PATH_REGEX
+        );
+      expect(match).not.toBeNull();
+      expect(match![7]).toBe('ui');
+      expect(match![8]).toBe('parallel');
+    });
+
+    it('does not match examples/ paths', () => {
+      expect(
+        SCOUT_CONFIG_PATH_REGEX.test(
+          'examples/hello_world/test/scout_examples/api/playwright.config.ts'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX', () => {
+    it('matches examples/ plugin config with custom config set', () => {
+      const match = 'examples/hello_world/test/scout_examples/api/playwright.config.ts'.match(
+        SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('examples');
+      expect(match![2]).toBe('hello_world');
+      expect(match![3]).toBe('examples');
+      expect(match![4]).toBe('api');
+      expect(match![5]).toBe('');
+    });
+
+    it('matches x-pack/examples/ plugin config', () => {
+      const match = 'x-pack/examples/hello_world/test/scout_examples/ui/playwright.config.ts'.match(
+        SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('x-pack/examples');
+      expect(match![2]).toBe('hello_world');
+      expect(match![3]).toBe('examples');
+      expect(match![4]).toBe('ui');
+    });
+
+    it('matches examples/ with bare scout/ (no custom config set)', () => {
+      const match = 'examples/hello_world/test/scout/api/playwright.config.ts'.match(
+        SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX
+      );
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('examples');
+      expect(match![3]).toBeUndefined();
+    });
+
+    it('matches named playwright config under examples/', () => {
+      const match =
+        'examples/hello_world/test/scout_examples/api/parallel.playwright.config.ts'.match(
+          SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX
+        );
+      expect(match).not.toBeNull();
+      expect(match![5]).toBe('parallel');
+    });
+
+    it('does not match platform plugin paths', () => {
+      expect(
+        SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX.test(
+          'src/platform/plugins/shared/my_plugin/test/scout/api/playwright.config.ts'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('SCOUT_UNIFIED_CONFIG_PATH_REGEX', () => {
+    it('matches platform plugin path with correct named groups', () => {
+      const match =
+        'src/platform/plugins/shared/my_plugin/test/scout/api/playwright.config.ts'.match(
+          SCOUT_UNIFIED_CONFIG_PATH_REGEX
+        );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          examplesRoot: undefined,
+          examplePlugin: undefined,
+          platformOrCore: 'platform',
+          solution: undefined,
+          moduleKind: 'plugins',
+          moduleVisibility: 'shared',
+          moduleName: 'my_plugin',
+          serverConfigSet: undefined,
+          testCategory: 'api',
+          testConfigType: '',
+        })
+      );
+    });
+
+    it('matches core package path with correct named groups', () => {
+      const match = 'src/core/packages/my_package/test/scout/api/playwright.config.ts'.match(
+        SCOUT_UNIFIED_CONFIG_PATH_REGEX
+      );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          platformOrCore: 'core',
+          moduleKind: 'packages',
+          moduleName: 'my_package',
+          testCategory: 'api',
+        })
+      );
+    });
+
+    it('matches solution plugin path with correct named groups', () => {
+      const match =
+        'x-pack/solutions/security/plugins/my_plugin/test/scout/ui/parallel.playwright.config.ts'.match(
+          SCOUT_UNIFIED_CONFIG_PATH_REGEX
+        );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          examplesRoot: undefined,
+          platformOrCore: undefined,
+          solution: 'security',
+          moduleKind: 'plugins',
+          moduleVisibility: '',
+          moduleName: 'my_plugin',
+          testCategory: 'ui',
+          testConfigType: 'parallel',
+        })
+      );
+    });
+
+    it('matches custom server config set', () => {
+      const match =
+        'src/platform/plugins/shared/my_plugin/test/scout_uiam_local/api/playwright.config.ts'.match(
+          SCOUT_UNIFIED_CONFIG_PATH_REGEX
+        );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          serverConfigSet: 'uiam_local',
+          testCategory: 'api',
+        })
+      );
+    });
+
+    it('matches nested module names (e.g. vis_types/timelion)', () => {
+      const match =
+        'src/platform/plugins/private/vis_types/timelion/test/scout/ui/playwright.config.ts'.match(
+          SCOUT_UNIFIED_CONFIG_PATH_REGEX
+        );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          moduleName: 'vis_types/timelion',
+          moduleVisibility: 'private',
+        })
+      );
+    });
+
+    it('matches examples/ path with correct named groups', () => {
+      const match = 'examples/hello_world/test/scout_examples/api/playwright.config.ts'.match(
+        SCOUT_UNIFIED_CONFIG_PATH_REGEX
+      );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          examplesRoot: 'examples',
+          examplePlugin: 'hello_world',
+          platformOrCore: undefined,
+          solution: undefined,
+          moduleKind: undefined,
+          moduleName: undefined,
+          serverConfigSet: 'examples',
+          testCategory: 'api',
+          testConfigType: '',
+        })
+      );
+    });
+
+    it('matches x-pack/examples/ path with correct named groups', () => {
+      const match =
+        'x-pack/examples/hello_world/test/scout_examples/ui/parallel.playwright.config.ts'.match(
+          SCOUT_UNIFIED_CONFIG_PATH_REGEX
+        );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          examplesRoot: 'x-pack/examples',
+          examplePlugin: 'hello_world',
+          serverConfigSet: 'examples',
+          testCategory: 'ui',
+          testConfigType: 'parallel',
+        })
+      );
+    });
+
+    it('matches examples/ with bare scout/ (no config set)', () => {
+      const match = 'examples/hello_world/test/scout/api/playwright.config.ts'.match(
+        SCOUT_UNIFIED_CONFIG_PATH_REGEX
+      );
+      expect(match?.groups).toEqual(
+        expect.objectContaining({
+          examplesRoot: 'examples',
+          examplePlugin: 'hello_world',
+          serverConfigSet: undefined,
+          testCategory: 'api',
+        })
+      );
+    });
+
+    it('does not match random paths', () => {
+      expect(
+        SCOUT_UNIFIED_CONFIG_PATH_REGEX.test('random/path/test/scout/api/playwright.config.ts')
+      ).toBe(false);
+    });
+
+    it('does not match non-playwright configs', () => {
+      expect(
+        SCOUT_UNIFIED_CONFIG_PATH_REGEX.test(
+          'src/platform/plugins/shared/my_plugin/test/scout/api/jest.config.ts'
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-scout-info/src/paths.ts
+++ b/src/platform/packages/private/kbn-scout-info/src/paths.ts
@@ -32,8 +32,15 @@ export const SCOUT_PLAYWRIGHT_CONFIGS_PATH = path.resolve(
   'scout_playwright_configs.json'
 );
 
-export const TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB =
+export const PLATFORM_AND_SOLUTION_SCOUT_ROOT_PATH_GLOB =
   '{src/platform,src/core,x-pack/**}/{plugins,packages}/**/test/scout{_*,}';
+
+export const EXAMPLE_PLUGIN_SCOUT_ROOT_PATH_GLOB = '{examples,x-pack/examples}/**/test/scout{_*,}';
+
+export const TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB = `{${[
+  PLATFORM_AND_SOLUTION_SCOUT_ROOT_PATH_GLOB,
+  EXAMPLE_PLUGIN_SCOUT_ROOT_PATH_GLOB,
+].join(',')}}`;
 
 export const TESTABLE_COMPONENT_SCOUT_ROOT_PATH_REGEX = new RegExp(
   `(?:src|x-pack)` +
@@ -58,6 +65,34 @@ export const SCOUT_CONFIG_PATH_REGEX = new RegExp(
 
 export const SCOUT_CONFIG_MANIFEST_PATH_GLOB =
   TESTABLE_COMPONENT_SCOUT_ROOT_PATH_GLOB + `/.meta/{${SCOUT_TEST_CATEGORIES.join(',')}}/*.json`;
+
+/**
+ * Playwright configs under top-level `examples/` and `x-pack/examples/` (developer example plugins).
+ * `module.name` for these paths is resolved from `plugin.id` in kibana.jsonc (see test_config.fromPath).
+ */
+export const SCOUT_EXAMPLES_PLAYWRIGHT_CONFIG_REGEX = new RegExp(
+  `^(examples|x-pack/examples)/([^/]+)/test/scout(?:_([^/]*))?/(${SCOUT_TEST_CATEGORIES.join(
+    '|'
+  )})/(\\w*)\\.?playwright\\.config\\.ts$`
+);
+
+/**
+ * Unified regex matching both platform/solution and example plugin Playwright config paths.
+ * Uses named capture groups so callers can branch on `examplesRoot` to decide how to
+ * resolve module metadata (kibana.jsonc vs directory-derived).
+ */
+export const SCOUT_UNIFIED_CONFIG_PATH_REGEX = new RegExp(
+  `^(?:` +
+    `(?<examplesRoot>examples|x-pack/examples)/(?<examplePlugin>[^/]+)` +
+    `|` +
+    `(?:src|x-pack)/(?:(?<platformOrCore>platform|core)|solutions/(?<solution>\\w+))` +
+    `/(?<moduleKind>plugins|packages)/?(?<moduleVisibility>shared|private|)` +
+    `/(?<moduleName>[\\w|-]+(?:\\/[\\w|-]+)*)` +
+    `)` +
+    `/test/scout(?:_(?<serverConfigSet>[^/]*))?` +
+    `/(?<testCategory>${SCOUT_TEST_CATEGORIES.join('|')})` +
+    `/(?<testConfigType>\\w*)\\.?playwright\\.config\\.ts$`
+);
 
 // Scout CI
 export const SCOUT_CI_CONFIG_PATH = path.resolve(REPO_ROOT, '.buildkite', 'scout_ci_config.yml');

--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
@@ -43,8 +43,17 @@ describe('read_manifest', () => {
     const pluginFilePath = '/plugins/my_plugin/kibana.jsonc';
     const packageFilePath = '/packages/my_package/kibana.jsonc';
 
+    let existsSyncSpy: jest.SpyInstance;
+    let readFileSyncSpy: jest.SpyInstance;
+
     beforeEach(() => {
-      jest.clearAllMocks();
+      existsSyncSpy = jest.spyOn(fs, 'existsSync');
+      readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+    });
+
+    afterEach(() => {
+      existsSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
     });
 
     it('should read and parse the manifest for plugin correctly', () => {

--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.test.ts
@@ -117,6 +117,41 @@ describe('read_manifest', () => {
       );
     });
 
+    it('should normalize a string owner to an array', () => {
+      const fileContent = `
+        {
+          "id": "@kbn/example-plugin",
+          "type": "plugin",
+          "group": "platform",
+          "visibility": "private",
+          "owner": "@elastic/kibana-core",
+          "plugin": { "id": "examplePlugin" }
+        }
+      `;
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue(fileContent);
+
+      const result = readKibanaModuleManifest(pluginFilePath);
+      expect(result.owner).toEqual(['@elastic/kibana-core']);
+    });
+
+    it('should default owner to empty array when missing', () => {
+      const fileContent = `
+        {
+          "id": "@kbn/example-plugin",
+          "type": "plugin",
+          "group": "platform",
+          "visibility": "private",
+          "plugin": { "id": "examplePlugin" }
+        }
+      `;
+      existsSyncSpy.mockReturnValue(true);
+      readFileSyncSpy.mockReturnValue(fileContent);
+
+      const result = readKibanaModuleManifest(pluginFilePath);
+      expect(result.owner).toEqual([]);
+    });
+
     it('should throw an error for missing required fields', () => {
       const fileContent = `{
         "group": "platform",

--- a/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/helpers/read_manifest.ts
@@ -15,7 +15,7 @@ export interface KibanaJsoncMetadata {
   id: string;
   type: string;
   group: string;
-  owner: string[];
+  owner: string | string[];
   visibility: string;
   plugin?: { id: string };
 }
@@ -85,7 +85,8 @@ export const readKibanaModuleManifest = (filePath: string): KibanaModuleMetadata
     );
   }
 
-  return { id, type, group, visibility, owner: owner || [] };
+  const normalizedOwner = Array.isArray(owner) ? owner : owner ? [owner] : [];
+  return { id, type, group, visibility, owner: normalizedOwner };
 };
 
 /**

--- a/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.test.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { testConfig, testConfigs } from './test_config';
+import { readKibanaModuleManifest } from '../helpers/read_manifest';
 import { REPO_ROOT } from '@kbn/repo-info';
 import fs from 'node:fs';
 import fg from 'fast-glob';
@@ -15,6 +16,9 @@ import path from 'node:path';
 
 jest.mock('node:fs');
 jest.mock('fast-glob');
+jest.mock('../helpers/read_manifest', () => ({
+  readKibanaModuleManifest: jest.fn(),
+}));
 
 const dummyManifestProps = {
   exists: false,
@@ -22,9 +26,14 @@ const dummyManifestProps = {
   tests: [],
 };
 
+const mockReadKibanaModuleManifest = readKibanaModuleManifest as jest.MockedFunction<
+  typeof readKibanaModuleManifest
+>;
+
 describe('test_config module', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockReadKibanaModuleManifest.mockReset();
   });
 
   describe('testConfig.fromPath', () => {
@@ -209,6 +218,48 @@ describe('test_config module', () => {
       expect(() => testConfig.fromPath(configPath)).toThrow(
         `Failed to create Scout config from path '${configPath}': path did not match the expected regex pattern`
       );
+    });
+
+    it('parses examples/ developer plugin paths using plugin.id from kibana.jsonc', () => {
+      const moduleRoot = path.join('examples', 'hello_world');
+      const scoutRoot = path.join(moduleRoot, 'test/scout_examples');
+      const configPath = path.join(scoutRoot, '/api/playwright.config.ts');
+      const manifestPath = path.join(scoutRoot, '/.meta/api/standard.json');
+
+      mockReadKibanaModuleManifest.mockReturnValue({
+        id: 'helloWorld',
+        type: 'plugin',
+        group: 'platform',
+        visibility: 'private',
+        owner: [],
+      });
+
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const config = testConfig.fromPath(configPath);
+
+      expect(mockReadKibanaModuleManifest).toHaveBeenCalledWith(
+        path.join(REPO_ROOT, moduleRoot, 'kibana.jsonc')
+      );
+      expect(config).toEqual({
+        path: configPath,
+        category: 'api',
+        type: 'standard',
+        module: {
+          name: 'helloWorld',
+          group: 'platform',
+          type: 'plugin',
+          visibility: 'private',
+          root: moduleRoot,
+        },
+        manifest: {
+          path: manifestPath,
+          ...dummyManifestProps,
+        },
+        server: {
+          configSet: 'examples',
+        },
+      });
     });
 
     it('throws if the manifest file is present but invalid', () => {

--- a/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.ts
+++ b/src/platform/packages/private/kbn-scout-reporting/src/registry/test_config.ts
@@ -11,8 +11,9 @@ import { globSync } from 'fast-glob';
 import { REPO_ROOT } from '@kbn/repo-info';
 import path from 'node:path';
 import { ToolingLog } from '@kbn/tooling-log';
-import { SCOUT_CONFIG_PATH_GLOB, SCOUT_CONFIG_PATH_REGEX } from '@kbn/scout-info';
+import { SCOUT_CONFIG_PATH_GLOB, SCOUT_UNIFIED_CONFIG_PATH_REGEX } from '@kbn/scout-info';
 import { existsSync, readFileSync } from 'node:fs';
+import { readKibanaModuleManifest } from '../helpers/read_manifest';
 import type { ScoutTestableModule } from './testable_module';
 import type { ScoutConfigManifest } from './manifest';
 
@@ -26,6 +27,74 @@ export interface ScoutTestConfig {
     configSet: string;
   };
 }
+
+const loadScoutManifestFile = (
+  manifestPath: string
+): { exists: boolean } & Pick<ScoutConfigManifest, 'sha1' | 'tests'> => {
+  const absoluteManifestPath = path.join(REPO_ROOT, manifestPath);
+  const manifestExists = existsSync(absoluteManifestPath);
+  if (manifestExists) {
+    try {
+      return {
+        exists: true,
+        ...JSON.parse(readFileSync(absoluteManifestPath, 'utf8')),
+      };
+    } catch (e) {
+      e.message = `Failed while trying to load manifest file at '${manifestPath}': ${e.message}`;
+      throw e;
+    }
+  }
+  return {
+    exists: false,
+    sha1: '000000000000000-000000000000000',
+    tests: [],
+  };
+};
+
+const resolveModuleMetadata = (
+  configPath: string,
+  moduleRoot: string
+): {
+  module: ScoutTestableModule;
+  serverConfigSet: string | undefined;
+  testCategory: string;
+  testConfigType: string;
+} => {
+  const match = configPath.match(SCOUT_UNIFIED_CONFIG_PATH_REGEX);
+  if (!match?.groups) {
+    throw new Error(
+      `Failed to create Scout config from path '${configPath}': ` +
+        'path did not match the expected regex pattern'
+    );
+  }
+
+  const g = match.groups;
+  const module: ScoutTestableModule = g.examplesRoot
+    ? (() => {
+        const manifest = readKibanaModuleManifest(path.join(REPO_ROOT, moduleRoot, 'kibana.jsonc'));
+        return {
+          name: manifest.id,
+          group: manifest.group,
+          type: manifest.type as ScoutTestableModule['type'],
+          visibility: manifest.visibility as ScoutTestableModule['visibility'],
+          root: moduleRoot,
+        };
+      })()
+    : {
+        name: g.moduleName,
+        group: g.platformOrCore ?? g.solution,
+        type: g.moduleKind.slice(0, -1) as ScoutTestableModule['type'],
+        visibility: (g.moduleVisibility || 'private') as ScoutTestableModule['visibility'],
+        root: moduleRoot,
+      };
+
+  return {
+    module,
+    serverConfigSet: g.serverConfigSet,
+    testCategory: g.testCategory,
+    testConfigType: g.testConfigType,
+  };
+};
 
 export const testConfig = {
   fromPath(configPath: string): ScoutTestConfig {
@@ -41,30 +110,13 @@ export const testConfig = {
       );
     }
 
-    const match = configPath.match(SCOUT_CONFIG_PATH_REGEX);
-
-    if (match == null) {
-      throw new Error(
-        `Failed to create Scout config from path '${configPath}': ` +
-          'path did not match the expected regex pattern'
-      );
-    }
-
-    const [
-      _,
-      platform,
-      solution,
-      moduleType,
-      moduleVisibility,
-      moduleName,
-      serverConfigSet,
-      testCategory,
-      testConfigType,
-    ] = match;
+    const moduleRoot = configPath.split('/test/scout')[0];
+    const { module, serverConfigSet, testCategory, testConfigType } = resolveModuleMetadata(
+      configPath,
+      moduleRoot
+    );
 
     const scoutDirName = `scout${serverConfigSet ? `_${serverConfigSet}` : ''}`;
-    const moduleRoot = configPath.split('/test/scout')[0];
-
     const manifestPath = path.join(
       moduleRoot,
       'test',
@@ -73,39 +125,18 @@ export const testConfig = {
       testCategory,
       `${testConfigType || 'standard'}.json`
     );
-    const absoluteManifestPath = path.join(REPO_ROOT, manifestPath);
-    const manifestExists = existsSync(absoluteManifestPath);
-    let manifestFileData;
-
-    if (manifestExists) {
-      try {
-        manifestFileData = JSON.parse(readFileSync(absoluteManifestPath, 'utf8'));
-      } catch (e) {
-        e.message = `Failed while trying to load manifest file at '${manifestPath}': ${e.message}`;
-        throw e;
-      }
-    } else {
-      manifestFileData = {
-        sha1: '000000000000000-000000000000000',
-        tests: [],
-      };
-    }
+    const manifestFileData = loadScoutManifestFile(manifestPath);
 
     return {
       path: configPath,
       category: testCategory,
       type: testConfigType || 'standard',
-      module: {
-        name: moduleName,
-        group: platform ?? solution,
-        type: moduleType.slice(0, -1) as ScoutTestableModule['type'],
-        visibility: (moduleVisibility || 'private') as ScoutTestableModule['visibility'],
-        root: moduleRoot,
-      },
+      module,
       manifest: {
         path: manifestPath,
-        exists: manifestExists,
-        ...manifestFileData,
+        exists: manifestFileData.exists,
+        sha1: manifestFileData.sha1,
+        tests: manifestFileData.tests,
       },
       server: {
         configSet: serverConfigSet || 'default',

--- a/src/platform/packages/shared/kbn-scout/moon.yml
+++ b/src/platform/packages/shared/kbn-scout/moon.yml
@@ -40,6 +40,7 @@ dependsOn:
   - '@kbn/axe-config'
   - '@kbn/peggy'
   - '@kbn/test-docker-servers'
+  - '@kbn/test'
 tags:
   - test-helper
   - package

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/examples/shared.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/examples/shared.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { resolve } from 'path';
+import { REPO_ROOT } from '@kbn/repo-info';
+import { findTestPluginPaths } from '@kbn/test';
+
+/**
+ * Server args aligned with x-pack/platform/test/examples/config.ts so developer
+ * example plugins (and their cross-dependencies) load via --plugin-path.
+ */
+export const examplesServerArgs = [
+  '--data.search.sessions.enabled=true',
+  ...findTestPluginPaths([resolve(REPO_ROOT, 'examples'), resolve(REPO_ROOT, 'x-pack/examples')]),
+];

--- a/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/examples/stateful/classic.stateful.config.ts
+++ b/src/platform/packages/shared/kbn-scout/src/servers/configs/config_sets/examples/stateful/classic.stateful.config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ScoutServerConfig } from '../../../../../types';
+import { defaultConfig } from '../../default/stateful/base.config';
+import { examplesServerArgs } from '../shared';
+
+export const servers: ScoutServerConfig = {
+  ...defaultConfig,
+  kbnTestServer: {
+    ...defaultConfig.kbnTestServer,
+    serverArgs: [...defaultConfig.kbnTestServer.serverArgs, ...examplesServerArgs],
+  },
+};

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -29,6 +29,7 @@
     "@kbn/core-http-common",
     "@kbn/axe-config",
     "@kbn/peggy",
-    "@kbn/test-docker-servers"
+    "@kbn/test-docker-servers",
+    "@kbn/test"
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[scout] support example plugins (#259170)](https://github.com/elastic/kibana/pull/259170)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2026-03-27T17:44:21Z","message":"[scout] support example plugins (#259170)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/708\n\n### Adds Scout support for plugins located in `/examples`, in\nparticular:\n\n- scout playwright config discovery\n- stateful shared config to use for all plugins (saves CI runtime by\navoiding restarts)\n- registration in `scout_ci_config.yml` for CI run\n\n### Code change:\n\n`loadScoutManifestFile` reads the Scout .meta/*.json next to a\nPlaywright config (test ids, tags, etc.), or returns a placeholder when\nthat file is not present so fromPath still works. It was extracted so\nboth the regular plugin/package path parsing and the new `examples/`\npath parsing share the same manifest-loading logic instead of\nduplicating it.\n\n---------\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4c8724bb8fe03db9d1c585072c450394ad7e8d4e","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:all-open","v9.4.0"],"title":"[scout] support example plugins","number":259170,"url":"https://github.com/elastic/kibana/pull/259170","mergeCommit":{"message":"[scout] support example plugins (#259170)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/708\n\n### Adds Scout support for plugins located in `/examples`, in\nparticular:\n\n- scout playwright config discovery\n- stateful shared config to use for all plugins (saves CI runtime by\navoiding restarts)\n- registration in `scout_ci_config.yml` for CI run\n\n### Code change:\n\n`loadScoutManifestFile` reads the Scout .meta/*.json next to a\nPlaywright config (test ids, tags, etc.), or returns a placeholder when\nthat file is not present so fromPath still works. It was extracted so\nboth the regular plugin/package path parsing and the new `examples/`\npath parsing share the same manifest-loading logic instead of\nduplicating it.\n\n---------\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4c8724bb8fe03db9d1c585072c450394ad7e8d4e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/259170","number":259170,"mergeCommit":{"message":"[scout] support example plugins (#259170)\n\n## Summary\n\nCloses https://github.com/elastic/appex-qa-team/issues/708\n\n### Adds Scout support for plugins located in `/examples`, in\nparticular:\n\n- scout playwright config discovery\n- stateful shared config to use for all plugins (saves CI runtime by\navoiding restarts)\n- registration in `scout_ci_config.yml` for CI run\n\n### Code change:\n\n`loadScoutManifestFile` reads the Scout .meta/*.json next to a\nPlaywright config (test ids, tags, etc.), or returns a placeholder when\nthat file is not present so fromPath still works. It was extracted so\nboth the regular plugin/package path parsing and the new `examples/`\npath parsing share the same manifest-loading logic instead of\nduplicating it.\n\n---------\n\nCo-authored-by: Stelios Mavro <81311181+steliosmavro@users.noreply.github.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4c8724bb8fe03db9d1c585072c450394ad7e8d4e"}},{"url":"https://github.com/elastic/kibana/pull/261384","number":261384,"branch":"9.3","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/261385","number":261385,"branch":"9.2","state":"OPEN"}]}] BACKPORT-->