### PR TITLE
[Chrome Next] Sidenav: renderContent, renderPopover, and customContent for ToolItem

### DIFF
--- a/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
+++ b/src/core/packages/chrome/feature-flags/chrome_next_toggle.tsx
@@ -11,7 +11,7 @@ import React, { useCallback } from 'react';
 import { EuiBadge, EuiToolTip } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { FeatureFlagsStart } from '@kbn/core-feature-flags-browser';
-import { isNextChrome, toggleNextChrome } from './index';
+import { isNextChrome, toggleNextChrome } from '.';
 
 const badgeStyles = css`
   cursor: pointer;
@@ -29,7 +29,9 @@ export const ChromeNextToggle: React.FC<ChromeNextToggleProps> = ({ featureFlags
   }, [featureFlags]);
 
   return (
-    <EuiToolTip content={`Click to ${isEnabled ? 'disable' : 'enable'} Vibranium chrome. Page will reload.`}>
+    <EuiToolTip
+      content={`Click to ${isEnabled ? 'disable' : 'enable'} Vibranium chrome. Page will reload.`}
+    >
       <EuiBadge
         color={isEnabled ? 'success' : 'danger'}
         css={badgeStyles}

--- a/src/core/packages/chrome/navigation/packaging/react/type_validation.ts
+++ b/src/core/packages/chrome/navigation/packaging/react/type_validation.ts
@@ -64,7 +64,16 @@ const _secondaryMenuSection: PackagedSecondaryMenuSection = {} as SourceSecondar
 const _sideNavLogo: PackagedSideNavLogo = {} as SourceSideNavLogo;
 
 type NormalizedSourceMenuItem = Omit<SourceMenuItem, 'iconType'> & { iconType: string };
-type NormalizedSourceToolItem = Omit<SourceToolItem, 'iconType'> & { iconType: string };
+
+type ToolItemStrippedFields = 'iconType' | 'renderContent' | 'renderPopover';
+
+type NormalizedSourceToolItem = Omit<SourceToolItem, ToolItemStrippedFields> & {
+  iconType?: string;
+};
+type NormalizedPackagedToolItem = Omit<PackagedToolItem, ToolItemStrippedFields> & {
+  iconType?: string;
+};
+
 type NormalizedSourceNavigationStructure = Omit<
   SourceNavigationStructure,
   'footerItems' | 'primaryItems'
@@ -76,10 +85,27 @@ type NormalizedSourceToolSlots = Omit<SourceToolSlots, 'headerTools' | 'footerTo
   headerTools?: NormalizedSourceToolItem[];
   footerTools?: NormalizedSourceToolItem[];
 };
+type NormalizedPackagedToolSlots = Omit<PackagedToolSlots, 'headerTools' | 'footerTools'> & {
+  headerTools?: NormalizedPackagedToolItem[];
+  footerTools?: NormalizedPackagedToolItem[];
+};
 
 const _menuItem: PackagedMenuItem = {} as NormalizedSourceMenuItem;
-const _toolItem: PackagedToolItem = {} as NormalizedSourceToolItem;
-const _toolSlots: PackagedToolSlots = {} as NormalizedSourceToolSlots;
+const _toolItemForward: NormalizedPackagedToolItem = {} as NormalizedSourceToolItem;
+const _toolItemReverse: NormalizedSourceToolItem = {} as NormalizedPackagedToolItem;
+
+type SourceRenderContentParam = Parameters<NonNullable<SourceToolItem['renderContent']>>[0];
+type PackagedRenderContentParam = Parameters<NonNullable<PackagedToolItem['renderContent']>>[0];
+const _renderContentParamForward: PackagedRenderContentParam = {} as SourceRenderContentParam;
+const _renderContentParamReverse: SourceRenderContentParam = {} as PackagedRenderContentParam;
+
+type SourceRenderPopoverParam = Parameters<NonNullable<SourceToolItem['renderPopover']>>[0];
+type PackagedRenderPopoverParam = Parameters<NonNullable<PackagedToolItem['renderPopover']>>[0];
+const _renderPopoverParamForward: PackagedRenderPopoverParam = {} as SourceRenderPopoverParam;
+const _renderPopoverParamReverse: SourceRenderPopoverParam = {} as PackagedRenderPopoverParam;
+
+const _toolSlotsForward: NormalizedPackagedToolSlots = {} as NormalizedSourceToolSlots;
+const _toolSlotsReverse: NormalizedSourceToolSlots = {} as NormalizedPackagedToolSlots;
 const _navigationStructure: PackagedNavigationStructure = {} as NormalizedSourceNavigationStructure;
 
 // `NavigationProps` validation — suppressed because `MenuItem.iconType` is
@@ -92,8 +118,14 @@ void _secondaryMenuItem;
 void _secondaryMenuSection;
 void _sideNavLogo;
 void _menuItem;
-void _toolItem;
-void _toolSlots;
+void _toolItemForward;
+void _toolItemReverse;
+void _renderContentParamForward;
+void _renderContentParamReverse;
+void _renderPopoverParamForward;
+void _renderPopoverParamReverse;
+void _toolSlotsForward;
+void _toolSlotsReverse;
 void _navigationStructure;
 void _navigationProps;
 

--- a/src/core/packages/chrome/navigation/packaging/react/types.ts
+++ b/src/core/packages/chrome/navigation/packaging/react/types.ts
@@ -76,11 +76,16 @@ export interface MenuItem {
 
 /**
  * A chrome tool control (search, help, etc.) — not a primary navigation destination.
+ *
+ * At least one of `iconType` or `renderContent` must be provided.
+ * When `renderPopover` is present, it takes precedence over `sections`.
  */
 export interface ToolItem {
   id: string;
   label: string;
-  iconType: string;
+  iconType?: string;
+  renderContent?: (state: { isCollapsed: boolean }) => ReactNode;
+  renderPopover?: (closePopover: () => void) => ReactNode;
   onClick?: () => void;
   sections?: SecondaryMenuSection[];
   badgeType?: BadgeType;

--- a/src/core/packages/chrome/navigation/src/__stories__/navigation.stories.tsx
+++ b/src/core/packages/chrome/navigation/src/__stories__/navigation.stories.tsx
@@ -9,7 +9,16 @@
 
 import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
-import { EuiSkipLink, useEuiTheme } from '@elastic/eui';
+import {
+  EuiAvatar,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiSkipLink,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { APP_MAIN_SCROLL_CONTAINER_ID } from '@kbn/core-chrome-layout-constants';
@@ -72,6 +81,151 @@ const CHROME_TOOLS: NonNullable<PropsAndArgs['tools']> = {
         {
           id: 'help-links',
           items: [{ id: 'documentation', label: 'Documentation', href: '/help/documentation' }],
+        },
+      ],
+    },
+  ],
+};
+
+const SpaceBadge = () => (
+  <span
+    css={css`
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      background-color: #f04e98;
+      color: #fff;
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1;
+    `}
+  >
+    D
+  </span>
+);
+
+const SPACES = [
+  { id: 'default', name: 'Default', color: '#f04e98', initial: 'D' },
+  { id: 'marketing', name: 'Marketing', color: '#00bfb3', initial: 'M' },
+  { id: 'engineering', name: 'Engineering', color: '#6092c0', initial: 'E' },
+  { id: 'sales', name: 'Sales', color: '#d6bf57', initial: 'S' },
+];
+
+const SpacePicker = ({ closePopover }: { closePopover: () => void }) => (
+  <EuiFlexGroup
+    direction="column"
+    gutterSize="none"
+    css={css`
+      padding: 12px;
+    `}
+  >
+    <EuiFlexItem>
+      <EuiText
+        size="xs"
+        css={css`
+          font-weight: 600;
+          margin-bottom: 8px;
+        `}
+      >
+        <p>Spaces</p>
+      </EuiText>
+    </EuiFlexItem>
+    {SPACES.map((space) => (
+      <EuiFlexItem key={space.id}>
+        <button
+          type="button"
+          onClick={closePopover}
+          css={css`
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 4px;
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            width: 100%;
+            border-radius: 4px;
+            &:hover {
+              background: rgba(0, 0, 0, 0.05);
+            }
+          `}
+        >
+          <span
+            css={css`
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              width: 18px;
+              height: 18px;
+              border-radius: 3px;
+              background-color: ${space.color};
+              color: #fff;
+              font-size: 10px;
+              font-weight: 700;
+              flex-shrink: 0;
+            `}
+          >
+            {space.initial}
+          </span>
+          <EuiText size="s">{space.name}</EuiText>
+        </button>
+      </EuiFlexItem>
+    ))}
+    <EuiFlexItem>
+      <EuiHorizontalRule margin="s" />
+      <EuiLink
+        href="/spaces"
+        onClick={(e) => {
+          e.preventDefault();
+          closePopover();
+        }}
+      >
+        <EuiText size="xs">Manage spaces</EuiText>
+      </EuiLink>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
+const CUSTOM_TOOLS: NonNullable<PropsAndArgs['tools']> = {
+  headerTools: [
+    {
+      id: 'spaces',
+      label: 'Current space',
+      renderContent: () => <SpaceBadge />,
+      renderPopover: (closePopover) => <SpacePicker closePopover={closePopover} />,
+    },
+    { id: 'search', label: 'Search', iconType: 'search', onClick: () => {} },
+  ],
+  footerTools: [
+    {
+      id: 'help',
+      label: 'Help',
+      iconType: 'question',
+      sections: [
+        {
+          id: 'help-links',
+          items: [{ id: 'docs', label: 'Documentation', href: '/docs' }],
+        },
+      ],
+    },
+    {
+      id: 'user',
+      label: 'Jane Doe',
+      renderContent: () => <EuiAvatar size="s" name="Jane Doe" />,
+      sections: [
+        {
+          id: 'account',
+          items: [
+            { id: 'profile', label: 'Profile', href: '/profile' },
+            { id: 'preferences', label: 'Preferences', href: '/preferences' },
+          ],
+        },
+        {
+          id: 'session',
+          items: [{ id: 'logout', label: 'Log out', href: '/logout' }],
         },
       ],
     },
@@ -205,6 +359,31 @@ export const WithManyItems: StoryObj<PropsAndArgs> = {
         },
       ],
       footerItems: PRIMARY_MENU_FOOTER_ITEMS,
+    },
+  },
+  render: (args) => <ControlledNavigation {...args} />,
+};
+
+export const WithCustomToolItems: StoryObj<PropsAndArgs> = {
+  name: 'With custom tool items (avatar & space badge)',
+  decorators: [
+    (Story) => {
+      return (
+        <>
+          <Global styles={styles} />
+          <Story />
+        </>
+      );
+    },
+  ],
+  args: {
+    tools: CUSTOM_TOOLS,
+    logo: {
+      id: 'observability',
+      href: LOGO.href,
+      label: LOGO.label,
+      iconType: LOGO.iconType,
+      hideLabel: true,
     },
   },
   render: (args) => <ControlledNavigation {...args} />,

--- a/src/core/packages/chrome/navigation/src/components/icon_button/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/icon_button/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { Suspense, forwardRef } from 'react';
-import type { KeyboardEvent, ComponentProps, Ref } from 'react';
+import type { KeyboardEvent, ReactNode, ComponentProps, Ref } from 'react';
 import { EuiButtonIcon, EuiToolTip, useEuiTheme } from '@elastic/eui';
 import type { EuiButtonIconProps, IconType } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -24,17 +24,33 @@ export interface IconButtonProps
   extends Omit<EuiButtonIconProps, 'href' | 'iconType' | 'onClick' | 'onKeyDown'> {
   badgeType?: BadgeType;
   hasContent?: boolean;
-  iconType: IconType;
+  iconType?: IconType;
+  isCollapsed?: boolean;
   isCurrent?: boolean;
   isHighlighted: boolean;
   isNew: boolean;
   label: string;
   onClick?: () => void;
   onKeyDown?: (e: KeyboardEvent) => void;
+  renderContent?: (state: { isCollapsed: boolean }) => ReactNode;
 }
 
 export const IconButton = forwardRef<HTMLElement, IconButtonProps>(
-  ({ badgeType, hasContent, iconType, isCurrent, isHighlighted, isNew, label, ...props }, ref) => {
+  (
+    {
+      badgeType,
+      hasContent,
+      iconType,
+      isCollapsed,
+      isCurrent,
+      isHighlighted,
+      isNew,
+      label,
+      renderContent,
+      ...props
+    },
+    ref
+  ) => {
     const buttonRef = ref as Ref<HTMLButtonElement>;
     const { euiTheme } = useEuiTheme();
     const { tooltipRef, handleMouseOut } = useTooltip();
@@ -58,31 +74,87 @@ export const IconButton = forwardRef<HTMLElement, IconButtonProps>(
       display: inline-flex;
     `;
 
-    const buttonProps: ComponentProps<typeof EuiButtonIcon> & {
-      'data-highlighted': string;
-      'data-menu-item': string;
-    } = {
-      'aria-current': isCurrent ? 'page' : undefined,
-      'aria-label': label,
-      buttonRef,
-      color: isHighlighted ? 'primary' : 'text',
-      'data-highlighted': isHighlighted ? 'true' : 'false',
-      'data-menu-item': 'true',
-      display: isHighlighted ? 'base' : 'empty',
-      iconType: 'empty',
-      size: 's',
-      css: buttonStyles,
-      ...props,
-    };
+    let item: JSX.Element;
 
-    const item = (
-      <div css={buttonWrapperStyles}>
-        <Suspense fallback={<EuiButtonIcon {...buttonProps} />}>
-          <EuiButtonIcon {...buttonProps} iconType={iconType || 'empty'} />
-        </Suspense>
-        {isNew && <NewItemIndicator isHighlighted={isHighlighted} />}
-      </div>
-    );
+    if (renderContent) {
+      const shellStyles = css`
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: ${euiTheme.size.xl};
+        width: ${euiTheme.size.xl};
+        border: none;
+        border-radius: ${euiTheme.border.radius.small};
+        background: ${isHighlighted ? euiTheme.colors.backgroundBasePrimary : 'transparent'};
+        cursor: pointer;
+        padding: 0;
+        color: ${isHighlighted ? euiTheme.colors.textPrimary : euiTheme.colors.textParagraph};
+        position: relative;
+        overflow: hidden;
+        &:hover::before {
+          content: '';
+          position: absolute;
+          z-index: 0;
+          inset: 0;
+          background-color: ${euiTheme.components.buttons.backgroundEmptyTextHover};
+          pointer-events: none;
+        }
+        &:active::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+          background-color: ${euiTheme.components.buttons.backgroundEmptyTextActive};
+        }
+        &:focus-visible {
+          outline: ${euiTheme.focus.width} solid ${euiTheme.focus.color};
+          outline-offset: 2px;
+        }
+      `;
+
+      item = (
+        <div css={buttonWrapperStyles}>
+          <button
+            ref={buttonRef}
+            type="button"
+            aria-current={isCurrent ? 'page' : undefined}
+            aria-label={label}
+            css={[shellStyles, buttonStyles]}
+            data-highlighted={isHighlighted ? 'true' : 'false'}
+            data-menu-item="true"
+            {...props}
+          >
+            {renderContent({ isCollapsed: !!isCollapsed })}
+          </button>
+          {isNew && <NewItemIndicator isHighlighted={isHighlighted} />}
+        </div>
+      );
+    } else {
+      const euiButtonProps: ComponentProps<typeof EuiButtonIcon> & {
+        'data-highlighted': string;
+        'data-menu-item': string;
+      } = {
+        'aria-current': isCurrent ? 'page' : undefined,
+        'aria-label': label,
+        buttonRef,
+        color: isHighlighted ? 'primary' : 'text',
+        'data-highlighted': isHighlighted ? 'true' : 'false',
+        'data-menu-item': 'true',
+        display: isHighlighted ? 'base' : 'empty',
+        iconType: 'empty',
+        size: 's',
+        css: buttonStyles,
+        ...props,
+      };
+
+      item = (
+        <div css={buttonWrapperStyles}>
+          <Suspense fallback={<EuiButtonIcon {...euiButtonProps} />}>
+            <EuiButtonIcon {...euiButtonProps} iconType={iconType || 'empty'} />
+          </Suspense>
+          {isNew && <NewItemIndicator isHighlighted={isHighlighted} />}
+        </div>
+      );
+    }
 
     if (!hasContent) {
       const tooltipStyles = css`

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -189,9 +189,11 @@ export const Navigation = ({
           {hasHeaderTools && (
             <SideNav.HeaderToolbar>
               {renderToolItems({
+                anchorPosition: 'rightDown',
                 items: headerTools,
                 itemComponent: SideNav.HeaderToolbar.Item,
                 isAnyPopoverLocked,
+                isCollapsed,
                 popoverItemPrefix: popoverHeaderToolPrefix,
               })}
             </SideNav.HeaderToolbar>
@@ -247,7 +249,7 @@ export const Navigation = ({
                                 const isFirstSubItem =
                                   sectionIndex === firstNonEmptySectionIndex && subItemIndex === 0;
                                 const subItemAriaDescribedBy = isFirstSubItem
-                                  ? ids?.popoverNavigationInstructionsId
+                                  ? ids.popoverNavigationInstructionsId
                                   : undefined;
                                 return (
                                   <SideNav.SecondaryMenu.Item
@@ -426,9 +428,11 @@ export const Navigation = ({
           <SideNav.FooterToolbar isCollapsed={isCollapsed}>
             {hasFooterTools &&
               renderToolItems({
+                anchorPosition: 'rightUp',
                 items: footerTools,
                 itemComponent: SideNav.FooterToolbar.Item,
                 isAnyPopoverLocked,
+                isCollapsed,
                 popoverItemPrefix: popoverFooterToolPrefix,
               })}
             {collapseToggle && (
@@ -558,7 +562,7 @@ const renderFooterNavItems = ({
                     const isFirstSubItem =
                       sectionIndex === firstNonEmptySectionIndex && subItemIndex === 0;
                     const subItemAriaDescribedBy = isFirstSubItem
-                      ? ids?.popoverNavigationInstructionsId
+                      ? ids.popoverNavigationInstructionsId
                       : undefined;
 
                     return (
@@ -591,25 +595,31 @@ const renderFooterNavItems = ({
   });
 
 interface RenderToolItemsArgs {
+  anchorPosition?: 'rightUp' | 'rightDown';
   isAnyPopoverLocked: boolean;
+  isCollapsed: boolean;
   itemComponent: ForwardRefExoticComponent<ToolItemProps & RefAttributes<HTMLButtonElement>>;
   items: ToolItem[];
   popoverItemPrefix: string;
 }
 
 const renderToolItems = ({
+  anchorPosition,
   isAnyPopoverLocked,
+  isCollapsed,
   itemComponent: ItemComponent,
   items,
   popoverItemPrefix,
 }: RenderToolItemsArgs) =>
   items.map((item) => {
-    const { onClick: itemOnClick, sections, ...itemProps } = item;
-
+    const { onClick: itemOnClick, sections, renderContent, renderPopover, ...itemProps } = item;
+    const hasPopoverContent = getHasSubmenu(item);
     return (
       <SideNav.Popover
         key={item.id}
-        hasContent={getHasSubmenu(item)}
+        anchorPosition={anchorPosition}
+        customContent={!!renderPopover}
+        hasContent={hasPopoverContent}
         isSidePanelOpen={false}
         isAnyPopoverLocked={isAnyPopoverLocked}
         label={item.label}
@@ -618,7 +628,9 @@ const renderToolItems = ({
           <ItemComponent
             isHighlighted={false}
             isNew={false}
-            hasContent={getHasSubmenu(item)}
+            isCollapsed={isCollapsed}
+            hasContent={hasPopoverContent}
+            renderContent={renderContent}
             onClick={() => {
               itemOnClick?.();
             }}
@@ -627,6 +639,10 @@ const renderToolItems = ({
         }
       >
         {(closePopover, ids) => {
+          if (renderPopover) {
+            return renderPopover(closePopover);
+          }
+
           const firstNonEmptySectionIndex = sections?.findIndex(
             (section) => section.items.length > 0
           );
@@ -638,7 +654,7 @@ const renderToolItems = ({
                     const isFirstSubItem =
                       sectionIndex === firstNonEmptySectionIndex && subItemIndex === 0;
                     const subItemAriaDescribedBy = isFirstSubItem
-                      ? ids?.popoverNavigationInstructionsId
+                      ? ids.popoverNavigationInstructionsId
                       : undefined;
 
                     return (

--- a/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
@@ -39,16 +39,23 @@ import { useHoverTimeout } from '../../hooks/use_hover_timeout';
 import { useScroll } from '../../hooks/use_scroll';
 
 export interface PopoverIds {
-  popoverNavigationInstructionsId: string;
+  popoverNavigationInstructionsId: string | undefined;
 }
 
 export type PopoverChildren =
   | ReactNode
-  | ((closePopover: () => void, ids?: PopoverIds) => ReactNode);
+  | ((closePopover: () => void, ids: PopoverIds) => ReactNode);
 
 export interface PopoverProps {
+  anchorPosition?: 'rightUp' | 'rightDown';
   children?: PopoverChildren;
   container?: HTMLElement;
+  /**
+   * When `true`, the popover delegates keyboard navigation and focus
+   * management to its children (e.g. EuiSelectable). Only Escape is
+   * handled by the popover itself.
+   */
+  customContent?: boolean;
   hasContent: boolean;
   isSidePanelOpen: boolean;
   isAnyPopoverLocked?: boolean;
@@ -75,8 +82,10 @@ export interface PopoverProps {
  *   - Escape to move focus back to the trigger.
  */
 export const Popover = ({
+  anchorPosition: anchorPositionProp,
   children,
   container,
+  customContent = false,
   hasContent,
   isSidePanelOpen,
   isAnyPopoverLocked = false,
@@ -192,6 +201,10 @@ export const Popover = ({
         return;
       }
 
+      if (customContent) {
+        return;
+      }
+
       if (e.key === 'Tab') {
         e.preventDefault();
         handleClose();
@@ -201,7 +214,7 @@ export const Popover = ({
 
       handleRovingIndex(e);
     },
-    [handleClose]
+    [customContent, handleClose]
   );
 
   const handleBlur: FocusEventHandler = useCallback(
@@ -293,7 +306,7 @@ export const Popover = ({
       )}
       <EuiPopover
         aria-label={label}
-        anchorPosition="rightUp"
+        anchorPosition={anchorPositionProp ?? 'rightUp'}
         buffer={[TOP_BAR_HEIGHT + TOP_BAR_POPOVER_GAP, 0, BOTTOM_POPOVER_GAP, POPOVER_OFFSET]}
         button={enhancedTrigger}
         closePopover={handleClose}
@@ -315,8 +328,10 @@ export const Popover = ({
             popoverRef.current = ref;
 
             if (ref) {
-              const elements = getFocusableElements(ref);
-              updateTabIndices(elements);
+              if (!customContent) {
+                const elements = getFocusableElements(ref);
+                updateTabIndices(elements);
+              }
 
               if (shouldFocusOnOpen) {
                 focusFirstElement(popoverRef);
@@ -327,19 +342,25 @@ export const Popover = ({
           onKeyDown={handlePopoverKeyDown}
           css={popoverContentStyles}
         >
-          <EuiScreenReaderOnly>
-            <p id={popoverNavigationInstructionsId}>
-              {i18n.translate('core.ui.chrome.sideNavigation.popoverNavigationInstructions', {
-                defaultMessage:
-                  'You are in the {label} secondary menu dialog. Use Up and Down arrow keys to navigate the menu. Press Escape to exit to the menu trigger.',
-                values: {
-                  label,
-                },
-              })}
-            </p>
-          </EuiScreenReaderOnly>
+          {!customContent && (
+            <EuiScreenReaderOnly>
+              <p id={popoverNavigationInstructionsId}>
+                {i18n.translate('core.ui.chrome.sideNavigation.popoverNavigationInstructions', {
+                  defaultMessage:
+                    'You are in the {label} secondary menu dialog. Use Up and Down arrow keys to navigate the menu. Press Escape to exit to the menu trigger.',
+                  values: {
+                    label,
+                  },
+                })}
+              </p>
+            </EuiScreenReaderOnly>
+          )}
           {typeof children === 'function'
-            ? children(handleClose, { popoverNavigationInstructionsId })
+            ? children(handleClose, {
+                popoverNavigationInstructionsId: customContent
+                  ? undefined
+                  : popoverNavigationInstructionsId,
+              })
             : children}
         </div>
       </EuiPopover>

--- a/src/core/packages/chrome/navigation/src/components/tool_item/index.tsx
+++ b/src/core/packages/chrome/navigation/src/components/tool_item/index.tsx
@@ -17,20 +17,19 @@ import { NAVIGATION_SELECTOR_PREFIX } from '../../constants';
 
 export interface ToolItemProps
   extends Omit<EuiButtonIconProps, 'href' | 'iconType' | 'onClick' | 'onKeyDown'>,
-    Omit<ToolItemData, 'sections'> {
+    Omit<ToolItemData, 'sections' | 'renderPopover'> {
   hasContent?: boolean;
+  isCollapsed?: boolean;
   isHighlighted: boolean;
   isNew: boolean;
   onClick?: () => void;
   onKeyDown?: (e: KeyboardEvent) => void;
 }
 
-export const ToolItem = forwardRef<HTMLButtonElement, ToolItemProps>(
-  ({ id, ...props }, ref) => (
-    <IconButton
-      ref={ref as Ref<HTMLElement>}
-      data-test-subj={`${NAVIGATION_SELECTOR_PREFIX}-toolItem-${id}`}
-      {...props}
-    />
-  )
-);
+export const ToolItem = forwardRef<HTMLButtonElement, ToolItemProps>(({ id, ...props }, ref) => (
+  <IconButton
+    ref={ref as Ref<HTMLElement>}
+    data-test-subj={`${NAVIGATION_SELECTOR_PREFIX}-toolItem-${id}`}
+    {...props}
+  />
+));

--- a/src/core/packages/chrome/navigation/src/utils/get_has_submenu.ts
+++ b/src/core/packages/chrome/navigation/src/utils/get_has_submenu.ts
@@ -13,6 +13,9 @@
  * @param item - the menu item to check.
  * @returns `true` if the menu item has a submenu, `false` otherwise.
  */
-export const getHasSubmenu = (item: { sections?: ReadonlyArray<unknown> }): boolean => {
-  return !!item.sections && item.sections.length > 0;
+export const getHasSubmenu = (item: {
+  sections?: ReadonlyArray<unknown>;
+  renderPopover?: unknown;
+}): boolean => {
+  return (!!item.sections && item.sections.length > 0) || !!item.renderPopover;
 };

--- a/src/core/packages/chrome/navigation/types.ts
+++ b/src/core/packages/chrome/navigation/types.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { ReactNode } from 'react';
 import type { IconType } from '@elastic/eui';
 
 export type BadgeType = 'beta' | 'techPreview' | 'new';
@@ -99,15 +100,20 @@ export interface MenuItem {
 /**
  * A chrome tool control (search, help, profile, etc.) — not a navigation destination.
  * Tool items can perform an action via `onClick` or expose submenu content via `sections`.
+ *
+ * At least one of `iconType` or `renderContent` must be provided.
+ * When both are present, `renderContent` takes precedence for the trigger visual.
+ *
+ * When `renderPopover` is present, it takes precedence over `sections` for the
+ * popover body content. They are not combined.
  */
 export interface ToolItem {
   id: string;
   label: string;
-  iconType: IconType;
+  iconType?: IconType;
+  renderContent?: (state: { isCollapsed: boolean }) => ReactNode;
+  renderPopover?: (closePopover: () => void) => ReactNode;
   onClick?: () => void;
-  /**
-   * Optional submenu content shown for the tool control.
-   */
   sections?: SecondaryMenuSection[];
   badgeType?: BadgeType;
   'data-test-subj'?: string;


### PR DESCRIPTION
## Summary

Extend the sidenav navigation component's `ToolItem` type to support custom rendering:

- `renderContent` — custom trigger content (e.g. avatar, space badge) instead of an icon
- `renderPopover` — custom popover body, taking precedence over `sections`
- `customContent` on `Popover` — delegates keyboard navigation to children when true
- `anchorPosition` on `Popover` — configurable popover anchor direction
- `iconType` is now optional when `renderContent` is provided


**These are needed to support (following PR)**
 - Custom icon/badge for user avatar to display user menu
 - Custom popover for space selector

Includes a storybook story demonstrating avatar and space badge tool items.

<img width="430" height="643" alt="Screenshot 2026-04-07 at 13 10 23" src="https://github.com/user-attachments/assets/844428b0-7210-460d-ab27-98befcb9d5f2" />

<img width="416" height="640" alt="Screenshot 2026-04-07 at 13 10 17" src="https://github.com/user-attachments/assets/df27e2bf-71d0-449a-b420-9267b0835c5e" />
