### PR TITLE
[Discover][Traces] Fix flaky test for trace summary in flyout with more reliable locator

### DIFF
--- a/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
+++ b/src/platform/plugins/shared/discover/test/scout/ui/fixtures/traces_experience/page_objects/flyout.ts
@@ -83,8 +83,6 @@ export interface TracesFlyout {
 }
 
 export function createTracesFlyout(page: ScoutPage): TracesFlyout {
-  const timelineFlyout = page.getByRole('dialog', { name: 'Trace timeline' });
-
   return {
     overviewTab: page.testSubj.locator('docViewerTab-doc_view_obs_traces_overview'),
 
@@ -141,6 +139,7 @@ export function createTracesFlyout(page: ScoutPage): TracesFlyout {
     },
 
     waterfallFlyout: (() => {
+      const timelineFlyout = page.testSubj.locator('traceWaterfallFlyout');
       const childDocContainer = page.locator('[id^="documentDetailFlyout"]');
       return {
         container: timelineFlyout,


### PR DESCRIPTION
## Summary

Closes #261265

Changed the waterfall flyout container locator to from getting by role to its `data-test-subj`, which is directly set on the `EuiFlyout` component and is more stable regardless of the flyout manager's session state or accessibility of the name. All child locators continue to work correctly since they're are scoped under the same DOM element.