### PR TITLE
[Controls] Replace deprecated EUI icons in timeslider control

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_prepend.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/components/time_slider_prepend.tsx
@@ -75,7 +75,7 @@ export const TimeSliderPrepend: FC<Props> = (props: Props) => {
             onPause();
             props.onPrevious();
           }}
-          iconType="framePrevious"
+          iconType="chevronLimitLeft"
           color="text"
           aria-label={TimeSliderStrings.control.getPreviousButtonAriaLabel()}
           data-test-subj="timeSlider-previousTimeWindow"
@@ -97,7 +97,7 @@ export const TimeSliderPrepend: FC<Props> = (props: Props) => {
             onPause();
             props.onNext();
           }}
-          iconType="frameNext"
+          iconType="chevronLimitRight"
           color="text"
           aria-label={TimeSliderStrings.control.getNextButtonAriaLabel()}
           data-test-subj="timeSlider-nextTimeWindow"


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/255620.

EUI will be deprecating the `framePrevious` and `frameNext` icons, which are used in the timeslider control. Per @MichaelMarcialis's suggestion, I'm replacing the deprecated icons with `chevronLimitLeft` and `chevronLimitRight`, which better match the empty `play` and `pause` icons.

### Timeslider control in Dashboard
<img width="819" height="63" alt="Screenshot 2026-04-06 at 1 25 20 PM" src="https://github.com/user-attachments/assets/a3d55b39-4a40-449d-9409-3fca352845d2" />

### Timeslider in Maps
<img width="484" height="109" alt="Screenshot 2026-04-06 at 1 26 34 PM" src="https://github.com/user-attachments/assets/380de8e7-2ca7-422d-92d2-151adba4636a" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



