### PR TITLE
[EDR Workflows] Osquery: hide query code from dropdown and show Elastic for automated Run By

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.test.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.test.tsx
@@ -249,6 +249,15 @@ describe('UnifiedHistoryTable', () => {
     expect(screen.getByText('Rule')).toBeInTheDocument();
   });
 
+  it('run by column shows Elastic for rule row', () => {
+    const row = createMockRuleRow();
+    mockHistory({ data: [row] });
+
+    renderWithProviders(<UnifiedHistoryTable />);
+
+    expect(screen.getByText('Elastic')).toBeInTheDocument();
+  });
+
   it('details button has correct href for navigation', () => {
     const row = createMockLiveRow({ actionId: 'action-42' });
     mockHistory({ data: [row] });
@@ -374,14 +383,13 @@ describe('UnifiedHistoryTable', () => {
       expect(screen.getByText('20')).toBeInTheDocument();
     });
 
-    it('run by column shows em dash for scheduled row', () => {
+    it('run by column shows Elastic for scheduled row', () => {
       const row = createMockScheduledRow();
       mockHistory({ data: [row] });
 
       renderWithProviders(<UnifiedHistoryTable />);
 
-      const dashes = screen.getAllByText('\u2014');
-      expect(dashes.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('Elastic')).toBeInTheDocument();
     });
 
     it('play button is not available for scheduled rows', () => {

--- a/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/unified_history_table.tsx
@@ -446,8 +446,8 @@ const UnifiedHistoryTableComponent = () => {
 
   const renderRunByColumn = useCallback(
     (_: unknown, row: UnifiedHistoryRow) => {
-      if (!isLiveRow(row)) {
-        return <>{'\u2014'}</>;
+      if (!isLiveRow(row) || !row.userId) {
+        return <>{'Elastic'}</>;
       }
 
       return (

--- a/x-pack/platform/plugins/shared/osquery/public/saved_queries/saved_queries_dropdown.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/saved_queries/saved_queries_dropdown.tsx
@@ -13,6 +13,7 @@ import { QUERIES_DROPDOWN_LABEL, QUERIES_DROPDOWN_SEARCH_FIELD_LABEL } from './c
 import { OsquerySchemaLink } from '../components/osquery_schema_link';
 import { useOsquerySchema } from '../common/hooks/use_osquery_schema';
 import { useSavedQueries } from './use_saved_queries';
+import { useIsExperimentalFeatureEnabled } from '../common/experimental_features_context';
 import type { SavedQuerySO } from '../routes/saved_queries/list';
 
 const euiCodeBlockCss = {
@@ -44,6 +45,7 @@ const SavedQueriesDropdownComponent: React.FC<SavedQueriesDropdownProps> = ({
   onChange,
 }) => {
   const { osqueryVersion } = useOsquerySchema();
+  const isHistoryReworkEnabled = useIsExperimentalFeatureEnabled('queryHistoryRework');
   const savedQueryId = useWatch({ name: 'savedQueryId' });
   const context = useFormContext();
   const { errors } = context.formState;
@@ -94,12 +96,14 @@ const SavedQueriesDropdownComponent: React.FC<SavedQueriesDropdownProps> = ({
         <div className="eui-textTruncate">
           <EuiTextColor color="subdued">{value.description}</EuiTextColor>
         </div>
-        <EuiCodeBlock css={euiCodeBlockCss} language="sql" fontSize="m" paddingSize="s">
-          {value.query.split('\n').join(' ')}
-        </EuiCodeBlock>
+        {!isHistoryReworkEnabled && (
+          <EuiCodeBlock css={euiCodeBlockCss} language="sql" fontSize="m" paddingSize="s">
+            {value.query.split('\n').join(' ')}
+          </EuiCodeBlock>
+        )}
       </>
     ),
-    []
+    [isHistoryReworkEnabled]
   );
 
   useEffect(() => {
@@ -138,7 +142,7 @@ const SavedQueriesDropdownComponent: React.FC<SavedQueriesDropdownProps> = ({
         selectedOptions={selectedOptions}
         onChange={handleSavedQueryChange}
         renderOption={renderOption}
-        rowHeight={110}
+        rowHeight={isHistoryReworkEnabled ? 55 : 110}
       />
     </EuiFormRow>
   );


### PR DESCRIPTION
Addresses two UX feedback items for the osquery history rework (behind `queryHistoryRework` feature flag):

1. **Saved queries dropdown** — removes the SQL code block from dropdown options. Only the query ID and description are shown now, reducing visual noise (especially for queries starting with comments). Row height is reduced accordingly.

2. **Run By column in history table** — shows "Elastic" instead of an em dash for scheduled rows and rule-triggered rows (live actions with no `user_id`). Live queries with a real user continue to show the user's name/avatar.

Both changes are gated behind the `queryHistoryRework` feature flag.

<img width="1265" height="714" alt="Screenshot 2026-04-06 at 11 08 47 AM" src="https://github.com/user-attachments/assets/a3548a79-4188-4796-8953-62ec928bbca8" />
<img width="1481" height="482" alt="Screenshot 2026-04-06 at 11 29 32 AM" src="https://github.com/user-attachments/assets/e02e3477-c603-41c6-af4e-9a59ce0a8683" />
