### PR TITLE
[9.3] [Ingest pipelines] Accept triple quotes in import modal (#247354)

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { OnDoneLoadJsonHandler } from './modal_provider';
 import { ModalProvider } from './modal_provider';
@@ -28,67 +29,84 @@ jest.mock('@kbn/code-editor', () => {
     // Mocking CodeEditor, which uses React Monaco under the hood
     CodeEditor: (props: any) => (
       <input
-        data-test-subj={props['data-test-subj'] || 'mockCodeEditor'}
-        data-currentvalue={props.value}
+        data-test-subj="mockedCodeEditor"
+        value={props.value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          props.onChange(e.currentTarget.getAttribute('data-currentvalue'));
+          props.onChange(e.currentTarget.value);
         }}
       />
     ),
   };
 });
 
-import type { TestBed } from '@kbn/test-jest-helpers';
-import { registerTestBed } from '@kbn/test-jest-helpers';
-
 const setup = ({ onDone }: { onDone: OnDoneLoadJsonHandler }) => {
-  return registerTestBed(
-    () => (
-      <KibanaContextProvider services={{ uiSettings: uiSettingsServiceMock.createSetupContract() }}>
-        <ModalProvider onDone={onDone}>
-          {(openModal) => {
-            return (
-              <button onClick={openModal} data-test-subj="button">
-                Load JSON
-              </button>
-            );
-          }}
-        </ModalProvider>
-      </KibanaContextProvider>
-    ),
-    {
-      memoryRouter: {
-        wrapComponent: false,
-      },
-    }
-  )();
+  render(
+    <KibanaContextProvider services={{ uiSettings: uiSettingsServiceMock.createSetupContract() }}>
+      <ModalProvider onDone={onDone}>
+        {(openModal) => {
+          return (
+            <button onClick={openModal} data-test-subj="button">
+              Load JSON
+            </button>
+          );
+        }}
+      </ModalProvider>
+    </KibanaContextProvider>
+  );
 };
 
 describe('Load from JSON ModalProvider', () => {
-  let testBed: TestBed;
   let onDone: jest.Mock;
 
   beforeEach(async () => {
     onDone = jest.fn();
-    testBed = await setup({ onDone });
+    setup({ onDone });
   });
 
   it('displays errors', () => {
-    const { find, exists } = testBed;
-    find('button').simulate('click');
-    expect(exists('loadJsonConfirmationModal'));
+    fireEvent.click(screen.getByTestId('button'));
+
+    const modal = screen.getByTestId('loadJsonConfirmationModal');
+
     const invalidPipeline = '{}';
-    find('mockCodeEditor').simulate('change', { jsonString: invalidPipeline });
-    find('confirmModalConfirmButton').simulate('click');
-    const errorCallout = find('loadJsonConfirmationModal.errorCallOut');
-    expect(errorCallout.text()).toContain('Please ensure the JSON is a valid pipeline object.');
-    expect(onDone).toHaveBeenCalledTimes(0);
+    fireEvent.change(within(modal).getByRole('textbox'), { target: { value: invalidPipeline } });
+    fireEvent.click(within(modal).getByTestId('confirmModalConfirmButton'));
+
+    expect(within(modal).getByTestId('errorCallOut')).toHaveTextContent(
+      'Please ensure the JSON is a valid pipeline object.'
+    );
+    expect(within(modal).getByTestId('confirmModalConfirmButton')).toBeDisabled();
+    expect(onDone).not.toHaveBeenCalled();
   });
 
-  it('passes through a valid pipeline object', () => {
-    const { find, exists } = testBed;
-    find('button').simulate('click');
-    expect(exists('loadJsonConfirmationModal'));
+  it('clears serialization errors on edit and re-enables submit', async () => {
+    fireEvent.click(screen.getByTestId('button'));
+
+    const modal = screen.getByTestId('loadJsonConfirmationModal');
+
+    fireEvent.change(within(modal).getByRole('textbox'), { target: { value: '{}' } });
+    fireEvent.click(within(modal).getByTestId('confirmModalConfirmButton'));
+    expect(within(modal).getByTestId('errorCallOut')).toBeInTheDocument();
+    expect(within(modal).getByTestId('confirmModalConfirmButton')).toBeDisabled();
+
+    const validPipeline = JSON.stringify({ processors: [] });
+    fireEvent.change(within(modal).getByRole('textbox'), { target: { value: validPipeline } });
+
+    expect(within(modal).queryByTestId('errorCallOut')).not.toBeInTheDocument();
+    expect(within(modal).getByTestId('confirmModalConfirmButton')).not.toBeDisabled();
+
+    fireEvent.click(within(modal).getByTestId('confirmModalConfirmButton'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('loadJsonConfirmationModal')).not.toBeInTheDocument()
+    );
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through a valid pipeline object', async () => {
+    fireEvent.click(screen.getByTestId('button'));
+
+    const modal = screen.getByTestId('loadJsonConfirmationModal');
+
     const validPipeline = JSON.stringify({
       processors: [{ set: { field: 'test', value: 123 } }, { badType1: null }, { badType2: 1 }],
       on_failure: [
@@ -101,12 +119,13 @@ describe('Load from JSON ModalProvider', () => {
         },
       ],
     });
-    // Set the value of the mock code editor
-    find('mockCodeEditor').getDOMNode().setAttribute('data-currentvalue', validPipeline);
-    find('mockCodeEditor').simulate('change');
+    const codeEditor = within(modal).getByTestId('mockedCodeEditor');
+    fireEvent.change(codeEditor, { target: { value: validPipeline } });
 
-    find('confirmModalConfirmButton').simulate('click');
-    expect(!exists('loadJsonConfirmationModal'));
+    fireEvent.click(within(modal).getByTestId('confirmModalConfirmButton'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('loadJsonConfirmationModal')).not.toBeInTheDocument()
+    );
     expect(onDone).toHaveBeenCalledTimes(1);
     expect(onDone.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
@@ -131,6 +150,47 @@ describe('Load from JSON ModalProvider', () => {
           },
           Object {
             "badType2": 1,
+          },
+        ],
+      }
+    `);
+  });
+
+  it('passes through a valid pipeline object with triple-quoted strings (xJSON)', async () => {
+    fireEvent.click(screen.getByTestId('button'));
+    const modal = screen.getByTestId('loadJsonConfirmationModal');
+    const validPipelineWithTripleQuotes = `{
+      "processors": [
+        {
+          "script": {
+            "description": "add a test_field",
+            "lang": "painless",
+            "source": """
+              ctx['test_field'] = 'This is a test'
+            """
+          }
+        }
+      ]
+    }`;
+    const codeEditor = within(modal).getByTestId('mockedCodeEditor');
+    fireEvent.change(codeEditor, { target: { value: validPipelineWithTripleQuotes } });
+
+    fireEvent.click(within(modal).getByTestId('confirmModalConfirmButton'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('loadJsonConfirmationModal')).not.toBeInTheDocument()
+    );
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onDone.mock.calls[0][0]).toMatchInlineSnapshot(`
+      Object {
+        "processors": Array [
+          Object {
+            "script": Object {
+              "description": "add a test_field",
+              "lang": "painless",
+              "source": "
+                    ctx['test_field'] = 'This is a test'
+                  ",
+            },
           },
         ],
       }

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { renderWithI18n } from '@kbn/test-jest-helpers';
 import type { OnDoneLoadJsonHandler } from './modal_provider';
 import { ModalProvider } from './modal_provider';
 
@@ -40,7 +41,7 @@ jest.mock('@kbn/code-editor', () => {
 });
 
 const setup = ({ onDone }: { onDone: OnDoneLoadJsonHandler }) => {
-  render(
+  renderWithI18n(
     <KibanaContextProvider services={{ uiSettings: uiSettingsServiceMock.createSetupContract() }}>
       <ModalProvider onDone={onDone}>
         {(openModal) => {
@@ -165,9 +166,7 @@ describe('Load from JSON ModalProvider', () => {
           "script": {
             "description": "add a test_field",
             "lang": "painless",
-            "source": """
-              ctx['test_field'] = 'This is a test'
-            """
+            "source": """ctx['test_field'] = 'This is a test'"""
           }
         }
       ]
@@ -187,9 +186,7 @@ describe('Load from JSON ModalProvider', () => {
             "script": Object {
               "description": "add a test_field",
               "lang": "painless",
-              "source": "
-                    ctx['test_field'] = 'This is a test'
-                  ",
+              "source": "ctx['test_field'] = 'This is a test'",
             },
           },
         ],

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
@@ -8,11 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { FunctionComponent } from 'react';
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { EuiConfirmModal, EuiSpacer, EuiText, EuiCallOut, useGeneratedHtmlId } from '@elastic/eui';
 
 import type { OnJsonEditorUpdateHandler } from '../../../../../shared_imports';
-import { JsonEditor } from '../../../../../shared_imports';
+import { JsonEditor, XJson } from '../../../../../shared_imports';
 
 import type { Processor } from '../../../../../../common/types';
 
@@ -55,25 +55,39 @@ const i18nTexts = {
   },
 };
 
+const { collapseLiteralStrings } = XJson;
+
 const defaultValue = {};
 const defaultValueRaw = JSON.stringify(defaultValue, null, 2);
+
+const isValidXJson = (content: string): boolean => {
+  if (content.trim() === '') return false;
+  try {
+    JSON.parse(collapseLiteralStrings(content));
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isValidJson, setIsValidJson] = useState(true);
   const [error, setError] = useState<Error | undefined>();
-  const jsonContent = useRef<Parameters<OnJsonEditorUpdateHandler>['0']>({
-    isValid: true,
-    validate: () => true,
-    data: {
-      format: () => defaultValue,
-      raw: defaultValueRaw,
-    },
-  });
+  const [editorContent, setEditorContent] = useState(defaultValueRaw);
+
+  useEffect(() => {
+    if (!isModalVisible) return;
+
+    setEditorContent(defaultValueRaw);
+    setIsValidJson(isValidXJson(defaultValueRaw));
+    setError(undefined);
+  }, [isModalVisible]);
 
   const onJsonUpdate: OnJsonEditorUpdateHandler = useCallback((jsonUpdateData) => {
-    setIsValidJson(jsonUpdateData.validate());
-    jsonContent.current = jsonUpdateData;
+    setEditorContent(jsonUpdateData.data.raw);
+    setIsValidJson(isValidXJson(jsonUpdateData.data.raw));
+    setError(undefined);
   }, []);
 
   const modalTitleId = useGeneratedHtmlId();
@@ -92,7 +106,7 @@ export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) =>
           titleProps={{ id: modalTitleId }}
           onConfirm={async () => {
             try {
-              const json = jsonContent.current.data.format();
+              const json = JSON.parse(collapseLiteralStrings(editorContent));
               const { processors, on_failure: onFailure } = json;
               // This function will throw if it cannot parse the pipeline object
               deserialize({ processors, onFailure });
@@ -103,7 +117,7 @@ export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) =>
             }
           }}
           cancelButtonText={i18nTexts.buttons.cancel}
-          confirmButtonDisabled={!isValidJson}
+          confirmButtonDisabled={!isValidJson || Boolean(error)}
           confirmButtonText={i18nTexts.buttons.confirm}
           maxWidth={600}
         >
@@ -134,9 +148,12 @@ export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) =>
 
             <JsonEditor
               label={i18nTexts.editor.label}
+              value={editorContent}
               onUpdate={onJsonUpdate}
+              error={!isValidJson || error ? i18nTexts.error.body : null}
               codeEditorProps={{
                 height: '300px',
+                languageId: 'xjson',
               }}
             />
           </div>

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_form/pipeline_request_flyout/pipeline_request_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_form/pipeline_request_flyout/pipeline_request_flyout.tsx
@@ -10,9 +10,10 @@ import React, { useState, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 
 import type { Pipeline } from '../../../../../common/types';
-import { useFormContext, ViewApiRequestFlyout, useKibana } from '../../../../shared_imports';
-
+import { useFormContext, ViewApiRequestFlyout, useKibana, XJson } from '../../../../shared_imports';
 import type { ReadProcessorsFunction } from '../types';
+
+const { expandLiteralStrings } = XJson;
 
 interface Props {
   closeFlyout: () => void;
@@ -41,7 +42,7 @@ export const PipelineRequestFlyout: FunctionComponent<Props> = ({
 
   const { name, ...pipelineBody } = pipeline;
   const endpoint = `PUT _ingest/pipeline/${name || '<pipelineName>'}`;
-  const request = `${endpoint}\n${JSON.stringify(pipelineBody, null, 2)}`;
+  const request = `${endpoint}\n${expandLiteralStrings(JSON.stringify(pipelineBody, null, 2))}`;
 
   const title = name
     ? i18n.translate('xpack.ingestPipelines.requestFlyout.namedTitle', {

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/details_json_block.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/details_json_block.tsx
@@ -8,6 +8,9 @@
 import type { FunctionComponent } from 'react';
 import React, { useRef } from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
+import { XJson } from '../../../shared_imports';
+
+const { expandLiteralStrings } = XJson;
 
 export interface Props {
   json: Record<string, any>;
@@ -20,15 +23,16 @@ export const PipelineDetailsJsonBlock: FunctionComponent<Props> = ({ json }) => 
   uuid.current++;
 
   // Convert JSON object to string
-  const jsonString = JSON.stringify(json, null, 2);
+  const jsonString = expandLiteralStrings(JSON.stringify(json, null, 2));
   // Replace all newline characters with empty spaces
   const formattedString = jsonString.replace(/\\n/g, ' ');
+  const formattedStringLength = formattedString.length;
 
   return (
     <EuiCodeBlock
       paddingSize="s"
       language="json"
-      overflowHeight={json.length > 0 ? 300 : undefined}
+      overflowHeight={formattedStringLength > 0 ? 300 : undefined}
       isCopyable
       key={uuid.current}
       data-test-subj="jsonCodeBlock"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Ingest pipelines] Accept triple quotes in import modal (#247354)](https://github.com/elastic/kibana/pull/247354)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sonia Sanz Vivas","email":"sonia.sanzvivas@elastic.co"},"sourceCommit":{"committedDate":"2026-03-27T08:15:34Z","message":"[Ingest pipelines] Accept triple quotes in import modal (#247354)\n\nhttps://github.com/elastic/kibana/issues/232563\n\n## Summary\nAttempting to import a pipeline via the Ingest Pipelines import UI\nfailed if the processor used triple quotes \"\"\". This PR fixes that and\nalso expand literal strings in the flyouts so the request is properly\ndisplayed.\n\n### How to test:\n\n* Navigate to Stack Management -> Ingest Pipelines -> Created pipeline\n* Click Import processors\n* Paste a pipeline snippet containing a processor that uses triple\nquotes - \"\"\"\n```\n\"processors\": [\n      {\n        \"script\": {\n          \"description\": \"add a test_field\",\n          \"lang\": \"painless\",\n          \"source\": \"\"\"\n            ctx['test_field'] = 'This is a test'\n          \"\"\"\n        }\n      }\n    ]\n```\n* Verify that the modal properly handle triple quotes\n* Verify that the triple quotes are also correctly displayed in the\npipeline request flyout and in the pipeline detail flyout\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/0addb615-1ef2-4530-b391-99c81c54c9a5\n\n\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Fixed error state clearing when resubmitting valid JSON after\nencountering validation errors.\n\n* **New Features**\n* Added real-time validation feedback with error messages displayed in\nthe JSON editor.\n* Enhanced support for special JSON formatting with preserved string\nindentation.\n* Improved UI feedback: submit button now disables during validation\nerrors.\n\n\n---------\n\nCo-authored-by: macroscopeapp[bot] <170038800+macroscopeapp[bot]@users.noreply.github.com>","sha":"e97d290eac76403a24b2204e6f46431bc8b0703f","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport missing","Feature:Ingest Node Pipelines","backport:all-open","v9.4.0"],"title":"[Ingest pipelines] Accept triple quotes in import modal","number":247354,"url":"https://github.com/elastic/kibana/pull/247354","mergeCommit":{"message":"[Ingest pipelines] Accept triple quotes in import modal (#247354)\n\nhttps://github.com/elastic/kibana/issues/232563\n\n## Summary\nAttempting to import a pipeline via the Ingest Pipelines import UI\nfailed if the processor used triple quotes \"\"\". This PR fixes that and\nalso expand literal strings in the flyouts so the request is properly\ndisplayed.\n\n### How to test:\n\n* Navigate to Stack Management -> Ingest Pipelines -> Created pipeline\n* Click Import processors\n* Paste a pipeline snippet containing a processor that uses triple\nquotes - \"\"\"\n```\n\"processors\": [\n      {\n        \"script\": {\n          \"description\": \"add a test_field\",\n          \"lang\": \"painless\",\n          \"source\": \"\"\"\n            ctx['test_field'] = 'This is a test'\n          \"\"\"\n        }\n      }\n    ]\n```\n* Verify that the modal properly handle triple quotes\n* Verify that the triple quotes are also correctly displayed in the\npipeline request flyout and in the pipeline detail flyout\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/0addb615-1ef2-4530-b391-99c81c54c9a5\n\n\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Fixed error state clearing when resubmitting valid JSON after\nencountering validation errors.\n\n* **New Features**\n* Added real-time validation feedback with error messages displayed in\nthe JSON editor.\n* Enhanced support for special JSON formatting with preserved string\nindentation.\n* Improved UI feedback: submit button now disables during validation\nerrors.\n\n\n---------\n\nCo-authored-by: macroscopeapp[bot] <170038800+macroscopeapp[bot]@users.noreply.github.com>","sha":"e97d290eac76403a24b2204e6f46431bc8b0703f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/247354","number":247354,"mergeCommit":{"message":"[Ingest pipelines] Accept triple quotes in import modal (#247354)\n\nhttps://github.com/elastic/kibana/issues/232563\n\n## Summary\nAttempting to import a pipeline via the Ingest Pipelines import UI\nfailed if the processor used triple quotes \"\"\". This PR fixes that and\nalso expand literal strings in the flyouts so the request is properly\ndisplayed.\n\n### How to test:\n\n* Navigate to Stack Management -> Ingest Pipelines -> Created pipeline\n* Click Import processors\n* Paste a pipeline snippet containing a processor that uses triple\nquotes - \"\"\"\n```\n\"processors\": [\n      {\n        \"script\": {\n          \"description\": \"add a test_field\",\n          \"lang\": \"painless\",\n          \"source\": \"\"\"\n            ctx['test_field'] = 'This is a test'\n          \"\"\"\n        }\n      }\n    ]\n```\n* Verify that the modal properly handle triple quotes\n* Verify that the triple quotes are also correctly displayed in the\npipeline request flyout and in the pipeline detail flyout\n\n### Demo\n\n\nhttps://github.com/user-attachments/assets/0addb615-1ef2-4530-b391-99c81c54c9a5\n\n\n\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n* Fixed error state clearing when resubmitting valid JSON after\nencountering validation errors.\n\n* **New Features**\n* Added real-time validation feedback with error messages displayed in\nthe JSON editor.\n* Enhanced support for special JSON formatting with preserved string\nindentation.\n* Improved UI feedback: submit button now disables during validation\nerrors.\n\n\n---------\n\nCo-authored-by: macroscopeapp[bot] <170038800+macroscopeapp[bot]@users.noreply.github.com>","sha":"e97d290eac76403a24b2204e6f46431bc8b0703f"}}]}] BACKPORT-->