### PR TITLE
[Dashboards Markdown] Move markdown help button tooltip to bottom

### DIFF
--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
@@ -137,8 +137,10 @@ export const MarkdownEditor = ({
                   settings={settings}
                   updateSettings={updateSettings}
                 />
-                {/* TODO: Add tooltipPosition: bottom when https://github.com/elastic/eui/pull/9546 merges */}
-                <EuiMarkdownEditorHelpButton uiPlugins={uiPlugins} />
+                <EuiMarkdownEditorHelpButton
+                  uiPlugins={uiPlugins}
+                  tooltipProps={{ position: 'bottom' }}
+                />
               </>
             ),
           }}

--- a/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
+++ b/src/platform/plugins/shared/dashboard_markdown/public/components/markdown_editor.tsx
@@ -139,7 +139,7 @@ export const MarkdownEditor = ({
                 />
                 <EuiMarkdownEditorHelpButton
                   uiPlugins={uiPlugins}
-                  tooltipProps={{ position: 'bottom' }}
+                  tooltipProps={{ position: 'bottom', delay: 'regular' }}
                 />
               </>
             ),


### PR DESCRIPTION
## Summary

Fixes this tooltip position discrepancy in the dashboard markdown editor:

<img width="996" height="196" alt="Screenshot 2026-03-31 at 3 10 26 PM" src="https://github.com/user-attachments/assets/c07fbe15-d7e1-431f-b89e-c556de68a806" />

<img width="265" height="150" alt="Screenshot 2026-03-31 at 3 42 08 PM" src="https://github.com/user-attachments/assets/6274b0d0-3456-45a2-b295-14841f818ef1" />

The help button position will now also be set to `bottom`

## Release note

Fixes the tooltip position for the help button on dashboard markdown editors so it no longer blocks the preview toggle


