### PR TITLE
[Agent Builder] Add line break for br elements in round input display

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/command_badge/command_badge_serializer.test.ts
@@ -86,6 +86,34 @@ describe('serializeEditorContent', () => {
     expect(serializeEditorContent(div)).toBe('[/Test](skill://skill-1?type=security)');
   });
 
+  it('preserves line breaks from <br> elements', () => {
+    const div = document.createElement('div');
+    div.appendChild(document.createTextNode('Hi can you tell'));
+    div.appendChild(document.createElement('br'));
+    div.appendChild(document.createTextNode('me the'));
+    div.appendChild(document.createElement('br'));
+    div.appendChild(document.createTextNode('wheather ?'));
+
+    expect(serializeEditorContent(div)).toBe('Hi can you tell\nme the\nwheather ?');
+  });
+
+  it('preserves line breaks adjacent to badges', () => {
+    const div = document.createElement('div');
+    div.appendChild(document.createTextNode('Use '));
+    div.appendChild(
+      createCommandBadgeElement({
+        commandId: CommandId.Skill,
+        label: 'Summarize',
+        id: 'skill-1',
+        metadata: {},
+      })
+    );
+    div.appendChild(document.createElement('br'));
+    div.appendChild(document.createTextNode('on this'));
+
+    expect(serializeEditorContent(div)).toBe('Use [/Summarize](skill://skill-1)\non this');
+  });
+
   it('serializes an SML badge element', () => {
     const div = document.createElement('div');
     const badge = createCommandBadgeElement({

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MessageEditor } from './message_editor';
+import { MessageEditor, createTextFragment } from './message_editor';
 import type { MessageEditorController, MessageEditorInstance } from './use_message_editor';
 import { CommandId } from './command_menu';
 import type {
@@ -76,6 +76,48 @@ const createMockMessageEditor = (): {
     },
   };
 };
+
+describe('createTextFragment', () => {
+  it('preserves line breaks as <br> elements', () => {
+    const text = [
+      'Create ES|QL SIEM detection rule (name, description, data sources, detection logic, severity, risk score, schedule, tags, and MITRE ATT&CK mappings) using dedicated detection rule creation tool. Always render inline the latest version of the rule attachment.',
+      '',
+      'You can review and edit everything before enabling the rule. ',
+      'Desired behavior or activity to detect:',
+      '',
+      '==== YOUR DESCRIPTION HERE====',
+    ].join('\n');
+
+    const fragment = createTextFragment(text);
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+
+    expect(container.querySelectorAll('br').length).toBe(5);
+    expect(container.textContent).toContain('Create ES|QL SIEM detection rule');
+    expect(container.textContent).toContain('Always render inline the latest version');
+    expect(container.textContent).toContain('You can review and edit everything');
+    expect(container.textContent).toContain('Desired behavior or activity to detect:');
+    expect(container.textContent).toContain('==== YOUR DESCRIPTION HERE====');
+  });
+
+  it('returns a single text node for text with no newlines', () => {
+    const fragment = createTextFragment('hello world');
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+
+    expect(container.querySelectorAll('br').length).toBe(0);
+    expect(container.textContent).toBe('hello world');
+  });
+
+  it('handles empty string', () => {
+    const fragment = createTextFragment('');
+    const container = document.createElement('div');
+    container.appendChild(fragment);
+
+    expect(container.querySelectorAll('br').length).toBe(0);
+    expect(container.textContent).toBe('');
+  });
+});
 
 describe('MessageEditor', () => {
   beforeEach(() => {
@@ -280,6 +322,46 @@ describe('MessageEditor', () => {
     );
 
     expect(screen.getByTestId('commandMenuPopover-content')).toBeInTheDocument();
+  });
+
+  it('preserves line breaks when pasting plain text', () => {
+    const { messageEditor } = createMockMessageEditor();
+    render(
+      <MessageEditor
+        messageEditor={messageEditor}
+        onSubmit={mockOnSubmit}
+        data-test-subj="messageEditor"
+      />
+    );
+
+    const editor = screen.getByTestId('messageEditor');
+
+    editor.focus();
+    const range = document.createRange();
+    range.setStart(editor, 0);
+    range.collapse(true);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    const text = [
+      'Create ES|QL SIEM detection rule (name, description, data sources, detection logic, severity, risk score, schedule, tags, and MITRE ATT&CK mappings) using dedicated detection rule creation tool. Always render inline the latest version of the rule attachment.',
+      '',
+      'You can review and edit everything before enabling the rule. ',
+      'Desired behavior or activity to detect:',
+      '',
+      '==== YOUR DESCRIPTION HERE====',
+    ].join('\n');
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) => (type === 'text/plain' ? text : ''),
+      },
+    });
+
+    expect(editor.querySelectorAll('br').length).toBe(5);
+    expect(editor.textContent).toContain('Create ES|QL SIEM detection rule');
+    expect(editor.textContent).toContain('==== YOUR DESCRIPTION HERE====');
   });
 
   it('calls handleCommandSelect when a menu option is clicked', () => {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.test.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MessageEditor, createTextFragment } from './message_editor';
+import { MessageEditor } from './message_editor';
+import { createTextFragment } from './utils';
 import type { MessageEditorController, MessageEditorInstance } from './use_message_editor';
 import { CommandId } from './command_menu';
 import type {

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
@@ -65,9 +65,27 @@ const fragmentContainsBadge = (fragment?: DocumentFragment): boolean => {
 };
 
 /**
+ * Converts a plain text string into a DocumentFragment, preserving line breaks
+ * as <br> elements. Text nodes alone cannot render \n in a contenteditable div.
+ */
+export const createTextFragment = (text: string): DocumentFragment => {
+  const fragment = document.createDocumentFragment();
+  const parts = text.split('\n');
+  parts.forEach((part, i) => {
+    if (part) {
+      fragment.appendChild(document.createTextNode(part));
+    }
+    if (i < parts.length - 1) {
+      fragment.appendChild(document.createElement('br'));
+    }
+  });
+  return fragment;
+};
+
+/**
  * Sanitizes pasted HTML to only allow badge spans.
  * Uses DOMParser to safely parse HTML, then walks its children,
- * keeping only badge spans and text nodes.
+ * keeping only badge spans, <br> elements, and text nodes.
  */
 const sanitizeHtmlIncludeOnlyTextAndBadges = (html: string): DocumentFragment => {
   const parser = new DOMParser();
@@ -82,6 +100,8 @@ const sanitizeHtmlIncludeOnlyTextAndBadges = (html: string): DocumentFragment =>
       if (isElementCommandBadge(element)) {
         // Clone the badge span
         fragment.appendChild(element.cloneNode(true));
+      } else if (element.tagName === 'BR') {
+        fragment.appendChild(document.createElement('br'));
       } else {
         // Strip other HTML, keep text content
         fragment.appendChild(document.createTextNode(element.textContent ?? ''));
@@ -207,7 +227,7 @@ export const MessageEditor: React.FC<MessageEditorProps> = ({
           const hasBadgeHtml = htmlData && stringContainsBadge(htmlData);
           const node = hasBadgeHtml
             ? sanitizeHtmlIncludeOnlyTextAndBadges(htmlData)
-            : document.createTextNode(textData);
+            : createTextFragment(textData);
 
           insertNodeAtCursor(node);
 

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/message_editor.tsx
@@ -25,7 +25,7 @@ import {
   isElementCommandBadge,
 } from './command_badge';
 import { serializeEditorContent } from './serialize';
-import { getSelectionRange, insertNodeAtCursor } from './utils';
+import { createTextFragment, getSelectionRange, insertNodeAtCursor } from './utils';
 
 const EDITOR_MAX_HEIGHT = 240;
 
@@ -62,24 +62,6 @@ const fragmentContainsBadge = (fragment?: DocumentFragment): boolean => {
     return false;
   }
   return fragment.querySelector(`[${COMMAND_BADGE_ATTRIBUTE}]`) !== null;
-};
-
-/**
- * Converts a plain text string into a DocumentFragment, preserving line breaks
- * as <br> elements. Text nodes alone cannot render \n in a contenteditable div.
- */
-export const createTextFragment = (text: string): DocumentFragment => {
-  const fragment = document.createDocumentFragment();
-  const parts = text.split('\n');
-  parts.forEach((part, i) => {
-    if (part) {
-      fragment.appendChild(document.createTextNode(part));
-    }
-    if (i < parts.length - 1) {
-      fragment.appendChild(document.createElement('br'));
-    }
-  });
-  return fragment;
 };
 
 /**

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/serialize.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/serialize.ts
@@ -27,8 +27,10 @@ export const serializeEditorContent = (editorElement: HTMLElement): string => {
     const element = node as HTMLElement;
     if (isElementCommandBadge(element)) {
       result += serializeCommandBadge(element);
+    } else if (element.tagName === 'BR') {
+      result += '\n';
     } else {
-      // For any other elements (e.g., <br>), append their text content
+      // For any other elements, append their text content
       result += element.textContent ?? '';
     }
   }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
@@ -11,7 +11,13 @@ import type { CommandMatchResult, CommandBadgeData } from './command_menu';
 import { useCommandMenu, useCommandMenuPrefetch } from './command_menu';
 import { createCommandBadgeElement, deserializeCommandBadge } from './command_badge';
 import { serializeEditorContent } from './serialize';
-import { createCommandRange, insertSpaceAfter, placeCursorAfter, placeCursorAtEnd } from './utils';
+import {
+  createCommandRange,
+  createTextFragment,
+  insertSpaceAfter,
+  placeCursorAfter,
+  placeCursorAtEnd,
+} from './utils';
 
 export interface MessageEditorInstance {
   ref: React.RefObject<HTMLDivElement>;
@@ -154,15 +160,7 @@ const useMessageEditorController = ({
 
         for (const segment of segments) {
           if (segment.type === 'text') {
-            const parts = segment.value.split('\n');
-            parts.forEach((part, i) => {
-              if (part) {
-                ref.current!.appendChild(document.createTextNode(part));
-              }
-              if (i < parts.length - 1) {
-                ref.current!.appendChild(document.createElement('br'));
-              }
-            });
+            ref.current.appendChild(createTextFragment(segment.value));
           } else if (segment.type === 'badge') {
             ref.current.appendChild(createCommandBadgeElement(segment.data));
           }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/use_message_editor.ts
@@ -154,7 +154,15 @@ const useMessageEditorController = ({
 
         for (const segment of segments) {
           if (segment.type === 'text') {
-            ref.current.appendChild(document.createTextNode(segment.value));
+            const parts = segment.value.split('\n');
+            parts.forEach((part, i) => {
+              if (part) {
+                ref.current!.appendChild(document.createTextNode(part));
+              }
+              if (i < parts.length - 1) {
+                ref.current!.appendChild(document.createElement('br'));
+              }
+            });
           } else if (segment.type === 'badge') {
             ref.current.appendChild(createCommandBadgeElement(segment.data));
           }

--- a/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/public/application/components/conversations/conversation_input/message_editor/utils.ts
@@ -9,6 +9,24 @@ import { charOffsetToDomPosition } from './command_badge';
 import type { ActiveCommand } from './command_menu';
 
 /**
+ * Converts a plain text string into a DocumentFragment, preserving line breaks
+ * as <br> elements. Text nodes alone cannot render \n in a contenteditable div.
+ */
+export const createTextFragment = (text: string): DocumentFragment => {
+  const fragment = document.createDocumentFragment();
+  const parts = text.split('\n');
+  parts.forEach((part, i) => {
+    if (part) {
+      fragment.appendChild(document.createTextNode(part));
+    }
+    if (i < parts.length - 1) {
+      fragment.appendChild(document.createElement('br'));
+    }
+  });
+  return fragment;
+};
+
+/**
  * Creates a DOM Range spanning the full command text (sequence + query)
  * within the editor, e.g. the range covering "/summ" in "hello /summ".
  */


### PR DESCRIPTION
## Summary

Three bugs, same root cause: line breaks not preserved in the message editor pipeline.

- `serialize.ts` — `serializeEditorContent` ignored `<br>` elements (empty textContent), so multi-line messages were serialized with words concatenated. Added explicit `<br>` → `\n` handling.

- `message_editor.tsx` — `onPaste` created a bare text node from pasted text; `\n` chars don't render as line breaks in `contenteditable`. Replaced with `createTextFragment()` which splits on `\n` and inserts `<br>` elements. Same fix applied to `sanitizeHtmlIncludeOnlyTextAndBadges` for HTML pastes.

- `use_message_editor.ts` — `setContent()` (pre-fills editor from initialMessage) had the same text-node problem. Applied the same `\n` → `<br>` split.

Before
<img width="738" height="256" alt="image" src="https://github.com/user-attachments/assets/10a42f85-6c2d-41a2-9e09-1dc7fa26acfc" />

After

https://github.com/user-attachments/assets/0c178cde-3dfa-47e1-83a6-7b2462579229




