### PR TITLE
[Alerting v2] Disable sorting drop down in rules list page

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -50,6 +50,12 @@ const overflowTooltipStyle = css`
   line-height: 0;
 `;
 
+const rulesListTableWithoutHeaderSortIconsStyle = css`
+  .euiTableSortIcon {
+    display: none;
+  }
+`;
+
 const descriptionTextStyle = css`
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -580,6 +586,7 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
       <EuiSpacer size="s" />
       <EuiHorizontalRule margin="none" style={{ height: 2 }} />
       <EuiBasicTable
+        css={rulesListTableWithoutHeaderSortIconsStyle}
         items={items}
         itemId="id"
         columns={columns}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.tsx
@@ -24,6 +24,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  useEuiTheme,
   type Criteria,
   type EuiBasicTableColumn,
 } from '@elastic/eui';
@@ -48,12 +49,6 @@ const labelBadgeStyle = css`
 const overflowTooltipStyle = css`
   flex-shrink: 0;
   line-height: 0;
-`;
-
-const rulesListTableWithoutHeaderSortIconsStyle = css`
-  .euiTableSortIcon {
-    display: none;
-  }
 `;
 
 const descriptionTextStyle = css`
@@ -230,6 +225,19 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
   onToggleEnabled,
   onTableChange,
 }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const hideMobileSortMenuOnWideScreensStyle = useMemo(
+    () => css`
+      @media (min-width: ${euiTheme.breakpoint.m}px) {
+        .euiTableSortMobile {
+          display: none;
+        }
+      }
+    `,
+    [euiTheme.breakpoint.m]
+  );
+
   const [isBulkActionsOpen, setIsBulkActionsOpen] = useState(false);
 
   const handleBulkEnable = () => {
@@ -586,7 +594,7 @@ export const RulesListTable: React.FC<RulesListTableProps> = ({
       <EuiSpacer size="s" />
       <EuiHorizontalRule margin="none" style={{ height: 2 }} />
       <EuiBasicTable
-        css={rulesListTableWithoutHeaderSortIconsStyle}
+        css={hideMobileSortMenuOnWideScreensStyle}
         items={items}
         itemId="id"
         columns={columns}


### PR DESCRIPTION
Removes the 'Sorting' drop down above the rules table on the Alerting v2 Rules list page. Sorting is unchanged: users still sort by clicking the column header.

**Changes**
- Applied scoped Emotion styles on the rules list `EuiBasicTable` that set `.euiTableSortMobile { display: none; } `inside `@media (min-width: ${euiTheme.breakpoint.m}px)`, using `useEuiTheme()` so the cutoff stays aligned with the active EUI theme.
- Below 'm' breakpoint, the rule does not apply, so the Sorting dropdown remains available on mobile.

**Testing**
1. `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_table.test.tsx`
`node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/pages/rules_list_page/rules_list_page.test.tsx` passed.
2. Manual testing on alerting v2 Rules list page.

<img width="1264" height="334" alt="image" src="https://github.com/user-attachments/assets/94b8acaa-2bf2-48e2-9f0f-3a4b333b48f0" />

