### PR TITLE
[Alerting v2] [Rule Authoring] Make rule form sections collapsible

### DIFF
--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/alert_conditions_field_group.tsx
@@ -47,6 +47,7 @@ export const AlertConditionsFieldGroup = () => {
       title={i18n.translate('xpack.alertingV2.ruleForm.alertConditions', {
         defaultMessage: 'Alert conditions',
       })}
+      defaultOpen
     >
       <AlertDelayField />
       <EuiSpacer size="m" />

--- a/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
+++ b/x-pack/platform/packages/shared/response-ops/alerting-v2-rule-form/form/field_groups/rule_execution_field_group.tsx
@@ -17,6 +17,7 @@ export const RuleExecutionFieldGroup = () => {
       title={i18n.translate('xpack.alertingV2.ruleForm.ruleExecution', {
         defaultMessage: 'Rule execution',
       })}
+      defaultOpen
     >
       <ScheduleField />
       <LookbackWindowField />


### PR DESCRIPTION
## Summary

Makes the **Rule execution** and **Alert conditions** section groups on the page rule form collapsible (open by default) by passing `defaultOpen` to `FieldGroup`.

This reuses the existing collapsible `FieldGroup` pattern already used by the Attachments section, which renders an `EuiSplitPanel` with a toggle arrow on the page layout and an `EuiAccordion` on the flyout layout.

Closes elastic/rna-program#242

## Changes

- `RuleExecutionFieldGroup`: add `defaultOpen` to `FieldGroup`
- `AlertConditionsFieldGroup`: add `defaultOpen` to `FieldGroup`

## Test plan

- [x] Open the page rule form (create/edit)
- [x] Verify **Rule execution** and **Alert conditions** sections render open by default with a collapse arrow
- [x] Click the collapse arrow — section content hides
- [x] Click again — section content reappears
- [x] Verify **Rule evaluation** remains static (no collapse arrow)
- [x] Verify **Attachments** still starts collapsed
- [x] Open the flyout rule form and verify no regressions (sections render as accordions)