### PR TITLE
[Security Solution] Fix flyout history not working

### DIFF
--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/constants.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/constants.ts
@@ -7,20 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  DocViewer,
-  DOC_VIEWER_FLYOUT_HISTORY_KEY,
-  type DocViewerProps,
-  type DocViewerApi,
-  type DocViewerRestorableState,
-  DocViewsRegistry,
-  ElasticRequestState,
-  FieldName,
-  registerDocViewerAnalyticsEvents,
-  type UseDocViewerSpanLogViewedEventParams,
-  type UseDocViewerTabViewedEventParams,
-  type UseDocViewerViewedEventParams,
-  useDocViewerSpanLogViewedEvent,
-  useDocViewerTabViewedEvent,
-  useDocViewerViewedEvent,
-} from './src';
+/**
+ * Shared EUI flyout history key for the Document Viewer flyout and any nested flyouts
+ * (e.g. Trace Waterfall). Using the same key groups them into a single back-button
+ * navigation history, enabling "Back" to return from a nested flyout to the Document Viewer.
+ *
+ * This is used by the unified-doc-viewer and security_solution plugins.
+ */
+export const DOC_VIEWER_FLYOUT_HISTORY_KEY = Symbol.for('docViewerFlyout');

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/index.ts
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/index.ts
@@ -10,3 +10,4 @@
 export * from './components';
 export * from './services';
 export * from './analytics';
+export * from './constants';

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -7,7 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useMemo, useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
+import type { DocViewerProps } from '@kbn/unified-doc-viewer';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { i18n } from '@kbn/i18n';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { EuiFlyoutProps } from '@elastic/eui';
@@ -17,22 +19,21 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
-  EuiPortal,
-  EuiPagination,
   EuiHorizontalRule,
+  EuiPagination,
+  EuiPortal,
+  EuiSpacer,
+  isDOMNode,
   keys,
   useEuiTheme,
   useIsWithinMinBreakpoint,
-  isDOMNode,
-  EuiSpacer,
 } from '@elastic/eui';
-import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
+import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import type { ToastsStart } from '@kbn/core-notifications-browser';
 import useObservable from 'react-use/lib/useObservable';
 import type { ChromeStart } from '@kbn/core/public';
 import type { DocViewFilterFn, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import type { DocViewerProps } from '@kbn/unified-doc-viewer';
 import { FlyoutHistoryKeyContext } from './flyout_history_key_context';
 import { UnifiedDocViewer } from '../lazy_doc_viewer';
 import { useFlyoutA11y } from './use_flyout_a11y';
@@ -261,7 +262,7 @@ export function UnifiedDocViewerFlyout({
   // Document Viewer flyout and any nested flyouts (e.g. Trace Waterfall) into
   // the same back-button navigation history, enabling "Back" to return the user
   // from the Trace Waterfall to the Document Viewer.
-  const historyKey = useMemo(() => Symbol.for('docViewerFlyout'), []);
+  const historyKey = DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   return (
     <FlyoutHistoryKeyContext.Provider value={historyKey}>

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -261,7 +261,7 @@ export function UnifiedDocViewerFlyout({
   // Document Viewer flyout and any nested flyouts (e.g. Trace Waterfall) into
   // the same back-button navigation history, enabling "Back" to return the user
   // from the Trace Waterfall to the Document Viewer.
-  const historyKey = useMemo(() => Symbol('docViewerFlyout'), []);
+  const historyKey = useMemo(() => Symbol.for('docViewerFlyout'), []);
 
   return (
     <FlyoutHistoryKeyContext.Provider value={historyKey}>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -12,6 +12,7 @@ import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { alertFlyoutHistoryKey } from '../../../../flyout_v2/document/constants/flyout_history';
 import { cellActionRenderer } from '../../../../flyout_v2/shared/components/cell_actions';
 import { DocumentFlyoutWrapper } from '../../../../flyout_v2/document/document_flyout_wrapper';
 import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
@@ -134,7 +135,11 @@ const RowActionComponent = ({
             />
           ),
         }),
-        { ...defaultFlyoutProperties }
+        {
+          ...defaultFlyoutProperties,
+          historyKey: alertFlyoutHistoryKey,
+          session: 'start',
+        }
       );
     } else {
       openFlyout({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.test.tsx
@@ -23,7 +23,8 @@ import { useRuleWithFallback } from '../../../detection_engine/rule_management/l
 import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { getColumns } from '../../prevalence/utils/get_columns';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -215,7 +216,7 @@ describe('InsightsSection', () => {
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        historyKey: discoverFlyoutHistoryKey,
+        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
         session: 'start',
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.test.tsx
@@ -23,6 +23,7 @@ import { useRuleWithFallback } from '../../../detection_engine/rule_management/l
 import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { getColumns } from '../../prevalence/utils/get_columns';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -186,6 +187,13 @@ describe('InsightsSection', () => {
     fireEvent.click(getByTestId('correlationsOverviewMock'));
 
     expect(mockOpenSystemFlyout).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: alertFlyoutHistoryKey,
+        session: 'start',
+      })
+    );
   });
 
   it('opens prevalence flyout and uses timeline-enabled columns in Security Solution', () => {
@@ -204,5 +212,12 @@ describe('InsightsSection', () => {
     fireEvent.click(getByTestId('prevalenceOverviewMock'));
 
     expect(mockGetColumns).toHaveBeenCalledWith(expect.any(Function), false, '');
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: discoverFlyoutHistoryKey,
+        session: 'start',
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
@@ -11,7 +11,8 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 import { DocumentFlyoutWrapper } from '../document_flyout_wrapper';
 import { cellActionRenderer } from '../../shared/components/cell_actions';
 import { EventKind } from '../constants/event_kinds';
@@ -68,7 +69,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
   const history = useHistory();
   const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
-  const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+  const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/insights_section.tsx
@@ -11,6 +11,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 import { DocumentFlyoutWrapper } from '../document_flyout_wrapper';
 import { cellActionRenderer } from '../../shared/components/cell_actions';
 import { EventKind } from '../constants/event_kinds';
@@ -67,6 +68,7 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
   const history = useHistory();
   const defaultFlyoutProperties = useDefaultDocumentFlyoutProperties();
   const isInSecurityApp = useIsInSecurityApp();
+  const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
 
   const expanded = useExpandSection({
     storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -99,12 +101,17 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
         history,
         children: <ThreatIntelligenceDetails hit={hit} />,
       }),
-      { ...defaultToolsFlyoutProperties }
+      {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      }
     );
-  }, [history, hit, overlays, services, store]);
+  }, [history, historyKey, hit, overlays, services, store]);
+
   const onShowAlert = useCallback(
     (id: string, indexName: string) =>
-      services.overlays?.openSystemFlyout(
+      overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
@@ -118,10 +125,14 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
             />
           ),
         }),
-        { ...defaultFlyoutProperties, session: 'inherit' }
+        {
+          ...defaultFlyoutProperties,
+          session: 'inherit',
+        }
       ),
-    [defaultFlyoutProperties, history, onAlertUpdated, services, store]
+    [defaultFlyoutProperties, history, onAlertUpdated, overlays, services, store]
   );
+
   const onShowCorrelationsDetails = useCallback(() => {
     overlays.openSystemFlyout(
       flyoutProviders({
@@ -137,9 +148,14 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
           />
         ),
       }),
-      { ...defaultToolsFlyoutProperties }
+      {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      }
     );
-  }, [history, hit, onShowAlert, overlays, services, store]);
+  }, [history, historyKey, hit, onShowAlert, overlays, services, store]);
+
   const onShowPrevalenceDetails = useCallback(() => {
     overlays.openSystemFlyout(
       flyoutProviders({
@@ -155,9 +171,13 @@ export const InsightsSection = memo(({ hit, onAlertUpdated }: InsightsSectionPro
           />
         ),
       }),
-      { ...defaultToolsFlyoutProperties }
+      {
+        ...defaultToolsFlyoutProperties,
+        historyKey,
+        session: 'start',
+      }
     );
-  }, [history, hit, investigationFields, isInSecurityApp, overlays, services, store]);
+  }, [history, historyKey, hit, investigationFields, isInSecurityApp, overlays, services, store]);
 
   return (
     <ExpandableSection

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
@@ -20,7 +20,9 @@ import {
 } from './investigation_section';
 import { useExpandSection } from '../../shared/hooks/use_expand_section';
 import { useKibana } from '../../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { HighlightedFields } from './highlighted_fields';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -29,9 +31,23 @@ jest.mock('../../shared/hooks/use_expand_section', () => ({
 jest.mock('../../../common/lib/kibana', () => ({
   useKibana: jest.fn(),
 }));
+jest.mock('../../shared/components/flyout_provider', () => ({
+  flyoutProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('../../../common/hooks/is_in_security_app', () => ({
+  useIsInSecurityApp: jest.fn(),
+}));
 
 jest.mock('./investigation_guide', () => ({
-  InvestigationGuide: () => <div data-test-subj="investigationGuideMock" />,
+  InvestigationGuide: ({ onShowInvestigationGuide }: { onShowInvestigationGuide: () => void }) => (
+    <button
+      type="button"
+      data-test-subj="investigationGuideMock"
+      onClick={onShowInvestigationGuide}
+    >
+      {'InvestigationGuide'}
+    </button>
+  ),
 }));
 
 jest.mock('./highlighted_fields', () => ({
@@ -65,7 +81,9 @@ const mockRenderCellActions = jest.fn(({ children }: { children: React.ReactNode
 describe('InvestigationSection', () => {
   const mockUseExpandSection = jest.mocked(useExpandSection);
   const mockUseKibana = jest.mocked(useKibana);
+  const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
   const mockHighlightedFields = jest.mocked(HighlightedFields);
+  const mockOpenSystemFlyout = jest.fn();
   const store = createStore(() => ({}));
   const history = createMemoryHistory();
 
@@ -74,10 +92,11 @@ describe('InvestigationSection', () => {
     mockUseKibana.mockReturnValue({
       services: {
         overlays: {
-          openSystemFlyout: jest.fn(),
+          openSystemFlyout: mockOpenSystemFlyout,
         },
       },
     } as unknown as ReturnType<typeof useKibana>);
+    mockUseIsInSecurityApp.mockReturnValue(true);
     mockHighlightedFields.mockReturnValue(<div data-test-subj="highlightedFieldsMock" />);
   });
 
@@ -189,6 +208,56 @@ describe('InvestigationSection', () => {
     expect(mockHighlightedFields).toHaveBeenCalledWith(
       expect.objectContaining({ renderCellActions: localMockRenderCellActions }),
       expect.anything()
+    );
+  });
+
+  it('uses Security history key when opening flyout inside Security app', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    mockUseIsInSecurityApp.mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={mockHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    act(() => getByTestId('investigationGuideMock').click());
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: alertFlyoutHistoryKey,
+        session: 'start',
+      })
+    );
+  });
+
+  it('uses Discover history key when opening flyout outside Security app', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    mockUseIsInSecurityApp.mockReturnValue(false);
+
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <Provider store={store}>
+          <Router history={history}>
+            <InvestigationSection hit={mockHit} renderCellActions={mockRenderCellActions} />
+          </Router>
+        </Provider>
+      </IntlProvider>
+    );
+
+    act(() => getByTestId('investigationGuideMock').click());
+
+    expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: discoverFlyoutHistoryKey,
+        session: 'start',
+      })
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.test.tsx
@@ -22,7 +22,8 @@ import { useExpandSection } from '../../shared/hooks/use_expand_section';
 import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { HighlightedFields } from './highlighted_fields';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -255,7 +256,7 @@ describe('InvestigationSection', () => {
     expect(mockOpenSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        historyKey: discoverFlyoutHistoryKey,
+        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
         session: 'start',
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
@@ -12,6 +12,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 import { EventKind } from '../constants/event_kinds';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
@@ -25,6 +26,7 @@ import { InvestigationGuide as InvestigationGuideToolsFlyout } from '../../inves
 import { flyoutProviders } from '../../shared/components/flyout_provider';
 import { HighlightedFields } from './highlighted_fields';
 import { useRuleWithFallback } from '../../../detection_engine/rule_management/logic/use_rule_with_fallback';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 
 export const INVESTIGATION_SECTION_TEST_ID = `${PREFIX}InvestigationSection` as const;
 
@@ -59,6 +61,8 @@ export const InvestigationSection = memo(
     const { overlays } = services;
     const store = useStore();
     const history = useHistory();
+    const isInSecurityApp = useIsInSecurityApp();
+    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
 
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
@@ -95,9 +99,13 @@ export const InvestigationSection = memo(
           history,
           children: <InvestigationGuideToolsFlyout hit={hit} />,
         }),
-        { ...defaultToolsFlyoutProperties }
+        {
+          ...defaultToolsFlyoutProperties,
+          historyKey,
+          session: 'start',
+        }
       );
-    }, [history, hit, overlays, services, store]);
+    }, [history, historyKey, hit, overlays, services, store]);
 
     return (
       <ExpandableSection

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/investigation_section.tsx
@@ -12,7 +12,8 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
 import { EventKind } from '../constants/event_kinds';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
@@ -62,7 +63,7 @@ export const InvestigationSection = memo(
     const store = useStore();
     const history = useHistory();
     const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
@@ -25,7 +25,8 @@ import { useKibana } from '../../../common/lib/kibana';
 import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { useIsAnalyzerEnabled } from '../../../detections/hooks/use_is_analyzer_enabled';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
@@ -190,7 +191,7 @@ describe('VisualizationsSection', () => {
     expect(openSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        historyKey: discoverFlyoutHistoryKey,
+        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
         session: 'start',
       })
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.test.tsx
@@ -22,13 +22,18 @@ import { useExpandSection } from '../../shared/hooks/use_expand_section';
 import { EXPANDABLE_PANEL_CONTENT_TEST_ID } from '../../shared/components/test_ids';
 import { ANALYZER_PREVIEW_TEST_ID } from './test_ids';
 import { useKibana } from '../../../common/lib/kibana';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 import { useIsAnalyzerEnabled } from '../../../detections/hooks/use_is_analyzer_enabled';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 
 jest.mock('../../shared/hooks/use_expand_section', () => ({
   useExpandSection: jest.fn(),
 }));
 jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/is_in_security_app', () => ({
+  useIsInSecurityApp: jest.fn(),
+}));
 jest.mock('../../shared/components/flyout_provider', () => ({
   flyoutProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -59,7 +64,11 @@ jest.mock('./analyzer_preview', () => ({
 }));
 
 jest.mock('./session_preview_container', () => ({
-  SessionPreviewContainer: () => <div data-test-subj="sessionPreviewContainerMock" />,
+  SessionPreviewContainer: ({ onShowSessionView }: { onShowSessionView: () => void }) => (
+    <button type="button" data-test-subj="sessionPreviewContainerMock" onClick={onShowSessionView}>
+      {'SessionPreview'}
+    </button>
+  ),
 }));
 
 const createMockHit = (flattened: DataTableRecord['flattened']): DataTableRecord =>
@@ -77,6 +86,7 @@ const mockHit = createMockHit({
 describe('VisualizationsSection', () => {
   const mockUseExpandSection = jest.mocked(useExpandSection);
   const mockUseKibana = jest.mocked(useKibana);
+  const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
   const mockIsAnalyzerEnabled = jest.mocked(useIsAnalyzerEnabled);
   const mockUseIsExperimentalFeatureEnabled = jest.mocked(useIsExperimentalFeatureEnabled);
 
@@ -115,6 +125,7 @@ describe('VisualizationsSection', () => {
       },
     } as unknown as ReturnType<typeof useKibana>);
     mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+    mockUseIsInSecurityApp.mockReturnValue(true);
     mockIsAnalyzerEnabled.mockReturnValue(true);
   });
 
@@ -151,5 +162,37 @@ describe('VisualizationsSection', () => {
     expect(
       getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID))
     ).toBeInTheDocument();
+  });
+
+  it('uses Security history key when opening session flyout in Security app', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    mockUseIsInSecurityApp.mockReturnValue(true);
+
+    const { getByTestId } = renderVisualizationsSection();
+    act(() => getByTestId('sessionPreviewContainerMock').click());
+
+    expect(openSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: alertFlyoutHistoryKey,
+        session: 'start',
+      })
+    );
+  });
+
+  it('uses Discover history key when opening session flyout outside Security app', () => {
+    mockUseExpandSection.mockReturnValue(true);
+    mockUseIsInSecurityApp.mockReturnValue(false);
+
+    const { getByTestId } = renderVisualizationsSection();
+    act(() => getByTestId('sessionPreviewContainerMock').click());
+
+    expect(openSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: discoverFlyoutHistoryKey,
+        session: 'start',
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
@@ -10,6 +10,7 @@ import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { useKibana } from '../../../common/lib/kibana';
@@ -23,6 +24,7 @@ import { AnalyzerGraph } from '../../analyzer';
 import { useSessionViewConfig } from '../../session_view/hooks/use_session_view_config';
 import { SessionView } from '../../session_view';
 import { defaultToolsFlyoutProperties } from '../../shared/hooks/use_default_flyout_properties';
+import { useIsInSecurityApp } from '../../../common/hooks/is_in_security_app';
 
 export const VISUALIZATION_SECTION_TEST_ID = `${PREFIX}Visualizations` as const;
 
@@ -61,6 +63,8 @@ export const VisualizationsSection = memo(
     const store = useStore();
     const history = useHistory();
     const sessionViewConfig = useSessionViewConfig(hit);
+    const isInSecurityApp = useIsInSecurityApp();
+    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
 
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,
@@ -83,10 +87,15 @@ export const VisualizationsSection = memo(
               />
             ),
           }),
-          { ...defaultToolsFlyoutProperties }
+          {
+            ...defaultToolsFlyoutProperties,
+            historyKey,
+            session: 'start',
+          }
         ),
-      [history, hit, onAlertUpdated, overlays, renderCellActions, services, store]
+      [history, historyKey, hit, onAlertUpdated, overlays, renderCellActions, services, store]
     );
+
     const onShowSessionView = useCallback(
       () =>
         overlays.openSystemFlyout(
@@ -104,10 +113,15 @@ export const VisualizationsSection = memo(
               />
             ),
           }),
-          { ...defaultToolsFlyoutProperties }
+          {
+            ...defaultToolsFlyoutProperties,
+            historyKey,
+            session: 'start',
+          }
         ),
       [
         history,
+        historyKey,
         hit,
         onAlertUpdated,
         overlays,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/components/visualizations_section.tsx
@@ -10,7 +10,8 @@ import { i18n } from '@kbn/i18n';
 import type { DataTableRecord } from '@kbn/discover-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from '../constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../constants/flyout_history';
 import type { CellActionRenderer } from '../../shared/components/cell_actions';
 import { FLYOUT_STORAGE_KEYS } from '../constants/local_storage';
 import { useKibana } from '../../../common/lib/kibana';
@@ -64,7 +65,7 @@ export const VisualizationsSection = memo(
     const history = useHistory();
     const sessionViewConfig = useSessionViewConfig(hit);
     const isInSecurityApp = useIsInSecurityApp();
-    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+    const historyKey = isInSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
     const expanded = useExpandSection({
       storageKey: FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS,

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/flyout_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/flyout_history.ts
@@ -9,8 +9,3 @@
  * Key when the flyout is opened in Security Solution
  */
 export const alertFlyoutHistoryKey = Symbol('alert');
-
-/**
- * Key when the flyout is opened in Discover. We need to use `Symbol.for` to ensure that we have a common history with the Discover document flyout
- */
-export const discoverFlyoutHistoryKey = Symbol.for('docViewerFlyout');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/flyout_history.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/constants/flyout_history.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Key when the flyout is opened in Security Solution
+ */
+export const alertFlyoutHistoryKey = Symbol('alert');
+
+/**
+ * Key when the flyout is opened in Discover. We need to use `Symbol.for` to ensure that we have a common history with the Discover document flyout
+ */
+export const discoverFlyoutHistoryKey = Symbol.for('docViewerFlyout');

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.test.tsx
@@ -131,7 +131,6 @@ describe('<DocumentFlyout />', () => {
         ownFocus: false,
         resizable: true,
         size: 'm',
-        type: 'overlay',
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
@@ -12,6 +12,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { defaultToolsFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { useAlertsPrivileges } from '../../detections/containers/detection_engine/alerts/use_alerts_privileges';
@@ -25,7 +26,7 @@ import { NotesDetails } from '../notes';
 import { useKibana } from '../../common/lib/kibana';
 import { flyoutProviders } from '../shared/components/flyout_provider';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
-import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from './constants/flyout_history';
+import { alertFlyoutHistoryKey } from './constants/flyout_history';
 
 export interface DocumentFlyoutProps {
   /**
@@ -56,7 +57,7 @@ export const DocumentFlyout = memo(
       [hit]
     );
     const isSecurityApp = useIsInSecurityApp();
-    const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+    const historyKey = isSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
     const { hasAlertsRead, loading } = useAlertsPrivileges();
     const missingAlertsPrivilege = !loading && !hasAlertsRead && isAlert;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/document/index.tsx
@@ -12,6 +12,7 @@ import { getFieldValue } from '@kbn/discover-utils';
 import { EVENT_KIND } from '@kbn/rule-data-utils';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { defaultToolsFlyoutProperties } from '../shared/hooks/use_default_flyout_properties';
 import type { CellActionRenderer } from '../shared/components/cell_actions';
 import { useAlertsPrivileges } from '../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { FlyoutLoading } from '../../flyout/shared/components/flyout_loading';
@@ -23,6 +24,8 @@ import { OverviewTab } from './tabs/overview_tab';
 import { NotesDetails } from '../notes';
 import { useKibana } from '../../common/lib/kibana';
 import { flyoutProviders } from '../shared/components/flyout_provider';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import { alertFlyoutHistoryKey, discoverFlyoutHistoryKey } from './constants/flyout_history';
 
 export interface DocumentFlyoutProps {
   /**
@@ -45,18 +48,21 @@ export interface DocumentFlyoutProps {
 export const DocumentFlyout = memo(
   ({ hit, onAlertUpdated, renderCellActions }: DocumentFlyoutProps) => {
     const { services } = useKibana();
+    const { overlays } = services;
     const store = useStore();
     const history = useHistory();
     const isAlert = useMemo(
       () => (getFieldValue(hit, EVENT_KIND) as string) === EventKind.signal,
       [hit]
     );
+    const isSecurityApp = useIsInSecurityApp();
+    const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
 
     const { hasAlertsRead, loading } = useAlertsPrivileges();
     const missingAlertsPrivilege = !loading && !hasAlertsRead && isAlert;
 
     const onShowNotes = useCallback(() => {
-      services.overlays?.openSystemFlyout(
+      overlays.openSystemFlyout(
         flyoutProviders({
           services,
           store,
@@ -64,13 +70,11 @@ export const DocumentFlyout = memo(
           children: <NotesDetails hit={hit} />,
         }),
         {
-          ownFocus: false,
-          resizable: true,
-          size: 'm',
-          type: 'overlay',
+          ...defaultToolsFlyoutProperties,
+          historyKey,
         }
       );
-    }, [history, hit, services, store]);
+    }, [history, historyKey, hit, overlays, services, store]);
 
     if (isAlert && loading) {
       return <FlyoutLoading data-test-subj="document-overview-loading" />;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/components/session_view_details.tsx
@@ -81,7 +81,7 @@ export const SessionViewDetails = memo(
 
     const onShowAlertDetails = useCallback(
       (alertId: string, alertIndex: string) => {
-        overlays?.openSystemFlyout(
+        overlays.openSystemFlyout(
           flyoutProviders({
             services,
             store,
@@ -95,7 +95,10 @@ export const SessionViewDetails = memo(
               />
             ),
           }),
-          { ...defaultFlyoutProperties, session: 'inherit' }
+          {
+            ...defaultFlyoutProperties,
+            session: 'inherit',
+          }
         );
       },
       [

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout_v2/session_view/index.tsx
@@ -88,7 +88,7 @@ export const SessionView: FC<SessionViewProps> = memo(
 
     const openAlertDetails = useCallback(
       (alertId: string, alertIndex: string, onClose?: () => void) =>
-        overlays?.openSystemFlyout(
+        overlays.openSystemFlyout(
           flyoutProviders({
             services,
             store,
@@ -102,7 +102,10 @@ export const SessionView: FC<SessionViewProps> = memo(
               />
             ),
           }),
-          { ...defaultFlyoutProperties, session: 'inherit' }
+          {
+            ...defaultFlyoutProperties,
+            session: 'inherit',
+          }
         ),
       [
         defaultFlyoutProperties,
@@ -167,7 +170,10 @@ export const SessionView: FC<SessionViewProps> = memo(
               />
             ),
           }),
-          { ...defaultFlyoutProperties, session: 'inherit' }
+          {
+            ...defaultFlyoutProperties,
+            session: 'inherit',
+          }
         );
       },
       [

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
@@ -13,10 +13,8 @@ import { AlertFlyoutFooter } from '.';
 import type { StartServices } from '../../types';
 import { SECURITY_FEATURE_ID } from '../../../common/constants';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
-import {
-  alertFlyoutHistoryKey,
-  discoverFlyoutHistoryKey,
-} from '../../flyout_v2/document/constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../../flyout_v2/document/constants/flyout_history';
 
 const mockDocumentFooter = jest.fn((props: unknown) => {
   const { onShowNotes } = props as { onShowNotes?: () => void };
@@ -160,7 +158,7 @@ describe('AlertFlyoutFooter', () => {
     expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        historyKey: discoverFlyoutHistoryKey,
+        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.test.tsx
@@ -7,13 +7,25 @@
 
 import type { DataTableRecord } from '@kbn/discover-utils';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createStore } from 'redux';
 import { AlertFlyoutFooter } from '.';
 import type { StartServices } from '../../types';
 import { SECURITY_FEATURE_ID } from '../../../common/constants';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import {
+  alertFlyoutHistoryKey,
+  discoverFlyoutHistoryKey,
+} from '../../flyout_v2/document/constants/flyout_history';
 
-const mockDocumentFooter = jest.fn((_props: unknown) => <div>{'MockDocumentFooter'}</div>);
+const mockDocumentFooter = jest.fn((props: unknown) => {
+  const { onShowNotes } = props as { onShowNotes?: () => void };
+  return (
+    <button type="button" onClick={onShowNotes}>
+      {'MockDocumentFooter'}
+    </button>
+  );
+});
 const mockFlyoutProviders = jest.fn(({ children }: { children: React.ReactNode }) => (
   <>{children}</>
 ));
@@ -24,14 +36,21 @@ jest.mock('../../flyout_v2/document/footer', () => ({
 jest.mock('../../flyout_v2/shared/components/flyout_provider', () => ({
   flyoutProviders: (props: unknown) => mockFlyoutProviders(props as { children: React.ReactNode }),
 }));
+jest.mock('../../common/hooks/is_in_security_app', () => ({
+  useIsInSecurityApp: jest.fn(),
+}));
 
 describe('AlertFlyoutFooter', () => {
+  const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
+
   beforeEach(() => {
     mockDocumentFooter.mockClear();
     mockFlyoutProviders.mockClear();
+    mockUseIsInSecurityApp.mockReturnValue(false);
   });
 
   const servicesMock = {
+    overlays: { openSystemFlyout: jest.fn() },
     core: { overlays: {} },
     uiActions: {
       getTriggerCompatibleActions: jest.fn().mockResolvedValue([]),
@@ -116,5 +135,61 @@ describe('AlertFlyoutFooter', () => {
     });
     expect(screen.queryByText('MockDocumentFooter')).not.toBeInTheDocument();
     expect(mockDocumentFooter).not.toHaveBeenCalled();
+  });
+
+  it('uses Discover history key when opening notes outside Security app', async () => {
+    mockUseIsInSecurityApp.mockReturnValue(false);
+    const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+
+    render(
+      <AlertFlyoutFooter
+        hit={hit}
+        servicesPromise={Promise.resolve(servicesMock)}
+        storePromise={Promise.resolve(store as never)}
+        onAlertUpdated={mockOnAlertUpdated}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MockDocumentFooter')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('MockDocumentFooter'));
+
+    expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: discoverFlyoutHistoryKey,
+      })
+    );
+  });
+
+  it('uses Security history key when opening notes in Security app', async () => {
+    mockUseIsInSecurityApp.mockReturnValue(true);
+    const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+
+    render(
+      <AlertFlyoutFooter
+        hit={hit}
+        servicesPromise={Promise.resolve(servicesMock)}
+        storePromise={Promise.resolve(store as never)}
+        onAlertUpdated={mockOnAlertUpdated}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MockDocumentFooter')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('MockDocumentFooter'));
+
+    expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: alertFlyoutHistoryKey,
+      })
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
@@ -8,11 +8,17 @@
 import type { DataTableRecord } from '@kbn/discover-utils';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import { Footer } from '../../flyout_v2/document/footer';
+import {
+  alertFlyoutHistoryKey,
+  discoverFlyoutHistoryKey,
+} from '../../flyout_v2/document/constants/flyout_history';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { NotesDetails } from '../../flyout_v2/notes';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 
 export interface AlertFlyoutFooterProps {
   /**
@@ -42,6 +48,9 @@ export const AlertFlyoutFooter = ({
   const history = useHistory();
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
+  const isSecurityApp = useIsInSecurityApp();
+  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+
   const openNotesFlyout = useCallback(() => {
     if (!services || !store) {
       return;
@@ -55,13 +64,11 @@ export const AlertFlyoutFooter = ({
         children: <NotesDetails hit={hit} />,
       }),
       {
-        ownFocus: false,
-        resizable: true,
-        size: 'm',
-        type: 'overlay',
+        ...defaultToolsFlyoutProperties,
+        historyKey,
       }
     );
-  }, [history, hit, services, store]);
+  }, [history, historyKey, hit, services, store]);
 
   useEffect(() => {
     let isCanceled = false;

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_footer_component/index.tsx
@@ -8,12 +8,10 @@
 import type { DataTableRecord } from '@kbn/discover-utils';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import { Footer } from '../../flyout_v2/document/footer';
-import {
-  alertFlyoutHistoryKey,
-  discoverFlyoutHistoryKey,
-} from '../../flyout_v2/document/constants/flyout_history';
+import { alertFlyoutHistoryKey } from '../../flyout_v2/document/constants/flyout_history';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { NotesDetails } from '../../flyout_v2/notes';
@@ -49,7 +47,7 @@ export const AlertFlyoutFooter = ({
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
   const isSecurityApp = useIsInSecurityApp();
-  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   const openNotesFlyout = useCallback(() => {
     if (!services || !store) {

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -15,6 +15,11 @@ import { Router } from '@kbn/shared-ux-router';
 import { createStore } from 'redux';
 import { AlertFlyoutHeader } from '.';
 import type { StartServices } from '../../types';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
+import {
+  alertFlyoutHistoryKey,
+  discoverFlyoutHistoryKey,
+} from '../../flyout_v2/document/constants/flyout_history';
 
 const mockDocumentHeader = jest.fn((props: unknown) => {
   const { onShowNotes } = props as { onShowNotes?: () => void };
@@ -55,10 +60,16 @@ jest.mock('../../cases/components/provider/provider', () => ({
 jest.mock('../../assistant/provider', () => ({
   AssistantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+jest.mock('../../common/hooks/is_in_security_app', () => ({
+  useIsInSecurityApp: jest.fn(),
+}));
 
 describe('AlertFlyoutHeader', () => {
+  const mockUseIsInSecurityApp = jest.mocked(useIsInSecurityApp);
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseIsInSecurityApp.mockReturnValue(false);
   });
 
   const servicesMock = {
@@ -196,10 +207,42 @@ describe('AlertFlyoutHeader', () => {
     expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
+        historyKey: discoverFlyoutHistoryKey,
         ownFocus: false,
         resizable: true,
         size: 'm',
-        type: 'overlay',
+      })
+    );
+  });
+
+  it('uses Security history key when opened inside Security app', async () => {
+    mockUseIsInSecurityApp.mockReturnValue(true);
+
+    const hit = { id: '1', raw: { _id: '1' }, flattened: {} } as unknown as DataTableRecord;
+    const store = createStore(() => ({}));
+    const history = createMemoryHistory({ initialEntries: ['/security'] });
+
+    render(
+      <Router history={history}>
+        <AlertFlyoutHeader
+          hit={hit}
+          servicesPromise={Promise.resolve(servicesMock)}
+          storePromise={Promise.resolve(store as never)}
+          onAlertUpdated={jest.fn()}
+        />
+      </Router>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('MockDocumentHeader')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('MockDocumentHeader'));
+
+    expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        historyKey: alertFlyoutHistoryKey,
       })
     );
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.test.tsx
@@ -16,10 +16,8 @@ import { createStore } from 'redux';
 import { AlertFlyoutHeader } from '.';
 import type { StartServices } from '../../types';
 import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
-import {
-  alertFlyoutHistoryKey,
-  discoverFlyoutHistoryKey,
-} from '../../flyout_v2/document/constants/flyout_history';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
+import { alertFlyoutHistoryKey } from '../../flyout_v2/document/constants/flyout_history';
 
 const mockDocumentHeader = jest.fn((props: unknown) => {
   const { onShowNotes } = props as { onShowNotes?: () => void };
@@ -207,7 +205,7 @@ describe('AlertFlyoutHeader', () => {
     expect(servicesMock.overlays.openSystemFlyout).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        historyKey: discoverFlyoutHistoryKey,
+        historyKey: DOC_VIEWER_FLYOUT_HISTORY_KEY,
         ownFocus: false,
         resizable: true,
         size: 'm',

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -10,12 +10,18 @@ import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
+import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { Header } from '../../flyout_v2/document/header';
+import {
+  alertFlyoutHistoryKey,
+  discoverFlyoutHistoryKey,
+} from '../../flyout_v2/document/constants/flyout_history';
 import { NotesDetails } from '../../flyout_v2/notes';
 import { noopCellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
+import { useIsInSecurityApp } from '../../common/hooks/is_in_security_app';
 
 export const MISSING_METADATA_CALLOUT = i18n.translate(
   'xpack.securitySolution.flyout.document.header.missingMetadataCallout',
@@ -53,6 +59,9 @@ export const AlertFlyoutHeader = ({
   const history = useHistory();
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
+  const isSecurityApp = useIsInSecurityApp();
+  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+
   const openNotesFlyout = useCallback(() => {
     if (!services || !store) {
       return;
@@ -66,13 +75,11 @@ export const AlertFlyoutHeader = ({
         children: <NotesDetails hit={hit} />,
       }),
       {
-        ownFocus: false,
-        resizable: true,
-        size: 'm',
-        type: 'overlay',
+        ...defaultToolsFlyoutProperties,
+        historyKey,
       }
     );
-  }, [history, hit, services, store]);
+  }, [history, historyKey, hit, services, store]);
 
   useEffect(() => {
     let isCanceled = false;

--- a/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/one_discover/alert_flyout_header_component/index.tsx
@@ -10,14 +10,12 @@ import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
+import { DOC_VIEWER_FLYOUT_HISTORY_KEY } from '@kbn/unified-doc-viewer';
 import { defaultToolsFlyoutProperties } from '../../flyout_v2/shared/hooks/use_default_flyout_properties';
 import type { SecurityAppStore } from '../../common/store/types';
 import type { StartServices } from '../../types';
 import { Header } from '../../flyout_v2/document/header';
-import {
-  alertFlyoutHistoryKey,
-  discoverFlyoutHistoryKey,
-} from '../../flyout_v2/document/constants/flyout_history';
+import { alertFlyoutHistoryKey } from '../../flyout_v2/document/constants/flyout_history';
 import { NotesDetails } from '../../flyout_v2/notes';
 import { noopCellActionRenderer } from '../../flyout_v2/shared/components/cell_actions';
 import { flyoutProviders } from '../../flyout_v2/shared/components/flyout_provider';
@@ -60,7 +58,7 @@ export const AlertFlyoutHeader = ({
   const [services, setServices] = useState<StartServices | null>(null);
   const [store, setStore] = useState<SecurityAppStore | null>(null);
   const isSecurityApp = useIsInSecurityApp();
-  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : discoverFlyoutHistoryKey;
+  const historyKey = isSecurityApp ? alertFlyoutHistoryKey : DOC_VIEWER_FLYOUT_HISTORY_KEY;
 
   const openNotesFlyout = useCallback(() => {
     if (!services || !store) {

--- a/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/resolver/view/resolver_without_providers.tsx
@@ -145,7 +145,7 @@ export const ResolverWithoutProviders = React.memo(
     const onShowEvent = useCallback<NodeEventOnClick>(
       ({ documentId, indexName }) =>
         () =>
-          overlays?.openSystemFlyout(
+          overlays.openSystemFlyout(
             flyoutProviders({
               services,
               store,
@@ -159,7 +159,10 @@ export const ResolverWithoutProviders = React.memo(
                 />
               ),
             }),
-            { ...defaultFlyoutProperties, session: 'inherit' }
+            {
+              ...defaultFlyoutProperties,
+              session: 'inherit',
+            }
           ),
       [
         defaultFlyoutProperties,
@@ -189,7 +192,10 @@ export const ResolverWithoutProviders = React.memo(
               </EuiPanel>
             ),
           }),
-          { ...defaultFlyoutProperties, session: 'inherit' }
+          {
+            ...defaultFlyoutProperties,
+            session: 'inherit',
+          }
         );
       } else {
         openPreviewPanel({

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -22,6 +22,7 @@ import type {
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useHistory } from 'react-router-dom';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
+import { alertFlyoutHistoryKey } from '../../../../../flyout_v2/document/constants/flyout_history';
 import { cellActionRenderer } from '../../../../../flyout_v2/shared/components/cell_actions';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { JEST_ENVIRONMENT } from '../../../../../../common/constants';
@@ -201,7 +202,11 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
                 />
               ),
             }),
-            { ...defaultFlyoutProperties }
+            {
+              ...defaultFlyoutProperties,
+              historyKey: alertFlyoutHistoryKey,
+              session: 'start',
+            }
           );
         } else {
           const isAttackRow = isAttackDiscoveryRow(eventData);


### PR DESCRIPTION
## Summary

This PR fixes the broken history functionality in our alert flyout. A recent EUI change required us to have a `historyKey` for the flyouts that have `session: 'start'` and want to be kept part of the same history.

### Code changes

- we have to make a small modification to Discover, from using `Symbol` to `Symbol.for`. This will ensure that we can have a similar `Symbol.for` in Security Solution and use that to stay in the same history (from the global symbol registry in that browser JS context). From the [EUI documentation](https://eui.elastic.co/docs/components/containers/flyout/#scoping-history-historykey), we need to  pass the same `Symbol` reference, which `Symbol.for` does.
- use the correct key depending on if the flyout is opened in Discover or Security Solution (using the `useIsInSecurityApp` hook)
- update all the flyouts (normal and tools) to use the `historyKey` and correct `session` value for each scenario:
  - `session: 'start'` and `historyKey` => a new flyout is opened in the same history
  - `session: 'inherit'` => a child flyout is opened

### UI changes

#### Current broken behavior in Security Solution

https://github.com/user-attachments/assets/56875b68-0514-4fc5-870a-72070597bedd

#### Current broken behavior in Discover

https://github.com/user-attachments/assets/0ab76674-4193-4b9e-895c-8ac3f1e30f13

#### Fixes behavior in Security Solution

https://github.com/user-attachments/assets/e03472f0-96e8-49cf-8a7e-374a077a9366

#### And fixed behavior in Discover

https://github.com/user-attachments/assets/ca05e12e-b6a3-4c71-a8c0-25ad2ccc155d

## How to test

To see the new (emtpy) flyout in Security Solution, add this to your `kibana.dev.yml` file:
```xpack.securitySolution.enableExperimental: [ 'newFlyoutSystemEnabled' ]```

Too see the new (emtpy) flyout in Discover, add this to your `kibana.dev.yml` file:
```discover.experimental.enabledProfiles: [ 'enhanced-security-document-profile' ]```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.
