### PR TITLE
[codeql] ignore scout spec

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -16,6 +16,7 @@ paths-ignore:
   - '**/*.mock.*'
   - '**/*.mocks.*'
   - '**/*.test.*'
+  - '**/*.spec.*'
   - '**/cypress/**'
   - '**/e2e/**'
   - '**/ftr_e2e/**'


### PR DESCRIPTION
## Summary

Based on comment left in https://github.com/elastic/kibana/pull/261409#discussion_r3044916536

Adding `**/*.spec.*` to ignore list



