### PR TITLE
[Alerting v2] Fix rule preview error in alerting_v2 due to missing EUI theme context

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/application/mount.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/application/mount.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import type { Container } from 'inversify';
 import type { AppMountParameters, AppUnmount } from '@kbn/core-application-browser';
-import type { ChromeBreadcrumb } from '@kbn/core/public';
+import type { ChromeBreadcrumb, CoreStart } from '@kbn/core/public';
 import { Context } from '@kbn/core-di-browser';
 import { Router } from '@kbn/shared-ux-router';
 import { I18nProvider } from '@kbn/i18n-react';
@@ -27,26 +27,30 @@ interface AlertingV2MountParams {
 export const mountAlertingV2App = ({
   params,
   container,
+  coreStart,
 }: {
   params: AlertingV2MountParams;
   container: Container;
+  coreStart: CoreStart;
 }): AppUnmount => {
   const { element, history, setBreadcrumbs } = params;
 
   const queryClient = new QueryClient();
 
   ReactDOM.render(
-    <Context.Provider value={container}>
-      <QueryClientProvider client={queryClient}>
-        <BreadcrumbProvider setBreadcrumbs={setBreadcrumbs}>
-          <I18nProvider>
-            <Router history={history}>
-              <RulesApp />
-            </Router>
-          </I18nProvider>
-        </BreadcrumbProvider>
-      </QueryClientProvider>
-    </Context.Provider>,
+    coreStart.rendering.addContext(
+      <Context.Provider value={container}>
+        <QueryClientProvider client={queryClient}>
+          <BreadcrumbProvider setBreadcrumbs={setBreadcrumbs}>
+            <I18nProvider>
+              <Router history={history}>
+                <RulesApp />
+              </Router>
+            </I18nProvider>
+          </BreadcrumbProvider>
+        </QueryClientProvider>
+      </Context.Provider>
+    ),
     element
   );
 
@@ -56,26 +60,30 @@ export const mountAlertingV2App = ({
 export const mountNotificationPoliciesApp = ({
   params,
   container,
+  coreStart,
 }: {
   params: AlertingV2MountParams;
   container: Container;
+  coreStart: CoreStart;
 }): AppUnmount => {
   const { element, history, setBreadcrumbs } = params;
 
   const queryClient = new QueryClient();
 
   ReactDOM.render(
-    <Context.Provider value={container}>
-      <QueryClientProvider client={queryClient}>
-        <BreadcrumbProvider setBreadcrumbs={setBreadcrumbs}>
-          <I18nProvider>
-            <Router history={history}>
-              <NotificationPoliciesApp />
-            </Router>
-          </I18nProvider>
-        </BreadcrumbProvider>
-      </QueryClientProvider>
-    </Context.Provider>,
+    coreStart.rendering.addContext(
+      <Context.Provider value={container}>
+        <QueryClientProvider client={queryClient}>
+          <BreadcrumbProvider setBreadcrumbs={setBreadcrumbs}>
+            <I18nProvider>
+              <Router history={history}>
+                <NotificationPoliciesApp />
+              </Router>
+            </I18nProvider>
+          </BreadcrumbProvider>
+        </QueryClientProvider>
+      </Context.Provider>
+    ),
     element
   );
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/index.ts
@@ -64,7 +64,11 @@ export const module = new ContainerModule(({ bind }) => {
       async mount(params) {
         const [coreStart] = await getStartServices();
         const { mountAlertingV2App } = await import('./application/mount');
-        return mountAlertingV2App({ params, container: coreStart.injection.getContainer() });
+        return mountAlertingV2App({
+          params,
+          container: coreStart.injection.getContainer(),
+          coreStart,
+        });
       },
     });
 
@@ -78,6 +82,7 @@ export const module = new ContainerModule(({ bind }) => {
         return mountNotificationPoliciesApp({
           params,
           container: coreStart.injection.getContainer(),
+          coreStart,
         });
       },
     });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/260954

### Summary

- Fixes `Cannot read properties of undefined (reading 'font')` error when rendering the Lens chart in the alerting_v2 rule preview
- Wraps both app mount functions with `coreStart.rendering.addContext()` to provide the EUI theme (and other Kibana global context) to the React tree

### Root Cause

The alerting_v2 app mounts via ReactDOM.render() which creates a standalone React tree without any EUI ThemeProvider. When Lens renders its embeddable chart inside the rule preview, `lnsNumericFontStyles` reads `euiTheme.font.family` (PR: https://github.com/elastic/kibana/pull/251576) from Emotion's theme context which is undefined without the provider, causing the error.

### Testing

- Open alerting_v2 rule form and trigger a rule preview with an ES|QL query that renders a Lens chart
- Verify the chart renders without errors
- Verify notification policies page still loads correctly

### Screenshots

<img width="1234" height="781" alt="Screenshot 2026-04-07 at 10 21 24 AM" src="https://github.com/user-attachments/assets/9375415e-8aae-493a-b8c3-006db48333ca" />
