### PR TITLE
Fix missing `GapAutoFillSchedulerProvider` in serverless Configurations > Rules tab*

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules.tsx
@@ -8,16 +8,19 @@
 import { EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import { SecuritySolutionPageWrapper } from '../../common/components/page_wrapper';
+import { GapAutoFillSchedulerProvider } from '../../detection_engine/rule_gaps/context/gap_auto_fill_scheduler_context';
 import { RulesTableContextProvider } from '../../detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context';
 import { PromotionRulesTable } from './promotion_rules/promotion_rules_table';
 
 export const PromotionRules: React.FC = () => {
   return (
-    <RulesTableContextProvider>
-      <SecuritySolutionPageWrapper>
-        <EuiSpacer />
-        <PromotionRulesTable />
-      </SecuritySolutionPageWrapper>
-    </RulesTableContextProvider>
+    <GapAutoFillSchedulerProvider>
+      <RulesTableContextProvider>
+        <SecuritySolutionPageWrapper>
+          <EuiSpacer />
+          <PromotionRulesTable />
+        </SecuritySolutionPageWrapper>
+      </RulesTableContextProvider>
+    </GapAutoFillSchedulerProvider>
   );
 };


### PR DESCRIPTION
**Fix missing `GapAutoFillSchedulerProvider` in serverless Configurations > Rules tab**

close: https://github.com/elastic/kibana/issues/261501

The `PromotionRules` component uses `RulesTableContextProvider`, which internally calls `useGapAutoFillSchedulerContext`. This context requires a `GapAutoFillSchedulerProvider` wrapper, which was present on the main Rules page but missing here, causing a runtime error when navigating to the Rules tab in Configurations > Integrations.