### PR TITLE
[Lens] [ES|QL] Refresh grid when time range changes

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
@@ -9,7 +9,6 @@ import { css } from '@emotion/react';
 import { EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import type { DefaultInspectorAdapters } from '@kbn/expressions-plugin/common';
 import { useFetchContext } from '@kbn/presentation-publishing';
 import type { CoreStart, IUiSettingsClient } from '@kbn/core/public';
 import { isEqual } from 'lodash';
@@ -88,6 +87,7 @@ export function ESQLEditor({
   onTextBasedQueryStateChange,
 }: ESQLEditorProps) {
   const prevQuery = useRef<AggregateQuery | Query>(attributes?.state.query || { esql: '' });
+  const submittedQueryRef = useRef<AggregateQuery | Query>(attributes?.state.query || { esql: '' });
   const [query, setQuery] = useState<AggregateQuery | Query>(
     attributes?.state.query || { esql: '' }
   );
@@ -108,6 +108,13 @@ export function ESQLEditor({
   const [isESQLResultsAccordionOpen, setIsESQLResultsAccordionOpen] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
+  /**
+   * After `runQuery`, the grid is already updated via `getSuggestions`; the chart then loads and
+   * `dataLoading$` completes once. Skip the post-load grid refresh for that completion to avoid a
+   * duplicate ES|QL request. Subsequent completions (e.g. time range only) still refresh the grid.
+   */
+  const suppressNextChartLoadGridRefreshRef = useRef(false);
+
   const currentAttributes = useCurrentAttributes({
     textBasedMode: isTextBasedLanguage,
     initialAttributes: attributes,
@@ -123,12 +130,37 @@ export function ESQLEditor({
       ? Object.values(attributes.state.adHocDataViews)
       : Object.values(framePublicAPI.dataViews.indexPatterns).map((index) => index.spec);
 
-  const previousAdapters = useRef<Partial<DefaultInspectorAdapters> | undefined>(lensAdapters);
+  const lensAdaptersRef = useRef(lensAdapters);
+  lensAdaptersRef.current = lensAdapters;
 
   const { esqlVariables } = useFetchContext({ uuid: panelId, parentApi });
   const esqlQueryStats = useESQLQueryStats(isTextBasedLanguage, lensAdapters?.requests);
 
   const dispatch = useLensDispatch();
+
+  submittedQueryRef.current = submittedQuery;
+
+  const refreshDataGridAfterChartLoad = useCallback(async () => {
+    const q = submittedQueryRef.current;
+    if (!isOfAggregateQueryType(q) || !q.esql?.trim()) {
+      return;
+    }
+    await getSuggestions(
+      q,
+      data,
+      http,
+      uiSettings,
+      datasourceMap,
+      visualizationMap,
+      adHocDataViews,
+      undefined,
+      undefined,
+      setDataGridAttrs,
+      esqlVariables,
+      false,
+      currentAttributesRef.current
+    );
+  }, [adHocDataViews, data, datasourceMap, esqlVariables, http, uiSettings, visualizationMap]);
 
   useEffect(() => {
     const s = dataLoading$?.subscribe((isDataLoading) => {
@@ -136,9 +168,14 @@ export function ESQLEditor({
       if (isDataLoading) {
         return;
       }
+      if (suppressNextChartLoadGridRefreshRef.current) {
+        suppressNextChartLoadGridRefreshRef.current = false;
+      } else {
+        void refreshDataGridAfterChartLoad();
+      }
       const activeData = getActiveDataFromDatatable(
         layerId,
-        previousAdapters.current?.tables?.tables
+        lensAdaptersRef.current?.tables?.tables
       );
       const table = activeData?.[layerId];
 
@@ -153,7 +190,7 @@ export function ESQLEditor({
       }
     });
     return () => s?.unsubscribe();
-  }, [dataLoading$, dispatch, layerId]);
+  }, [dataLoading$, dispatch, layerId, refreshDataGridAfterChartLoad]);
 
   const runQuery = useCallback(
     async (q: AggregateQuery, abortController?: AbortController, shouldUpdateAttrs?: boolean) => {
@@ -172,13 +209,17 @@ export function ESQLEditor({
         shouldUpdateAttrs,
         currentAttributesRef.current
       );
+
       if (attrs) {
         setCurrentAttributes?.(attrs);
         setErrors([]);
         updateSuggestion?.(attrs);
       }
+
       prevQuery.current = q;
       setSubmittedQuery(q);
+      submittedQueryRef.current = q;
+      suppressNextChartLoadGridRefreshRef.current = true;
       setIsVisualizationLoading(false);
     },
     [

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/config_panel/esql_editor.tsx
@@ -145,6 +145,7 @@ export function ESQLEditor({
     if (!isOfAggregateQueryType(q) || !q.esql?.trim()) {
       return;
     }
+
     await getSuggestions(
       q,
       data,
@@ -164,19 +165,24 @@ export function ESQLEditor({
 
   useEffect(() => {
     const s = dataLoading$?.subscribe((isDataLoading) => {
-      // go thru only when the loading is complete
+      // Only refresh the grid and sync activeData once loading completes
       if (isDataLoading) {
         return;
       }
+
+      // When a refresh was already driven elsewhere (e.g. query submit), skip one redundant
+      // grid refresh on the subsequent chart load completion
       if (suppressNextChartLoadGridRefreshRef.current) {
         suppressNextChartLoadGridRefreshRef.current = false;
       } else {
         void refreshDataGridAfterChartLoad();
       }
+
       const activeData = getActiveDataFromDatatable(
         layerId,
         lensAdaptersRef.current?.tables?.tables
       );
+
       const table = activeData?.[layerId];
 
       if (table) {
@@ -189,6 +195,7 @@ export function ESQLEditor({
         dispatch(onActiveDataChange({ activeData }));
       }
     });
+
     return () => s?.unsubscribe();
   }, [dataLoading$, dispatch, layerId, refreshDataGridAfterChartLoad]);
 
@@ -218,8 +225,10 @@ export function ESQLEditor({
 
       prevQuery.current = q;
       setSubmittedQuery(q);
+
       submittedQueryRef.current = q;
       suppressNextChartLoadGridRefreshRef.current = true;
+
       setIsVisualizationLoading(false);
     },
     [


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/259082

**Problem explanation**

The “ES|QL query results” section in the inline editor is fed by `dataGridAttrs` from `getSuggestions` → `getGridAttrs`, which **runs on query submit, not on every chart refresh**. So it can stay out of sync with activeData when the time range changes but the query string doesn’t.

**Solution**

When the chart finishes loading (`dataLoading$` → not loading), refresh `dataGridAttrs` by calling `getSuggestions(..., shouldUpdateAttrs: false)` so the “ES|QL query results” grid uses the current time range without requiring a new query submit.

### Screen recording


https://github.com/user-attachments/assets/caf2e2c7-8baa-4228-8137-f3fb602e4a85


## Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [x] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.