### PR TITLE
[Streams] Register streams as SML type in Agent Builder

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.test.ts
@@ -195,8 +195,53 @@ describe('resolveSmlAttachItems', () => {
         type: 'visualization',
         data: { layers: [] },
         origin: 'custom-origin',
+        description: 'Test Viz',
       });
       expect(results[0].chunk_id).toBe('chunk-1');
+    }
+  });
+
+  it('uses description from toAttachment when provided', async () => {
+    const smlDoc = createSmlDoc();
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue({
+        type: 'visualization',
+        data: {},
+        description: 'Custom Description',
+      }),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      chunkIds: ['chunk-1'],
+    });
+    expect(results[0].success).toBe(true);
+    if (results[0].success) {
+      expect(results[0].attachment.description).toBe('Custom Description');
+    }
+  });
+
+  it('falls back to smlDoc.title when toAttachment omits description', async () => {
+    const smlDoc = createSmlDoc({ title: 'My Dashboard' });
+    mockCheckItemsAccess.mockResolvedValue(new Map([['chunk-1', true]]));
+    mockGetDocuments.mockResolvedValue(new Map([['chunk-1', smlDoc]]));
+    mockGetTypeDefinition.mockReturnValue({
+      id: 'visualization',
+      list: jest.fn(),
+      getSmlData: jest.fn(),
+      toAttachment: jest.fn().mockResolvedValue({ type: 'visualization', data: {} }),
+    });
+    const results = await resolveSmlAttachItems({
+      ...baseParams,
+      chunkIds: ['chunk-1'],
+    });
+    expect(results[0].success).toBe(true);
+    if (results[0].success) {
+      expect(results[0].attachment.description).toBe('My Dashboard');
     }
   });
 
@@ -268,6 +313,7 @@ describe('resolveSmlAttachItems', () => {
         type: 'visualization',
         data: {},
         origin: 'r-ok',
+        description: 'Test Viz',
       });
     }
   });

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/sml/execute_sml_attach_items.ts
@@ -19,6 +19,7 @@ export type SmlResolvedItemResult =
         type: string;
         data: unknown;
         origin: string;
+        description?: string;
       };
     }
   | {
@@ -118,6 +119,7 @@ export const resolveSmlAttachItems = async ({
             type: convertedAttachment.type,
             data: convertedAttachment.data,
             origin: convertedAttachment.origin ?? smlDoc.origin_id,
+            description: convertedAttachment.description ?? smlDoc.title,
           },
         };
       } catch (error) {

--- a/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder/server/services/tools/builtin/sml/sml_attach.test.ts
@@ -209,6 +209,7 @@ describe('createSmlAttachTool', () => {
         type: 'visualization',
         data: { layers: [] },
         origin: 'ref-1',
+        description: 'Test Viz',
       },
       'agent'
     );

--- a/x-pack/platform/plugins/shared/streams/common/agent_builder/stream_attachment.ts
+++ b/x-pack/platform/plugins/shared/streams/common/agent_builder/stream_attachment.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const STREAM_ATTACHMENT_TYPE = 'stream';
+export const STREAM_SML_TYPE = 'stream';
+
+export type StreamType = 'wired' | 'classic' | 'query' | 'unknown';
+
+export interface StreamAttachmentData {
+  stream_name: string;
+  stream_type: StreamType;
+  description: string;
+}

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/stream_attachment_type.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/stream_attachment_type.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import { STREAM_ATTACHMENT_TYPE } from '../../../common/agent_builder/stream_attachment';
+import { STREAMS_TOOL_IDS } from '../tools/tool_ids';
+import { createStreamAttachmentType } from './stream_attachment_type';
+
+const mockStorageClient = {
+  get: jest.fn(),
+};
+
+jest.mock('../../lib/streams/storage/streams_storage_client', () => ({
+  createStreamsStorageClient: jest.fn(() => mockStorageClient),
+}));
+
+const logger = loggingSystemMock.createLogger();
+const coreSetup = coreMock.createSetup();
+
+const attachmentType = createStreamAttachmentType({ core: coreSetup, logger });
+
+describe('streamAttachmentType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('id', () => {
+    it('equals stream', () => {
+      expect(attachmentType.id).toBe(STREAM_ATTACHMENT_TYPE);
+    });
+  });
+
+  describe('isReadonly', () => {
+    it('is true', () => {
+      expect(attachmentType.isReadonly).toBe(true);
+    });
+  });
+
+  describe('validate', () => {
+    it('accepts valid stream attachment data', () => {
+      const result = attachmentType.validate({
+        stream_name: 'logs.nginx',
+        stream_type: 'wired',
+        description: 'Nginx logs',
+      });
+      expect(result).toEqual({
+        valid: true,
+        data: { stream_name: 'logs.nginx', stream_type: 'wired', description: 'Nginx logs' },
+      });
+    });
+
+    it('rejects missing stream_name', () => {
+      const result = attachmentType.validate({
+        stream_type: 'wired',
+        description: 'Nginx logs',
+      });
+      expect(result).toEqual(expect.objectContaining({ valid: false }));
+    });
+
+    it('rejects invalid stream_type', () => {
+      const result = attachmentType.validate({
+        stream_name: 'logs.nginx',
+        stream_type: 'invalid',
+        description: '',
+      });
+      expect(result).toEqual(expect.objectContaining({ valid: false }));
+    });
+
+    it('accepts all valid stream types', () => {
+      for (const streamType of ['wired', 'classic', 'query', 'unknown']) {
+        const result = attachmentType.validate({
+          stream_name: 'test',
+          stream_type: streamType,
+          description: '',
+        });
+        expect(result).toEqual(expect.objectContaining({ valid: true }));
+      }
+    });
+  });
+
+  describe('format', () => {
+    it('returns text representation with stream metadata', async () => {
+      const formatted = await attachmentType.format(
+        {
+          data: {
+            stream_name: 'logs.nginx',
+            stream_type: 'wired',
+            description: 'Nginx access logs',
+          },
+        } as never,
+        {} as never
+      );
+
+      const representation = await formatted.getRepresentation!();
+      expect(representation.type).toBe('text');
+      expect(representation.value).toContain('Stream: logs.nginx');
+      expect(representation.value).toContain('Type: wired');
+      expect(representation.value).toContain('Description: Nginx access logs');
+    });
+
+    it('omits description line when empty', async () => {
+      const formatted = await attachmentType.format(
+        {
+          data: {
+            stream_name: 'metrics.cpu',
+            stream_type: 'classic',
+            description: '',
+          },
+        } as never,
+        {} as never
+      );
+
+      const representation = await formatted.getRepresentation!();
+      expect(representation.value).not.toContain('Description:');
+    });
+  });
+
+  describe('resolve', () => {
+    it('resolves stream definition by origin name', async () => {
+      const mockCoreStart = {
+        elasticsearch: {
+          client: {
+            asInternalUser: {},
+          },
+        },
+      };
+      coreSetup.getStartServices.mockResolvedValueOnce([mockCoreStart, {}, {}] as never);
+
+      mockStorageClient.get.mockResolvedValueOnce({
+        _source: {
+          name: 'logs.nginx',
+          type: 'wired',
+          description: 'Nginx access logs',
+          ingest: { wired: {} },
+        },
+      });
+
+      const result = await attachmentType.resolve!('logs.nginx', {} as never);
+
+      expect(result).toEqual({
+        stream_name: 'logs.nginx',
+        stream_type: 'wired',
+        description: 'Nginx access logs',
+      });
+    });
+
+    it('returns undefined and logs warning on error', async () => {
+      const mockCoreStart = {
+        elasticsearch: {
+          client: {
+            asInternalUser: {},
+          },
+        },
+      };
+      coreSetup.getStartServices.mockResolvedValueOnce([mockCoreStart, {}, {}] as never);
+      mockStorageClient.get.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await attachmentType.resolve!('missing', {} as never);
+
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to resolve 'missing'")
+      );
+    });
+  });
+
+  describe('getTools', () => {
+    it('returns all streams tool IDs', () => {
+      expect(attachmentType.getTools!()).toEqual([...STREAMS_TOOL_IDS]);
+    });
+  });
+
+  describe('getAgentDescription', () => {
+    it('returns a description string', () => {
+      const description = attachmentType.getAgentDescription!();
+      expect(description).toContain('stream');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/stream_attachment_type.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/attachments/stream_attachment_type.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod/v4';
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type { AttachmentTypeDefinition } from '@kbn/agent-builder-server/attachments';
+import { createStreamsStorageClient } from '../../lib/streams/storage/streams_storage_client';
+import {
+  STREAM_ATTACHMENT_TYPE,
+  type StreamAttachmentData,
+} from '../../../common/agent_builder/stream_attachment';
+import { STREAMS_TOOL_IDS } from '../tools/tool_ids';
+import { getStreamType } from '../sml/utils';
+
+const streamAttachmentDataSchema = z.object({
+  stream_name: z.string(),
+  stream_type: z.enum(['wired', 'classic', 'query', 'unknown']),
+  description: z.string(),
+});
+
+export const createStreamAttachmentType = ({
+  core,
+  logger,
+}: {
+  core: CoreSetup;
+  logger: Logger;
+}): AttachmentTypeDefinition<typeof STREAM_ATTACHMENT_TYPE, StreamAttachmentData> => ({
+  id: STREAM_ATTACHMENT_TYPE,
+
+  isReadonly: true,
+
+  validate: (input) => {
+    const result = streamAttachmentDataSchema.safeParse(input);
+    if (result.success) {
+      return { valid: true, data: result.data };
+    }
+    return { valid: false, error: result.error.message };
+  },
+
+  format: (attachment) => {
+    const { stream_name: name, stream_type: streamType, description } = attachment.data;
+
+    return {
+      getRepresentation: () => {
+        const parts: string[] = [`Stream: ${name}`, `Type: ${streamType}`];
+        if (description) {
+          parts.push(`Description: ${description}`);
+        }
+        parts.push(
+          '',
+          'Use the streams tools (list_streams, get_stream, get_schema, query_documents, etc.) to inspect and query this stream.'
+        );
+        return { type: 'text' as const, value: parts.join('\n') };
+      },
+    };
+  },
+
+  resolve: async (origin) => {
+    try {
+      const [coreStart] = await core.getStartServices();
+      const esClient = coreStart.elasticsearch.client.asInternalUser;
+      const storageClient = createStreamsStorageClient(esClient, logger);
+      const response = await storageClient.get({ id: origin });
+      const definition = response._source;
+
+      if (!definition) {
+        return undefined;
+      }
+
+      return {
+        stream_name: definition.name,
+        stream_type: getStreamType(definition),
+        description: definition.description || '',
+      };
+    } catch (error) {
+      logger.warn(`Stream attachment: failed to resolve '${origin}': ${(error as Error).message}`);
+      return undefined;
+    }
+  },
+
+  getTools: () => [...STREAMS_TOOL_IDS],
+
+  getAgentDescription: () =>
+    'A stream attachment represents an Elasticsearch data stream. ' +
+    'Use the streams tools to list, inspect, query, and analyze the attached stream.',
+});

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/register.ts
@@ -6,23 +6,33 @@
  */
 
 import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-plugin/server';
-import type { Logger } from '@kbn/core/server';
+import type { CoreSetup, Logger } from '@kbn/core/server';
 import type { GetScopedClients } from '../routes/types';
 import type { StreamsServer } from '../types';
 import { registerAgentBuilderTools } from './tools/register_tools';
 import { streamExplorationSkill } from './skills/stream_exploration_skill';
+import { createStreamSmlType } from './sml/stream_sml_type';
+import { createStreamAttachmentType } from './attachments/stream_attachment_type';
 
 export const registerStreamsAgentBuilder = ({
   agentBuilder,
   getScopedClients,
   server,
   logger,
+  core,
 }: {
   agentBuilder: AgentBuilderPluginSetup;
   getScopedClients: GetScopedClients;
   server: StreamsServer;
   logger: Logger;
+  core: CoreSetup;
 }) => {
   registerAgentBuilderTools({ agentBuilder, getScopedClients, server, logger });
   agentBuilder.skills.register(streamExplorationSkill);
+  agentBuilder.sml.registerType(createStreamSmlType({ core, logger }));
+  agentBuilder.attachments.registerType(
+    createStreamAttachmentType({ core, logger }) as Parameters<
+      typeof agentBuilder.attachments.registerType
+    >[0]
+  );
 };

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.test.ts
@@ -166,6 +166,84 @@ describe('streamSmlType', () => {
       expect(mockStorageClient.search).toHaveBeenCalledTimes(2);
     });
 
+    it('continues past pages consisting entirely of filtered group documents', async () => {
+      const groupOnlyPage = Array.from({ length: 1000 }, (_, i) => ({
+        _id: `group-${i}`,
+        _source: {
+          name: `group-${i}`,
+          type: 'wired',
+          description: '',
+          updated_at: '2025-01-01T00:00:00Z',
+          group: {},
+        },
+        sort: [`group-${i}`],
+      }));
+
+      const validPage = [
+        {
+          _id: 'logs.nginx',
+          _source: {
+            name: 'logs.nginx',
+            type: 'wired',
+            description: 'Nginx',
+            updated_at: '2025-01-02T00:00:00Z',
+          },
+          sort: ['logs.nginx'],
+        },
+      ];
+
+      mockStorageClient.search
+        .mockResolvedValueOnce({ hits: { hits: groupOnlyPage } })
+        .mockResolvedValueOnce({ hits: { hits: validPage } });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(mockStorageClient.search).toHaveBeenCalledTimes(2);
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('logs.nginx');
+    });
+
+    it('handles multiple consecutive pages of only group documents before valid items', async () => {
+      const makeGroupPage = (prefix: string) =>
+        Array.from({ length: 1000 }, (_, i) => ({
+          _id: `${prefix}-${i}`,
+          _source: {
+            name: `${prefix}-${i}`,
+            type: 'wired',
+            description: '',
+            updated_at: '2025-01-01T00:00:00Z',
+            group: {},
+          },
+          sort: [`${prefix}-${i}`],
+        }));
+
+      mockStorageClient.search
+        .mockResolvedValueOnce({ hits: { hits: makeGroupPage('g1') } })
+        .mockResolvedValueOnce({ hits: { hits: makeGroupPage('g2') } })
+        .mockResolvedValueOnce({
+          hits: {
+            hits: [
+              {
+                _id: 'metrics.cpu',
+                _source: {
+                  name: 'metrics.cpu',
+                  type: 'classic',
+                  description: 'CPU metrics',
+                  updated_at: '2025-01-03T00:00:00Z',
+                },
+                sort: ['metrics.cpu'],
+              },
+            ],
+          },
+        });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(mockStorageClient.search).toHaveBeenCalledTimes(3);
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('metrics.cpu');
+    });
+
     it('returns empty when no streams exist', async () => {
       mockStorageClient.search.mockResolvedValueOnce({
         hits: { hits: [] },

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.test.ts
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { coreMock } from '@kbn/core/server/mocks';
+import type { SmlListItem } from '@kbn/agent-builder-plugin/server';
+import {
+  STREAM_SML_TYPE,
+  STREAM_ATTACHMENT_TYPE,
+} from '../../../common/agent_builder/stream_attachment';
+import { createStreamSmlType } from './stream_sml_type';
+
+const mockStorageClient = {
+  search: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('../../lib/streams/storage/streams_storage_client', () => ({
+  createStreamsStorageClient: jest.fn(() => mockStorageClient),
+}));
+
+const logger = loggingSystemMock.createLogger();
+const coreSetup = coreMock.createSetup();
+
+const smlType = createStreamSmlType({ core: coreSetup, logger });
+
+const createContext = () => ({
+  esClient: {} as never,
+  savedObjectsClient: {} as never,
+  logger: loggingSystemMock.createLogger(),
+});
+
+async function collectPages(iterable: AsyncIterable<SmlListItem[]>): Promise<SmlListItem[]> {
+  const items: SmlListItem[] = [];
+  for await (const page of iterable) {
+    items.push(...page);
+  }
+  return items;
+}
+
+describe('streamSmlType', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('id', () => {
+    it('equals stream', () => {
+      expect(smlType.id).toBe(STREAM_SML_TYPE);
+    });
+  });
+
+  describe('fetchFrequency', () => {
+    it('returns 30m', () => {
+      expect(smlType.fetchFrequency!()).toBe('30m');
+    });
+  });
+
+  describe('list', () => {
+    it('yields stream items with spaces: ["*"]', async () => {
+      mockStorageClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            {
+              _id: 'logs.nginx',
+              _source: {
+                name: 'logs.nginx',
+                type: 'wired',
+                description: 'Nginx logs',
+                updated_at: '2025-01-01T00:00:00Z',
+              },
+              sort: ['logs.nginx'],
+            },
+            {
+              _id: 'metrics.cpu',
+              _source: {
+                name: 'metrics.cpu',
+                type: 'classic',
+                description: '',
+                updated_at: '2025-01-02T00:00:00Z',
+              },
+              sort: ['metrics.cpu'],
+            },
+          ],
+        },
+      });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(items).toEqual([
+        { id: 'logs.nginx', updatedAt: '2025-01-01T00:00:00Z', spaces: ['*'] },
+        { id: 'metrics.cpu', updatedAt: '2025-01-02T00:00:00Z', spaces: ['*'] },
+      ]);
+    });
+
+    it('filters out legacy group documents', async () => {
+      mockStorageClient.search.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            {
+              _id: 'logs',
+              _source: {
+                name: 'logs',
+                type: 'wired',
+                description: '',
+                updated_at: '2025-01-01T00:00:00Z',
+                group: {},
+              },
+              sort: ['logs'],
+            },
+            {
+              _id: 'logs.nginx',
+              _source: {
+                name: 'logs.nginx',
+                type: 'wired',
+                description: 'Nginx',
+                updated_at: '2025-01-01T00:00:00Z',
+              },
+              sort: ['logs.nginx'],
+            },
+          ],
+        },
+      });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('logs.nginx');
+    });
+
+    it('paginates through multiple pages', async () => {
+      const page1Hits = Array.from({ length: 1000 }, (_, i) => ({
+        _id: `stream-${i}`,
+        _source: {
+          name: `stream-${i}`,
+          type: 'wired',
+          description: '',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        sort: [`stream-${i}`],
+      }));
+
+      const page2Hits = [
+        {
+          _id: 'stream-1000',
+          _source: {
+            name: 'stream-1000',
+            type: 'classic',
+            description: '',
+            updated_at: '2025-01-01T00:00:00Z',
+          },
+          sort: ['stream-1000'],
+        },
+      ];
+
+      mockStorageClient.search
+        .mockResolvedValueOnce({ hits: { hits: page1Hits } })
+        .mockResolvedValueOnce({ hits: { hits: page2Hits } });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(items).toHaveLength(1001);
+      expect(mockStorageClient.search).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty when no streams exist', async () => {
+      mockStorageClient.search.mockResolvedValueOnce({
+        hits: { hits: [] },
+      });
+
+      const items = await collectPages(smlType.list(createContext() as never));
+
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('getSmlData', () => {
+    it('returns chunk with name, description, and type for a wired stream', async () => {
+      mockStorageClient.get.mockResolvedValueOnce({
+        _source: {
+          name: 'logs.nginx',
+          type: 'wired',
+          description: 'Nginx access logs',
+          ingest: { wired: {} },
+        },
+      });
+
+      const result = await smlType.getSmlData('logs.nginx', createContext() as never);
+
+      expect(result).toEqual({
+        chunks: [
+          {
+            type: STREAM_SML_TYPE,
+            title: 'logs.nginx',
+            content: 'logs.nginx\nNginx access logs\ntype: wired',
+            permissions: ['api:read_stream'],
+          },
+        ],
+      });
+    });
+
+    it('returns chunk for a query stream', async () => {
+      mockStorageClient.get.mockResolvedValueOnce({
+        _source: {
+          name: 'logs.nginx.errors',
+          type: 'query',
+          description: 'Nginx error subset',
+          query: { esql: 'FROM logs.nginx | WHERE level = "error"' },
+        },
+      });
+
+      const result = await smlType.getSmlData('logs.nginx.errors', createContext() as never);
+
+      expect(result!.chunks[0].content).toContain('type: query');
+      expect(result!.chunks[0].title).toBe('logs.nginx.errors');
+    });
+
+    it('returns undefined and logs warning on error', async () => {
+      mockStorageClient.get.mockRejectedValueOnce(new Error('Not found'));
+      const context = createContext();
+
+      const result = await smlType.getSmlData('missing-stream', context as never);
+
+      expect(result).toBeUndefined();
+      expect(context.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to get data for 'missing-stream'")
+      );
+    });
+  });
+
+  describe('toAttachment', () => {
+    it('returns stream attachment with resolved data', async () => {
+      const mockCoreStart = {
+        elasticsearch: {
+          client: {
+            asInternalUser: {},
+          },
+        },
+      };
+      coreSetup.getStartServices.mockResolvedValueOnce([mockCoreStart, {}, {}] as never);
+
+      mockStorageClient.get.mockResolvedValueOnce({
+        _source: {
+          name: 'logs.nginx',
+          type: 'classic',
+          description: 'Classic nginx stream',
+          ingest: { classic: {} },
+        },
+      });
+
+      const result = await smlType.toAttachment({ origin_id: 'logs.nginx' } as never, {} as never);
+
+      expect(result).toEqual({
+        type: STREAM_ATTACHMENT_TYPE,
+        data: {
+          stream_name: 'logs.nginx',
+          stream_type: 'classic',
+          description: 'Classic nginx stream',
+        },
+        origin: 'logs.nginx',
+        description: 'logs.nginx',
+      });
+    });
+
+    it('returns undefined and logs warning on error', async () => {
+      const mockCoreStart = {
+        elasticsearch: {
+          client: {
+            asInternalUser: {},
+          },
+        },
+      };
+      coreSetup.getStartServices.mockResolvedValueOnce([mockCoreStart, {}, {}] as never);
+      mockStorageClient.get.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await smlType.toAttachment(
+        { origin_id: 'missing-stream' } as never,
+        {} as never
+      );
+
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("failed to convert 'missing-stream' to attachment")
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type { SmlTypeDefinition } from '@kbn/agent-builder-plugin/server';
+import type { Streams } from '@kbn/streams-schema';
+import { createStreamsStorageClient } from '../../lib/streams/storage/streams_storage_client';
+import {
+  STREAM_SML_TYPE,
+  STREAM_ATTACHMENT_TYPE,
+  type StreamAttachmentData,
+} from '../../../common/agent_builder/stream_attachment';
+import { getStreamType } from './utils';
+
+const PAGE_SIZE = 1000;
+
+const hasSource = (hit: {
+  _source?: Streams.all.Definition;
+}): hit is { _source: Streams.all.Definition } => hit._source !== undefined;
+
+export const createStreamSmlType = ({
+  core,
+  logger,
+}: {
+  core: CoreSetup;
+  logger: Logger;
+}): SmlTypeDefinition => ({
+  id: STREAM_SML_TYPE,
+  fetchFrequency: () => '30m',
+
+  async *list(context) {
+    const storageClient = createStreamsStorageClient(context.esClient, context.logger);
+
+    let searchAfter: string[] | undefined;
+
+    while (true) {
+      const response = await storageClient.search({
+        size: PAGE_SIZE,
+        sort: [{ name: 'asc' }],
+        track_total_hits: false,
+        ...(searchAfter ? { search_after: searchAfter } : {}),
+      });
+
+      const hits = response.hits.hits
+        .filter(hasSource)
+        .filter(({ _source }) => !('group' in _source));
+
+      if (hits.length === 0) {
+        break;
+      }
+
+      yield hits.map(({ _source }) => ({
+        id: _source.name,
+        updatedAt: _source.updated_at ?? new Date().toISOString(),
+        spaces: ['*'],
+      }));
+
+      const lastHit = response.hits.hits[response.hits.hits.length - 1];
+      searchAfter = lastHit.sort as string[] | undefined;
+
+      if (response.hits.hits.length < PAGE_SIZE) {
+        break;
+      }
+    }
+  },
+
+  getSmlData: async (originId, context) => {
+    try {
+      const storageClient = createStreamsStorageClient(context.esClient, context.logger);
+      const response = await storageClient.get({ id: originId });
+      const definition = response._source;
+
+      if (!definition) {
+        return undefined;
+      }
+
+      const streamType = getStreamType(definition);
+      const contentParts = [definition.name, definition.description, `type: ${streamType}`].filter(
+        Boolean
+      );
+
+      return {
+        chunks: [
+          {
+            type: STREAM_SML_TYPE,
+            title: definition.name,
+            content: contentParts.join('\n'),
+            permissions: ['api:read_stream'],
+          },
+        ],
+      };
+    } catch (error) {
+      context.logger.warn(
+        `SML stream: failed to get data for '${originId}': ${(error as Error).message}`
+      );
+      return undefined;
+    }
+  },
+
+  toAttachment: async (item) => {
+    try {
+      const [coreStart] = await core.getStartServices();
+      const esClient = coreStart.elasticsearch.client.asInternalUser;
+      const storageClient = createStreamsStorageClient(esClient, logger);
+      const response = await storageClient.get({ id: item.origin_id });
+      const definition = response._source;
+
+      if (!definition) {
+        return undefined;
+      }
+
+      const data: StreamAttachmentData = {
+        stream_name: definition.name,
+        stream_type: getStreamType(definition),
+        description: definition.description || '',
+      };
+
+      return {
+        type: STREAM_ATTACHMENT_TYPE,
+        data,
+        origin: item.origin_id,
+        description: definition.name,
+      };
+    } catch (error) {
+      logger.warn(
+        `SML stream: failed to convert '${item.origin_id}' to attachment: ${
+          (error as Error).message
+        }`
+      );
+      return undefined;
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/stream_sml_type.ts
@@ -45,19 +45,21 @@ export const createStreamSmlType = ({
         ...(searchAfter ? { search_after: searchAfter } : {}),
       });
 
+      if (response.hits.hits.length === 0) {
+        break;
+      }
+
       const hits = response.hits.hits
         .filter(hasSource)
         .filter(({ _source }) => !('group' in _source));
 
-      if (hits.length === 0) {
-        break;
+      if (hits.length > 0) {
+        yield hits.map(({ _source }) => ({
+          id: _source.name,
+          updatedAt: _source.updated_at ?? new Date().toISOString(),
+          spaces: ['*'],
+        }));
       }
-
-      yield hits.map(({ _source }) => ({
-        id: _source.name,
-        updatedAt: _source.updated_at ?? new Date().toISOString(),
-        spaces: ['*'],
-      }));
 
       const lastHit = response.hits.hits[response.hits.hits.length - 1];
       searchAfter = lastHit.sort as string[] | undefined;

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/utils.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Streams } from '@kbn/streams-schema';
+import { getStreamType } from './utils';
+
+describe('getStreamType', () => {
+  it('returns "wired" for a wired stream', () => {
+    const definition = {
+      name: 'logs.nginx',
+      type: 'wired',
+      description: '',
+      updated_at: '',
+      ingest: { wired: { fields: {} }, processing: [], routing: [] },
+    } as unknown as Streams.all.Definition;
+    expect(getStreamType(definition)).toBe('wired');
+  });
+
+  it('returns "classic" for a classic stream', () => {
+    const definition = {
+      name: 'logs.legacy',
+      type: 'classic',
+      description: '',
+      updated_at: '',
+      ingest: { classic: {} },
+    } as unknown as Streams.all.Definition;
+    expect(getStreamType(definition)).toBe('classic');
+  });
+
+  it('returns "query" for a query stream', () => {
+    const definition = {
+      name: 'logs.nginx.errors',
+      type: 'query',
+      description: '',
+      updated_at: '',
+      query: { esql: 'FROM logs.nginx' },
+    } as unknown as Streams.all.Definition;
+    expect(getStreamType(definition)).toBe('query');
+  });
+
+  it('returns "unknown" for an unrecognized stream type', () => {
+    const definition = {
+      name: 'mystery',
+      type: 'other',
+      description: '',
+      updated_at: '',
+    } as unknown as Streams.all.Definition;
+    expect(getStreamType(definition)).toBe('unknown');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/utils.ts
+++ b/x-pack/platform/plugins/shared/streams/server/agent_builder/sml/utils.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Streams } from '@kbn/streams-schema';
+import type { StreamType } from '../../../common/agent_builder/stream_attachment';
+
+export const getStreamType = (definition: Streams.all.Definition): StreamType => {
+  if (Streams.WiredStream.Definition.is(definition)) {
+    return 'wired';
+  }
+  if (Streams.ClassicStream.Definition.is(definition)) {
+    return 'classic';
+  }
+  if (Streams.QueryStream.Definition.is(definition)) {
+    return 'query';
+  }
+  return 'unknown';
+};

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -219,6 +219,7 @@ export class StreamsPlugin
         getScopedClients,
         server: this.server,
         logger: this.logger,
+        core,
       });
     }
 


### PR DESCRIPTION
## Summary

Makes streams discoverable in Agent Builder through `sml_search` and `sml_attach` by registering a Semantic Metadata Layer (SML) type definition and a `stream` attachment type.

- **SML type (`stream`)**: Crawls `.kibana_streams`, indexes stream name, description, and type (wired/classic/query) as searchable content. Uses `spaces: ['*']` (streams are not space-scoped) and `permissions: ['api:read_stream']` for authorization filtering at query time.
- **Attachment type (`stream`)**: Validates, formats, and resolves stream metadata for conversation attachments. Exposes all streams tool IDs so the agent can act on attached streams. Includes a `resolve` hook for by-reference creation from `sml_attach`.
- **Bug fix in `execute_sml_attach_items`**: Forwards the `description` field from `toAttachment` (falling back to `smlDoc.title`), so the "Attachment added:" UI label renders correctly for all SML types — not just streams.

## Screenshot

<img width="693" height="1027" alt="Screenshot 2026-04-07 at 17 36 33" src="https://github.com/user-attachments/assets/2f7280df-3632-46a2-a47f-65e827d0cb97" />

## Testing

```yml
uiSettings.overrides.agentBuilder:experimentalFeatures: true
```