### PR TITLE
[FeatureBranch/DoNotReview][Chrome Next] Add a user menu and space selector to the sidenav

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -42,7 +42,7 @@ pageLoadAssetSize:
   dataViewManagement: 6250
   dataViews: 66000
   dataVisualizer: 32727
-  developerToolbar: 4467
+  developerToolbar: 15000
   devTools: 8109
   discover: 31186
   discoverEnhanced: 5509

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/navigation.tsx
@@ -99,10 +99,17 @@ const useNavigationItems = (): NavigationState | null => {
     const emptyToolSlots: ToolSlots = { headerTools: [], footerTools: [] };
 
     const toolSlots$ = isNextChrome
-      ? combineLatest([chrome.next.globalSearch.get$(), helpLinks$]).pipe(
-          map(([searchConfig, helpLinks]) =>
+      ? combineLatest([
+          chrome.next.globalSearch.get$(),
+          chrome.next.spaceSelector.get$(),
+          chrome.next.userMenu.get$(),
+          helpLinks$,
+        ]).pipe(
+          map(([searchConfig, spaceSelectorConfig, userMenuConfig, helpLinks]) =>
             buildToolSlots({
               globalSearch: searchConfig,
+              spaceSelector: spaceSelectorConfig,
+              userMenu: userMenuConfig,
               helpLinks,
             })
           )

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
@@ -8,7 +8,11 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { ChromeNextGlobalSearchConfig } from '@kbn/core-chrome-browser';
+import type {
+  ChromeNextGlobalSearchConfig,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
+} from '@kbn/core-chrome-browser';
 import type {
   SecondaryMenuItem,
   SecondaryMenuSection,
@@ -19,34 +23,99 @@ import type { HelpLinks, HelpMenuLinkItem } from '../../../shared/help_menu_link
 
 export interface ToolSlotsInput {
   globalSearch?: ChromeNextGlobalSearchConfig;
+  spaceSelector?: ChromeNextSpaceSelectorConfig;
+  userMenu?: ChromeNextUserMenuConfig;
   helpLinks: HelpLinks;
 }
 
 export const buildToolSlots = (input: ToolSlotsInput): ToolSlots => ({
-  headerTools: getHeaderTools(input.globalSearch),
-  footerTools: getFooterTools(input.helpLinks),
+  headerTools: getHeaderTools(input.globalSearch, input.spaceSelector),
+  footerTools: getFooterTools(input.userMenu, input.helpLinks),
 });
 
-const getHeaderTools = (globalSearch?: ChromeNextGlobalSearchConfig): ToolItem[] => {
-  if (!globalSearch) {
-    return [];
+const getHeaderTools = (
+  globalSearch?: ChromeNextGlobalSearchConfig,
+  spaceSelector?: ChromeNextSpaceSelectorConfig
+): ToolItem[] => {
+  const tools: ToolItem[] = [];
+
+  const spaceSelectorItem = getSpaceSelectorToolItem(spaceSelector);
+  if (spaceSelectorItem) {
+    tools.push(spaceSelectorItem);
   }
 
-  return [
-    {
+  if (globalSearch) {
+    tools.push({
       id: 'globalSearch',
       label: i18n.translate('core.chrome.projectSideNav.globalSearchLabel', {
         defaultMessage: 'Search',
       }),
       iconType: 'search',
       onClick: globalSearch.onClick,
-    },
-  ];
+    });
+  }
+
+  return tools;
 };
 
-const getFooterTools = (helpLinks: HelpLinks): ToolItem[] => {
+const getSpaceSelectorToolItem = (
+  config: ChromeNextSpaceSelectorConfig | undefined
+): ToolItem | undefined => {
+  if (!config) {
+    return undefined;
+  }
+
+  return {
+    id: 'spaceSelector',
+    label: config.label,
+    renderContent: () => config.renderAvatar(),
+    renderPopover: (closePopover) => config.renderPopover(closePopover),
+    'data-test-subj': 'sideNavSpaceSelector',
+  };
+};
+
+const getFooterTools = (
+  userMenu: ChromeNextUserMenuConfig | undefined,
+  helpLinks: HelpLinks
+): ToolItem[] => {
+  const tools: ToolItem[] = [];
+  const userMenuItem = getUserMenuToolItem(userMenu);
+  if (userMenuItem) {
+    tools.push(userMenuItem);
+  }
   const helpItem = getHelpToolItem(helpLinks);
-  return helpItem ? [helpItem] : [];
+  if (helpItem) {
+    tools.push(helpItem);
+  }
+  return tools;
+};
+
+const getUserMenuToolItem = (
+  config: ChromeNextUserMenuConfig | undefined
+): ToolItem | undefined => {
+  if (!config) {
+    return undefined;
+  }
+
+  const items: SecondaryMenuItem[] = config.items.map((item) => ({
+    id: item.id,
+    label: item.label,
+    href: item.href,
+    isExternal: item.isExternal,
+    'data-test-subj': item['data-test-subj'],
+  }));
+
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  return {
+    id: 'userMenu',
+    label: config.label,
+    renderContent: () => config.renderAvatar(),
+    sections: [{ id: 'userMenuLinks', items }],
+    'data-test-subj': 'sideNavUserMenu',
+  };
 };
 
 const getHelpToolItem = (helpLinks: HelpLinks): ToolItem | undefined => {

--- a/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
+++ b/src/core/packages/chrome/browser-components/src/project/sidenav/navigation/to_chrome_tool_slots.ts
@@ -70,6 +70,7 @@ const getSpaceSelectorToolItem = (
     label: config.label,
     renderContent: () => config.renderAvatar(),
     renderPopover: (closePopover) => config.renderPopover(closePopover),
+    popoverWidth: 360,
     'data-test-subj': 'sideNavSpaceSelector',
   };
 };

--- a/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
+++ b/src/core/packages/chrome/browser-components/src/shared/header_help_menu.tsx
@@ -182,9 +182,6 @@ export const HeaderHelpMenu = () => {
       id="headerHelpMenu"
       isOpen={isOpen}
       repositionOnScroll
-      aria-label={i18n.translate('core.ui.chrome.headerGlobalNav.helpMenuAriaLabel', {
-        defaultMessage: 'Help menu',
-      })}
     >
       <EuiPopoverTitle>
         <EuiFlexGroup responsive={false}>

--- a/src/core/packages/chrome/browser-internal-types/index.ts
+++ b/src/core/packages/chrome/browser-internal-types/index.ts
@@ -19,6 +19,8 @@ import type {
   ChromeNextAiButton,
   ChromeNextHeaderConfig,
   ChromeNextGlobalSearchConfig,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
   ChromeProjectNavigationNode,
   ChromeSetProjectBreadcrumbsParams,
   ChromeUserBanner,
@@ -123,5 +125,11 @@ export interface InternalChromeNext extends ChromeNext {
   };
   globalSearch: ChromeNext['globalSearch'] & {
     get$(): Observable<ChromeNextGlobalSearchConfig | undefined>;
+  };
+  userMenu: ChromeNext['userMenu'] & {
+    get$(): Observable<ChromeNextUserMenuConfig | undefined>;
+  };
+  spaceSelector: ChromeNext['spaceSelector'] & {
+    get$(): Observable<ChromeNextSpaceSelectorConfig | undefined>;
   };
 }

--- a/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_api.tsx
@@ -193,6 +193,14 @@ export function createChromeApi({ state, services, sidebar }: ChromeApiDeps): In
         get$: () => state.globalSearch.$,
         set: state.globalSearch.set,
       },
+      userMenu: {
+        get$: () => state.userMenu.$,
+        set: state.userMenu.set,
+      },
+      spaceSelector: {
+        get$: () => state.spaceSelector.$,
+        set: state.spaceSelector.set,
+      },
     },
 
     sidebar,

--- a/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
+++ b/src/core/packages/chrome/browser-internal/src/state/chrome_state.ts
@@ -21,6 +21,8 @@ import type {
   ChromeNavLink,
   ChromeNextAiButton,
   ChromeNextGlobalSearchConfig,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
   ChromeUserBanner,
 } from '@kbn/core-chrome-browser';
 import type { AppMenuConfig } from '@kbn/core-chrome-app-menu-components';
@@ -68,6 +70,8 @@ export interface ChromeState {
   appMenu: State<AppMenuConfig | undefined>;
   aiButton: State<ReadonlySet<ChromeNextAiButton>>;
   globalSearch: State<ChromeNextGlobalSearchConfig | undefined>;
+  userMenu: State<ChromeNextUserMenuConfig | undefined>;
+  spaceSelector: State<ChromeNextSpaceSelectorConfig | undefined>;
 
   /** Help system */
   help: {
@@ -113,6 +117,8 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
   const globalFooter = createState<ReactNode>(null);
   const aiButton = createState<ReadonlySet<ChromeNextAiButton>>(new Set());
   const globalSearch = createState<ChromeNextGlobalSearchConfig | undefined>(undefined);
+  const userMenu = createState<ChromeNextUserMenuConfig | undefined>(undefined);
+  const spaceSelector = createState<ChromeNextSpaceSelectorConfig | undefined>(undefined);
   const customNavLink = createState<ChromeNavLink | undefined>(undefined);
 
   // Help System
@@ -138,6 +144,8 @@ export function createChromeState({ application, docLinks }: ChromeStateDeps): C
     globalFooter,
     aiButton,
     globalSearch,
+    userMenu,
+    spaceSelector,
     customNavLink,
     appMenu,
     help: {

--- a/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
+++ b/src/core/packages/chrome/browser-mocks/src/chrome_service.mock.ts
@@ -14,6 +14,8 @@ import type {
   ChromeBreadcrumb,
   ChromeNextHeaderConfig,
   ChromeNextGlobalSearchConfig,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
 } from '@kbn/core-chrome-browser';
 import type {
   InternalChromeSetup,
@@ -31,6 +33,10 @@ const createSetupContractMock = (): DeeplyMockedKeys<InternalChromeSetup> => {
 const createStartContractMock = () => {
   const nextHeaderState$ = new BehaviorSubject<ChromeNextHeaderConfig | undefined>(undefined);
   const nextGlobalSearchState$ = new BehaviorSubject<ChromeNextGlobalSearchConfig | undefined>(
+    undefined
+  );
+  const nextUserMenuState$ = new BehaviorSubject<ChromeNextUserMenuConfig | undefined>(undefined);
+  const nextSpaceSelectorState$ = new BehaviorSubject<ChromeNextSpaceSelectorConfig | undefined>(
     undefined
   );
 
@@ -123,6 +129,18 @@ const createStartContractMock = () => {
         get$: jest.fn().mockReturnValue(nextGlobalSearchState$),
         set: jest.fn((config?: ChromeNextGlobalSearchConfig) => {
           nextGlobalSearchState$.next(config);
+        }),
+      }),
+      userMenu: lazyObject({
+        get$: jest.fn().mockReturnValue(nextUserMenuState$),
+        set: jest.fn((config?: ChromeNextUserMenuConfig) => {
+          nextUserMenuState$.next(config);
+        }),
+      }),
+      spaceSelector: lazyObject({
+        get$: jest.fn().mockReturnValue(nextSpaceSelectorState$),
+        set: jest.fn((config?: ChromeNextSpaceSelectorConfig) => {
+          nextSpaceSelectorState$.next(config);
         }),
       }),
     }),

--- a/src/core/packages/chrome/browser/index.ts
+++ b/src/core/packages/chrome/browser/index.ts
@@ -65,4 +65,7 @@ export type {
   ChromeNextHeaderGlobalActions,
   ChromeNextHeaderMetadataSlotItem,
   ChromeNextHeaderTab,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
+  ChromeNextUserMenuItem,
 } from './src';

--- a/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/chrome_next.ts
@@ -10,9 +10,11 @@
 import type { ChromeNextAiButton } from './ai_button';
 import type { ChromeNextGlobalSearchConfig } from './global_search';
 import type { ChromeNextHeaderConfig } from './header';
+import type { ChromeNextSpaceSelectorConfig } from './space_selector';
+import type { ChromeNextUserMenuConfig } from './user_menu';
 
 /**
- * Chrome-Next APIs: header configuration, AI button slot, global search, and future slots.
+ * Chrome-Next APIs: header configuration, AI button slot, global search, user menu, and space selector.
  * @public
  */
 export interface ChromeNext {
@@ -43,5 +45,21 @@ export interface ChromeNext {
      * Pass `undefined` to remove the button. Global — persists across app changes.
      */
     set(config?: ChromeNextGlobalSearchConfig): void;
+  };
+  userMenu: {
+    /**
+     * Set the user menu configuration for the Chrome-Next sidenav.
+     * Chrome renders a user avatar in the sidenav footer with a popover listing the provided items.
+     * Pass `undefined` to remove. Global — persists across app changes.
+     */
+    set(config?: ChromeNextUserMenuConfig): void;
+  };
+  spaceSelector: {
+    /**
+     * Set the space selector configuration for the Chrome-Next sidenav.
+     * Chrome renders a space avatar in the sidenav header with a custom popover.
+     * Pass `undefined` to remove. Global — persists across app changes.
+     */
+    set(config?: ChromeNextSpaceSelectorConfig): void;
   };
 }

--- a/src/core/packages/chrome/browser/src/chrome_next/index.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/index.ts
@@ -19,3 +19,5 @@ export type {
   ChromeNextHeaderMetadataSlotItem,
   ChromeNextHeaderTab,
 } from './header';
+export type { ChromeNextSpaceSelectorConfig } from './space_selector';
+export type { ChromeNextUserMenuConfig, ChromeNextUserMenuItem } from './user_menu';

--- a/src/core/packages/chrome/browser/src/chrome_next/space_selector.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/space_selector.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+
+export interface ChromeNextSpaceSelectorConfig {
+  label: string;
+  renderAvatar: () => ReactNode;
+  renderPopover: (closePopover: () => void) => ReactNode;
+}

--- a/src/core/packages/chrome/browser/src/chrome_next/user_menu.ts
+++ b/src/core/packages/chrome/browser/src/chrome_next/user_menu.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ReactNode } from 'react';
+
+export interface ChromeNextUserMenuConfig {
+  label: string;
+  renderAvatar: () => ReactNode;
+  items: ChromeNextUserMenuItem[];
+}
+
+export interface ChromeNextUserMenuItem {
+  id: string;
+  label: string;
+  href: string;
+  isExternal?: boolean;
+  'data-test-subj'?: string;
+}

--- a/src/core/packages/chrome/browser/src/index.ts
+++ b/src/core/packages/chrome/browser/src/index.ts
@@ -71,4 +71,7 @@ export type {
   ChromeNextHeaderGlobalActions,
   ChromeNextHeaderMetadataSlotItem,
   ChromeNextHeaderTab,
+  ChromeNextSpaceSelectorConfig,
+  ChromeNextUserMenuConfig,
+  ChromeNextUserMenuItem,
 } from './chrome_next';

--- a/src/core/packages/chrome/navigation/packaging/react/types.ts
+++ b/src/core/packages/chrome/navigation/packaging/react/types.ts
@@ -88,6 +88,7 @@ export interface ToolItem {
   renderPopover?: (closePopover: () => void) => ReactNode;
   onClick?: () => void;
   sections?: SecondaryMenuSection[];
+  popoverWidth?: number | string;
   badgeType?: BadgeType;
   'data-test-subj'?: string;
 }

--- a/src/core/packages/chrome/navigation/src/__stories__/navigation.stories.tsx
+++ b/src/core/packages/chrome/navigation/src/__stories__/navigation.stories.tsx
@@ -196,6 +196,7 @@ const CUSTOM_TOOLS: NonNullable<PropsAndArgs['tools']> = {
       label: 'Current space',
       renderContent: () => <SpaceBadge />,
       renderPopover: (closePopover) => <SpacePicker closePopover={closePopover} />,
+      popoverWidth: 360,
     },
     { id: 'search', label: 'Search', iconType: 'search', onClick: () => {} },
   ],

--- a/src/core/packages/chrome/navigation/src/components/navigation.tsx
+++ b/src/core/packages/chrome/navigation/src/components/navigation.tsx
@@ -612,7 +612,7 @@ const renderToolItems = ({
   popoverItemPrefix,
 }: RenderToolItemsArgs) =>
   items.map((item) => {
-    const { onClick: itemOnClick, sections, renderContent, renderPopover, ...itemProps } = item;
+    const { onClick: itemOnClick, sections, renderContent, renderPopover, popoverWidth, ...itemProps } = item;
     const hasPopoverContent = getHasSubmenu(item);
     return (
       <SideNav.Popover
@@ -620,6 +620,7 @@ const renderToolItems = ({
         anchorPosition={anchorPosition}
         customContent={!!renderPopover}
         hasContent={hasPopoverContent}
+        popoverWidth={popoverWidth}
         isSidePanelOpen={false}
         isAnyPopoverLocked={isAnyPopoverLocked}
         label={item.label}

--- a/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
+++ b/src/core/packages/chrome/navigation/src/components/side_nav/popover.tsx
@@ -57,6 +57,7 @@ export interface PopoverProps {
    */
   customContent?: boolean;
   hasContent: boolean;
+  popoverWidth?: number | string;
   isSidePanelOpen: boolean;
   isAnyPopoverLocked?: boolean;
   setIsLocked?: (isLocked: boolean) => void;
@@ -87,6 +88,7 @@ export const Popover = ({
   container,
   customContent = false,
   hasContent,
+  popoverWidth,
   isSidePanelOpen,
   isAnyPopoverLocked = false,
   setIsLocked = () => {},
@@ -274,9 +276,15 @@ export const Popover = ({
     width: 100%;
   `;
 
+  const resolvedWidth = popoverWidth
+    ? typeof popoverWidth === 'number'
+      ? `${popoverWidth}px`
+      : popoverWidth
+    : `${SIDE_PANEL_WIDTH}px`;
+
   const popoverContentStyles = css`
     --popover-max-height: 37.5rem;
-    width: ${SIDE_PANEL_WIDTH}px;
+    width: ${resolvedWidth};
     max-height: var(--popover-max-height);
     ${scrollStyles};
   `;

--- a/src/core/packages/chrome/navigation/types.ts
+++ b/src/core/packages/chrome/navigation/types.ts
@@ -115,6 +115,7 @@ export interface ToolItem {
   renderPopover?: (closePopover: () => void) => ReactNode;
   onClick?: () => void;
   sections?: SecondaryMenuSection[];
+  popoverWidth?: number | string;
   badgeType?: BadgeType;
   'data-test-subj'?: string;
 }

--- a/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
+++ b/x-pack/platform/plugins/shared/security/public/nav_control/nav_control_service.tsx
@@ -12,6 +12,8 @@ import type { Subscription } from 'rxjs';
 import { BehaviorSubject, map, ReplaySubject, takeUntil } from 'rxjs';
 
 import type { CoreStart } from '@kbn/core/public';
+import type { ChromeNextUserMenuItem } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type {
   AuthenticationServiceSetup,
@@ -19,9 +21,11 @@ import type {
   UserMenuLink,
 } from '@kbn/security-plugin-types-public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
+import { UserAvatar, type UserProfileAvatarData } from '@kbn/user-profile-components';
 
 import { SecurityNavControl } from './nav_control_component';
 import type { SecurityLicense } from '../../common';
+import { getUserDisplayName, isUserAnonymous } from '../../common/model';
 import type { SecurityApiClients } from '../components';
 import { AuthenticationProvider, SecurityApiClientsProvider } from '../components';
 
@@ -118,7 +122,97 @@ export class SecurityNavControlService {
       ),
     });
 
+    this.registerChromeNextUserMenu(core, authc);
+
     this.navControlRegistered = true;
+  }
+
+  private registerChromeNextUserMenu(core: CoreStart, authc: AuthenticationServiceSetup) {
+    const editProfileUrl = core.http.basePath.prepend('/security/account');
+    const { userProfiles } = this.securityApiClients;
+
+    Promise.all([
+      authc.getCurrentUser(),
+      userProfiles
+        .getCurrent<{ avatar: UserProfileAvatarData }>({ dataPath: 'avatar' })
+        .catch(() => null),
+    ])
+      .then(([currentUser, userProfile]) => {
+        const userDisplayName = getUserDisplayName(currentUser);
+        const isAnonymous = isUserAnonymous(currentUser);
+
+        const renderAvatar = () =>
+          userProfile ? (
+            <UserAvatar
+              user={userProfile.user}
+              avatar={userProfile.data.avatar}
+              size="s"
+              data-test-subj="sideNavUserMenuAvatar"
+            />
+          ) : (
+            <UserAvatar user={currentUser} size="s" data-test-subj="sideNavUserMenuAvatar" />
+          );
+
+        const buildItems = (userMenuLinks: UserMenuLink[]): ChromeNextUserMenuItem[] => {
+          const items: ChromeNextUserMenuItem[] = [];
+
+          const sorted = this.sortUserMenuLinks(userMenuLinks);
+          const hasCustomProfileLinks = sorted.some(({ setAsProfile }) => setAsProfile === true);
+
+          if (!isAnonymous && !hasCustomProfileLinks) {
+            items.push({
+              id: 'profileLink',
+              label: i18n.translate('xpack.security.navControlComponent.editProfileLinkText', {
+                defaultMessage: 'Edit profile',
+              }),
+              href: editProfileUrl,
+              'data-test-subj': 'profileLink',
+            });
+          }
+
+          for (const link of sorted) {
+            if (link.content || !link.label || !link.href) {
+              continue;
+            }
+            items.push({
+              id: `userMenuLink__${link.label}`,
+              label: link.label,
+              href: link.href,
+              'data-test-subj': `userMenuLink__${link.label}`,
+            });
+          }
+
+          items.push({
+            id: 'logoutLink',
+            label: isAnonymous
+              ? i18n.translate('xpack.security.navControlComponent.loginLinkText', {
+                  defaultMessage: 'Log in',
+                })
+              : i18n.translate('xpack.security.navControlComponent.logoutLinkText', {
+                  defaultMessage: 'Log out',
+                }),
+            href: this.logoutUrl,
+            'data-test-subj': 'logoutLink',
+          });
+
+          return items;
+        };
+
+        const setConfig = (userMenuLinks: UserMenuLink[]) => {
+          core.chrome.next.userMenu.set({
+            label: userDisplayName,
+            renderAvatar,
+            items: buildItems(userMenuLinks),
+          });
+        };
+
+        setConfig(this.userMenuLinks$.value);
+
+        this.userMenuLinks$.pipe(takeUntil(this.stop$)).subscribe((links) => setConfig(links));
+      })
+      .catch(() => {
+        // Chrome Next user menu unavailable — legacy nav control still active
+      });
   }
 
   private sortUserMenuLinks(userMenuLinks: UserMenuLink[]) {

--- a/x-pack/platform/plugins/shared/spaces/public/nav_control/components/spaces_menu.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/nav_control/components/spaces_menu.tsx
@@ -54,6 +54,7 @@ interface Props {
   allowSolutionVisibility: boolean;
   eventTracker: EventTracker;
   isLoading: boolean;
+  width?: number | string;
 }
 class SpacesMenuUI extends Component<Props & WithEuiThemeProps> {
   public render() {
@@ -107,7 +108,9 @@ class SpacesMenuUI extends Component<Props & WithEuiThemeProps> {
           options={spaceOptions}
           singleSelection={'always'}
           css={css`
-            width: 400px;
+            width: ${typeof this.props.width === 'number'
+              ? `${this.props.width}px`
+              : this.props.width ?? '400px'};
           `}
           onChange={this.spaceSelectionChange}
           listProps={{

--- a/x-pack/platform/plugins/shared/spaces/public/nav_control/nav_control.tsx
+++ b/x-pack/platform/plugins/shared/spaces/public/nav_control/nav_control.tsx
@@ -5,22 +5,31 @@
  * 2.0.
  */
 
-import { EuiSkeletonRectangle } from '@elastic/eui';
+import { EuiSkeletonCircle, EuiSkeletonRectangle } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 
 import type { CoreStart } from '@kbn/core/public';
+import type { ChromeNextSpaceSelectorConfig } from '@kbn/core-chrome-browser';
 import { QueryClient, QueryClientProvider } from '@kbn/react-query';
 import { euiThemeVars } from '@kbn/ui-theme';
 
+import { SpacesMenu } from './components/spaces_menu';
+import { useSpaces } from './hooks/use_spaces';
+import type { Space } from '../../common';
 import type { EventTracker } from '../analytics';
 import type { ConfigType } from '../config';
+import { getSpaceAvatarComponent } from '../space_avatar';
 import type { SpacesManager } from '../spaces_manager';
 
 const LazyNavControlPopover = lazy(() =>
   import('./nav_control_popover').then(({ NavControlPopover }) => ({
     default: NavControlPopover,
   }))
+);
+
+const LazySpaceAvatar = lazy(() =>
+  getSpaceAvatarComponent().then((component) => ({ default: component }))
 );
 
 export function initSpacesNavControl(
@@ -38,6 +47,17 @@ export function initSpacesNavControl(
     },
   });
 
+  registerHeaderSpacesControl(spacesManager, core, config, eventTracker, queryClient);
+  registerSidenavSpacesControl(spacesManager, core, config, eventTracker, queryClient);
+}
+
+function registerHeaderSpacesControl(
+  spacesManager: SpacesManager,
+  core: CoreStart,
+  config: ConfigType,
+  eventTracker: EventTracker,
+  queryClient: QueryClient
+) {
   const SpacesNavControl = () => {
     if (core.http.anonymousPaths.isAnonymous(window.location.pathname)) {
       return null;
@@ -75,5 +95,79 @@ export function initSpacesNavControl(
   core.chrome.navControls.registerLeft({
     order: 1000,
     content: <SpacesNavControl />,
+  });
+}
+
+function registerSidenavSpacesControl(
+  spacesManager: SpacesManager,
+  core: CoreStart,
+  config: ConfigType,
+  eventTracker: EventTracker,
+  queryClient: QueryClient
+) {
+  if (core.http.anonymousPaths.isAnonymous(window.location.pathname)) {
+    return;
+  }
+
+  const SidenavSpacesPopoverContent = ({ closePopover }: { closePopover: () => void }) => {
+    const [activeSpace, setActiveSpace] = useState<Space | null>(null);
+    const { data, isLoading } = useSpaces(spacesManager);
+
+    useEffect(() => {
+      const sub = spacesManager.onActiveSpaceChange$.subscribe((space) => {
+        setActiveSpace(space);
+      });
+      return () => sub.unsubscribe();
+    }, []);
+
+    const handleToggle = useCallback(() => {
+      closePopover();
+    }, [closePopover]);
+
+    return (
+      <SpacesMenu
+        id="sidenavSpacesMenuContent"
+        spaces={data || []}
+        serverBasePath={core.http.basePath.serverBasePath}
+        toggleSpaceSelector={handleToggle}
+        capabilities={core.application.capabilities}
+        navigateToApp={core.application.navigateToApp}
+        navigateToUrl={core.application.navigateToUrl}
+        activeSpace={activeSpace}
+        allowSolutionVisibility={config.allowSolutionVisibility}
+        eventTracker={eventTracker}
+        onClickManageSpaceBtn={handleToggle}
+        isLoading={isLoading}
+        width="100%"
+      />
+    );
+  };
+
+  const setConfig = (space: Space | null) => {
+    if (!space) {
+      core.chrome.next.spaceSelector.set(undefined);
+      return;
+    }
+
+    const selectorConfig: ChromeNextSpaceSelectorConfig = {
+      label: space.name,
+      renderAvatar: () => (
+        <Suspense fallback={<EuiSkeletonCircle size="s" />}>
+          <LazySpaceAvatar space={space} size="s" />
+        </Suspense>
+      ),
+      renderPopover: (closePopover) => (
+        <QueryClientProvider client={queryClient}>
+          <SidenavSpacesPopoverContent closePopover={closePopover} />
+        </QueryClientProvider>
+      ),
+    };
+
+    core.chrome.next.spaceSelector.set(selectorConfig);
+  };
+
+  // Subscription intentionally lives for the page lifetime — no teardown needed.
+  spacesManager.onActiveSpaceChange$.subscribe((space) => {
+    setConfig(space);
   });
 }


### PR DESCRIPTION
## Summary

Wire the user menu and space selector into the Chrome-Next sidenav via new `chrome.next.userMenu` and `chrome.next.spaceSelector` APIs.

- Security plugin provides user avatar, profile link, custom menu links, and logout via `chrome.next.userMenu`
- Spaces plugin provides space avatar and selector popover via `chrome.next.spaceSelector`
- Add `popoverWidth` to `ToolItem` so custom popovers can override the default 248px width (space selector uses 360px)


<img width="513" height="342" alt="Screenshot 2026-04-07 at 16 00 57" src="https://github.com/user-attachments/assets/d9d9c823-95fb-460d-b833-5753e057a87e" />

<img width="350" height="216" alt="Screenshot 2026-04-07 at 16 01 01" src="https://github.com/user-attachments/assets/a6001e0f-32dc-4b65-8581-c9ccc77650d1" />
