### PR TITLE
 [Osquery] Move "Save query" from run form to detail page behind queryHistoryRework flag

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/common/api/saved_query/find_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/common/api/saved_query/find_saved_query_route.ts
@@ -15,6 +15,7 @@ export const findSavedQueryRequestQuerySchema = t.type({
   sortOrder: t.union([t.union([t.literal('asc'), t.literal('desc')]), t.undefined]),
   search: t.union([t.string, t.undefined]),
   createdBy: t.union([t.string, t.undefined]),
+  id: t.union([t.string, t.undefined]),
 });
 
 export type FindSavedQueryRequestQuerySchema = t.OutputOf<typeof findSavedQueryRequestQuerySchema>;

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
@@ -374,7 +374,7 @@ describe(
       cy.getBySel('osquery-save-query-flyout').should('exist');
 
       cy.getBySel('osquery-save-query-flyout').within(() => {
-        cy.get('.euiCodeBlock').should('exist');
+        cy.get('.monaco-editor').should('exist');
         cy.get('input[name="id"]').type(`${savedQueryId}{downArrow}{enter}`);
         cy.get('input[name="description"]').type('Saved from detail page');
       });

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
@@ -7,6 +7,7 @@
 
 import { navigateTo } from '../../tasks/navigation';
 import { checkResults, inputQuery, selectAllAgents, submitQuery } from '../../tasks/live_query';
+import { closeToastIfVisible } from '../../tasks/integrations';
 import {
   loadLiveQuery,
   addTagsToLiveQuery,
@@ -353,6 +354,36 @@ describe(
       navigateTo('/app/osquery/history');
       cy.getBySel(UNIFIED_HISTORY_TABLE, { timeout: 60000 }).should('exist');
       cy.getBySel(UNIFIED_HISTORY_TABLE).find('tbody tr').first().should('contain', 'os_version');
+    });
+
+    it('should save a query from the detail page via Save query button', () => {
+      const savedQueryId = `saved-from-details-${Date.now()}`;
+
+      cy.getBySel(UNIFIED_HISTORY_TABLE).within(() => {
+        cy.get('tbody tr')
+          .first()
+          .within(() => {
+            cy.get('[aria-label="Details"]').click();
+          });
+      });
+      cy.contains('Query results');
+
+      cy.getBySel('save-query-button').should('exist').click();
+
+      cy.getBySel('osquery-save-query-flyout').should('exist');
+
+      cy.getBySel('osquery-save-query-flyout').within(() => {
+        cy.get('.euiCodeBlock').should('exist');
+        cy.get('input[name="id"]').type(`${savedQueryId}{downArrow}{enter}`);
+        cy.get('input[name="description"]').type('Saved from detail page');
+      });
+
+      cy.getBySel('savedQueryFlyoutSaveButton').click();
+      cy.contains('Successfully saved');
+      closeToastIfVisible();
+
+      navigateTo('/app/osquery/saved_queries');
+      cy.contains(savedQueryId);
     });
   }
 );

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/experimental/history.cy.ts
@@ -16,6 +16,7 @@ import {
   getPackSavedObject,
   loadScheduledResponse,
   cleanupScheduledResponse,
+  cleanupSavedQueryByName,
 } from '../../tasks/api_fixtures';
 import {
   UNIFIED_HISTORY_TABLE,
@@ -384,6 +385,8 @@ describe(
 
       navigateTo('/app/osquery/saved_queries');
       cy.contains(savedQueryId);
+
+      cleanupSavedQueryByName(savedQueryId);
     });
   }
 );

--- a/x-pack/platform/plugins/shared/osquery/cypress/tasks/api_fixtures.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/tasks/api_fixtures.ts
@@ -148,6 +148,22 @@ export const cleanupSavedQuery = (id: string) => {
   });
 };
 
+export const cleanupSavedQueryByName = (name: string) => {
+  request<{ data: SavedQuerySO[] }>({
+    method: 'GET',
+    url: `/api/osquery/saved_queries?id=${encodeURIComponent(name)}&pageSize=1`,
+    headers: {
+      'Elastic-Api-Version': API_VERSIONS.public.v1,
+    },
+    failOnStatusCode: false,
+  }).then((response) => {
+    const match = response.body?.data?.[0];
+    if (match?.saved_object_id) {
+      cleanupSavedQuery(match.saved_object_id);
+    }
+  });
+};
+
 export const loadPack = (payload: Partial<PackItem> = {}, space = 'default') =>
   request<{ data: PackSavedObject }>({
     method: 'POST',

--- a/x-pack/platform/plugins/shared/osquery/public/actions/use_live_query_details.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/actions/use_live_query_details.ts
@@ -32,6 +32,7 @@ export interface PackQueriesQuery {
   platform?: string;
   saved_query_id?: string;
   expiration?: string;
+  timeout?: number;
 }
 
 export interface LiveQueryDetailsItem {

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../common/utils/replace_params_query';
 import { QueryPackSelectable } from './query_pack_selectable';
 import type { SavedQuerySOFormData } from '../../saved_queries/form/use_saved_query_form';
+import { savedQueryDataSerializer } from '../../saved_queries/form/use_saved_query_form';
 import { useKibana } from '../../common/lib/kibana';
 import { ResultTabs } from '../../routes/saved_queries/edit/tabs';
 import { SavedQueryFlyout } from '../../saved_queries';
@@ -29,7 +30,6 @@ import type { AgentSelection } from '../../agents/types';
 import type { AddToTimelineHandler } from '../../types';
 import LiveQueryQueryField from './live_query_query_field';
 import { AgentsTableField } from './agents_table_field';
-import { savedQueryDataSerializer } from '../../saved_queries/form/use_saved_query_form';
 import { PackFieldWrapper } from '../../shared_components/osquery_response_action_type/pack_field_wrapper';
 import { AlertAttachmentContext } from '../../common/contexts';
 import { useIsExperimentalFeatureEnabled } from '../../common/experimental_features_context';
@@ -181,7 +181,7 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
     () => (
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="flexEnd">
-          {formType === 'steps' && queryType !== 'pack' && (
+          {!isHistoryEnabled && formType === 'steps' && queryType !== 'pack' && (
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty
                 disabled={!permissions.writeSavedQueries || resultsStatus === 'disabled'}
@@ -211,6 +211,7 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
       </EuiFlexItem>
     ),
     [
+      isHistoryEnabled,
       formType,
       queryType,
       permissions.writeSavedQueries,
@@ -356,7 +357,7 @@ const LiveQueryFormComponent: React.FC<LiveQueryFormProps> = ({
         </EuiFlexGroup>
       </FormProvider>
 
-      {showSavedQueryFlyout ? (
+      {!isHistoryEnabled && showSavedQueryFlyout ? (
         <SavedQueryFlyout onClose={handleCloseSaveQueryFlyout} defaultValue={serializedData} />
       ) : null}
     </>

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/index.tsx
@@ -19,7 +19,6 @@ import {
 } from '../../../common/utils/replace_params_query';
 import { QueryPackSelectable } from './query_pack_selectable';
 import type { SavedQuerySOFormData } from '../../saved_queries/form/use_saved_query_form';
-import { savedQueryDataSerializer } from '../../saved_queries/form/use_saved_query_form';
 import { useKibana } from '../../common/lib/kibana';
 import { ResultTabs } from '../../routes/saved_queries/edit/tabs';
 import { SavedQueryFlyout } from '../../saved_queries';
@@ -30,6 +29,7 @@ import type { AgentSelection } from '../../agents/types';
 import type { AddToTimelineHandler } from '../../types';
 import LiveQueryQueryField from './live_query_query_field';
 import { AgentsTableField } from './agents_table_field';
+import { savedQueryDataSerializer } from '../../saved_queries/form/use_saved_query_form';
 import { PackFieldWrapper } from '../../shared_components/osquery_response_action_type/pack_field_wrapper';
 import { AlertAttachmentContext } from '../../common/contexts';
 import { useIsExperimentalFeatureEnabled } from '../../common/experimental_features_context';

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_queries_status_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_queries_status_table.tsx
@@ -174,6 +174,7 @@ interface PackQueriesStatusTableProps {
   executionCount?: number;
   packName?: string;
   tags?: string[];
+  onSaveQuery?: () => void;
 }
 
 const PackQueriesStatusTableComponent: React.FC<PackQueriesStatusTableProps> = ({
@@ -189,6 +190,7 @@ const PackQueriesStatusTableComponent: React.FC<PackQueriesStatusTableProps> = (
   executionCount,
   packName,
   tags,
+  onSaveQuery,
 }) => {
   const isHistoryEnabled = useIsExperimentalFeatureEnabled('queryHistoryRework');
   const [queryDetailsFlyoutOpen, setQueryDetailsFlyoutOpen] = useState<{
@@ -674,6 +676,7 @@ const PackQueriesStatusTableComponent: React.FC<PackQueriesStatusTableProps> = (
           agentIds={agentIds}
           addToTimeline={addToTimeline}
           isScheduled={!!scheduleId}
+          onSaveQuery={onSaveQuery}
         />
       )}
       <EuiBasicTable

--- a/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/live_queries/form/pack_results_header.tsx
@@ -7,6 +7,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import type { UseEuiTheme } from '@elastic/eui';
 import {
+  EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiFlexGroup,
@@ -42,6 +43,7 @@ interface PackResultsHeadersProps {
   agentIds?: string[];
   addToTimeline?: AddToTimelineHandler;
   isScheduled?: boolean;
+  onSaveQuery?: () => void;
 }
 
 const resultsHeadingCss = ({ euiTheme }: UseEuiTheme) => ({
@@ -60,7 +62,7 @@ const actionsGroupCss = {
 };
 
 export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
-  ({ actionId, agentIds, queryIds, addToTimeline, isScheduled }) => {
+  ({ actionId, agentIds, queryIds, addToTimeline, isScheduled, onSaveQuery }) => {
     const iconProps = useMemo(() => ({ color: 'text', size: 'xs', iconSize: 'l' } as const), []);
     const isHistoryEnabled = useIsExperimentalFeatureEnabled('queryHistoryRework');
     const permissions = useKibana().services.application.capabilities.osquery;
@@ -130,6 +132,21 @@ export const PackResultsHeader = React.memo<PackResultsHeadersProps>(
                           {ADD_TAGS_LABEL}
                         </EuiButtonEmpty>
                       </EuiToolTip>
+                    </EuiFlexItem>
+                  )}
+                  {onSaveQuery && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButton
+                        fill
+                        size="m"
+                        onClick={onSaveQuery}
+                        data-test-subj="save-query-button"
+                      >
+                        <FormattedMessage
+                          id="xpack.osquery.packResultsHeader.saveQueryButtonLabel"
+                          defaultMessage="Save query"
+                        />
+                      </EuiButton>
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/index.tsx
@@ -93,7 +93,7 @@ const LiveQueryDetailsPageComponent = () => {
     setIsLive(() => !(data?.status === 'completed'));
   }, [data?.status]);
 
-  const onSaveQuery = canSave ? handleShowSaveQueryFlyout : undefined;
+  const onSaveQuery = isHistoryEnabled && canSave ? handleShowSaveQueryFlyout : undefined;
 
   const tableBlock = (
     <div css={tableWrapperCss}>
@@ -141,11 +141,9 @@ const LiveQueryDetailsPageComponent = () => {
             agentIds={data?.agents}
             showResultsHeader
             tags={data?.tags}
-            onSaveQuery={onSaveQuery}
           />
         </EuiFlexItem>
       </WithHeaderLayout>
-      {savedQueryFlyout}
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/index.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/index.tsx
@@ -22,6 +22,8 @@ import { useBreadcrumbs } from '../../../common/hooks/use_breadcrumbs';
 import { pagePathGetters } from '../../../common/page_paths';
 import { PackQueriesStatusTable } from '../../../live_queries/form/pack_queries_status_table';
 import { useIsExperimentalFeatureEnabled } from '../../../common/experimental_features_context';
+import { SavedQueryFlyout } from '../../../saved_queries';
+import { useSaveQueryFromDetails } from './use_save_query_from_details';
 
 const tableWrapperCss = {
   paddingLeft: 0,
@@ -38,6 +40,14 @@ const LiveQueryDetailsPageComponent = () => {
   const liveQueryListProps = useRouterNavigate(backNavigationTarget, handleGoBack);
   const [isLive, setIsLive] = useState(false);
   const { data } = useLiveQueryDetails({ actionId, isLive });
+
+  const {
+    canSave,
+    showSavedQueryFlyout,
+    handleShowSaveQueryFlyout,
+    handleCloseSaveQueryFlyout,
+    savedQueryDefaultValue,
+  } = useSaveQueryFromDetails({ data });
 
   const LeftColumn = useMemo(
     () => (
@@ -83,6 +93,8 @@ const LiveQueryDetailsPageComponent = () => {
     setIsLive(() => !(data?.status === 'completed'));
   }, [data?.status]);
 
+  const onSaveQuery = canSave ? handleShowSaveQueryFlyout : undefined;
+
   const tableBlock = (
     <div css={tableWrapperCss}>
       <PackQueriesStatusTable
@@ -93,36 +105,48 @@ const LiveQueryDetailsPageComponent = () => {
         agentIds={data?.agents}
         showResultsHeader
         tags={data?.tags}
+        onSaveQuery={onSaveQuery}
       />
     </div>
   );
 
+  const savedQueryFlyout = showSavedQueryFlyout ? (
+    <SavedQueryFlyout onClose={handleCloseSaveQueryFlyout} defaultValue={savedQueryDefaultValue} />
+  ) : null;
+
   if (isHistoryEnabled) {
     return (
-      <WithoutHeaderLayout restrictWidth={false}>
-        <div css={fullWidthContentCss}>
-          {LeftColumn}
-          <EuiSpacer size="m" />
-          {tableBlock}
-        </div>
-      </WithoutHeaderLayout>
+      <>
+        <WithoutHeaderLayout restrictWidth={false}>
+          <div css={fullWidthContentCss}>
+            {LeftColumn}
+            <EuiSpacer size="m" />
+            {tableBlock}
+          </div>
+        </WithoutHeaderLayout>
+        {savedQueryFlyout}
+      </>
     );
   }
 
   return (
-    <WithHeaderLayout leftColumn={LeftColumn} rightColumnGrow={false}>
-      <EuiFlexItem css={tableWrapperCss}>
-        <PackQueriesStatusTable
-          actionId={actionId}
-          data={data?.queries}
-          startDate={data?.['@timestamp']}
-          expirationDate={data?.expiration}
-          agentIds={data?.agents}
-          showResultsHeader
-          tags={data?.tags}
-        />
-      </EuiFlexItem>
-    </WithHeaderLayout>
+    <>
+      <WithHeaderLayout leftColumn={LeftColumn} rightColumnGrow={false}>
+        <EuiFlexItem css={tableWrapperCss}>
+          <PackQueriesStatusTable
+            actionId={actionId}
+            data={data?.queries}
+            startDate={data?.['@timestamp']}
+            expirationDate={data?.expiration}
+            agentIds={data?.agents}
+            showResultsHeader
+            tags={data?.tags}
+            onSaveQuery={onSaveQuery}
+          />
+        </EuiFlexItem>
+      </WithHeaderLayout>
+      {savedQueryFlyout}
+    </>
   );
 };
 

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@kbn/react-query';
+import { useKibana } from '../../../common/lib/kibana';
+import type { LiveQueryDetailsItem } from '../../../actions/use_live_query_details';
+import { useSaveQueryFromDetails } from './use_save_query_from_details';
+
+jest.mock('../../../common/lib/kibana');
+jest.mock('../../../common/hooks/use_error_toast', () => ({
+  useErrorToast: () => jest.fn(),
+}));
+
+const useKibanaMock = useKibana as jest.MockedFunction<typeof useKibana>;
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return Wrapper;
+};
+
+const createMockData = (
+  overrides: Partial<LiveQueryDetailsItem> = {}
+): LiveQueryDetailsItem => ({
+  action_id: 'test-action-id',
+  '@timestamp': '2026-04-07T00:00:00Z',
+  agent_all: true,
+  agent_ids: ['agent-1'],
+  agent_platforms: ['linux'],
+  agent_policy_ids: ['policy-1'],
+  queries: [
+    {
+      action_id: 'query-action-id',
+      id: 'query-id',
+      query: 'select * from users;',
+      agents: ['agent-1'],
+      ecs_mapping: { 'user.name': { field: 'username' } },
+      timeout: 300,
+    },
+  ],
+  ...overrides,
+});
+
+describe('useSaveQueryFromDetails', () => {
+  let mockHttp: { get: jest.Mock };
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHttp = { get: jest.fn() };
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+      logger: { log: () => null, warn: () => null, error: () => null },
+    });
+
+    useKibanaMock.mockReturnValue({
+      services: {
+        http: mockHttp,
+        application: {
+          capabilities: {
+            osquery: {
+              writeSavedQueries: true,
+            },
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+  });
+
+  it('should allow save for single-query actions with write permission', () => {
+    const data = createMockData();
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.canSave).toBe(true);
+  });
+
+  it('should not allow save for pack-based actions', () => {
+    const data = createMockData({ pack_id: 'some-pack' });
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it('should not allow save for multi-query actions', () => {
+    const data = createMockData({
+      queries: [
+        { action_id: 'q1', id: '1', query: 'select 1;', agents: [] },
+        { action_id: 'q2', id: '2', query: 'select 2;', agents: [] },
+      ],
+    });
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it('should not allow save without writeSavedQueries permission', () => {
+    useKibanaMock.mockReturnValue({
+      services: {
+        http: mockHttp,
+        application: {
+          capabilities: {
+            osquery: { writeSavedQueries: false },
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useKibana>);
+
+    const data = createMockData();
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it('should build defaultValue from action query data', () => {
+    const data = createMockData();
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.savedQueryDefaultValue).toEqual({
+      query: 'select * from users;',
+      ecs_mapping: { 'user.name': { field: 'username' } },
+      timeout: 300,
+    });
+  });
+
+  it('should enrich defaultValue from saved query when saved_query_id exists', async () => {
+    const data = createMockData({
+      queries: [
+        {
+          action_id: 'query-action-id',
+          id: 'query-id',
+          query: 'select * from users;',
+          agents: ['agent-1'],
+          ecs_mapping: { 'user.name': { field: 'username' } },
+          timeout: 300,
+          saved_query_id: 'my-saved-query',
+        },
+      ],
+    });
+
+    mockHttp.get.mockResolvedValue({
+      data: [
+        {
+          id: 'my-saved-query',
+          description: 'List all users',
+          platform: 'linux,darwin',
+          version: '5.0.0',
+          interval: '3600',
+          query: 'select * from users;',
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() =>
+      expect(result.current.savedQueryDefaultValue.description).toBe('List all users')
+    );
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/osquery/saved_queries', {
+      version: '2023-10-31',
+      query: { id: 'my-saved-query', pageSize: 1 },
+    });
+
+    expect(result.current.savedQueryDefaultValue).toEqual({
+      query: 'select * from users;',
+      ecs_mapping: { 'user.name': { field: 'username' } },
+      timeout: 300,
+      description: 'List all users',
+      platform: 'linux,darwin',
+      version: '5.0.0',
+      interval: '3600',
+    });
+  });
+
+  it('should fall back to base data when saved query fetch fails', async () => {
+    const data = createMockData({
+      queries: [
+        {
+          action_id: 'query-action-id',
+          id: 'query-id',
+          query: 'select * from users;',
+          agents: ['agent-1'],
+          saved_query_id: 'deleted-query',
+        },
+      ],
+    });
+
+    mockHttp.get.mockRejectedValue(new Error('Not found'));
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // Wait for query to settle
+    await waitFor(() => expect(mockHttp.get).toHaveBeenCalled());
+
+    expect(result.current.savedQueryDefaultValue).toEqual({
+      query: 'select * from users;',
+      ecs_mapping: undefined,
+      timeout: undefined,
+    });
+  });
+
+  it('should not fetch saved query when saved_query_id is absent', () => {
+    const data = createMockData();
+
+    renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(mockHttp.get).not.toHaveBeenCalled();
+  });
+
+  it('should toggle flyout visibility', () => {
+    const data = createMockData();
+
+    const { result } = renderHook(() => useSaveQueryFromDetails({ data }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.showSavedQueryFlyout).toBe(false);
+
+    act(() => result.current.handleShowSaveQueryFlyout());
+    expect(result.current.showSavedQueryFlyout).toBe(true);
+
+    act(() => result.current.handleCloseSaveQueryFlyout());
+    expect(result.current.showSavedQueryFlyout).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.test.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.test.ts
@@ -26,9 +26,7 @@ const createWrapper = (queryClient: QueryClient) => {
   return Wrapper;
 };
 
-const createMockData = (
-  overrides: Partial<LiveQueryDetailsItem> = {}
-): LiveQueryDetailsItem => ({
+const createMockData = (overrides: Partial<LiveQueryDetailsItem> = {}): LiveQueryDetailsItem => ({
   action_id: 'test-action-id',
   '@timestamp': '2026-04-07T00:00:00Z',
   agent_all: true,

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery } from '@kbn/react-query';
+
+import { API_VERSIONS } from '../../../../common/constants';
+import { useKibana } from '../../../common/lib/kibana';
+import type { LiveQueryDetailsItem } from '../../../actions/use_live_query_details';
+import type { SavedQuerySOFormData } from '../../../saved_queries/form/use_saved_query_form';
+
+interface UseSaveQueryFromDetailsProps {
+  data: LiveQueryDetailsItem | undefined;
+}
+
+export const useSaveQueryFromDetails = ({ data }: UseSaveQueryFromDetailsProps) => {
+  const { application, http } = useKibana().services;
+  const permissions = application.capabilities.osquery;
+
+  const [showSavedQueryFlyout, setShowSavedQueryFlyout] = useState(false);
+  const handleShowSaveQueryFlyout = useCallback(() => setShowSavedQueryFlyout(true), []);
+  const handleCloseSaveQueryFlyout = useCallback(() => setShowSavedQueryFlyout(false), []);
+
+  const singleQuery = data?.queries?.[0];
+  const savedQueryId = singleQuery?.saved_query_id;
+  const canSave = !!permissions.writeSavedQueries && !data?.pack_id && data?.queries?.length === 1;
+
+  const { data: savedQueryData } = useQuery<
+    { data: SavedQuerySOFormData },
+    unknown,
+    SavedQuerySOFormData
+  >(
+    ['savedQueryEnrichment', savedQueryId],
+    () =>
+      http.get(`/api/osquery/saved_queries/${savedQueryId}`, {
+        version: API_VERSIONS.public.v1,
+      }),
+    {
+      enabled: !!savedQueryId,
+      retry: false,
+      refetchOnWindowFocus: false,
+      select: (response) => response.data,
+    }
+  );
+
+  const savedQueryDefaultValue: SavedQuerySOFormData = useMemo(() => {
+    const base: SavedQuerySOFormData = {
+      query: singleQuery?.query,
+      ecs_mapping: singleQuery?.ecs_mapping,
+      timeout: singleQuery?.timeout,
+    };
+
+    if (savedQueryData) {
+      return {
+        ...base,
+        description: savedQueryData.description,
+        platform: savedQueryData.platform,
+        version: savedQueryData.version,
+        interval: savedQueryData.interval,
+      };
+    }
+
+    return base;
+  }, [singleQuery, savedQueryData]);
+
+  return {
+    canSave,
+    showSavedQueryFlyout,
+    handleShowSaveQueryFlyout,
+    handleCloseSaveQueryFlyout,
+    savedQueryDefaultValue,
+  };
+};

--- a/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.ts
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/live_queries/details/use_save_query_from_details.ts
@@ -29,21 +29,24 @@ export const useSaveQueryFromDetails = ({ data }: UseSaveQueryFromDetailsProps) 
   const savedQueryId = singleQuery?.saved_query_id;
   const canSave = !!permissions.writeSavedQueries && !data?.pack_id && data?.queries?.length === 1;
 
+  // The action document stores the custom "id" field (e.g. "my-query"), not the
+  // Kibana saved object UUID. Use the find endpoint with exact id filter.
   const { data: savedQueryData } = useQuery<
-    { data: SavedQuerySOFormData },
+    { data: SavedQuerySOFormData[] },
     unknown,
-    SavedQuerySOFormData
+    SavedQuerySOFormData | undefined
   >(
     ['savedQueryEnrichment', savedQueryId],
     () =>
-      http.get(`/api/osquery/saved_queries/${savedQueryId}`, {
+      http.get('/api/osquery/saved_queries', {
         version: API_VERSIONS.public.v1,
+        query: { id: savedQueryId, pageSize: 1 },
       }),
     {
       enabled: !!savedQueryId,
       retry: false,
       refetchOnWindowFocus: false,
-      select: (response) => response.data,
+      select: (response) => response.data?.[0],
     }
   );
 

--- a/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/saved_queries_table.tsx
+++ b/x-pack/platform/plugins/shared/osquery/public/routes/saved_queries/list/saved_queries_table.tsx
@@ -351,8 +351,8 @@ const SavedQueriesTableComponent = () => {
         isDisabled={!permissions.writeSavedQueries}
       >
         <FormattedMessage
-          id="xpack.osquery.savedQueryList.saveQueryButtonLabel"
-          defaultMessage="Save query"
+          id="xpack.osquery.savedQueryList.createQueryButtonLabel"
+          defaultMessage="Create query"
         />
       </EuiButton>
     ),

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
@@ -67,10 +67,8 @@ export const findSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAppC
           }
 
           if (request.query.id) {
-            const idTerm = escapeKuery(request.query.id.trim());
-            filters.push(
-              `${savedQuerySavedObjectType}.attributes.id: "${escapeQuotes(idTerm)}"`
-            );
+            const idTerm = request.query.id.trim();
+            filters.push(`${savedQuerySavedObjectType}.attributes.id: "${escapeQuotes(idTerm)}"`);
           } else if (request.query.search) {
             const searchTerm = escapeKuery(request.query.search.trim());
             if (searchTerm) {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
@@ -68,9 +68,7 @@ export const findSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAppC
 
           if (request.query.id) {
             const idTerm = escapeKuery(request.query.id.trim());
-            filters.push(
-              `${savedQuerySavedObjectType}.attributes.id: "${escapeQuotes(idTerm)}"`
-            );
+            filters.push(`${savedQuerySavedObjectType}.attributes.id: "${escapeQuotes(idTerm)}"`);
           } else if (request.query.search) {
             const searchTerm = escapeKuery(request.query.search.trim());
             if (searchTerm) {

--- a/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
+++ b/x-pack/platform/plugins/shared/osquery/server/routes/saved_query/find_saved_query_route.ts
@@ -66,7 +66,12 @@ export const findSavedQueryRoute = (router: IRouter, osqueryContext: OsqueryAppC
             filters.push(`(${userFilters.join(' OR ')})`);
           }
 
-          if (request.query.search) {
+          if (request.query.id) {
+            const idTerm = escapeKuery(request.query.id.trim());
+            filters.push(
+              `${savedQuerySavedObjectType}.attributes.id: "${escapeQuotes(idTerm)}"`
+            );
+          } else if (request.query.search) {
             const searchTerm = escapeKuery(request.query.search.trim());
             if (searchTerm) {
               const searchFilter = [


### PR DESCRIPTION
## Summary

Moves the "Save for later" functionality from the Run Query form to the query detail page, gated behind the `queryHistoryRework` feature flag. Also renames the saved queries list button from "Save query" to "Create query", and adds an exact `id` filter to the saved queries find endpoint.

### Changes

- **Detail page**: Added a filled "Save query" button in the results header (next to "Add to case" and "Add tags") that opens the `SavedQueryFlyout` pre-filled with query data from the action document
- **Saved query enrichment**: When the action was run from an existing saved query, fetches `platform`, `version`, `interval`, and `description` from the saved query SO using the new exact `id` filter
- **Feature flag gating**: Old UI (`!queryHistoryRework`) retains the original "Save for later" button on the Run Query form; new UI removes it and uses the detail page instead
- **Saved queries find endpoint**: Added `id` query param for exact-match filtering by custom query id (the action document stores the custom id, not the SO uuid)
- **Saved queries list**: Renamed button from "Save query" to "Create query"
- **Type fix**: Added missing `timeout` field to `PackQueriesQuery` interface

## Test plan

- [ ] Old UI (flag off): "Save for later" still works on Run Query form
- [ ] New UI (flag on): "Save query" button appears on detail page next to "Add to case" / "Add tags"
- [ ] Clicking "Save query" opens flyout with query, ecs_mapping, timeout pre-filled
- [ ] When run from a saved query, flyout also pre-fills platform/version/interval/description
- [ ] Button hidden for pack-based actions
- [ ] Button hidden for users without `writeSavedQueries` permission
- [ ] Saved queries list shows "Create query" instead of "Save query"
- [ ] Existing Cypress tests pass (old UI "Save for later" flow unchanged)
- [ ] Find endpoint: `?id=exact-name` returns only the matching saved query
- [ ] Find endpoint: `?search=prefix` still works as before (prefix match on id + description)
