### PR TITLE
[8.19] [Mappings Editor] Fix _source field (#255122)

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -75,7 +75,7 @@ pageLoadAssetSize:
   home: 13710
   imageEmbeddable: 21386
   indexLifecycleManagement: 29870
-  indexManagement: 35861
+  indexManagement: 39694
   inference: 10368
   infra: 56302
   ingestPipelines: 17866

--- a/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.test.ts
@@ -98,6 +98,60 @@ describe('Component template serialization', () => {
         },
       });
     });
+
+    test('does not migrate deprecated mappings._source.mode to index.mapping.source.mode on deserialize', () => {
+      expect(
+        deserializeComponentTemplate(
+          {
+            name: 'my_component_template',
+            component_template: {
+              template: {
+                mappings: {
+                  _source: {
+                    mode: 'stored',
+                    includes: ['a'],
+                  },
+                },
+              },
+            },
+          },
+          []
+        )
+      ).toHaveProperty('template', {
+        mappings: {
+          _source: {
+            mode: 'stored',
+            includes: ['a'],
+          },
+        },
+      });
+    });
+
+    test('does not migrate enabled _source property - it remains represented via _source.enabled', () => {
+      expect(
+        deserializeComponentTemplate(
+          {
+            name: 'my_component_template',
+            component_template: {
+              template: {
+                mappings: {
+                  _source: {
+                    enabled: false,
+                  },
+                },
+              },
+            },
+          },
+          []
+        )
+      ).toHaveProperty('template', {
+        mappings: {
+          _source: {
+            enabled: false,
+          },
+        },
+      });
+    });
   });
 
   describe('serializeComponentTemplate()', () => {
@@ -166,6 +220,95 @@ describe('Component template serialization', () => {
         },
       });
     });
+
+    test('migrates deprecated mappings._source.mode to index.mapping.source.mode on serialize', () => {
+      expect(
+        serializeComponentTemplate({
+          ...deserializedComponentTemplate,
+          template: {
+            ...deserializedComponentTemplate.template,
+            mappings: {
+              ...deserializedComponentTemplate.template.mappings,
+              _source: {
+                mode: 'synthetic',
+                excludes: ['b'],
+              },
+            },
+          },
+        })
+      ).toHaveProperty('template', {
+        settings: {
+          number_of_shards: 1,
+          index: {
+            mapping: {
+              source: {
+                mode: 'synthetic',
+              },
+            },
+          },
+        },
+        mappings: {
+          _source: {
+            excludes: ['b'],
+          },
+          properties: deserializedComponentTemplate.template.mappings.properties,
+        },
+      });
+    });
+
+    test('does not include _source.mode in mappings when it is the only mappings value', () => {
+      expect(
+        serializeComponentTemplate({
+          ...deserializedComponentTemplate,
+          template: {
+            ...deserializedComponentTemplate.template,
+            mappings: {
+              _source: {
+                mode: 'synthetic',
+              },
+            },
+          },
+        })
+      ).toHaveProperty('template', {
+        mappings: {},
+        settings: {
+          number_of_shards: 1,
+          index: {
+            mapping: {
+              source: {
+                mode: 'synthetic',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    test('does not migrate enabled _source property - it remains represented via _source.enabled', () => {
+      expect(
+        serializeComponentTemplate({
+          ...deserializedComponentTemplate,
+          template: {
+            ...deserializedComponentTemplate.template,
+            mappings: {
+              ...deserializedComponentTemplate.template.mappings,
+              _source: {
+                enabled: false,
+              },
+            },
+          },
+        })
+      ).toHaveProperty('template', {
+        ...deserializedComponentTemplate.template,
+        mappings: {
+          ...deserializedComponentTemplate.template.mappings,
+          _source: {
+            enabled: false,
+          },
+        },
+      });
+    });
+
     test('serialize a component template with data stream options', () => {
       expect(
         serializeComponentTemplate(deserializedComponentTemplate, {

--- a/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/component_template_serialization.ts
@@ -12,7 +12,8 @@ import {
   ComponentTemplateListItem,
   ComponentTemplateSerialized,
 } from '../types';
-import { DataStreamOptions } from '../types/data_streams';
+import type { DataStreamOptions } from '../types/data_streams';
+import { buildTemplateMappings, buildTemplateSettings } from './utils';
 
 const hasEntries = (data: object = {}) => Object.entries(data).length > 0;
 
@@ -56,9 +57,20 @@ export function deserializeComponentTemplate(
 
   const indexTemplatesToUsedBy = getIndexTemplatesToUsedBy(indexTemplatesEs);
 
+  // When deserializing, preferMappingsSourceMode is false by default.
+  // This means _source.mode is not migrated to settings so the flyout shows the raw payload correctly.
+  const migratedSettings = buildTemplateSettings(template, undefined);
+  const migratedMappings = buildTemplateMappings(template);
+  const { mappings: _templateMappings, settings: _templateSettings, ...otherTemplate } = template;
+  const migratedTemplate = {
+    ...otherTemplate,
+    ...(migratedMappings ? { mappings: migratedMappings } : {}),
+    ...(migratedSettings ? { settings: migratedSettings } : {}),
+  };
+
   const deserializedComponentTemplate: ComponentTemplateDeserialized = {
     name,
-    template,
+    template: migratedTemplate,
     version,
     _meta,
     deprecated,
@@ -101,10 +113,21 @@ export function serializeComponentTemplate(
 ): ComponentTemplateSerialized {
   const { version, template, _meta, deprecated } = componentTemplateDeserialized;
 
+  // Normalize deprecated `_source.mode` (mappings) into `index.mapping.source.mode` (settings)
+  // and strip the deprecated `_source.mode` from mappings.
+  // During serialization, we prefer the source mode from mappings since it represents the latest user choice in the UI.
+  const migratedSettings = buildTemplateSettings(template, undefined, {
+    preferMappingsSourceMode: true,
+  });
+  const migratedMappings = buildTemplateMappings(template, { preferMappingsSourceMode: true });
+  const { mappings: _templateMappings, settings: _templateSettings, ...otherTemplate } = template;
+
   // If the existing component template contains data stream options, we need to persist them.
   // Otherwise, they will be lost when the component template is updated.
   const updatedTemplate = {
-    ...template,
+    ...otherTemplate,
+    ...(migratedMappings ? { mappings: migratedMappings } : {}),
+    ...(migratedSettings ? { settings: migratedSettings } : {}),
     ...(dataStreamOptions && { data_stream_options: dataStreamOptions }),
   };
 

--- a/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.test.ts
@@ -179,6 +179,64 @@ describe('Template serialization', () => {
           serializeTemplate(defaultDeserializedTemplate, { failure_store: { enabled: true } })
         ).toHaveProperty('template.data_stream_options', { failure_store: { enabled: true } });
       });
+
+      test('migrates deprecated mappings._source.mode to index.mapping.source.mode (stored)', () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+          template: {
+            mappings: {
+              _source: {
+                mode: 'stored',
+                includes: ['foo'],
+                excludes: ['bar'],
+              },
+            },
+          },
+        });
+
+        expect(result.template?.settings?.index?.mapping?.source?.mode).toBe('stored');
+        expect(result.template?.mappings?._source).toEqual({
+          includes: ['foo'],
+          excludes: ['bar'],
+        });
+      });
+
+      test('migrates deprecated mappings._source.mode to index.mapping.source.mode (synthetic)', () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+          template: {
+            mappings: {
+              _source: {
+                mode: 'synthetic',
+              },
+            },
+          },
+        });
+
+        expect(result.template?.settings?.index?.mapping?.source?.mode).toBe('synthetic');
+        expect(result.template?.mappings?._source?.mode).toBeUndefined();
+      });
+
+      test('does not migrate enabled _source property - it remains represented via _source.enabled', () => {
+        const result = serializeTemplate({
+          ...defaultDeserializedTemplate,
+          indexMode: undefined,
+          template: {
+            mappings: {
+              _source: {
+                enabled: false,
+              },
+            },
+          },
+        });
+
+        expect(result.template?.settings?.index?.mapping?.source?.mode).toBeUndefined();
+        expect(result.template?.mappings?._source).toEqual({
+          enabled: false,
+        });
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/template_serialization.ts
@@ -20,7 +20,7 @@ import {
   LOGSDB_INDEX_MODE,
 } from '../constants';
 import type { DataStreamOptions } from '../types/data_streams';
-import { buildTemplateSettings } from './utils';
+import { buildTemplateMappings, buildTemplateSettings } from './utils';
 
 const hasEntries = (data: object = {}) => Object.entries(data).length > 0;
 
@@ -42,20 +42,29 @@ export function serializeTemplate(
     deprecated,
   } = templateDeserialized;
 
-  // Build settings object, properly handling index mode
-  const settings = buildTemplateSettings(template, indexMode);
+  // Build settings object, properly handling index mode source mode.
+  // During serialization, we prefer the source mode from mappings since it represents the latest user choice in the UI.
+  const settings = buildTemplateSettings(template, indexMode, { preferMappingsSourceMode: true });
+  const mappings = buildTemplateMappings(template, { preferMappingsSourceMode: true });
 
   // Separate settings and lifecycle from other template properties so we can rebuild template cleanly
-  const { settings: _templateSettings, lifecycle, ...otherTemplateProperties } = template || {};
+  const {
+    settings: _templateSettings,
+    lifecycle,
+    mappings: _templateMappings,
+    ...otherTemplateProperties
+  } = template || {};
 
   const showTemplateOptions =
     Object.keys(otherTemplateProperties).length > 0 ||
+    (mappings && Object.keys(mappings).length > 0) ||
     (settings && Object.keys(settings).length > 0) ||
     (lifecycle && Object.keys(lifecycle).length > 0) ||
     dataStreamOptions;
 
   const templateOptions = {
     ...otherTemplateProperties,
+    ...(mappings && { mappings }),
     ...(settings && { settings }),
     ...(lifecycle && { lifecycle }),
     // If the existing template contains data stream options, we need to persist them.
@@ -113,13 +122,24 @@ export function deserializeTemplate(
       ? LOGSDB_INDEX_MODE
       : undefined)) as IndexMode | undefined;
 
+  // When deserializing, preferMappingsSourceMode is false by default.
+  // This means _source.mode is not migrated to settings so the flyout shows the raw payload correctly.
+  const migratedSettings = buildTemplateSettings(template, indexMode);
+  const migratedMappings = buildTemplateMappings(template);
+  const { mappings: _templateMappings, settings: _templateSettings, ...otherTemplate } = template;
+  const migratedTemplate = {
+    ...otherTemplate,
+    ...(migratedSettings ? { settings: migratedSettings } : {}),
+    ...(migratedMappings ? { mappings: migratedMappings } : {}),
+  };
+
   const deserializedTemplate: TemplateDeserialized = {
     name,
     version,
     priority,
     ...(template.lifecycle ? { lifecycle: deserializeESLifecycle(template.lifecycle) } : {}),
     indexPatterns: indexPatterns.sort(),
-    template,
+    template: migratedTemplate,
     indexMode,
     ilmPolicy: ilmPolicyName ? { name: ilmPolicyName } : undefined,
     composedOf: composedOf ?? [],
@@ -165,21 +185,36 @@ export function deserializeTemplateList(
  * ------------------------------------------
  */
 
-export function serializeLegacyTemplate(template: TemplateDeserialized): LegacyTemplateSerialized {
-  const {
-    version,
-    order,
-    indexPatterns,
-    template: { settings, aliases, mappings } = {},
-  } = template;
+export function serializeLegacyTemplate({
+  template,
+  indexPatterns,
+  version,
+  order,
+  indexMode,
+}: TemplateDeserialized): LegacyTemplateSerialized {
+  const migratedTemplatePayload = {
+    settings: template?.settings,
+    mappings: template?.mappings,
+  } as TemplateDeserialized['template'];
+
+  const migratedSettings = buildTemplateSettings(
+    migratedTemplatePayload,
+    (indexMode ?? (template?.settings?.index?.mode as IndexMode | undefined)) as
+      | IndexMode
+      | undefined,
+    { preferMappingsSourceMode: true }
+  );
+  const migratedMappings = buildTemplateMappings(migratedTemplatePayload, {
+    preferMappingsSourceMode: true,
+  });
 
   return {
     version,
     order,
     index_patterns: indexPatterns,
-    settings,
-    aliases,
-    mappings,
+    settings: migratedSettings,
+    aliases: template?.aliases,
+    mappings: migratedMappings,
   };
 }
 

--- a/x-pack/platform/plugins/shared/index_management/common/lib/utils.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/utils.test.ts
@@ -74,11 +74,11 @@ describe('utils', () => {
       });
     });
 
-    test('should remove existing mode when indexMode is undefined', () => {
+    test('should preserve existing mode when indexMode is undefined', () => {
       const template = {
         settings: {
           index: {
-            mode: IndexMode.standard,
+            mode: IndexMode.logsdb,
             number_of_shards: 3,
           },
         },
@@ -86,6 +86,7 @@ describe('utils', () => {
       const result = buildTemplateSettings(template, undefined);
       expect(result).toEqual({
         index: {
+          mode: IndexMode.logsdb,
           number_of_shards: 3,
         },
       });
@@ -141,18 +142,6 @@ describe('utils', () => {
         number_of_shards: 3,
         other_setting: 10000,
       });
-    });
-
-    test('should return undefined when only mode exists and indexMode is undefined', () => {
-      const template = {
-        settings: {
-          index: {
-            mode: IndexMode.standard,
-          },
-        },
-      };
-      const result = buildTemplateSettings(template, undefined);
-      expect(result).toBeUndefined();
     });
 
     test('should handle complex nested settings', () => {

--- a/x-pack/platform/plugins/shared/index_management/common/lib/utils.ts
+++ b/x-pack/platform/plugins/shared/index_management/common/lib/utils.ts
@@ -11,6 +11,7 @@ import type {
   TemplateSerialized,
   IndexMode,
   IndexSettings,
+  Mappings,
 } from '../types';
 
 /**
@@ -27,23 +28,53 @@ import type {
  */
 export const buildTemplateSettings = (
   template?: TemplateDeserialized['template'],
-  indexMode?: IndexMode
+  indexMode?: IndexMode,
+  options: { preferMappingsSourceMode?: boolean } = {}
 ): IndexSettings | undefined => {
+  const { preferMappingsSourceMode = false } = options;
   // Extract existing settings, separating index settings from other settings
-  const { index: existingIndexSettings, ...otherSettings } = template?.settings || {};
+  const {
+    index: existingIndexSettings,
+    'index.mapping.source.mode': flatSourceMode,
+    ...otherSettings
+  } = template?.settings || {};
 
   // Remove mode from existing index settings as we'll set it from indexMode parameter
-  const { mode: _existingMode, ...otherIndexSettings } = existingIndexSettings || {};
+  const {
+    mode: existingMode,
+    mapping: existingMappingSettings,
+    ...otherIndexSettings
+  } = existingIndexSettings || {};
 
   // Build index settings: include if we have indexMode to set or other index settings to preserve
   const hasIndexMode = indexMode !== undefined;
-  const hasOtherIndexSettings = Object.keys(otherIndexSettings).length > 0;
+  const hasOtherIndexSettings =
+    Object.keys(otherIndexSettings).length > 0 || existingMode !== undefined;
+
+  const { source: existingSourceSettings, ...otherMappingSettings } = existingMappingSettings || {};
+  const sourceModeFromMappings = template?.mappings?._source?.mode;
+
+  // Only migrate source mode from mappings if we prefer it (e.g. during serialization)
+  const sourceMode = preferMappingsSourceMode
+    ? sourceModeFromMappings ?? existingSourceSettings?.mode ?? flatSourceMode
+    : existingSourceSettings?.mode ?? flatSourceMode;
+
+  const hasSourceMode = sourceMode !== undefined;
+  const hasOtherMappingSettings = Object.keys(otherMappingSettings).length > 0;
 
   const indexSettings =
-    hasIndexMode || hasOtherIndexSettings
+    hasIndexMode || hasOtherIndexSettings || hasSourceMode || hasOtherMappingSettings
       ? {
           ...otherIndexSettings,
-          ...(hasIndexMode && { mode: indexMode }),
+          ...(hasIndexMode ? { mode: indexMode } : existingMode && { mode: existingMode }),
+          ...((sourceMode || hasOtherMappingSettings) && {
+            mapping: {
+              ...otherMappingSettings,
+              ...(sourceMode && {
+                source: { ...(existingSourceSettings ?? {}), mode: sourceMode },
+              }),
+            },
+          }),
         }
       : undefined;
 
@@ -53,8 +84,46 @@ export const buildTemplateSettings = (
     ...(indexSettings && { index: indexSettings }),
   };
 
-  // Return undefined if settings object is empty
-  return Object.keys(settings).length > 0 ? settings : undefined;
+  // Return undefined if settings object is empty, unless the original settings object existed
+  if (Object.keys(settings).length > 0) {
+    return settings;
+  }
+  return template?.settings ? {} : undefined;
+};
+
+export const buildTemplateMappings = (
+  template?: { mappings?: Mappings } | TemplateDeserialized['template'],
+  options: { preferMappingsSourceMode?: boolean } = {}
+): Mappings | undefined => {
+  const { preferMappingsSourceMode = false } = options;
+  // Extract existing mappings, separating source mappings from other mappings
+  const { _source: existingSourceMappings, ...otherMappings } = template?.mappings || {};
+
+  // Remove mode from existing source mappings as we'll set it from template settings
+  const { mode: existingSourceMode, ...otherSourceMappings } = existingSourceMappings || {};
+  const hasOtherSourceMappings = Object.keys(otherSourceMappings).length > 0;
+
+  // If not preferring mappings source mode (e.g. deserializing), preserve the existing source mode in mappings
+  const sourceMappings =
+    hasOtherSourceMappings || (!preferMappingsSourceMode && existingSourceMode !== undefined)
+      ? {
+          ...otherSourceMappings,
+          ...(!preferMappingsSourceMode &&
+            existingSourceMode !== undefined && { mode: existingSourceMode }),
+        }
+      : undefined;
+
+  // Build mappings object: only include if we have source mappings or other mappings
+  const mappings = {
+    ...otherMappings,
+    ...(sourceMappings && { _source: sourceMappings }),
+  };
+
+  // Return undefined if mappings object is empty, unless the original mappings object existed
+  if (Object.keys(mappings).length > 0) {
+    return mappings;
+  }
+  return template?.mappings ? {} : undefined;
 };
 
 /**

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/component_template_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/component_templates/component_template_wizard/component_template_form/component_template_form.tsx
@@ -101,11 +101,32 @@ export const ComponentTemplateForm = ({
   onStepChange,
 }: Props) => {
   const {
-    template: { settings, mappings, aliases, lifecycle, data_stream_options: dataStreamOptions },
+    template: {
+      settings,
+      mappings: initialMappings,
+      aliases,
+      lifecycle,
+      data_stream_options: dataStreamOptions,
+    },
     ...logistics
   } = defaultValue;
 
   const { documentation } = useComponentTemplatesContext();
+
+  const mappings = useMemo(() => {
+    if (initialMappings && initialMappings._source && 'mode' in initialMappings._source) {
+      const { mode, ...otherSource } = initialMappings._source;
+      const newMappings = {
+        ...initialMappings,
+        _source: Object.keys(otherSource).length > 0 ? otherSource : undefined,
+      };
+      if (newMappings._source === undefined) {
+        delete newMappings._source;
+      }
+      return Object.keys(newMappings).length > 0 ? newMappings : undefined;
+    }
+    return initialMappings;
+  }, [initialMappings]);
 
   const wizardDefaultValue: WizardContent = {
     logistics: {

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/configuration_form.tsx
@@ -25,11 +25,13 @@ import { RoutingSection } from './routing_section';
 import { MapperSizePluginSection } from './mapper_size_plugin_section';
 import { SubobjectsSection } from './subobjects_section';
 import { configurationFormSchema } from './configuration_form_schema';
+import type { IndexMode } from '../../../../../../common/types/data_streams';
 
 interface Props {
   value?: MappingsConfiguration;
   /** List of plugins installed in the cluster nodes */
   esNodesPlugins: string[];
+  indexMode?: IndexMode;
 }
 
 interface SerializedSourceField {
@@ -129,7 +131,7 @@ export const formDeserializer = (formData: GenericObject) => {
   };
 };
 
-export const ConfigurationForm = React.memo(({ value, esNodesPlugins }: Props) => {
+export const ConfigurationForm = React.memo(({ value, esNodesPlugins, indexMode }: Props) => {
   const {
     config: { enableMappingsSourceFieldSection },
   } = useAppContext();
@@ -199,7 +201,7 @@ export const ConfigurationForm = React.memo(({ value, esNodesPlugins }: Props) =
       <EuiSpacer size="xl" />
       {enableMappingsSourceFieldSection && (
         <>
-          <SourceFieldSection /> <EuiSpacer size="xl" />
+          <SourceFieldSection indexMode={indexMode} /> <EuiSpacer size="xl" />
         </>
       )}
       <RoutingSection />

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/components/configuration_form/source_field_section/source_field_section.tsx
@@ -16,14 +16,12 @@ import { documentationService } from '../../../../../services/documentation';
 import { UseField, FormDataProvider, FormRow, SuperSelectField } from '../../../shared_imports';
 import { ComboBoxOption } from '../../../types';
 import { sourceOptionLabels, sourceOptionDescriptions } from './i18n_texts';
-import {
-  STORED_SOURCE_OPTION,
-  DISABLED_SOURCE_OPTION,
-  SYNTHETIC_SOURCE_OPTION,
-  SourceOptionKey,
-} from './constants';
+import type { SourceOptionKey } from './constants';
+import { STORED_SOURCE_OPTION, DISABLED_SOURCE_OPTION, SYNTHETIC_SOURCE_OPTION } from './constants';
+import type { IndexMode } from '../../../../../../../common/types/data_streams';
+import { LOGSDB_INDEX_MODE } from '../../../../../../../common/constants';
 
-export const SourceFieldSection = () => {
+export const SourceFieldSection = ({ indexMode }: { indexMode?: IndexMode }) => {
   const { canUseSyntheticSource } = useAppContext();
 
   const renderOptionDropdownDisplay = (option: SourceOptionKey) => (
@@ -263,7 +261,9 @@ export const SourceFieldSection = () => {
             ? renderFormFields()
             : sourceField?.option === DISABLED_SOURCE_OPTION
             ? renderDisableWarning()
-            : renderSyntheticWarning();
+            : indexMode === LOGSDB_INDEX_MODE
+            ? renderSyntheticWarning()
+            : null;
         }}
       </FormDataProvider>
     </FormRow>

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/mappings_editor.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/mappings_editor/mappings_editor.tsx
@@ -34,7 +34,11 @@ import { DocLinksStart } from './shared_imports';
 import { DocumentFieldsHeader } from './components/document_fields/document_fields_header';
 import { SearchResult } from './components/document_fields/search_fields';
 import { parseMappings } from '../../shared/parse_mappings';
-import { LOGSDB_INDEX_MODE, TIME_SERIES_MODE } from '../../../../common/constants';
+import {
+  STANDARD_INDEX_MODE,
+  LOGSDB_INDEX_MODE,
+  TIME_SERIES_MODE,
+} from '../../../../common/constants';
 
 type TabName = 'fields' | 'runtimeFields' | 'advanced' | 'templates';
 
@@ -58,13 +62,50 @@ export interface Props {
   indexMode?: IndexMode;
 }
 
+const getSourceModeFromIndexSettings = (
+  settings?: IndexSettings | any
+): 'stored' | 'synthetic' | undefined => {
+  if (!settings) return undefined;
+
+  const nestedMode = settings.index?.mapping?.source?.mode;
+  if (nestedMode === 'stored' || nestedMode === 'synthetic') return nestedMode;
+
+  const flatMode = settings['index.mapping.source.mode'];
+  if (flatMode === 'stored' || flatMode === 'synthetic') return flatMode;
+
+  return undefined;
+};
+
 export const MappingsEditor = React.memo(
   ({ onChange, value, docLinks, indexSettings, esNodesPlugins, indexMode }: Props) => {
     const { canUseSyntheticSource } = useAppContext();
-    const { parsedDefaultValue, multipleMappingsDeclared } = useMemo<MappingsEditorParsedMetadata>(
-      () => parseMappings(value),
-      [value]
-    );
+    const { parsedDefaultValue, multipleMappingsDeclared } =
+      useMemo<MappingsEditorParsedMetadata>(() => {
+        const parsed = parseMappings(value);
+        const modeFromSettings = getSourceModeFromIndexSettings(indexSettings);
+
+        if (
+          parsed.parsedDefaultValue?.configuration &&
+          modeFromSettings !== undefined &&
+          parsed.parsedDefaultValue.configuration?._source?.enabled !== false &&
+          parsed.parsedDefaultValue.configuration?._source?.mode === undefined
+        ) {
+          return {
+            ...parsed,
+            parsedDefaultValue: {
+              ...parsed.parsedDefaultValue,
+              configuration: {
+                ...parsed.parsedDefaultValue.configuration,
+                _source: {
+                  ...(parsed.parsedDefaultValue.configuration._source ?? {}),
+                  mode: modeFromSettings,
+                },
+              },
+            },
+          };
+        }
+        return parsed;
+      }, [value, indexSettings]);
     /**
      * Hook that will listen to:
      * 1. "value" prop changes in order to reset the mappings editor
@@ -169,6 +210,7 @@ export const MappingsEditor = React.memo(
       advanced: (
         <ConfigurationForm
           value={state.configuration.defaultValue}
+          indexMode={indexMode ?? STANDARD_INDEX_MODE}
           esNodesPlugins={esNodesPlugins}
         />
       ),

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/template_form.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/template_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSpacer, EuiButton, EuiPageHeader } from '@elastic/eui';
@@ -129,11 +129,31 @@ export const TemplateForm = ({
   };
 
   const {
-    template: { settings, mappings, aliases, data_stream_options: dataStreamOptions } = {},
+    template: {
+      settings,
+      mappings: initialMappings,
+      aliases,
+      data_stream_options: dataStreamOptions,
+    } = {},
     composedOf,
     _kbnMeta,
     ...logistics
   } = indexTemplate;
+
+  const mappings = useMemo(() => {
+    if (initialMappings && initialMappings._source && 'mode' in initialMappings._source) {
+      const { mode, ...otherSource } = initialMappings._source;
+      const newMappings = {
+        ...initialMappings,
+        _source: Object.keys(otherSource).length > 0 ? otherSource : undefined,
+      };
+      if (newMappings._source === undefined) {
+        delete newMappings._source;
+      }
+      return Object.keys(newMappings).length > 0 ? newMappings : undefined;
+    }
+    return initialMappings;
+  }, [initialMappings]);
 
   const wizardDefaultValue: WizardContent = {
     logistics,

--- a/x-pack/platform/test/functional/apps/index_management/index_templates_tab/index_template_tab.ts
+++ b/x-pack/platform/test/functional/apps/index_management/index_templates_tab/index_template_tab.ts
@@ -173,6 +173,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             mode: 'logsdb',
             mapping: {
               ignore_above: '20',
+              source: {
+                mode: 'synthetic',
+              },
               total_fields: {
                 ignore_dynamic_beyond_limit: 'true',
               },
@@ -188,9 +191,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         const mappingsTabContent = await testSubjects.getVisibleText('mappingsTabContent');
         expect(JSON.parse(mappingsTabContent)).to.eql({
           dynamic_date_formats: ['basic_date'],
-          _source: {
-            mode: 'synthetic',
-          },
           subobjects: false,
         });
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Mappings Editor] Fix _source field (#255122)](https://github.com/elastic/kibana/pull/255122)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-03-04T13:38:52Z","message":"[Mappings Editor] Fix _source field (#255122)\n\nCloses https://github.com/elastic/kibana/issues/255069\nCloses https://github.com/elastic/kibana/issues/254638\n\n## Summary\n\nThis PR fixes the _source field in the Mappings editor Advanced options\nso that it sets the correct property in the template.\n\n- Migrates deprecated `template.mappings._source.mode` usage to the\nsupported index setting `template.settings.index.mapping.source.mode`\n(for `stored`/`synthetic`) and strips `_source.mode` from mappings to\navoid reintroducing the deprecation/no-op config.\n- Preserves mappings semantics for `_source.enabled: false` and\n`_source.includes` / `_source.excludes` (these remain in mappings).\n- An existing template that has the deprecated `_source.mode` is\nmigrated to new `index.mapping.source.mode` setting on editing the\ntemplate in the UI.\n\n## Implementation notes\nUpdated mappings and settings builders for index templates and component\ntemplates serialization/deserialization:\n- `buildTemplateSettings()` promotes `_source.mode` →\n`settings.index.mapping.source.mode` (nested form) and creates\n`settings.index` when needed.\n- `buildTemplateMappings()` removes `_source.mode` from mappings and but\nkeeps any other `_source` properties (e.g.\n`enabled`/`include`/`exclude`).\n\n\n## Additional fixes\nThe synthetic mode warning banner is now only displayed if the selected\n`indexMode` in the form is `logsdb`.\n\n\n\nhttps://github.com/user-attachments/assets/4ebc4a70-4d0a-4d53-a1ec-6eb4d9b65cc5\n\n\n## Release notes\n\nWe fixed a bug where the index and component template form in the Index\nManagement UI was setting the deprecated `_source.mode` mappings setting\nwhich doesn't take any effect. The form now uses the correct\n`index.mapping.source.mode` setting. If you use the UI to edit a\ntemplate that contains the deprecated `_source.mode` setting, the\ndeprecated setting will be automatically migrated to the correct one.","sha":"41531729d78f3abfa699170bf279b2e4e20544ec","branchLabelMapping":{"^v9.4.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:breaking","Team:Kibana Management","Feature:Mappings Editor","backport:all-open","v9.4.0","v9.3.2"],"title":"[Mappings Editor] Fix _source field","number":255122,"url":"https://github.com/elastic/kibana/pull/255122","mergeCommit":{"message":"[Mappings Editor] Fix _source field (#255122)\n\nCloses https://github.com/elastic/kibana/issues/255069\nCloses https://github.com/elastic/kibana/issues/254638\n\n## Summary\n\nThis PR fixes the _source field in the Mappings editor Advanced options\nso that it sets the correct property in the template.\n\n- Migrates deprecated `template.mappings._source.mode` usage to the\nsupported index setting `template.settings.index.mapping.source.mode`\n(for `stored`/`synthetic`) and strips `_source.mode` from mappings to\navoid reintroducing the deprecation/no-op config.\n- Preserves mappings semantics for `_source.enabled: false` and\n`_source.includes` / `_source.excludes` (these remain in mappings).\n- An existing template that has the deprecated `_source.mode` is\nmigrated to new `index.mapping.source.mode` setting on editing the\ntemplate in the UI.\n\n## Implementation notes\nUpdated mappings and settings builders for index templates and component\ntemplates serialization/deserialization:\n- `buildTemplateSettings()` promotes `_source.mode` →\n`settings.index.mapping.source.mode` (nested form) and creates\n`settings.index` when needed.\n- `buildTemplateMappings()` removes `_source.mode` from mappings and but\nkeeps any other `_source` properties (e.g.\n`enabled`/`include`/`exclude`).\n\n\n## Additional fixes\nThe synthetic mode warning banner is now only displayed if the selected\n`indexMode` in the form is `logsdb`.\n\n\n\nhttps://github.com/user-attachments/assets/4ebc4a70-4d0a-4d53-a1ec-6eb4d9b65cc5\n\n\n## Release notes\n\nWe fixed a bug where the index and component template form in the Index\nManagement UI was setting the deprecated `_source.mode` mappings setting\nwhich doesn't take any effect. The form now uses the correct\n`index.mapping.source.mode` setting. If you use the UI to edit a\ntemplate that contains the deprecated `_source.mode` setting, the\ndeprecated setting will be automatically migrated to the correct one.","sha":"41531729d78f3abfa699170bf279b2e4e20544ec"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.4.0","branchLabelMappingKey":"^v9.4.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/255122","number":255122,"mergeCommit":{"message":"[Mappings Editor] Fix _source field (#255122)\n\nCloses https://github.com/elastic/kibana/issues/255069\nCloses https://github.com/elastic/kibana/issues/254638\n\n## Summary\n\nThis PR fixes the _source field in the Mappings editor Advanced options\nso that it sets the correct property in the template.\n\n- Migrates deprecated `template.mappings._source.mode` usage to the\nsupported index setting `template.settings.index.mapping.source.mode`\n(for `stored`/`synthetic`) and strips `_source.mode` from mappings to\navoid reintroducing the deprecation/no-op config.\n- Preserves mappings semantics for `_source.enabled: false` and\n`_source.includes` / `_source.excludes` (these remain in mappings).\n- An existing template that has the deprecated `_source.mode` is\nmigrated to new `index.mapping.source.mode` setting on editing the\ntemplate in the UI.\n\n## Implementation notes\nUpdated mappings and settings builders for index templates and component\ntemplates serialization/deserialization:\n- `buildTemplateSettings()` promotes `_source.mode` →\n`settings.index.mapping.source.mode` (nested form) and creates\n`settings.index` when needed.\n- `buildTemplateMappings()` removes `_source.mode` from mappings and but\nkeeps any other `_source` properties (e.g.\n`enabled`/`include`/`exclude`).\n\n\n## Additional fixes\nThe synthetic mode warning banner is now only displayed if the selected\n`indexMode` in the form is `logsdb`.\n\n\n\nhttps://github.com/user-attachments/assets/4ebc4a70-4d0a-4d53-a1ec-6eb4d9b65cc5\n\n\n## Release notes\n\nWe fixed a bug where the index and component template form in the Index\nManagement UI was setting the deprecated `_source.mode` mappings setting\nwhich doesn't take any effect. The form now uses the correct\n`index.mapping.source.mode` setting. If you use the UI to edit a\ntemplate that contains the deprecated `_source.mode` setting, the\ndeprecated setting will be automatically migrated to the correct one.","sha":"41531729d78f3abfa699170bf279b2e4e20544ec"}},{"branch":"9.3","label":"v9.3.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/256005","number":256005,"state":"MERGED","mergeCommit":{"sha":"eabd2b30a5ecc08ec7e44415f024da4def01d0b2","message":"[9.3] [Mappings Editor] Fix _source field (#255122) (#256005)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.3`:\n- [[Mappings Editor] Fix _source field\n(#255122)](https://github.com/elastic/kibana/pull/255122)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Stoeva <59341489+ElenaStoeva@users.noreply.github.com>"}}]}] BACKPORT-->