### PR TITLE
[Agent Builder] remove `request` from SmlContext

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/plugin.ts
@@ -354,7 +354,6 @@ export class AgentBuilderPlugin
             esClient: elasticsearch.client.asInternalUser,
             savedObjectsClient: soClient,
             logger: this.logger.get('services.sml'),
-            request: params.request,
           });
         },
       },

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/connector_lifecycle/connector_lifecycle_handler.ts
@@ -70,7 +70,6 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 includedHiddenTypes: ['action'],
               }),
               logger,
-              request,
             });
             logger.info(`Connector lifecycle: indexed connector ${connectorId} into SML`);
           } catch (smlError) {
@@ -120,7 +119,6 @@ export function createConnectorLifecycleHandler(deps: ConnectorLifecycleHandlerD
                 includedHiddenTypes: ['action'],
               }),
               logger,
-              request,
             });
             logger.info(`Connector lifecycle: removed connector ${connectorId} from SML`);
           } catch (smlError) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.test.ts
@@ -138,7 +138,6 @@ describe('createSmlIndexer', () => {
         esClient,
         savedObjectsClient: {},
         logger: contextLogger,
-        request: undefined,
       });
       expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
       expect(esClient.deleteByQuery).toHaveBeenCalledWith({

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/sml_indexer.ts
@@ -12,7 +12,6 @@ import type {
   ISavedObjectsRepository,
 } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
-import type { KibanaRequest } from '@kbn/core-http-server';
 import type { SmlTypeRegistry } from './sml_type_registry';
 import type { SmlIndexAction, SmlContext } from './types';
 import { createSmlStorage, smlIndexName } from './sml_storage';
@@ -35,7 +34,6 @@ export interface SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
-    request?: KibanaRequest;
   }) => Promise<void>;
 }
 
@@ -60,7 +58,6 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient,
     savedObjectsClient,
     logger: contextLogger,
-    request,
   }: {
     originId: string;
     attachmentType: string;
@@ -69,7 +66,6 @@ class SmlIndexerImpl implements SmlIndexer {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract | ISavedObjectsRepository;
     logger: Logger;
-    request?: KibanaRequest;
   }): Promise<void> {
     this.logger.info(
       `SML indexer: indexAttachment called — originId='${originId}', type='${attachmentType}', action='${action}', spaces=[${spaces.join(
@@ -98,7 +94,6 @@ class SmlIndexerImpl implements SmlIndexer {
       esClient,
       savedObjectsClient,
       logger: contextLogger,
-      request,
     };
 
     this.logger.info(

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/types.ts
@@ -42,8 +42,6 @@ export interface SmlContext {
   esClient: ElasticsearchClient;
   savedObjectsClient: SavedObjectsClientContract;
   logger: Logger;
-  /** The current user's request, when available. Absent during background crawler runs. */
-  request?: KibanaRequest;
 }
 
 /**
@@ -224,7 +222,6 @@ export interface SmlService {
     esClient: ElasticsearchClient;
     savedObjectsClient: SavedObjectsClientContract;
     logger: Logger;
-    request?: KibanaRequest;
   }) => Promise<void>;
 
   /** Fetch SML documents by their chunk IDs, scoped to a space */

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.test.ts
@@ -26,7 +26,7 @@ const mockLogger = loggingSystemMock.createLogger();
 
 const createContext = () => ({
   logger: loggingSystemMock.createLogger(),
-  request: httpServerMock.createKibanaRequest(),
+  savedObjectsClient: mockSavedObjectsClient as any,
 });
 
 const createAttachmentContext = () => ({
@@ -96,14 +96,6 @@ describe('connectorSmlType', () => {
           },
         ],
       });
-    });
-
-    it('throws when request is not available', async () => {
-      const context = { logger: loggingSystemMock.createLogger() };
-
-      await expect(connectorSmlType.getSmlData!('conn-1', context as never)).rejects.toThrow(
-        'no request available'
-      );
     });
 
     it('returns undefined on error and logs warning', async () => {

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/sml_types/connector.ts
@@ -46,14 +46,8 @@ export const createConnectorSmlType = (deps: ConnectorSmlTypeDeps): SmlTypeDefin
     }),
 
     getSmlData: async (originId, context) => {
-      if (!context.request) {
-        throw new Error(
-          `SML connector: no request available for '${originId}' — cannot create scoped client`
-        );
-      }
       try {
-        const soClient = await getActionSavedObjectsClient(context.request);
-        const so = await soClient.get('action', originId);
+        const so = await context.savedObjectsClient.get('action', originId);
         const attrs = so.attributes as { name?: string; actionTypeId?: string };
         const name = attrs.name ?? originId;
         const actionTypeId = attrs.actionTypeId ?? '';


### PR DESCRIPTION
## Summary

`request` is not available in the crawler context from where getSmlData() is called.

Also we should not be scoping services to specific user inside the getSmlData(), permissions/access is is handled on query time rather than on index time.
