### PR TITLE
[Synthetics] fix to the flaky tests, reduced the quantity of the monitors

### DIFF
--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/delete_monitor_project.ts
@@ -66,15 +66,16 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
     it('only allows 500 requests at a time', async () => {
       const project = 'test-brower-suite';
-      const monitors = [];
-      for (let i = 0; i < 550; i++) {
-        monitors.push({
-          ...projectMonitors.monitors[0],
-          id: `test-id-${i}`,
-          name: `test-name-${i}`,
-        });
-      }
-      const monitorsToDelete = monitors.map((monitor) => monitor.id);
+      // Create only 2 real monitors — the 500-item limit is a request body validation,
+      // so we don't need hundreds of monitors to trigger it.
+      const monitors = [
+        { ...projectMonitors.monitors[0], id: 'test-id-0', name: 'test-name-0' },
+        { ...projectMonitors.monitors[0], id: 'test-id-1', name: 'test-name-1' },
+      ];
+      const realMonitorIds = monitors.map((m) => m.id);
+      // Build a delete payload with 501 IDs (2 real + 499 fake) to exceed the 500 limit
+      const fakeIds = Array.from({ length: 499 }, (_, i) => `fake-id-${i}`);
+      const oversizedDeletePayload = [...realMonitorIds, ...fakeIds];
 
       try {
         await supertest
@@ -83,16 +84,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           )
           .set(editorUser.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitors.slice(0, 250) })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitors.slice(250, 251) })
+          .send({ monitors })
           .expect(200);
 
         const savedObjectsResponse = await supertest
@@ -104,7 +96,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .expect(200);
         const { total } = savedObjectsResponse.body;
-        expect(total).to.eql(251);
+        expect(total).to.eql(2);
 
         const response = await supertest
           .delete(
@@ -112,10 +104,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           )
           .set(editorUser.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
-          .send({ monitors: monitorsToDelete })
+          .send({ monitors: oversizedDeletePayload })
           .expect(400);
         expect(response.body.message).to.eql(
-          '[request body.monitors]: array size is [550], but cannot be greater than [500]'
+          '[request body.monitors]: array size is [501], but cannot be greater than [500]'
         );
       } finally {
         try {
@@ -128,21 +120,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             )
             .set(editorUser.apiKeyHeader)
             .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) });
-        } catch (e) {
-          // best-effort cleanup
-        }
-        try {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 251) });
+            .send({ monitors: realMonitorIds });
         } catch (e) {
           // best-effort cleanup
         }

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
@@ -396,7 +396,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       const monitors = [];
       const project = 'test-suite';
       const perPage = 10;
-      for (let i = 0; i < TOTAL_MONITORS; i++) {
+      const totalMonitors = 25; // not evenly divisible by perPage so the last page is partial
+      for (let i = 0; i < totalMonitors; i++) {
         monitors.push({
           ...icmpProjectMonitors.monitors[0],
           id: `test-id-${i}`,
@@ -407,11 +408,11 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       try {
         await createProjectMonitors(monitors, project);
 
-        let count = Number.MAX_VALUE;
         let afterId;
         const fullResponse: ProjectMonitorMetaData[] = [];
         let page = 1;
-        while (count >= perPage) {
+        let count: number;
+        do {
           const response: SuperTest.Response = await supertest
             .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
             .set(editorUser.apiKeyHeader)
@@ -424,19 +425,19 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             .expect(200);
 
           const { monitors: monitorsResponse, after_key: afterKey, total } = response.body;
-          expect(total).to.eql(TOTAL_MONITORS);
+          expect(total).to.eql(totalMonitors);
           count = monitorsResponse.length;
           fullResponse.push(...monitorsResponse);
           if (page < 3) {
             expect(count).to.eql(perPage);
           } else {
-            expect(count).to.eql(TOTAL_MONITORS - perPage * 2);
+            expect(count).to.eql(totalMonitors - perPage * 2);
           }
           page++;
 
           afterId = afterKey;
-        }
-        expect(fullResponse.length).to.eql(TOTAL_MONITORS);
+        } while (count === perPage);
+        expect(fullResponse.length).to.eql(totalMonitors);
         checkFields(fullResponse, monitors);
       } finally {
         try {

--- a/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
+++ b/x-pack/solutions/observability/test/api_integration_deployment_agnostic/apis/synthetics/get_monitor_project.ts
@@ -24,7 +24,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     const supertest = getService('supertestWithoutAuth');
     const kibanaServer = getService('kibanaServer');
     const samlAuth = getService('samlAuth');
-    const retry = getService('retry');
+
+    const TOTAL_MONITORS = 30;
+    const PER_PAGE = 20;
 
     let projectMonitors: LegacyProjectMonitorsRequest;
     let httpProjectMonitors: LegacyProjectMonitorsRequest;
@@ -49,6 +51,27 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           privateLocations: privateLocations.map((location) => location.label),
         })),
       };
+    };
+
+    const createProjectMonitors = async (monitors: ProjectMonitor[], project: string) => {
+      await supertest
+        .put(
+          SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
+        )
+        .set(editorUser.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ monitors })
+        .expect(200);
+    };
+
+    const deleteProjectMonitors = async (monitorIds: string[], project: string) => {
+      await supertest
+        .delete(
+          SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace('{projectName}', project)
+        )
+        .set(editorUser.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send({ monitors: monitorIds });
     };
 
     before(async () => {
@@ -84,7 +107,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('project monitors - fetches all monitors - browser', async () => {
       const monitors = [];
       const project = 'test-brower-suite';
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...projectMonitors.monitors[0],
           id: `test browser id ${i}`,
@@ -93,50 +116,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, project);
 
         const firstPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
           .set(editorUser.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
-          .query({ per_page: 500 })
+          .query({ per_page: PER_PAGE })
           .send()
           .expect(200);
 
         const { monitors: firstPageMonitors, total, after_key: afterKey } = firstPageResponse.body;
-        expect(firstPageMonitors.length).to.eql(500);
-        expect(total).to.eql(600);
-        expect(afterKey).to.eql('test browser id 548');
+        expect(firstPageMonitors.length).to.eql(PER_PAGE);
+        expect(total).to.eql(TOTAL_MONITORS);
+        expect(afterKey).to.be.a('string');
 
         const secondPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
@@ -144,47 +137,19 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .query({
             search_after: afterKey,
-            per_page: 500,
+            per_page: PER_PAGE,
           })
           .send()
           .expect(200);
         const { monitors: secondPageMonitors } = secondPageResponse.body;
-        expect(secondPageMonitors.length).to.eql(100);
+        expect(secondPageMonitors.length).to.eql(TOTAL_MONITORS - PER_PAGE);
         checkFields([...firstPageMonitors, ...secondPageMonitors], monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
         try {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) });
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            project
+          );
         } catch (e) {
           // best-effort cleanup; beforeEach will handle leftovers
         }
@@ -194,7 +159,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('project monitors - fetches all monitors - http', async () => {
       const monitors = [];
       const project = 'test-http-suite';
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...httpProjectMonitors.monitors[1],
           id: `test http id ${i}`,
@@ -203,43 +168,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, project);
 
         const firstPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
           .set(editorUser.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
-          .query({ per_page: 500 })
+          .query({ per_page: PER_PAGE })
           .send()
           .expect(200);
 
@@ -248,9 +183,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           after_key: afterKey,
           total,
         } = firstPageResponse.body;
-        expect(firstPageProjectMonitors.length).to.eql(500);
-        expect(total).to.eql(600);
-        expect(afterKey).to.eql('test http id 548');
+        expect(firstPageProjectMonitors.length).to.eql(PER_PAGE);
+        expect(total).to.eql(TOTAL_MONITORS);
+        expect(afterKey).to.be.a('string');
 
         const secondPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
@@ -258,47 +193,19 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .query({
             search_after: afterKey,
-            per_page: 500,
+            per_page: PER_PAGE,
           })
           .send()
           .expect(200);
         const { monitors: secondPageProjectMonitors } = secondPageResponse.body;
-        expect(secondPageProjectMonitors.length).to.eql(100);
+        expect(secondPageProjectMonitors.length).to.eql(TOTAL_MONITORS - PER_PAGE);
         checkFields([...firstPageProjectMonitors, ...secondPageProjectMonitors], monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
         try {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) });
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            project
+          );
         } catch (e) {
           // best-effort cleanup; beforeEach will handle leftovers
         }
@@ -308,7 +215,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('project monitors - fetches all monitors - tcp', async () => {
       const monitors = [];
       const project = 'test-tcp-suite';
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...tcpProjectMonitors.monitors[0],
           id: `test tcp id ${i}`,
@@ -317,42 +224,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, project);
 
         const firstPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
           .set(editorUser.apiKeyHeader)
-          .query({ per_page: 500 })
+          .query({ per_page: PER_PAGE })
           .set(samlAuth.getInternalRequestHeader())
           .send()
           .expect(200);
@@ -362,9 +239,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           after_key: afterKey,
           total,
         } = firstPageResponse.body;
-        expect(firstPageProjectMonitors.length).to.eql(500);
-        expect(total).to.eql(600);
-        expect(afterKey).to.eql('test tcp id 548');
+        expect(firstPageProjectMonitors.length).to.eql(PER_PAGE);
+        expect(total).to.eql(TOTAL_MONITORS);
+        expect(afterKey).to.be.a('string');
 
         const secondPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
@@ -372,47 +249,19 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .query({
             search_after: afterKey,
-            per_page: 500,
+            per_page: PER_PAGE,
           })
           .send()
           .expect(200);
         const { monitors: secondPageProjectMonitors } = secondPageResponse.body;
-        expect(secondPageProjectMonitors.length).to.eql(100);
+        expect(secondPageProjectMonitors.length).to.eql(TOTAL_MONITORS - PER_PAGE);
         checkFields([...firstPageProjectMonitors, ...secondPageProjectMonitors], monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
         try {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) });
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            project
+          );
         } catch (e) {
           // best-effort cleanup; beforeEach will handle leftovers
         }
@@ -422,7 +271,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('project monitors - fetches all monitors - icmp', async () => {
       const monitors = [];
       const project = 'test-icmp-suite';
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...icmpProjectMonitors.monitors[0],
           id: `test icmp id ${i}`,
@@ -431,41 +280,12 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, project);
 
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
         const firstPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
           .set(editorUser.apiKeyHeader)
-          .query({ per_page: 500 })
+          .query({ per_page: PER_PAGE })
           .set(samlAuth.getInternalRequestHeader())
           .send()
           .expect(200);
@@ -475,9 +295,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           after_key: afterKey,
           total,
         } = firstPageResponse.body;
-        expect(firstPageProjectMonitors.length).to.eql(500);
-        expect(total).to.eql(600);
-        expect(afterKey).to.eql('test icmp id 548');
+        expect(firstPageProjectMonitors.length).to.eql(PER_PAGE);
+        expect(total).to.eql(TOTAL_MONITORS);
+        expect(afterKey).to.be.a('string');
 
         const secondPageResponse = await supertest
           .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
@@ -485,48 +305,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .query({
             search_after: afterKey,
-            per_page: 500,
+            per_page: PER_PAGE,
           })
           .send()
           .expect(200);
         const { monitors: secondPageProjectMonitors } = secondPageResponse.body;
-        expect(secondPageProjectMonitors.length).to.eql(100);
+        expect(secondPageProjectMonitors.length).to.eql(TOTAL_MONITORS - PER_PAGE);
 
         checkFields([...firstPageProjectMonitors, ...secondPageProjectMonitors], monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
         try {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) });
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) });
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            project
+          );
         } catch (e) {
           // best-effort cleanup; beforeEach will handle leftovers
         }
@@ -536,7 +328,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
     it('project monitors - handles url ecoded project names', async () => {
       const monitors = [];
       const projectName = 'Test project';
-      for (let i = 0; i < 600; i++) {
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...icmpProjectMonitors.monitors[0],
           id: `test url id ${i}`,
@@ -545,46 +337,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace(
-              '{projectName}',
-              projectName
-            )
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace(
-              '{projectName}',
-              projectName
-            )
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace(
-              '{projectName}',
-              projectName
-            )
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, projectName);
 
         const firstPageResponse = await supertest
           .get(
@@ -593,7 +346,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
               encodeURI(projectName)
             )
           )
-          .query({ per_page: 500 })
+          .query({ per_page: PER_PAGE })
           .set(editorUser.apiKeyHeader)
           .set(samlAuth.getInternalRequestHeader())
           .send()
@@ -604,9 +357,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           after_key: afterKey,
           total,
         } = firstPageResponse.body;
-        expect(firstPageProjectMonitors.length).to.eql(500);
-        expect(total).to.eql(600);
-        expect(afterKey).to.eql('test url id 548');
+        expect(firstPageProjectMonitors.length).to.eql(PER_PAGE);
+        expect(total).to.eql(TOTAL_MONITORS);
+        expect(afterKey).to.be.a('string');
 
         const secondPageResponse = await supertest
           .get(
@@ -619,64 +372,31 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .set(samlAuth.getInternalRequestHeader())
           .query({
             search_after: afterKey,
-            per_page: 500,
+            per_page: PER_PAGE,
           })
           .send()
           .expect(200);
         const { monitors: secondPageProjectMonitors } = secondPageResponse.body;
-        expect(secondPageProjectMonitors.length).to.eql(100);
+        expect(secondPageProjectMonitors.length).to.eql(TOTAL_MONITORS - PER_PAGE);
 
         checkFields([...firstPageProjectMonitors, ...secondPageProjectMonitors], monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                encodeURI(projectName)
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) })
-            .expect(200);
-        });
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                encodeURI(projectName)
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) })
-            .expect(200);
-        });
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                encodeURI(projectName)
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) })
-            .expect(200);
-        });
+        try {
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            encodeURI(projectName)
+          );
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
 
     it('project monitors - handles per_page parameter', async () => {
       const monitors = [];
       const project = 'test-suite';
-      const perPage = 250;
-      for (let i = 0; i < 600; i++) {
+      const perPage = 10;
+      for (let i = 0; i < TOTAL_MONITORS; i++) {
         monitors.push({
           ...icmpProjectMonitors.monitors[0],
           id: `test-id-${i}`,
@@ -685,43 +405,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       }
 
       try {
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(0, 250),
-          })
-          .expect(200);
-
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(250, 500),
-          })
-          .expect(200);
-        await supertest
-          .put(
-            SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_UPDATE.replace('{projectName}', project)
-          )
-          .set(editorUser.apiKeyHeader)
-          .set(samlAuth.getInternalRequestHeader())
-          .send({
-            monitors: monitors.slice(500, 600),
-          })
-          .expect(200);
+        await createProjectMonitors(monitors, project);
 
         let count = Number.MAX_VALUE;
         let afterId;
         const fullResponse: ProjectMonitorMetaData[] = [];
         let page = 1;
-        while (count >= 250) {
+        while (count >= perPage) {
           const response: SuperTest.Response = await supertest
             .get(SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT.replace('{projectName}', project))
             .set(editorUser.apiKeyHeader)
@@ -734,62 +424,29 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
             .expect(200);
 
           const { monitors: monitorsResponse, after_key: afterKey, total } = response.body;
-          expect(total).to.eql(600);
+          expect(total).to.eql(TOTAL_MONITORS);
           count = monitorsResponse.length;
           fullResponse.push(...monitorsResponse);
           if (page < 3) {
             expect(count).to.eql(perPage);
           } else {
-            expect(count).to.eql(100);
+            expect(count).to.eql(TOTAL_MONITORS - perPage * 2);
           }
           page++;
 
           afterId = afterKey;
         }
-        // expect(fullResponse.length).to.eql(600);
-        // checkFields(fullResponse, monitors);
+        expect(fullResponse.length).to.eql(TOTAL_MONITORS);
+        checkFields(fullResponse, monitors);
       } finally {
-        const monitorsToDelete = monitors.map((monitor) => monitor.id);
-
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(0, 250) })
-            .expect(200);
-        });
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(250, 500) })
-            .expect(200);
-        });
-        await retry.try(async () => {
-          await supertest
-            .delete(
-              SYNTHETICS_API_URLS.SYNTHETICS_MONITORS_PROJECT_DELETE.replace(
-                '{projectName}',
-                project
-              )
-            )
-            .set(editorUser.apiKeyHeader)
-            .set(samlAuth.getInternalRequestHeader())
-            .send({ monitors: monitorsToDelete.slice(500, 600) })
-            .expect(200);
-        });
+        try {
+          await deleteProjectMonitors(
+            monitors.map((m) => m.id),
+            project
+          );
+        } catch (e) {
+          // best-effort cleanup; beforeEach will handle leftovers
+        }
       }
     });
   });


### PR DESCRIPTION
Fix for flaky synthetics API tests by reducing bulk monitor counts

### Summary

**Fixes flaky tests in:**
- get_monitor_project.ts
- delete_monitor_project.ts
These tests were overwhelming the server by creating hundreds of monitors, which caused intermittent 502 Bad Gateway errors in CI.

**Root cause**
Both tests used large bulk PUT requests to create hundreds of monitors:

`get_monitor_project.ts:` 600 monitors
`delete_monitor_project.ts:` 251 monitors

When cleanup fails, orphaned monitors leak into later tests and create cascading failures across the suite, including:
`migrate_legacy_policies.ts`and other tests that run afterward

**Fix**
1. `get_monitor_project.ts`
Reduced monitor creation from 600 → 25
Reduced per_page from 500 → 20
Preserves the same pagination coverage with much lower server load
Replaced hardcoded after_key assertions with dynamic checks
2. `delete_monitor_project.ts`
Reduced monitor creation from 251 → 2 in the "only allows 500 requests at a time" test
The >500 validation is based on request body size, not on the number of real monitors
Now sends 501 IDs total:
2 real IDs
499 fake IDs
This still triggers the same 400 validation error without creating unnecessary monitors

**Test plan**

- [x] Run CI flaky test runner (50+ runs) via /flaky
- [x] The migrate_legacy_policies.ts should no longer fail as collateral damage
