### PR TITLE
Revert "Enable wired streams views creation on stateful"

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -107,9 +107,5 @@ xpack.ml.nlp:
         max: 128
 xpack.ml.compatibleModuleType: 'observability'
 
-# ES|QL Views API is not available in serverless Elasticsearch builds
-uiSettings.overrides:
-  observability:streamsEnableWiredStreamViews: false
-
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false

--- a/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
+++ b/x-pack/platform/plugins/shared/streams/server/feature_flags.ts
@@ -214,10 +214,9 @@ export function registerFeatureFlags(
       name: i18n.translate('xpack.streams.wiredStreamViewsSettingsName', {
         defaultMessage: 'Wired stream views',
       }),
-      value: true,
+      value: false,
       description: i18n.translate('xpack.streams.wiredStreamViewsSettingsDescription', {
-        defaultMessage:
-          'Enable ES|QL views for wired streams (stateful). Off by default on serverless where the Views API is unavailable.',
+        defaultMessage: 'Enable ES|QL views for wired streams.',
       }),
       type: 'boolean',
       schema: schema.boolean(),

--- a/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_privileges.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/hooks/use_streams_privileges.ts
@@ -59,7 +59,7 @@ export function useStreamsPrivileges() {
 
   const wiredStreamViewsEnabled = uiSettings.get(
     OBSERVABILITY_STREAMS_ENABLE_WIRED_STREAM_VIEWS,
-    true
+    false
   );
 
   const overviewPageEnabled = uiSettings.get(OBSERVABILITY_STREAMS_ENABLE_OVERVIEW_PAGE, false);


### PR DESCRIPTION
Reverts elastic/kibana#260948

We are reverting this so it doesn’t land in 9.4