### PR TITLE
[Security Solution] Add note action to footer Take action dropdown for event only

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.test.tsx
@@ -34,6 +34,7 @@ const createMockHit = (raw: Partial<DataTableRecord['raw']> = {}): DataTableReco
 const mockEcsData: Ecs = { _id: 'test-event-id', _index: 'test-index' };
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 const mockOnAlertUpdated = jest.fn();
+const mockOnShowNotes = jest.fn();
 
 const mockDataFormattedForFieldBrowser: TimelineEventsDetailsItem[] = [
   { field: 'host.name', values: ['test-host'], originalValue: ['test-host'], isObjectArray: false },
@@ -60,7 +61,11 @@ describe('<TakeAction />', () => {
     });
 
     const { getByTestId, queryByTestId } = render(
-      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
     );
     const button = getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID);
 
@@ -78,7 +83,11 @@ describe('<TakeAction />', () => {
     });
 
     const { getByTestId, queryByTestId } = render(
-      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
     );
 
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
@@ -95,7 +104,11 @@ describe('<TakeAction />', () => {
     });
 
     const { getByTestId, queryByTestId } = render(
-      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
     );
 
     expect(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID)).toBeDisabled();
@@ -105,7 +118,11 @@ describe('<TakeAction />', () => {
 
   it('should render TakeActionButton when data is available', () => {
     const { getByTestId, queryByTestId } = render(
-      <TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
     );
 
     expect(getByTestId('take-action-button-mock')).toBeInTheDocument();
@@ -113,7 +130,13 @@ describe('<TakeAction />', () => {
   });
 
   it('should call useEventDetails with eventId and indexName from hit', () => {
-    render(<TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />);
+    render(
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
+    );
 
     expect(mockUseEventDetails).toHaveBeenCalledWith({
       eventId: 'test-event-id',
@@ -121,10 +144,10 @@ describe('<TakeAction />', () => {
     });
   });
 
-  it('should pass hit, ecsData, refetchFlyoutData and onAlertUpdated from useEventDetails to TakeActionButton', () => {
+  it('should pass hit, ecsData, refetchFlyoutData, onAlertUpdated and onShowNotes from useEventDetails to TakeActionButton', () => {
     const hit = createMockHit();
     const onAlertUpdated = jest.fn();
-    render(<TakeAction hit={hit} onAlertUpdated={onAlertUpdated} />);
+    render(<TakeAction hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={mockOnShowNotes} />);
 
     expect(mockTakeActionButton).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -132,13 +155,20 @@ describe('<TakeAction />', () => {
         ecsData: mockEcsData,
         refetchFlyoutData: mockRefetchFlyoutData,
         onAlertUpdated,
+        onShowNotes: mockOnShowNotes,
       }),
       expect.anything()
     );
   });
 
   it('should compute nonEcsData from dataFormattedForFieldBrowser and pass it to TakeActionButton', () => {
-    render(<TakeAction hit={createMockHit()} onAlertUpdated={mockOnAlertUpdated} />);
+    render(
+      <TakeAction
+        hit={createMockHit()}
+        onAlertUpdated={mockOnAlertUpdated}
+        onShowNotes={mockOnShowNotes}
+      />
+    );
 
     expect(mockTakeActionButton).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action.tsx
@@ -32,6 +32,10 @@ export interface TakeActionProps {
    * Callback invoked after alert mutations to refresh flyout data.
    */
   onAlertUpdated: () => void;
+  /**
+   * Callback to open the notes flyout.
+   */
+  onShowNotes: () => void;
 }
 
 /**
@@ -42,7 +46,7 @@ export interface TakeActionProps {
  * We're doing all of this to avoid having to refactor all the actions that are currently using dataAsNestedObject and dataFormattedForFieldBrowser/
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
-export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated }) => {
+export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated, onShowNotes }) => {
   const eventId = hit.raw._id;
   const indexName = hit.raw._index;
 
@@ -80,6 +84,7 @@ export const TakeAction: FC<TakeActionProps> = ({ hit, onAlertUpdated }) => {
       nonEcsData={nonEcsData}
       refetchFlyoutData={refetchFlyoutData}
       onAlertUpdated={onAlertUpdated}
+      onShowNotes={onShowNotes}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.test.tsx
@@ -34,7 +34,6 @@ const mockUseAddToCaseActions = useAddToCaseActions as jest.Mock;
 const mockUseAlertsActions = useAlertsActions as jest.Mock;
 const mockUseAlertAssigneesActions = useAlertAssigneesActions as jest.Mock;
 const mockUseAlertTagsActions = useAlertTagsActions as jest.Mock;
-
 const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord =>
   ({
     id: 'test-id',
@@ -42,12 +41,14 @@ const createMockHit = (flattened: Record<string, unknown> = {}): DataTableRecord
     flattened,
     isAnchor: false,
   } as DataTableRecord);
+
 const mockUseInvestigateInTimeline = useInvestigateInTimeline as jest.Mock;
 const mockUseIsInSecurityApp = useIsInSecurityApp as jest.Mock;
 const mockEcsData: Ecs = { _id: 'test-id', _index: 'test-index' };
 const mockNonEcsData: TimelineNonEcsData[] = [{ field: 'host.name', value: ['test-host'] }];
 const mockRefetchFlyoutData = jest.fn().mockResolvedValue(undefined);
 const mockOnAlertUpdated = jest.fn();
+const mockOnShowNotes = jest.fn();
 
 const defaultProps = {
   hit: createMockHit(),
@@ -55,6 +56,7 @@ const defaultProps = {
   nonEcsData: mockNonEcsData,
   refetchFlyoutData: mockRefetchFlyoutData,
   onAlertUpdated: mockOnAlertUpdated,
+  onShowNotes: mockOnShowNotes,
 };
 
 const renderTakeActionButton = (props = defaultProps) => render(<TakeActionButton {...props} />);
@@ -222,20 +224,24 @@ describe('<TakeActionButton />', () => {
       mockUseAlertTagsActions.mockReturnValue({ alertTagsItems: [tagsItem], alertTagsPanels: [] });
     });
 
-    it('should include status and assignees items for alert documents (event.kind === signal)', () => {
+    it('should include status, assignees and tags items for alert documents (event.kind === signal)', () => {
       const alertHit = createMockHit({ 'event.kind': 'signal' });
-      const { getByTestId, getByText } = renderTakeActionButton({ ...defaultProps, hit: alertHit });
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
+        ...defaultProps,
+        hit: alertHit,
+      });
 
       fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
 
       expect(getByText('Mark as acknowledged')).toBeInTheDocument();
       expect(getByText('Assign alert')).toBeInTheDocument();
       expect(getByText('Apply alert tags')).toBeInTheDocument();
+      expect(queryByText('Add note')).not.toBeInTheDocument();
     });
 
-    it('should exclude status and assignees items for non-alert documents', () => {
+    it('should exclude status, assignees and tags items but have note item for non-alert documents', () => {
       const eventHit = createMockHit({ 'event.kind': 'event' });
-      const { getByTestId, queryByText } = renderTakeActionButton({
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
         ...defaultProps,
         hit: eventHit,
       });
@@ -245,10 +251,11 @@ describe('<TakeActionButton />', () => {
       expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
       expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
+      expect(getByText('Add note')).toBeInTheDocument();
     });
 
-    it('should exclude status and assignees items when event.kind is not set', () => {
-      const { getByTestId, queryByText } = renderTakeActionButton({
+    it('should exclude status, assignees and tags items but have note item when event.kind is not set', () => {
+      const { getByTestId, getByText, queryByText } = renderTakeActionButton({
         ...defaultProps,
         hit: createMockHit(),
       });
@@ -258,6 +265,19 @@ describe('<TakeActionButton />', () => {
       expect(queryByText('Mark as acknowledged')).not.toBeInTheDocument();
       expect(queryByText('Assign alert')).not.toBeInTheDocument();
       expect(queryByText('Apply alert tags')).not.toBeInTheDocument();
+      expect(getByText('Add note')).toBeInTheDocument();
     });
+  });
+
+  it('should call onShowNotes when "Add note" is clicked', () => {
+    const { getByTestId, getByText } = renderTakeActionButton({
+      ...defaultProps,
+      hit: createMockHit(),
+    });
+
+    fireEvent.click(getByTestId(FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID));
+    fireEvent.click(getByText('Add note'));
+
+    expect(mockOnShowNotes).toHaveBeenCalledTimes(1);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/take_action_button.tsx
@@ -27,6 +27,10 @@ const TAKE_ACTION = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeA
   defaultMessage: 'Take action',
 });
 
+const ADD_NOTE = i18n.translate('xpack.securitySolution.flyoutV2.footer.takeAction.addNoteLabel', {
+  defaultMessage: 'Add note',
+});
+
 export interface TakeActionButtonProps {
   /**
    * The raw document record, used to extract alert metadata
@@ -48,6 +52,10 @@ export interface TakeActionButtonProps {
    * Callback invoked after alert mutations to refresh flyout data.
    */
   onAlertUpdated: () => void;
+  /**
+   * Callback to open the notes flyout. Shown in the dropdown only for raw events (not alerts).
+   */
+  onShowNotes: () => void;
 }
 
 /**
@@ -55,7 +63,14 @@ export interface TakeActionButtonProps {
  * // TODO: refactor all actions to take a DataTableRecord as input.
  */
 export const TakeActionButton = memo(
-  ({ hit, ecsData, nonEcsData, refetchFlyoutData, onAlertUpdated }: TakeActionButtonProps) => {
+  ({
+    hit,
+    ecsData,
+    nonEcsData,
+    refetchFlyoutData,
+    onAlertUpdated,
+    onShowNotes,
+  }: TakeActionButtonProps) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const togglePopoverHandler = useCallback(() => {
       setIsPopoverOpen((open) => !open);
@@ -67,9 +82,14 @@ export const TakeActionButton = memo(
     const isInSecurityApp = useIsInSecurityApp();
 
     const eventId = hit.raw._id as string;
-    const isAlert = (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal;
-    const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
-    const alertStatus = (Array.isArray(rawStatus) ? rawStatus[0] : rawStatus) as Status;
+    const isAlert = useMemo(
+      () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
+      [hit]
+    );
+    const alertStatus = useMemo(() => {
+      const rawStatus = getFieldValue(hit, ALERT_WORKFLOW_STATUS);
+      return (Array.isArray(rawStatus) ? rawStatus[0] : rawStatus) as Status;
+    }, [hit]);
 
     const { addToCaseActionItems } = useAddToCaseActions({
       ecsData,
@@ -108,12 +128,29 @@ export const TakeActionButton = memo(
       onInvestigateInTimelineAlertClick: closePopoverHandler,
     });
 
+    const noteItems = useMemo(
+      () => [
+        {
+          'data-test-subj': 'add-note-action',
+          key: 'add-note-action',
+          name: ADD_NOTE,
+          size: 's' as const,
+          onClick: () => {
+            closePopoverHandler();
+            onShowNotes();
+          },
+        },
+      ],
+      [closePopoverHandler, onShowNotes]
+    );
+
     const items = useMemo(
       () => [
         ...addToCaseActionItems,
         ...(isAlert ? statusActionItems : []),
         ...(isAlert ? alertAssigneesItems : []),
         ...(isAlert ? alertTagsItems : []),
+        ...(isAlert ? [] : noteItems),
         ...(isInSecurityApp ? investigateInTimelineActionItems : []),
       ],
       [
@@ -122,6 +159,7 @@ export const TakeActionButton = memo(
         investigateInTimelineActionItems,
         isAlert,
         isInSecurityApp,
+        noteItems,
         statusActionItems,
         alertAssigneesItems,
       ]

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.test.tsx
@@ -31,6 +31,7 @@ const createMockHit = (): DataTableRecord =>
   } as DataTableRecord);
 
 const mockOnAlertUpdated = jest.fn();
+const mockOnShowNotes = jest.fn();
 
 describe('<Footer />', () => {
   beforeEach(() => {
@@ -40,7 +41,9 @@ describe('<Footer />', () => {
   it('renders FooterAiActions with the provided hit', () => {
     const hit = createMockHit();
 
-    const { getByTestId } = render(<Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} />);
+    const { getByTestId } = render(
+      <Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} onShowNotes={mockOnShowNotes} />
+    );
 
     const aiActions = getByTestId('footerAiActions');
     expect(aiActions).toBeInTheDocument();
@@ -50,7 +53,9 @@ describe('<Footer />', () => {
   it('renders TakeAction with the provided hit', () => {
     const hit = createMockHit();
 
-    const { getByTestId } = render(<Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} />);
+    const { getByTestId } = render(
+      <Footer hit={hit} onAlertUpdated={mockOnAlertUpdated} onShowNotes={mockOnShowNotes} />
+    );
 
     const aiActions = getByTestId('takeAction');
     expect(aiActions).toBeInTheDocument();
@@ -61,7 +66,7 @@ describe('<Footer />', () => {
     const hit = createMockHit();
     const onAlertUpdated = jest.fn();
 
-    render(<Footer hit={hit} onAlertUpdated={onAlertUpdated} />);
+    render(<Footer hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={mockOnShowNotes} />);
 
     expect(mockTakeAction).toHaveBeenCalledWith(expect.objectContaining({ onAlertUpdated }));
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/footer.tsx
@@ -20,19 +20,23 @@ export interface FooterProps {
    * Callback invoked after alert mutations to refresh flyout data.
    */
   onAlertUpdated: () => void;
+  /**
+   * Callback to open the notes flyout.
+   */
+  onShowNotes: () => void;
 }
 
 /**
  * Footer component rendered at the top of the new document flyout in Security Solution and in Discover
  */
-export const Footer = memo(({ hit, onAlertUpdated }: FooterProps) => {
+export const Footer = memo(({ hit, onAlertUpdated, onShowNotes }: FooterProps) => {
   return (
     <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
       <EuiFlexItem grow={false}>
         <FooterAiActions hit={hit} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <TakeAction hit={hit} onAlertUpdated={onAlertUpdated} />
+        <TakeAction hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={onShowNotes} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
@@ -75,9 +75,6 @@ export const DocumentFlyout = memo(
     if (isAlert && loading) {
       return <FlyoutLoading data-test-subj="document-overview-loading" />;
     }
-    if (isAlert && loading) {
-      return <FlyoutLoading data-test-subj="document-overview-loading" />;
-    }
 
     if (missingAlertsPrivilege) {
       return <FlyoutMissingAlertsPrivilege />;
@@ -101,7 +98,7 @@ export const DocumentFlyout = memo(
           />
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
-          <Footer hit={hit} onAlertUpdated={onAlertUpdated} />
+          <Footer hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={onShowNotes} />
         </EuiFlyoutFooter>
       </>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
@@ -6,10 +6,12 @@
  */
 
 import type { DataTableRecord } from '@kbn/discover-utils';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Footer } from '../../flyout_v2/document/footer';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
+import { NotesDetails } from '../../flyout_v2/notes';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
 
 export interface AlertFlyoutFooterProps {
@@ -37,8 +39,29 @@ export const AlertFlyoutFooter = ({
   storePromise,
   onAlertUpdated,
 }: AlertFlyoutFooterProps) => {
+  const history = useHistory();
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
+  const openNotesFlyout = useCallback(() => {
+    if (!services || !store) {
+      return;
+    }
+
+    services.overlays?.openSystemFlyout(
+      flyoutProviders({
+        services,
+        store,
+        history,
+        children: <NotesDetails hit={hit} />,
+      }),
+      {
+        ownFocus: false,
+        resizable: true,
+        size: 'm',
+        type: 'overlay',
+      }
+    );
+  }, [history, hit, services, store]);
 
   useEffect(() => {
     let isCanceled = false;
@@ -71,6 +94,6 @@ export const AlertFlyoutFooter = ({
   return flyoutProviders({
     services,
     store,
-    children: <Footer hit={hit} onAlertUpdated={onAlertUpdated} />,
+    children: <Footer hit={hit} onAlertUpdated={onAlertUpdated} onShowNotes={openNotesFlyout} />,
   });
 };


### PR DESCRIPTION
## Summary

This PR adds the add note action to the footer of the new flyout, visible only for events (for alerts we have that logic in the header).

#### The actions are accessible when the flyout is opened in Security Solution

Nothing for alerts
<img width="1512" height="935" alt="Screenshot 2026-04-06 at 12 15 19 PM" src="https://github.com/user-attachments/assets/3241ecb6-82ab-4e9c-a49c-6fcecb178665" />

Visible for events

https://github.com/user-attachments/assets/3047a634-9909-44d1-878f-458d5380ca55

#### And in Discover

Nothing for alerts

<img width="1512" height="933" alt="Screenshot 2026-04-06 at 12 26 33 PM" src="https://github.com/user-attachments/assets/375335e7-2853-4726-9a85-1b8ae9dcd1bc" />

Visible for events

https://github.com/user-attachments/assets/8754bfe3-8000-4539-b111-24de5198ea3b

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
