### PR TITLE
[Significant events] Format event count with locale-aware number separators

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/sig_events/significant_events_discovery/components/insights/summary.tsx
@@ -277,7 +277,7 @@ export function Summary({ count }: { count: number }) {
             'xpack.streams.sigEventsDiscovery.insightsTab.significantEventsFoundTitle',
             {
               defaultMessage:
-                '{count} {count, plural, one {event} other {events}} found in your system',
+                '{count, number} {count, plural, one {event} other {events}} found in your system',
               values: { count },
             }
           )}


### PR DESCRIPTION
## Summary

Simple PR to format the number of events detected in the significant events tab. Uses ICU's `{count, number}` format in the `i18n` message so large counts render with locale-appropriate thousand separators (e.g. 1,000 in en-US) instead of plain integers.

<img width="7848" height="2568" alt="image" src="https://github.com/user-attachments/assets/70351324-d604-415f-b27f-787e2639d6ca" />


