### PR TITLE
[Automatic Import] Improve KV prompts, add null guidance and field mapping state

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/prompts.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/prompts.ts
@@ -119,6 +119,14 @@ Classify the log format:
 - **Key-Value**: Structured as key=value pairs with delimiters
   - Assess: are KV pairs 100% consistent across all samples, or variable?
   - If variable: what determines which keys appear?
+  - **Separator analysis** (critical for pipeline quality):
+    - What character(s) separate one KV pair from the next (field separator)? Usually space, tab, comma, or semicolon.
+    - What character(s) separate key from value (value separator)? Usually \`=\` or \`:\`.
+    - Are values ever quoted? (e.g. \`msg="Connection Closed"\`, \`time="2022-05-16 15:22:26 UTC"\`). If yes, note the quoting style (double quotes, single quotes, brackets).
+    - **Does the field separator appear inside quoted values?** (e.g. spaces inside \`time="2022-05-16 15:22:26 UTC"\`). This is a critical edge case — note it explicitly as the pipeline generator will need regex lookaheads or \`strip_brackets\` to handle it.
+    - Are there any keys or values that contain the separator characters? (e.g. dotted keys like \`src.ip=...\`, values with \`=\` in them).
+    - Is there a prefix/header before the KV pairs (e.g. syslog priority \`<134>\`, timestamp) that must be stripped first?
+  - Provide concrete examples of the separator patterns observed.
 - **CEF**: Common Event Format (fixed header with pipe separators + KV extension)
 - **LEEF**: Log Event Extended Format (similar structure to CEF)
 - **Unstructured**: Free-form text without consistent structural patterns
@@ -215,6 +223,12 @@ Provide analysis in this exact structure:
 ### Delimiters
 - Primary delimiter: [specify]
 - Field separators: [specify]
+- For KV formats:
+  - Field separator (between pairs): [e.g. space, tab, comma]
+  - Value separator (key from value): [e.g. =, :]
+  - Quoting style: [e.g. double-quoted values, none]
+  - Field separator inside quoted values: [yes/no — if yes, give example]
+  - Prefix/header before KV body: [e.g. syslog priority <NNN>, or none]
 
 ### Special Patterns
 - Timestamps: [format and location]
@@ -412,10 +426,29 @@ If \`<review_feedback>\` is present, you are in review-iteration mode:
 - Use for: Logs with structural variants, optional segments, or mixed formats
 - Config: \`{ "grok": { "field": "event.original", "patterns": [...] } }\`
 - Best practices: anchor with ^/$, avoid GREEDYDATA except at end, order patterns most-common first
+- **Extracting body for downstream processors**: When logs have a structured header (e.g. syslog priority, timestamp) followed by a KV or structured body, use grok to separate them. Capture the body into a temporary field (e.g. \`_tmp.kv_body\`) and then apply kv/dissect on that field. Always verify grok output with \`test_pipeline verbose=true\` — the verbose output shows the full document state after each processor, so you can confirm the capture is correct before adding downstream processors.
+- **Named captures produce nested fields**: \`%{PATTERN:_tmp.field_name}\` creates a nested object \`_tmp: { field_name: ... }\`, not a dotted key. Downstream processors can reference it as \`_tmp.field_name\`.
+- **Debugging**: If a downstream processor fails on a grok-extracted field, use \`test_pipeline\` with \`verbose=true\` to inspect the actual document after the grok step — this shows the real field values and structure, not just field names.
 
 ### kv
 - Use for: key=value logs with consistent delimiters
-- Config: \`{ "kv": { "field": "...", "field_split": " ", "value_split": "=" } }\`
+- Config: \`{ "kv": { "field": "...", "field_split": " ", "value_split": "=", "target_field": "_tmp" } }\`
+- Key parameters:
+  - \`field_split\` (required): Regex pattern to split between key-value pairs. Common: \`" "\` for space-separated, \`"\\\\t"\` for tab, \`","\` for comma.
+  - \`value_split\` (required): Regex pattern to split key from value. Common: \`"="\`, \`":"\`.
+  - \`target_field\`: Write parsed fields under this prefix (e.g. \`"_tmp"\`) instead of document root. Strongly recommended to avoid polluting root.
+  - \`trim_key\`: Characters to trim from extracted keys (e.g. \`" "\` to strip leading/trailing spaces from keys).
+  - \`trim_value\`: Characters to trim from extracted values (e.g. \`" \\\\t"\` to strip spaces/tabs).
+  - \`strip_brackets\`: If \`true\`, strips \`()\`, \`<>\`, \`[]\` and quotes \`'\` \`"\` from extracted values. Essential when values are quoted (e.g. \`msg="Connection Closed"\`).
+  - \`include_keys\` / \`exclude_keys\`: Filter which keys are kept.
+  - \`prefix\`: Prefix prepended to all extracted key names.
+- **Regex in field_split / value_split**: These are full regex patterns. Use lookahead/lookbehind for complex separators:
+  - When values can contain the field separator (e.g. quoted values with spaces): use \`strip_brackets: true\` and \`field_split\` with a lookahead like \`"(?<=[^=])\\\\s(?=[a-zA-Z_]+=)"\` to only split on spaces followed by a key=value pattern.
+  - When value_split characters appear inside values: use a lookbehind like \`"(?<![\\\\w])="\` or restructure the parse.
+- **Common pitfall — quoted values**: If values contain the field_split character inside quotes (e.g. \`time="2022-05-16 15:22:26 UTC"\`), a simple \`field_split: " "\` will split mid-value. Fix with one of:
+  1. \`strip_brackets: true\` + regex field_split that requires the next token to look like a key: \`"field_split": "(?<=\\") |(?<=[^\\"])\\\\s+(?=[\\\\w.]+=)"\`
+  2. Pre-extract the structured body with grok into a clean field, then apply kv on that field.
+- **Nested field access**: The kv processor accesses \`field\` using dot-notation (e.g. \`"field": "_tmp.kv_body"\`). This works for nested fields — but only if the parent object exists. If unsure, use a top-level field name instead.
 
 ### csv
 - Use for: Comma/tab-separated data with a known column order
@@ -449,7 +482,18 @@ The pipeline follows this exact processor order. Items marked [PRE-SEEDED] are a
 9. **ECS append/set processors** — event.action, event.type, event.category (conditional \`if\` clauses), and related.* field population.
    - **related.* fields** (\`related.ip\`, \`related.user\`, \`related.hosts\`, \`related.hash\`): Use one \`append\` processor per source field, each with \`allow_duplicates: false\` and \`ignore_missing: true\`. Do NOT combine multiple source fields into a single append — each source field gets its own append processor targeting the appropriate related field. Example: if \`source.ip\` and \`destination.ip\` both need to go into \`related.ip\`, create two separate append processors.
 10. **Cleanup remove** — Remove temporary/intermediate fields at the end.
-11. [PRE-SEEDED] **Top-level \`on_failure\`** — Already configured. Do NOT modify.
+11. **Drop null/empty values** — Always add this as the LAST processor (after cleanup, before on_failure). Use this exact script processor — do NOT modify it:
+    \`\`\`json
+    {
+      "script": {
+        "tag": "script_to_drop_null_values",
+        "lang": "painless",
+        "description": "Drops null/empty values recursively.",
+        "source": "boolean drop(Object object) { if (object == null || object == '') { return true; } else if (object instanceof Map) { ((Map) object).values().removeIf(v -> drop(v)); return (((Map) object).size() == 0); } else if (object instanceof List) { ((List) object).removeIf(v -> drop(v)); return (((List) object).length == 0); } return false; } drop(ctx);"
+      }
+    }
+    \`\`\`
+12. [PRE-SEEDED] **Top-level \`on_failure\`** — Already configured. Do NOT modify.
 </pipeline_structure>
 
 <mandatory_rules>
@@ -532,8 +576,11 @@ Account for edge cases from the analysis:
 - Variable whitespace
 - Multiple message variants via pattern arrays
 
+## Before validation: add the drop-null script
+Once your pipeline is working and all processors are in place, insert the \`script_to_drop_null_values\` processor as the **last** processor (after cleanup remove, before on_failure). Use the exact script from the pipeline structure section — do not modify it. This cleans up null and empty values from the final document.
+
 ## Final step: validate_pipeline
-When the pipeline matches the analysis and the TOC looks correct, call \`validate_pipeline\` (no arguments). It runs simulation on **all** samples and **persists** results to state. You MUST call it before responding.
+When the pipeline matches the analysis, the TOC looks correct, and the drop-null script is in place, call \`validate_pipeline\` (no arguments). It runs simulation on **all** samples and **persists** results to state. You MUST call it before responding.
 
 - Address failures using indices from injected pipeline / compact TOC + \`modify_pipeline\`, then \`validate_pipeline\` again (\`fetch_pipeline\` only if JSON is missing from context)
 - Fix all ECS warnings and field naming errors — they are authoritative
@@ -579,7 +626,7 @@ The pipeline and samples have already been validated against ECS by \`validate_p
 <tools>
 - **fetch_pipeline**: Retrieves the current pipeline from state if it was not injected. Supports optional start_index/end_index to fetch specific processor ranges.
 - **get_ecs_info**: Looks up ECS field definitions. Prefer \`field_paths\` for specific fields you need to verify (e.g. \`["source.ip", "event.action"]\`). Only use \`root_fields\` when you genuinely do not know which children exist under a root group — each root field returns all direct children, which can be very token-heavy. Batch all lookups into a single call.
-- **submit_review**: MUST be called as your final action. Pass your full review (all issues, details, and recommendations) as \`full_review\` and a concise summary (PASSED/FAILED, issue count, severity, which agent should fix) as \`summary\`. The full review is stored in shared state; the summary is returned to the orchestrator.
+- **submit_review**: MUST be called as your final action. Pass your full review (all issues, details, and recommendations) as \`content\` and a concise summary (PASSED/FAILED, issue count, severity, which agent should fix) as \`summary\`. When the review PASSES, you MUST also provide \`field_mappings\` — see the field mappings section below. The full review is stored in shared state; the summary is returned to the orchestrator.
 </tools>
 
 <review_checklist>
@@ -590,7 +637,8 @@ The pipeline and samples have already been validated against ECS by \`validate_p
 - Parsing processors operate on \`event.original\`, NOT \`message\`
 - Has the mandatory top-level \`on_failure\` handler (sets event.kind to pipeline_error, appends to error.message with processor type/tag/pipeline/message, appends preserve_original_event to tags)
 - No duplicate processors doing the same work
-- Processors in logical order (ecs.version → message rename/remove → parse event.original → convert → rename → event.kind → append → cleanup → on_failure)
+- Processors in logical order (ecs.version → message rename/remove → parse event.original → convert → rename → event.kind → append → cleanup → drop-null script → on_failure)
+- The \`script_to_drop_null_values\` processor is present as the last processor before on_failure
 - Every processor has a unique \`tag\` field
 
 ### 2. Parsing Quality
@@ -639,10 +687,51 @@ The pipeline and samples have already been validated against ECS by \`validate_p
 - \`ctx['dotted.key']\` bracket notation in Painless creates literal dotted keys instead of nested structures — this is a critical bug that causes pipeline failures
 </review_checklist>
 
+<field_mappings>
+When your review PASSES, you MUST provide \`field_mappings\` in your \`submit_review\` call. This maps the custom-namespaced fields to their Elasticsearch field types for index template generation.
+
+### What to include
+- ONLY fields under the custom namespace \`<integration>.<datastream>.*\` (e.g. \`sonicwall.firewall.pri\`, \`sonicwall.firewall.sess\`)
+- Base your mappings on the **post-processed document output** (the successful simulation results in your context), NOT the raw log samples
+
+### What to exclude
+- ALL ECS fields (\`source.ip\`, \`event.action\`, \`user.name\`, etc.)
+- \`@timestamp\` (ECS field, always mapped automatically)
+- \`event.original\`, \`ecs.version\`, \`tags\`, \`error.*\` (pipeline infrastructure fields)
+- Any \`related.*\` fields (\`related.ip\`, \`related.user\`, etc.)
+- Fields outside the \`<integration>.<datastream>.*\` namespace
+
+### Type rules
+Only these four types are allowed:
+- \`"keyword"\` — for string values (actions, names, identifiers, status codes, etc.)
+- \`"long"\` — for numeric values (counts, ports, sizes, IDs that are numbers)
+- \`"ip"\` — for IP address values (IPv4 or IPv6)
+- \`"date"\` — for date/time values that are stored as date strings (only if a date processor targets this field)
+
+### Example
+If the post-processed document contains:
+\`\`\`json
+{
+  "sonicwall": {
+    "firewall": {
+      "pri": 6,
+      "sess": "Web",
+      "m": 537,
+      "fw": "10.0.0.96",
+      "sn": "0040103CE114"
+    }
+  }
+}
+\`\`\`
+Then field_mappings would be:
+\`[{"name": "sonicwall.firewall.pri", "type": "long"}, {"name": "sonicwall.firewall.sess", "type": "keyword"}, {"name": "sonicwall.firewall.m", "type": "long"}, {"name": "sonicwall.firewall.fw", "type": "ip"}, {"name": "sonicwall.firewall.sn", "type": "keyword"}]\`
+</field_mappings>
+
 <output_format>
 After completing your review, call \`submit_review\` with:
-- \`full_review\`: Your complete review including all issues, details, specific processor references, and recommendations
+- \`content\`: Your complete review including all issues, details, specific processor references, and recommendations
 - \`summary\`: A concise summary following the format below
+- \`field_mappings\`: (PASS only) Array of custom field mappings — see the field mappings section above
 
 ### Summary format on Success
 "REVIEW PASSED. Pipeline is valid and ECS-compliant. [brief summary: format parsed, success rate, key ECS fields mapped]"

--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/state.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/state.ts
@@ -22,6 +22,14 @@ export interface PipelineValidationResults {
   failure_details: PipelineValidationFailureDetail[];
 }
 
+export const FIELD_MAPPING_TYPES = ['keyword', 'long', 'ip', 'date'] as const;
+export type FieldMappingType = (typeof FIELD_MAPPING_TYPES)[number];
+
+export interface FieldMapping {
+  name: string;
+  type: FieldMappingType;
+}
+
 const lastValueReducer = <T>(_: T, right: T): T => right;
 
 export const AutomaticImportAgentState = Annotation.Root({
@@ -58,6 +66,10 @@ export const AutomaticImportAgentState = Annotation.Root({
   review: Annotation<string>({
     reducer: lastValueReducer,
     default: () => '',
+  }),
+  field_mappings: Annotation<FieldMapping[]>({
+    reducer: lastValueReducer,
+    default: () => [],
   }),
 });
 

--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/sub_agents/sub_agent.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/sub_agents/sub_agent.ts
@@ -62,12 +62,22 @@ const buildAnalyzerContext: ContextBuilder = (taskDescription, _state, samples) 
   );
 };
 
-const buildGeneratorContext: ContextBuilder = (taskDescription, state) => {
+const buildGeneratorContext: ContextBuilder = (taskDescription, state, samples) => {
   const isReviewIteration = Boolean(state.review);
   const parts: string[] = ['<task>', taskDescription, '</task>'];
 
   if (!isReviewIteration && state.analysis) {
     parts.push('', '<log_format_analysis>', state.analysis, '</log_format_analysis>');
+  }
+
+  if (!isReviewIteration && samples && samples.length > 0) {
+    const slice = samples.slice(0, MAX_INJECTED_SAMPLES);
+    parts.push(
+      '',
+      `<log_samples count="${slice.length}" total_available="${samples.length}">`,
+      slice.map((s, i) => `### Sample ${i + 1}\n\`\`\`\n${s}\n\`\`\``).join('\n\n'),
+      '</log_samples>'
+    );
   }
 
   if (isReviewIteration && state.review) {
@@ -273,6 +283,7 @@ export const createTaskTool = (params: TaskToolParams) => {
           'pipeline_generation_results',
           'pipeline_validation_results',
           'failure_count',
+          'field_mappings',
         ] as const;
         for (const field of propagatedFields) {
           if (parentState[field] != null) {

--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/submit_review.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/submit_review.ts
@@ -14,7 +14,9 @@ import type { CallbackManagerForToolRun } from '@langchain/core/callbacks/manage
 import { FIELD_MAPPING_TYPES } from '../state';
 
 const fieldMappingSchema = z.object({
-  name: z.string().describe('Flattened dot-notation path to the field (e.g. "myintegration.myds.src_port")'),
+  name: z
+    .string()
+    .describe('Flattened dot-notation path to the field (e.g. "myintegration.myds.src_port")'),
   type: z
     .enum(FIELD_MAPPING_TYPES)
     .describe(
@@ -24,7 +26,9 @@ const fieldMappingSchema = z.object({
 
 export const submitReviewTool = (): DynamicStructuredTool => {
   const schema = z.object({
-    content: z.string().describe('The complete review with all issues, details, and recommendations'),
+    content: z
+      .string()
+      .describe('The complete review with all issues, details, and recommendations'),
     summary: z
       .string()
       .describe(

--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/submit_review.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/submit_review.ts
@@ -5,19 +5,74 @@
  * 2.0.
  */
 
-import type { DynamicStructuredTool } from '@langchain/core/tools';
-import { createSubmitTool } from './submit_analysis';
+import type { ToolRunnableConfig } from '@langchain/core/tools';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { Command } from '@langchain/langgraph';
+import { ToolMessage } from '@langchain/core/messages';
+import { z } from '@kbn/zod/v4';
+import type { CallbackManagerForToolRun } from '@langchain/core/callbacks/manager';
+import { FIELD_MAPPING_TYPES } from '../state';
 
-export const submitReviewTool = (): DynamicStructuredTool =>
-  createSubmitTool({
+const fieldMappingSchema = z.object({
+  name: z.string().describe('Flattened dot-notation path to the field (e.g. "myintegration.myds.src_port")'),
+  type: z
+    .enum(FIELD_MAPPING_TYPES)
+    .describe(
+      'Elasticsearch field type: "keyword" for strings, "long" for numbers, "ip" for IP addresses, "date" for date values'
+    ),
+});
+
+export const submitReviewTool = (): DynamicStructuredTool => {
+  const schema = z.object({
+    content: z.string().describe('The complete review with all issues, details, and recommendations'),
+    summary: z
+      .string()
+      .describe(
+        'A concise summary: PASSED or FAILED, number of issues, severity, and which agent should address them'
+      ),
+    field_mappings: z
+      .array(fieldMappingSchema)
+      .optional()
+      .describe(
+        'Field mappings for custom (non-ECS) fields only — fields under <integration>.<datastream>.*. ' +
+          'Required when review PASSES. Each entry maps a flattened field path to its Elasticsearch type. ' +
+          'Only use types: "keyword" (strings), "long" (numbers), "ip" (IP addresses), "date" (dates). ' +
+          'Do NOT include ECS fields, @timestamp, or fields outside the custom namespace.'
+      ),
+  });
+
+  return new DynamicStructuredTool({
     name: 'submit_review',
     description:
       'Submit your completed review. Stores the full review in shared state and returns ' +
-      'a summary to the orchestrator. ' +
+      'a summary to the orchestrator. When the review PASSES, you MUST also provide ' +
+      'field_mappings for all custom-namespaced fields. ' +
       'You MUST call this as your final action after completing your review.',
-    stateField: 'review',
-    contentLabel: 'Review',
-    contentDescription: 'The complete review with all issues, details, and recommendations',
-    summaryDescription:
-      'A concise summary: PASSED or FAILED, number of issues, severity, and which agent should address them',
+    schema,
+    func: async (
+      input: z.infer<typeof schema>,
+      _runManager?: CallbackManagerForToolRun,
+      toolConfig?: ToolRunnableConfig
+    ) => {
+      const update: Record<string, unknown> = {
+        review: input.content,
+      };
+
+      if (input.field_mappings && input.field_mappings.length > 0) {
+        update.field_mappings = input.field_mappings;
+      }
+
+      return new Command({
+        update: {
+          ...update,
+          messages: [
+            new ToolMessage({
+              content: `Review stored. Summary: ${input.summary}`,
+              tool_call_id: toolConfig?.toolCall?.id ?? '',
+            }),
+          ],
+        },
+      });
+    },
   });
+};

--- a/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/test_pipeline.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/agents/tools/test_pipeline.ts
@@ -31,6 +31,12 @@ interface TestPipelineToolOptions {
   samples: string[];
 }
 
+const indentJson = (obj: Record<string, unknown>, indent: string): string =>
+  JSON.stringify(obj, null, 2)
+    .split('\n')
+    .map((line) => `${indent}${line}`)
+    .join('\n');
+
 const formatVerboseResults = (
   processorResults: estypes.IngestPipelineProcessorResult[]
 ): string => {
@@ -57,15 +63,9 @@ const formatVerboseResults = (
       const src = pr.doc?._source as Record<string, unknown> | undefined;
       if (src) {
         const stripped = stripBoilerplateFields(src);
-        const allKeys = Object.keys(stripped);
-        const shown = allKeys.slice(0, 10);
-        if (shown.length > 0) {
-          lines.push(
-            `        output fields: ${shown.join(', ')}${
-              allKeys.length > 10 ? ` (+${allKeys.length - 10} more)` : ''
-            }`
-          );
-        }
+        const label = isLastBeforeFailure ? 'document before failure' : 'final document';
+        lines.push(`        ${label}:`);
+        lines.push(indentJson(stripped, '          '));
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds much needed improvements to KV, as it initially assumed just basic functionality and not actual regex features (lookaheads, lookbacks etc etc).
Adds guidance we usually have on most integrations to filter out null fields.
Adds a general field mapping guidance report from review agent once review passes to include date and IP types mainly for our non-ecs fields, to improve the resulting mapping types for date and IP.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.




