### PR TITLE
[skills] Update FTR to Scout migration skill with "qaf-tests pipeline generator"

### DIFF
--- a/.agents/skills/scout-migrate-from-ftr/SKILL.md
+++ b/.agents/skills/scout-migrate-from-ftr/SKILL.md
@@ -224,6 +224,12 @@ If the module uses **Pattern B**, treat the Scout API directory as isolated:
 - Add stable `data-test-subj` attributes when selectors are unstable.
 - Centralize deep links + page-ready waits in page objects.
 
+## After migration: update the QAF cloud pipeline
+
+If the FTR configs you migrated away from were listed in `.buildkite/ftr_<solution>_serverless_configs.yml` (i.e. they ran against real cloud deployments via the `appex-qa-serverless-kibana-ftr-tests` Buildkite pipeline), **you must also update the pipeline generator in the `qaf-tests` repo** at `.buildkite/pipeline_generators/cloud/serverless/ftr-tests.py`.
+
+That script hardcodes which configs to schedule as cloud jobs. If you added new FTR config groups (e.g. `config.group13.ts`) or renamed/removed existing ones, bump `group_count` (or adjust the config list) accordingly so those tests continue to run on cloud. Groups above the hardcoded cap are silently skipped.
+
 ## Common mistakes
 
 - Migrating data validation UI tests instead of converting to API tests.


### PR DESCRIPTION
## Summary

When FTR serverless configs are split into more groups during (or after) an FTR-to-Scout migration, the new groups won't run on cloud unless the `qaf-tests` pipeline generator is also updated. This was the root cause of elastic/appex-qa-team#832, where groups 13+ were silently skipped.

## Changes

- Added a new section to the `scout-migrate-from-ftr` skill reminding engineers to update `.buildkite/pipeline_generators/cloud/serverless/ftr-tests.py` in the `qaf-tests` repo when FTR config groups are added, renamed, or removed as part of a migration.