### PR TITLE
[Agent Builder] Dashboards: Enables Dashboard skill in Agent Builder

### DIFF
--- a/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/dashboard_agent/server/skills/dashboard_management_skill.ts
@@ -15,7 +15,6 @@ export const dashboardManagementSkill = defineSkillType({
   id: 'dashboard-management',
   name: 'dashboard-management',
   basePath: 'skills/platform/dashboard',
-  experimental: true,
   description:
     'Compose and update in-memory Kibana dashboards using ordered operations, visualization attachments, and inline visualization editing.',
   content: `## When to Use This Skill


### PR DESCRIPTION
## Summary

Closes [[Dashboards in chat] Release to main](https://github.com/elastic/kibana/issues/249048) 

This PR removes the `experimental` guard from the dashboard skill, enabling it for 9.4 and future serverless releases. 